### PR TITLE
all: Regenerate all bindings with new XML data.

### DIFF
--- a/all-core/gl/package.go
+++ b/all-core/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -89,26 +87,34 @@ package gl
 // typedef ptrdiff_t GLsizeiptr;
 // typedef int64_t GLint64;
 // typedef uint64_t GLuint64;
+// typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCARB)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCKHR)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcoreall(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcoreall(source, type, id, severity, length, message, userParam);
 // }
 // typedef void  (APIENTRYP GPACCUM)(GLenum  op, GLfloat  value);
+// typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
+// typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVETEXTURE)(GLenum  texture);
 // typedef void  (APIENTRYP GPALPHAFUNC)(GLenum  func, GLfloat  ref);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef GLboolean  (APIENTRYP GPARETEXTURESRESIDENT)(GLsizei  n, const GLuint * textures, GLboolean * residences);
 // typedef void  (APIENTRYP GPARRAYELEMENT)(GLint  i);
 // typedef void  (APIENTRYP GPATTACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPBEGIN)(GLenum  mode);
 // typedef void  (APIENTRYP GPBEGINCONDITIONALRENDER)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINCONDITIONALRENDERNV)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPBEGINPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPBEGINQUERY)(GLenum  target, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINQUERYINDEXED)(GLenum  target, GLuint  index, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINTRANSFORMFEEDBACK)(GLenum  primitiveMode);
@@ -123,7 +129,9 @@ package gl
 // typedef void  (APIENTRYP GPBINDFRAMEBUFFER)(GLenum  target, GLuint  framebuffer);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURE)(GLuint  unit, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  access, GLenum  format);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURES)(GLuint  first, GLsizei  count, const GLuint * textures);
+// typedef void  (APIENTRYP GPBINDMULTITEXTUREEXT)(GLenum  texunit, GLenum  target, GLuint  texture);
 // typedef void  (APIENTRYP GPBINDPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPBINDPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPBINDRENDERBUFFER)(GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPBINDSAMPLER)(GLuint  unit, GLuint  sampler);
 // typedef void  (APIENTRYP GPBINDSAMPLERS)(GLuint  first, GLsizei  count, const GLuint * samplers);
@@ -135,6 +143,8 @@ package gl
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFER)(GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFERS)(GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
 // typedef void  (APIENTRYP GPBITMAP)(GLsizei  width, GLsizei  height, GLfloat  xorig, GLfloat  yorig, GLfloat  xmove, GLfloat  ymove, const GLubyte * bitmap);
+// typedef void  (APIENTRYP GPBLENDBARRIERKHR)();
+// typedef void  (APIENTRYP GPBLENDBARRIERNV)();
 // typedef void  (APIENTRYP GPBLENDCOLOR)(GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha);
 // typedef void  (APIENTRYP GPBLENDEQUATION)(GLenum  mode);
 // typedef void  (APIENTRYP GPBLENDEQUATIONSEPARATE)(GLenum  modeRGB, GLenum  modeAlpha);
@@ -148,16 +158,20 @@ package gl
 // typedef void  (APIENTRYP GPBLENDFUNCSEPARATEIARB)(GLuint  buf, GLenum  srcRGB, GLenum  dstRGB, GLenum  srcAlpha, GLenum  dstAlpha);
 // typedef void  (APIENTRYP GPBLENDFUNCI)(GLuint  buf, GLenum  src, GLenum  dst);
 // typedef void  (APIENTRYP GPBLENDFUNCIARB)(GLuint  buf, GLenum  src, GLenum  dst);
+// typedef void  (APIENTRYP GPBLENDPARAMETERINV)(GLenum  pname, GLint  value);
 // typedef void  (APIENTRYP GPBLITFRAMEBUFFER)(GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
 // typedef void  (APIENTRYP GPBLITNAMEDFRAMEBUFFER)(GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLIST)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLISTS)(GLsizei  n, GLenum  type, const void * lists);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
 // typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUS)(GLuint  framebuffer, GLenum  target);
+// typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(GLuint  framebuffer, GLenum  target);
 // typedef void  (APIENTRYP GPCLAMPCOLOR)(GLenum  target, GLenum  clamp);
 // typedef void  (APIENTRYP GPCLEAR)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPCLEARACCUM)(GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha);
@@ -172,8 +186,10 @@ package gl
 // typedef void  (APIENTRYP GPCLEARDEPTHF)(GLfloat  d);
 // typedef void  (APIENTRYP GPCLEARINDEX)(GLfloat  c);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
@@ -181,6 +197,7 @@ package gl
 // typedef void  (APIENTRYP GPCLEARTEXIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARTEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLIENTACTIVETEXTURE)(GLenum  texture);
+// typedef void  (APIENTRYP GPCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef GLenum  (APIENTRYP GPCLIENTWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
 // typedef void  (APIENTRYP GPCLIPCONTROL)(GLenum  origin, GLenum  depth);
 // typedef void  (APIENTRYP GPCLIPPLANE)(GLenum  plane, const GLdouble * equation);
@@ -216,42 +233,81 @@ package gl
 // typedef void  (APIENTRYP GPCOLOR4UIV)(const GLuint * v);
 // typedef void  (APIENTRYP GPCOLOR4US)(GLushort  red, GLushort  green, GLushort  blue, GLushort  alpha);
 // typedef void  (APIENTRYP GPCOLOR4USV)(const GLushort * v);
+// typedef void  (APIENTRYP GPCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPCOLORMASK)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPCOLORMASKI)(GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a);
 // typedef void  (APIENTRYP GPCOLORMATERIAL)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPCOLORPOINTER)(GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE3D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOPYBUFFERSUBDATA)(GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYIMAGESUBDATA)(GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  type);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef void  (APIENTRYP GPCREATEPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPCREATEQUERIES)(GLenum  target, GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPCREATERENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPCREATESAMPLERS)(GLsizei  n, GLuint * samplers);
 // typedef GLuint  (APIENTRYP GPCREATESHADER)(GLenum  type);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -267,15 +323,21 @@ package gl
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTARB)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTKHR)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETELISTS)(GLuint  list, GLsizei  range);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef void  (APIENTRYP GPDELETEPATHSNV)(GLuint  path, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
+// typedef void  (APIENTRYP GPDELETEPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPDELETEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINES)(GLsizei  n, const GLuint * pipelines);
+// typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINESEXT)(GLsizei  n, const GLuint * pipelines);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETRANSFORMFEEDBACKS)(GLsizei  n, const GLuint * ids);
@@ -289,7 +351,12 @@ package gl
 // typedef void  (APIENTRYP GPDETACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPDISABLE)(GLenum  cap);
 // typedef void  (APIENTRYP GPDISABLECLIENTSTATE)(GLenum  array);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPDISABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISPATCHCOMPUTE)(GLuint  num_groups_x, GLuint  num_groups_y, GLuint  num_groups_z);
@@ -298,16 +365,24 @@ package gl
 // typedef void  (APIENTRYP GPDRAWARRAYS)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCED)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDARB)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDBASEINSTANCE)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDEXT)(GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWBUFFER)(GLenum  buf);
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWELEMENTSBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCED)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDARB)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDEXT)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWPIXELS)(GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTS)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTSBASEVERTEX)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
@@ -315,17 +390,27 @@ package gl
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKINSTANCED)(GLenum  mode, GLuint  id, GLsizei  instancecount);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
 // typedef void  (APIENTRYP GPEDGEFLAG)(GLboolean  flag);
+// typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPEDGEFLAGPOINTER)(GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPEDGEFLAGV)(const GLboolean * flag);
 // typedef void  (APIENTRYP GPENABLE)(GLenum  cap);
 // typedef void  (APIENTRYP GPENABLECLIENTSTATE)(GLenum  array);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPENABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPENABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPEND)();
 // typedef void  (APIENTRYP GPENDCONDITIONALRENDER)();
+// typedef void  (APIENTRYP GPENDCONDITIONALRENDERNV)();
 // typedef void  (APIENTRYP GPENDLIST)();
+// typedef void  (APIENTRYP GPENDPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPENDPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPENDQUERY)(GLenum  target);
 // typedef void  (APIENTRYP GPENDQUERYINDEXED)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDTRANSFORMFEEDBACK)();
@@ -341,12 +426,15 @@ package gl
 // typedef void  (APIENTRYP GPEVALMESH2)(GLenum  mode, GLint  i1, GLint  i2, GLint  j1, GLint  j2);
 // typedef void  (APIENTRYP GPEVALPOINT1)(GLint  i);
 // typedef void  (APIENTRYP GPEVALPOINT2)(GLint  i, GLint  j);
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef void  (APIENTRYP GPFEEDBACKBUFFER)(GLsizei  size, GLenum  type, GLfloat * buffer);
 // typedef GLsync  (APIENTRYP GPFENCESYNC)(GLenum  condition, GLbitfield  flags);
 // typedef void  (APIENTRYP GPFINISH)();
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFOGCOORDFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPFOGCOORDPOINTER)(GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPFOGCOORDD)(GLdouble  coord);
 // typedef void  (APIENTRYP GPFOGCOORDDV)(const GLdouble * coord);
@@ -356,19 +444,33 @@ package gl
 // typedef void  (APIENTRYP GPFOGFV)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPFOGI)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPFOGIV)(GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE2D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE3D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREFACEARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPFRUSTUM)(GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
 // typedef void  (APIENTRYP GPGENBUFFERS)(GLsizei  n, GLuint * buffers);
 // typedef void  (APIENTRYP GPGENFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
 // typedef GLuint  (APIENTRYP GPGENLISTS)(GLsizei  range);
+// typedef GLuint  (APIENTRYP GPGENPATHSNV)(GLsizei  range);
+// typedef void  (APIENTRYP GPGENPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
 // typedef void  (APIENTRYP GPGENPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
+// typedef void  (APIENTRYP GPGENPROGRAMPIPELINESEXT)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
@@ -376,7 +478,9 @@ package gl
 // typedef void  (APIENTRYP GPGENTRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENVERTEXARRAYS)(GLsizei  n, GLuint * arrays);
 // typedef void  (APIENTRYP GPGENERATEMIPMAP)(GLenum  target);
+// typedef void  (APIENTRYP GPGENERATEMULTITEXMIPMAPEXT)(GLenum  texunit, GLenum  target);
 // typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAP)(GLuint  texture);
+// typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAPEXT)(GLuint  texture, GLenum  target);
 // typedef void  (APIENTRYP GPGETACTIVEATOMICCOUNTERBUFFERIV)(GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETACTIVEATTRIB)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLint * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETACTIVESUBROUTINENAME)(GLuint  program, GLenum  shadertype, GLuint  index, GLsizei  bufsize, GLsizei * length, GLchar * name);
@@ -389,36 +493,53 @@ package gl
 // typedef void  (APIENTRYP GPGETACTIVEUNIFORMSIV)(GLuint  program, GLsizei  uniformCount, const GLuint * uniformIndices, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETATTACHEDSHADERS)(GLuint  program, GLsizei  maxCount, GLsizei * count, GLuint * shaders);
 // typedef GLint  (APIENTRYP GPGETATTRIBLOCATION)(GLuint  program, const GLchar * name);
+// typedef void  (APIENTRYP GPGETBOOLEANINDEXEDVEXT)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANI_V)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANV)(GLenum  pname, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERI64V)(GLenum  target, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETBUFFERPARAMETERUI64VNV)(GLenum  target, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETBUFFERPOINTERV)(GLenum  target, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETCLIPPLANE)(GLenum  plane, GLdouble * equation);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGE)(GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGKHR)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
+// typedef void  (APIENTRYP GPGETDOUBLEINDEXEDVEXT)(GLenum  target, GLuint  index, GLdouble * data);
 // typedef void  (APIENTRYP GPGETDOUBLEI_V)(GLenum  target, GLuint  index, GLdouble * data);
+// typedef void  (APIENTRYP GPGETDOUBLEI_VEXT)(GLenum  pname, GLuint  index, GLdouble * params);
 // typedef void  (APIENTRYP GPGETDOUBLEV)(GLenum  pname, GLdouble * data);
 // typedef GLenum  (APIENTRYP GPGETERROR)();
+// typedef void  (APIENTRYP GPGETFIRSTPERFQUERYIDINTEL)(GLuint * queryId);
+// typedef void  (APIENTRYP GPGETFLOATINDEXEDVEXT)(GLenum  target, GLuint  index, GLfloat * data);
 // typedef void  (APIENTRYP GPGETFLOATI_V)(GLenum  target, GLuint  index, GLfloat * data);
+// typedef void  (APIENTRYP GPGETFLOATI_VEXT)(GLenum  pname, GLuint  index, GLfloat * params);
 // typedef void  (APIENTRYP GPGETFLOATV)(GLenum  pname, GLfloat * data);
 // typedef GLint  (APIENTRYP GPGETFRAGDATAINDEX)(GLuint  program, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETFRAGDATALOCATION)(GLuint  program, const GLchar * name);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSARB)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSKHR)();
 // typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLEARB)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
+// typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLENV)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
 // typedef void  (APIENTRYP GPGETINTEGER64I_V)(GLenum  target, GLuint  index, GLint64 * data);
 // typedef void  (APIENTRYP GPGETINTEGER64V)(GLenum  pname, GLint64 * data);
+// typedef void  (APIENTRYP GPGETINTEGERINDEXEDVEXT)(GLenum  target, GLuint  index, GLint * data);
 // typedef void  (APIENTRYP GPGETINTEGERI_V)(GLenum  target, GLuint  index, GLint * data);
+// typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
+// typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETLIGHTFV)(GLenum  light, GLenum  pname, GLfloat * params);
@@ -428,23 +549,71 @@ package gl
 // typedef void  (APIENTRYP GPGETMAPIV)(GLenum  target, GLenum  query, GLint * v);
 // typedef void  (APIENTRYP GPGETMATERIALFV)(GLenum  face, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETMATERIALIV)(GLenum  face, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMULTISAMPLEFV)(GLenum  pname, GLuint  index, GLfloat * val);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERI64V)(GLuint  buffer, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIV)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIVEXT)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  pname, void * string);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMIVEXT)(GLuint  program, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIV)(GLuint  renderbuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(GLuint  renderbuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGARB)(GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGIVARB)(GLint  namelen, const GLchar * name, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNEXTPERFQUERYIDINTEL)(GLuint  queryId, GLuint * nextQueryId);
 // typedef void  (APIENTRYP GPGETOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETOBJECTLABELEXT)(GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABEL)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABELKHR)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETPATHCOMMANDSNV)(GLuint  path, GLubyte * commands);
+// typedef void  (APIENTRYP GPGETPATHCOORDSNV)(GLuint  path, GLfloat * coords);
+// typedef void  (APIENTRYP GPGETPATHDASHARRAYNV)(GLuint  path, GLfloat * dashArray);
+// typedef GLfloat  (APIENTRYP GPGETPATHLENGTHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments);
+// typedef void  (APIENTRYP GPGETPATHMETRICRANGENV)(GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHMETRICSNV)(GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, GLfloat * value);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, GLint * value);
+// typedef void  (APIENTRYP GPGETPATHSPACINGNV)(GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing);
+// typedef void  (APIENTRYP GPGETPERFCOUNTERINFOINTEL)(GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERDATAAMD)(GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERINFOAMD)(GLuint  group, GLuint  counter, GLenum  pname, void * data);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSTRINGAMD)(GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
+// typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
 // typedef void  (APIENTRYP GPGETPIXELMAPFV)(GLenum  map, GLfloat * values);
 // typedef void  (APIENTRYP GPGETPIXELMAPUIV)(GLenum  map, GLuint * values);
 // typedef void  (APIENTRYP GPGETPIXELMAPUSV)(GLenum  map, GLushort * values);
+// typedef void  (APIENTRYP GPGETPOINTERINDEXEDVEXT)(GLenum  target, GLuint  index, void ** data);
+// typedef void  (APIENTRYP GPGETPOINTERI_VEXT)(GLenum  pname, GLuint  index, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERV)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERVKHR)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPOLYGONSTIPPLE)(GLubyte * mask);
@@ -452,14 +621,21 @@ package gl
 // typedef void  (APIENTRYP GPGETPROGRAMINFOLOG)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMINTERFACEIV)(GLuint  program, GLenum  programInterface, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOG)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOGEXT)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIV)(GLuint  pipeline, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIVEXT)(GLuint  pipeline, GLenum  pname, GLint * params);
 // typedef GLuint  (APIENTRYP GPGETPROGRAMRESOURCEINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATION)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATIONINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCENAME)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name);
+// typedef void  (APIENTRYP GPGETPROGRAMRESOURCEFVNV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCEIV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMSTAGEIV)(GLuint  program, GLenum  shadertype, GLenum  pname, GLint * values);
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTIV)(GLuint  id, GLenum  pname, GLint * params);
@@ -475,6 +651,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERPRECISIONFORMAT)(GLenum  shadertype, GLenum  precisiontype, GLint * range, GLint * precision);
 // typedef void  (APIENTRYP GPGETSHADERSOURCE)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -493,14 +670,23 @@ package gl
 // typedef void  (APIENTRYP GPGETTEXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLEARB)(GLuint  texture);
+// typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLENV)(GLuint  texture);
 // typedef void  (APIENTRYP GPGETTEXTUREIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFV)(GLuint  texture, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIV)(GLuint  texture, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLEARB)(GLuint  texture, GLuint  sampler);
+// typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLENV)(GLuint  texture, GLuint  sampler);
 // typedef void  (APIENTRYP GPGETTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKVARYING)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLsizei * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKI64_V)(GLuint  xfb, GLenum  pname, GLuint  index, GLint64 * param);
@@ -512,19 +698,30 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMSUBROUTINEUIV)(GLenum  shadertype, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXED64IV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint64 * param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXEDIV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERVEXT)(GLuint  vaobj, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, void ** param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERVEXT)(GLuint  vaobj, GLenum  pname, void ** param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYIV)(GLuint  vaobj, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIIV)(GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIUIV)(GLuint  index, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLDV)(GLuint  index, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLI64VNV)(GLuint  index, GLenum  pname, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VARB)(GLuint  index, GLenum  pname, GLuint64EXT * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VNV)(GLuint  index, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBPOINTERV)(GLuint  index, GLenum  pname, void ** pointer);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBDV)(GLuint  index, GLenum  pname, GLdouble * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBFV)(GLuint  index, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIV)(GLuint  index, GLenum  pname, GLint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  lod, GLsizei  bufSize, void * pixels);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNTEXIMAGE)(GLenum  target, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
@@ -534,13 +731,16 @@ package gl
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPHINT)(GLenum  target, GLenum  mode);
+// typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPINDEXMASK)(GLuint  mask);
 // typedef void  (APIENTRYP GPINDEXPOINTER)(GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPINDEXD)(GLdouble  c);
@@ -554,7 +754,9 @@ package gl
 // typedef void  (APIENTRYP GPINDEXUB)(GLubyte  c);
 // typedef void  (APIENTRYP GPINDEXUBV)(const GLubyte * c);
 // typedef void  (APIENTRYP GPINITNAMES)();
+// typedef void  (APIENTRYP GPINSERTEVENTMARKEREXT)(GLsizei  length, const GLchar * marker);
 // typedef void  (APIENTRYP GPINTERLEAVEDARRAYS)(GLenum  format, GLsizei  stride, const void * pointer);
+// typedef void  (APIENTRYP GPINTERPOLATEPATHSNV)(GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERDATA)(GLuint  buffer);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPINVALIDATEFRAMEBUFFER)(GLenum  target, GLsizei  numAttachments, const GLenum * attachments);
@@ -564,23 +766,35 @@ package gl
 // typedef void  (APIENTRYP GPINVALIDATETEXIMAGE)(GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPINVALIDATETEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
+// typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISFRAMEBUFFER)(GLuint  framebuffer);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISLIST)(GLuint  list);
+// typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef GLboolean  (APIENTRYP GPISPATHNV)(GLuint  path);
+// typedef GLboolean  (APIENTRYP GPISPOINTINFILLPATHNV)(GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y);
+// typedef GLboolean  (APIENTRYP GPISPOINTINSTROKEPATHNV)(GLuint  path, GLfloat  x, GLfloat  y);
 // typedef GLboolean  (APIENTRYP GPISPROGRAM)(GLuint  program);
 // typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef GLboolean  (APIENTRYP GPISQUERY)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISTRANSFORMFEEDBACK)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
+// typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLIGHTMODELF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPLIGHTMODELFV)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPLIGHTMODELI)(GLenum  pname, GLint  param);
@@ -593,6 +807,7 @@ package gl
 // typedef void  (APIENTRYP GPLINEWIDTH)(GLfloat  width);
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPLISTBASE)(GLuint  base);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLOADIDENTITY)();
 // typedef void  (APIENTRYP GPLOADMATRIXD)(const GLdouble * m);
 // typedef void  (APIENTRYP GPLOADMATRIXF)(const GLfloat * m);
@@ -600,10 +815,18 @@ package gl
 // typedef void  (APIENTRYP GPLOADTRANSPOSEMATRIXD)(const GLdouble * m);
 // typedef void  (APIENTRYP GPLOADTRANSPOSEMATRIXF)(const GLfloat * m);
 // typedef void  (APIENTRYP GPLOGICOP)(GLenum  opcode);
+// typedef void  (APIENTRYP GPMAKEBUFFERNONRESIDENTNV)(GLenum  target);
+// typedef void  (APIENTRYP GPMAKEBUFFERRESIDENTNV)(GLenum  target, GLenum  access);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTARB)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTNV)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERNONRESIDENTNV)(GLuint  buffer);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERRESIDENTNV)(GLuint  buffer, GLenum  access);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAP1D)(GLenum  target, GLdouble  u1, GLdouble  u2, GLint  stride, GLint  order, const GLdouble * points);
 // typedef void  (APIENTRYP GPMAP1F)(GLenum  target, GLfloat  u1, GLfloat  u2, GLint  stride, GLint  order, const GLfloat * points);
 // typedef void  (APIENTRYP GPMAP2D)(GLenum  target, GLdouble  u1, GLdouble  u2, GLint  ustride, GLint  uorder, GLdouble  v1, GLdouble  v2, GLint  vstride, GLint  vorder, const GLdouble * points);
@@ -615,12 +838,41 @@ package gl
 // typedef void  (APIENTRYP GPMAPGRID2D)(GLint  un, GLdouble  u1, GLdouble  u2, GLint  vn, GLdouble  v1, GLdouble  v2);
 // typedef void  (APIENTRYP GPMAPGRID2F)(GLint  un, GLfloat  u1, GLfloat  u2, GLint  vn, GLfloat  v1, GLfloat  v2);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void  (APIENTRYP GPMATERIALF)(GLenum  face, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPMATERIALFV)(GLenum  face, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPMATERIALI)(GLenum  face, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPMATERIALIV)(GLenum  face, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMATRIXFRUSTUMEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADIDENTITYEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADFEXT)(GLenum  mode, const GLfloat * m);
 // typedef void  (APIENTRYP GPMATRIXMODE)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXMULT3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXORTHOEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXPOPEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXPUSHEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXROTATEDEXT)(GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXROTATEFEXT)(GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMINSAMPLESHADING)(GLfloat  value);
@@ -631,11 +883,18 @@ package gl
 // typedef void  (APIENTRYP GPMULTTRANSPOSEMATRIXF)(const GLfloat * m);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYS)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNT)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNT)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTITEXBUFFEREXT)(GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPMULTITEXCOORD1D)(GLenum  target, GLdouble  s);
 // typedef void  (APIENTRYP GPMULTITEXCOORD1DV)(GLenum  target, const GLdouble * v);
 // typedef void  (APIENTRYP GPMULTITEXCOORD1F)(GLenum  target, GLfloat  s);
@@ -668,20 +927,73 @@ package gl
 // typedef void  (APIENTRYP GPMULTITEXCOORD4IV)(GLenum  target, const GLint * v);
 // typedef void  (APIENTRYP GPMULTITEXCOORD4S)(GLenum  target, GLshort  s, GLshort  t, GLshort  r, GLshort  q);
 // typedef void  (APIENTRYP GPMULTITEXCOORD4SV)(GLenum  target, const GLshort * v);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPMULTITEXCOORDPOINTEREXT)(GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
+// typedef void  (APIENTRYP GPMULTITEXENVFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXENVIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXGENDEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param);
+// typedef void  (APIENTRYP GPMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params);
+// typedef void  (APIENTRYP GPMULTITEXGENFEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXGENIEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXRENDERBUFFEREXT)(GLenum  texunit, GLenum  target, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFERS)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERI)(GLuint  framebuffer, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERIEXT)(GLuint  framebuffer, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYER)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLdouble * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGE)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEEXT)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDSTRINGARB)(GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string);
 // typedef void  (APIENTRYP GPNEWLIST)(GLuint  list, GLenum  mode);
 // typedef void  (APIENTRYP GPNORMAL3B)(GLbyte  nx, GLbyte  ny, GLbyte  nz);
@@ -694,6 +1006,7 @@ package gl
 // typedef void  (APIENTRYP GPNORMAL3IV)(const GLint * v);
 // typedef void  (APIENTRYP GPNORMAL3S)(GLshort  nx, GLshort  ny, GLshort  nz);
 // typedef void  (APIENTRYP GPNORMAL3SV)(const GLshort * v);
+// typedef void  (APIENTRYP GPNORMALFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPNORMALPOINTER)(GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
@@ -703,6 +1016,24 @@ package gl
 // typedef void  (APIENTRYP GPPASSTHROUGH)(GLfloat  token);
 // typedef void  (APIENTRYP GPPATCHPARAMETERFV)(GLenum  pname, const GLfloat * values);
 // typedef void  (APIENTRYP GPPATCHPARAMETERI)(GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHCOMMANDSNV)(GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOORDSNV)(GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOVERDEPTHFUNCNV)(GLenum  func);
+// typedef void  (APIENTRYP GPPATHDASHARRAYNV)(GLuint  path, GLsizei  dashCount, const GLfloat * dashArray);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXRANGENV)(GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount);
+// typedef void  (APIENTRYP GPPATHGLYPHRANGENV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHGLYPHSNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHMEMORYGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHPARAMETERFNV)(GLuint  path, GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, const GLfloat * value);
+// typedef void  (APIENTRYP GPPATHPARAMETERINV)(GLuint  path, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, const GLint * value);
+// typedef void  (APIENTRYP GPPATHSTENCILDEPTHOFFSETNV)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPATHSTENCILFUNCNV)(GLenum  func, GLint  ref, GLuint  mask);
+// typedef void  (APIENTRYP GPPATHSTRINGNV)(GLuint  path, GLenum  format, GLsizei  length, const void * pathString);
+// typedef void  (APIENTRYP GPPATHSUBCOMMANDSNV)(GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHSUBCOORDSNV)(GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords);
 // typedef void  (APIENTRYP GPPAUSETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPPIXELMAPFV)(GLenum  map, GLsizei  mapsize, const GLfloat * values);
 // typedef void  (APIENTRYP GPPIXELMAPUIV)(GLenum  map, GLsizei  mapsize, const GLuint * values);
@@ -712,6 +1043,7 @@ package gl
 // typedef void  (APIENTRYP GPPIXELTRANSFERF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPIXELTRANSFERI)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPPIXELZOOM)(GLfloat  xfactor, GLfloat  yfactor);
+// typedef GLboolean  (APIENTRYP GPPOINTALONGPATHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY);
 // typedef void  (APIENTRYP GPPOINTPARAMETERF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPOINTPARAMETERFV)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPPOINTPARAMETERI)(GLenum  pname, GLint  param);
@@ -719,74 +1051,169 @@ package gl
 // typedef void  (APIENTRYP GPPOINTSIZE)(GLfloat  size);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOLYGONSTIPPLE)(const GLubyte * mask);
 // typedef void  (APIENTRYP GPPOPATTRIB)();
 // typedef void  (APIENTRYP GPPOPCLIENTATTRIB)();
 // typedef void  (APIENTRYP GPPOPDEBUGGROUP)();
 // typedef void  (APIENTRYP GPPOPDEBUGGROUPKHR)();
+// typedef void  (APIENTRYP GPPOPGROUPMARKEREXT)();
 // typedef void  (APIENTRYP GPPOPMATRIX)();
 // typedef void  (APIENTRYP GPPOPNAME)();
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIORITIZETEXTURES)(GLsizei  n, const GLuint * textures, const GLfloat * priorities);
 // typedef void  (APIENTRYP GPPROGRAMBINARY)(GLuint  program, GLenum  binaryFormat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPPROGRAMPARAMETERI)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIARB)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIEXT)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPATHFRAGMENTINPUTGENNV)(GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1D)(GLuint  program, GLint  location, GLdouble  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DEXT)(GLuint  program, GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1F)(GLuint  program, GLint  location, GLfloat  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FEXT)(GLuint  program, GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64ARB)(GLuint  program, GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64NV)(GLuint  program, GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64NV)(GLuint  program, GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROVOKINGVERTEX)(GLenum  mode);
 // typedef void  (APIENTRYP GPPUSHATTRIB)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPPUSHCLIENTATTRIB)(GLbitfield  mask);
+// typedef void  (APIENTRYP GPPUSHCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUP)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUPKHR)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
+// typedef void  (APIENTRYP GPPUSHGROUPMARKEREXT)(GLsizei  length, const GLchar * marker);
 // typedef void  (APIENTRYP GPPUSHMATRIX)();
 // typedef void  (APIENTRYP GPPUSHNAME)(GLuint  name);
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
@@ -814,6 +1241,7 @@ package gl
 // typedef void  (APIENTRYP GPRASTERPOS4IV)(const GLint * v);
 // typedef void  (APIENTRYP GPRASTERPOS4S)(GLshort  x, GLshort  y, GLshort  z, GLshort  w);
 // typedef void  (APIENTRYP GPRASTERPOS4SV)(const GLshort * v);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPREADNPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, GLsizei  bufSize, void * data);
@@ -831,6 +1259,8 @@ package gl
 // typedef GLint  (APIENTRYP GPRENDERMODE)(GLenum  mode);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPROTATED)(GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPROTATEF)(GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z);
@@ -864,19 +1294,36 @@ package gl
 // typedef void  (APIENTRYP GPSECONDARYCOLOR3UIV)(const GLuint * v);
 // typedef void  (APIENTRYP GPSECONDARYCOLOR3US)(GLushort  red, GLushort  green, GLushort  blue);
 // typedef void  (APIENTRYP GPSECONDARYCOLOR3USV)(const GLushort * v);
+// typedef void  (APIENTRYP GPSECONDARYCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPSECONDARYCOLORPOINTER)(GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPSELECTBUFFER)(GLsizei  size, GLuint * buffer);
+// typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
 // typedef void  (APIENTRYP GPSHADEMODEL)(GLenum  mode);
 // typedef void  (APIENTRYP GPSHADERBINARY)(GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPSHADERSOURCE)(GLuint  shader, GLsizei  count, const GLchar *const* string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADER)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNC)(GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNCSEPARATE)(GLenum  face, GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASK)(GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASKSEPARATE)(GLenum  face, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILOP)(GLenum  fail, GLenum  zfail, GLenum  zpass);
 // typedef void  (APIENTRYP GPSTENCILOPSEPARATE)(GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPTEXBUFFER)(GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXBUFFERARB)(GLenum  target, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXBUFFERRANGE)(GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXCOORD1D)(GLdouble  s);
 // typedef void  (APIENTRYP GPTEXCOORD1DV)(const GLdouble * v);
@@ -910,6 +1357,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXCOORD4IV)(const GLint * v);
 // typedef void  (APIENTRYP GPTEXCOORD4S)(GLshort  s, GLshort  t, GLshort  r, GLshort  q);
 // typedef void  (APIENTRYP GPTEXCOORD4SV)(const GLshort * v);
+// typedef void  (APIENTRYP GPTEXCOORDFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPTEXCOORDPOINTER)(GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPTEXENVF)(GLenum  target, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPTEXENVFV)(GLenum  target, GLenum  pname, const GLfloat * params);
@@ -926,7 +1374,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXIMAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERF)(GLenum  target, GLenum  pname, GLfloat  param);
@@ -942,26 +1390,49 @@ package gl
 // typedef void  (APIENTRYP GPTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREBARRIER)();
+// typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERF)(GLuint  texture, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, const GLfloat * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERI)(GLuint  texture, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, const GLint * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTURERENDERBUFFEREXT)(GLuint  texture, GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE1D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE1DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREVIEW)(GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
+// typedef void  (APIENTRYP GPTRANSFORMPATHNV)(GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPTRANSLATED)(GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPTRANSLATEF)(GLfloat  x, GLfloat  y, GLfloat  z);
 // typedef void  (APIENTRYP GPUNIFORM1D)(GLint  location, GLdouble  x);
@@ -969,36 +1440,70 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM1F)(GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM2D)(GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPUNIFORM2DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM2F)(GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM3D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPUNIFORM3DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM3F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM4D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPUNIFORM4DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM4F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORMBLOCKBINDING)(GLuint  program, GLuint  uniformBlockIndex, GLuint  uniformBlockBinding);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64ARB)(GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64NV)(GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VNV)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
@@ -1018,12 +1523,18 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMSUBROUTINESUIV)(GLenum  shadertype, GLsizei  count, const GLuint * indices);
+// typedef void  (APIENTRYP GPUNIFORMUI64NV)(GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPUNIFORMUI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef GLboolean  (APIENTRYP GPUNMAPBUFFER)(GLenum  target);
 // typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFEREXT)(GLuint  buffer);
 // typedef void  (APIENTRYP GPUSEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPUSEPROGRAMSTAGES)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSEPROGRAMSTAGESEXT)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSESHADERPROGRAMEXT)(GLenum  type, GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPVERTEX2D)(GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPVERTEX2DV)(const GLdouble * v);
 // typedef void  (APIENTRYP GPVERTEX2F)(GLfloat  x, GLfloat  y);
@@ -1052,10 +1563,29 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBIFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBLFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYBINDVERTEXBUFFEREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYBINDINGDIVISOR)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYEDGEFLAGOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXARRAYELEMENTBUFFER)(GLuint  vaobj, GLuint  buffer);
+// typedef void  (APIENTRYP GPVERTEXARRAYFOGCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYINDEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYNORMALOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYTEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(GLuint  vaobj, GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFER)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFERS)(GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1DV)(GLuint  index, const GLdouble * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1F)(GLuint  index, GLfloat  x);
@@ -1094,7 +1624,9 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIB4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBBINDING)(GLuint  attribindex, GLuint  bindingindex);
 // typedef void  (APIENTRYP GPVERTEXATTRIBDIVISOR)(GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXATTRIBDIVISORARB)(GLuint  index, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXATTRIBFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1I)(GLuint  index, GLint  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1IV)(GLuint  index, const GLint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1UI)(GLuint  index, GLuint  x);
@@ -1116,18 +1648,36 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4UIV)(GLuint  index, const GLuint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBIFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64NV)(GLuint  index, GLint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64VNV)(GLuint  index, const GLint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64ARB)(GLuint  index, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64NV)(GLuint  index, GLuint64EXT  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VARB)(GLuint  index, const GLuint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2D)(GLuint  index, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBLFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UI)(GLuint  index, GLenum  type, GLboolean  normalized, GLuint  value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
@@ -1139,12 +1689,17 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBP4UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBPOINTER)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXBINDINGDIVISOR)(GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXPOINTER)(GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVIEWPORT)(GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
 // typedef void  (APIENTRYP GPWINDOWPOS2D)(GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPWINDOWPOS2DV)(const GLdouble * v);
 // typedef void  (APIENTRYP GPWINDOWPOS2F)(GLfloat  x, GLfloat  y);
@@ -1161,10 +1716,17 @@ package gl
 // typedef void  (APIENTRYP GPWINDOWPOS3IV)(const GLint * v);
 // typedef void  (APIENTRYP GPWINDOWPOS3S)(GLshort  x, GLshort  y, GLshort  z);
 // typedef void  (APIENTRYP GPWINDOWPOS3SV)(const GLshort * v);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
 // static void  glowAccum(GPACCUM fnptr, GLenum  op, GLfloat  value) {
 //   (*fnptr)(op, value);
 // }
+// static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
+//   (*fnptr)(program);
+// }
 // static void  glowActiveShaderProgram(GPACTIVESHADERPROGRAM fnptr, GLuint  pipeline, GLuint  program) {
+//   (*fnptr)(pipeline, program);
+// }
+// static void  glowActiveShaderProgramEXT(GPACTIVESHADERPROGRAMEXT fnptr, GLuint  pipeline, GLuint  program) {
 //   (*fnptr)(pipeline, program);
 // }
 // static void  glowActiveTexture(GPACTIVETEXTURE fnptr, GLenum  texture) {
@@ -1172,6 +1734,9 @@ package gl
 // }
 // static void  glowAlphaFunc(GPALPHAFUNC fnptr, GLenum  func, GLfloat  ref) {
 //   (*fnptr)(func, ref);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static GLboolean  glowAreTexturesResident(GPARETEXTURESRESIDENT fnptr, GLsizei  n, const GLuint * textures, GLboolean * residences) {
 //   return (*fnptr)(n, textures, residences);
@@ -1187,6 +1752,15 @@ package gl
 // }
 // static void  glowBeginConditionalRender(GPBEGINCONDITIONALRENDER fnptr, GLuint  id, GLenum  mode) {
 //   (*fnptr)(id, mode);
+// }
+// static void  glowBeginConditionalRenderNV(GPBEGINCONDITIONALRENDERNV fnptr, GLuint  id, GLenum  mode) {
+//   (*fnptr)(id, mode);
+// }
+// static void  glowBeginPerfMonitorAMD(GPBEGINPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowBeginPerfQueryINTEL(GPBEGINPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
 // }
 // static void  glowBeginQuery(GPBEGINQUERY fnptr, GLenum  target, GLuint  id) {
 //   (*fnptr)(target, id);
@@ -1230,7 +1804,13 @@ package gl
 // static void  glowBindImageTextures(GPBINDIMAGETEXTURES fnptr, GLuint  first, GLsizei  count, const GLuint * textures) {
 //   (*fnptr)(first, count, textures);
 // }
+// static void  glowBindMultiTextureEXT(GPBINDMULTITEXTUREEXT fnptr, GLenum  texunit, GLenum  target, GLuint  texture) {
+//   (*fnptr)(texunit, target, texture);
+// }
 // static void  glowBindProgramPipeline(GPBINDPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowBindProgramPipelineEXT(GPBINDPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowBindRenderbuffer(GPBINDRENDERBUFFER fnptr, GLenum  target, GLuint  renderbuffer) {
@@ -1265,6 +1845,12 @@ package gl
 // }
 // static void  glowBitmap(GPBITMAP fnptr, GLsizei  width, GLsizei  height, GLfloat  xorig, GLfloat  yorig, GLfloat  xmove, GLfloat  ymove, const GLubyte * bitmap) {
 //   (*fnptr)(width, height, xorig, yorig, xmove, ymove, bitmap);
+// }
+// static void  glowBlendBarrierKHR(GPBLENDBARRIERKHR fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowBlendBarrierNV(GPBLENDBARRIERNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowBlendColor(GPBLENDCOLOR fnptr, GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
@@ -1305,16 +1891,22 @@ package gl
 // static void  glowBlendFunciARB(GPBLENDFUNCIARB fnptr, GLuint  buf, GLenum  src, GLenum  dst) {
 //   (*fnptr)(buf, src, dst);
 // }
+// static void  glowBlendParameteriNV(GPBLENDPARAMETERINV fnptr, GLenum  pname, GLint  value) {
+//   (*fnptr)(pname, value);
+// }
 // static void  glowBlitFramebuffer(GPBLITFRAMEBUFFER fnptr, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
 // static void  glowBlitNamedFramebuffer(GPBLITNAMEDFRAMEBUFFER fnptr, GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
+// static void  glowBufferAddressRangeNV(GPBUFFERADDRESSRANGENV fnptr, GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length) {
+//   (*fnptr)(pname, index, address, length);
+// }
 // static void  glowBufferData(GPBUFFERDATA fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
@@ -1322,6 +1914,9 @@ package gl
 // }
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
 // }
 // static void  glowCallList(GPCALLLIST fnptr, GLuint  list) {
 //   (*fnptr)(list);
@@ -1333,6 +1928,9 @@ package gl
 //   return (*fnptr)(target);
 // }
 // static GLenum  glowCheckNamedFramebufferStatus(GPCHECKNAMEDFRAMEBUFFERSTATUS fnptr, GLuint  framebuffer, GLenum  target) {
+//   return (*fnptr)(framebuffer, target);
+// }
+// static GLenum  glowCheckNamedFramebufferStatusEXT(GPCHECKNAMEDFRAMEBUFFERSTATUSEXT fnptr, GLuint  framebuffer, GLenum  target) {
 //   return (*fnptr)(framebuffer, target);
 // }
 // static void  glowClampColor(GPCLAMPCOLOR fnptr, GLenum  target, GLenum  clamp) {
@@ -1377,11 +1975,17 @@ package gl
 // static void  glowClearNamedBufferData(GPCLEARNAMEDBUFFERDATA fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, format, type, data);
+// }
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
+// }
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -1403,6 +2007,9 @@ package gl
 // }
 // static void  glowClientActiveTexture(GPCLIENTACTIVETEXTURE fnptr, GLenum  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowClientAttribDefaultEXT(GPCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static GLenum  glowClientWaitSync(GPCLIENTWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   return (*fnptr)(sync, flags, timeout);
@@ -1509,6 +2116,9 @@ package gl
 // static void  glowColor4usv(GPCOLOR4USV fnptr, const GLushort * v) {
 //   (*fnptr)(v);
 // }
+// static void  glowColorFormatNV(GPCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
 // static void  glowColorMask(GPCOLORMASK fnptr, GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
 // }
@@ -1521,11 +2131,35 @@ package gl
 // static void  glowColorPointer(GPCOLORPOINTER fnptr, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(size, type, stride, pointer);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
 // static void  glowCompileShaderIncludeARB(GPCOMPILESHADERINCLUDEARB fnptr, GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length) {
 //   (*fnptr)(shader, count, path, length);
+// }
+// static void  glowCompressedMultiTexImage1DEXT(GPCOMPRESSEDMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage2DEXT(GPCOMPRESSEDMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage3DEXT(GPCOMPRESSEDMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage1DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage2DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage3DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
 // }
 // static void  glowCompressedTexImage1D(GPCOMPRESSEDTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, internalformat, width, border, imageSize, data);
@@ -1545,14 +2179,38 @@ package gl
 // static void  glowCompressedTexSubImage3D(GPCOMPRESSEDTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
 // }
+// static void  glowCompressedTextureImage1DEXT(GPCOMPRESSEDTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage2DEXT(GPCOMPRESSEDTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage3DEXT(GPCOMPRESSEDTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage1D(GPCOMPRESSEDTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, width, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage1DEXT(GPCOMPRESSEDTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, imageSize, bits);
 // }
 // static void  glowCompressedTextureSubImage2D(GPCOMPRESSEDTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, imageSize, data);
 // }
+// static void  glowCompressedTextureSubImage2DEXT(GPCOMPRESSEDTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage3D(GPCOMPRESSEDTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowCopyBufferSubData(GPCOPYBUFFERSUBDATA fnptr, GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readTarget, writeTarget, readOffset, writeOffset, size);
@@ -1560,8 +2218,26 @@ package gl
 // static void  glowCopyImageSubData(GPCOPYIMAGESUBDATA fnptr, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
 //   (*fnptr)(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyMultiTexImage1DEXT(GPCOPYMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyMultiTexImage2DEXT(GPCOPYMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, height, border);
+// }
+// static void  glowCopyMultiTexSubImage1DEXT(GPCOPYMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texunit, target, level, xoffset, x, y, width);
+// }
+// static void  glowCopyMultiTexSubImage2DEXT(GPCOPYMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, x, y, width, height);
+// }
+// static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
+//   (*fnptr)(resultPath, srcPath);
 // }
 // static void  glowCopyPixels(GPCOPYPIXELS fnptr, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  type) {
 //   (*fnptr)(x, y, width, height, type);
@@ -1581,20 +2257,59 @@ package gl
 // static void  glowCopyTexSubImage3D(GPCOPYTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureImage1DEXT(GPCOPYTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyTextureImage2DEXT(GPCOPYTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, height, border);
+// }
 // static void  glowCopyTextureSubImage1D(GPCOPYTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
 //   (*fnptr)(texture, level, xoffset, x, y, width);
+// }
+// static void  glowCopyTextureSubImage1DEXT(GPCOPYTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texture, target, level, xoffset, x, y, width);
 // }
 // static void  glowCopyTextureSubImage2D(GPCOPYTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureSubImage2DEXT(GPCOPYTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, x, y, width, height);
+// }
 // static void  glowCopyTextureSubImage3D(GPCOPYTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyTextureSubImage3DEXT(GPCOPYTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCoverFillPathInstancedNV(GPCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverFillPathNV(GPCOVERFILLPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverStrokePathInstancedNV(GPCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
 // }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
+//   (*fnptr)(queryId, queryHandle);
 // }
 // static GLuint  glowCreateProgram(GPCREATEPROGRAM fnptr) {
 //   return (*fnptr)();
@@ -1614,8 +2329,17 @@ package gl
 // static GLuint  glowCreateShader(GPCREATESHADER fnptr, GLenum  type) {
 //   return (*fnptr)(type);
 // }
+// static GLuint  glowCreateShaderProgramEXT(GPCREATESHADERPROGRAMEXT fnptr, GLenum  type, const GLchar * string) {
+//   return (*fnptr)(type, string);
+// }
 // static GLuint  glowCreateShaderProgramv(GPCREATESHADERPROGRAMV fnptr, GLenum  type, GLsizei  count, const GLchar *const* strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
+//   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -1662,6 +2386,9 @@ package gl
 // static void  glowDeleteBuffers(GPDELETEBUFFERS fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFramebuffers(GPDELETEFRAMEBUFFERS fnptr, GLsizei  n, const GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
@@ -1671,10 +2398,22 @@ package gl
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
 // }
+// static void  glowDeletePathsNV(GPDELETEPATHSNV fnptr, GLuint  path, GLsizei  range) {
+//   (*fnptr)(path, range);
+// }
+// static void  glowDeletePerfMonitorsAMD(GPDELETEPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
+// static void  glowDeletePerfQueryINTEL(GPDELETEPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowDeleteProgram(GPDELETEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowDeleteProgramPipelines(GPDELETEPROGRAMPIPELINES fnptr, GLsizei  n, const GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowDeleteProgramPipelinesEXT(GPDELETEPROGRAMPIPELINESEXT fnptr, GLsizei  n, const GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowDeleteQueries(GPDELETEQUERIES fnptr, GLsizei  n, const GLuint * ids) {
@@ -1688,6 +2427,9 @@ package gl
 // }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -1728,8 +2470,23 @@ package gl
 // static void  glowDisableClientState(GPDISABLECLIENTSTATE fnptr, GLenum  array) {
 //   (*fnptr)(array);
 // }
+// static void  glowDisableClientStateIndexedEXT(GPDISABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableClientStateiEXT(GPDISABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableIndexedEXT(GPDISABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowDisableVertexArrayAttrib(GPDISABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayAttribEXT(GPDISABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayEXT(GPDISABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowDisableVertexAttribArray(GPDISABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1755,14 +2512,32 @@ package gl
 // static void  glowDrawArraysInstanced(GPDRAWARRAYSINSTANCED fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount) {
 //   (*fnptr)(mode, first, count, instancecount);
 // }
+// static void  glowDrawArraysInstancedARB(GPDRAWARRAYSINSTANCEDARB fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, first, count, primcount);
+// }
 // static void  glowDrawArraysInstancedBaseInstance(GPDRAWARRAYSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, first, count, instancecount, baseinstance);
+// }
+// static void  glowDrawArraysInstancedEXT(GPDRAWARRAYSINSTANCEDEXT fnptr, GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, start, count, primcount);
 // }
 // static void  glowDrawBuffer(GPDRAWBUFFER fnptr, GLenum  buf) {
 //   (*fnptr)(buf);
 // }
 // static void  glowDrawBuffers(GPDRAWBUFFERS fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
+// }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
 // }
 // static void  glowDrawElements(GPDRAWELEMENTS fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, count, type, indices);
@@ -1776,6 +2551,9 @@ package gl
 // static void  glowDrawElementsInstanced(GPDRAWELEMENTSINSTANCED fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount) {
 //   (*fnptr)(mode, count, type, indices, instancecount);
 // }
+// static void  glowDrawElementsInstancedARB(GPDRAWELEMENTSINSTANCEDARB fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
+// }
 // static void  glowDrawElementsInstancedBaseInstance(GPDRAWELEMENTSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, baseinstance);
 // }
@@ -1784,6 +2562,9 @@ package gl
 // }
 // static void  glowDrawElementsInstancedBaseVertexBaseInstance(GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, basevertex, baseinstance);
+// }
+// static void  glowDrawElementsInstancedEXT(GPDRAWELEMENTSINSTANCEDEXT fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
 // }
 // static void  glowDrawPixels(GPDRAWPIXELS fnptr, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(width, height, format, type, pixels);
@@ -1806,8 +2587,14 @@ package gl
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
 // }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
+// }
 // static void  glowEdgeFlag(GPEDGEFLAG fnptr, GLboolean  flag) {
 //   (*fnptr)(flag);
+// }
+// static void  glowEdgeFlagFormatNV(GPEDGEFLAGFORMATNV fnptr, GLsizei  stride) {
+//   (*fnptr)(stride);
 // }
 // static void  glowEdgeFlagPointer(GPEDGEFLAGPOINTER fnptr, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(stride, pointer);
@@ -1821,8 +2608,23 @@ package gl
 // static void  glowEnableClientState(GPENABLECLIENTSTATE fnptr, GLenum  array) {
 //   (*fnptr)(array);
 // }
+// static void  glowEnableClientStateIndexedEXT(GPENABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableClientStateiEXT(GPENABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableIndexedEXT(GPENABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowEnableVertexArrayAttrib(GPENABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayAttribEXT(GPENABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayEXT(GPENABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowEnableVertexAttribArray(GPENABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1836,8 +2638,17 @@ package gl
 // static void  glowEndConditionalRender(GPENDCONDITIONALRENDER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowEndConditionalRenderNV(GPENDCONDITIONALRENDERNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowEndList(GPENDLIST fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowEndPerfMonitorAMD(GPENDPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowEndPerfQueryINTEL(GPENDPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
 // }
 // static void  glowEndQuery(GPENDQUERY fnptr, GLenum  target) {
 //   (*fnptr)(target);
@@ -1884,6 +2695,9 @@ package gl
 // static void  glowEvalPoint2(GPEVALPOINT2 fnptr, GLint  i, GLint  j) {
 //   (*fnptr)(i, j);
 // }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowFeedbackBuffer(GPFEEDBACKBUFFER fnptr, GLsizei  size, GLenum  type, GLfloat * buffer) {
 //   (*fnptr)(size, type, buffer);
 // }
@@ -1899,8 +2713,14 @@ package gl
 // static void  glowFlushMappedBufferRange(GPFLUSHMAPPEDBUFFERRANGE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(target, offset, length);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
+//   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFogCoordFormatNV(GPFOGCOORDFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
 // }
 // static void  glowFogCoordPointer(GPFOGCOORDPOINTER fnptr, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(type, stride, pointer);
@@ -1929,11 +2749,32 @@ package gl
 // static void  glowFogiv(GPFOGIV fnptr, GLenum  pname, const GLint * params) {
 //   (*fnptr)(pname, params);
 // }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
+// static void  glowFramebufferDrawBufferEXT(GPFRAMEBUFFERDRAWBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
+// static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
+//   (*fnptr)(framebuffer, n, bufs);
+// }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
+// static void  glowFramebufferReadBufferEXT(GPFRAMEBUFFERREADBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
 // static void  glowFramebufferRenderbuffer(GPFRAMEBUFFERRENDERBUFFER fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -1947,8 +2788,20 @@ package gl
 // static void  glowFramebufferTexture3D(GPFRAMEBUFFERTEXTURE3D fnptr, GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
 //   (*fnptr)(target, attachment, textarget, texture, level, zoffset);
 // }
+// static void  glowFramebufferTextureARB(GPFRAMEBUFFERTEXTUREARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(target, attachment, texture, level);
+// }
+// static void  glowFramebufferTextureFaceARB(GPFRAMEBUFFERTEXTUREFACEARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(target, attachment, texture, level, face);
+// }
 // static void  glowFramebufferTextureLayer(GPFRAMEBUFFERTEXTURELAYER fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureLayerARB(GPFRAMEBUFFERTEXTURELAYERARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFrontFace(GPFRONTFACE fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -1965,7 +2818,16 @@ package gl
 // static GLuint  glowGenLists(GPGENLISTS fnptr, GLsizei  range) {
 //   return (*fnptr)(range);
 // }
+// static GLuint  glowGenPathsNV(GPGENPATHSNV fnptr, GLsizei  range) {
+//   return (*fnptr)(range);
+// }
+// static void  glowGenPerfMonitorsAMD(GPGENPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
 // static void  glowGenProgramPipelines(GPGENPROGRAMPIPELINES fnptr, GLsizei  n, GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowGenProgramPipelinesEXT(GPGENPROGRAMPIPELINESEXT fnptr, GLsizei  n, GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowGenQueries(GPGENQUERIES fnptr, GLsizei  n, GLuint * ids) {
@@ -1989,8 +2851,14 @@ package gl
 // static void  glowGenerateMipmap(GPGENERATEMIPMAP fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
+// static void  glowGenerateMultiTexMipmapEXT(GPGENERATEMULTITEXMIPMAPEXT fnptr, GLenum  texunit, GLenum  target) {
+//   (*fnptr)(texunit, target);
+// }
 // static void  glowGenerateTextureMipmap(GPGENERATETEXTUREMIPMAP fnptr, GLuint  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowGenerateTextureMipmapEXT(GPGENERATETEXTUREMIPMAPEXT fnptr, GLuint  texture, GLenum  target) {
+//   (*fnptr)(texture, target);
 // }
 // static void  glowGetActiveAtomicCounterBufferiv(GPGETACTIVEATOMICCOUNTERBUFFERIV fnptr, GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, bufferIndex, pname, params);
@@ -2028,6 +2896,9 @@ package gl
 // static GLint  glowGetAttribLocation(GPGETATTRIBLOCATION fnptr, GLuint  program, const GLchar * name) {
 //   return (*fnptr)(program, name);
 // }
+// static void  glowGetBooleanIndexedvEXT(GPGETBOOLEANINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLboolean * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetBooleani_v(GPGETBOOLEANI_V fnptr, GLenum  target, GLuint  index, GLboolean * data) {
 //   (*fnptr)(target, index, data);
 // }
@@ -2040,6 +2911,9 @@ package gl
 // static void  glowGetBufferParameteriv(GPGETBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetBufferParameterui64vNV(GPGETBUFFERPARAMETERUI64VNV fnptr, GLenum  target, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(target, pname, params);
+// }
 // static void  glowGetBufferPointerv(GPGETBUFFERPOINTERV fnptr, GLenum  target, GLenum  pname, void ** params) {
 //   (*fnptr)(target, pname, params);
 // }
@@ -2049,14 +2923,26 @@ package gl
 // static void  glowGetClipPlane(GPGETCLIPPLANE fnptr, GLenum  plane, GLdouble * equation) {
 //   (*fnptr)(plane, equation);
 // }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
+// static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texunit, target, lod, img);
+// }
 // static void  glowGetCompressedTexImage(GPGETCOMPRESSEDTEXIMAGE fnptr, GLenum  target, GLint  level, void * img) {
 //   (*fnptr)(target, level, img);
 // }
 // static void  glowGetCompressedTextureImage(GPGETCOMPRESSEDTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, bufSize, pixels);
 // }
+// static void  glowGetCompressedTextureImageEXT(GPGETCOMPRESSEDTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texture, target, lod, img);
+// }
 // static void  glowGetCompressedTextureSubImage(GPGETCOMPRESSEDTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -2067,8 +2953,14 @@ package gl
 // static GLuint  glowGetDebugMessageLogKHR(GPGETDEBUGMESSAGELOGKHR fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
 // }
+// static void  glowGetDoubleIndexedvEXT(GPGETDOUBLEINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLdouble * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetDoublei_v(GPGETDOUBLEI_V fnptr, GLenum  target, GLuint  index, GLdouble * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetDoublei_vEXT(GPGETDOUBLEI_VEXT fnptr, GLenum  pname, GLuint  index, GLdouble * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetDoublev(GPGETDOUBLEV fnptr, GLenum  pname, GLdouble * data) {
 //   (*fnptr)(pname, data);
@@ -2076,8 +2968,17 @@ package gl
 // static GLenum  glowGetError(GPGETERROR fnptr) {
 //   return (*fnptr)();
 // }
+// static void  glowGetFirstPerfQueryIdINTEL(GPGETFIRSTPERFQUERYIDINTEL fnptr, GLuint * queryId) {
+//   (*fnptr)(queryId);
+// }
+// static void  glowGetFloatIndexedvEXT(GPGETFLOATINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLfloat * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetFloati_v(GPGETFLOATI_V fnptr, GLenum  target, GLuint  index, GLfloat * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetFloati_vEXT(GPGETFLOATI_VEXT fnptr, GLenum  pname, GLuint  index, GLfloat * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetFloatv(GPGETFLOATV fnptr, GLenum  pname, GLfloat * data) {
 //   (*fnptr)(pname, data);
@@ -2094,6 +2995,9 @@ package gl
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetFramebufferParameterivEXT(GPGETFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
 // static GLenum  glowGetGraphicsResetStatus(GPGETGRAPHICSRESETSTATUS fnptr) {
 //   return (*fnptr)();
 // }
@@ -2106,17 +3010,32 @@ package gl
 // static GLuint64  glowGetImageHandleARB(GPGETIMAGEHANDLEARB fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
 //   return (*fnptr)(texture, level, layered, layer, format);
 // }
+// static GLuint64  glowGetImageHandleNV(GPGETIMAGEHANDLENV fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
+//   return (*fnptr)(texture, level, layered, layer, format);
+// }
 // static void  glowGetInteger64i_v(GPGETINTEGER64I_V fnptr, GLenum  target, GLuint  index, GLint64 * data) {
 //   (*fnptr)(target, index, data);
 // }
 // static void  glowGetInteger64v(GPGETINTEGER64V fnptr, GLenum  pname, GLint64 * data) {
 //   (*fnptr)(pname, data);
 // }
+// static void  glowGetIntegerIndexedvEXT(GPGETINTEGERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLint * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetIntegeri_v(GPGETINTEGERI_V fnptr, GLenum  target, GLuint  index, GLint * data) {
 //   (*fnptr)(target, index, data);
 // }
+// static void  glowGetIntegerui64i_vNV(GPGETINTEGERUI64I_VNV fnptr, GLenum  value, GLuint  index, GLuint64EXT * result) {
+//   (*fnptr)(value, index, result);
+// }
+// static void  glowGetIntegerui64vNV(GPGETINTEGERUI64VNV fnptr, GLenum  value, GLuint64EXT * result) {
+//   (*fnptr)(value, result);
+// }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
@@ -2145,6 +3064,42 @@ package gl
 // static void  glowGetMaterialiv(GPGETMATERIALIV fnptr, GLenum  face, GLenum  pname, GLint * params) {
 //   (*fnptr)(face, pname, params);
 // }
+// static void  glowGetMultiTexEnvfvEXT(GPGETMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexEnvivEXT(GPGETMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexGendvEXT(GPGETMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenfvEXT(GPGETMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenivEXT(GPGETMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexImageEXT(GPGETMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texunit, target, level, format, type, pixels);
+// }
+// static void  glowGetMultiTexLevelParameterfvEXT(GPGETMULTITEXLEVELPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexLevelParameterivEXT(GPGETMULTITEXLEVELPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexParameterIivEXT(GPGETMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterIuivEXT(GPGETMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterfvEXT(GPGETMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterivEXT(GPGETMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
 // static void  glowGetMultisamplefv(GPGETMULTISAMPLEFV fnptr, GLenum  pname, GLuint  index, GLfloat * val) {
 //   (*fnptr)(pname, index, val);
 // }
@@ -2154,19 +3109,58 @@ package gl
 // static void  glowGetNamedBufferParameteriv(GPGETNAMEDBUFFERPARAMETERIV fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(buffer, pname, params);
 // }
+// static void  glowGetNamedBufferParameterivEXT(GPGETNAMEDBUFFERPARAMETERIVEXT fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferParameterui64vNV(GPGETNAMEDBUFFERPARAMETERUI64VNV fnptr, GLuint  buffer, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
 // static void  glowGetNamedBufferPointerv(GPGETNAMEDBUFFERPOINTERV fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedFramebufferAttachmentParameteriv(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
 // }
+// static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, attachment, pname, params);
+// }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowGetNamedFramebufferParameterivEXT(GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIuivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterdvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterfvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramStringEXT(GPGETNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, void * string) {
+//   (*fnptr)(program, target, pname, string);
+// }
+// static void  glowGetNamedProgramivEXT(GPGETNAMEDPROGRAMIVEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(program, target, pname, params);
+// }
 // static void  glowGetNamedRenderbufferParameteriv(GPGETNAMEDRENDERBUFFERPARAMETERIV fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(renderbuffer, pname, params);
+// }
+// static void  glowGetNamedRenderbufferParameterivEXT(GPGETNAMEDRENDERBUFFERPARAMETERIVEXT fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(renderbuffer, pname, params);
 // }
 // static void  glowGetNamedStringARB(GPGETNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string) {
@@ -2175,8 +3169,14 @@ package gl
 // static void  glowGetNamedStringivARB(GPGETNAMEDSTRINGIVARB fnptr, GLint  namelen, const GLchar * name, GLenum  pname, GLint * params) {
 //   (*fnptr)(namelen, name, pname, params);
 // }
+// static void  glowGetNextPerfQueryIdINTEL(GPGETNEXTPERFQUERYIDINTEL fnptr, GLuint  queryId, GLuint * nextQueryId) {
+//   (*fnptr)(queryId, nextQueryId);
+// }
 // static void  glowGetObjectLabel(GPGETOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
+// }
+// static void  glowGetObjectLabelEXT(GPGETOBJECTLABELEXT fnptr, GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label) {
+//   (*fnptr)(type, object, bufSize, length, label);
 // }
 // static void  glowGetObjectLabelKHR(GPGETOBJECTLABELKHR fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
@@ -2187,6 +3187,63 @@ package gl
 // static void  glowGetObjectPtrLabelKHR(GPGETOBJECTPTRLABELKHR fnptr, const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(ptr, bufSize, length, label);
 // }
+// static void  glowGetPathCommandsNV(GPGETPATHCOMMANDSNV fnptr, GLuint  path, GLubyte * commands) {
+//   (*fnptr)(path, commands);
+// }
+// static void  glowGetPathCoordsNV(GPGETPATHCOORDSNV fnptr, GLuint  path, GLfloat * coords) {
+//   (*fnptr)(path, coords);
+// }
+// static void  glowGetPathDashArrayNV(GPGETPATHDASHARRAYNV fnptr, GLuint  path, GLfloat * dashArray) {
+//   (*fnptr)(path, dashArray);
+// }
+// static GLfloat  glowGetPathLengthNV(GPGETPATHLENGTHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments) {
+//   return (*fnptr)(path, startSegment, numSegments);
+// }
+// static void  glowGetPathMetricRangeNV(GPGETPATHMETRICRANGENV fnptr, GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, firstPathName, numPaths, stride, metrics);
+// }
+// static void  glowGetPathMetricsNV(GPGETPATHMETRICSNV fnptr, GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, numPaths, pathNameType, paths, pathBase, stride, metrics);
+// }
+// static void  glowGetPathParameterfvNV(GPGETPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathParameterivNV(GPGETPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathSpacingNV(GPGETPATHSPACINGNV fnptr, GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing) {
+//   (*fnptr)(pathListMode, numPaths, pathNameType, paths, pathBase, advanceScale, kerningScale, transformType, returnedSpacing);
+// }
+// static void  glowGetPerfCounterInfoINTEL(GPGETPERFCOUNTERINFOINTEL fnptr, GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue) {
+//   (*fnptr)(queryId, counterId, counterNameLength, counterName, counterDescLength, counterDesc, counterOffset, counterDataSize, counterTypeEnum, counterDataTypeEnum, rawCounterMaxValue);
+// }
+// static void  glowGetPerfMonitorCounterDataAMD(GPGETPERFMONITORCOUNTERDATAAMD fnptr, GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten) {
+//   (*fnptr)(monitor, pname, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfMonitorCounterInfoAMD(GPGETPERFMONITORCOUNTERINFOAMD fnptr, GLuint  group, GLuint  counter, GLenum  pname, void * data) {
+//   (*fnptr)(group, counter, pname, data);
+// }
+// static void  glowGetPerfMonitorCounterStringAMD(GPGETPERFMONITORCOUNTERSTRINGAMD fnptr, GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString) {
+//   (*fnptr)(group, counter, bufSize, length, counterString);
+// }
+// static void  glowGetPerfMonitorCountersAMD(GPGETPERFMONITORCOUNTERSAMD fnptr, GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters) {
+//   (*fnptr)(group, numCounters, maxActiveCounters, counterSize, counters);
+// }
+// static void  glowGetPerfMonitorGroupStringAMD(GPGETPERFMONITORGROUPSTRINGAMD fnptr, GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString) {
+//   (*fnptr)(group, bufSize, length, groupString);
+// }
+// static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
+//   (*fnptr)(numGroups, groupsSize, groups);
+// }
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
+//   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
+//   (*fnptr)(queryName, queryId);
+// }
+// static void  glowGetPerfQueryInfoINTEL(GPGETPERFQUERYINFOINTEL fnptr, GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask) {
+//   (*fnptr)(queryId, queryNameLength, queryName, dataSize, noCounters, noInstances, capsMask);
+// }
 // static void  glowGetPixelMapfv(GPGETPIXELMAPFV fnptr, GLenum  map, GLfloat * values) {
 //   (*fnptr)(map, values);
 // }
@@ -2195,6 +3252,12 @@ package gl
 // }
 // static void  glowGetPixelMapusv(GPGETPIXELMAPUSV fnptr, GLenum  map, GLushort * values) {
 //   (*fnptr)(map, values);
+// }
+// static void  glowGetPointerIndexedvEXT(GPGETPOINTERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, void ** data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetPointeri_vEXT(GPGETPOINTERI_VEXT fnptr, GLenum  pname, GLuint  index, void ** params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetPointerv(GPGETPOINTERV fnptr, GLenum  pname, void ** params) {
 //   (*fnptr)(pname, params);
@@ -2217,7 +3280,13 @@ package gl
 // static void  glowGetProgramPipelineInfoLog(GPGETPROGRAMPIPELINEINFOLOG fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
 //   (*fnptr)(pipeline, bufSize, length, infoLog);
 // }
+// static void  glowGetProgramPipelineInfoLogEXT(GPGETPROGRAMPIPELINEINFOLOGEXT fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
+//   (*fnptr)(pipeline, bufSize, length, infoLog);
+// }
 // static void  glowGetProgramPipelineiv(GPGETPROGRAMPIPELINEIV fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
+//   (*fnptr)(pipeline, pname, params);
+// }
+// static void  glowGetProgramPipelineivEXT(GPGETPROGRAMPIPELINEIVEXT fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
 //   (*fnptr)(pipeline, pname, params);
 // }
 // static GLuint  glowGetProgramResourceIndex(GPGETPROGRAMRESOURCEINDEX fnptr, GLuint  program, GLenum  programInterface, const GLchar * name) {
@@ -2232,6 +3301,9 @@ package gl
 // static void  glowGetProgramResourceName(GPGETPROGRAMRESOURCENAME fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name) {
 //   (*fnptr)(program, programInterface, index, bufSize, length, name);
 // }
+// static void  glowGetProgramResourcefvNV(GPGETPROGRAMRESOURCEFVNV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params) {
+//   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
+// }
 // static void  glowGetProgramResourceiv(GPGETPROGRAMRESOURCEIV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params) {
 //   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
 // }
@@ -2240,6 +3312,18 @@ package gl
 // }
 // static void  glowGetProgramiv(GPGETPROGRAMIV fnptr, GLuint  program, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, pname, params);
+// }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
 // }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
@@ -2285,6 +3369,9 @@ package gl
 // }
 // static void  glowGetShaderiv(GPGETSHADERIV fnptr, GLuint  shader, GLenum  pname, GLint * params) {
 //   (*fnptr)(shader, pname, params);
+// }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
 // }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
@@ -2340,28 +3427,55 @@ package gl
 // static GLuint64  glowGetTextureHandleARB(GPGETTEXTUREHANDLEARB fnptr, GLuint  texture) {
 //   return (*fnptr)(texture);
 // }
+// static GLuint64  glowGetTextureHandleNV(GPGETTEXTUREHANDLENV fnptr, GLuint  texture) {
+//   return (*fnptr)(texture);
+// }
 // static void  glowGetTextureImage(GPGETTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, format, type, bufSize, pixels);
+// }
+// static void  glowGetTextureImageEXT(GPGETTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texture, target, level, format, type, pixels);
 // }
 // static void  glowGetTextureLevelParameterfv(GPGETTEXTURELEVELPARAMETERFV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, level, pname, params);
 // }
+// static void  glowGetTextureLevelParameterfvEXT(GPGETTEXTURELEVELPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, level, pname, params);
+// }
 // static void  glowGetTextureLevelParameteriv(GPGETTEXTURELEVELPARAMETERIV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, level, pname, params);
+// }
+// static void  glowGetTextureLevelParameterivEXT(GPGETTEXTURELEVELPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, level, pname, params);
 // }
 // static void  glowGetTextureParameterIiv(GPGETTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterIivEXT(GPGETTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameterIuiv(GPGETTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowGetTextureParameterIuivEXT(GPGETTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowGetTextureParameterfv(GPGETTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterfvEXT(GPGETTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameteriv(GPGETTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterivEXT(GPGETTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static GLuint64  glowGetTextureSamplerHandleARB(GPGETTEXTURESAMPLERHANDLEARB fnptr, GLuint  texture, GLuint  sampler) {
+//   return (*fnptr)(texture, sampler);
+// }
+// static GLuint64  glowGetTextureSamplerHandleNV(GPGETTEXTURESAMPLERHANDLENV fnptr, GLuint  texture, GLuint  sampler) {
 //   return (*fnptr)(texture, sampler);
 // }
 // static void  glowGetTextureSubImage(GPGETTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
@@ -2397,7 +3511,19 @@ package gl
 // static void  glowGetUniformfv(GPGETUNIFORMFV fnptr, GLuint  program, GLint  location, GLfloat * params) {
 //   (*fnptr)(program, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformiv(GPGETUNIFORMIV fnptr, GLuint  program, GLint  location, GLint * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
 // static void  glowGetUniformuiv(GPGETUNIFORMUIV fnptr, GLuint  program, GLint  location, GLuint * params) {
@@ -2408,6 +3534,18 @@ package gl
 // }
 // static void  glowGetVertexArrayIndexediv(GPGETVERTEXARRAYINDEXEDIV fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegeri_vEXT(GPGETVERTEXARRAYINTEGERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegervEXT(GPGETVERTEXARRAYINTEGERVEXT fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, pname, param);
+// }
+// static void  glowGetVertexArrayPointeri_vEXT(GPGETVERTEXARRAYPOINTERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayPointervEXT(GPGETVERTEXARRAYPOINTERVEXT fnptr, GLuint  vaobj, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, pname, param);
 // }
 // static void  glowGetVertexArrayiv(GPGETVERTEXARRAYIV fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, pname, param);
@@ -2421,7 +3559,13 @@ package gl
 // static void  glowGetVertexAttribLdv(GPGETVERTEXATTRIBLDV fnptr, GLuint  index, GLenum  pname, GLdouble * params) {
 //   (*fnptr)(index, pname, params);
 // }
+// static void  glowGetVertexAttribLi64vNV(GPGETVERTEXATTRIBLI64VNV fnptr, GLuint  index, GLenum  pname, GLint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
 // static void  glowGetVertexAttribLui64vARB(GPGETVERTEXATTRIBLUI64VARB fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
+// static void  glowGetVertexAttribLui64vNV(GPGETVERTEXATTRIBLUI64VNV fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
 //   (*fnptr)(index, pname, params);
 // }
 // static void  glowGetVertexAttribPointerv(GPGETVERTEXATTRIBPOINTERV fnptr, GLuint  index, GLenum  pname, void ** pointer) {
@@ -2435,6 +3579,9 @@ package gl
 // }
 // static void  glowGetVertexAttribiv(GPGETVERTEXATTRIBIV fnptr, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(index, pname, params);
+// }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
 // }
 // static void  glowGetnCompressedTexImage(GPGETNCOMPRESSEDTEXIMAGE fnptr, GLenum  target, GLint  lod, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(target, lod, bufSize, pixels);
@@ -2463,6 +3610,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -2470,6 +3620,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -2483,6 +3636,9 @@ package gl
 // }
 // static void  glowHint(GPHINT fnptr, GLenum  target, GLenum  mode) {
 //   (*fnptr)(target, mode);
+// }
+// static void  glowIndexFormatNV(GPINDEXFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
 // }
 // static void  glowIndexMask(GPINDEXMASK fnptr, GLuint  mask) {
 //   (*fnptr)(mask);
@@ -2523,8 +3679,14 @@ package gl
 // static void  glowInitNames(GPINITNAMES fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowInsertEventMarkerEXT(GPINSERTEVENTMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
 // static void  glowInterleavedArrays(GPINTERLEAVEDARRAYS fnptr, GLenum  format, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(format, stride, pointer);
+// }
+// static void  glowInterpolatePathsNV(GPINTERPOLATEPATHSNV fnptr, GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight) {
+//   (*fnptr)(resultPath, pathA, pathB, weight);
 // }
 // static void  glowInvalidateBufferData(GPINVALIDATEBUFFERDATA fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -2553,8 +3715,17 @@ package gl
 // static GLboolean  glowIsBuffer(GPISBUFFER fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
+// static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
+//   return (*fnptr)(target);
+// }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
+// }
+// static GLboolean  glowIsEnabledIndexedEXT(GPISENABLEDINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   return (*fnptr)(target, index);
 // }
 // static GLboolean  glowIsEnabledi(GPISENABLEDI fnptr, GLenum  target, GLuint  index) {
 //   return (*fnptr)(target, index);
@@ -2565,16 +3736,34 @@ package gl
 // static GLboolean  glowIsImageHandleResidentARB(GPISIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsImageHandleResidentNV(GPISIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
 // static GLboolean  glowIsList(GPISLIST fnptr, GLuint  list) {
 //   return (*fnptr)(list);
 // }
+// static GLboolean  glowIsNamedBufferResidentNV(GPISNAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
 // static GLboolean  glowIsNamedStringARB(GPISNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   return (*fnptr)(namelen, name);
+// }
+// static GLboolean  glowIsPathNV(GPISPATHNV fnptr, GLuint  path) {
+//   return (*fnptr)(path);
+// }
+// static GLboolean  glowIsPointInFillPathNV(GPISPOINTINFILLPATHNV fnptr, GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, mask, x, y);
+// }
+// static GLboolean  glowIsPointInStrokePathNV(GPISPOINTINSTROKEPATHNV fnptr, GLuint  path, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, x, y);
 // }
 // static GLboolean  glowIsProgram(GPISPROGRAM fnptr, GLuint  program) {
 //   return (*fnptr)(program);
 // }
 // static GLboolean  glowIsProgramPipeline(GPISPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   return (*fnptr)(pipeline);
+// }
+// static GLboolean  glowIsProgramPipelineEXT(GPISPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   return (*fnptr)(pipeline);
 // }
 // static GLboolean  glowIsQuery(GPISQUERY fnptr, GLuint  id) {
@@ -2589,6 +3778,9 @@ package gl
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
 // }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
+// }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
 // }
@@ -2598,11 +3790,17 @@ package gl
 // static GLboolean  glowIsTextureHandleResidentARB(GPISTEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsTextureHandleResidentNV(GPISTEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
 // static GLboolean  glowIsTransformFeedback(GPISTRANSFORMFEEDBACK fnptr, GLuint  id) {
 //   return (*fnptr)(id);
 // }
 // static GLboolean  glowIsVertexArray(GPISVERTEXARRAY fnptr, GLuint  array) {
 //   return (*fnptr)(array);
+// }
+// static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
+//   (*fnptr)(type, object, length, label);
 // }
 // static void  glowLightModelf(GPLIGHTMODELF fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
@@ -2640,6 +3838,9 @@ package gl
 // static void  glowListBase(GPLISTBASE fnptr, GLuint  base) {
 //   (*fnptr)(base);
 // }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
+// }
 // static void  glowLoadIdentity(GPLOADIDENTITY fnptr) {
 //   (*fnptr)();
 // }
@@ -2661,16 +3862,40 @@ package gl
 // static void  glowLogicOp(GPLOGICOP fnptr, GLenum  opcode) {
 //   (*fnptr)(opcode);
 // }
+// static void  glowMakeBufferNonResidentNV(GPMAKEBUFFERNONRESIDENTNV fnptr, GLenum  target) {
+//   (*fnptr)(target);
+// }
+// static void  glowMakeBufferResidentNV(GPMAKEBUFFERRESIDENTNV fnptr, GLenum  target, GLenum  access) {
+//   (*fnptr)(target, access);
+// }
 // static void  glowMakeImageHandleNonResidentARB(GPMAKEIMAGEHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeImageHandleNonResidentNV(GPMAKEIMAGEHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void  glowMakeImageHandleResidentARB(GPMAKEIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle, GLenum  access) {
 //   (*fnptr)(handle, access);
 // }
+// static void  glowMakeImageHandleResidentNV(GPMAKEIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle, GLenum  access) {
+//   (*fnptr)(handle, access);
+// }
+// static void  glowMakeNamedBufferNonResidentNV(GPMAKENAMEDBUFFERNONRESIDENTNV fnptr, GLuint  buffer) {
+//   (*fnptr)(buffer);
+// }
+// static void  glowMakeNamedBufferResidentNV(GPMAKENAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer, GLenum  access) {
+//   (*fnptr)(buffer, access);
+// }
 // static void  glowMakeTextureHandleNonResidentARB(GPMAKETEXTUREHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
+// static void  glowMakeTextureHandleNonResidentNV(GPMAKETEXTUREHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
 // static void  glowMakeTextureHandleResidentARB(GPMAKETEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeTextureHandleResidentNV(GPMAKETEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void  glowMap1d(GPMAP1D fnptr, GLenum  target, GLdouble  u1, GLdouble  u2, GLint  stride, GLint  order, const GLdouble * points) {
@@ -2706,7 +3931,13 @@ package gl
 // static void * glowMapNamedBuffer(GPMAPNAMEDBUFFER fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
+//   return (*fnptr)(buffer, access);
+// }
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
+//   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
 // }
 // static void  glowMaterialf(GPMATERIALF fnptr, GLenum  face, GLenum  pname, GLfloat  param) {
@@ -2721,8 +3952,89 @@ package gl
 // static void  glowMaterialiv(GPMATERIALIV fnptr, GLenum  face, GLenum  pname, const GLint * params) {
 //   (*fnptr)(face, pname, params);
 // }
+// static void  glowMatrixFrustumEXT(GPMATRIXFRUSTUMEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixLoad3x2fNV(GPMATRIXLOAD3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoad3x3fNV(GPMATRIXLOAD3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadIdentityEXT(GPMATRIXLOADIDENTITYEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixLoadTranspose3x3fNV(GPMATRIXLOADTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadTransposedEXT(GPMATRIXLOADTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadTransposefEXT(GPMATRIXLOADTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoaddEXT(GPMATRIXLOADDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadfEXT(GPMATRIXLOADFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
 // static void  glowMatrixMode(GPMATRIXMODE fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
+// }
+// static void  glowMatrixMult3x2fNV(GPMATRIXMULT3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMult3x3fNV(GPMATRIXMULT3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTranspose3x3fNV(GPMATRIXMULTTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTransposedEXT(GPMATRIXMULTTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultTransposefEXT(GPMATRIXMULTTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultdEXT(GPMATRIXMULTDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultfEXT(GPMATRIXMULTFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixOrthoEXT(GPMATRIXORTHOEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixPopEXT(GPMATRIXPOPEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixPushEXT(GPMATRIXPUSHEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixRotatedEXT(GPMATRIXROTATEDEXT fnptr, GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixRotatefEXT(GPMATRIXROTATEFEXT fnptr, GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixScaledEXT(GPMATRIXSCALEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixScalefEXT(GPMATRIXSCALEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatedEXT(GPMATRIXTRANSLATEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
 // }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
@@ -2754,7 +4066,16 @@ package gl
 // static void  glowMultiDrawArraysIndirect(GPMULTIDRAWARRAYSINDIRECT fnptr, GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectBindlessCountNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectCount(GPMULTIDRAWARRAYSINDIRECTCOUNT fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+//   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
+// }
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElements(GPMULTIDRAWELEMENTS fnptr, GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount) {
@@ -2766,8 +4087,20 @@ package gl
 // static void  glowMultiDrawElementsIndirect(GPMULTIDRAWELEMENTSINDIRECT fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectBindlessCountNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectCount(GPMULTIDRAWELEMENTSINDIRECTCOUNT fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
+// }
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+//   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
+// }
+// static void  glowMultiTexBufferEXT(GPMULTITEXBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texunit, target, internalformat, buffer);
 // }
 // static void  glowMultiTexCoord1d(GPMULTITEXCOORD1D fnptr, GLenum  target, GLdouble  s) {
 //   (*fnptr)(target, s);
@@ -2865,20 +4198,104 @@ package gl
 // static void  glowMultiTexCoord4sv(GPMULTITEXCOORD4SV fnptr, GLenum  target, const GLshort * v) {
 //   (*fnptr)(target, v);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMultiTexCoordPointerEXT(GPMULTITEXCOORDPOINTEREXT fnptr, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
+//   (*fnptr)(texunit, size, type, stride, pointer);
+// }
+// static void  glowMultiTexEnvfEXT(GPMULTITEXENVFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvfvEXT(GPMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexEnviEXT(GPMULTITEXENVIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvivEXT(GPMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexGendEXT(GPMULTITEXGENDEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGendvEXT(GPMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGenfEXT(GPMULTITEXGENFEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenfvEXT(GPMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGeniEXT(GPMULTITEXGENIEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenivEXT(GPMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexImage1DEXT(GPMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage2DEXT(GPMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage3DEXT(GPMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowMultiTexParameterIivEXT(GPMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterIuivEXT(GPMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterfEXT(GPMULTITEXPARAMETERFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterfvEXT(GPMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameteriEXT(GPMULTITEXPARAMETERIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterivEXT(GPMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexRenderbufferEXT(GPMULTITEXRENDERBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texunit, target, renderbuffer);
+// }
+// static void  glowMultiTexSubImage1DEXT(GPMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage2DEXT(GPMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
+//   (*fnptr)(buffer, size, data, usage);
+// }
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
+//   (*fnptr)(buffer, size, data, flags);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedCopyBufferSubDataEXT(GPNAMEDCOPYBUFFERSUBDATAEXT fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowNamedFramebufferDrawBuffer(GPNAMEDFRAMEBUFFERDRAWBUFFER fnptr, GLuint  framebuffer, GLenum  buf) {
 //   (*fnptr)(framebuffer, buf);
@@ -2889,22 +4306,97 @@ package gl
 // static void  glowNamedFramebufferParameteri(GPNAMEDFRAMEBUFFERPARAMETERI fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowNamedFramebufferParameteriEXT(GPNAMEDFRAMEBUFFERPARAMETERIEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
+//   (*fnptr)(framebuffer, pname, param);
+// }
 // static void  glowNamedFramebufferReadBuffer(GPNAMEDFRAMEBUFFERREADBUFFER fnptr, GLuint  framebuffer, GLenum  src) {
 //   (*fnptr)(framebuffer, src);
 // }
 // static void  glowNamedFramebufferRenderbuffer(GPNAMEDFRAMEBUFFERRENDERBUFFER fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
 // }
+// static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
+//   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTexture1DEXT(GPNAMEDFRAMEBUFFERTEXTURE1DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture2DEXT(GPNAMEDFRAMEBUFFERTEXTURE2DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture3DEXT(GPNAMEDFRAMEBUFFERTEXTURE3DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level, zoffset);
+// }
+// static void  glowNamedFramebufferTextureEXT(GPNAMEDFRAMEBUFFERTEXTUREEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTextureFaceEXT(GPNAMEDFRAMEBUFFERTEXTUREFACEEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(framebuffer, attachment, texture, level, face);
 // }
 // static void  glowNamedFramebufferTextureLayer(GPNAMEDFRAMEBUFFERTEXTURELAYER fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(framebuffer, attachment, texture, level, layer);
 // }
+// static void  glowNamedFramebufferTextureLayerEXT(GPNAMEDFRAMEBUFFERTEXTURELAYEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(framebuffer, attachment, texture, level, layer);
+// }
+// static void  glowNamedProgramLocalParameter4dEXT(GPNAMEDPROGRAMLOCALPARAMETER4DEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4dvEXT(GPNAMEDPROGRAMLOCALPARAMETER4DVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameter4fEXT(GPNAMEDPROGRAMLOCALPARAMETER4FEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4fvEXT(GPNAMEDPROGRAMLOCALPARAMETER4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4iEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4uiEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameters4fvEXT(GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramStringEXT(GPNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string) {
+//   (*fnptr)(program, target, format, len, string);
+// }
 // static void  glowNamedRenderbufferStorage(GPNAMEDRENDERBUFFERSTORAGE fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, internalformat, width, height);
 // }
+// static void  glowNamedRenderbufferStorageEXT(GPNAMEDRENDERBUFFERSTORAGEEXT fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, internalformat, width, height);
+// }
 // static void  glowNamedRenderbufferStorageMultisample(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, samples, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageMultisampleCoverageEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT fnptr, GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageMultisampleEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, samples, internalformat, width, height);
 // }
 // static void  glowNamedStringARB(GPNAMEDSTRINGARB fnptr, GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string) {
@@ -2943,6 +4435,9 @@ package gl
 // static void  glowNormal3sv(GPNORMAL3SV fnptr, const GLshort * v) {
 //   (*fnptr)(v);
 // }
+// static void  glowNormalFormatNV(GPNORMALFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
 // static void  glowNormalPointer(GPNORMALPOINTER fnptr, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(type, stride, pointer);
 // }
@@ -2969,6 +4464,60 @@ package gl
 // }
 // static void  glowPatchParameteri(GPPATCHPARAMETERI fnptr, GLenum  pname, GLint  value) {
 //   (*fnptr)(pname, value);
+// }
+// static void  glowPathCommandsNV(GPPATHCOMMANDSNV fnptr, GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathCoordsNV(GPPATHCOORDSNV fnptr, GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCoords, coordType, coords);
+// }
+// static void  glowPathCoverDepthFuncNV(GPPATHCOVERDEPTHFUNCNV fnptr, GLenum  func) {
+//   (*fnptr)(func);
+// }
+// static void  glowPathDashArrayNV(GPPATHDASHARRAYNV fnptr, GLuint  path, GLsizei  dashCount, const GLfloat * dashArray) {
+//   (*fnptr)(path, dashCount, dashArray);
+// }
+// static GLenum  glowPathGlyphIndexArrayNV(GPPATHGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathGlyphIndexRangeNV(GPPATHGLYPHINDEXRANGENV fnptr, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount) {
+//   return (*fnptr)(fontTarget, fontName, fontStyle, pathParameterTemplate, emScale, baseAndCount);
+// }
+// static void  glowPathGlyphRangeNV(GPPATHGLYPHRANGENV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyph, numGlyphs, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathGlyphsNV(GPPATHGLYPHSNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, numGlyphs, type, charcodes, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathMemoryGlyphIndexArrayNV(GPPATHMEMORYGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontSize, fontData, faceIndex, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathParameterfNV(GPPATHPARAMETERFNV fnptr, GLuint  path, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterfvNV(GPPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, const GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameteriNV(GPPATHPARAMETERINV fnptr, GLuint  path, GLenum  pname, GLint  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterivNV(GPPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, const GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathStencilDepthOffsetNV(GPPATHSTENCILDEPTHOFFSETNV fnptr, GLfloat  factor, GLfloat  units) {
+//   (*fnptr)(factor, units);
+// }
+// static void  glowPathStencilFuncNV(GPPATHSTENCILFUNCNV fnptr, GLenum  func, GLint  ref, GLuint  mask) {
+//   (*fnptr)(func, ref, mask);
+// }
+// static void  glowPathStringNV(GPPATHSTRINGNV fnptr, GLuint  path, GLenum  format, GLsizei  length, const void * pathString) {
+//   (*fnptr)(path, format, length, pathString);
+// }
+// static void  glowPathSubCommandsNV(GPPATHSUBCOMMANDSNV fnptr, GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, commandStart, commandsToDelete, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathSubCoordsNV(GPPATHSUBCOORDSNV fnptr, GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, coordStart, numCoords, coordType, coords);
 // }
 // static void  glowPauseTransformFeedback(GPPAUSETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
@@ -2997,6 +4546,9 @@ package gl
 // static void  glowPixelZoom(GPPIXELZOOM fnptr, GLfloat  xfactor, GLfloat  yfactor) {
 //   (*fnptr)(xfactor, yfactor);
 // }
+// static GLboolean  glowPointAlongPathNV(GPPOINTALONGPATHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY) {
+//   return (*fnptr)(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
+// }
 // static void  glowPointParameterf(GPPOINTPARAMETERF fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -3018,6 +4570,12 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPolygonStipple(GPPOLYGONSTIPPLE fnptr, const GLubyte * mask) {
 //   (*fnptr)(mask);
 // }
@@ -3033,11 +4591,17 @@ package gl
 // static void  glowPopDebugGroupKHR(GPPOPDEBUGGROUPKHR fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowPopGroupMarkerEXT(GPPOPGROUPMARKEREXT fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowPopMatrix(GPPOPMATRIX fnptr) {
 //   (*fnptr)();
 // }
 // static void  glowPopName(GPPOPNAME fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -3051,161 +4615,428 @@ package gl
 // static void  glowProgramParameteri(GPPROGRAMPARAMETERI fnptr, GLuint  program, GLenum  pname, GLint  value) {
 //   (*fnptr)(program, pname, value);
 // }
+// static void  glowProgramParameteriARB(GPPROGRAMPARAMETERIARB fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramParameteriEXT(GPPROGRAMPARAMETERIEXT fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramPathFragmentInputGenNV(GPPROGRAMPATHFRAGMENTINPUTGENNV fnptr, GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs) {
+//   (*fnptr)(program, location, genMode, components, coeffs);
+// }
 // static void  glowProgramUniform1d(GPPROGRAMUNIFORM1D fnptr, GLuint  program, GLint  location, GLdouble  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1dEXT(GPPROGRAMUNIFORM1DEXT fnptr, GLuint  program, GLint  location, GLdouble  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1dv(GPPROGRAMUNIFORM1DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1dvEXT(GPPROGRAMUNIFORM1DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1f(GPPROGRAMUNIFORM1F fnptr, GLuint  program, GLint  location, GLfloat  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1fEXT(GPPROGRAMUNIFORM1FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1fv(GPPROGRAMUNIFORM1FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1fvEXT(GPPROGRAMUNIFORM1FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1iEXT(GPPROGRAMUNIFORM1IEXT fnptr, GLuint  program, GLint  location, GLint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1iv(GPPROGRAMUNIFORM1IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ivEXT(GPPROGRAMUNIFORM1IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uiEXT(GPPROGRAMUNIFORM1UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1uiv(GPPROGRAMUNIFORM1UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uivEXT(GPPROGRAMUNIFORM1UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2d(GPPROGRAMUNIFORM2D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2dEXT(GPPROGRAMUNIFORM2DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2dv(GPPROGRAMUNIFORM2DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2dvEXT(GPPROGRAMUNIFORM2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2f(GPPROGRAMUNIFORM2F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2fEXT(GPPROGRAMUNIFORM2FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2fv(GPPROGRAMUNIFORM2FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2fvEXT(GPPROGRAMUNIFORM2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2iEXT(GPPROGRAMUNIFORM2IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2iv(GPPROGRAMUNIFORM2IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ivEXT(GPPROGRAMUNIFORM2IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uiEXT(GPPROGRAMUNIFORM2UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2uiv(GPPROGRAMUNIFORM2UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uivEXT(GPPROGRAMUNIFORM2UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3d(GPPROGRAMUNIFORM3D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3dEXT(GPPROGRAMUNIFORM3DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3dv(GPPROGRAMUNIFORM3DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3dvEXT(GPPROGRAMUNIFORM3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3f(GPPROGRAMUNIFORM3F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3fEXT(GPPROGRAMUNIFORM3FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3fv(GPPROGRAMUNIFORM3FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3fvEXT(GPPROGRAMUNIFORM3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3iEXT(GPPROGRAMUNIFORM3IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3iv(GPPROGRAMUNIFORM3IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ivEXT(GPPROGRAMUNIFORM3IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uiEXT(GPPROGRAMUNIFORM3UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3uiv(GPPROGRAMUNIFORM3UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uivEXT(GPPROGRAMUNIFORM3UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4d(GPPROGRAMUNIFORM4D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4dEXT(GPPROGRAMUNIFORM4DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4dv(GPPROGRAMUNIFORM4DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4dvEXT(GPPROGRAMUNIFORM4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4f(GPPROGRAMUNIFORM4F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4fEXT(GPPROGRAMUNIFORM4FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4fv(GPPROGRAMUNIFORM4FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4fvEXT(GPPROGRAMUNIFORM4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4iEXT(GPPROGRAMUNIFORM4IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4iv(GPPROGRAMUNIFORM4IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ivEXT(GPPROGRAMUNIFORM4IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uiEXT(GPPROGRAMUNIFORM4UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4uiv(GPPROGRAMUNIFORM4UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uivEXT(GPPROGRAMUNIFORM4UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniformHandleui64ARB(GPPROGRAMUNIFORMHANDLEUI64ARB fnptr, GLuint  program, GLint  location, GLuint64  value) {
 //   (*fnptr)(program, location, value);
 // }
+// static void  glowProgramUniformHandleui64NV(GPPROGRAMUNIFORMHANDLEUI64NV fnptr, GLuint  program, GLint  location, GLuint64  value) {
+//   (*fnptr)(program, location, value);
+// }
 // static void  glowProgramUniformHandleui64vARB(GPPROGRAMUNIFORMHANDLEUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
+//   (*fnptr)(program, location, count, values);
+// }
+// static void  glowProgramUniformHandleui64vNV(GPPROGRAMUNIFORMHANDLEUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
 //   (*fnptr)(program, location, count, values);
 // }
 // static void  glowProgramUniformMatrix2dv(GPPROGRAMUNIFORMMATRIX2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2dvEXT(GPPROGRAMUNIFORMMATRIX2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2fv(GPPROGRAMUNIFORMMATRIX2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2fvEXT(GPPROGRAMUNIFORMMATRIX2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x3dv(GPPROGRAMUNIFORMMATRIX2X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x3dvEXT(GPPROGRAMUNIFORMMATRIX2X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x3fv(GPPROGRAMUNIFORMMATRIX2X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x3fvEXT(GPPROGRAMUNIFORMMATRIX2X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x4dv(GPPROGRAMUNIFORMMATRIX2X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x4dvEXT(GPPROGRAMUNIFORMMATRIX2X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x4fv(GPPROGRAMUNIFORMMATRIX2X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x4fvEXT(GPPROGRAMUNIFORMMATRIX2X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3dv(GPPROGRAMUNIFORMMATRIX3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3dvEXT(GPPROGRAMUNIFORMMATRIX3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3fv(GPPROGRAMUNIFORMMATRIX3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3fvEXT(GPPROGRAMUNIFORMMATRIX3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x2dv(GPPROGRAMUNIFORMMATRIX3X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x2dvEXT(GPPROGRAMUNIFORMMATRIX3X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x2fv(GPPROGRAMUNIFORMMATRIX3X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x2fvEXT(GPPROGRAMUNIFORMMATRIX3X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x4dv(GPPROGRAMUNIFORMMATRIX3X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x4dvEXT(GPPROGRAMUNIFORMMATRIX3X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x4fv(GPPROGRAMUNIFORMMATRIX3X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x4fvEXT(GPPROGRAMUNIFORMMATRIX3X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4dv(GPPROGRAMUNIFORMMATRIX4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4dvEXT(GPPROGRAMUNIFORMMATRIX4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4fv(GPPROGRAMUNIFORMMATRIX4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4fvEXT(GPPROGRAMUNIFORMMATRIX4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x2dv(GPPROGRAMUNIFORMMATRIX4X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x2dvEXT(GPPROGRAMUNIFORMMATRIX4X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x2fv(GPPROGRAMUNIFORMMATRIX4X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4x2fvEXT(GPPROGRAMUNIFORMMATRIX4X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x3dv(GPPROGRAMUNIFORMMATRIX4X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3dvEXT(GPPROGRAMUNIFORMMATRIX4X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x3fv(GPPROGRAMUNIFORMMATRIX4X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4x3fvEXT(GPPROGRAMUNIFORMMATRIX4X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformui64NV(GPPROGRAMUNIFORMUI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(program, location, value);
+// }
+// static void  glowProgramUniformui64vNV(GPPROGRAMUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProvokingVertex(GPPROVOKINGVERTEX fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -3216,11 +5047,17 @@ package gl
 // static void  glowPushClientAttrib(GPPUSHCLIENTATTRIB fnptr, GLbitfield  mask) {
 //   (*fnptr)(mask);
 // }
+// static void  glowPushClientAttribDefaultEXT(GPPUSHCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
+// }
 // static void  glowPushDebugGroup(GPPUSHDEBUGGROUP fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
 // }
 // static void  glowPushDebugGroupKHR(GPPUSHDEBUGGROUPKHR fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
+// }
+// static void  glowPushGroupMarkerEXT(GPPUSHGROUPMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
 // }
 // static void  glowPushMatrix(GPPUSHMATRIX fnptr) {
 //   (*fnptr)();
@@ -3303,6 +5140,9 @@ package gl
 // static void  glowRasterPos4sv(GPRASTERPOS4SV fnptr, const GLshort * v) {
 //   (*fnptr)(v);
 // }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
+// }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
 // }
@@ -3353,6 +5193,12 @@ package gl
 // }
 // static void  glowRenderbufferStorageMultisample(GPRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, samples, internalformat, width, height);
+// }
+// static void  glowRenderbufferStorageMultisampleCoverageNV(GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV fnptr, GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(target, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
@@ -3453,11 +5299,17 @@ package gl
 // static void  glowSecondaryColor3usv(GPSECONDARYCOLOR3USV fnptr, const GLushort * v) {
 //   (*fnptr)(v);
 // }
+// static void  glowSecondaryColorFormatNV(GPSECONDARYCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
 // static void  glowSecondaryColorPointer(GPSECONDARYCOLORPOINTER fnptr, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(size, type, stride, pointer);
 // }
 // static void  glowSelectBuffer(GPSELECTBUFFER fnptr, GLsizei  size, GLuint * buffer) {
 //   (*fnptr)(size, buffer);
+// }
+// static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
+//   (*fnptr)(monitor, enable, group, numCounters, counterList);
 // }
 // static void  glowShadeModel(GPSHADEMODEL fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -3470,6 +5322,27 @@ package gl
 // }
 // static void  glowShaderStorageBlockBinding(GPSHADERSTORAGEBLOCKBINDING fnptr, GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding) {
 //   (*fnptr)(program, storageBlockIndex, storageBlockBinding);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShader(GPSPECIALIZESHADER fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
+// }
+// static void  glowStencilFillPathInstancedNV(GPSTENCILFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, transformType, transformValues);
+// }
+// static void  glowStencilFillPathNV(GPSTENCILFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask) {
+//   (*fnptr)(path, fillMode, mask);
 // }
 // static void  glowStencilFunc(GPSTENCILFUNC fnptr, GLenum  func, GLint  ref, GLuint  mask) {
 //   (*fnptr)(func, ref, mask);
@@ -3489,7 +5362,31 @@ package gl
 // static void  glowStencilOpSeparate(GPSTENCILOPSEPARATE fnptr, GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass) {
 //   (*fnptr)(face, sfail, dpfail, dppass);
 // }
+// static void  glowStencilStrokePathInstancedNV(GPSTENCILSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, transformType, transformValues);
+// }
+// static void  glowStencilStrokePathNV(GPSTENCILSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask) {
+//   (*fnptr)(path, reference, mask);
+// }
+// static void  glowStencilThenCoverFillPathInstancedNV(GPSTENCILTHENCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverFillPathNV(GPSTENCILTHENCOVERFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, fillMode, mask, coverMode);
+// }
+// static void  glowStencilThenCoverStrokePathInstancedNV(GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverStrokePathNV(GPSTENCILTHENCOVERSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, reference, mask, coverMode);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
+// }
 // static void  glowTexBuffer(GPTEXBUFFER fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(target, internalformat, buffer);
+// }
+// static void  glowTexBufferARB(GPTEXBUFFERARB fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(target, internalformat, buffer);
 // }
 // static void  glowTexBufferRange(GPTEXBUFFERRANGE fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
@@ -3591,6 +5488,9 @@ package gl
 // static void  glowTexCoord4sv(GPTEXCOORD4SV fnptr, const GLshort * v) {
 //   (*fnptr)(v);
 // }
+// static void  glowTexCoordFormatNV(GPTEXCOORDFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
 // static void  glowTexCoordPointer(GPTEXCOORDPOINTER fnptr, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(size, type, stride, pointer);
 // }
@@ -3639,8 +5539,8 @@ package gl
 // static void  glowTexImage3DMultisample(GPTEXIMAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -3687,53 +5587,119 @@ package gl
 // static void  glowTextureBarrier(GPTEXTUREBARRIER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowTextureBarrierNV(GPTEXTUREBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowTextureBuffer(GPTEXTUREBUFFER fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texture, target, internalformat, buffer);
+// }
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
+//   (*fnptr)(texture, target, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureImage1DEXT(GPTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowTextureImage2DEXT(GPTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowTextureImage3DEXT(GPTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowTextureParameterIivEXT(GPTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowTextureParameterIuiv(GPTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, const GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowTextureParameterIuivEXT(GPTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameterf(GPTEXTUREPARAMETERF fnptr, GLuint  texture, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameterfEXT(GPTEXTUREPARAMETERFEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameterfv(GPTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, const GLfloat * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterfvEXT(GPTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameteri(GPTEXTUREPARAMETERI fnptr, GLuint  texture, GLenum  pname, GLint  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameteriEXT(GPTEXTUREPARAMETERIEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameteriv(GPTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, const GLint * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterivEXT(GPTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
+// static void  glowTextureRenderbufferEXT(GPTEXTURERENDERBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texture, target, renderbuffer);
 // }
 // static void  glowTextureStorage1D(GPTEXTURESTORAGE1D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
 //   (*fnptr)(texture, levels, internalformat, width);
 // }
+// static void  glowTextureStorage1DEXT(GPTEXTURESTORAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
+//   (*fnptr)(texture, target, levels, internalformat, width);
+// }
 // static void  glowTextureStorage2D(GPTEXTURESTORAGE2D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, levels, internalformat, width, height);
+// }
+// static void  glowTextureStorage2DEXT(GPTEXTURESTORAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height);
 // }
 // static void  glowTextureStorage2DMultisample(GPTEXTURESTORAGE2DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, fixedsamplelocations);
 // }
+// static void  glowTextureStorage2DMultisampleEXT(GPTEXTURESTORAGE2DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, fixedsamplelocations);
+// }
 // static void  glowTextureStorage3D(GPTEXTURESTORAGE3D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
 //   (*fnptr)(texture, levels, internalformat, width, height, depth);
+// }
+// static void  glowTextureStorage3DEXT(GPTEXTURESTORAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height, depth);
 // }
 // static void  glowTextureStorage3DMultisample(GPTEXTURESTORAGE3DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
+// }
 // static void  glowTextureSubImage1D(GPTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowTextureSubImage1DEXT(GPTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, type, pixels);
 // }
 // static void  glowTextureSubImage2D(GPTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, type, pixels);
 // }
+// static void  glowTextureSubImage2DEXT(GPTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
 // static void  glowTextureSubImage3D(GPTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowTextureSubImage3DEXT(GPTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
 // static void  glowTextureView(GPTEXTUREVIEW fnptr, GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers) {
 //   (*fnptr)(texture, target, origtexture, internalformat, minlevel, numlevels, minlayer, numlayers);
@@ -3741,11 +5707,14 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackVaryings(GPTRANSFORMFEEDBACKVARYINGS fnptr, GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode) {
 //   (*fnptr)(program, count, varyings, bufferMode);
+// }
+// static void  glowTransformPathNV(GPTRANSFORMPATHNV fnptr, GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(resultPath, srcPath, transformType, transformValues);
 // }
 // static void  glowTranslated(GPTRANSLATED fnptr, GLdouble  x, GLdouble  y, GLdouble  z) {
 //   (*fnptr)(x, y, z);
@@ -3768,11 +5737,35 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform1iv(GPUNIFORM1IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
+// }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1uiv(GPUNIFORM1UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -3792,11 +5785,35 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform2iv(GPUNIFORM2IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
+// }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2uiv(GPUNIFORM2UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -3816,11 +5833,35 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform3iv(GPUNIFORM3IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
+// }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3uiv(GPUNIFORM3UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -3840,11 +5881,35 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform4iv(GPUNIFORM4IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
+// }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4uiv(GPUNIFORM4UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -3855,7 +5920,13 @@ package gl
 // static void  glowUniformHandleui64ARB(GPUNIFORMHANDLEUI64ARB fnptr, GLint  location, GLuint64  value) {
 //   (*fnptr)(location, value);
 // }
+// static void  glowUniformHandleui64NV(GPUNIFORMHANDLEUI64NV fnptr, GLint  location, GLuint64  value) {
+//   (*fnptr)(location, value);
+// }
 // static void  glowUniformHandleui64vARB(GPUNIFORMHANDLEUI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniformHandleui64vNV(GPUNIFORMHANDLEUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniformMatrix2dv(GPUNIFORMMATRIX2DV fnptr, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
@@ -3915,10 +5986,19 @@ package gl
 // static void  glowUniformSubroutinesuiv(GPUNIFORMSUBROUTINESUIV fnptr, GLenum  shadertype, GLsizei  count, const GLuint * indices) {
 //   (*fnptr)(shadertype, count, indices);
 // }
+// static void  glowUniformui64NV(GPUNIFORMUI64NV fnptr, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(location, value);
+// }
+// static void  glowUniformui64vNV(GPUNIFORMUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static GLboolean  glowUnmapBuffer(GPUNMAPBUFFER fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLboolean  glowUnmapNamedBuffer(GPUNMAPNAMEDBUFFER fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
+// static GLboolean  glowUnmapNamedBufferEXT(GPUNMAPNAMEDBUFFEREXT fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
 // static void  glowUseProgram(GPUSEPROGRAM fnptr, GLuint  program) {
@@ -3927,10 +6007,19 @@ package gl
 // static void  glowUseProgramStages(GPUSEPROGRAMSTAGES fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
 //   (*fnptr)(pipeline, stages, program);
 // }
+// static void  glowUseProgramStagesEXT(GPUSEPROGRAMSTAGESEXT fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
+//   (*fnptr)(pipeline, stages, program);
+// }
+// static void  glowUseShaderProgramEXT(GPUSESHADERPROGRAMEXT fnptr, GLenum  type, GLuint  program) {
+//   (*fnptr)(type, program);
+// }
 // static void  glowValidateProgram(GPVALIDATEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowValidateProgramPipeline(GPVALIDATEPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowValidateProgramPipelineEXT(GPVALIDATEPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowVertex2d(GPVERTEX2D fnptr, GLdouble  x, GLdouble  y) {
@@ -4017,17 +6106,74 @@ package gl
 // static void  glowVertexArrayAttribLFormat(GPVERTEXARRAYATTRIBLFORMAT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexArrayBindVertexBufferEXT(GPVERTEXARRAYBINDVERTEXBUFFEREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
+//   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
+// }
 // static void  glowVertexArrayBindingDivisor(GPVERTEXARRAYBINDINGDIVISOR fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(vaobj, bindingindex, divisor);
 // }
+// static void  glowVertexArrayColorOffsetEXT(GPVERTEXARRAYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayEdgeFlagOffsetEXT(GPVERTEXARRAYEDGEFLAGOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, stride, offset);
+// }
 // static void  glowVertexArrayElementBuffer(GPVERTEXARRAYELEMENTBUFFER fnptr, GLuint  vaobj, GLuint  buffer) {
 //   (*fnptr)(vaobj, buffer);
+// }
+// static void  glowVertexArrayFogCoordOffsetEXT(GPVERTEXARRAYFOGCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayIndexOffsetEXT(GPVERTEXARRAYINDEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayMultiTexCoordOffsetEXT(GPVERTEXARRAYMULTITEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, texunit, size, type, stride, offset);
+// }
+// static void  glowVertexArrayNormalOffsetEXT(GPVERTEXARRAYNORMALOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArraySecondaryColorOffsetEXT(GPVERTEXARRAYSECONDARYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayTexCoordOffsetEXT(GPVERTEXARRAYTEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribBindingEXT(GPVERTEXARRAYVERTEXATTRIBBINDINGEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
+//   (*fnptr)(vaobj, attribindex, bindingindex);
+// }
+// static void  glowVertexArrayVertexAttribDivisorEXT(GPVERTEXARRAYVERTEXATTRIBDIVISOREXT fnptr, GLuint  vaobj, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(vaobj, index, divisor);
+// }
+// static void  glowVertexArrayVertexAttribFormatEXT(GPVERTEXARRAYVERTEXATTRIBFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIFormatEXT(GPVERTEXARRAYVERTEXATTRIBIFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIOffsetEXT(GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribLFormatEXT(GPVERTEXARRAYVERTEXATTRIBLFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribLOffsetEXT(GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribOffsetEXT(GPVERTEXARRAYVERTEXATTRIBOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, normalized, stride, offset);
+// }
+// static void  glowVertexArrayVertexBindingDivisorEXT(GPVERTEXARRAYVERTEXBINDINGDIVISOREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
+//   (*fnptr)(vaobj, bindingindex, divisor);
 // }
 // static void  glowVertexArrayVertexBuffer(GPVERTEXARRAYVERTEXBUFFER fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
 //   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
 // }
 // static void  glowVertexArrayVertexBuffers(GPVERTEXARRAYVERTEXBUFFERS fnptr, GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(vaobj, first, count, buffers, offsets, strides);
+// }
+// static void  glowVertexArrayVertexOffsetEXT(GPVERTEXARRAYVERTEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
 // }
 // static void  glowVertexAttrib1d(GPVERTEXATTRIB1D fnptr, GLuint  index, GLdouble  x) {
 //   (*fnptr)(index, x);
@@ -4143,8 +6289,14 @@ package gl
 // static void  glowVertexAttribDivisor(GPVERTEXATTRIBDIVISOR fnptr, GLuint  index, GLuint  divisor) {
 //   (*fnptr)(index, divisor);
 // }
+// static void  glowVertexAttribDivisorARB(GPVERTEXATTRIBDIVISORARB fnptr, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(index, divisor);
+// }
 // static void  glowVertexAttribFormat(GPVERTEXATTRIBFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexAttribFormatNV(GPVERTEXATTRIBFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride) {
+//   (*fnptr)(index, size, type, normalized, stride);
 // }
 // static void  glowVertexAttribI1i(GPVERTEXATTRIBI1I fnptr, GLuint  index, GLint  x) {
 //   (*fnptr)(index, x);
@@ -4209,6 +6361,9 @@ package gl
 // static void  glowVertexAttribIFormat(GPVERTEXATTRIBIFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexAttribIFormatNV(GPVERTEXATTRIBIFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
+// }
 // static void  glowVertexAttribIPointer(GPVERTEXATTRIBIPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
 // }
@@ -4218,10 +6373,22 @@ package gl
 // static void  glowVertexAttribL1dv(GPVERTEXATTRIBL1DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL1i64NV(GPVERTEXATTRIBL1I64NV fnptr, GLuint  index, GLint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
+// static void  glowVertexAttribL1i64vNV(GPVERTEXATTRIBL1I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL1ui64ARB(GPVERTEXATTRIBL1UI64ARB fnptr, GLuint  index, GLuint64EXT  x) {
 //   (*fnptr)(index, x);
 // }
+// static void  glowVertexAttribL1ui64NV(GPVERTEXATTRIBL1UI64NV fnptr, GLuint  index, GLuint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
 // static void  glowVertexAttribL1ui64vARB(GPVERTEXATTRIBL1UI64VARB fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL1ui64vNV(GPVERTEXATTRIBL1UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL2d(GPVERTEXATTRIBL2D fnptr, GLuint  index, GLdouble  x, GLdouble  y) {
@@ -4230,10 +6397,34 @@ package gl
 // static void  glowVertexAttribL2dv(GPVERTEXATTRIBL2DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL2i64NV(GPVERTEXATTRIBL2I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2i64vNV(GPVERTEXATTRIBL2I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL2ui64NV(GPVERTEXATTRIBL2UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2ui64vNV(GPVERTEXATTRIBL2UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL3d(GPVERTEXATTRIBL3D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z) {
 //   (*fnptr)(index, x, y, z);
 // }
 // static void  glowVertexAttribL3dv(GPVERTEXATTRIBL3DV fnptr, GLuint  index, const GLdouble * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3i64NV(GPVERTEXATTRIBL3I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3i64vNV(GPVERTEXATTRIBL3I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3ui64NV(GPVERTEXATTRIBL3UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3ui64vNV(GPVERTEXATTRIBL3UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL4d(GPVERTEXATTRIBL4D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
@@ -4242,8 +6433,23 @@ package gl
 // static void  glowVertexAttribL4dv(GPVERTEXATTRIBL4DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL4i64NV(GPVERTEXATTRIBL4I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4i64vNV(GPVERTEXATTRIBL4I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL4ui64NV(GPVERTEXATTRIBL4UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4ui64vNV(GPVERTEXATTRIBL4UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribLFormat(GPVERTEXATTRIBLFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexAttribLFormatNV(GPVERTEXATTRIBLFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
 // }
 // static void  glowVertexAttribLPointer(GPVERTEXATTRIBLPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
@@ -4278,6 +6484,9 @@ package gl
 // static void  glowVertexBindingDivisor(GPVERTEXBINDINGDIVISOR fnptr, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(bindingindex, divisor);
 // }
+// static void  glowVertexFormatNV(GPVERTEXFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
 // static void  glowVertexPointer(GPVERTEXPOINTER fnptr, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(size, type, stride, pointer);
 // }
@@ -4293,8 +6502,20 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
+//   (*fnptr)(resultPath, numPaths, paths, weights);
 // }
 // static void  glowWindowPos2d(GPWINDOWPOS2D fnptr, GLdouble  x, GLdouble  y) {
 //   (*fnptr)(x, y);
@@ -4344,6 +6565,9 @@ package gl
 // static void  glowWindowPos3sv(GPWINDOWPOS3SV fnptr, const GLshort * v) {
 //   (*fnptr)(v);
 // }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
+// }
 import "C"
 import (
 	"unsafe"
@@ -4359,6 +6583,7 @@ const (
 	GL_4D_COLOR_TEXTURE                                        = 0x0604
 	GL_4_BYTES                                                 = 0x1409
 	ACCUM                                                      = 0x0100
+	ACCUM_ADJACENT_PAIRS_NV                                    = 0x90AD
 	ACCUM_ALPHA_BITS                                           = 0x0D5B
 	ACCUM_BLUE_BITS                                            = 0x0D5A
 	ACCUM_BUFFER_BIT                                           = 0x00000200
@@ -4369,6 +6594,7 @@ const (
 	ACTIVE_ATTRIBUTES                                          = 0x8B89
 	ACTIVE_ATTRIBUTE_MAX_LENGTH                                = 0x8B8A
 	ACTIVE_PROGRAM                                             = 0x8259
+	ACTIVE_PROGRAM_EXT                                         = 0x8B8D
 	ACTIVE_RESOURCES                                           = 0x92F5
 	ACTIVE_SUBROUTINES                                         = 0x8DE5
 	ACTIVE_SUBROUTINE_MAX_LENGTH                               = 0x8E48
@@ -4383,11 +6609,15 @@ const (
 	ACTIVE_VARIABLES                                           = 0x9305
 	ADD                                                        = 0x0104
 	ADD_SIGNED                                                 = 0x8574
+	ADJACENT_PAIRS_NV                                          = 0x90AE
+	AFFINE_2D_NV                                               = 0x9092
+	AFFINE_3D_NV                                               = 0x9094
 	ALIASED_LINE_WIDTH_RANGE                                   = 0x846E
 	ALIASED_POINT_SIZE_RANGE                                   = 0x846D
 	ALL_ATTRIB_BITS                                            = 0xFFFFFFFF
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
+	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALPHA                                                      = 0x1906
 	ALPHA12                                                    = 0x803D
 	ALPHA16                                                    = 0x803E
@@ -4396,6 +6626,7 @@ const (
 	ALPHA_BIAS                                                 = 0x0D1D
 	ALPHA_BITS                                                 = 0x0D55
 	ALPHA_INTEGER                                              = 0x8D97
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALPHA_SCALE                                                = 0x0D1C
 	ALPHA_TEST                                                 = 0x0BC0
 	ALPHA_TEST_FUNC                                            = 0x0BC1
@@ -4409,6 +6640,7 @@ const (
 	AND_REVERSE                                                = 0x1502
 	ANY_SAMPLES_PASSED                                         = 0x8C2F
 	ANY_SAMPLES_PASSED_CONSERVATIVE                            = 0x8D6A
+	ARC_TO_NV                                                  = 0xFE
 	ARRAY_BUFFER                                               = 0x8892
 	ARRAY_BUFFER_BINDING                                       = 0x8894
 	ARRAY_SIZE                                                 = 0x92FB
@@ -4429,6 +6661,7 @@ const (
 	ATOMIC_COUNTER_BUFFER_SIZE                                 = 0x92C3
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	ATTRIB_STACK_DEPTH                                         = 0x0BB0
 	AUTO_GENERATE_MIPMAP                                       = 0x8295
 	AUTO_NORMAL                                                = 0x0D80
@@ -4440,6 +6673,7 @@ const (
 	BACK                                                       = 0x0405
 	BACK_LEFT                                                  = 0x0402
 	BACK_RIGHT                                                 = 0x0403
+	BEVEL_NV                                                   = 0x90A6
 	BGR                                                        = 0x80E0
 	BGRA                                                       = 0x80E1
 	BGRA_INTEGER                                               = 0x8D9B
@@ -4447,13 +6681,18 @@ const (
 	BITMAP                                                     = 0x1A00
 	BITMAP_TOKEN                                               = 0x0704
 	BLEND                                                      = 0x0BE2
+	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
+	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
 	BLEND_DST_RGB                                              = 0x80C8
 	BLEND_EQUATION                                             = 0x8009
 	BLEND_EQUATION_ALPHA                                       = 0x883D
 	BLEND_EQUATION_RGB                                         = 0x8009
+	BLEND_OVERLAP_NV                                           = 0x9281
+	BLEND_PREMULTIPLIED_SRC_NV                                 = 0x9280
 	BLEND_SRC                                                  = 0x0BE1
 	BLEND_SRC_ALPHA                                            = 0x80CB
 	BLEND_SRC_RGB                                              = 0x80C9
@@ -4462,22 +6701,28 @@ const (
 	BLUE_BIAS                                                  = 0x0D1B
 	BLUE_BITS                                                  = 0x0D54
 	BLUE_INTEGER                                               = 0x8D96
+	BLUE_NV                                                    = 0x1905
 	BLUE_SCALE                                                 = 0x0D1A
+	BOLD_BIT_NV                                                = 0x01
 	BOOL                                                       = 0x8B56
 	BOOL_VEC2                                                  = 0x8B57
 	BOOL_VEC3                                                  = 0x8B58
 	BOOL_VEC4                                                  = 0x8B59
+	BOUNDING_BOX_NV                                            = 0x908D
+	BOUNDING_BOX_OF_BOUNDING_BOXES_NV                          = 0x909C
 	BUFFER                                                     = 0x82E0
 	BUFFER_ACCESS                                              = 0x88BB
 	BUFFER_ACCESS_FLAGS                                        = 0x911F
 	BUFFER_BINDING                                             = 0x9302
 	BUFFER_DATA_SIZE                                           = 0x9303
+	BUFFER_GPU_ADDRESS_NV                                      = 0x8F1D
 	BUFFER_IMMUTABLE_STORAGE                                   = 0x821F
 	BUFFER_KHR                                                 = 0x82E0
 	BUFFER_MAPPED                                              = 0x88BC
 	BUFFER_MAP_LENGTH                                          = 0x9120
 	BUFFER_MAP_OFFSET                                          = 0x9121
 	BUFFER_MAP_POINTER                                         = 0x88BD
+	BUFFER_OBJECT_EXT                                          = 0x9151
 	BUFFER_SIZE                                                = 0x8764
 	BUFFER_STORAGE_FLAGS                                       = 0x8220
 	BUFFER_UPDATE_BARRIER_BIT                                  = 0x00000200
@@ -4490,10 +6735,14 @@ const (
 	C4UB_V3F                                                   = 0x2A23
 	CAVEAT_SUPPORT                                             = 0x82B8
 	CCW                                                        = 0x0901
+	CIRCULAR_CCW_ARC_TO_NV                                     = 0xF8
+	CIRCULAR_CW_ARC_TO_NV                                      = 0xFA
+	CIRCULAR_TANGENT_ARC_TO_NV                                 = 0xFC
 	CLAMP                                                      = 0x2900
 	CLAMP_FRAGMENT_COLOR                                       = 0x891B
 	CLAMP_READ_COLOR                                           = 0x891C
 	CLAMP_TO_BORDER                                            = 0x812D
+	CLAMP_TO_BORDER_ARB                                        = 0x812D
 	CLAMP_TO_EDGE                                              = 0x812F
 	CLAMP_VERTEX_COLOR                                         = 0x891A
 	CLEAR                                                      = 0x1500
@@ -4506,7 +6755,9 @@ const (
 	CLIENT_PIXEL_STORE_BIT                                     = 0x00000001
 	CLIENT_STORAGE_BIT                                         = 0x0200
 	CLIENT_VERTEX_ARRAY_BIT                                    = 0x00000002
+	CLIPPING_INPUT_PRIMITIVES                                  = 0x82F6
 	CLIPPING_INPUT_PRIMITIVES_ARB                              = 0x82F6
+	CLIPPING_OUTPUT_PRIMITIVES                                 = 0x82F7
 	CLIPPING_OUTPUT_PRIMITIVES_ARB                             = 0x82F7
 	CLIP_DEPTH_MODE                                            = 0x935D
 	CLIP_DISTANCE0                                             = 0x3000
@@ -4524,10 +6775,17 @@ const (
 	CLIP_PLANE3                                                = 0x3003
 	CLIP_PLANE4                                                = 0x3004
 	CLIP_PLANE5                                                = 0x3005
+	CLOSE_PATH_NV                                              = 0x00
 	COEFF                                                      = 0x0A00
 	COLOR                                                      = 0x1800
+	COLORBURN_KHR                                              = 0x929A
+	COLORBURN_NV                                               = 0x929A
+	COLORDODGE_KHR                                             = 0x9299
+	COLORDODGE_NV                                              = 0x9299
 	COLOR_ARRAY                                                = 0x8076
+	COLOR_ARRAY_ADDRESS_NV                                     = 0x8F23
 	COLOR_ARRAY_BUFFER_BINDING                                 = 0x8898
+	COLOR_ARRAY_LENGTH_NV                                      = 0x8F2D
 	COLOR_ARRAY_POINTER                                        = 0x8090
 	COLOR_ARRAY_SIZE                                           = 0x8081
 	COLOR_ARRAY_STRIDE                                         = 0x8083
@@ -4540,8 +6798,24 @@ const (
 	COLOR_ATTACHMENT13                                         = 0x8CED
 	COLOR_ATTACHMENT14                                         = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT5                                          = 0x8CE5
 	COLOR_ATTACHMENT6                                          = 0x8CE6
@@ -4559,6 +6833,7 @@ const (
 	COLOR_MATERIAL_FACE                                        = 0x0B55
 	COLOR_MATERIAL_PARAMETER                                   = 0x0B56
 	COLOR_RENDERABLE                                           = 0x8286
+	COLOR_SAMPLES_NV                                           = 0x8E20
 	COLOR_SUM                                                  = 0x8458
 	COLOR_WRITEMASK                                            = 0x0C23
 	COMBINE                                                    = 0x8570
@@ -4571,6 +6846,8 @@ const (
 	COMPILE                                                    = 0x1300
 	COMPILE_AND_EXECUTE                                        = 0x1301
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_ALPHA                                           = 0x84E9
 	COMPRESSED_INTENSITY                                       = 0x84EC
 	COMPRESSED_LUMINANCE                                       = 0x84EA
@@ -4601,10 +6878,14 @@ const (
 	COMPRESSED_RGBA_ASTC_8x8_KHR                               = 0x93B7
 	COMPRESSED_RGBA_BPTC_UNORM                                 = 0x8E8C
 	COMPRESSED_RGBA_BPTC_UNORM_ARB                             = 0x8E8C
+	COMPRESSED_RGBA_S3TC_DXT1_EXT                              = 0x83F1
+	COMPRESSED_RGBA_S3TC_DXT3_EXT                              = 0x83F2
+	COMPRESSED_RGBA_S3TC_DXT5_EXT                              = 0x83F3
 	COMPRESSED_RGB_BPTC_SIGNED_FLOAT                           = 0x8E8E
 	COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB                       = 0x8E8E
 	COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT                         = 0x8E8F
 	COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB                     = 0x8E8F
+	COMPRESSED_RGB_S3TC_DXT1_EXT                               = 0x83F0
 	COMPRESSED_RG_RGTC2                                        = 0x8DBD
 	COMPRESSED_SIGNED_R11_EAC                                  = 0x9271
 	COMPRESSED_SIGNED_RED_RGTC1                                = 0x8DBC
@@ -4636,12 +6917,25 @@ const (
 	COMPRESSED_TEXTURE_FORMATS                                 = 0x86A3
 	COMPUTE_SHADER                                             = 0x91B9
 	COMPUTE_SHADER_BIT                                         = 0x00000020
+	COMPUTE_SHADER_INVOCATIONS                                 = 0x82F5
 	COMPUTE_SHADER_INVOCATIONS_ARB                             = 0x82F5
 	COMPUTE_SUBROUTINE                                         = 0x92ED
 	COMPUTE_SUBROUTINE_UNIFORM                                 = 0x92F3
 	COMPUTE_TEXTURE                                            = 0x82A0
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
+	CONIC_CURVE_TO_NV                                          = 0x1A
+	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSTANT                                                   = 0x8576
 	CONSTANT_ALPHA                                             = 0x8003
 	CONSTANT_ATTENUATION                                       = 0x1207
@@ -4652,6 +6946,8 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT                                  = 0x00000008
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT                             = 0x00000004
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
@@ -4663,6 +6959,8 @@ const (
 	CONTEXT_RELEASE_BEHAVIOR_KHR                               = 0x82FB
 	CONTEXT_ROBUST_ACCESS                                      = 0x90F3
 	CONTEXT_ROBUST_ACCESS_KHR                                  = 0x90F3
+	CONTRAST_NV                                                = 0x92A1
+	CONVEX_HULL_NV                                             = 0x908B
 	COORD_REPLACE                                              = 0x8862
 	COPY                                                       = 0x1503
 	COPY_INVERTED                                              = 0x150C
@@ -4671,6 +6969,14 @@ const (
 	COPY_READ_BUFFER_BINDING                                   = 0x8F36
 	COPY_WRITE_BUFFER                                          = 0x8F37
 	COPY_WRITE_BUFFER_BINDING                                  = 0x8F37
+	COUNTER_RANGE_AMD                                          = 0x8BC1
+	COUNTER_TYPE_AMD                                           = 0x8BC0
+	COUNT_DOWN_NV                                              = 0x9089
+	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
+	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CULL_FACE                                                  = 0x0B44
 	CULL_FACE_MODE                                             = 0x0B45
 	CURRENT_BIT                                                = 0x00000001
@@ -4692,6 +6998,8 @@ const (
 	CURRENT_TEXTURE_COORDS                                     = 0x0B03
 	CURRENT_VERTEX_ATTRIB                                      = 0x8626
 	CW                                                         = 0x0900
+	DARKEN_KHR                                                 = 0x9297
+	DARKEN_NV                                                  = 0x9297
 	DEBUG_CALLBACK_FUNCTION                                    = 0x8244
 	DEBUG_CALLBACK_FUNCTION_ARB                                = 0x8244
 	DEBUG_CALLBACK_FUNCTION_KHR                                = 0x8244
@@ -4765,6 +7073,7 @@ const (
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_ARB                          = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_KHR                          = 0x824E
 	DECAL                                                      = 0x2101
+	DECODE_EXT                                                 = 0x8A49
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DELETE_STATUS                                              = 0x8B80
@@ -4786,6 +7095,7 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_SCALE                                                = 0x0D1E
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
@@ -4793,7 +7103,10 @@ const (
 	DEPTH_TEST                                                 = 0x0B71
 	DEPTH_TEXTURE_MODE                                         = 0x884B
 	DEPTH_WRITEMASK                                            = 0x0B72
+	DIFFERENCE_KHR                                             = 0x929E
+	DIFFERENCE_NV                                              = 0x929E
 	DIFFUSE                                                    = 0x1201
+	DISJOINT_NV                                                = 0x9283
 	DISPATCH_INDIRECT_BUFFER                                   = 0x90EE
 	DISPATCH_INDIRECT_BUFFER_BINDING                           = 0x90EF
 	DITHER                                                     = 0x0BD0
@@ -4815,6 +7128,9 @@ const (
 	DOUBLE_VEC2                                                = 0x8FFC
 	DOUBLE_VEC3                                                = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER1                                               = 0x8826
@@ -4832,48 +7148,80 @@ const (
 	DRAW_BUFFER7                                               = 0x882C
 	DRAW_BUFFER8                                               = 0x882D
 	DRAW_BUFFER9                                               = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
+	DRAW_INDIRECT_ADDRESS_NV                                   = 0x8F41
 	DRAW_INDIRECT_BUFFER                                       = 0x8F3F
 	DRAW_INDIRECT_BUFFER_BINDING                               = 0x8F43
+	DRAW_INDIRECT_LENGTH_NV                                    = 0x8F42
+	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DRAW_PIXEL_TOKEN                                           = 0x0705
 	DST_ALPHA                                                  = 0x0304
+	DST_ATOP_NV                                                = 0x928F
 	DST_COLOR                                                  = 0x0306
+	DST_IN_NV                                                  = 0x928B
+	DST_NV                                                     = 0x9287
+	DST_OUT_NV                                                 = 0x928D
+	DST_OVER_NV                                                = 0x9289
+	DUP_FIRST_CUBIC_CURVE_TO_NV                                = 0xF2
+	DUP_LAST_CUBIC_CURVE_TO_NV                                 = 0xF4
 	DYNAMIC_COPY                                               = 0x88EA
 	DYNAMIC_DRAW                                               = 0x88E8
 	DYNAMIC_READ                                               = 0x88E9
 	DYNAMIC_STORAGE_BIT                                        = 0x0100
 	EDGE_FLAG                                                  = 0x0B43
 	EDGE_FLAG_ARRAY                                            = 0x8079
+	EDGE_FLAG_ARRAY_ADDRESS_NV                                 = 0x8F26
 	EDGE_FLAG_ARRAY_BUFFER_BINDING                             = 0x889B
+	EDGE_FLAG_ARRAY_LENGTH_NV                                  = 0x8F30
 	EDGE_FLAG_ARRAY_POINTER                                    = 0x8093
 	EDGE_FLAG_ARRAY_STRIDE                                     = 0x808C
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
+	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_BARRIER_BIT                                  = 0x00000002
 	ELEMENT_ARRAY_BUFFER                                       = 0x8893
 	ELEMENT_ARRAY_BUFFER_BINDING                               = 0x8895
+	ELEMENT_ARRAY_LENGTH_NV                                    = 0x8F33
+	ELEMENT_ARRAY_UNIFIED_NV                                   = 0x8F1F
 	EMISSION                                                   = 0x1600
 	ENABLE_BIT                                                 = 0x00002000
 	EQUAL                                                      = 0x0202
 	EQUIV                                                      = 0x1509
 	EVAL_BIT                                                   = 0x00010000
+	EXCLUSION_KHR                                              = 0x92A0
+	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXP                                                        = 0x0800
 	EXP2                                                       = 0x0801
 	EXTENSIONS                                                 = 0x1F03
 	EYE_LINEAR                                                 = 0x2400
 	EYE_PLANE                                                  = 0x2502
+	FACTOR_MAX_AMD                                             = 0x901D
+	FACTOR_MIN_AMD                                             = 0x901C
 	FALSE                                                      = 0
 	FASTEST                                                    = 0x1101
 	FEEDBACK                                                   = 0x1C01
 	FEEDBACK_BUFFER_POINTER                                    = 0x0DF0
 	FEEDBACK_BUFFER_SIZE                                       = 0x0DF1
 	FEEDBACK_BUFFER_TYPE                                       = 0x0DF2
+	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
+	FIRST_TO_REST_NV                                           = 0x90AF
 	FIRST_VERTEX_CONVENTION                                    = 0x8E4D
 	FIXED                                                      = 0x140C
 	FIXED_ONLY                                                 = 0x891D
 	FLAT                                                       = 0x1D00
 	FLOAT                                                      = 0x1406
+	FLOAT16_NV                                                 = 0x8FF8
+	FLOAT16_VEC2_NV                                            = 0x8FF9
+	FLOAT16_VEC3_NV                                            = 0x8FFA
+	FLOAT16_VEC4_NV                                            = 0x8FFB
 	FLOAT_32_UNSIGNED_INT_24_8_REV                             = 0x8DAD
 	FLOAT_MAT2                                                 = 0x8B5A
 	FLOAT_MAT2x3                                               = 0x8B65
@@ -4899,7 +7247,9 @@ const (
 	FOG_COORDINATE_ARRAY_TYPE                                  = 0x8454
 	FOG_COORDINATE_SOURCE                                      = 0x8450
 	FOG_COORD_ARRAY                                            = 0x8457
+	FOG_COORD_ARRAY_ADDRESS_NV                                 = 0x8F28
 	FOG_COORD_ARRAY_BUFFER_BINDING                             = 0x889D
+	FOG_COORD_ARRAY_LENGTH_NV                                  = 0x8F32
 	FOG_COORD_ARRAY_POINTER                                    = 0x8456
 	FOG_COORD_ARRAY_STRIDE                                     = 0x8455
 	FOG_COORD_ARRAY_TYPE                                       = 0x8454
@@ -4910,13 +7260,37 @@ const (
 	FOG_INDEX                                                  = 0x0B61
 	FOG_MODE                                                   = 0x0B65
 	FOG_START                                                  = 0x0B63
+	FONT_ASCENDER_BIT_NV                                       = 0x00200000
+	FONT_DESCENDER_BIT_NV                                      = 0x00400000
+	FONT_GLYPHS_AVAILABLE_NV                                   = 0x9368
+	FONT_HAS_KERNING_BIT_NV                                    = 0x10000000
+	FONT_HEIGHT_BIT_NV                                         = 0x00800000
+	FONT_MAX_ADVANCE_HEIGHT_BIT_NV                             = 0x02000000
+	FONT_MAX_ADVANCE_WIDTH_BIT_NV                              = 0x01000000
+	FONT_NUM_GLYPH_INDICES_BIT_NV                              = 0x20000000
+	FONT_TARGET_UNAVAILABLE_NV                                 = 0x9369
+	FONT_UNAVAILABLE_NV                                        = 0x936A
+	FONT_UNDERLINE_POSITION_BIT_NV                             = 0x04000000
+	FONT_UNDERLINE_THICKNESS_BIT_NV                            = 0x08000000
+	FONT_UNINTELLIGIBLE_NV                                     = 0x936B
+	FONT_UNITS_PER_EM_BIT_NV                                   = 0x00100000
+	FONT_X_MAX_BOUNDS_BIT_NV                                   = 0x00040000
+	FONT_X_MIN_BOUNDS_BIT_NV                                   = 0x00010000
+	FONT_Y_MAX_BOUNDS_BIT_NV                                   = 0x00080000
+	FONT_Y_MIN_BOUNDS_BIT_NV                                   = 0x00020000
 	FRACTIONAL_EVEN                                            = 0x8E7C
 	FRACTIONAL_ODD                                             = 0x8E7B
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
 	FRAGMENT_DEPTH                                             = 0x8452
+	FRAGMENT_INPUT_NV                                          = 0x936D
 	FRAGMENT_INTERPOLATION_OFFSET_BITS                         = 0x8E5D
 	FRAGMENT_SHADER                                            = 0x8B30
 	FRAGMENT_SHADER_BIT                                        = 0x00000002
+	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
+	FRAGMENT_SHADER_INVOCATIONS                                = 0x82F4
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -4929,13 +7303,16 @@ const (
 	FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE                          = 0x8216
 	FRAMEBUFFER_ATTACHMENT_GREEN_SIZE                          = 0x8213
 	FRAMEBUFFER_ATTACHMENT_LAYERED                             = 0x8DA7
+	FRAMEBUFFER_ATTACHMENT_LAYERED_ARB                         = 0x8DA7
 	FRAMEBUFFER_ATTACHMENT_OBJECT_NAME                         = 0x8CD1
 	FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE                         = 0x8CD0
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
 	FRAMEBUFFER_BLEND                                          = 0x828B
@@ -4948,18 +7325,26 @@ const (
 	FRAMEBUFFER_DEFAULT_WIDTH                                  = 0x9310
 	FRAMEBUFFER_INCOMPLETE_ATTACHMENT                          = 0x8CD6
 	FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER                         = 0x8CDB
+	FRAMEBUFFER_INCOMPLETE_LAYER_COUNT_ARB                     = 0x8DA9
 	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS                       = 0x8DA8
+	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS_ARB                   = 0x8DA8
 	FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT                  = 0x8CD7
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE                         = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_UNDEFINED                                      = 0x8219
 	FRAMEBUFFER_UNSUPPORTED                                    = 0x8CDD
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_SUPPORT                                               = 0x82B7
@@ -4969,31 +7354,59 @@ const (
 	GENERATE_MIPMAP                                            = 0x8191
 	GENERATE_MIPMAP_HINT                                       = 0x8192
 	GEOMETRY_INPUT_TYPE                                        = 0x8917
+	GEOMETRY_INPUT_TYPE_ARB                                    = 0x8DDB
 	GEOMETRY_OUTPUT_TYPE                                       = 0x8918
+	GEOMETRY_OUTPUT_TYPE_ARB                                   = 0x8DDC
 	GEOMETRY_SHADER                                            = 0x8DD9
+	GEOMETRY_SHADER_ARB                                        = 0x8DD9
 	GEOMETRY_SHADER_BIT                                        = 0x00000004
 	GEOMETRY_SHADER_INVOCATIONS                                = 0x887F
+	GEOMETRY_SHADER_PRIMITIVES_EMITTED                         = 0x82F3
 	GEOMETRY_SHADER_PRIMITIVES_EMITTED_ARB                     = 0x82F3
 	GEOMETRY_SUBROUTINE                                        = 0x92EB
 	GEOMETRY_SUBROUTINE_UNIFORM                                = 0x92F1
 	GEOMETRY_TEXTURE                                           = 0x829E
 	GEOMETRY_VERTICES_OUT                                      = 0x8916
+	GEOMETRY_VERTICES_OUT_ARB                                  = 0x8DDA
 	GEQUAL                                                     = 0x0206
 	GET_TEXTURE_IMAGE_FORMAT                                   = 0x8291
 	GET_TEXTURE_IMAGE_TYPE                                     = 0x8292
+	GLYPH_HAS_KERNING_BIT_NV                                   = 0x100
+	GLYPH_HEIGHT_BIT_NV                                        = 0x02
+	GLYPH_HORIZONTAL_BEARING_ADVANCE_BIT_NV                    = 0x10
+	GLYPH_HORIZONTAL_BEARING_X_BIT_NV                          = 0x04
+	GLYPH_HORIZONTAL_BEARING_Y_BIT_NV                          = 0x08
+	GLYPH_VERTICAL_BEARING_ADVANCE_BIT_NV                      = 0x80
+	GLYPH_VERTICAL_BEARING_X_BIT_NV                            = 0x20
+	GLYPH_VERTICAL_BEARING_Y_BIT_NV                            = 0x40
+	GLYPH_WIDTH_BIT_NV                                         = 0x01
+	GPU_ADDRESS_NV                                             = 0x8F34
 	GREATER                                                    = 0x0204
 	GREEN                                                      = 0x1904
 	GREEN_BIAS                                                 = 0x0D19
 	GREEN_BITS                                                 = 0x0D53
 	GREEN_INTEGER                                              = 0x8D95
+	GREEN_NV                                                   = 0x1904
 	GREEN_SCALE                                                = 0x0D18
 	GUILTY_CONTEXT_RESET                                       = 0x8253
 	GUILTY_CONTEXT_RESET_ARB                                   = 0x8253
 	GUILTY_CONTEXT_RESET_KHR                                   = 0x8253
 	HALF_FLOAT                                                 = 0x140B
+	HARDLIGHT_KHR                                              = 0x929B
+	HARDLIGHT_NV                                               = 0x929B
+	HARDMIX_NV                                                 = 0x92A9
 	HIGH_FLOAT                                                 = 0x8DF2
 	HIGH_INT                                                   = 0x8DF5
 	HINT_BIT                                                   = 0x00008000
+	HORIZONTAL_LINE_TO_NV                                      = 0x06
+	HSL_COLOR_KHR                                              = 0x92AF
+	HSL_COLOR_NV                                               = 0x92AF
+	HSL_HUE_KHR                                                = 0x92AD
+	HSL_HUE_NV                                                 = 0x92AD
+	HSL_LUMINOSITY_KHR                                         = 0x92B0
+	HSL_LUMINOSITY_NV                                          = 0x92B0
+	HSL_SATURATION_KHR                                         = 0x92AE
+	HSL_SATURATION_NV                                          = 0x92AE
 	IMAGE_1D                                                   = 0x904C
 	IMAGE_1D_ARRAY                                             = 0x9052
 	IMAGE_2D                                                   = 0x904D
@@ -5031,10 +7444,13 @@ const (
 	IMAGE_TEXEL_SIZE                                           = 0x82A7
 	IMPLEMENTATION_COLOR_READ_FORMAT                           = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
 	INDEX_ARRAY                                                = 0x8077
+	INDEX_ARRAY_ADDRESS_NV                                     = 0x8F24
 	INDEX_ARRAY_BUFFER_BINDING                                 = 0x8899
+	INDEX_ARRAY_LENGTH_NV                                      = 0x8F2E
 	INDEX_ARRAY_POINTER                                        = 0x8091
 	INDEX_ARRAY_STRIDE                                         = 0x8086
 	INDEX_ARRAY_TYPE                                           = 0x8085
@@ -5050,6 +7466,22 @@ const (
 	INNOCENT_CONTEXT_RESET_ARB                                 = 0x8254
 	INNOCENT_CONTEXT_RESET_KHR                                 = 0x8254
 	INT                                                        = 0x1404
+	INT16_NV                                                   = 0x8FE4
+	INT16_VEC2_NV                                              = 0x8FE5
+	INT16_VEC3_NV                                              = 0x8FE6
+	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
+	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
+	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
+	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
+	INT64_VEC4_NV                                              = 0x8FEB
+	INT8_NV                                                    = 0x8FE0
+	INT8_VEC2_NV                                               = 0x8FE1
+	INT8_VEC3_NV                                               = 0x8FE2
+	INT8_VEC4_NV                                               = 0x8FE3
 	INTENSITY                                                  = 0x8049
 	INTENSITY12                                                = 0x804C
 	INTENSITY16                                                = 0x804D
@@ -5105,10 +7537,15 @@ const (
 	INVALID_OPERATION                                          = 0x0502
 	INVALID_VALUE                                              = 0x0501
 	INVERT                                                     = 0x150A
+	INVERT_OVG_NV                                              = 0x92B4
+	INVERT_RGB_NV                                              = 0x92A3
 	ISOLINES                                                   = 0x8E7A
 	IS_PER_PATCH                                               = 0x92E7
 	IS_ROW_MAJOR                                               = 0x9300
+	ITALIC_BIT_NV                                              = 0x02
 	KEEP                                                       = 0x1E00
+	LARGE_CCW_ARC_TO_NV                                        = 0x16
+	LARGE_CW_ARC_TO_NV                                         = 0x18
 	LAST_VERTEX_CONVENTION                                     = 0x8E4E
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
 	LEFT                                                       = 0x0406
@@ -5122,6 +7559,8 @@ const (
 	LIGHT5                                                     = 0x4005
 	LIGHT6                                                     = 0x4006
 	LIGHT7                                                     = 0x4007
+	LIGHTEN_KHR                                                = 0x9298
+	LIGHTEN_NV                                                 = 0x9298
 	LIGHTING                                                   = 0x0B50
 	LIGHTING_BIT                                               = 0x00000040
 	LIGHT_MODEL_AMBIENT                                        = 0x0B53
@@ -5130,11 +7569,15 @@ const (
 	LIGHT_MODEL_TWO_SIDE                                       = 0x0B52
 	LINE                                                       = 0x1B01
 	LINEAR                                                     = 0x2601
+	LINEARBURN_NV                                              = 0x92A5
+	LINEARDODGE_NV                                             = 0x92A4
+	LINEARLIGHT_NV                                             = 0x92A7
 	LINEAR_ATTENUATION                                         = 0x1208
 	LINEAR_MIPMAP_LINEAR                                       = 0x2703
 	LINEAR_MIPMAP_NEAREST                                      = 0x2701
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
+	LINES_ADJACENCY_ARB                                        = 0x000A
 	LINE_BIT                                                   = 0x00000004
 	LINE_LOOP                                                  = 0x0002
 	LINE_RESET_TOKEN                                           = 0x0707
@@ -5145,8 +7588,11 @@ const (
 	LINE_STIPPLE_REPEAT                                        = 0x0B26
 	LINE_STRIP                                                 = 0x0003
 	LINE_STRIP_ADJACENCY                                       = 0x000B
+	LINE_STRIP_ADJACENCY_ARB                                   = 0x000B
 	LINE_TOKEN                                                 = 0x0702
+	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -5293,12 +7739,17 @@ const (
 	MAX_GEOMETRY_INPUT_COMPONENTS                              = 0x9123
 	MAX_GEOMETRY_OUTPUT_COMPONENTS                             = 0x9124
 	MAX_GEOMETRY_OUTPUT_VERTICES                               = 0x8DE0
+	MAX_GEOMETRY_OUTPUT_VERTICES_ARB                           = 0x8DE0
 	MAX_GEOMETRY_SHADER_INVOCATIONS                            = 0x8E5A
 	MAX_GEOMETRY_SHADER_STORAGE_BLOCKS                         = 0x90D7
 	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS                           = 0x8C29
+	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS_ARB                       = 0x8C29
 	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS                       = 0x8DE1
+	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS_ARB                   = 0x8DE1
 	MAX_GEOMETRY_UNIFORM_BLOCKS                                = 0x8A2C
 	MAX_GEOMETRY_UNIFORM_COMPONENTS                            = 0x8DDF
+	MAX_GEOMETRY_UNIFORM_COMPONENTS_ARB                        = 0x8DDF
+	MAX_GEOMETRY_VARYING_COMPONENTS_ARB                        = 0x8DDD
 	MAX_HEIGHT                                                 = 0x827F
 	MAX_IMAGE_SAMPLES                                          = 0x906D
 	MAX_IMAGE_UNITS                                            = 0x8F38
@@ -5309,6 +7760,7 @@ const (
 	MAX_LIGHTS                                                 = 0x0D31
 	MAX_LIST_NESTING                                           = 0x0B31
 	MAX_MODELVIEW_STACK_DEPTH                                  = 0x0D36
+	MAX_MULTISAMPLE_COVERAGE_MODES_NV                          = 0x8E11
 	MAX_NAME_LENGTH                                            = 0x92F6
 	MAX_NAME_STACK_DEPTH                                       = 0x0D37
 	MAX_NUM_ACTIVE_VARIABLES                                   = 0x92F7
@@ -5320,16 +7772,21 @@ const (
 	MAX_PROGRAM_TEXTURE_GATHER_OFFSET                          = 0x8E5F
 	MAX_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5F
 	MAX_PROJECTION_STACK_DEPTH                                 = 0x0D38
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RENDERBUFFER_SIZE                                      = 0x84E8
 	MAX_SAMPLES                                                = 0x8D57
 	MAX_SAMPLE_MASK_WORDS                                      = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
+	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SPARSE_3D_TEXTURE_SIZE_ARB                             = 0x9199
 	MAX_SPARSE_ARRAY_TEXTURE_LAYERS_ARB                        = 0x919A
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -5354,9 +7811,11 @@ const (
 	MAX_TESS_GEN_LEVEL                                         = 0x8E7E
 	MAX_TESS_PATCH_COMPONENTS                                  = 0x8E84
 	MAX_TEXTURE_BUFFER_SIZE                                    = 0x8C2B
+	MAX_TEXTURE_BUFFER_SIZE_ARB                                = 0x8C2B
 	MAX_TEXTURE_COORDS                                         = 0x8871
 	MAX_TEXTURE_IMAGE_UNITS                                    = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TEXTURE_STACK_DEPTH                                    = 0x0D39
 	MAX_TEXTURE_UNITS                                          = 0x84E2
@@ -5384,13 +7843,18 @@ const (
 	MAX_VERTEX_UNIFORM_BLOCKS                                  = 0x8A2B
 	MAX_VERTEX_UNIFORM_COMPONENTS                              = 0x8B4A
 	MAX_VERTEX_UNIFORM_VECTORS                                 = 0x8DFB
+	MAX_VERTEX_VARYING_COMPONENTS_ARB                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
 	MINOR_VERSION                                              = 0x821C
+	MINUS_CLAMPED_NV                                           = 0x92B3
+	MINUS_NV                                                   = 0x929F
 	MIN_FRAGMENT_INTERPOLATION_OFFSET                          = 0x8E5B
 	MIN_MAP_BUFFER_ALIGNMENT                                   = 0x90BC
 	MIN_PROGRAM_TEXEL_OFFSET                                   = 0x8904
@@ -5398,17 +7862,31 @@ const (
 	MIN_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5E
 	MIN_SAMPLE_SHADING_VALUE                                   = 0x8C37
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
+	MIRRORED_REPEAT_ARB                                        = 0x8370
 	MIRROR_CLAMP_TO_EDGE                                       = 0x8743
+	MITER_REVERT_NV                                            = 0x90A7
+	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
 	MODELVIEW                                                  = 0x1700
 	MODELVIEW_MATRIX                                           = 0x0BA6
 	MODELVIEW_STACK_DEPTH                                      = 0x0BA3
 	MODULATE                                                   = 0x2100
+	MOVE_TO_CONTINUES_NV                                       = 0x90B6
+	MOVE_TO_NV                                                 = 0x02
+	MOVE_TO_RESETS_NV                                          = 0x90B5
 	MULT                                                       = 0x0103
+	MULTIPLY_KHR                                               = 0x9294
+	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
 	MULTISAMPLE_BIT                                            = 0x20000000
+	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	N3F_V3F                                                    = 0x2A25
 	NAMED_STRING_LENGTH_ARB                                    = 0x8DE9
 	NAMED_STRING_TYPE_ARB                                      = 0x8DEA
@@ -5423,10 +7901,13 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
 	NORMALIZE                                                  = 0x0BA1
 	NORMAL_ARRAY                                               = 0x8075
+	NORMAL_ARRAY_ADDRESS_NV                                    = 0x8F22
 	NORMAL_ARRAY_BUFFER_BINDING                                = 0x8897
+	NORMAL_ARRAY_LENGTH_NV                                     = 0x8F2C
 	NORMAL_ARRAY_POINTER                                       = 0x808F
 	NORMAL_ARRAY_STRIDE                                        = 0x807F
 	NORMAL_ARRAY_TYPE                                          = 0x807E
@@ -5444,7 +7925,10 @@ const (
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
 	NUM_SHADING_LANGUAGE_VERSIONS                              = 0x82E9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_LINEAR                                              = 0x2401
 	OBJECT_PLANE                                               = 0x2501
 	OBJECT_TYPE                                                = 0x9112
@@ -5469,6 +7953,8 @@ const (
 	OR_INVERTED                                                = 0x150D
 	OR_REVERSE                                                 = 0x150B
 	OUT_OF_MEMORY                                              = 0x0505
+	OVERLAY_KHR                                                = 0x9296
+	OVERLAY_NV                                                 = 0x9296
 	PACK_ALIGNMENT                                             = 0x0D05
 	PACK_COMPRESSED_BLOCK_DEPTH                                = 0x912D
 	PACK_COMPRESSED_BLOCK_HEIGHT                               = 0x912C
@@ -5481,14 +7967,87 @@ const (
 	PACK_SKIP_PIXELS                                           = 0x0D04
 	PACK_SKIP_ROWS                                             = 0x0D03
 	PACK_SWAP_BYTES                                            = 0x0D00
+	PARAMETER_BUFFER                                           = 0x80EE
 	PARAMETER_BUFFER_ARB                                       = 0x80EE
+	PARAMETER_BUFFER_BINDING                                   = 0x80EF
 	PARAMETER_BUFFER_BINDING_ARB                               = 0x80EF
 	PASS_THROUGH_TOKEN                                         = 0x0700
 	PATCHES                                                    = 0x000E
 	PATCH_DEFAULT_INNER_LEVEL                                  = 0x8E73
 	PATCH_DEFAULT_OUTER_LEVEL                                  = 0x8E74
 	PATCH_VERTICES                                             = 0x8E72
+	PATH_CLIENT_LENGTH_NV                                      = 0x907F
+	PATH_COMMAND_COUNT_NV                                      = 0x909D
+	PATH_COMPUTED_LENGTH_NV                                    = 0x90A0
+	PATH_COORD_COUNT_NV                                        = 0x909E
+	PATH_COVER_DEPTH_FUNC_NV                                   = 0x90BF
+	PATH_DASH_ARRAY_COUNT_NV                                   = 0x909F
+	PATH_DASH_CAPS_NV                                          = 0x907B
+	PATH_DASH_OFFSET_NV                                        = 0x907E
+	PATH_DASH_OFFSET_RESET_NV                                  = 0x90B4
+	PATH_END_CAPS_NV                                           = 0x9076
+	PATH_ERROR_POSITION_NV                                     = 0x90AB
+	PATH_FILL_BOUNDING_BOX_NV                                  = 0x90A1
+	PATH_FILL_COVER_MODE_NV                                    = 0x9082
+	PATH_FILL_MASK_NV                                          = 0x9081
+	PATH_FILL_MODE_NV                                          = 0x9080
+	PATH_FORMAT_PS_NV                                          = 0x9071
+	PATH_FORMAT_SVG_NV                                         = 0x9070
+	PATH_GEN_COEFF_NV                                          = 0x90B1
+	PATH_GEN_COMPONENTS_NV                                     = 0x90B3
+	PATH_GEN_MODE_NV                                           = 0x90B0
+	PATH_INITIAL_DASH_CAP_NV                                   = 0x907C
+	PATH_INITIAL_END_CAP_NV                                    = 0x9077
+	PATH_JOIN_STYLE_NV                                         = 0x9079
+	PATH_MAX_MODELVIEW_STACK_DEPTH_NV                          = 0x0D36
+	PATH_MAX_PROJECTION_STACK_DEPTH_NV                         = 0x0D38
+	PATH_MITER_LIMIT_NV                                        = 0x907A
+	PATH_MODELVIEW_MATRIX_NV                                   = 0x0BA6
+	PATH_MODELVIEW_NV                                          = 0x1700
+	PATH_MODELVIEW_STACK_DEPTH_NV                              = 0x0BA3
+	PATH_OBJECT_BOUNDING_BOX_NV                                = 0x908A
+	PATH_PROJECTION_MATRIX_NV                                  = 0x0BA7
+	PATH_PROJECTION_NV                                         = 0x1701
+	PATH_PROJECTION_STACK_DEPTH_NV                             = 0x0BA4
+	PATH_STENCIL_DEPTH_OFFSET_FACTOR_NV                        = 0x90BD
+	PATH_STENCIL_DEPTH_OFFSET_UNITS_NV                         = 0x90BE
+	PATH_STENCIL_FUNC_NV                                       = 0x90B7
+	PATH_STENCIL_REF_NV                                        = 0x90B8
+	PATH_STENCIL_VALUE_MASK_NV                                 = 0x90B9
+	PATH_STROKE_BOUNDING_BOX_NV                                = 0x90A2
+	PATH_STROKE_COVER_MODE_NV                                  = 0x9083
+	PATH_STROKE_MASK_NV                                        = 0x9084
+	PATH_STROKE_WIDTH_NV                                       = 0x9075
+	PATH_TERMINAL_DASH_CAP_NV                                  = 0x907D
+	PATH_TERMINAL_END_CAP_NV                                   = 0x9078
+	PATH_TRANSPOSE_MODELVIEW_MATRIX_NV                         = 0x84E3
+	PATH_TRANSPOSE_PROJECTION_MATRIX_NV                        = 0x84E4
+	PERCENTAGE_AMD                                             = 0x8BC3
+	PERFMON_RESULT_AMD                                         = 0x8BC6
+	PERFMON_RESULT_AVAILABLE_AMD                               = 0x8BC4
+	PERFMON_RESULT_SIZE_AMD                                    = 0x8BC5
+	PERFQUERY_COUNTER_DATA_BOOL32_INTEL                        = 0x94FC
+	PERFQUERY_COUNTER_DATA_DOUBLE_INTEL                        = 0x94FB
+	PERFQUERY_COUNTER_DATA_FLOAT_INTEL                         = 0x94FA
+	PERFQUERY_COUNTER_DATA_UINT32_INTEL                        = 0x94F8
+	PERFQUERY_COUNTER_DATA_UINT64_INTEL                        = 0x94F9
+	PERFQUERY_COUNTER_DESC_LENGTH_MAX_INTEL                    = 0x94FF
+	PERFQUERY_COUNTER_DURATION_NORM_INTEL                      = 0x94F1
+	PERFQUERY_COUNTER_DURATION_RAW_INTEL                       = 0x94F2
+	PERFQUERY_COUNTER_EVENT_INTEL                              = 0x94F0
+	PERFQUERY_COUNTER_NAME_LENGTH_MAX_INTEL                    = 0x94FE
+	PERFQUERY_COUNTER_RAW_INTEL                                = 0x94F4
+	PERFQUERY_COUNTER_THROUGHPUT_INTEL                         = 0x94F3
+	PERFQUERY_COUNTER_TIMESTAMP_INTEL                          = 0x94F5
+	PERFQUERY_DONOT_FLUSH_INTEL                                = 0x83F9
+	PERFQUERY_FLUSH_INTEL                                      = 0x83FA
+	PERFQUERY_GLOBAL_CONTEXT_INTEL                             = 0x00000001
+	PERFQUERY_GPA_EXTENDED_COUNTERS_INTEL                      = 0x9500
+	PERFQUERY_QUERY_NAME_LENGTH_MAX_INTEL                      = 0x94FD
+	PERFQUERY_SINGLE_CONTEXT_INTEL                             = 0x00000000
+	PERFQUERY_WAIT_INTEL                                       = 0x83FB
 	PERSPECTIVE_CORRECTION_HINT                                = 0x0C50
+	PINLIGHT_NV                                                = 0x92A8
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_MAP_A_TO_A                                           = 0x0C79
 	PIXEL_MAP_A_TO_A_SIZE                                      = 0x0CB9
@@ -5512,9 +8071,17 @@ const (
 	PIXEL_MAP_S_TO_S_SIZE                                      = 0x0CB1
 	PIXEL_MODE_BIT                                             = 0x00000020
 	PIXEL_PACK_BUFFER                                          = 0x88EB
+	PIXEL_PACK_BUFFER_ARB                                      = 0x88EB
 	PIXEL_PACK_BUFFER_BINDING                                  = 0x88ED
+	PIXEL_PACK_BUFFER_BINDING_ARB                              = 0x88ED
 	PIXEL_UNPACK_BUFFER                                        = 0x88EC
+	PIXEL_UNPACK_BUFFER_ARB                                    = 0x88EC
 	PIXEL_UNPACK_BUFFER_BINDING                                = 0x88EF
+	PIXEL_UNPACK_BUFFER_BINDING_ARB                            = 0x88EF
+	PLUS_CLAMPED_ALPHA_NV                                      = 0x92B2
+	PLUS_CLAMPED_NV                                            = 0x92B1
+	PLUS_DARKER_NV                                             = 0x9292
+	PLUS_NV                                                    = 0x9291
 	POINT                                                      = 0x1B00
 	POINTS                                                     = 0x0000
 	POINT_BIT                                                  = 0x00000002
@@ -5533,6 +8100,9 @@ const (
 	POLYGON                                                    = 0x0009
 	POLYGON_BIT                                                = 0x00000008
 	POLYGON_MODE                                               = 0x0B40
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FILL                                        = 0x8037
 	POLYGON_OFFSET_LINE                                        = 0x2A02
@@ -5547,22 +8117,36 @@ const (
 	PREVIOUS                                                   = 0x8578
 	PRIMARY_COLOR                                              = 0x8577
 	PRIMITIVES_GENERATED                                       = 0x8C87
+	PRIMITIVES_SUBMITTED                                       = 0x82EF
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
 	PRIMITIVE_RESTART_FOR_PATCHES_SUPPORTED                    = 0x8221
 	PRIMITIVE_RESTART_INDEX                                    = 0x8F9E
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_INPUT                                              = 0x92E3
 	PROGRAM_KHR                                                = 0x82E2
+	PROGRAM_MATRIX_EXT                                         = 0x8E2D
+	PROGRAM_MATRIX_STACK_DEPTH_EXT                             = 0x8E2F
+	PROGRAM_OBJECT_EXT                                         = 0x8B40
 	PROGRAM_OUTPUT                                             = 0x92E4
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
+	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
+	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
+	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
 	PROGRAM_SEPARABLE                                          = 0x8258
+	PROGRAM_SEPARABLE_EXT                                      = 0x8258
 	PROJECTION                                                 = 0x1701
 	PROJECTION_MATRIX                                          = 0x0BA7
 	PROJECTION_STACK_DEPTH                                     = 0x0BA4
@@ -5580,6 +8164,7 @@ const (
 	PROXY_TEXTURE_RECTANGLE                                    = 0x84F7
 	Q                                                          = 0x2003
 	QUADRATIC_ATTENUATION                                      = 0x1209
+	QUADRATIC_CURVE_TO_NV                                      = 0x0A
 	QUADS                                                      = 0x0007
 	QUADS_FOLLOW_PROVOKING_VERTEX_CONVENTION                   = 0x8E4C
 	QUAD_STRIP                                                 = 0x0008
@@ -5589,18 +8174,23 @@ const (
 	QUERY_BUFFER_BINDING                                       = 0x9193
 	QUERY_BY_REGION_NO_WAIT                                    = 0x8E16
 	QUERY_BY_REGION_NO_WAIT_INVERTED                           = 0x8E1A
+	QUERY_BY_REGION_NO_WAIT_NV                                 = 0x8E16
 	QUERY_BY_REGION_WAIT                                       = 0x8E15
 	QUERY_BY_REGION_WAIT_INVERTED                              = 0x8E19
+	QUERY_BY_REGION_WAIT_NV                                    = 0x8E15
 	QUERY_COUNTER_BITS                                         = 0x8864
 	QUERY_KHR                                                  = 0x82E3
 	QUERY_NO_WAIT                                              = 0x8E14
 	QUERY_NO_WAIT_INVERTED                                     = 0x8E18
+	QUERY_NO_WAIT_NV                                           = 0x8E14
+	QUERY_OBJECT_EXT                                           = 0x9153
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
 	QUERY_RESULT_NO_WAIT                                       = 0x9194
 	QUERY_TARGET                                               = 0x82EA
 	QUERY_WAIT                                                 = 0x8E13
 	QUERY_WAIT_INVERTED                                        = 0x8E17
+	QUERY_WAIT_NV                                              = 0x8E13
 	R                                                          = 0x2002
 	R11F_G11F_B10F                                             = 0x8C3A
 	R16                                                        = 0x822A
@@ -5617,6 +8207,9 @@ const (
 	R8UI                                                       = 0x8232
 	R8_SNORM                                                   = 0x8F94
 	RASTERIZER_DISCARD                                         = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -5625,10 +8218,12 @@ const (
 	READ_PIXELS_FORMAT                                         = 0x828D
 	READ_PIXELS_TYPE                                           = 0x828E
 	READ_WRITE                                                 = 0x88BA
+	RECT_NV                                                    = 0xF6
 	RED                                                        = 0x1903
 	RED_BIAS                                                   = 0x0D15
 	RED_BITS                                                   = 0x0D52
 	RED_INTEGER                                                = 0x8D94
+	RED_NV                                                     = 0x1903
 	RED_SCALE                                                  = 0x0D14
 	REFERENCED_BY_COMPUTE_SHADER                               = 0x930B
 	REFERENCED_BY_FRAGMENT_SHADER                              = 0x930A
@@ -5637,11 +8232,32 @@ const (
 	REFERENCED_BY_TESS_EVALUATION_SHADER                       = 0x9308
 	REFERENCED_BY_VERTEX_SHADER                                = 0x9306
 	REFLECTION_MAP                                             = 0x8512
+	RELATIVE_ARC_TO_NV                                         = 0xFF
+	RELATIVE_CONIC_CURVE_TO_NV                                 = 0x1B
+	RELATIVE_CUBIC_CURVE_TO_NV                                 = 0x0D
+	RELATIVE_HORIZONTAL_LINE_TO_NV                             = 0x07
+	RELATIVE_LARGE_CCW_ARC_TO_NV                               = 0x17
+	RELATIVE_LARGE_CW_ARC_TO_NV                                = 0x19
+	RELATIVE_LINE_TO_NV                                        = 0x05
+	RELATIVE_MOVE_TO_NV                                        = 0x03
+	RELATIVE_QUADRATIC_CURVE_TO_NV                             = 0x0B
+	RELATIVE_RECT_NV                                           = 0xF7
+	RELATIVE_ROUNDED_RECT2_NV                                  = 0xEB
+	RELATIVE_ROUNDED_RECT4_NV                                  = 0xED
+	RELATIVE_ROUNDED_RECT8_NV                                  = 0xEF
+	RELATIVE_ROUNDED_RECT_NV                                   = 0xE9
+	RELATIVE_SMALL_CCW_ARC_TO_NV                               = 0x13
+	RELATIVE_SMALL_CW_ARC_TO_NV                                = 0x15
+	RELATIVE_SMOOTH_CUBIC_CURVE_TO_NV                          = 0x11
+	RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV                      = 0x0F
+	RELATIVE_VERTICAL_LINE_TO_NV                               = 0x09
 	RENDER                                                     = 0x1C00
 	RENDERBUFFER                                               = 0x8D41
 	RENDERBUFFER_ALPHA_SIZE                                    = 0x8D53
 	RENDERBUFFER_BINDING                                       = 0x8CA7
 	RENDERBUFFER_BLUE_SIZE                                     = 0x8D52
+	RENDERBUFFER_COLOR_SAMPLES_NV                              = 0x8E10
+	RENDERBUFFER_COVERAGE_SAMPLES_NV                           = 0x8CAB
 	RENDERBUFFER_DEPTH_SIZE                                    = 0x8D54
 	RENDERBUFFER_GREEN_SIZE                                    = 0x8D51
 	RENDERBUFFER_HEIGHT                                        = 0x8D43
@@ -5658,6 +8274,7 @@ const (
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
 	RESET_NOTIFICATION_STRATEGY_ARB                            = 0x8256
 	RESET_NOTIFICATION_STRATEGY_KHR                            = 0x8256
+	RESTART_PATH_NV                                            = 0xF0
 	RETURN                                                     = 0x0102
 	RG                                                         = 0x8227
 	RG16                                                       = 0x822C
@@ -5712,10 +8329,17 @@ const (
 	RGBA8_SNORM                                                = 0x8F97
 	RGBA_INTEGER                                               = 0x8D99
 	RGBA_MODE                                                  = 0x0C31
+	RGB_422_APPLE                                              = 0x8A1F
 	RGB_INTEGER                                                = 0x8D98
+	RGB_RAW_422_APPLE                                          = 0x8A51
 	RGB_SCALE                                                  = 0x8573
 	RG_INTEGER                                                 = 0x8228
 	RIGHT                                                      = 0x0407
+	ROUNDED_RECT2_NV                                           = 0xEA
+	ROUNDED_RECT4_NV                                           = 0xEC
+	ROUNDED_RECT8_NV                                           = 0xEE
+	ROUNDED_RECT_NV                                            = 0xE8
+	ROUND_NV                                                   = 0x90A4
 	S                                                          = 0x2000
 	SAMPLER                                                    = 0x82E6
 	SAMPLER_1D                                                 = 0x8B5D
@@ -5748,6 +8372,14 @@ const (
 	SAMPLE_COVERAGE                                            = 0x80A0
 	SAMPLE_COVERAGE_INVERT                                     = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_VALUE                                          = 0x8E52
 	SAMPLE_POSITION                                            = 0x8E50
@@ -5755,9 +8387,14 @@ const (
 	SAMPLE_SHADING_ARB                                         = 0x8C36
 	SCISSOR_BIT                                                = 0x00080000
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
+	SCREEN_KHR                                                 = 0x9295
+	SCREEN_NV                                                  = 0x9295
 	SECONDARY_COLOR_ARRAY                                      = 0x845E
+	SECONDARY_COLOR_ARRAY_ADDRESS_NV                           = 0x8F27
 	SECONDARY_COLOR_ARRAY_BUFFER_BINDING                       = 0x889C
+	SECONDARY_COLOR_ARRAY_LENGTH_NV                            = 0x8F31
 	SECONDARY_COLOR_ARRAY_POINTER                              = 0x845D
 	SECONDARY_COLOR_ARRAY_SIZE                                 = 0x845A
 	SECONDARY_COLOR_ARRAY_STRIDE                               = 0x845C
@@ -5770,13 +8407,17 @@ const (
 	SET                                                        = 0x150F
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V                                = 0x9551
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
+	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
 	SHADER_IMAGE_ACCESS_BARRIER_BIT                            = 0x00000020
 	SHADER_IMAGE_ATOMIC                                        = 0x82A6
 	SHADER_IMAGE_LOAD                                          = 0x82A4
 	SHADER_IMAGE_STORE                                         = 0x82A5
 	SHADER_INCLUDE_ARB                                         = 0x8DAE
 	SHADER_KHR                                                 = 0x82E1
+	SHADER_OBJECT_EXT                                          = 0x8B48
 	SHADER_SOURCE_LENGTH                                       = 0x8B88
 	SHADER_STORAGE_BARRIER_BIT                                 = 0x00002000
 	SHADER_STORAGE_BLOCK                                       = 0x92E6
@@ -5788,6 +8429,7 @@ const (
 	SHADER_TYPE                                                = 0x8B4F
 	SHADE_MODEL                                                = 0x0B54
 	SHADING_LANGUAGE_VERSION                                   = 0x8B8C
+	SHARED_EDGE_NV                                             = 0xC0
 	SHININESS                                                  = 0x1601
 	SHORT                                                      = 0x1402
 	SIGNALED                                                   = 0x9119
@@ -5797,15 +8439,24 @@ const (
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_TEST                      = 0x82AD
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_WRITE                     = 0x82AF
 	SINGLE_COLOR                                               = 0x81F9
+	SKIP_DECODE_EXT                                            = 0x8A4A
+	SKIP_MISSING_GLYPH_NV                                      = 0x90A9
 	SLUMINANCE                                                 = 0x8C46
 	SLUMINANCE8                                                = 0x8C47
 	SLUMINANCE8_ALPHA8                                         = 0x8C45
 	SLUMINANCE_ALPHA                                           = 0x8C44
+	SMALL_CCW_ARC_TO_NV                                        = 0x12
+	SMALL_CW_ARC_TO_NV                                         = 0x14
 	SMOOTH                                                     = 0x1D01
+	SMOOTH_CUBIC_CURVE_TO_NV                                   = 0x10
 	SMOOTH_LINE_WIDTH_GRANULARITY                              = 0x0B23
 	SMOOTH_LINE_WIDTH_RANGE                                    = 0x0B22
 	SMOOTH_POINT_SIZE_GRANULARITY                              = 0x0B13
 	SMOOTH_POINT_SIZE_RANGE                                    = 0x0B12
+	SMOOTH_QUADRATIC_CURVE_TO_NV                               = 0x0E
+	SM_COUNT_NV                                                = 0x933B
+	SOFTLIGHT_KHR                                              = 0x929C
+	SOFTLIGHT_NV                                               = 0x929C
 	SOURCE0_ALPHA                                              = 0x8588
 	SOURCE0_RGB                                                = 0x8580
 	SOURCE1_ALPHA                                              = 0x8589
@@ -5817,9 +8468,13 @@ const (
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
 	SPECULAR                                                   = 0x1202
 	SPHERE_MAP                                                 = 0x2402
+	SPIR_V_BINARY                                              = 0x9552
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
 	SPOT_CUTOFF                                                = 0x1206
 	SPOT_DIRECTION                                             = 0x1204
 	SPOT_EXPONENT                                              = 0x1205
+	SQUARE_NV                                                  = 0x90A3
 	SRC0_ALPHA                                                 = 0x8588
 	SRC0_RGB                                                   = 0x8580
 	SRC1_ALPHA                                                 = 0x8589
@@ -5829,7 +8484,12 @@ const (
 	SRC2_RGB                                                   = 0x8582
 	SRC_ALPHA                                                  = 0x0302
 	SRC_ALPHA_SATURATE                                         = 0x0308
+	SRC_ATOP_NV                                                = 0x928E
 	SRC_COLOR                                                  = 0x0300
+	SRC_IN_NV                                                  = 0x928A
+	SRC_NV                                                     = 0x9286
+	SRC_OUT_NV                                                 = 0x928C
+	SRC_OVER_NV                                                = 0x9288
 	SRGB                                                       = 0x8C40
 	SRGB8                                                      = 0x8C41
 	SRGB8_ALPHA8                                               = 0x8C43
@@ -5841,6 +8501,8 @@ const (
 	STACK_OVERFLOW_KHR                                         = 0x0503
 	STACK_UNDERFLOW                                            = 0x0504
 	STACK_UNDERFLOW_KHR                                        = 0x0504
+	STANDARD_FONT_FORMAT_NV                                    = 0x936C
+	STANDARD_FONT_NAME_NV                                      = 0x9072
 	STATIC_COPY                                                = 0x88E6
 	STATIC_DRAW                                                = 0x88E4
 	STATIC_READ                                                = 0x88E5
@@ -5867,7 +8529,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_VALUE_MASK                                         = 0x0B93
 	STENCIL_WRITEMASK                                          = 0x0B98
@@ -5876,7 +8540,11 @@ const (
 	STREAM_DRAW                                                = 0x88E0
 	STREAM_READ                                                = 0x88E1
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
 	SUBTRACT                                                   = 0x84E7
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SYNC_CL_EVENT_ARB                                          = 0x8240
 	SYNC_CL_EVENT_COMPLETE_ARB                                 = 0x8241
 	SYNC_CONDITION                                             = 0x9113
@@ -5885,6 +8553,7 @@ const (
 	SYNC_FLUSH_COMMANDS_BIT                                    = 0x00000001
 	SYNC_GPU_COMMANDS_COMPLETE                                 = 0x9117
 	SYNC_STATUS                                                = 0x9114
+	SYSTEM_FONT_NAME_NV                                        = 0x9073
 	T                                                          = 0x2001
 	T2F_C3F_V3F                                                = 0x2A2A
 	T2F_C4F_N3F_V3F                                            = 0x2A2C
@@ -5893,15 +8562,18 @@ const (
 	T2F_V3F                                                    = 0x2A27
 	T4F_C4F_N3F_V4F                                            = 0x2A2D
 	T4F_V4F                                                    = 0x2A28
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
 	TESS_CONTROL_SHADER                                        = 0x8E88
 	TESS_CONTROL_SHADER_BIT                                    = 0x00000008
+	TESS_CONTROL_SHADER_PATCHES                                = 0x82F1
 	TESS_CONTROL_SHADER_PATCHES_ARB                            = 0x82F1
 	TESS_CONTROL_SUBROUTINE                                    = 0x92E9
 	TESS_CONTROL_SUBROUTINE_UNIFORM                            = 0x92EF
 	TESS_CONTROL_TEXTURE                                       = 0x829C
 	TESS_EVALUATION_SHADER                                     = 0x8E87
 	TESS_EVALUATION_SHADER_BIT                                 = 0x00000010
+	TESS_EVALUATION_SHADER_INVOCATIONS                         = 0x82F2
 	TESS_EVALUATION_SHADER_INVOCATIONS_ARB                     = 0x82F2
 	TESS_EVALUATION_SUBROUTINE                                 = 0x92EA
 	TESS_EVALUATION_SUBROUTINE_UNIFORM                         = 0x92F0
@@ -5953,7 +8625,6 @@ const (
 	TEXTURE_ALPHA_SIZE                                         = 0x805F
 	TEXTURE_ALPHA_TYPE                                         = 0x8C13
 	TEXTURE_BASE_LEVEL                                         = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_2D                                         = 0x8069
@@ -5962,6 +8633,7 @@ const (
 	TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY                       = 0x9105
 	TEXTURE_BINDING_3D                                         = 0x806A
 	TEXTURE_BINDING_BUFFER                                     = 0x8C2C
+	TEXTURE_BINDING_BUFFER_ARB                                 = 0x8C2C
 	TEXTURE_BINDING_CUBE_MAP                                   = 0x8514
 	TEXTURE_BINDING_CUBE_MAP_ARRAY                             = 0x900A
 	TEXTURE_BINDING_CUBE_MAP_ARRAY_ARB                         = 0x900A
@@ -5972,8 +8644,11 @@ const (
 	TEXTURE_BORDER                                             = 0x1005
 	TEXTURE_BORDER_COLOR                                       = 0x1004
 	TEXTURE_BUFFER                                             = 0x8C2A
+	TEXTURE_BUFFER_ARB                                         = 0x8C2A
 	TEXTURE_BUFFER_BINDING                                     = 0x8C2A
 	TEXTURE_BUFFER_DATA_STORE_BINDING                          = 0x8C2D
+	TEXTURE_BUFFER_DATA_STORE_BINDING_ARB                      = 0x8C2D
+	TEXTURE_BUFFER_FORMAT_ARB                                  = 0x8C2E
 	TEXTURE_BUFFER_OFFSET                                      = 0x919D
 	TEXTURE_BUFFER_OFFSET_ALIGNMENT                            = 0x919F
 	TEXTURE_BUFFER_SIZE                                        = 0x919E
@@ -5987,7 +8662,9 @@ const (
 	TEXTURE_COMPRESSED_IMAGE_SIZE                              = 0x86A0
 	TEXTURE_COMPRESSION_HINT                                   = 0x84EF
 	TEXTURE_COORD_ARRAY                                        = 0x8078
+	TEXTURE_COORD_ARRAY_ADDRESS_NV                             = 0x8F25
 	TEXTURE_COORD_ARRAY_BUFFER_BINDING                         = 0x889A
+	TEXTURE_COORD_ARRAY_LENGTH_NV                              = 0x8F2F
 	TEXTURE_COORD_ARRAY_POINTER                                = 0x8092
 	TEXTURE_COORD_ARRAY_SIZE                                   = 0x8088
 	TEXTURE_COORD_ARRAY_STRIDE                                 = 0x808A
@@ -6031,12 +8708,15 @@ const (
 	TEXTURE_LUMINANCE_SIZE                                     = 0x8060
 	TEXTURE_MAG_FILTER                                         = 0x2800
 	TEXTURE_MATRIX                                             = 0x0BA8
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_LEVEL                                          = 0x813D
 	TEXTURE_MAX_LOD                                            = 0x813B
 	TEXTURE_MIN_FILTER                                         = 0x2801
 	TEXTURE_MIN_LOD                                            = 0x813A
 	TEXTURE_PRIORITY                                           = 0x8066
 	TEXTURE_RECTANGLE                                          = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
 	TEXTURE_RESIDENT                                           = 0x8067
@@ -6044,6 +8724,7 @@ const (
 	TEXTURE_SHADOW                                             = 0x82A1
 	TEXTURE_SHARED_SIZE                                        = 0x8C3F
 	TEXTURE_SPARSE_ARB                                         = 0x91A6
+	TEXTURE_SRGB_DECODE_EXT                                    = 0x8A48
 	TEXTURE_STACK_DEPTH                                        = 0x0BA5
 	TEXTURE_STENCIL_SIZE                                       = 0x88F1
 	TEXTURE_SWIZZLE_A                                          = 0x8E45
@@ -6082,26 +8763,40 @@ const (
 	TRANSFORM_FEEDBACK_BUFFER_SIZE                             = 0x8C85
 	TRANSFORM_FEEDBACK_BUFFER_START                            = 0x8C84
 	TRANSFORM_FEEDBACK_BUFFER_STRIDE                           = 0x934C
+	TRANSFORM_FEEDBACK_OVERFLOW                                = 0x82EC
 	TRANSFORM_FEEDBACK_OVERFLOW_ARB                            = 0x82EC
 	TRANSFORM_FEEDBACK_PAUSED                                  = 0x8E23
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN                      = 0x8C88
+	TRANSFORM_FEEDBACK_STREAM_OVERFLOW                         = 0x82ED
 	TRANSFORM_FEEDBACK_STREAM_OVERFLOW_ARB                     = 0x82ED
 	TRANSFORM_FEEDBACK_VARYING                                 = 0x92F4
 	TRANSFORM_FEEDBACK_VARYINGS                                = 0x8C83
 	TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH                      = 0x8C76
+	TRANSLATE_2D_NV                                            = 0x9090
+	TRANSLATE_3D_NV                                            = 0x9091
+	TRANSLATE_X_NV                                             = 0x908E
+	TRANSLATE_Y_NV                                             = 0x908F
+	TRANSPOSE_AFFINE_2D_NV                                     = 0x9096
+	TRANSPOSE_AFFINE_3D_NV                                     = 0x9098
 	TRANSPOSE_COLOR_MATRIX                                     = 0x84E6
 	TRANSPOSE_MODELVIEW_MATRIX                                 = 0x84E3
+	TRANSPOSE_PROGRAM_MATRIX_EXT                               = 0x8E2E
 	TRANSPOSE_PROJECTION_MATRIX                                = 0x84E4
 	TRANSPOSE_TEXTURE_MATRIX                                   = 0x84E5
 	TRIANGLES                                                  = 0x0004
 	TRIANGLES_ADJACENCY                                        = 0x000C
+	TRIANGLES_ADJACENCY_ARB                                    = 0x000C
 	TRIANGLE_FAN                                               = 0x0006
 	TRIANGLE_STRIP                                             = 0x0005
 	TRIANGLE_STRIP_ADJACENCY                                   = 0x000D
+	TRIANGLE_STRIP_ADJACENCY_ARB                               = 0x000D
+	TRIANGULAR_NV                                              = 0x90A5
 	TRUE                                                       = 1
 	TYPE                                                       = 0x92FA
+	UNCORRELATED_NV                                            = 0x9282
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -6119,10 +8814,13 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -6149,7 +8847,23 @@ const (
 	UNSIGNED_BYTE_2_3_3_REV                                    = 0x8362
 	UNSIGNED_BYTE_3_3_2                                        = 0x8032
 	UNSIGNED_INT                                               = 0x1405
+	UNSIGNED_INT16_NV                                          = 0x8FF0
+	UNSIGNED_INT16_VEC2_NV                                     = 0x8FF1
+	UNSIGNED_INT16_VEC3_NV                                     = 0x8FF2
+	UNSIGNED_INT16_VEC4_NV                                     = 0x8FF3
+	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
+	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
+	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
+	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
+	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
+	UNSIGNED_INT8_NV                                           = 0x8FEC
+	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
+	UNSIGNED_INT8_VEC3_NV                                      = 0x8FEE
+	UNSIGNED_INT8_VEC4_NV                                      = 0x8FEF
 	UNSIGNED_INT_10F_11F_11F_REV                               = 0x8C3B
 	UNSIGNED_INT_10_10_10_2                                    = 0x8036
 	UNSIGNED_INT_24_8                                          = 0x84FA
@@ -6192,31 +8906,43 @@ const (
 	UNSIGNED_SHORT_5_5_5_1                                     = 0x8034
 	UNSIGNED_SHORT_5_6_5                                       = 0x8363
 	UNSIGNED_SHORT_5_6_5_REV                                   = 0x8364
+	UNSIGNED_SHORT_8_8_APPLE                                   = 0x85BA
+	UNSIGNED_SHORT_8_8_REV_APPLE                               = 0x85BB
 	UPPER_LEFT                                                 = 0x8CA2
+	USE_MISSING_GLYPH_NV                                       = 0x90AA
+	UTF16_NV                                                   = 0x909B
+	UTF8_NV                                                    = 0x909A
 	V2F                                                        = 0x2A20
 	V3F                                                        = 0x2A21
 	VALIDATE_STATUS                                            = 0x8B83
 	VENDOR                                                     = 0x1F00
 	VERSION                                                    = 0x1F02
 	VERTEX_ARRAY                                               = 0x8074
+	VERTEX_ARRAY_ADDRESS_NV                                    = 0x8F21
 	VERTEX_ARRAY_BINDING                                       = 0x85B5
 	VERTEX_ARRAY_BUFFER_BINDING                                = 0x8896
 	VERTEX_ARRAY_KHR                                           = 0x8074
+	VERTEX_ARRAY_LENGTH_NV                                     = 0x8F2B
+	VERTEX_ARRAY_OBJECT_EXT                                    = 0x9154
 	VERTEX_ARRAY_POINTER                                       = 0x808E
 	VERTEX_ARRAY_SIZE                                          = 0x807A
 	VERTEX_ARRAY_STRIDE                                        = 0x807C
 	VERTEX_ARRAY_TYPE                                          = 0x807B
+	VERTEX_ATTRIB_ARRAY_ADDRESS_NV                             = 0x8F20
 	VERTEX_ATTRIB_ARRAY_BARRIER_BIT                            = 0x00000001
 	VERTEX_ATTRIB_ARRAY_BUFFER_BINDING                         = 0x889F
 	VERTEX_ATTRIB_ARRAY_DIVISOR                                = 0x88FE
+	VERTEX_ATTRIB_ARRAY_DIVISOR_ARB                            = 0x88FE
 	VERTEX_ATTRIB_ARRAY_ENABLED                                = 0x8622
 	VERTEX_ATTRIB_ARRAY_INTEGER                                = 0x88FD
+	VERTEX_ATTRIB_ARRAY_LENGTH_NV                              = 0x8F2A
 	VERTEX_ATTRIB_ARRAY_LONG                                   = 0x874E
 	VERTEX_ATTRIB_ARRAY_NORMALIZED                             = 0x886A
 	VERTEX_ATTRIB_ARRAY_POINTER                                = 0x8645
 	VERTEX_ATTRIB_ARRAY_SIZE                                   = 0x8623
 	VERTEX_ATTRIB_ARRAY_STRIDE                                 = 0x8624
 	VERTEX_ATTRIB_ARRAY_TYPE                                   = 0x8625
+	VERTEX_ATTRIB_ARRAY_UNIFIED_NV                             = 0x8F1E
 	VERTEX_ATTRIB_BINDING                                      = 0x82D4
 	VERTEX_ATTRIB_RELATIVE_OFFSET                              = 0x82D5
 	VERTEX_BINDING_BUFFER                                      = 0x8F4F
@@ -6227,16 +8953,36 @@ const (
 	VERTEX_PROGRAM_TWO_SIDE                                    = 0x8643
 	VERTEX_SHADER                                              = 0x8B31
 	VERTEX_SHADER_BIT                                          = 0x00000001
+	VERTEX_SHADER_BIT_EXT                                      = 0x00000001
+	VERTEX_SHADER_INVOCATIONS                                  = 0x82F0
 	VERTEX_SHADER_INVOCATIONS_ARB                              = 0x82F0
 	VERTEX_SUBROUTINE                                          = 0x92E8
 	VERTEX_SUBROUTINE_UNIFORM                                  = 0x92EE
 	VERTEX_TEXTURE                                             = 0x829B
+	VERTICAL_LINE_TO_NV                                        = 0x08
+	VERTICES_SUBMITTED                                         = 0x82EE
 	VERTICES_SUBMITTED_ARB                                     = 0x82EE
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BIT                                               = 0x00000800
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -6258,10 +9004,18 @@ const (
 	VIRTUAL_PAGE_SIZE_X_ARB                                    = 0x9195
 	VIRTUAL_PAGE_SIZE_Y_ARB                                    = 0x9196
 	VIRTUAL_PAGE_SIZE_Z_ARB                                    = 0x9197
+	VIVIDLIGHT_NV                                              = 0x92A6
 	WAIT_FAILED                                                = 0x911D
+	WARPS_PER_SM_NV                                            = 0x933A
+	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
 	WEIGHT_ARRAY_BUFFER_BINDING                                = 0x889E
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRITE_ONLY                                                 = 0x88B9
 	XOR                                                        = 0x1506
+	XOR_NV                                                     = 0x1506
 	ZERO                                                       = 0
 	ZERO_TO_ONE                                                = 0x935F
 	ZOOM_X                                                     = 0x0D16
@@ -6269,1067 +9023,1623 @@ const (
 )
 
 var (
-	gpAccum                                       C.GPACCUM
-	gpActiveShaderProgram                         C.GPACTIVESHADERPROGRAM
-	gpActiveTexture                               C.GPACTIVETEXTURE
-	gpAlphaFunc                                   C.GPALPHAFUNC
-	gpAreTexturesResident                         C.GPARETEXTURESRESIDENT
-	gpArrayElement                                C.GPARRAYELEMENT
-	gpAttachShader                                C.GPATTACHSHADER
-	gpBegin                                       C.GPBEGIN
-	gpBeginConditionalRender                      C.GPBEGINCONDITIONALRENDER
-	gpBeginQuery                                  C.GPBEGINQUERY
-	gpBeginQueryIndexed                           C.GPBEGINQUERYINDEXED
-	gpBeginTransformFeedback                      C.GPBEGINTRANSFORMFEEDBACK
-	gpBindAttribLocation                          C.GPBINDATTRIBLOCATION
-	gpBindBuffer                                  C.GPBINDBUFFER
-	gpBindBufferBase                              C.GPBINDBUFFERBASE
-	gpBindBufferRange                             C.GPBINDBUFFERRANGE
-	gpBindBuffersBase                             C.GPBINDBUFFERSBASE
-	gpBindBuffersRange                            C.GPBINDBUFFERSRANGE
-	gpBindFragDataLocation                        C.GPBINDFRAGDATALOCATION
-	gpBindFragDataLocationIndexed                 C.GPBINDFRAGDATALOCATIONINDEXED
-	gpBindFramebuffer                             C.GPBINDFRAMEBUFFER
-	gpBindImageTexture                            C.GPBINDIMAGETEXTURE
-	gpBindImageTextures                           C.GPBINDIMAGETEXTURES
-	gpBindProgramPipeline                         C.GPBINDPROGRAMPIPELINE
-	gpBindRenderbuffer                            C.GPBINDRENDERBUFFER
-	gpBindSampler                                 C.GPBINDSAMPLER
-	gpBindSamplers                                C.GPBINDSAMPLERS
-	gpBindTexture                                 C.GPBINDTEXTURE
-	gpBindTextureUnit                             C.GPBINDTEXTUREUNIT
-	gpBindTextures                                C.GPBINDTEXTURES
-	gpBindTransformFeedback                       C.GPBINDTRANSFORMFEEDBACK
-	gpBindVertexArray                             C.GPBINDVERTEXARRAY
-	gpBindVertexBuffer                            C.GPBINDVERTEXBUFFER
-	gpBindVertexBuffers                           C.GPBINDVERTEXBUFFERS
-	gpBitmap                                      C.GPBITMAP
-	gpBlendColor                                  C.GPBLENDCOLOR
-	gpBlendEquation                               C.GPBLENDEQUATION
-	gpBlendEquationSeparate                       C.GPBLENDEQUATIONSEPARATE
-	gpBlendEquationSeparatei                      C.GPBLENDEQUATIONSEPARATEI
-	gpBlendEquationSeparateiARB                   C.GPBLENDEQUATIONSEPARATEIARB
-	gpBlendEquationi                              C.GPBLENDEQUATIONI
-	gpBlendEquationiARB                           C.GPBLENDEQUATIONIARB
-	gpBlendFunc                                   C.GPBLENDFUNC
-	gpBlendFuncSeparate                           C.GPBLENDFUNCSEPARATE
-	gpBlendFuncSeparatei                          C.GPBLENDFUNCSEPARATEI
-	gpBlendFuncSeparateiARB                       C.GPBLENDFUNCSEPARATEIARB
-	gpBlendFunci                                  C.GPBLENDFUNCI
-	gpBlendFunciARB                               C.GPBLENDFUNCIARB
-	gpBlitFramebuffer                             C.GPBLITFRAMEBUFFER
-	gpBlitNamedFramebuffer                        C.GPBLITNAMEDFRAMEBUFFER
-	gpBufferData                                  C.GPBUFFERDATA
-	gpBufferPageCommitmentARB                     C.GPBUFFERPAGECOMMITMENTARB
-	gpBufferStorage                               C.GPBUFFERSTORAGE
-	gpBufferSubData                               C.GPBUFFERSUBDATA
-	gpCallList                                    C.GPCALLLIST
-	gpCallLists                                   C.GPCALLLISTS
-	gpCheckFramebufferStatus                      C.GPCHECKFRAMEBUFFERSTATUS
-	gpCheckNamedFramebufferStatus                 C.GPCHECKNAMEDFRAMEBUFFERSTATUS
-	gpClampColor                                  C.GPCLAMPCOLOR
-	gpClear                                       C.GPCLEAR
-	gpClearAccum                                  C.GPCLEARACCUM
-	gpClearBufferData                             C.GPCLEARBUFFERDATA
-	gpClearBufferSubData                          C.GPCLEARBUFFERSUBDATA
-	gpClearBufferfi                               C.GPCLEARBUFFERFI
-	gpClearBufferfv                               C.GPCLEARBUFFERFV
-	gpClearBufferiv                               C.GPCLEARBUFFERIV
-	gpClearBufferuiv                              C.GPCLEARBUFFERUIV
-	gpClearColor                                  C.GPCLEARCOLOR
-	gpClearDepth                                  C.GPCLEARDEPTH
-	gpClearDepthf                                 C.GPCLEARDEPTHF
-	gpClearIndex                                  C.GPCLEARINDEX
-	gpClearNamedBufferData                        C.GPCLEARNAMEDBUFFERDATA
-	gpClearNamedBufferSubData                     C.GPCLEARNAMEDBUFFERSUBDATA
-	gpClearNamedFramebufferfi                     C.GPCLEARNAMEDFRAMEBUFFERFI
-	gpClearNamedFramebufferfv                     C.GPCLEARNAMEDFRAMEBUFFERFV
-	gpClearNamedFramebufferiv                     C.GPCLEARNAMEDFRAMEBUFFERIV
-	gpClearNamedFramebufferuiv                    C.GPCLEARNAMEDFRAMEBUFFERUIV
-	gpClearStencil                                C.GPCLEARSTENCIL
-	gpClearTexImage                               C.GPCLEARTEXIMAGE
-	gpClearTexSubImage                            C.GPCLEARTEXSUBIMAGE
-	gpClientActiveTexture                         C.GPCLIENTACTIVETEXTURE
-	gpClientWaitSync                              C.GPCLIENTWAITSYNC
-	gpClipControl                                 C.GPCLIPCONTROL
-	gpClipPlane                                   C.GPCLIPPLANE
-	gpColor3b                                     C.GPCOLOR3B
-	gpColor3bv                                    C.GPCOLOR3BV
-	gpColor3d                                     C.GPCOLOR3D
-	gpColor3dv                                    C.GPCOLOR3DV
-	gpColor3f                                     C.GPCOLOR3F
-	gpColor3fv                                    C.GPCOLOR3FV
-	gpColor3i                                     C.GPCOLOR3I
-	gpColor3iv                                    C.GPCOLOR3IV
-	gpColor3s                                     C.GPCOLOR3S
-	gpColor3sv                                    C.GPCOLOR3SV
-	gpColor3ub                                    C.GPCOLOR3UB
-	gpColor3ubv                                   C.GPCOLOR3UBV
-	gpColor3ui                                    C.GPCOLOR3UI
-	gpColor3uiv                                   C.GPCOLOR3UIV
-	gpColor3us                                    C.GPCOLOR3US
-	gpColor3usv                                   C.GPCOLOR3USV
-	gpColor4b                                     C.GPCOLOR4B
-	gpColor4bv                                    C.GPCOLOR4BV
-	gpColor4d                                     C.GPCOLOR4D
-	gpColor4dv                                    C.GPCOLOR4DV
-	gpColor4f                                     C.GPCOLOR4F
-	gpColor4fv                                    C.GPCOLOR4FV
-	gpColor4i                                     C.GPCOLOR4I
-	gpColor4iv                                    C.GPCOLOR4IV
-	gpColor4s                                     C.GPCOLOR4S
-	gpColor4sv                                    C.GPCOLOR4SV
-	gpColor4ub                                    C.GPCOLOR4UB
-	gpColor4ubv                                   C.GPCOLOR4UBV
-	gpColor4ui                                    C.GPCOLOR4UI
-	gpColor4uiv                                   C.GPCOLOR4UIV
-	gpColor4us                                    C.GPCOLOR4US
-	gpColor4usv                                   C.GPCOLOR4USV
-	gpColorMask                                   C.GPCOLORMASK
-	gpColorMaski                                  C.GPCOLORMASKI
-	gpColorMaterial                               C.GPCOLORMATERIAL
-	gpColorPointer                                C.GPCOLORPOINTER
-	gpCompileShader                               C.GPCOMPILESHADER
-	gpCompileShaderIncludeARB                     C.GPCOMPILESHADERINCLUDEARB
-	gpCompressedTexImage1D                        C.GPCOMPRESSEDTEXIMAGE1D
-	gpCompressedTexImage2D                        C.GPCOMPRESSEDTEXIMAGE2D
-	gpCompressedTexImage3D                        C.GPCOMPRESSEDTEXIMAGE3D
-	gpCompressedTexSubImage1D                     C.GPCOMPRESSEDTEXSUBIMAGE1D
-	gpCompressedTexSubImage2D                     C.GPCOMPRESSEDTEXSUBIMAGE2D
-	gpCompressedTexSubImage3D                     C.GPCOMPRESSEDTEXSUBIMAGE3D
-	gpCompressedTextureSubImage1D                 C.GPCOMPRESSEDTEXTURESUBIMAGE1D
-	gpCompressedTextureSubImage2D                 C.GPCOMPRESSEDTEXTURESUBIMAGE2D
-	gpCompressedTextureSubImage3D                 C.GPCOMPRESSEDTEXTURESUBIMAGE3D
-	gpCopyBufferSubData                           C.GPCOPYBUFFERSUBDATA
-	gpCopyImageSubData                            C.GPCOPYIMAGESUBDATA
-	gpCopyNamedBufferSubData                      C.GPCOPYNAMEDBUFFERSUBDATA
-	gpCopyPixels                                  C.GPCOPYPIXELS
-	gpCopyTexImage1D                              C.GPCOPYTEXIMAGE1D
-	gpCopyTexImage2D                              C.GPCOPYTEXIMAGE2D
-	gpCopyTexSubImage1D                           C.GPCOPYTEXSUBIMAGE1D
-	gpCopyTexSubImage2D                           C.GPCOPYTEXSUBIMAGE2D
-	gpCopyTexSubImage3D                           C.GPCOPYTEXSUBIMAGE3D
-	gpCopyTextureSubImage1D                       C.GPCOPYTEXTURESUBIMAGE1D
-	gpCopyTextureSubImage2D                       C.GPCOPYTEXTURESUBIMAGE2D
-	gpCopyTextureSubImage3D                       C.GPCOPYTEXTURESUBIMAGE3D
-	gpCreateBuffers                               C.GPCREATEBUFFERS
-	gpCreateFramebuffers                          C.GPCREATEFRAMEBUFFERS
-	gpCreateProgram                               C.GPCREATEPROGRAM
-	gpCreateProgramPipelines                      C.GPCREATEPROGRAMPIPELINES
-	gpCreateQueries                               C.GPCREATEQUERIES
-	gpCreateRenderbuffers                         C.GPCREATERENDERBUFFERS
-	gpCreateSamplers                              C.GPCREATESAMPLERS
-	gpCreateShader                                C.GPCREATESHADER
-	gpCreateShaderProgramv                        C.GPCREATESHADERPROGRAMV
-	gpCreateSyncFromCLeventARB                    C.GPCREATESYNCFROMCLEVENTARB
-	gpCreateTextures                              C.GPCREATETEXTURES
-	gpCreateTransformFeedbacks                    C.GPCREATETRANSFORMFEEDBACKS
-	gpCreateVertexArrays                          C.GPCREATEVERTEXARRAYS
-	gpCullFace                                    C.GPCULLFACE
-	gpDebugMessageCallback                        C.GPDEBUGMESSAGECALLBACK
-	gpDebugMessageCallbackARB                     C.GPDEBUGMESSAGECALLBACKARB
-	gpDebugMessageCallbackKHR                     C.GPDEBUGMESSAGECALLBACKKHR
-	gpDebugMessageControl                         C.GPDEBUGMESSAGECONTROL
-	gpDebugMessageControlARB                      C.GPDEBUGMESSAGECONTROLARB
-	gpDebugMessageControlKHR                      C.GPDEBUGMESSAGECONTROLKHR
-	gpDebugMessageInsert                          C.GPDEBUGMESSAGEINSERT
-	gpDebugMessageInsertARB                       C.GPDEBUGMESSAGEINSERTARB
-	gpDebugMessageInsertKHR                       C.GPDEBUGMESSAGEINSERTKHR
-	gpDeleteBuffers                               C.GPDELETEBUFFERS
-	gpDeleteFramebuffers                          C.GPDELETEFRAMEBUFFERS
-	gpDeleteLists                                 C.GPDELETELISTS
-	gpDeleteNamedStringARB                        C.GPDELETENAMEDSTRINGARB
-	gpDeleteProgram                               C.GPDELETEPROGRAM
-	gpDeleteProgramPipelines                      C.GPDELETEPROGRAMPIPELINES
-	gpDeleteQueries                               C.GPDELETEQUERIES
-	gpDeleteRenderbuffers                         C.GPDELETERENDERBUFFERS
-	gpDeleteSamplers                              C.GPDELETESAMPLERS
-	gpDeleteShader                                C.GPDELETESHADER
-	gpDeleteSync                                  C.GPDELETESYNC
-	gpDeleteTextures                              C.GPDELETETEXTURES
-	gpDeleteTransformFeedbacks                    C.GPDELETETRANSFORMFEEDBACKS
-	gpDeleteVertexArrays                          C.GPDELETEVERTEXARRAYS
-	gpDepthFunc                                   C.GPDEPTHFUNC
-	gpDepthMask                                   C.GPDEPTHMASK
-	gpDepthRange                                  C.GPDEPTHRANGE
-	gpDepthRangeArrayv                            C.GPDEPTHRANGEARRAYV
-	gpDepthRangeIndexed                           C.GPDEPTHRANGEINDEXED
-	gpDepthRangef                                 C.GPDEPTHRANGEF
-	gpDetachShader                                C.GPDETACHSHADER
-	gpDisable                                     C.GPDISABLE
-	gpDisableClientState                          C.GPDISABLECLIENTSTATE
-	gpDisableVertexArrayAttrib                    C.GPDISABLEVERTEXARRAYATTRIB
-	gpDisableVertexAttribArray                    C.GPDISABLEVERTEXATTRIBARRAY
-	gpDisablei                                    C.GPDISABLEI
-	gpDispatchCompute                             C.GPDISPATCHCOMPUTE
-	gpDispatchComputeGroupSizeARB                 C.GPDISPATCHCOMPUTEGROUPSIZEARB
-	gpDispatchComputeIndirect                     C.GPDISPATCHCOMPUTEINDIRECT
-	gpDrawArrays                                  C.GPDRAWARRAYS
-	gpDrawArraysIndirect                          C.GPDRAWARRAYSINDIRECT
-	gpDrawArraysInstanced                         C.GPDRAWARRAYSINSTANCED
-	gpDrawArraysInstancedBaseInstance             C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
-	gpDrawBuffer                                  C.GPDRAWBUFFER
-	gpDrawBuffers                                 C.GPDRAWBUFFERS
-	gpDrawElements                                C.GPDRAWELEMENTS
-	gpDrawElementsBaseVertex                      C.GPDRAWELEMENTSBASEVERTEX
-	gpDrawElementsIndirect                        C.GPDRAWELEMENTSINDIRECT
-	gpDrawElementsInstanced                       C.GPDRAWELEMENTSINSTANCED
-	gpDrawElementsInstancedBaseInstance           C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
-	gpDrawElementsInstancedBaseVertex             C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
-	gpDrawElementsInstancedBaseVertexBaseInstance C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
-	gpDrawPixels                                  C.GPDRAWPIXELS
-	gpDrawRangeElements                           C.GPDRAWRANGEELEMENTS
-	gpDrawRangeElementsBaseVertex                 C.GPDRAWRANGEELEMENTSBASEVERTEX
-	gpDrawTransformFeedback                       C.GPDRAWTRANSFORMFEEDBACK
-	gpDrawTransformFeedbackInstanced              C.GPDRAWTRANSFORMFEEDBACKINSTANCED
-	gpDrawTransformFeedbackStream                 C.GPDRAWTRANSFORMFEEDBACKSTREAM
-	gpDrawTransformFeedbackStreamInstanced        C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
-	gpEdgeFlag                                    C.GPEDGEFLAG
-	gpEdgeFlagPointer                             C.GPEDGEFLAGPOINTER
-	gpEdgeFlagv                                   C.GPEDGEFLAGV
-	gpEnable                                      C.GPENABLE
-	gpEnableClientState                           C.GPENABLECLIENTSTATE
-	gpEnableVertexArrayAttrib                     C.GPENABLEVERTEXARRAYATTRIB
-	gpEnableVertexAttribArray                     C.GPENABLEVERTEXATTRIBARRAY
-	gpEnablei                                     C.GPENABLEI
-	gpEnd                                         C.GPEND
-	gpEndConditionalRender                        C.GPENDCONDITIONALRENDER
-	gpEndList                                     C.GPENDLIST
-	gpEndQuery                                    C.GPENDQUERY
-	gpEndQueryIndexed                             C.GPENDQUERYINDEXED
-	gpEndTransformFeedback                        C.GPENDTRANSFORMFEEDBACK
-	gpEvalCoord1d                                 C.GPEVALCOORD1D
-	gpEvalCoord1dv                                C.GPEVALCOORD1DV
-	gpEvalCoord1f                                 C.GPEVALCOORD1F
-	gpEvalCoord1fv                                C.GPEVALCOORD1FV
-	gpEvalCoord2d                                 C.GPEVALCOORD2D
-	gpEvalCoord2dv                                C.GPEVALCOORD2DV
-	gpEvalCoord2f                                 C.GPEVALCOORD2F
-	gpEvalCoord2fv                                C.GPEVALCOORD2FV
-	gpEvalMesh1                                   C.GPEVALMESH1
-	gpEvalMesh2                                   C.GPEVALMESH2
-	gpEvalPoint1                                  C.GPEVALPOINT1
-	gpEvalPoint2                                  C.GPEVALPOINT2
-	gpFeedbackBuffer                              C.GPFEEDBACKBUFFER
-	gpFenceSync                                   C.GPFENCESYNC
-	gpFinish                                      C.GPFINISH
-	gpFlush                                       C.GPFLUSH
-	gpFlushMappedBufferRange                      C.GPFLUSHMAPPEDBUFFERRANGE
-	gpFlushMappedNamedBufferRange                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
-	gpFogCoordPointer                             C.GPFOGCOORDPOINTER
-	gpFogCoordd                                   C.GPFOGCOORDD
-	gpFogCoorddv                                  C.GPFOGCOORDDV
-	gpFogCoordf                                   C.GPFOGCOORDF
-	gpFogCoordfv                                  C.GPFOGCOORDFV
-	gpFogf                                        C.GPFOGF
-	gpFogfv                                       C.GPFOGFV
-	gpFogi                                        C.GPFOGI
-	gpFogiv                                       C.GPFOGIV
-	gpFramebufferParameteri                       C.GPFRAMEBUFFERPARAMETERI
-	gpFramebufferRenderbuffer                     C.GPFRAMEBUFFERRENDERBUFFER
-	gpFramebufferTexture                          C.GPFRAMEBUFFERTEXTURE
-	gpFramebufferTexture1D                        C.GPFRAMEBUFFERTEXTURE1D
-	gpFramebufferTexture2D                        C.GPFRAMEBUFFERTEXTURE2D
-	gpFramebufferTexture3D                        C.GPFRAMEBUFFERTEXTURE3D
-	gpFramebufferTextureLayer                     C.GPFRAMEBUFFERTEXTURELAYER
-	gpFrontFace                                   C.GPFRONTFACE
-	gpFrustum                                     C.GPFRUSTUM
-	gpGenBuffers                                  C.GPGENBUFFERS
-	gpGenFramebuffers                             C.GPGENFRAMEBUFFERS
-	gpGenLists                                    C.GPGENLISTS
-	gpGenProgramPipelines                         C.GPGENPROGRAMPIPELINES
-	gpGenQueries                                  C.GPGENQUERIES
-	gpGenRenderbuffers                            C.GPGENRENDERBUFFERS
-	gpGenSamplers                                 C.GPGENSAMPLERS
-	gpGenTextures                                 C.GPGENTEXTURES
-	gpGenTransformFeedbacks                       C.GPGENTRANSFORMFEEDBACKS
-	gpGenVertexArrays                             C.GPGENVERTEXARRAYS
-	gpGenerateMipmap                              C.GPGENERATEMIPMAP
-	gpGenerateTextureMipmap                       C.GPGENERATETEXTUREMIPMAP
-	gpGetActiveAtomicCounterBufferiv              C.GPGETACTIVEATOMICCOUNTERBUFFERIV
-	gpGetActiveAttrib                             C.GPGETACTIVEATTRIB
-	gpGetActiveSubroutineName                     C.GPGETACTIVESUBROUTINENAME
-	gpGetActiveSubroutineUniformName              C.GPGETACTIVESUBROUTINEUNIFORMNAME
-	gpGetActiveSubroutineUniformiv                C.GPGETACTIVESUBROUTINEUNIFORMIV
-	gpGetActiveUniform                            C.GPGETACTIVEUNIFORM
-	gpGetActiveUniformBlockName                   C.GPGETACTIVEUNIFORMBLOCKNAME
-	gpGetActiveUniformBlockiv                     C.GPGETACTIVEUNIFORMBLOCKIV
-	gpGetActiveUniformName                        C.GPGETACTIVEUNIFORMNAME
-	gpGetActiveUniformsiv                         C.GPGETACTIVEUNIFORMSIV
-	gpGetAttachedShaders                          C.GPGETATTACHEDSHADERS
-	gpGetAttribLocation                           C.GPGETATTRIBLOCATION
-	gpGetBooleani_v                               C.GPGETBOOLEANI_V
-	gpGetBooleanv                                 C.GPGETBOOLEANV
-	gpGetBufferParameteri64v                      C.GPGETBUFFERPARAMETERI64V
-	gpGetBufferParameteriv                        C.GPGETBUFFERPARAMETERIV
-	gpGetBufferPointerv                           C.GPGETBUFFERPOINTERV
-	gpGetBufferSubData                            C.GPGETBUFFERSUBDATA
-	gpGetClipPlane                                C.GPGETCLIPPLANE
-	gpGetCompressedTexImage                       C.GPGETCOMPRESSEDTEXIMAGE
-	gpGetCompressedTextureImage                   C.GPGETCOMPRESSEDTEXTUREIMAGE
-	gpGetCompressedTextureSubImage                C.GPGETCOMPRESSEDTEXTURESUBIMAGE
-	gpGetDebugMessageLog                          C.GPGETDEBUGMESSAGELOG
-	gpGetDebugMessageLogARB                       C.GPGETDEBUGMESSAGELOGARB
-	gpGetDebugMessageLogKHR                       C.GPGETDEBUGMESSAGELOGKHR
-	gpGetDoublei_v                                C.GPGETDOUBLEI_V
-	gpGetDoublev                                  C.GPGETDOUBLEV
-	gpGetError                                    C.GPGETERROR
-	gpGetFloati_v                                 C.GPGETFLOATI_V
-	gpGetFloatv                                   C.GPGETFLOATV
-	gpGetFragDataIndex                            C.GPGETFRAGDATAINDEX
-	gpGetFragDataLocation                         C.GPGETFRAGDATALOCATION
-	gpGetFramebufferAttachmentParameteriv         C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetFramebufferParameteriv                   C.GPGETFRAMEBUFFERPARAMETERIV
-	gpGetGraphicsResetStatus                      C.GPGETGRAPHICSRESETSTATUS
-	gpGetGraphicsResetStatusARB                   C.GPGETGRAPHICSRESETSTATUSARB
-	gpGetGraphicsResetStatusKHR                   C.GPGETGRAPHICSRESETSTATUSKHR
-	gpGetImageHandleARB                           C.GPGETIMAGEHANDLEARB
-	gpGetInteger64i_v                             C.GPGETINTEGER64I_V
-	gpGetInteger64v                               C.GPGETINTEGER64V
-	gpGetIntegeri_v                               C.GPGETINTEGERI_V
-	gpGetIntegerv                                 C.GPGETINTEGERV
-	gpGetInternalformati64v                       C.GPGETINTERNALFORMATI64V
-	gpGetInternalformativ                         C.GPGETINTERNALFORMATIV
-	gpGetLightfv                                  C.GPGETLIGHTFV
-	gpGetLightiv                                  C.GPGETLIGHTIV
-	gpGetMapdv                                    C.GPGETMAPDV
-	gpGetMapfv                                    C.GPGETMAPFV
-	gpGetMapiv                                    C.GPGETMAPIV
-	gpGetMaterialfv                               C.GPGETMATERIALFV
-	gpGetMaterialiv                               C.GPGETMATERIALIV
-	gpGetMultisamplefv                            C.GPGETMULTISAMPLEFV
-	gpGetNamedBufferParameteri64v                 C.GPGETNAMEDBUFFERPARAMETERI64V
-	gpGetNamedBufferParameteriv                   C.GPGETNAMEDBUFFERPARAMETERIV
-	gpGetNamedBufferPointerv                      C.GPGETNAMEDBUFFERPOINTERV
-	gpGetNamedBufferSubData                       C.GPGETNAMEDBUFFERSUBDATA
-	gpGetNamedFramebufferAttachmentParameteriv    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetNamedFramebufferParameteriv              C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
-	gpGetNamedRenderbufferParameteriv             C.GPGETNAMEDRENDERBUFFERPARAMETERIV
-	gpGetNamedStringARB                           C.GPGETNAMEDSTRINGARB
-	gpGetNamedStringivARB                         C.GPGETNAMEDSTRINGIVARB
-	gpGetObjectLabel                              C.GPGETOBJECTLABEL
-	gpGetObjectLabelKHR                           C.GPGETOBJECTLABELKHR
-	gpGetObjectPtrLabel                           C.GPGETOBJECTPTRLABEL
-	gpGetObjectPtrLabelKHR                        C.GPGETOBJECTPTRLABELKHR
-	gpGetPixelMapfv                               C.GPGETPIXELMAPFV
-	gpGetPixelMapuiv                              C.GPGETPIXELMAPUIV
-	gpGetPixelMapusv                              C.GPGETPIXELMAPUSV
-	gpGetPointerv                                 C.GPGETPOINTERV
-	gpGetPointervKHR                              C.GPGETPOINTERVKHR
-	gpGetPolygonStipple                           C.GPGETPOLYGONSTIPPLE
-	gpGetProgramBinary                            C.GPGETPROGRAMBINARY
-	gpGetProgramInfoLog                           C.GPGETPROGRAMINFOLOG
-	gpGetProgramInterfaceiv                       C.GPGETPROGRAMINTERFACEIV
-	gpGetProgramPipelineInfoLog                   C.GPGETPROGRAMPIPELINEINFOLOG
-	gpGetProgramPipelineiv                        C.GPGETPROGRAMPIPELINEIV
-	gpGetProgramResourceIndex                     C.GPGETPROGRAMRESOURCEINDEX
-	gpGetProgramResourceLocation                  C.GPGETPROGRAMRESOURCELOCATION
-	gpGetProgramResourceLocationIndex             C.GPGETPROGRAMRESOURCELOCATIONINDEX
-	gpGetProgramResourceName                      C.GPGETPROGRAMRESOURCENAME
-	gpGetProgramResourceiv                        C.GPGETPROGRAMRESOURCEIV
-	gpGetProgramStageiv                           C.GPGETPROGRAMSTAGEIV
-	gpGetProgramiv                                C.GPGETPROGRAMIV
-	gpGetQueryIndexediv                           C.GPGETQUERYINDEXEDIV
-	gpGetQueryObjecti64v                          C.GPGETQUERYOBJECTI64V
-	gpGetQueryObjectiv                            C.GPGETQUERYOBJECTIV
-	gpGetQueryObjectui64v                         C.GPGETQUERYOBJECTUI64V
-	gpGetQueryObjectuiv                           C.GPGETQUERYOBJECTUIV
-	gpGetQueryiv                                  C.GPGETQUERYIV
-	gpGetRenderbufferParameteriv                  C.GPGETRENDERBUFFERPARAMETERIV
-	gpGetSamplerParameterIiv                      C.GPGETSAMPLERPARAMETERIIV
-	gpGetSamplerParameterIuiv                     C.GPGETSAMPLERPARAMETERIUIV
-	gpGetSamplerParameterfv                       C.GPGETSAMPLERPARAMETERFV
-	gpGetSamplerParameteriv                       C.GPGETSAMPLERPARAMETERIV
-	gpGetShaderInfoLog                            C.GPGETSHADERINFOLOG
-	gpGetShaderPrecisionFormat                    C.GPGETSHADERPRECISIONFORMAT
-	gpGetShaderSource                             C.GPGETSHADERSOURCE
-	gpGetShaderiv                                 C.GPGETSHADERIV
-	gpGetString                                   C.GPGETSTRING
-	gpGetStringi                                  C.GPGETSTRINGI
-	gpGetSubroutineIndex                          C.GPGETSUBROUTINEINDEX
-	gpGetSubroutineUniformLocation                C.GPGETSUBROUTINEUNIFORMLOCATION
-	gpGetSynciv                                   C.GPGETSYNCIV
-	gpGetTexEnvfv                                 C.GPGETTEXENVFV
-	gpGetTexEnviv                                 C.GPGETTEXENVIV
-	gpGetTexGendv                                 C.GPGETTEXGENDV
-	gpGetTexGenfv                                 C.GPGETTEXGENFV
-	gpGetTexGeniv                                 C.GPGETTEXGENIV
-	gpGetTexImage                                 C.GPGETTEXIMAGE
-	gpGetTexLevelParameterfv                      C.GPGETTEXLEVELPARAMETERFV
-	gpGetTexLevelParameteriv                      C.GPGETTEXLEVELPARAMETERIV
-	gpGetTexParameterIiv                          C.GPGETTEXPARAMETERIIV
-	gpGetTexParameterIuiv                         C.GPGETTEXPARAMETERIUIV
-	gpGetTexParameterfv                           C.GPGETTEXPARAMETERFV
-	gpGetTexParameteriv                           C.GPGETTEXPARAMETERIV
-	gpGetTextureHandleARB                         C.GPGETTEXTUREHANDLEARB
-	gpGetTextureImage                             C.GPGETTEXTUREIMAGE
-	gpGetTextureLevelParameterfv                  C.GPGETTEXTURELEVELPARAMETERFV
-	gpGetTextureLevelParameteriv                  C.GPGETTEXTURELEVELPARAMETERIV
-	gpGetTextureParameterIiv                      C.GPGETTEXTUREPARAMETERIIV
-	gpGetTextureParameterIuiv                     C.GPGETTEXTUREPARAMETERIUIV
-	gpGetTextureParameterfv                       C.GPGETTEXTUREPARAMETERFV
-	gpGetTextureParameteriv                       C.GPGETTEXTUREPARAMETERIV
-	gpGetTextureSamplerHandleARB                  C.GPGETTEXTURESAMPLERHANDLEARB
-	gpGetTextureSubImage                          C.GPGETTEXTURESUBIMAGE
-	gpGetTransformFeedbackVarying                 C.GPGETTRANSFORMFEEDBACKVARYING
-	gpGetTransformFeedbacki64_v                   C.GPGETTRANSFORMFEEDBACKI64_V
-	gpGetTransformFeedbacki_v                     C.GPGETTRANSFORMFEEDBACKI_V
-	gpGetTransformFeedbackiv                      C.GPGETTRANSFORMFEEDBACKIV
-	gpGetUniformBlockIndex                        C.GPGETUNIFORMBLOCKINDEX
-	gpGetUniformIndices                           C.GPGETUNIFORMINDICES
-	gpGetUniformLocation                          C.GPGETUNIFORMLOCATION
-	gpGetUniformSubroutineuiv                     C.GPGETUNIFORMSUBROUTINEUIV
-	gpGetUniformdv                                C.GPGETUNIFORMDV
-	gpGetUniformfv                                C.GPGETUNIFORMFV
-	gpGetUniformiv                                C.GPGETUNIFORMIV
-	gpGetUniformuiv                               C.GPGETUNIFORMUIV
-	gpGetVertexArrayIndexed64iv                   C.GPGETVERTEXARRAYINDEXED64IV
-	gpGetVertexArrayIndexediv                     C.GPGETVERTEXARRAYINDEXEDIV
-	gpGetVertexArrayiv                            C.GPGETVERTEXARRAYIV
-	gpGetVertexAttribIiv                          C.GPGETVERTEXATTRIBIIV
-	gpGetVertexAttribIuiv                         C.GPGETVERTEXATTRIBIUIV
-	gpGetVertexAttribLdv                          C.GPGETVERTEXATTRIBLDV
-	gpGetVertexAttribLui64vARB                    C.GPGETVERTEXATTRIBLUI64VARB
-	gpGetVertexAttribPointerv                     C.GPGETVERTEXATTRIBPOINTERV
-	gpGetVertexAttribdv                           C.GPGETVERTEXATTRIBDV
-	gpGetVertexAttribfv                           C.GPGETVERTEXATTRIBFV
-	gpGetVertexAttribiv                           C.GPGETVERTEXATTRIBIV
-	gpGetnCompressedTexImage                      C.GPGETNCOMPRESSEDTEXIMAGE
-	gpGetnCompressedTexImageARB                   C.GPGETNCOMPRESSEDTEXIMAGEARB
-	gpGetnTexImage                                C.GPGETNTEXIMAGE
-	gpGetnTexImageARB                             C.GPGETNTEXIMAGEARB
-	gpGetnUniformdv                               C.GPGETNUNIFORMDV
-	gpGetnUniformdvARB                            C.GPGETNUNIFORMDVARB
-	gpGetnUniformfv                               C.GPGETNUNIFORMFV
-	gpGetnUniformfvARB                            C.GPGETNUNIFORMFVARB
-	gpGetnUniformfvKHR                            C.GPGETNUNIFORMFVKHR
-	gpGetnUniformiv                               C.GPGETNUNIFORMIV
-	gpGetnUniformivARB                            C.GPGETNUNIFORMIVARB
-	gpGetnUniformivKHR                            C.GPGETNUNIFORMIVKHR
-	gpGetnUniformuiv                              C.GPGETNUNIFORMUIV
-	gpGetnUniformuivARB                           C.GPGETNUNIFORMUIVARB
-	gpGetnUniformuivKHR                           C.GPGETNUNIFORMUIVKHR
-	gpHint                                        C.GPHINT
-	gpIndexMask                                   C.GPINDEXMASK
-	gpIndexPointer                                C.GPINDEXPOINTER
-	gpIndexd                                      C.GPINDEXD
-	gpIndexdv                                     C.GPINDEXDV
-	gpIndexf                                      C.GPINDEXF
-	gpIndexfv                                     C.GPINDEXFV
-	gpIndexi                                      C.GPINDEXI
-	gpIndexiv                                     C.GPINDEXIV
-	gpIndexs                                      C.GPINDEXS
-	gpIndexsv                                     C.GPINDEXSV
-	gpIndexub                                     C.GPINDEXUB
-	gpIndexubv                                    C.GPINDEXUBV
-	gpInitNames                                   C.GPINITNAMES
-	gpInterleavedArrays                           C.GPINTERLEAVEDARRAYS
-	gpInvalidateBufferData                        C.GPINVALIDATEBUFFERDATA
-	gpInvalidateBufferSubData                     C.GPINVALIDATEBUFFERSUBDATA
-	gpInvalidateFramebuffer                       C.GPINVALIDATEFRAMEBUFFER
-	gpInvalidateNamedFramebufferData              C.GPINVALIDATENAMEDFRAMEBUFFERDATA
-	gpInvalidateNamedFramebufferSubData           C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
-	gpInvalidateSubFramebuffer                    C.GPINVALIDATESUBFRAMEBUFFER
-	gpInvalidateTexImage                          C.GPINVALIDATETEXIMAGE
-	gpInvalidateTexSubImage                       C.GPINVALIDATETEXSUBIMAGE
-	gpIsBuffer                                    C.GPISBUFFER
-	gpIsEnabled                                   C.GPISENABLED
-	gpIsEnabledi                                  C.GPISENABLEDI
-	gpIsFramebuffer                               C.GPISFRAMEBUFFER
-	gpIsImageHandleResidentARB                    C.GPISIMAGEHANDLERESIDENTARB
-	gpIsList                                      C.GPISLIST
-	gpIsNamedStringARB                            C.GPISNAMEDSTRINGARB
-	gpIsProgram                                   C.GPISPROGRAM
-	gpIsProgramPipeline                           C.GPISPROGRAMPIPELINE
-	gpIsQuery                                     C.GPISQUERY
-	gpIsRenderbuffer                              C.GPISRENDERBUFFER
-	gpIsSampler                                   C.GPISSAMPLER
-	gpIsShader                                    C.GPISSHADER
-	gpIsSync                                      C.GPISSYNC
-	gpIsTexture                                   C.GPISTEXTURE
-	gpIsTextureHandleResidentARB                  C.GPISTEXTUREHANDLERESIDENTARB
-	gpIsTransformFeedback                         C.GPISTRANSFORMFEEDBACK
-	gpIsVertexArray                               C.GPISVERTEXARRAY
-	gpLightModelf                                 C.GPLIGHTMODELF
-	gpLightModelfv                                C.GPLIGHTMODELFV
-	gpLightModeli                                 C.GPLIGHTMODELI
-	gpLightModeliv                                C.GPLIGHTMODELIV
-	gpLightf                                      C.GPLIGHTF
-	gpLightfv                                     C.GPLIGHTFV
-	gpLighti                                      C.GPLIGHTI
-	gpLightiv                                     C.GPLIGHTIV
-	gpLineStipple                                 C.GPLINESTIPPLE
-	gpLineWidth                                   C.GPLINEWIDTH
-	gpLinkProgram                                 C.GPLINKPROGRAM
-	gpListBase                                    C.GPLISTBASE
-	gpLoadIdentity                                C.GPLOADIDENTITY
-	gpLoadMatrixd                                 C.GPLOADMATRIXD
-	gpLoadMatrixf                                 C.GPLOADMATRIXF
-	gpLoadName                                    C.GPLOADNAME
-	gpLoadTransposeMatrixd                        C.GPLOADTRANSPOSEMATRIXD
-	gpLoadTransposeMatrixf                        C.GPLOADTRANSPOSEMATRIXF
-	gpLogicOp                                     C.GPLOGICOP
-	gpMakeImageHandleNonResidentARB               C.GPMAKEIMAGEHANDLENONRESIDENTARB
-	gpMakeImageHandleResidentARB                  C.GPMAKEIMAGEHANDLERESIDENTARB
-	gpMakeTextureHandleNonResidentARB             C.GPMAKETEXTUREHANDLENONRESIDENTARB
-	gpMakeTextureHandleResidentARB                C.GPMAKETEXTUREHANDLERESIDENTARB
-	gpMap1d                                       C.GPMAP1D
-	gpMap1f                                       C.GPMAP1F
-	gpMap2d                                       C.GPMAP2D
-	gpMap2f                                       C.GPMAP2F
-	gpMapBuffer                                   C.GPMAPBUFFER
-	gpMapBufferRange                              C.GPMAPBUFFERRANGE
-	gpMapGrid1d                                   C.GPMAPGRID1D
-	gpMapGrid1f                                   C.GPMAPGRID1F
-	gpMapGrid2d                                   C.GPMAPGRID2D
-	gpMapGrid2f                                   C.GPMAPGRID2F
-	gpMapNamedBuffer                              C.GPMAPNAMEDBUFFER
-	gpMapNamedBufferRange                         C.GPMAPNAMEDBUFFERRANGE
-	gpMaterialf                                   C.GPMATERIALF
-	gpMaterialfv                                  C.GPMATERIALFV
-	gpMateriali                                   C.GPMATERIALI
-	gpMaterialiv                                  C.GPMATERIALIV
-	gpMatrixMode                                  C.GPMATRIXMODE
-	gpMemoryBarrier                               C.GPMEMORYBARRIER
-	gpMemoryBarrierByRegion                       C.GPMEMORYBARRIERBYREGION
-	gpMinSampleShading                            C.GPMINSAMPLESHADING
-	gpMinSampleShadingARB                         C.GPMINSAMPLESHADINGARB
-	gpMultMatrixd                                 C.GPMULTMATRIXD
-	gpMultMatrixf                                 C.GPMULTMATRIXF
-	gpMultTransposeMatrixd                        C.GPMULTTRANSPOSEMATRIXD
-	gpMultTransposeMatrixf                        C.GPMULTTRANSPOSEMATRIXF
-	gpMultiDrawArrays                             C.GPMULTIDRAWARRAYS
-	gpMultiDrawArraysIndirect                     C.GPMULTIDRAWARRAYSINDIRECT
-	gpMultiDrawArraysIndirectCountARB             C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
-	gpMultiDrawElements                           C.GPMULTIDRAWELEMENTS
-	gpMultiDrawElementsBaseVertex                 C.GPMULTIDRAWELEMENTSBASEVERTEX
-	gpMultiDrawElementsIndirect                   C.GPMULTIDRAWELEMENTSINDIRECT
-	gpMultiDrawElementsIndirectCountARB           C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
-	gpMultiTexCoord1d                             C.GPMULTITEXCOORD1D
-	gpMultiTexCoord1dv                            C.GPMULTITEXCOORD1DV
-	gpMultiTexCoord1f                             C.GPMULTITEXCOORD1F
-	gpMultiTexCoord1fv                            C.GPMULTITEXCOORD1FV
-	gpMultiTexCoord1i                             C.GPMULTITEXCOORD1I
-	gpMultiTexCoord1iv                            C.GPMULTITEXCOORD1IV
-	gpMultiTexCoord1s                             C.GPMULTITEXCOORD1S
-	gpMultiTexCoord1sv                            C.GPMULTITEXCOORD1SV
-	gpMultiTexCoord2d                             C.GPMULTITEXCOORD2D
-	gpMultiTexCoord2dv                            C.GPMULTITEXCOORD2DV
-	gpMultiTexCoord2f                             C.GPMULTITEXCOORD2F
-	gpMultiTexCoord2fv                            C.GPMULTITEXCOORD2FV
-	gpMultiTexCoord2i                             C.GPMULTITEXCOORD2I
-	gpMultiTexCoord2iv                            C.GPMULTITEXCOORD2IV
-	gpMultiTexCoord2s                             C.GPMULTITEXCOORD2S
-	gpMultiTexCoord2sv                            C.GPMULTITEXCOORD2SV
-	gpMultiTexCoord3d                             C.GPMULTITEXCOORD3D
-	gpMultiTexCoord3dv                            C.GPMULTITEXCOORD3DV
-	gpMultiTexCoord3f                             C.GPMULTITEXCOORD3F
-	gpMultiTexCoord3fv                            C.GPMULTITEXCOORD3FV
-	gpMultiTexCoord3i                             C.GPMULTITEXCOORD3I
-	gpMultiTexCoord3iv                            C.GPMULTITEXCOORD3IV
-	gpMultiTexCoord3s                             C.GPMULTITEXCOORD3S
-	gpMultiTexCoord3sv                            C.GPMULTITEXCOORD3SV
-	gpMultiTexCoord4d                             C.GPMULTITEXCOORD4D
-	gpMultiTexCoord4dv                            C.GPMULTITEXCOORD4DV
-	gpMultiTexCoord4f                             C.GPMULTITEXCOORD4F
-	gpMultiTexCoord4fv                            C.GPMULTITEXCOORD4FV
-	gpMultiTexCoord4i                             C.GPMULTITEXCOORD4I
-	gpMultiTexCoord4iv                            C.GPMULTITEXCOORD4IV
-	gpMultiTexCoord4s                             C.GPMULTITEXCOORD4S
-	gpMultiTexCoord4sv                            C.GPMULTITEXCOORD4SV
-	gpNamedBufferData                             C.GPNAMEDBUFFERDATA
-	gpNamedBufferPageCommitmentARB                C.GPNAMEDBUFFERPAGECOMMITMENTARB
-	gpNamedBufferPageCommitmentEXT                C.GPNAMEDBUFFERPAGECOMMITMENTEXT
-	gpNamedBufferStorage                          C.GPNAMEDBUFFERSTORAGE
-	gpNamedBufferSubData                          C.GPNAMEDBUFFERSUBDATA
-	gpNamedFramebufferDrawBuffer                  C.GPNAMEDFRAMEBUFFERDRAWBUFFER
-	gpNamedFramebufferDrawBuffers                 C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
-	gpNamedFramebufferParameteri                  C.GPNAMEDFRAMEBUFFERPARAMETERI
-	gpNamedFramebufferReadBuffer                  C.GPNAMEDFRAMEBUFFERREADBUFFER
-	gpNamedFramebufferRenderbuffer                C.GPNAMEDFRAMEBUFFERRENDERBUFFER
-	gpNamedFramebufferTexture                     C.GPNAMEDFRAMEBUFFERTEXTURE
-	gpNamedFramebufferTextureLayer                C.GPNAMEDFRAMEBUFFERTEXTURELAYER
-	gpNamedRenderbufferStorage                    C.GPNAMEDRENDERBUFFERSTORAGE
-	gpNamedRenderbufferStorageMultisample         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
-	gpNamedStringARB                              C.GPNAMEDSTRINGARB
-	gpNewList                                     C.GPNEWLIST
-	gpNormal3b                                    C.GPNORMAL3B
-	gpNormal3bv                                   C.GPNORMAL3BV
-	gpNormal3d                                    C.GPNORMAL3D
-	gpNormal3dv                                   C.GPNORMAL3DV
-	gpNormal3f                                    C.GPNORMAL3F
-	gpNormal3fv                                   C.GPNORMAL3FV
-	gpNormal3i                                    C.GPNORMAL3I
-	gpNormal3iv                                   C.GPNORMAL3IV
-	gpNormal3s                                    C.GPNORMAL3S
-	gpNormal3sv                                   C.GPNORMAL3SV
-	gpNormalPointer                               C.GPNORMALPOINTER
-	gpObjectLabel                                 C.GPOBJECTLABEL
-	gpObjectLabelKHR                              C.GPOBJECTLABELKHR
-	gpObjectPtrLabel                              C.GPOBJECTPTRLABEL
-	gpObjectPtrLabelKHR                           C.GPOBJECTPTRLABELKHR
-	gpOrtho                                       C.GPORTHO
-	gpPassThrough                                 C.GPPASSTHROUGH
-	gpPatchParameterfv                            C.GPPATCHPARAMETERFV
-	gpPatchParameteri                             C.GPPATCHPARAMETERI
-	gpPauseTransformFeedback                      C.GPPAUSETRANSFORMFEEDBACK
-	gpPixelMapfv                                  C.GPPIXELMAPFV
-	gpPixelMapuiv                                 C.GPPIXELMAPUIV
-	gpPixelMapusv                                 C.GPPIXELMAPUSV
-	gpPixelStoref                                 C.GPPIXELSTOREF
-	gpPixelStorei                                 C.GPPIXELSTOREI
-	gpPixelTransferf                              C.GPPIXELTRANSFERF
-	gpPixelTransferi                              C.GPPIXELTRANSFERI
-	gpPixelZoom                                   C.GPPIXELZOOM
-	gpPointParameterf                             C.GPPOINTPARAMETERF
-	gpPointParameterfv                            C.GPPOINTPARAMETERFV
-	gpPointParameteri                             C.GPPOINTPARAMETERI
-	gpPointParameteriv                            C.GPPOINTPARAMETERIV
-	gpPointSize                                   C.GPPOINTSIZE
-	gpPolygonMode                                 C.GPPOLYGONMODE
-	gpPolygonOffset                               C.GPPOLYGONOFFSET
-	gpPolygonStipple                              C.GPPOLYGONSTIPPLE
-	gpPopAttrib                                   C.GPPOPATTRIB
-	gpPopClientAttrib                             C.GPPOPCLIENTATTRIB
-	gpPopDebugGroup                               C.GPPOPDEBUGGROUP
-	gpPopDebugGroupKHR                            C.GPPOPDEBUGGROUPKHR
-	gpPopMatrix                                   C.GPPOPMATRIX
-	gpPopName                                     C.GPPOPNAME
-	gpPrimitiveRestartIndex                       C.GPPRIMITIVERESTARTINDEX
-	gpPrioritizeTextures                          C.GPPRIORITIZETEXTURES
-	gpProgramBinary                               C.GPPROGRAMBINARY
-	gpProgramParameteri                           C.GPPROGRAMPARAMETERI
-	gpProgramUniform1d                            C.GPPROGRAMUNIFORM1D
-	gpProgramUniform1dv                           C.GPPROGRAMUNIFORM1DV
-	gpProgramUniform1f                            C.GPPROGRAMUNIFORM1F
-	gpProgramUniform1fv                           C.GPPROGRAMUNIFORM1FV
-	gpProgramUniform1i                            C.GPPROGRAMUNIFORM1I
-	gpProgramUniform1iv                           C.GPPROGRAMUNIFORM1IV
-	gpProgramUniform1ui                           C.GPPROGRAMUNIFORM1UI
-	gpProgramUniform1uiv                          C.GPPROGRAMUNIFORM1UIV
-	gpProgramUniform2d                            C.GPPROGRAMUNIFORM2D
-	gpProgramUniform2dv                           C.GPPROGRAMUNIFORM2DV
-	gpProgramUniform2f                            C.GPPROGRAMUNIFORM2F
-	gpProgramUniform2fv                           C.GPPROGRAMUNIFORM2FV
-	gpProgramUniform2i                            C.GPPROGRAMUNIFORM2I
-	gpProgramUniform2iv                           C.GPPROGRAMUNIFORM2IV
-	gpProgramUniform2ui                           C.GPPROGRAMUNIFORM2UI
-	gpProgramUniform2uiv                          C.GPPROGRAMUNIFORM2UIV
-	gpProgramUniform3d                            C.GPPROGRAMUNIFORM3D
-	gpProgramUniform3dv                           C.GPPROGRAMUNIFORM3DV
-	gpProgramUniform3f                            C.GPPROGRAMUNIFORM3F
-	gpProgramUniform3fv                           C.GPPROGRAMUNIFORM3FV
-	gpProgramUniform3i                            C.GPPROGRAMUNIFORM3I
-	gpProgramUniform3iv                           C.GPPROGRAMUNIFORM3IV
-	gpProgramUniform3ui                           C.GPPROGRAMUNIFORM3UI
-	gpProgramUniform3uiv                          C.GPPROGRAMUNIFORM3UIV
-	gpProgramUniform4d                            C.GPPROGRAMUNIFORM4D
-	gpProgramUniform4dv                           C.GPPROGRAMUNIFORM4DV
-	gpProgramUniform4f                            C.GPPROGRAMUNIFORM4F
-	gpProgramUniform4fv                           C.GPPROGRAMUNIFORM4FV
-	gpProgramUniform4i                            C.GPPROGRAMUNIFORM4I
-	gpProgramUniform4iv                           C.GPPROGRAMUNIFORM4IV
-	gpProgramUniform4ui                           C.GPPROGRAMUNIFORM4UI
-	gpProgramUniform4uiv                          C.GPPROGRAMUNIFORM4UIV
-	gpProgramUniformHandleui64ARB                 C.GPPROGRAMUNIFORMHANDLEUI64ARB
-	gpProgramUniformHandleui64vARB                C.GPPROGRAMUNIFORMHANDLEUI64VARB
-	gpProgramUniformMatrix2dv                     C.GPPROGRAMUNIFORMMATRIX2DV
-	gpProgramUniformMatrix2fv                     C.GPPROGRAMUNIFORMMATRIX2FV
-	gpProgramUniformMatrix2x3dv                   C.GPPROGRAMUNIFORMMATRIX2X3DV
-	gpProgramUniformMatrix2x3fv                   C.GPPROGRAMUNIFORMMATRIX2X3FV
-	gpProgramUniformMatrix2x4dv                   C.GPPROGRAMUNIFORMMATRIX2X4DV
-	gpProgramUniformMatrix2x4fv                   C.GPPROGRAMUNIFORMMATRIX2X4FV
-	gpProgramUniformMatrix3dv                     C.GPPROGRAMUNIFORMMATRIX3DV
-	gpProgramUniformMatrix3fv                     C.GPPROGRAMUNIFORMMATRIX3FV
-	gpProgramUniformMatrix3x2dv                   C.GPPROGRAMUNIFORMMATRIX3X2DV
-	gpProgramUniformMatrix3x2fv                   C.GPPROGRAMUNIFORMMATRIX3X2FV
-	gpProgramUniformMatrix3x4dv                   C.GPPROGRAMUNIFORMMATRIX3X4DV
-	gpProgramUniformMatrix3x4fv                   C.GPPROGRAMUNIFORMMATRIX3X4FV
-	gpProgramUniformMatrix4dv                     C.GPPROGRAMUNIFORMMATRIX4DV
-	gpProgramUniformMatrix4fv                     C.GPPROGRAMUNIFORMMATRIX4FV
-	gpProgramUniformMatrix4x2dv                   C.GPPROGRAMUNIFORMMATRIX4X2DV
-	gpProgramUniformMatrix4x2fv                   C.GPPROGRAMUNIFORMMATRIX4X2FV
-	gpProgramUniformMatrix4x3dv                   C.GPPROGRAMUNIFORMMATRIX4X3DV
-	gpProgramUniformMatrix4x3fv                   C.GPPROGRAMUNIFORMMATRIX4X3FV
-	gpProvokingVertex                             C.GPPROVOKINGVERTEX
-	gpPushAttrib                                  C.GPPUSHATTRIB
-	gpPushClientAttrib                            C.GPPUSHCLIENTATTRIB
-	gpPushDebugGroup                              C.GPPUSHDEBUGGROUP
-	gpPushDebugGroupKHR                           C.GPPUSHDEBUGGROUPKHR
-	gpPushMatrix                                  C.GPPUSHMATRIX
-	gpPushName                                    C.GPPUSHNAME
-	gpQueryCounter                                C.GPQUERYCOUNTER
-	gpRasterPos2d                                 C.GPRASTERPOS2D
-	gpRasterPos2dv                                C.GPRASTERPOS2DV
-	gpRasterPos2f                                 C.GPRASTERPOS2F
-	gpRasterPos2fv                                C.GPRASTERPOS2FV
-	gpRasterPos2i                                 C.GPRASTERPOS2I
-	gpRasterPos2iv                                C.GPRASTERPOS2IV
-	gpRasterPos2s                                 C.GPRASTERPOS2S
-	gpRasterPos2sv                                C.GPRASTERPOS2SV
-	gpRasterPos3d                                 C.GPRASTERPOS3D
-	gpRasterPos3dv                                C.GPRASTERPOS3DV
-	gpRasterPos3f                                 C.GPRASTERPOS3F
-	gpRasterPos3fv                                C.GPRASTERPOS3FV
-	gpRasterPos3i                                 C.GPRASTERPOS3I
-	gpRasterPos3iv                                C.GPRASTERPOS3IV
-	gpRasterPos3s                                 C.GPRASTERPOS3S
-	gpRasterPos3sv                                C.GPRASTERPOS3SV
-	gpRasterPos4d                                 C.GPRASTERPOS4D
-	gpRasterPos4dv                                C.GPRASTERPOS4DV
-	gpRasterPos4f                                 C.GPRASTERPOS4F
-	gpRasterPos4fv                                C.GPRASTERPOS4FV
-	gpRasterPos4i                                 C.GPRASTERPOS4I
-	gpRasterPos4iv                                C.GPRASTERPOS4IV
-	gpRasterPos4s                                 C.GPRASTERPOS4S
-	gpRasterPos4sv                                C.GPRASTERPOS4SV
-	gpReadBuffer                                  C.GPREADBUFFER
-	gpReadPixels                                  C.GPREADPIXELS
-	gpReadnPixels                                 C.GPREADNPIXELS
-	gpReadnPixelsARB                              C.GPREADNPIXELSARB
-	gpReadnPixelsKHR                              C.GPREADNPIXELSKHR
-	gpRectd                                       C.GPRECTD
-	gpRectdv                                      C.GPRECTDV
-	gpRectf                                       C.GPRECTF
-	gpRectfv                                      C.GPRECTFV
-	gpRecti                                       C.GPRECTI
-	gpRectiv                                      C.GPRECTIV
-	gpRects                                       C.GPRECTS
-	gpRectsv                                      C.GPRECTSV
-	gpReleaseShaderCompiler                       C.GPRELEASESHADERCOMPILER
-	gpRenderMode                                  C.GPRENDERMODE
-	gpRenderbufferStorage                         C.GPRENDERBUFFERSTORAGE
-	gpRenderbufferStorageMultisample              C.GPRENDERBUFFERSTORAGEMULTISAMPLE
-	gpResumeTransformFeedback                     C.GPRESUMETRANSFORMFEEDBACK
-	gpRotated                                     C.GPROTATED
-	gpRotatef                                     C.GPROTATEF
-	gpSampleCoverage                              C.GPSAMPLECOVERAGE
-	gpSampleMaski                                 C.GPSAMPLEMASKI
-	gpSamplerParameterIiv                         C.GPSAMPLERPARAMETERIIV
-	gpSamplerParameterIuiv                        C.GPSAMPLERPARAMETERIUIV
-	gpSamplerParameterf                           C.GPSAMPLERPARAMETERF
-	gpSamplerParameterfv                          C.GPSAMPLERPARAMETERFV
-	gpSamplerParameteri                           C.GPSAMPLERPARAMETERI
-	gpSamplerParameteriv                          C.GPSAMPLERPARAMETERIV
-	gpScaled                                      C.GPSCALED
-	gpScalef                                      C.GPSCALEF
-	gpScissor                                     C.GPSCISSOR
-	gpScissorArrayv                               C.GPSCISSORARRAYV
-	gpScissorIndexed                              C.GPSCISSORINDEXED
-	gpScissorIndexedv                             C.GPSCISSORINDEXEDV
-	gpSecondaryColor3b                            C.GPSECONDARYCOLOR3B
-	gpSecondaryColor3bv                           C.GPSECONDARYCOLOR3BV
-	gpSecondaryColor3d                            C.GPSECONDARYCOLOR3D
-	gpSecondaryColor3dv                           C.GPSECONDARYCOLOR3DV
-	gpSecondaryColor3f                            C.GPSECONDARYCOLOR3F
-	gpSecondaryColor3fv                           C.GPSECONDARYCOLOR3FV
-	gpSecondaryColor3i                            C.GPSECONDARYCOLOR3I
-	gpSecondaryColor3iv                           C.GPSECONDARYCOLOR3IV
-	gpSecondaryColor3s                            C.GPSECONDARYCOLOR3S
-	gpSecondaryColor3sv                           C.GPSECONDARYCOLOR3SV
-	gpSecondaryColor3ub                           C.GPSECONDARYCOLOR3UB
-	gpSecondaryColor3ubv                          C.GPSECONDARYCOLOR3UBV
-	gpSecondaryColor3ui                           C.GPSECONDARYCOLOR3UI
-	gpSecondaryColor3uiv                          C.GPSECONDARYCOLOR3UIV
-	gpSecondaryColor3us                           C.GPSECONDARYCOLOR3US
-	gpSecondaryColor3usv                          C.GPSECONDARYCOLOR3USV
-	gpSecondaryColorPointer                       C.GPSECONDARYCOLORPOINTER
-	gpSelectBuffer                                C.GPSELECTBUFFER
-	gpShadeModel                                  C.GPSHADEMODEL
-	gpShaderBinary                                C.GPSHADERBINARY
-	gpShaderSource                                C.GPSHADERSOURCE
-	gpShaderStorageBlockBinding                   C.GPSHADERSTORAGEBLOCKBINDING
-	gpStencilFunc                                 C.GPSTENCILFUNC
-	gpStencilFuncSeparate                         C.GPSTENCILFUNCSEPARATE
-	gpStencilMask                                 C.GPSTENCILMASK
-	gpStencilMaskSeparate                         C.GPSTENCILMASKSEPARATE
-	gpStencilOp                                   C.GPSTENCILOP
-	gpStencilOpSeparate                           C.GPSTENCILOPSEPARATE
-	gpTexBuffer                                   C.GPTEXBUFFER
-	gpTexBufferRange                              C.GPTEXBUFFERRANGE
-	gpTexCoord1d                                  C.GPTEXCOORD1D
-	gpTexCoord1dv                                 C.GPTEXCOORD1DV
-	gpTexCoord1f                                  C.GPTEXCOORD1F
-	gpTexCoord1fv                                 C.GPTEXCOORD1FV
-	gpTexCoord1i                                  C.GPTEXCOORD1I
-	gpTexCoord1iv                                 C.GPTEXCOORD1IV
-	gpTexCoord1s                                  C.GPTEXCOORD1S
-	gpTexCoord1sv                                 C.GPTEXCOORD1SV
-	gpTexCoord2d                                  C.GPTEXCOORD2D
-	gpTexCoord2dv                                 C.GPTEXCOORD2DV
-	gpTexCoord2f                                  C.GPTEXCOORD2F
-	gpTexCoord2fv                                 C.GPTEXCOORD2FV
-	gpTexCoord2i                                  C.GPTEXCOORD2I
-	gpTexCoord2iv                                 C.GPTEXCOORD2IV
-	gpTexCoord2s                                  C.GPTEXCOORD2S
-	gpTexCoord2sv                                 C.GPTEXCOORD2SV
-	gpTexCoord3d                                  C.GPTEXCOORD3D
-	gpTexCoord3dv                                 C.GPTEXCOORD3DV
-	gpTexCoord3f                                  C.GPTEXCOORD3F
-	gpTexCoord3fv                                 C.GPTEXCOORD3FV
-	gpTexCoord3i                                  C.GPTEXCOORD3I
-	gpTexCoord3iv                                 C.GPTEXCOORD3IV
-	gpTexCoord3s                                  C.GPTEXCOORD3S
-	gpTexCoord3sv                                 C.GPTEXCOORD3SV
-	gpTexCoord4d                                  C.GPTEXCOORD4D
-	gpTexCoord4dv                                 C.GPTEXCOORD4DV
-	gpTexCoord4f                                  C.GPTEXCOORD4F
-	gpTexCoord4fv                                 C.GPTEXCOORD4FV
-	gpTexCoord4i                                  C.GPTEXCOORD4I
-	gpTexCoord4iv                                 C.GPTEXCOORD4IV
-	gpTexCoord4s                                  C.GPTEXCOORD4S
-	gpTexCoord4sv                                 C.GPTEXCOORD4SV
-	gpTexCoordPointer                             C.GPTEXCOORDPOINTER
-	gpTexEnvf                                     C.GPTEXENVF
-	gpTexEnvfv                                    C.GPTEXENVFV
-	gpTexEnvi                                     C.GPTEXENVI
-	gpTexEnviv                                    C.GPTEXENVIV
-	gpTexGend                                     C.GPTEXGEND
-	gpTexGendv                                    C.GPTEXGENDV
-	gpTexGenf                                     C.GPTEXGENF
-	gpTexGenfv                                    C.GPTEXGENFV
-	gpTexGeni                                     C.GPTEXGENI
-	gpTexGeniv                                    C.GPTEXGENIV
-	gpTexImage1D                                  C.GPTEXIMAGE1D
-	gpTexImage2D                                  C.GPTEXIMAGE2D
-	gpTexImage2DMultisample                       C.GPTEXIMAGE2DMULTISAMPLE
-	gpTexImage3D                                  C.GPTEXIMAGE3D
-	gpTexImage3DMultisample                       C.GPTEXIMAGE3DMULTISAMPLE
-	gpTexPageCommitmentARB                        C.GPTEXPAGECOMMITMENTARB
-	gpTexParameterIiv                             C.GPTEXPARAMETERIIV
-	gpTexParameterIuiv                            C.GPTEXPARAMETERIUIV
-	gpTexParameterf                               C.GPTEXPARAMETERF
-	gpTexParameterfv                              C.GPTEXPARAMETERFV
-	gpTexParameteri                               C.GPTEXPARAMETERI
-	gpTexParameteriv                              C.GPTEXPARAMETERIV
-	gpTexStorage1D                                C.GPTEXSTORAGE1D
-	gpTexStorage2D                                C.GPTEXSTORAGE2D
-	gpTexStorage2DMultisample                     C.GPTEXSTORAGE2DMULTISAMPLE
-	gpTexStorage3D                                C.GPTEXSTORAGE3D
-	gpTexStorage3DMultisample                     C.GPTEXSTORAGE3DMULTISAMPLE
-	gpTexSubImage1D                               C.GPTEXSUBIMAGE1D
-	gpTexSubImage2D                               C.GPTEXSUBIMAGE2D
-	gpTexSubImage3D                               C.GPTEXSUBIMAGE3D
-	gpTextureBarrier                              C.GPTEXTUREBARRIER
-	gpTextureBuffer                               C.GPTEXTUREBUFFER
-	gpTextureBufferRange                          C.GPTEXTUREBUFFERRANGE
-	gpTextureParameterIiv                         C.GPTEXTUREPARAMETERIIV
-	gpTextureParameterIuiv                        C.GPTEXTUREPARAMETERIUIV
-	gpTextureParameterf                           C.GPTEXTUREPARAMETERF
-	gpTextureParameterfv                          C.GPTEXTUREPARAMETERFV
-	gpTextureParameteri                           C.GPTEXTUREPARAMETERI
-	gpTextureParameteriv                          C.GPTEXTUREPARAMETERIV
-	gpTextureStorage1D                            C.GPTEXTURESTORAGE1D
-	gpTextureStorage2D                            C.GPTEXTURESTORAGE2D
-	gpTextureStorage2DMultisample                 C.GPTEXTURESTORAGE2DMULTISAMPLE
-	gpTextureStorage3D                            C.GPTEXTURESTORAGE3D
-	gpTextureStorage3DMultisample                 C.GPTEXTURESTORAGE3DMULTISAMPLE
-	gpTextureSubImage1D                           C.GPTEXTURESUBIMAGE1D
-	gpTextureSubImage2D                           C.GPTEXTURESUBIMAGE2D
-	gpTextureSubImage3D                           C.GPTEXTURESUBIMAGE3D
-	gpTextureView                                 C.GPTEXTUREVIEW
-	gpTransformFeedbackBufferBase                 C.GPTRANSFORMFEEDBACKBUFFERBASE
-	gpTransformFeedbackBufferRange                C.GPTRANSFORMFEEDBACKBUFFERRANGE
-	gpTransformFeedbackVaryings                   C.GPTRANSFORMFEEDBACKVARYINGS
-	gpTranslated                                  C.GPTRANSLATED
-	gpTranslatef                                  C.GPTRANSLATEF
-	gpUniform1d                                   C.GPUNIFORM1D
-	gpUniform1dv                                  C.GPUNIFORM1DV
-	gpUniform1f                                   C.GPUNIFORM1F
-	gpUniform1fv                                  C.GPUNIFORM1FV
-	gpUniform1i                                   C.GPUNIFORM1I
-	gpUniform1iv                                  C.GPUNIFORM1IV
-	gpUniform1ui                                  C.GPUNIFORM1UI
-	gpUniform1uiv                                 C.GPUNIFORM1UIV
-	gpUniform2d                                   C.GPUNIFORM2D
-	gpUniform2dv                                  C.GPUNIFORM2DV
-	gpUniform2f                                   C.GPUNIFORM2F
-	gpUniform2fv                                  C.GPUNIFORM2FV
-	gpUniform2i                                   C.GPUNIFORM2I
-	gpUniform2iv                                  C.GPUNIFORM2IV
-	gpUniform2ui                                  C.GPUNIFORM2UI
-	gpUniform2uiv                                 C.GPUNIFORM2UIV
-	gpUniform3d                                   C.GPUNIFORM3D
-	gpUniform3dv                                  C.GPUNIFORM3DV
-	gpUniform3f                                   C.GPUNIFORM3F
-	gpUniform3fv                                  C.GPUNIFORM3FV
-	gpUniform3i                                   C.GPUNIFORM3I
-	gpUniform3iv                                  C.GPUNIFORM3IV
-	gpUniform3ui                                  C.GPUNIFORM3UI
-	gpUniform3uiv                                 C.GPUNIFORM3UIV
-	gpUniform4d                                   C.GPUNIFORM4D
-	gpUniform4dv                                  C.GPUNIFORM4DV
-	gpUniform4f                                   C.GPUNIFORM4F
-	gpUniform4fv                                  C.GPUNIFORM4FV
-	gpUniform4i                                   C.GPUNIFORM4I
-	gpUniform4iv                                  C.GPUNIFORM4IV
-	gpUniform4ui                                  C.GPUNIFORM4UI
-	gpUniform4uiv                                 C.GPUNIFORM4UIV
-	gpUniformBlockBinding                         C.GPUNIFORMBLOCKBINDING
-	gpUniformHandleui64ARB                        C.GPUNIFORMHANDLEUI64ARB
-	gpUniformHandleui64vARB                       C.GPUNIFORMHANDLEUI64VARB
-	gpUniformMatrix2dv                            C.GPUNIFORMMATRIX2DV
-	gpUniformMatrix2fv                            C.GPUNIFORMMATRIX2FV
-	gpUniformMatrix2x3dv                          C.GPUNIFORMMATRIX2X3DV
-	gpUniformMatrix2x3fv                          C.GPUNIFORMMATRIX2X3FV
-	gpUniformMatrix2x4dv                          C.GPUNIFORMMATRIX2X4DV
-	gpUniformMatrix2x4fv                          C.GPUNIFORMMATRIX2X4FV
-	gpUniformMatrix3dv                            C.GPUNIFORMMATRIX3DV
-	gpUniformMatrix3fv                            C.GPUNIFORMMATRIX3FV
-	gpUniformMatrix3x2dv                          C.GPUNIFORMMATRIX3X2DV
-	gpUniformMatrix3x2fv                          C.GPUNIFORMMATRIX3X2FV
-	gpUniformMatrix3x4dv                          C.GPUNIFORMMATRIX3X4DV
-	gpUniformMatrix3x4fv                          C.GPUNIFORMMATRIX3X4FV
-	gpUniformMatrix4dv                            C.GPUNIFORMMATRIX4DV
-	gpUniformMatrix4fv                            C.GPUNIFORMMATRIX4FV
-	gpUniformMatrix4x2dv                          C.GPUNIFORMMATRIX4X2DV
-	gpUniformMatrix4x2fv                          C.GPUNIFORMMATRIX4X2FV
-	gpUniformMatrix4x3dv                          C.GPUNIFORMMATRIX4X3DV
-	gpUniformMatrix4x3fv                          C.GPUNIFORMMATRIX4X3FV
-	gpUniformSubroutinesuiv                       C.GPUNIFORMSUBROUTINESUIV
-	gpUnmapBuffer                                 C.GPUNMAPBUFFER
-	gpUnmapNamedBuffer                            C.GPUNMAPNAMEDBUFFER
-	gpUseProgram                                  C.GPUSEPROGRAM
-	gpUseProgramStages                            C.GPUSEPROGRAMSTAGES
-	gpValidateProgram                             C.GPVALIDATEPROGRAM
-	gpValidateProgramPipeline                     C.GPVALIDATEPROGRAMPIPELINE
-	gpVertex2d                                    C.GPVERTEX2D
-	gpVertex2dv                                   C.GPVERTEX2DV
-	gpVertex2f                                    C.GPVERTEX2F
-	gpVertex2fv                                   C.GPVERTEX2FV
-	gpVertex2i                                    C.GPVERTEX2I
-	gpVertex2iv                                   C.GPVERTEX2IV
-	gpVertex2s                                    C.GPVERTEX2S
-	gpVertex2sv                                   C.GPVERTEX2SV
-	gpVertex3d                                    C.GPVERTEX3D
-	gpVertex3dv                                   C.GPVERTEX3DV
-	gpVertex3f                                    C.GPVERTEX3F
-	gpVertex3fv                                   C.GPVERTEX3FV
-	gpVertex3i                                    C.GPVERTEX3I
-	gpVertex3iv                                   C.GPVERTEX3IV
-	gpVertex3s                                    C.GPVERTEX3S
-	gpVertex3sv                                   C.GPVERTEX3SV
-	gpVertex4d                                    C.GPVERTEX4D
-	gpVertex4dv                                   C.GPVERTEX4DV
-	gpVertex4f                                    C.GPVERTEX4F
-	gpVertex4fv                                   C.GPVERTEX4FV
-	gpVertex4i                                    C.GPVERTEX4I
-	gpVertex4iv                                   C.GPVERTEX4IV
-	gpVertex4s                                    C.GPVERTEX4S
-	gpVertex4sv                                   C.GPVERTEX4SV
-	gpVertexArrayAttribBinding                    C.GPVERTEXARRAYATTRIBBINDING
-	gpVertexArrayAttribFormat                     C.GPVERTEXARRAYATTRIBFORMAT
-	gpVertexArrayAttribIFormat                    C.GPVERTEXARRAYATTRIBIFORMAT
-	gpVertexArrayAttribLFormat                    C.GPVERTEXARRAYATTRIBLFORMAT
-	gpVertexArrayBindingDivisor                   C.GPVERTEXARRAYBINDINGDIVISOR
-	gpVertexArrayElementBuffer                    C.GPVERTEXARRAYELEMENTBUFFER
-	gpVertexArrayVertexBuffer                     C.GPVERTEXARRAYVERTEXBUFFER
-	gpVertexArrayVertexBuffers                    C.GPVERTEXARRAYVERTEXBUFFERS
-	gpVertexAttrib1d                              C.GPVERTEXATTRIB1D
-	gpVertexAttrib1dv                             C.GPVERTEXATTRIB1DV
-	gpVertexAttrib1f                              C.GPVERTEXATTRIB1F
-	gpVertexAttrib1fv                             C.GPVERTEXATTRIB1FV
-	gpVertexAttrib1s                              C.GPVERTEXATTRIB1S
-	gpVertexAttrib1sv                             C.GPVERTEXATTRIB1SV
-	gpVertexAttrib2d                              C.GPVERTEXATTRIB2D
-	gpVertexAttrib2dv                             C.GPVERTEXATTRIB2DV
-	gpVertexAttrib2f                              C.GPVERTEXATTRIB2F
-	gpVertexAttrib2fv                             C.GPVERTEXATTRIB2FV
-	gpVertexAttrib2s                              C.GPVERTEXATTRIB2S
-	gpVertexAttrib2sv                             C.GPVERTEXATTRIB2SV
-	gpVertexAttrib3d                              C.GPVERTEXATTRIB3D
-	gpVertexAttrib3dv                             C.GPVERTEXATTRIB3DV
-	gpVertexAttrib3f                              C.GPVERTEXATTRIB3F
-	gpVertexAttrib3fv                             C.GPVERTEXATTRIB3FV
-	gpVertexAttrib3s                              C.GPVERTEXATTRIB3S
-	gpVertexAttrib3sv                             C.GPVERTEXATTRIB3SV
-	gpVertexAttrib4Nbv                            C.GPVERTEXATTRIB4NBV
-	gpVertexAttrib4Niv                            C.GPVERTEXATTRIB4NIV
-	gpVertexAttrib4Nsv                            C.GPVERTEXATTRIB4NSV
-	gpVertexAttrib4Nub                            C.GPVERTEXATTRIB4NUB
-	gpVertexAttrib4Nubv                           C.GPVERTEXATTRIB4NUBV
-	gpVertexAttrib4Nuiv                           C.GPVERTEXATTRIB4NUIV
-	gpVertexAttrib4Nusv                           C.GPVERTEXATTRIB4NUSV
-	gpVertexAttrib4bv                             C.GPVERTEXATTRIB4BV
-	gpVertexAttrib4d                              C.GPVERTEXATTRIB4D
-	gpVertexAttrib4dv                             C.GPVERTEXATTRIB4DV
-	gpVertexAttrib4f                              C.GPVERTEXATTRIB4F
-	gpVertexAttrib4fv                             C.GPVERTEXATTRIB4FV
-	gpVertexAttrib4iv                             C.GPVERTEXATTRIB4IV
-	gpVertexAttrib4s                              C.GPVERTEXATTRIB4S
-	gpVertexAttrib4sv                             C.GPVERTEXATTRIB4SV
-	gpVertexAttrib4ubv                            C.GPVERTEXATTRIB4UBV
-	gpVertexAttrib4uiv                            C.GPVERTEXATTRIB4UIV
-	gpVertexAttrib4usv                            C.GPVERTEXATTRIB4USV
-	gpVertexAttribBinding                         C.GPVERTEXATTRIBBINDING
-	gpVertexAttribDivisor                         C.GPVERTEXATTRIBDIVISOR
-	gpVertexAttribFormat                          C.GPVERTEXATTRIBFORMAT
-	gpVertexAttribI1i                             C.GPVERTEXATTRIBI1I
-	gpVertexAttribI1iv                            C.GPVERTEXATTRIBI1IV
-	gpVertexAttribI1ui                            C.GPVERTEXATTRIBI1UI
-	gpVertexAttribI1uiv                           C.GPVERTEXATTRIBI1UIV
-	gpVertexAttribI2i                             C.GPVERTEXATTRIBI2I
-	gpVertexAttribI2iv                            C.GPVERTEXATTRIBI2IV
-	gpVertexAttribI2ui                            C.GPVERTEXATTRIBI2UI
-	gpVertexAttribI2uiv                           C.GPVERTEXATTRIBI2UIV
-	gpVertexAttribI3i                             C.GPVERTEXATTRIBI3I
-	gpVertexAttribI3iv                            C.GPVERTEXATTRIBI3IV
-	gpVertexAttribI3ui                            C.GPVERTEXATTRIBI3UI
-	gpVertexAttribI3uiv                           C.GPVERTEXATTRIBI3UIV
-	gpVertexAttribI4bv                            C.GPVERTEXATTRIBI4BV
-	gpVertexAttribI4i                             C.GPVERTEXATTRIBI4I
-	gpVertexAttribI4iv                            C.GPVERTEXATTRIBI4IV
-	gpVertexAttribI4sv                            C.GPVERTEXATTRIBI4SV
-	gpVertexAttribI4ubv                           C.GPVERTEXATTRIBI4UBV
-	gpVertexAttribI4ui                            C.GPVERTEXATTRIBI4UI
-	gpVertexAttribI4uiv                           C.GPVERTEXATTRIBI4UIV
-	gpVertexAttribI4usv                           C.GPVERTEXATTRIBI4USV
-	gpVertexAttribIFormat                         C.GPVERTEXATTRIBIFORMAT
-	gpVertexAttribIPointer                        C.GPVERTEXATTRIBIPOINTER
-	gpVertexAttribL1d                             C.GPVERTEXATTRIBL1D
-	gpVertexAttribL1dv                            C.GPVERTEXATTRIBL1DV
-	gpVertexAttribL1ui64ARB                       C.GPVERTEXATTRIBL1UI64ARB
-	gpVertexAttribL1ui64vARB                      C.GPVERTEXATTRIBL1UI64VARB
-	gpVertexAttribL2d                             C.GPVERTEXATTRIBL2D
-	gpVertexAttribL2dv                            C.GPVERTEXATTRIBL2DV
-	gpVertexAttribL3d                             C.GPVERTEXATTRIBL3D
-	gpVertexAttribL3dv                            C.GPVERTEXATTRIBL3DV
-	gpVertexAttribL4d                             C.GPVERTEXATTRIBL4D
-	gpVertexAttribL4dv                            C.GPVERTEXATTRIBL4DV
-	gpVertexAttribLFormat                         C.GPVERTEXATTRIBLFORMAT
-	gpVertexAttribLPointer                        C.GPVERTEXATTRIBLPOINTER
-	gpVertexAttribP1ui                            C.GPVERTEXATTRIBP1UI
-	gpVertexAttribP1uiv                           C.GPVERTEXATTRIBP1UIV
-	gpVertexAttribP2ui                            C.GPVERTEXATTRIBP2UI
-	gpVertexAttribP2uiv                           C.GPVERTEXATTRIBP2UIV
-	gpVertexAttribP3ui                            C.GPVERTEXATTRIBP3UI
-	gpVertexAttribP3uiv                           C.GPVERTEXATTRIBP3UIV
-	gpVertexAttribP4ui                            C.GPVERTEXATTRIBP4UI
-	gpVertexAttribP4uiv                           C.GPVERTEXATTRIBP4UIV
-	gpVertexAttribPointer                         C.GPVERTEXATTRIBPOINTER
-	gpVertexBindingDivisor                        C.GPVERTEXBINDINGDIVISOR
-	gpVertexPointer                               C.GPVERTEXPOINTER
-	gpViewport                                    C.GPVIEWPORT
-	gpViewportArrayv                              C.GPVIEWPORTARRAYV
-	gpViewportIndexedf                            C.GPVIEWPORTINDEXEDF
-	gpViewportIndexedfv                           C.GPVIEWPORTINDEXEDFV
-	gpWaitSync                                    C.GPWAITSYNC
-	gpWindowPos2d                                 C.GPWINDOWPOS2D
-	gpWindowPos2dv                                C.GPWINDOWPOS2DV
-	gpWindowPos2f                                 C.GPWINDOWPOS2F
-	gpWindowPos2fv                                C.GPWINDOWPOS2FV
-	gpWindowPos2i                                 C.GPWINDOWPOS2I
-	gpWindowPos2iv                                C.GPWINDOWPOS2IV
-	gpWindowPos2s                                 C.GPWINDOWPOS2S
-	gpWindowPos2sv                                C.GPWINDOWPOS2SV
-	gpWindowPos3d                                 C.GPWINDOWPOS3D
-	gpWindowPos3dv                                C.GPWINDOWPOS3DV
-	gpWindowPos3f                                 C.GPWINDOWPOS3F
-	gpWindowPos3fv                                C.GPWINDOWPOS3FV
-	gpWindowPos3i                                 C.GPWINDOWPOS3I
-	gpWindowPos3iv                                C.GPWINDOWPOS3IV
-	gpWindowPos3s                                 C.GPWINDOWPOS3S
-	gpWindowPos3sv                                C.GPWINDOWPOS3SV
+	gpAccum                                          C.GPACCUM
+	gpActiveProgramEXT                               C.GPACTIVEPROGRAMEXT
+	gpActiveShaderProgram                            C.GPACTIVESHADERPROGRAM
+	gpActiveShaderProgramEXT                         C.GPACTIVESHADERPROGRAMEXT
+	gpActiveTexture                                  C.GPACTIVETEXTURE
+	gpAlphaFunc                                      C.GPALPHAFUNC
+	gpApplyFramebufferAttachmentCMAAINTEL            C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
+	gpAreTexturesResident                            C.GPARETEXTURESRESIDENT
+	gpArrayElement                                   C.GPARRAYELEMENT
+	gpAttachShader                                   C.GPATTACHSHADER
+	gpBegin                                          C.GPBEGIN
+	gpBeginConditionalRender                         C.GPBEGINCONDITIONALRENDER
+	gpBeginConditionalRenderNV                       C.GPBEGINCONDITIONALRENDERNV
+	gpBeginPerfMonitorAMD                            C.GPBEGINPERFMONITORAMD
+	gpBeginPerfQueryINTEL                            C.GPBEGINPERFQUERYINTEL
+	gpBeginQuery                                     C.GPBEGINQUERY
+	gpBeginQueryIndexed                              C.GPBEGINQUERYINDEXED
+	gpBeginTransformFeedback                         C.GPBEGINTRANSFORMFEEDBACK
+	gpBindAttribLocation                             C.GPBINDATTRIBLOCATION
+	gpBindBuffer                                     C.GPBINDBUFFER
+	gpBindBufferBase                                 C.GPBINDBUFFERBASE
+	gpBindBufferRange                                C.GPBINDBUFFERRANGE
+	gpBindBuffersBase                                C.GPBINDBUFFERSBASE
+	gpBindBuffersRange                               C.GPBINDBUFFERSRANGE
+	gpBindFragDataLocation                           C.GPBINDFRAGDATALOCATION
+	gpBindFragDataLocationIndexed                    C.GPBINDFRAGDATALOCATIONINDEXED
+	gpBindFramebuffer                                C.GPBINDFRAMEBUFFER
+	gpBindImageTexture                               C.GPBINDIMAGETEXTURE
+	gpBindImageTextures                              C.GPBINDIMAGETEXTURES
+	gpBindMultiTextureEXT                            C.GPBINDMULTITEXTUREEXT
+	gpBindProgramPipeline                            C.GPBINDPROGRAMPIPELINE
+	gpBindProgramPipelineEXT                         C.GPBINDPROGRAMPIPELINEEXT
+	gpBindRenderbuffer                               C.GPBINDRENDERBUFFER
+	gpBindSampler                                    C.GPBINDSAMPLER
+	gpBindSamplers                                   C.GPBINDSAMPLERS
+	gpBindTexture                                    C.GPBINDTEXTURE
+	gpBindTextureUnit                                C.GPBINDTEXTUREUNIT
+	gpBindTextures                                   C.GPBINDTEXTURES
+	gpBindTransformFeedback                          C.GPBINDTRANSFORMFEEDBACK
+	gpBindVertexArray                                C.GPBINDVERTEXARRAY
+	gpBindVertexBuffer                               C.GPBINDVERTEXBUFFER
+	gpBindVertexBuffers                              C.GPBINDVERTEXBUFFERS
+	gpBitmap                                         C.GPBITMAP
+	gpBlendBarrierKHR                                C.GPBLENDBARRIERKHR
+	gpBlendBarrierNV                                 C.GPBLENDBARRIERNV
+	gpBlendColor                                     C.GPBLENDCOLOR
+	gpBlendEquation                                  C.GPBLENDEQUATION
+	gpBlendEquationSeparate                          C.GPBLENDEQUATIONSEPARATE
+	gpBlendEquationSeparatei                         C.GPBLENDEQUATIONSEPARATEI
+	gpBlendEquationSeparateiARB                      C.GPBLENDEQUATIONSEPARATEIARB
+	gpBlendEquationi                                 C.GPBLENDEQUATIONI
+	gpBlendEquationiARB                              C.GPBLENDEQUATIONIARB
+	gpBlendFunc                                      C.GPBLENDFUNC
+	gpBlendFuncSeparate                              C.GPBLENDFUNCSEPARATE
+	gpBlendFuncSeparatei                             C.GPBLENDFUNCSEPARATEI
+	gpBlendFuncSeparateiARB                          C.GPBLENDFUNCSEPARATEIARB
+	gpBlendFunci                                     C.GPBLENDFUNCI
+	gpBlendFunciARB                                  C.GPBLENDFUNCIARB
+	gpBlendParameteriNV                              C.GPBLENDPARAMETERINV
+	gpBlitFramebuffer                                C.GPBLITFRAMEBUFFER
+	gpBlitNamedFramebuffer                           C.GPBLITNAMEDFRAMEBUFFER
+	gpBufferAddressRangeNV                           C.GPBUFFERADDRESSRANGENV
+	gpBufferData                                     C.GPBUFFERDATA
+	gpBufferPageCommitmentARB                        C.GPBUFFERPAGECOMMITMENTARB
+	gpBufferStorage                                  C.GPBUFFERSTORAGE
+	gpBufferSubData                                  C.GPBUFFERSUBDATA
+	gpCallCommandListNV                              C.GPCALLCOMMANDLISTNV
+	gpCallList                                       C.GPCALLLIST
+	gpCallLists                                      C.GPCALLLISTS
+	gpCheckFramebufferStatus                         C.GPCHECKFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatus                    C.GPCHECKNAMEDFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatusEXT                 C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT
+	gpClampColor                                     C.GPCLAMPCOLOR
+	gpClear                                          C.GPCLEAR
+	gpClearAccum                                     C.GPCLEARACCUM
+	gpClearBufferData                                C.GPCLEARBUFFERDATA
+	gpClearBufferSubData                             C.GPCLEARBUFFERSUBDATA
+	gpClearBufferfi                                  C.GPCLEARBUFFERFI
+	gpClearBufferfv                                  C.GPCLEARBUFFERFV
+	gpClearBufferiv                                  C.GPCLEARBUFFERIV
+	gpClearBufferuiv                                 C.GPCLEARBUFFERUIV
+	gpClearColor                                     C.GPCLEARCOLOR
+	gpClearDepth                                     C.GPCLEARDEPTH
+	gpClearDepthf                                    C.GPCLEARDEPTHF
+	gpClearIndex                                     C.GPCLEARINDEX
+	gpClearNamedBufferData                           C.GPCLEARNAMEDBUFFERDATA
+	gpClearNamedBufferDataEXT                        C.GPCLEARNAMEDBUFFERDATAEXT
+	gpClearNamedBufferSubData                        C.GPCLEARNAMEDBUFFERSUBDATA
+	gpClearNamedBufferSubDataEXT                     C.GPCLEARNAMEDBUFFERSUBDATAEXT
+	gpClearNamedFramebufferfi                        C.GPCLEARNAMEDFRAMEBUFFERFI
+	gpClearNamedFramebufferfv                        C.GPCLEARNAMEDFRAMEBUFFERFV
+	gpClearNamedFramebufferiv                        C.GPCLEARNAMEDFRAMEBUFFERIV
+	gpClearNamedFramebufferuiv                       C.GPCLEARNAMEDFRAMEBUFFERUIV
+	gpClearStencil                                   C.GPCLEARSTENCIL
+	gpClearTexImage                                  C.GPCLEARTEXIMAGE
+	gpClearTexSubImage                               C.GPCLEARTEXSUBIMAGE
+	gpClientActiveTexture                            C.GPCLIENTACTIVETEXTURE
+	gpClientAttribDefaultEXT                         C.GPCLIENTATTRIBDEFAULTEXT
+	gpClientWaitSync                                 C.GPCLIENTWAITSYNC
+	gpClipControl                                    C.GPCLIPCONTROL
+	gpClipPlane                                      C.GPCLIPPLANE
+	gpColor3b                                        C.GPCOLOR3B
+	gpColor3bv                                       C.GPCOLOR3BV
+	gpColor3d                                        C.GPCOLOR3D
+	gpColor3dv                                       C.GPCOLOR3DV
+	gpColor3f                                        C.GPCOLOR3F
+	gpColor3fv                                       C.GPCOLOR3FV
+	gpColor3i                                        C.GPCOLOR3I
+	gpColor3iv                                       C.GPCOLOR3IV
+	gpColor3s                                        C.GPCOLOR3S
+	gpColor3sv                                       C.GPCOLOR3SV
+	gpColor3ub                                       C.GPCOLOR3UB
+	gpColor3ubv                                      C.GPCOLOR3UBV
+	gpColor3ui                                       C.GPCOLOR3UI
+	gpColor3uiv                                      C.GPCOLOR3UIV
+	gpColor3us                                       C.GPCOLOR3US
+	gpColor3usv                                      C.GPCOLOR3USV
+	gpColor4b                                        C.GPCOLOR4B
+	gpColor4bv                                       C.GPCOLOR4BV
+	gpColor4d                                        C.GPCOLOR4D
+	gpColor4dv                                       C.GPCOLOR4DV
+	gpColor4f                                        C.GPCOLOR4F
+	gpColor4fv                                       C.GPCOLOR4FV
+	gpColor4i                                        C.GPCOLOR4I
+	gpColor4iv                                       C.GPCOLOR4IV
+	gpColor4s                                        C.GPCOLOR4S
+	gpColor4sv                                       C.GPCOLOR4SV
+	gpColor4ub                                       C.GPCOLOR4UB
+	gpColor4ubv                                      C.GPCOLOR4UBV
+	gpColor4ui                                       C.GPCOLOR4UI
+	gpColor4uiv                                      C.GPCOLOR4UIV
+	gpColor4us                                       C.GPCOLOR4US
+	gpColor4usv                                      C.GPCOLOR4USV
+	gpColorFormatNV                                  C.GPCOLORFORMATNV
+	gpColorMask                                      C.GPCOLORMASK
+	gpColorMaski                                     C.GPCOLORMASKI
+	gpColorMaterial                                  C.GPCOLORMATERIAL
+	gpColorPointer                                   C.GPCOLORPOINTER
+	gpCommandListSegmentsNV                          C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                           C.GPCOMPILECOMMANDLISTNV
+	gpCompileShader                                  C.GPCOMPILESHADER
+	gpCompileShaderIncludeARB                        C.GPCOMPILESHADERINCLUDEARB
+	gpCompressedMultiTexImage1DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE1DEXT
+	gpCompressedMultiTexImage2DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE2DEXT
+	gpCompressedMultiTexImage3DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE3DEXT
+	gpCompressedMultiTexSubImage1DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT
+	gpCompressedMultiTexSubImage2DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT
+	gpCompressedMultiTexSubImage3DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT
+	gpCompressedTexImage1D                           C.GPCOMPRESSEDTEXIMAGE1D
+	gpCompressedTexImage2D                           C.GPCOMPRESSEDTEXIMAGE2D
+	gpCompressedTexImage3D                           C.GPCOMPRESSEDTEXIMAGE3D
+	gpCompressedTexSubImage1D                        C.GPCOMPRESSEDTEXSUBIMAGE1D
+	gpCompressedTexSubImage2D                        C.GPCOMPRESSEDTEXSUBIMAGE2D
+	gpCompressedTexSubImage3D                        C.GPCOMPRESSEDTEXSUBIMAGE3D
+	gpCompressedTextureImage1DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE1DEXT
+	gpCompressedTextureImage2DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE2DEXT
+	gpCompressedTextureImage3DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE3DEXT
+	gpCompressedTextureSubImage1D                    C.GPCOMPRESSEDTEXTURESUBIMAGE1D
+	gpCompressedTextureSubImage1DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT
+	gpCompressedTextureSubImage2D                    C.GPCOMPRESSEDTEXTURESUBIMAGE2D
+	gpCompressedTextureSubImage2DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
+	gpCompressedTextureSubImage3D                    C.GPCOMPRESSEDTEXTURESUBIMAGE3D
+	gpCompressedTextureSubImage3DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                 C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                 C.GPCONSERVATIVERASTERPARAMETERINV
+	gpCopyBufferSubData                              C.GPCOPYBUFFERSUBDATA
+	gpCopyImageSubData                               C.GPCOPYIMAGESUBDATA
+	gpCopyMultiTexImage1DEXT                         C.GPCOPYMULTITEXIMAGE1DEXT
+	gpCopyMultiTexImage2DEXT                         C.GPCOPYMULTITEXIMAGE2DEXT
+	gpCopyMultiTexSubImage1DEXT                      C.GPCOPYMULTITEXSUBIMAGE1DEXT
+	gpCopyMultiTexSubImage2DEXT                      C.GPCOPYMULTITEXSUBIMAGE2DEXT
+	gpCopyMultiTexSubImage3DEXT                      C.GPCOPYMULTITEXSUBIMAGE3DEXT
+	gpCopyNamedBufferSubData                         C.GPCOPYNAMEDBUFFERSUBDATA
+	gpCopyPathNV                                     C.GPCOPYPATHNV
+	gpCopyPixels                                     C.GPCOPYPIXELS
+	gpCopyTexImage1D                                 C.GPCOPYTEXIMAGE1D
+	gpCopyTexImage2D                                 C.GPCOPYTEXIMAGE2D
+	gpCopyTexSubImage1D                              C.GPCOPYTEXSUBIMAGE1D
+	gpCopyTexSubImage2D                              C.GPCOPYTEXSUBIMAGE2D
+	gpCopyTexSubImage3D                              C.GPCOPYTEXSUBIMAGE3D
+	gpCopyTextureImage1DEXT                          C.GPCOPYTEXTUREIMAGE1DEXT
+	gpCopyTextureImage2DEXT                          C.GPCOPYTEXTUREIMAGE2DEXT
+	gpCopyTextureSubImage1D                          C.GPCOPYTEXTURESUBIMAGE1D
+	gpCopyTextureSubImage1DEXT                       C.GPCOPYTEXTURESUBIMAGE1DEXT
+	gpCopyTextureSubImage2D                          C.GPCOPYTEXTURESUBIMAGE2D
+	gpCopyTextureSubImage2DEXT                       C.GPCOPYTEXTURESUBIMAGE2DEXT
+	gpCopyTextureSubImage3D                          C.GPCOPYTEXTURESUBIMAGE3D
+	gpCopyTextureSubImage3DEXT                       C.GPCOPYTEXTURESUBIMAGE3DEXT
+	gpCoverFillPathInstancedNV                       C.GPCOVERFILLPATHINSTANCEDNV
+	gpCoverFillPathNV                                C.GPCOVERFILLPATHNV
+	gpCoverStrokePathInstancedNV                     C.GPCOVERSTROKEPATHINSTANCEDNV
+	gpCoverStrokePathNV                              C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                           C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                      C.GPCOVERAGEMODULATIONTABLENV
+	gpCreateBuffers                                  C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                           C.GPCREATECOMMANDLISTSNV
+	gpCreateFramebuffers                             C.GPCREATEFRAMEBUFFERS
+	gpCreatePerfQueryINTEL                           C.GPCREATEPERFQUERYINTEL
+	gpCreateProgram                                  C.GPCREATEPROGRAM
+	gpCreateProgramPipelines                         C.GPCREATEPROGRAMPIPELINES
+	gpCreateQueries                                  C.GPCREATEQUERIES
+	gpCreateRenderbuffers                            C.GPCREATERENDERBUFFERS
+	gpCreateSamplers                                 C.GPCREATESAMPLERS
+	gpCreateShader                                   C.GPCREATESHADER
+	gpCreateShaderProgramEXT                         C.GPCREATESHADERPROGRAMEXT
+	gpCreateShaderProgramv                           C.GPCREATESHADERPROGRAMV
+	gpCreateShaderProgramvEXT                        C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                 C.GPCREATESTATESNV
+	gpCreateSyncFromCLeventARB                       C.GPCREATESYNCFROMCLEVENTARB
+	gpCreateTextures                                 C.GPCREATETEXTURES
+	gpCreateTransformFeedbacks                       C.GPCREATETRANSFORMFEEDBACKS
+	gpCreateVertexArrays                             C.GPCREATEVERTEXARRAYS
+	gpCullFace                                       C.GPCULLFACE
+	gpDebugMessageCallback                           C.GPDEBUGMESSAGECALLBACK
+	gpDebugMessageCallbackARB                        C.GPDEBUGMESSAGECALLBACKARB
+	gpDebugMessageCallbackKHR                        C.GPDEBUGMESSAGECALLBACKKHR
+	gpDebugMessageControl                            C.GPDEBUGMESSAGECONTROL
+	gpDebugMessageControlARB                         C.GPDEBUGMESSAGECONTROLARB
+	gpDebugMessageControlKHR                         C.GPDEBUGMESSAGECONTROLKHR
+	gpDebugMessageInsert                             C.GPDEBUGMESSAGEINSERT
+	gpDebugMessageInsertARB                          C.GPDEBUGMESSAGEINSERTARB
+	gpDebugMessageInsertKHR                          C.GPDEBUGMESSAGEINSERTKHR
+	gpDeleteBuffers                                  C.GPDELETEBUFFERS
+	gpDeleteCommandListsNV                           C.GPDELETECOMMANDLISTSNV
+	gpDeleteFramebuffers                             C.GPDELETEFRAMEBUFFERS
+	gpDeleteLists                                    C.GPDELETELISTS
+	gpDeleteNamedStringARB                           C.GPDELETENAMEDSTRINGARB
+	gpDeletePathsNV                                  C.GPDELETEPATHSNV
+	gpDeletePerfMonitorsAMD                          C.GPDELETEPERFMONITORSAMD
+	gpDeletePerfQueryINTEL                           C.GPDELETEPERFQUERYINTEL
+	gpDeleteProgram                                  C.GPDELETEPROGRAM
+	gpDeleteProgramPipelines                         C.GPDELETEPROGRAMPIPELINES
+	gpDeleteProgramPipelinesEXT                      C.GPDELETEPROGRAMPIPELINESEXT
+	gpDeleteQueries                                  C.GPDELETEQUERIES
+	gpDeleteRenderbuffers                            C.GPDELETERENDERBUFFERS
+	gpDeleteSamplers                                 C.GPDELETESAMPLERS
+	gpDeleteShader                                   C.GPDELETESHADER
+	gpDeleteStatesNV                                 C.GPDELETESTATESNV
+	gpDeleteSync                                     C.GPDELETESYNC
+	gpDeleteTextures                                 C.GPDELETETEXTURES
+	gpDeleteTransformFeedbacks                       C.GPDELETETRANSFORMFEEDBACKS
+	gpDeleteVertexArrays                             C.GPDELETEVERTEXARRAYS
+	gpDepthFunc                                      C.GPDEPTHFUNC
+	gpDepthMask                                      C.GPDEPTHMASK
+	gpDepthRange                                     C.GPDEPTHRANGE
+	gpDepthRangeArrayv                               C.GPDEPTHRANGEARRAYV
+	gpDepthRangeIndexed                              C.GPDEPTHRANGEINDEXED
+	gpDepthRangef                                    C.GPDEPTHRANGEF
+	gpDetachShader                                   C.GPDETACHSHADER
+	gpDisable                                        C.GPDISABLE
+	gpDisableClientState                             C.GPDISABLECLIENTSTATE
+	gpDisableClientStateIndexedEXT                   C.GPDISABLECLIENTSTATEINDEXEDEXT
+	gpDisableClientStateiEXT                         C.GPDISABLECLIENTSTATEIEXT
+	gpDisableIndexedEXT                              C.GPDISABLEINDEXEDEXT
+	gpDisableVertexArrayAttrib                       C.GPDISABLEVERTEXARRAYATTRIB
+	gpDisableVertexArrayAttribEXT                    C.GPDISABLEVERTEXARRAYATTRIBEXT
+	gpDisableVertexArrayEXT                          C.GPDISABLEVERTEXARRAYEXT
+	gpDisableVertexAttribArray                       C.GPDISABLEVERTEXATTRIBARRAY
+	gpDisablei                                       C.GPDISABLEI
+	gpDispatchCompute                                C.GPDISPATCHCOMPUTE
+	gpDispatchComputeGroupSizeARB                    C.GPDISPATCHCOMPUTEGROUPSIZEARB
+	gpDispatchComputeIndirect                        C.GPDISPATCHCOMPUTEINDIRECT
+	gpDrawArrays                                     C.GPDRAWARRAYS
+	gpDrawArraysIndirect                             C.GPDRAWARRAYSINDIRECT
+	gpDrawArraysInstanced                            C.GPDRAWARRAYSINSTANCED
+	gpDrawArraysInstancedARB                         C.GPDRAWARRAYSINSTANCEDARB
+	gpDrawArraysInstancedBaseInstance                C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
+	gpDrawArraysInstancedEXT                         C.GPDRAWARRAYSINSTANCEDEXT
+	gpDrawBuffer                                     C.GPDRAWBUFFER
+	gpDrawBuffers                                    C.GPDRAWBUFFERS
+	gpDrawCommandsAddressNV                          C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                 C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                    C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                           C.GPDRAWCOMMANDSSTATESNV
+	gpDrawElements                                   C.GPDRAWELEMENTS
+	gpDrawElementsBaseVertex                         C.GPDRAWELEMENTSBASEVERTEX
+	gpDrawElementsIndirect                           C.GPDRAWELEMENTSINDIRECT
+	gpDrawElementsInstanced                          C.GPDRAWELEMENTSINSTANCED
+	gpDrawElementsInstancedARB                       C.GPDRAWELEMENTSINSTANCEDARB
+	gpDrawElementsInstancedBaseInstance              C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
+	gpDrawElementsInstancedBaseVertex                C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
+	gpDrawElementsInstancedBaseVertexBaseInstance    C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
+	gpDrawElementsInstancedEXT                       C.GPDRAWELEMENTSINSTANCEDEXT
+	gpDrawPixels                                     C.GPDRAWPIXELS
+	gpDrawRangeElements                              C.GPDRAWRANGEELEMENTS
+	gpDrawRangeElementsBaseVertex                    C.GPDRAWRANGEELEMENTSBASEVERTEX
+	gpDrawTransformFeedback                          C.GPDRAWTRANSFORMFEEDBACK
+	gpDrawTransformFeedbackInstanced                 C.GPDRAWTRANSFORMFEEDBACKINSTANCED
+	gpDrawTransformFeedbackStream                    C.GPDRAWTRANSFORMFEEDBACKSTREAM
+	gpDrawTransformFeedbackStreamInstanced           C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                  C.GPDRAWVKIMAGENV
+	gpEdgeFlag                                       C.GPEDGEFLAG
+	gpEdgeFlagFormatNV                               C.GPEDGEFLAGFORMATNV
+	gpEdgeFlagPointer                                C.GPEDGEFLAGPOINTER
+	gpEdgeFlagv                                      C.GPEDGEFLAGV
+	gpEnable                                         C.GPENABLE
+	gpEnableClientState                              C.GPENABLECLIENTSTATE
+	gpEnableClientStateIndexedEXT                    C.GPENABLECLIENTSTATEINDEXEDEXT
+	gpEnableClientStateiEXT                          C.GPENABLECLIENTSTATEIEXT
+	gpEnableIndexedEXT                               C.GPENABLEINDEXEDEXT
+	gpEnableVertexArrayAttrib                        C.GPENABLEVERTEXARRAYATTRIB
+	gpEnableVertexArrayAttribEXT                     C.GPENABLEVERTEXARRAYATTRIBEXT
+	gpEnableVertexArrayEXT                           C.GPENABLEVERTEXARRAYEXT
+	gpEnableVertexAttribArray                        C.GPENABLEVERTEXATTRIBARRAY
+	gpEnablei                                        C.GPENABLEI
+	gpEnd                                            C.GPEND
+	gpEndConditionalRender                           C.GPENDCONDITIONALRENDER
+	gpEndConditionalRenderNV                         C.GPENDCONDITIONALRENDERNV
+	gpEndList                                        C.GPENDLIST
+	gpEndPerfMonitorAMD                              C.GPENDPERFMONITORAMD
+	gpEndPerfQueryINTEL                              C.GPENDPERFQUERYINTEL
+	gpEndQuery                                       C.GPENDQUERY
+	gpEndQueryIndexed                                C.GPENDQUERYINDEXED
+	gpEndTransformFeedback                           C.GPENDTRANSFORMFEEDBACK
+	gpEvalCoord1d                                    C.GPEVALCOORD1D
+	gpEvalCoord1dv                                   C.GPEVALCOORD1DV
+	gpEvalCoord1f                                    C.GPEVALCOORD1F
+	gpEvalCoord1fv                                   C.GPEVALCOORD1FV
+	gpEvalCoord2d                                    C.GPEVALCOORD2D
+	gpEvalCoord2dv                                   C.GPEVALCOORD2DV
+	gpEvalCoord2f                                    C.GPEVALCOORD2F
+	gpEvalCoord2fv                                   C.GPEVALCOORD2FV
+	gpEvalMesh1                                      C.GPEVALMESH1
+	gpEvalMesh2                                      C.GPEVALMESH2
+	gpEvalPoint1                                     C.GPEVALPOINT1
+	gpEvalPoint2                                     C.GPEVALPOINT2
+	gpEvaluateDepthValuesARB                         C.GPEVALUATEDEPTHVALUESARB
+	gpFeedbackBuffer                                 C.GPFEEDBACKBUFFER
+	gpFenceSync                                      C.GPFENCESYNC
+	gpFinish                                         C.GPFINISH
+	gpFlush                                          C.GPFLUSH
+	gpFlushMappedBufferRange                         C.GPFLUSHMAPPEDBUFFERRANGE
+	gpFlushMappedNamedBufferRange                    C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
+	gpFlushMappedNamedBufferRangeEXT                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT
+	gpFogCoordFormatNV                               C.GPFOGCOORDFORMATNV
+	gpFogCoordPointer                                C.GPFOGCOORDPOINTER
+	gpFogCoordd                                      C.GPFOGCOORDD
+	gpFogCoorddv                                     C.GPFOGCOORDDV
+	gpFogCoordf                                      C.GPFOGCOORDF
+	gpFogCoordfv                                     C.GPFOGCOORDFV
+	gpFogf                                           C.GPFOGF
+	gpFogfv                                          C.GPFOGFV
+	gpFogi                                           C.GPFOGI
+	gpFogiv                                          C.GPFOGIV
+	gpFragmentCoverageColorNV                        C.GPFRAGMENTCOVERAGECOLORNV
+	gpFramebufferDrawBufferEXT                       C.GPFRAMEBUFFERDRAWBUFFEREXT
+	gpFramebufferDrawBuffersEXT                      C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                     C.GPFRAMEBUFFERFETCHBARRIEREXT
+	gpFramebufferParameteri                          C.GPFRAMEBUFFERPARAMETERI
+	gpFramebufferReadBufferEXT                       C.GPFRAMEBUFFERREADBUFFEREXT
+	gpFramebufferRenderbuffer                        C.GPFRAMEBUFFERRENDERBUFFER
+	gpFramebufferSampleLocationsfvARB                C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                 C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferTexture                             C.GPFRAMEBUFFERTEXTURE
+	gpFramebufferTexture1D                           C.GPFRAMEBUFFERTEXTURE1D
+	gpFramebufferTexture2D                           C.GPFRAMEBUFFERTEXTURE2D
+	gpFramebufferTexture3D                           C.GPFRAMEBUFFERTEXTURE3D
+	gpFramebufferTextureARB                          C.GPFRAMEBUFFERTEXTUREARB
+	gpFramebufferTextureFaceARB                      C.GPFRAMEBUFFERTEXTUREFACEARB
+	gpFramebufferTextureLayer                        C.GPFRAMEBUFFERTEXTURELAYER
+	gpFramebufferTextureLayerARB                     C.GPFRAMEBUFFERTEXTURELAYERARB
+	gpFramebufferTextureMultiviewOVR                 C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
+	gpFrontFace                                      C.GPFRONTFACE
+	gpFrustum                                        C.GPFRUSTUM
+	gpGenBuffers                                     C.GPGENBUFFERS
+	gpGenFramebuffers                                C.GPGENFRAMEBUFFERS
+	gpGenLists                                       C.GPGENLISTS
+	gpGenPathsNV                                     C.GPGENPATHSNV
+	gpGenPerfMonitorsAMD                             C.GPGENPERFMONITORSAMD
+	gpGenProgramPipelines                            C.GPGENPROGRAMPIPELINES
+	gpGenProgramPipelinesEXT                         C.GPGENPROGRAMPIPELINESEXT
+	gpGenQueries                                     C.GPGENQUERIES
+	gpGenRenderbuffers                               C.GPGENRENDERBUFFERS
+	gpGenSamplers                                    C.GPGENSAMPLERS
+	gpGenTextures                                    C.GPGENTEXTURES
+	gpGenTransformFeedbacks                          C.GPGENTRANSFORMFEEDBACKS
+	gpGenVertexArrays                                C.GPGENVERTEXARRAYS
+	gpGenerateMipmap                                 C.GPGENERATEMIPMAP
+	gpGenerateMultiTexMipmapEXT                      C.GPGENERATEMULTITEXMIPMAPEXT
+	gpGenerateTextureMipmap                          C.GPGENERATETEXTUREMIPMAP
+	gpGenerateTextureMipmapEXT                       C.GPGENERATETEXTUREMIPMAPEXT
+	gpGetActiveAtomicCounterBufferiv                 C.GPGETACTIVEATOMICCOUNTERBUFFERIV
+	gpGetActiveAttrib                                C.GPGETACTIVEATTRIB
+	gpGetActiveSubroutineName                        C.GPGETACTIVESUBROUTINENAME
+	gpGetActiveSubroutineUniformName                 C.GPGETACTIVESUBROUTINEUNIFORMNAME
+	gpGetActiveSubroutineUniformiv                   C.GPGETACTIVESUBROUTINEUNIFORMIV
+	gpGetActiveUniform                               C.GPGETACTIVEUNIFORM
+	gpGetActiveUniformBlockName                      C.GPGETACTIVEUNIFORMBLOCKNAME
+	gpGetActiveUniformBlockiv                        C.GPGETACTIVEUNIFORMBLOCKIV
+	gpGetActiveUniformName                           C.GPGETACTIVEUNIFORMNAME
+	gpGetActiveUniformsiv                            C.GPGETACTIVEUNIFORMSIV
+	gpGetAttachedShaders                             C.GPGETATTACHEDSHADERS
+	gpGetAttribLocation                              C.GPGETATTRIBLOCATION
+	gpGetBooleanIndexedvEXT                          C.GPGETBOOLEANINDEXEDVEXT
+	gpGetBooleani_v                                  C.GPGETBOOLEANI_V
+	gpGetBooleanv                                    C.GPGETBOOLEANV
+	gpGetBufferParameteri64v                         C.GPGETBUFFERPARAMETERI64V
+	gpGetBufferParameteriv                           C.GPGETBUFFERPARAMETERIV
+	gpGetBufferParameterui64vNV                      C.GPGETBUFFERPARAMETERUI64VNV
+	gpGetBufferPointerv                              C.GPGETBUFFERPOINTERV
+	gpGetBufferSubData                               C.GPGETBUFFERSUBDATA
+	gpGetClipPlane                                   C.GPGETCLIPPLANE
+	gpGetCommandHeaderNV                             C.GPGETCOMMANDHEADERNV
+	gpGetCompressedMultiTexImageEXT                  C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
+	gpGetCompressedTexImage                          C.GPGETCOMPRESSEDTEXIMAGE
+	gpGetCompressedTextureImage                      C.GPGETCOMPRESSEDTEXTUREIMAGE
+	gpGetCompressedTextureImageEXT                   C.GPGETCOMPRESSEDTEXTUREIMAGEEXT
+	gpGetCompressedTextureSubImage                   C.GPGETCOMPRESSEDTEXTURESUBIMAGE
+	gpGetCoverageModulationTableNV                   C.GPGETCOVERAGEMODULATIONTABLENV
+	gpGetDebugMessageLog                             C.GPGETDEBUGMESSAGELOG
+	gpGetDebugMessageLogARB                          C.GPGETDEBUGMESSAGELOGARB
+	gpGetDebugMessageLogKHR                          C.GPGETDEBUGMESSAGELOGKHR
+	gpGetDoubleIndexedvEXT                           C.GPGETDOUBLEINDEXEDVEXT
+	gpGetDoublei_v                                   C.GPGETDOUBLEI_V
+	gpGetDoublei_vEXT                                C.GPGETDOUBLEI_VEXT
+	gpGetDoublev                                     C.GPGETDOUBLEV
+	gpGetError                                       C.GPGETERROR
+	gpGetFirstPerfQueryIdINTEL                       C.GPGETFIRSTPERFQUERYIDINTEL
+	gpGetFloatIndexedvEXT                            C.GPGETFLOATINDEXEDVEXT
+	gpGetFloati_v                                    C.GPGETFLOATI_V
+	gpGetFloati_vEXT                                 C.GPGETFLOATI_VEXT
+	gpGetFloatv                                      C.GPGETFLOATV
+	gpGetFragDataIndex                               C.GPGETFRAGDATAINDEX
+	gpGetFragDataLocation                            C.GPGETFRAGDATALOCATION
+	gpGetFramebufferAttachmentParameteriv            C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetFramebufferParameteriv                      C.GPGETFRAMEBUFFERPARAMETERIV
+	gpGetFramebufferParameterivEXT                   C.GPGETFRAMEBUFFERPARAMETERIVEXT
+	gpGetGraphicsResetStatus                         C.GPGETGRAPHICSRESETSTATUS
+	gpGetGraphicsResetStatusARB                      C.GPGETGRAPHICSRESETSTATUSARB
+	gpGetGraphicsResetStatusKHR                      C.GPGETGRAPHICSRESETSTATUSKHR
+	gpGetImageHandleARB                              C.GPGETIMAGEHANDLEARB
+	gpGetImageHandleNV                               C.GPGETIMAGEHANDLENV
+	gpGetInteger64i_v                                C.GPGETINTEGER64I_V
+	gpGetInteger64v                                  C.GPGETINTEGER64V
+	gpGetIntegerIndexedvEXT                          C.GPGETINTEGERINDEXEDVEXT
+	gpGetIntegeri_v                                  C.GPGETINTEGERI_V
+	gpGetIntegerui64i_vNV                            C.GPGETINTEGERUI64I_VNV
+	gpGetIntegerui64vNV                              C.GPGETINTEGERUI64VNV
+	gpGetIntegerv                                    C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                    C.GPGETINTERNALFORMATSAMPLEIVNV
+	gpGetInternalformati64v                          C.GPGETINTERNALFORMATI64V
+	gpGetInternalformativ                            C.GPGETINTERNALFORMATIV
+	gpGetLightfv                                     C.GPGETLIGHTFV
+	gpGetLightiv                                     C.GPGETLIGHTIV
+	gpGetMapdv                                       C.GPGETMAPDV
+	gpGetMapfv                                       C.GPGETMAPFV
+	gpGetMapiv                                       C.GPGETMAPIV
+	gpGetMaterialfv                                  C.GPGETMATERIALFV
+	gpGetMaterialiv                                  C.GPGETMATERIALIV
+	gpGetMultiTexEnvfvEXT                            C.GPGETMULTITEXENVFVEXT
+	gpGetMultiTexEnvivEXT                            C.GPGETMULTITEXENVIVEXT
+	gpGetMultiTexGendvEXT                            C.GPGETMULTITEXGENDVEXT
+	gpGetMultiTexGenfvEXT                            C.GPGETMULTITEXGENFVEXT
+	gpGetMultiTexGenivEXT                            C.GPGETMULTITEXGENIVEXT
+	gpGetMultiTexImageEXT                            C.GPGETMULTITEXIMAGEEXT
+	gpGetMultiTexLevelParameterfvEXT                 C.GPGETMULTITEXLEVELPARAMETERFVEXT
+	gpGetMultiTexLevelParameterivEXT                 C.GPGETMULTITEXLEVELPARAMETERIVEXT
+	gpGetMultiTexParameterIivEXT                     C.GPGETMULTITEXPARAMETERIIVEXT
+	gpGetMultiTexParameterIuivEXT                    C.GPGETMULTITEXPARAMETERIUIVEXT
+	gpGetMultiTexParameterfvEXT                      C.GPGETMULTITEXPARAMETERFVEXT
+	gpGetMultiTexParameterivEXT                      C.GPGETMULTITEXPARAMETERIVEXT
+	gpGetMultisamplefv                               C.GPGETMULTISAMPLEFV
+	gpGetNamedBufferParameteri64v                    C.GPGETNAMEDBUFFERPARAMETERI64V
+	gpGetNamedBufferParameteriv                      C.GPGETNAMEDBUFFERPARAMETERIV
+	gpGetNamedBufferParameterivEXT                   C.GPGETNAMEDBUFFERPARAMETERIVEXT
+	gpGetNamedBufferParameterui64vNV                 C.GPGETNAMEDBUFFERPARAMETERUI64VNV
+	gpGetNamedBufferPointerv                         C.GPGETNAMEDBUFFERPOINTERV
+	gpGetNamedBufferPointervEXT                      C.GPGETNAMEDBUFFERPOINTERVEXT
+	gpGetNamedBufferSubData                          C.GPGETNAMEDBUFFERSUBDATA
+	gpGetNamedBufferSubDataEXT                       C.GPGETNAMEDBUFFERSUBDATAEXT
+	gpGetNamedFramebufferAttachmentParameteriv       C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetNamedFramebufferAttachmentParameterivEXT    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameteriv                 C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
+	gpGetNamedFramebufferParameterivEXT              C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
+	gpGetNamedProgramLocalParameterIivEXT            C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
+	gpGetNamedProgramLocalParameterIuivEXT           C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT
+	gpGetNamedProgramLocalParameterdvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT
+	gpGetNamedProgramLocalParameterfvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT
+	gpGetNamedProgramStringEXT                       C.GPGETNAMEDPROGRAMSTRINGEXT
+	gpGetNamedProgramivEXT                           C.GPGETNAMEDPROGRAMIVEXT
+	gpGetNamedRenderbufferParameteriv                C.GPGETNAMEDRENDERBUFFERPARAMETERIV
+	gpGetNamedRenderbufferParameterivEXT             C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT
+	gpGetNamedStringARB                              C.GPGETNAMEDSTRINGARB
+	gpGetNamedStringivARB                            C.GPGETNAMEDSTRINGIVARB
+	gpGetNextPerfQueryIdINTEL                        C.GPGETNEXTPERFQUERYIDINTEL
+	gpGetObjectLabel                                 C.GPGETOBJECTLABEL
+	gpGetObjectLabelEXT                              C.GPGETOBJECTLABELEXT
+	gpGetObjectLabelKHR                              C.GPGETOBJECTLABELKHR
+	gpGetObjectPtrLabel                              C.GPGETOBJECTPTRLABEL
+	gpGetObjectPtrLabelKHR                           C.GPGETOBJECTPTRLABELKHR
+	gpGetPathCommandsNV                              C.GPGETPATHCOMMANDSNV
+	gpGetPathCoordsNV                                C.GPGETPATHCOORDSNV
+	gpGetPathDashArrayNV                             C.GPGETPATHDASHARRAYNV
+	gpGetPathLengthNV                                C.GPGETPATHLENGTHNV
+	gpGetPathMetricRangeNV                           C.GPGETPATHMETRICRANGENV
+	gpGetPathMetricsNV                               C.GPGETPATHMETRICSNV
+	gpGetPathParameterfvNV                           C.GPGETPATHPARAMETERFVNV
+	gpGetPathParameterivNV                           C.GPGETPATHPARAMETERIVNV
+	gpGetPathSpacingNV                               C.GPGETPATHSPACINGNV
+	gpGetPerfCounterInfoINTEL                        C.GPGETPERFCOUNTERINFOINTEL
+	gpGetPerfMonitorCounterDataAMD                   C.GPGETPERFMONITORCOUNTERDATAAMD
+	gpGetPerfMonitorCounterInfoAMD                   C.GPGETPERFMONITORCOUNTERINFOAMD
+	gpGetPerfMonitorCounterStringAMD                 C.GPGETPERFMONITORCOUNTERSTRINGAMD
+	gpGetPerfMonitorCountersAMD                      C.GPGETPERFMONITORCOUNTERSAMD
+	gpGetPerfMonitorGroupStringAMD                   C.GPGETPERFMONITORGROUPSTRINGAMD
+	gpGetPerfMonitorGroupsAMD                        C.GPGETPERFMONITORGROUPSAMD
+	gpGetPerfQueryDataINTEL                          C.GPGETPERFQUERYDATAINTEL
+	gpGetPerfQueryIdByNameINTEL                      C.GPGETPERFQUERYIDBYNAMEINTEL
+	gpGetPerfQueryInfoINTEL                          C.GPGETPERFQUERYINFOINTEL
+	gpGetPixelMapfv                                  C.GPGETPIXELMAPFV
+	gpGetPixelMapuiv                                 C.GPGETPIXELMAPUIV
+	gpGetPixelMapusv                                 C.GPGETPIXELMAPUSV
+	gpGetPointerIndexedvEXT                          C.GPGETPOINTERINDEXEDVEXT
+	gpGetPointeri_vEXT                               C.GPGETPOINTERI_VEXT
+	gpGetPointerv                                    C.GPGETPOINTERV
+	gpGetPointervKHR                                 C.GPGETPOINTERVKHR
+	gpGetPolygonStipple                              C.GPGETPOLYGONSTIPPLE
+	gpGetProgramBinary                               C.GPGETPROGRAMBINARY
+	gpGetProgramInfoLog                              C.GPGETPROGRAMINFOLOG
+	gpGetProgramInterfaceiv                          C.GPGETPROGRAMINTERFACEIV
+	gpGetProgramPipelineInfoLog                      C.GPGETPROGRAMPIPELINEINFOLOG
+	gpGetProgramPipelineInfoLogEXT                   C.GPGETPROGRAMPIPELINEINFOLOGEXT
+	gpGetProgramPipelineiv                           C.GPGETPROGRAMPIPELINEIV
+	gpGetProgramPipelineivEXT                        C.GPGETPROGRAMPIPELINEIVEXT
+	gpGetProgramResourceIndex                        C.GPGETPROGRAMRESOURCEINDEX
+	gpGetProgramResourceLocation                     C.GPGETPROGRAMRESOURCELOCATION
+	gpGetProgramResourceLocationIndex                C.GPGETPROGRAMRESOURCELOCATIONINDEX
+	gpGetProgramResourceName                         C.GPGETPROGRAMRESOURCENAME
+	gpGetProgramResourcefvNV                         C.GPGETPROGRAMRESOURCEFVNV
+	gpGetProgramResourceiv                           C.GPGETPROGRAMRESOURCEIV
+	gpGetProgramStageiv                              C.GPGETPROGRAMSTAGEIV
+	gpGetProgramiv                                   C.GPGETPROGRAMIV
+	gpGetQueryBufferObjecti64v                       C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                         C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                      C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                        C.GPGETQUERYBUFFEROBJECTUIV
+	gpGetQueryIndexediv                              C.GPGETQUERYINDEXEDIV
+	gpGetQueryObjecti64v                             C.GPGETQUERYOBJECTI64V
+	gpGetQueryObjectiv                               C.GPGETQUERYOBJECTIV
+	gpGetQueryObjectui64v                            C.GPGETQUERYOBJECTUI64V
+	gpGetQueryObjectuiv                              C.GPGETQUERYOBJECTUIV
+	gpGetQueryiv                                     C.GPGETQUERYIV
+	gpGetRenderbufferParameteriv                     C.GPGETRENDERBUFFERPARAMETERIV
+	gpGetSamplerParameterIiv                         C.GPGETSAMPLERPARAMETERIIV
+	gpGetSamplerParameterIuiv                        C.GPGETSAMPLERPARAMETERIUIV
+	gpGetSamplerParameterfv                          C.GPGETSAMPLERPARAMETERFV
+	gpGetSamplerParameteriv                          C.GPGETSAMPLERPARAMETERIV
+	gpGetShaderInfoLog                               C.GPGETSHADERINFOLOG
+	gpGetShaderPrecisionFormat                       C.GPGETSHADERPRECISIONFORMAT
+	gpGetShaderSource                                C.GPGETSHADERSOURCE
+	gpGetShaderiv                                    C.GPGETSHADERIV
+	gpGetStageIndexNV                                C.GPGETSTAGEINDEXNV
+	gpGetString                                      C.GPGETSTRING
+	gpGetStringi                                     C.GPGETSTRINGI
+	gpGetSubroutineIndex                             C.GPGETSUBROUTINEINDEX
+	gpGetSubroutineUniformLocation                   C.GPGETSUBROUTINEUNIFORMLOCATION
+	gpGetSynciv                                      C.GPGETSYNCIV
+	gpGetTexEnvfv                                    C.GPGETTEXENVFV
+	gpGetTexEnviv                                    C.GPGETTEXENVIV
+	gpGetTexGendv                                    C.GPGETTEXGENDV
+	gpGetTexGenfv                                    C.GPGETTEXGENFV
+	gpGetTexGeniv                                    C.GPGETTEXGENIV
+	gpGetTexImage                                    C.GPGETTEXIMAGE
+	gpGetTexLevelParameterfv                         C.GPGETTEXLEVELPARAMETERFV
+	gpGetTexLevelParameteriv                         C.GPGETTEXLEVELPARAMETERIV
+	gpGetTexParameterIiv                             C.GPGETTEXPARAMETERIIV
+	gpGetTexParameterIuiv                            C.GPGETTEXPARAMETERIUIV
+	gpGetTexParameterfv                              C.GPGETTEXPARAMETERFV
+	gpGetTexParameteriv                              C.GPGETTEXPARAMETERIV
+	gpGetTextureHandleARB                            C.GPGETTEXTUREHANDLEARB
+	gpGetTextureHandleNV                             C.GPGETTEXTUREHANDLENV
+	gpGetTextureImage                                C.GPGETTEXTUREIMAGE
+	gpGetTextureImageEXT                             C.GPGETTEXTUREIMAGEEXT
+	gpGetTextureLevelParameterfv                     C.GPGETTEXTURELEVELPARAMETERFV
+	gpGetTextureLevelParameterfvEXT                  C.GPGETTEXTURELEVELPARAMETERFVEXT
+	gpGetTextureLevelParameteriv                     C.GPGETTEXTURELEVELPARAMETERIV
+	gpGetTextureLevelParameterivEXT                  C.GPGETTEXTURELEVELPARAMETERIVEXT
+	gpGetTextureParameterIiv                         C.GPGETTEXTUREPARAMETERIIV
+	gpGetTextureParameterIivEXT                      C.GPGETTEXTUREPARAMETERIIVEXT
+	gpGetTextureParameterIuiv                        C.GPGETTEXTUREPARAMETERIUIV
+	gpGetTextureParameterIuivEXT                     C.GPGETTEXTUREPARAMETERIUIVEXT
+	gpGetTextureParameterfv                          C.GPGETTEXTUREPARAMETERFV
+	gpGetTextureParameterfvEXT                       C.GPGETTEXTUREPARAMETERFVEXT
+	gpGetTextureParameteriv                          C.GPGETTEXTUREPARAMETERIV
+	gpGetTextureParameterivEXT                       C.GPGETTEXTUREPARAMETERIVEXT
+	gpGetTextureSamplerHandleARB                     C.GPGETTEXTURESAMPLERHANDLEARB
+	gpGetTextureSamplerHandleNV                      C.GPGETTEXTURESAMPLERHANDLENV
+	gpGetTextureSubImage                             C.GPGETTEXTURESUBIMAGE
+	gpGetTransformFeedbackVarying                    C.GPGETTRANSFORMFEEDBACKVARYING
+	gpGetTransformFeedbacki64_v                      C.GPGETTRANSFORMFEEDBACKI64_V
+	gpGetTransformFeedbacki_v                        C.GPGETTRANSFORMFEEDBACKI_V
+	gpGetTransformFeedbackiv                         C.GPGETTRANSFORMFEEDBACKIV
+	gpGetUniformBlockIndex                           C.GPGETUNIFORMBLOCKINDEX
+	gpGetUniformIndices                              C.GPGETUNIFORMINDICES
+	gpGetUniformLocation                             C.GPGETUNIFORMLOCATION
+	gpGetUniformSubroutineuiv                        C.GPGETUNIFORMSUBROUTINEUIV
+	gpGetUniformdv                                   C.GPGETUNIFORMDV
+	gpGetUniformfv                                   C.GPGETUNIFORMFV
+	gpGetUniformi64vARB                              C.GPGETUNIFORMI64VARB
+	gpGetUniformi64vNV                               C.GPGETUNIFORMI64VNV
+	gpGetUniformiv                                   C.GPGETUNIFORMIV
+	gpGetUniformui64vARB                             C.GPGETUNIFORMUI64VARB
+	gpGetUniformui64vNV                              C.GPGETUNIFORMUI64VNV
+	gpGetUniformuiv                                  C.GPGETUNIFORMUIV
+	gpGetVertexArrayIndexed64iv                      C.GPGETVERTEXARRAYINDEXED64IV
+	gpGetVertexArrayIndexediv                        C.GPGETVERTEXARRAYINDEXEDIV
+	gpGetVertexArrayIntegeri_vEXT                    C.GPGETVERTEXARRAYINTEGERI_VEXT
+	gpGetVertexArrayIntegervEXT                      C.GPGETVERTEXARRAYINTEGERVEXT
+	gpGetVertexArrayPointeri_vEXT                    C.GPGETVERTEXARRAYPOINTERI_VEXT
+	gpGetVertexArrayPointervEXT                      C.GPGETVERTEXARRAYPOINTERVEXT
+	gpGetVertexArrayiv                               C.GPGETVERTEXARRAYIV
+	gpGetVertexAttribIiv                             C.GPGETVERTEXATTRIBIIV
+	gpGetVertexAttribIuiv                            C.GPGETVERTEXATTRIBIUIV
+	gpGetVertexAttribLdv                             C.GPGETVERTEXATTRIBLDV
+	gpGetVertexAttribLi64vNV                         C.GPGETVERTEXATTRIBLI64VNV
+	gpGetVertexAttribLui64vARB                       C.GPGETVERTEXATTRIBLUI64VARB
+	gpGetVertexAttribLui64vNV                        C.GPGETVERTEXATTRIBLUI64VNV
+	gpGetVertexAttribPointerv                        C.GPGETVERTEXATTRIBPOINTERV
+	gpGetVertexAttribdv                              C.GPGETVERTEXATTRIBDV
+	gpGetVertexAttribfv                              C.GPGETVERTEXATTRIBFV
+	gpGetVertexAttribiv                              C.GPGETVERTEXATTRIBIV
+	gpGetVkProcAddrNV                                C.GPGETVKPROCADDRNV
+	gpGetnCompressedTexImage                         C.GPGETNCOMPRESSEDTEXIMAGE
+	gpGetnCompressedTexImageARB                      C.GPGETNCOMPRESSEDTEXIMAGEARB
+	gpGetnTexImage                                   C.GPGETNTEXIMAGE
+	gpGetnTexImageARB                                C.GPGETNTEXIMAGEARB
+	gpGetnUniformdv                                  C.GPGETNUNIFORMDV
+	gpGetnUniformdvARB                               C.GPGETNUNIFORMDVARB
+	gpGetnUniformfv                                  C.GPGETNUNIFORMFV
+	gpGetnUniformfvARB                               C.GPGETNUNIFORMFVARB
+	gpGetnUniformfvKHR                               C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                             C.GPGETNUNIFORMI64VARB
+	gpGetnUniformiv                                  C.GPGETNUNIFORMIV
+	gpGetnUniformivARB                               C.GPGETNUNIFORMIVARB
+	gpGetnUniformivKHR                               C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                            C.GPGETNUNIFORMUI64VARB
+	gpGetnUniformuiv                                 C.GPGETNUNIFORMUIV
+	gpGetnUniformuivARB                              C.GPGETNUNIFORMUIVARB
+	gpGetnUniformuivKHR                              C.GPGETNUNIFORMUIVKHR
+	gpHint                                           C.GPHINT
+	gpIndexFormatNV                                  C.GPINDEXFORMATNV
+	gpIndexMask                                      C.GPINDEXMASK
+	gpIndexPointer                                   C.GPINDEXPOINTER
+	gpIndexd                                         C.GPINDEXD
+	gpIndexdv                                        C.GPINDEXDV
+	gpIndexf                                         C.GPINDEXF
+	gpIndexfv                                        C.GPINDEXFV
+	gpIndexi                                         C.GPINDEXI
+	gpIndexiv                                        C.GPINDEXIV
+	gpIndexs                                         C.GPINDEXS
+	gpIndexsv                                        C.GPINDEXSV
+	gpIndexub                                        C.GPINDEXUB
+	gpIndexubv                                       C.GPINDEXUBV
+	gpInitNames                                      C.GPINITNAMES
+	gpInsertEventMarkerEXT                           C.GPINSERTEVENTMARKEREXT
+	gpInterleavedArrays                              C.GPINTERLEAVEDARRAYS
+	gpInterpolatePathsNV                             C.GPINTERPOLATEPATHSNV
+	gpInvalidateBufferData                           C.GPINVALIDATEBUFFERDATA
+	gpInvalidateBufferSubData                        C.GPINVALIDATEBUFFERSUBDATA
+	gpInvalidateFramebuffer                          C.GPINVALIDATEFRAMEBUFFER
+	gpInvalidateNamedFramebufferData                 C.GPINVALIDATENAMEDFRAMEBUFFERDATA
+	gpInvalidateNamedFramebufferSubData              C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
+	gpInvalidateSubFramebuffer                       C.GPINVALIDATESUBFRAMEBUFFER
+	gpInvalidateTexImage                             C.GPINVALIDATETEXIMAGE
+	gpInvalidateTexSubImage                          C.GPINVALIDATETEXSUBIMAGE
+	gpIsBuffer                                       C.GPISBUFFER
+	gpIsBufferResidentNV                             C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                C.GPISCOMMANDLISTNV
+	gpIsEnabled                                      C.GPISENABLED
+	gpIsEnabledIndexedEXT                            C.GPISENABLEDINDEXEDEXT
+	gpIsEnabledi                                     C.GPISENABLEDI
+	gpIsFramebuffer                                  C.GPISFRAMEBUFFER
+	gpIsImageHandleResidentARB                       C.GPISIMAGEHANDLERESIDENTARB
+	gpIsImageHandleResidentNV                        C.GPISIMAGEHANDLERESIDENTNV
+	gpIsList                                         C.GPISLIST
+	gpIsNamedBufferResidentNV                        C.GPISNAMEDBUFFERRESIDENTNV
+	gpIsNamedStringARB                               C.GPISNAMEDSTRINGARB
+	gpIsPathNV                                       C.GPISPATHNV
+	gpIsPointInFillPathNV                            C.GPISPOINTINFILLPATHNV
+	gpIsPointInStrokePathNV                          C.GPISPOINTINSTROKEPATHNV
+	gpIsProgram                                      C.GPISPROGRAM
+	gpIsProgramPipeline                              C.GPISPROGRAMPIPELINE
+	gpIsProgramPipelineEXT                           C.GPISPROGRAMPIPELINEEXT
+	gpIsQuery                                        C.GPISQUERY
+	gpIsRenderbuffer                                 C.GPISRENDERBUFFER
+	gpIsSampler                                      C.GPISSAMPLER
+	gpIsShader                                       C.GPISSHADER
+	gpIsStateNV                                      C.GPISSTATENV
+	gpIsSync                                         C.GPISSYNC
+	gpIsTexture                                      C.GPISTEXTURE
+	gpIsTextureHandleResidentARB                     C.GPISTEXTUREHANDLERESIDENTARB
+	gpIsTextureHandleResidentNV                      C.GPISTEXTUREHANDLERESIDENTNV
+	gpIsTransformFeedback                            C.GPISTRANSFORMFEEDBACK
+	gpIsVertexArray                                  C.GPISVERTEXARRAY
+	gpLabelObjectEXT                                 C.GPLABELOBJECTEXT
+	gpLightModelf                                    C.GPLIGHTMODELF
+	gpLightModelfv                                   C.GPLIGHTMODELFV
+	gpLightModeli                                    C.GPLIGHTMODELI
+	gpLightModeliv                                   C.GPLIGHTMODELIV
+	gpLightf                                         C.GPLIGHTF
+	gpLightfv                                        C.GPLIGHTFV
+	gpLighti                                         C.GPLIGHTI
+	gpLightiv                                        C.GPLIGHTIV
+	gpLineStipple                                    C.GPLINESTIPPLE
+	gpLineWidth                                      C.GPLINEWIDTH
+	gpLinkProgram                                    C.GPLINKPROGRAM
+	gpListBase                                       C.GPLISTBASE
+	gpListDrawCommandsStatesClientNV                 C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
+	gpLoadIdentity                                   C.GPLOADIDENTITY
+	gpLoadMatrixd                                    C.GPLOADMATRIXD
+	gpLoadMatrixf                                    C.GPLOADMATRIXF
+	gpLoadName                                       C.GPLOADNAME
+	gpLoadTransposeMatrixd                           C.GPLOADTRANSPOSEMATRIXD
+	gpLoadTransposeMatrixf                           C.GPLOADTRANSPOSEMATRIXF
+	gpLogicOp                                        C.GPLOGICOP
+	gpMakeBufferNonResidentNV                        C.GPMAKEBUFFERNONRESIDENTNV
+	gpMakeBufferResidentNV                           C.GPMAKEBUFFERRESIDENTNV
+	gpMakeImageHandleNonResidentARB                  C.GPMAKEIMAGEHANDLENONRESIDENTARB
+	gpMakeImageHandleNonResidentNV                   C.GPMAKEIMAGEHANDLENONRESIDENTNV
+	gpMakeImageHandleResidentARB                     C.GPMAKEIMAGEHANDLERESIDENTARB
+	gpMakeImageHandleResidentNV                      C.GPMAKEIMAGEHANDLERESIDENTNV
+	gpMakeNamedBufferNonResidentNV                   C.GPMAKENAMEDBUFFERNONRESIDENTNV
+	gpMakeNamedBufferResidentNV                      C.GPMAKENAMEDBUFFERRESIDENTNV
+	gpMakeTextureHandleNonResidentARB                C.GPMAKETEXTUREHANDLENONRESIDENTARB
+	gpMakeTextureHandleNonResidentNV                 C.GPMAKETEXTUREHANDLENONRESIDENTNV
+	gpMakeTextureHandleResidentARB                   C.GPMAKETEXTUREHANDLERESIDENTARB
+	gpMakeTextureHandleResidentNV                    C.GPMAKETEXTUREHANDLERESIDENTNV
+	gpMap1d                                          C.GPMAP1D
+	gpMap1f                                          C.GPMAP1F
+	gpMap2d                                          C.GPMAP2D
+	gpMap2f                                          C.GPMAP2F
+	gpMapBuffer                                      C.GPMAPBUFFER
+	gpMapBufferRange                                 C.GPMAPBUFFERRANGE
+	gpMapGrid1d                                      C.GPMAPGRID1D
+	gpMapGrid1f                                      C.GPMAPGRID1F
+	gpMapGrid2d                                      C.GPMAPGRID2D
+	gpMapGrid2f                                      C.GPMAPGRID2F
+	gpMapNamedBuffer                                 C.GPMAPNAMEDBUFFER
+	gpMapNamedBufferEXT                              C.GPMAPNAMEDBUFFEREXT
+	gpMapNamedBufferRange                            C.GPMAPNAMEDBUFFERRANGE
+	gpMapNamedBufferRangeEXT                         C.GPMAPNAMEDBUFFERRANGEEXT
+	gpMaterialf                                      C.GPMATERIALF
+	gpMaterialfv                                     C.GPMATERIALFV
+	gpMateriali                                      C.GPMATERIALI
+	gpMaterialiv                                     C.GPMATERIALIV
+	gpMatrixFrustumEXT                               C.GPMATRIXFRUSTUMEXT
+	gpMatrixLoad3x2fNV                               C.GPMATRIXLOAD3X2FNV
+	gpMatrixLoad3x3fNV                               C.GPMATRIXLOAD3X3FNV
+	gpMatrixLoadIdentityEXT                          C.GPMATRIXLOADIDENTITYEXT
+	gpMatrixLoadTranspose3x3fNV                      C.GPMATRIXLOADTRANSPOSE3X3FNV
+	gpMatrixLoadTransposedEXT                        C.GPMATRIXLOADTRANSPOSEDEXT
+	gpMatrixLoadTransposefEXT                        C.GPMATRIXLOADTRANSPOSEFEXT
+	gpMatrixLoaddEXT                                 C.GPMATRIXLOADDEXT
+	gpMatrixLoadfEXT                                 C.GPMATRIXLOADFEXT
+	gpMatrixMode                                     C.GPMATRIXMODE
+	gpMatrixMult3x2fNV                               C.GPMATRIXMULT3X2FNV
+	gpMatrixMult3x3fNV                               C.GPMATRIXMULT3X3FNV
+	gpMatrixMultTranspose3x3fNV                      C.GPMATRIXMULTTRANSPOSE3X3FNV
+	gpMatrixMultTransposedEXT                        C.GPMATRIXMULTTRANSPOSEDEXT
+	gpMatrixMultTransposefEXT                        C.GPMATRIXMULTTRANSPOSEFEXT
+	gpMatrixMultdEXT                                 C.GPMATRIXMULTDEXT
+	gpMatrixMultfEXT                                 C.GPMATRIXMULTFEXT
+	gpMatrixOrthoEXT                                 C.GPMATRIXORTHOEXT
+	gpMatrixPopEXT                                   C.GPMATRIXPOPEXT
+	gpMatrixPushEXT                                  C.GPMATRIXPUSHEXT
+	gpMatrixRotatedEXT                               C.GPMATRIXROTATEDEXT
+	gpMatrixRotatefEXT                               C.GPMATRIXROTATEFEXT
+	gpMatrixScaledEXT                                C.GPMATRIXSCALEDEXT
+	gpMatrixScalefEXT                                C.GPMATRIXSCALEFEXT
+	gpMatrixTranslatedEXT                            C.GPMATRIXTRANSLATEDEXT
+	gpMatrixTranslatefEXT                            C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                    C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                    C.GPMAXSHADERCOMPILERTHREADSKHR
+	gpMemoryBarrier                                  C.GPMEMORYBARRIER
+	gpMemoryBarrierByRegion                          C.GPMEMORYBARRIERBYREGION
+	gpMinSampleShading                               C.GPMINSAMPLESHADING
+	gpMinSampleShadingARB                            C.GPMINSAMPLESHADINGARB
+	gpMultMatrixd                                    C.GPMULTMATRIXD
+	gpMultMatrixf                                    C.GPMULTMATRIXF
+	gpMultTransposeMatrixd                           C.GPMULTTRANSPOSEMATRIXD
+	gpMultTransposeMatrixf                           C.GPMULTTRANSPOSEMATRIXF
+	gpMultiDrawArrays                                C.GPMULTIDRAWARRAYS
+	gpMultiDrawArraysIndirect                        C.GPMULTIDRAWARRAYSINDIRECT
+	gpMultiDrawArraysIndirectBindlessCountNV         C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawArraysIndirectBindlessNV              C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV
+	gpMultiDrawArraysIndirectCount                   C.GPMULTIDRAWARRAYSINDIRECTCOUNT
+	gpMultiDrawArraysIndirectCountARB                C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
+	gpMultiDrawElements                              C.GPMULTIDRAWELEMENTS
+	gpMultiDrawElementsBaseVertex                    C.GPMULTIDRAWELEMENTSBASEVERTEX
+	gpMultiDrawElementsIndirect                      C.GPMULTIDRAWELEMENTSINDIRECT
+	gpMultiDrawElementsIndirectBindlessCountNV       C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawElementsIndirectBindlessNV            C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV
+	gpMultiDrawElementsIndirectCount                 C.GPMULTIDRAWELEMENTSINDIRECTCOUNT
+	gpMultiDrawElementsIndirectCountARB              C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
+	gpMultiTexBufferEXT                              C.GPMULTITEXBUFFEREXT
+	gpMultiTexCoord1d                                C.GPMULTITEXCOORD1D
+	gpMultiTexCoord1dv                               C.GPMULTITEXCOORD1DV
+	gpMultiTexCoord1f                                C.GPMULTITEXCOORD1F
+	gpMultiTexCoord1fv                               C.GPMULTITEXCOORD1FV
+	gpMultiTexCoord1i                                C.GPMULTITEXCOORD1I
+	gpMultiTexCoord1iv                               C.GPMULTITEXCOORD1IV
+	gpMultiTexCoord1s                                C.GPMULTITEXCOORD1S
+	gpMultiTexCoord1sv                               C.GPMULTITEXCOORD1SV
+	gpMultiTexCoord2d                                C.GPMULTITEXCOORD2D
+	gpMultiTexCoord2dv                               C.GPMULTITEXCOORD2DV
+	gpMultiTexCoord2f                                C.GPMULTITEXCOORD2F
+	gpMultiTexCoord2fv                               C.GPMULTITEXCOORD2FV
+	gpMultiTexCoord2i                                C.GPMULTITEXCOORD2I
+	gpMultiTexCoord2iv                               C.GPMULTITEXCOORD2IV
+	gpMultiTexCoord2s                                C.GPMULTITEXCOORD2S
+	gpMultiTexCoord2sv                               C.GPMULTITEXCOORD2SV
+	gpMultiTexCoord3d                                C.GPMULTITEXCOORD3D
+	gpMultiTexCoord3dv                               C.GPMULTITEXCOORD3DV
+	gpMultiTexCoord3f                                C.GPMULTITEXCOORD3F
+	gpMultiTexCoord3fv                               C.GPMULTITEXCOORD3FV
+	gpMultiTexCoord3i                                C.GPMULTITEXCOORD3I
+	gpMultiTexCoord3iv                               C.GPMULTITEXCOORD3IV
+	gpMultiTexCoord3s                                C.GPMULTITEXCOORD3S
+	gpMultiTexCoord3sv                               C.GPMULTITEXCOORD3SV
+	gpMultiTexCoord4d                                C.GPMULTITEXCOORD4D
+	gpMultiTexCoord4dv                               C.GPMULTITEXCOORD4DV
+	gpMultiTexCoord4f                                C.GPMULTITEXCOORD4F
+	gpMultiTexCoord4fv                               C.GPMULTITEXCOORD4FV
+	gpMultiTexCoord4i                                C.GPMULTITEXCOORD4I
+	gpMultiTexCoord4iv                               C.GPMULTITEXCOORD4IV
+	gpMultiTexCoord4s                                C.GPMULTITEXCOORD4S
+	gpMultiTexCoord4sv                               C.GPMULTITEXCOORD4SV
+	gpMultiTexCoordPointerEXT                        C.GPMULTITEXCOORDPOINTEREXT
+	gpMultiTexEnvfEXT                                C.GPMULTITEXENVFEXT
+	gpMultiTexEnvfvEXT                               C.GPMULTITEXENVFVEXT
+	gpMultiTexEnviEXT                                C.GPMULTITEXENVIEXT
+	gpMultiTexEnvivEXT                               C.GPMULTITEXENVIVEXT
+	gpMultiTexGendEXT                                C.GPMULTITEXGENDEXT
+	gpMultiTexGendvEXT                               C.GPMULTITEXGENDVEXT
+	gpMultiTexGenfEXT                                C.GPMULTITEXGENFEXT
+	gpMultiTexGenfvEXT                               C.GPMULTITEXGENFVEXT
+	gpMultiTexGeniEXT                                C.GPMULTITEXGENIEXT
+	gpMultiTexGenivEXT                               C.GPMULTITEXGENIVEXT
+	gpMultiTexImage1DEXT                             C.GPMULTITEXIMAGE1DEXT
+	gpMultiTexImage2DEXT                             C.GPMULTITEXIMAGE2DEXT
+	gpMultiTexImage3DEXT                             C.GPMULTITEXIMAGE3DEXT
+	gpMultiTexParameterIivEXT                        C.GPMULTITEXPARAMETERIIVEXT
+	gpMultiTexParameterIuivEXT                       C.GPMULTITEXPARAMETERIUIVEXT
+	gpMultiTexParameterfEXT                          C.GPMULTITEXPARAMETERFEXT
+	gpMultiTexParameterfvEXT                         C.GPMULTITEXPARAMETERFVEXT
+	gpMultiTexParameteriEXT                          C.GPMULTITEXPARAMETERIEXT
+	gpMultiTexParameterivEXT                         C.GPMULTITEXPARAMETERIVEXT
+	gpMultiTexRenderbufferEXT                        C.GPMULTITEXRENDERBUFFEREXT
+	gpMultiTexSubImage1DEXT                          C.GPMULTITEXSUBIMAGE1DEXT
+	gpMultiTexSubImage2DEXT                          C.GPMULTITEXSUBIMAGE2DEXT
+	gpMultiTexSubImage3DEXT                          C.GPMULTITEXSUBIMAGE3DEXT
+	gpNamedBufferData                                C.GPNAMEDBUFFERDATA
+	gpNamedBufferDataEXT                             C.GPNAMEDBUFFERDATAEXT
+	gpNamedBufferPageCommitmentARB                   C.GPNAMEDBUFFERPAGECOMMITMENTARB
+	gpNamedBufferPageCommitmentEXT                   C.GPNAMEDBUFFERPAGECOMMITMENTEXT
+	gpNamedBufferStorage                             C.GPNAMEDBUFFERSTORAGE
+	gpNamedBufferStorageEXT                          C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferSubData                             C.GPNAMEDBUFFERSUBDATA
+	gpNamedBufferSubDataEXT                          C.GPNAMEDBUFFERSUBDATAEXT
+	gpNamedCopyBufferSubDataEXT                      C.GPNAMEDCOPYBUFFERSUBDATAEXT
+	gpNamedFramebufferDrawBuffer                     C.GPNAMEDFRAMEBUFFERDRAWBUFFER
+	gpNamedFramebufferDrawBuffers                    C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
+	gpNamedFramebufferParameteri                     C.GPNAMEDFRAMEBUFFERPARAMETERI
+	gpNamedFramebufferParameteriEXT                  C.GPNAMEDFRAMEBUFFERPARAMETERIEXT
+	gpNamedFramebufferReadBuffer                     C.GPNAMEDFRAMEBUFFERREADBUFFER
+	gpNamedFramebufferRenderbuffer                   C.GPNAMEDFRAMEBUFFERRENDERBUFFER
+	gpNamedFramebufferRenderbufferEXT                C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB           C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV            C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferTexture                        C.GPNAMEDFRAMEBUFFERTEXTURE
+	gpNamedFramebufferTexture1DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
+	gpNamedFramebufferTexture2DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
+	gpNamedFramebufferTexture3DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT
+	gpNamedFramebufferTextureEXT                     C.GPNAMEDFRAMEBUFFERTEXTUREEXT
+	gpNamedFramebufferTextureFaceEXT                 C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT
+	gpNamedFramebufferTextureLayer                   C.GPNAMEDFRAMEBUFFERTEXTURELAYER
+	gpNamedFramebufferTextureLayerEXT                C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT
+	gpNamedProgramLocalParameter4dEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT
+	gpNamedProgramLocalParameter4dvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT
+	gpNamedProgramLocalParameter4fEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT
+	gpNamedProgramLocalParameter4fvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT
+	gpNamedProgramLocalParameterI4iEXT               C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT
+	gpNamedProgramLocalParameterI4ivEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT
+	gpNamedProgramLocalParameterI4uiEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT
+	gpNamedProgramLocalParameterI4uivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT
+	gpNamedProgramLocalParameters4fvEXT              C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT
+	gpNamedProgramLocalParametersI4ivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT
+	gpNamedProgramLocalParametersI4uivEXT            C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT
+	gpNamedProgramStringEXT                          C.GPNAMEDPROGRAMSTRINGEXT
+	gpNamedRenderbufferStorage                       C.GPNAMEDRENDERBUFFERSTORAGE
+	gpNamedRenderbufferStorageEXT                    C.GPNAMEDRENDERBUFFERSTORAGEEXT
+	gpNamedRenderbufferStorageMultisample            C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
+	gpNamedRenderbufferStorageMultisampleCoverageEXT C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT
+	gpNamedRenderbufferStorageMultisampleEXT         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT
+	gpNamedStringARB                                 C.GPNAMEDSTRINGARB
+	gpNewList                                        C.GPNEWLIST
+	gpNormal3b                                       C.GPNORMAL3B
+	gpNormal3bv                                      C.GPNORMAL3BV
+	gpNormal3d                                       C.GPNORMAL3D
+	gpNormal3dv                                      C.GPNORMAL3DV
+	gpNormal3f                                       C.GPNORMAL3F
+	gpNormal3fv                                      C.GPNORMAL3FV
+	gpNormal3i                                       C.GPNORMAL3I
+	gpNormal3iv                                      C.GPNORMAL3IV
+	gpNormal3s                                       C.GPNORMAL3S
+	gpNormal3sv                                      C.GPNORMAL3SV
+	gpNormalFormatNV                                 C.GPNORMALFORMATNV
+	gpNormalPointer                                  C.GPNORMALPOINTER
+	gpObjectLabel                                    C.GPOBJECTLABEL
+	gpObjectLabelKHR                                 C.GPOBJECTLABELKHR
+	gpObjectPtrLabel                                 C.GPOBJECTPTRLABEL
+	gpObjectPtrLabelKHR                              C.GPOBJECTPTRLABELKHR
+	gpOrtho                                          C.GPORTHO
+	gpPassThrough                                    C.GPPASSTHROUGH
+	gpPatchParameterfv                               C.GPPATCHPARAMETERFV
+	gpPatchParameteri                                C.GPPATCHPARAMETERI
+	gpPathCommandsNV                                 C.GPPATHCOMMANDSNV
+	gpPathCoordsNV                                   C.GPPATHCOORDSNV
+	gpPathCoverDepthFuncNV                           C.GPPATHCOVERDEPTHFUNCNV
+	gpPathDashArrayNV                                C.GPPATHDASHARRAYNV
+	gpPathGlyphIndexArrayNV                          C.GPPATHGLYPHINDEXARRAYNV
+	gpPathGlyphIndexRangeNV                          C.GPPATHGLYPHINDEXRANGENV
+	gpPathGlyphRangeNV                               C.GPPATHGLYPHRANGENV
+	gpPathGlyphsNV                                   C.GPPATHGLYPHSNV
+	gpPathMemoryGlyphIndexArrayNV                    C.GPPATHMEMORYGLYPHINDEXARRAYNV
+	gpPathParameterfNV                               C.GPPATHPARAMETERFNV
+	gpPathParameterfvNV                              C.GPPATHPARAMETERFVNV
+	gpPathParameteriNV                               C.GPPATHPARAMETERINV
+	gpPathParameterivNV                              C.GPPATHPARAMETERIVNV
+	gpPathStencilDepthOffsetNV                       C.GPPATHSTENCILDEPTHOFFSETNV
+	gpPathStencilFuncNV                              C.GPPATHSTENCILFUNCNV
+	gpPathStringNV                                   C.GPPATHSTRINGNV
+	gpPathSubCommandsNV                              C.GPPATHSUBCOMMANDSNV
+	gpPathSubCoordsNV                                C.GPPATHSUBCOORDSNV
+	gpPauseTransformFeedback                         C.GPPAUSETRANSFORMFEEDBACK
+	gpPixelMapfv                                     C.GPPIXELMAPFV
+	gpPixelMapuiv                                    C.GPPIXELMAPUIV
+	gpPixelMapusv                                    C.GPPIXELMAPUSV
+	gpPixelStoref                                    C.GPPIXELSTOREF
+	gpPixelStorei                                    C.GPPIXELSTOREI
+	gpPixelTransferf                                 C.GPPIXELTRANSFERF
+	gpPixelTransferi                                 C.GPPIXELTRANSFERI
+	gpPixelZoom                                      C.GPPIXELZOOM
+	gpPointAlongPathNV                               C.GPPOINTALONGPATHNV
+	gpPointParameterf                                C.GPPOINTPARAMETERF
+	gpPointParameterfv                               C.GPPOINTPARAMETERFV
+	gpPointParameteri                                C.GPPOINTPARAMETERI
+	gpPointParameteriv                               C.GPPOINTPARAMETERIV
+	gpPointSize                                      C.GPPOINTSIZE
+	gpPolygonMode                                    C.GPPOLYGONMODE
+	gpPolygonOffset                                  C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                             C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                          C.GPPOLYGONOFFSETCLAMPEXT
+	gpPolygonStipple                                 C.GPPOLYGONSTIPPLE
+	gpPopAttrib                                      C.GPPOPATTRIB
+	gpPopClientAttrib                                C.GPPOPCLIENTATTRIB
+	gpPopDebugGroup                                  C.GPPOPDEBUGGROUP
+	gpPopDebugGroupKHR                               C.GPPOPDEBUGGROUPKHR
+	gpPopGroupMarkerEXT                              C.GPPOPGROUPMARKEREXT
+	gpPopMatrix                                      C.GPPOPMATRIX
+	gpPopName                                        C.GPPOPNAME
+	gpPrimitiveBoundingBoxARB                        C.GPPRIMITIVEBOUNDINGBOXARB
+	gpPrimitiveRestartIndex                          C.GPPRIMITIVERESTARTINDEX
+	gpPrioritizeTextures                             C.GPPRIORITIZETEXTURES
+	gpProgramBinary                                  C.GPPROGRAMBINARY
+	gpProgramParameteri                              C.GPPROGRAMPARAMETERI
+	gpProgramParameteriARB                           C.GPPROGRAMPARAMETERIARB
+	gpProgramParameteriEXT                           C.GPPROGRAMPARAMETERIEXT
+	gpProgramPathFragmentInputGenNV                  C.GPPROGRAMPATHFRAGMENTINPUTGENNV
+	gpProgramUniform1d                               C.GPPROGRAMUNIFORM1D
+	gpProgramUniform1dEXT                            C.GPPROGRAMUNIFORM1DEXT
+	gpProgramUniform1dv                              C.GPPROGRAMUNIFORM1DV
+	gpProgramUniform1dvEXT                           C.GPPROGRAMUNIFORM1DVEXT
+	gpProgramUniform1f                               C.GPPROGRAMUNIFORM1F
+	gpProgramUniform1fEXT                            C.GPPROGRAMUNIFORM1FEXT
+	gpProgramUniform1fv                              C.GPPROGRAMUNIFORM1FV
+	gpProgramUniform1fvEXT                           C.GPPROGRAMUNIFORM1FVEXT
+	gpProgramUniform1i                               C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                          C.GPPROGRAMUNIFORM1I64ARB
+	gpProgramUniform1i64NV                           C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                         C.GPPROGRAMUNIFORM1I64VARB
+	gpProgramUniform1i64vNV                          C.GPPROGRAMUNIFORM1I64VNV
+	gpProgramUniform1iEXT                            C.GPPROGRAMUNIFORM1IEXT
+	gpProgramUniform1iv                              C.GPPROGRAMUNIFORM1IV
+	gpProgramUniform1ivEXT                           C.GPPROGRAMUNIFORM1IVEXT
+	gpProgramUniform1ui                              C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                         C.GPPROGRAMUNIFORM1UI64ARB
+	gpProgramUniform1ui64NV                          C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                        C.GPPROGRAMUNIFORM1UI64VARB
+	gpProgramUniform1ui64vNV                         C.GPPROGRAMUNIFORM1UI64VNV
+	gpProgramUniform1uiEXT                           C.GPPROGRAMUNIFORM1UIEXT
+	gpProgramUniform1uiv                             C.GPPROGRAMUNIFORM1UIV
+	gpProgramUniform1uivEXT                          C.GPPROGRAMUNIFORM1UIVEXT
+	gpProgramUniform2d                               C.GPPROGRAMUNIFORM2D
+	gpProgramUniform2dEXT                            C.GPPROGRAMUNIFORM2DEXT
+	gpProgramUniform2dv                              C.GPPROGRAMUNIFORM2DV
+	gpProgramUniform2dvEXT                           C.GPPROGRAMUNIFORM2DVEXT
+	gpProgramUniform2f                               C.GPPROGRAMUNIFORM2F
+	gpProgramUniform2fEXT                            C.GPPROGRAMUNIFORM2FEXT
+	gpProgramUniform2fv                              C.GPPROGRAMUNIFORM2FV
+	gpProgramUniform2fvEXT                           C.GPPROGRAMUNIFORM2FVEXT
+	gpProgramUniform2i                               C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                          C.GPPROGRAMUNIFORM2I64ARB
+	gpProgramUniform2i64NV                           C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                         C.GPPROGRAMUNIFORM2I64VARB
+	gpProgramUniform2i64vNV                          C.GPPROGRAMUNIFORM2I64VNV
+	gpProgramUniform2iEXT                            C.GPPROGRAMUNIFORM2IEXT
+	gpProgramUniform2iv                              C.GPPROGRAMUNIFORM2IV
+	gpProgramUniform2ivEXT                           C.GPPROGRAMUNIFORM2IVEXT
+	gpProgramUniform2ui                              C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                         C.GPPROGRAMUNIFORM2UI64ARB
+	gpProgramUniform2ui64NV                          C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                        C.GPPROGRAMUNIFORM2UI64VARB
+	gpProgramUniform2ui64vNV                         C.GPPROGRAMUNIFORM2UI64VNV
+	gpProgramUniform2uiEXT                           C.GPPROGRAMUNIFORM2UIEXT
+	gpProgramUniform2uiv                             C.GPPROGRAMUNIFORM2UIV
+	gpProgramUniform2uivEXT                          C.GPPROGRAMUNIFORM2UIVEXT
+	gpProgramUniform3d                               C.GPPROGRAMUNIFORM3D
+	gpProgramUniform3dEXT                            C.GPPROGRAMUNIFORM3DEXT
+	gpProgramUniform3dv                              C.GPPROGRAMUNIFORM3DV
+	gpProgramUniform3dvEXT                           C.GPPROGRAMUNIFORM3DVEXT
+	gpProgramUniform3f                               C.GPPROGRAMUNIFORM3F
+	gpProgramUniform3fEXT                            C.GPPROGRAMUNIFORM3FEXT
+	gpProgramUniform3fv                              C.GPPROGRAMUNIFORM3FV
+	gpProgramUniform3fvEXT                           C.GPPROGRAMUNIFORM3FVEXT
+	gpProgramUniform3i                               C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                          C.GPPROGRAMUNIFORM3I64ARB
+	gpProgramUniform3i64NV                           C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                         C.GPPROGRAMUNIFORM3I64VARB
+	gpProgramUniform3i64vNV                          C.GPPROGRAMUNIFORM3I64VNV
+	gpProgramUniform3iEXT                            C.GPPROGRAMUNIFORM3IEXT
+	gpProgramUniform3iv                              C.GPPROGRAMUNIFORM3IV
+	gpProgramUniform3ivEXT                           C.GPPROGRAMUNIFORM3IVEXT
+	gpProgramUniform3ui                              C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                         C.GPPROGRAMUNIFORM3UI64ARB
+	gpProgramUniform3ui64NV                          C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                        C.GPPROGRAMUNIFORM3UI64VARB
+	gpProgramUniform3ui64vNV                         C.GPPROGRAMUNIFORM3UI64VNV
+	gpProgramUniform3uiEXT                           C.GPPROGRAMUNIFORM3UIEXT
+	gpProgramUniform3uiv                             C.GPPROGRAMUNIFORM3UIV
+	gpProgramUniform3uivEXT                          C.GPPROGRAMUNIFORM3UIVEXT
+	gpProgramUniform4d                               C.GPPROGRAMUNIFORM4D
+	gpProgramUniform4dEXT                            C.GPPROGRAMUNIFORM4DEXT
+	gpProgramUniform4dv                              C.GPPROGRAMUNIFORM4DV
+	gpProgramUniform4dvEXT                           C.GPPROGRAMUNIFORM4DVEXT
+	gpProgramUniform4f                               C.GPPROGRAMUNIFORM4F
+	gpProgramUniform4fEXT                            C.GPPROGRAMUNIFORM4FEXT
+	gpProgramUniform4fv                              C.GPPROGRAMUNIFORM4FV
+	gpProgramUniform4fvEXT                           C.GPPROGRAMUNIFORM4FVEXT
+	gpProgramUniform4i                               C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                          C.GPPROGRAMUNIFORM4I64ARB
+	gpProgramUniform4i64NV                           C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                         C.GPPROGRAMUNIFORM4I64VARB
+	gpProgramUniform4i64vNV                          C.GPPROGRAMUNIFORM4I64VNV
+	gpProgramUniform4iEXT                            C.GPPROGRAMUNIFORM4IEXT
+	gpProgramUniform4iv                              C.GPPROGRAMUNIFORM4IV
+	gpProgramUniform4ivEXT                           C.GPPROGRAMUNIFORM4IVEXT
+	gpProgramUniform4ui                              C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                         C.GPPROGRAMUNIFORM4UI64ARB
+	gpProgramUniform4ui64NV                          C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                        C.GPPROGRAMUNIFORM4UI64VARB
+	gpProgramUniform4ui64vNV                         C.GPPROGRAMUNIFORM4UI64VNV
+	gpProgramUniform4uiEXT                           C.GPPROGRAMUNIFORM4UIEXT
+	gpProgramUniform4uiv                             C.GPPROGRAMUNIFORM4UIV
+	gpProgramUniform4uivEXT                          C.GPPROGRAMUNIFORM4UIVEXT
+	gpProgramUniformHandleui64ARB                    C.GPPROGRAMUNIFORMHANDLEUI64ARB
+	gpProgramUniformHandleui64NV                     C.GPPROGRAMUNIFORMHANDLEUI64NV
+	gpProgramUniformHandleui64vARB                   C.GPPROGRAMUNIFORMHANDLEUI64VARB
+	gpProgramUniformHandleui64vNV                    C.GPPROGRAMUNIFORMHANDLEUI64VNV
+	gpProgramUniformMatrix2dv                        C.GPPROGRAMUNIFORMMATRIX2DV
+	gpProgramUniformMatrix2dvEXT                     C.GPPROGRAMUNIFORMMATRIX2DVEXT
+	gpProgramUniformMatrix2fv                        C.GPPROGRAMUNIFORMMATRIX2FV
+	gpProgramUniformMatrix2fvEXT                     C.GPPROGRAMUNIFORMMATRIX2FVEXT
+	gpProgramUniformMatrix2x3dv                      C.GPPROGRAMUNIFORMMATRIX2X3DV
+	gpProgramUniformMatrix2x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3DVEXT
+	gpProgramUniformMatrix2x3fv                      C.GPPROGRAMUNIFORMMATRIX2X3FV
+	gpProgramUniformMatrix2x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3FVEXT
+	gpProgramUniformMatrix2x4dv                      C.GPPROGRAMUNIFORMMATRIX2X4DV
+	gpProgramUniformMatrix2x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4DVEXT
+	gpProgramUniformMatrix2x4fv                      C.GPPROGRAMUNIFORMMATRIX2X4FV
+	gpProgramUniformMatrix2x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4FVEXT
+	gpProgramUniformMatrix3dv                        C.GPPROGRAMUNIFORMMATRIX3DV
+	gpProgramUniformMatrix3dvEXT                     C.GPPROGRAMUNIFORMMATRIX3DVEXT
+	gpProgramUniformMatrix3fv                        C.GPPROGRAMUNIFORMMATRIX3FV
+	gpProgramUniformMatrix3fvEXT                     C.GPPROGRAMUNIFORMMATRIX3FVEXT
+	gpProgramUniformMatrix3x2dv                      C.GPPROGRAMUNIFORMMATRIX3X2DV
+	gpProgramUniformMatrix3x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2DVEXT
+	gpProgramUniformMatrix3x2fv                      C.GPPROGRAMUNIFORMMATRIX3X2FV
+	gpProgramUniformMatrix3x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2FVEXT
+	gpProgramUniformMatrix3x4dv                      C.GPPROGRAMUNIFORMMATRIX3X4DV
+	gpProgramUniformMatrix3x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4DVEXT
+	gpProgramUniformMatrix3x4fv                      C.GPPROGRAMUNIFORMMATRIX3X4FV
+	gpProgramUniformMatrix3x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4FVEXT
+	gpProgramUniformMatrix4dv                        C.GPPROGRAMUNIFORMMATRIX4DV
+	gpProgramUniformMatrix4dvEXT                     C.GPPROGRAMUNIFORMMATRIX4DVEXT
+	gpProgramUniformMatrix4fv                        C.GPPROGRAMUNIFORMMATRIX4FV
+	gpProgramUniformMatrix4fvEXT                     C.GPPROGRAMUNIFORMMATRIX4FVEXT
+	gpProgramUniformMatrix4x2dv                      C.GPPROGRAMUNIFORMMATRIX4X2DV
+	gpProgramUniformMatrix4x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2DVEXT
+	gpProgramUniformMatrix4x2fv                      C.GPPROGRAMUNIFORMMATRIX4X2FV
+	gpProgramUniformMatrix4x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2FVEXT
+	gpProgramUniformMatrix4x3dv                      C.GPPROGRAMUNIFORMMATRIX4X3DV
+	gpProgramUniformMatrix4x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3DVEXT
+	gpProgramUniformMatrix4x3fv                      C.GPPROGRAMUNIFORMMATRIX4X3FV
+	gpProgramUniformMatrix4x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3FVEXT
+	gpProgramUniformui64NV                           C.GPPROGRAMUNIFORMUI64NV
+	gpProgramUniformui64vNV                          C.GPPROGRAMUNIFORMUI64VNV
+	gpProvokingVertex                                C.GPPROVOKINGVERTEX
+	gpPushAttrib                                     C.GPPUSHATTRIB
+	gpPushClientAttrib                               C.GPPUSHCLIENTATTRIB
+	gpPushClientAttribDefaultEXT                     C.GPPUSHCLIENTATTRIBDEFAULTEXT
+	gpPushDebugGroup                                 C.GPPUSHDEBUGGROUP
+	gpPushDebugGroupKHR                              C.GPPUSHDEBUGGROUPKHR
+	gpPushGroupMarkerEXT                             C.GPPUSHGROUPMARKEREXT
+	gpPushMatrix                                     C.GPPUSHMATRIX
+	gpPushName                                       C.GPPUSHNAME
+	gpQueryCounter                                   C.GPQUERYCOUNTER
+	gpRasterPos2d                                    C.GPRASTERPOS2D
+	gpRasterPos2dv                                   C.GPRASTERPOS2DV
+	gpRasterPos2f                                    C.GPRASTERPOS2F
+	gpRasterPos2fv                                   C.GPRASTERPOS2FV
+	gpRasterPos2i                                    C.GPRASTERPOS2I
+	gpRasterPos2iv                                   C.GPRASTERPOS2IV
+	gpRasterPos2s                                    C.GPRASTERPOS2S
+	gpRasterPos2sv                                   C.GPRASTERPOS2SV
+	gpRasterPos3d                                    C.GPRASTERPOS3D
+	gpRasterPos3dv                                   C.GPRASTERPOS3DV
+	gpRasterPos3f                                    C.GPRASTERPOS3F
+	gpRasterPos3fv                                   C.GPRASTERPOS3FV
+	gpRasterPos3i                                    C.GPRASTERPOS3I
+	gpRasterPos3iv                                   C.GPRASTERPOS3IV
+	gpRasterPos3s                                    C.GPRASTERPOS3S
+	gpRasterPos3sv                                   C.GPRASTERPOS3SV
+	gpRasterPos4d                                    C.GPRASTERPOS4D
+	gpRasterPos4dv                                   C.GPRASTERPOS4DV
+	gpRasterPos4f                                    C.GPRASTERPOS4F
+	gpRasterPos4fv                                   C.GPRASTERPOS4FV
+	gpRasterPos4i                                    C.GPRASTERPOS4I
+	gpRasterPos4iv                                   C.GPRASTERPOS4IV
+	gpRasterPos4s                                    C.GPRASTERPOS4S
+	gpRasterPos4sv                                   C.GPRASTERPOS4SV
+	gpRasterSamplesEXT                               C.GPRASTERSAMPLESEXT
+	gpReadBuffer                                     C.GPREADBUFFER
+	gpReadPixels                                     C.GPREADPIXELS
+	gpReadnPixels                                    C.GPREADNPIXELS
+	gpReadnPixelsARB                                 C.GPREADNPIXELSARB
+	gpReadnPixelsKHR                                 C.GPREADNPIXELSKHR
+	gpRectd                                          C.GPRECTD
+	gpRectdv                                         C.GPRECTDV
+	gpRectf                                          C.GPRECTF
+	gpRectfv                                         C.GPRECTFV
+	gpRecti                                          C.GPRECTI
+	gpRectiv                                         C.GPRECTIV
+	gpRects                                          C.GPRECTS
+	gpRectsv                                         C.GPRECTSV
+	gpReleaseShaderCompiler                          C.GPRELEASESHADERCOMPILER
+	gpRenderMode                                     C.GPRENDERMODE
+	gpRenderbufferStorage                            C.GPRENDERBUFFERSTORAGE
+	gpRenderbufferStorageMultisample                 C.GPRENDERBUFFERSTORAGEMULTISAMPLE
+	gpRenderbufferStorageMultisampleCoverageNV       C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV
+	gpResolveDepthValuesNV                           C.GPRESOLVEDEPTHVALUESNV
+	gpResumeTransformFeedback                        C.GPRESUMETRANSFORMFEEDBACK
+	gpRotated                                        C.GPROTATED
+	gpRotatef                                        C.GPROTATEF
+	gpSampleCoverage                                 C.GPSAMPLECOVERAGE
+	gpSampleMaski                                    C.GPSAMPLEMASKI
+	gpSamplerParameterIiv                            C.GPSAMPLERPARAMETERIIV
+	gpSamplerParameterIuiv                           C.GPSAMPLERPARAMETERIUIV
+	gpSamplerParameterf                              C.GPSAMPLERPARAMETERF
+	gpSamplerParameterfv                             C.GPSAMPLERPARAMETERFV
+	gpSamplerParameteri                              C.GPSAMPLERPARAMETERI
+	gpSamplerParameteriv                             C.GPSAMPLERPARAMETERIV
+	gpScaled                                         C.GPSCALED
+	gpScalef                                         C.GPSCALEF
+	gpScissor                                        C.GPSCISSOR
+	gpScissorArrayv                                  C.GPSCISSORARRAYV
+	gpScissorIndexed                                 C.GPSCISSORINDEXED
+	gpScissorIndexedv                                C.GPSCISSORINDEXEDV
+	gpSecondaryColor3b                               C.GPSECONDARYCOLOR3B
+	gpSecondaryColor3bv                              C.GPSECONDARYCOLOR3BV
+	gpSecondaryColor3d                               C.GPSECONDARYCOLOR3D
+	gpSecondaryColor3dv                              C.GPSECONDARYCOLOR3DV
+	gpSecondaryColor3f                               C.GPSECONDARYCOLOR3F
+	gpSecondaryColor3fv                              C.GPSECONDARYCOLOR3FV
+	gpSecondaryColor3i                               C.GPSECONDARYCOLOR3I
+	gpSecondaryColor3iv                              C.GPSECONDARYCOLOR3IV
+	gpSecondaryColor3s                               C.GPSECONDARYCOLOR3S
+	gpSecondaryColor3sv                              C.GPSECONDARYCOLOR3SV
+	gpSecondaryColor3ub                              C.GPSECONDARYCOLOR3UB
+	gpSecondaryColor3ubv                             C.GPSECONDARYCOLOR3UBV
+	gpSecondaryColor3ui                              C.GPSECONDARYCOLOR3UI
+	gpSecondaryColor3uiv                             C.GPSECONDARYCOLOR3UIV
+	gpSecondaryColor3us                              C.GPSECONDARYCOLOR3US
+	gpSecondaryColor3usv                             C.GPSECONDARYCOLOR3USV
+	gpSecondaryColorFormatNV                         C.GPSECONDARYCOLORFORMATNV
+	gpSecondaryColorPointer                          C.GPSECONDARYCOLORPOINTER
+	gpSelectBuffer                                   C.GPSELECTBUFFER
+	gpSelectPerfMonitorCountersAMD                   C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpShadeModel                                     C.GPSHADEMODEL
+	gpShaderBinary                                   C.GPSHADERBINARY
+	gpShaderSource                                   C.GPSHADERSOURCE
+	gpShaderStorageBlockBinding                      C.GPSHADERSTORAGEBLOCKBINDING
+	gpSignalVkFenceNV                                C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                            C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShader                               C.GPSPECIALIZESHADER
+	gpSpecializeShaderARB                            C.GPSPECIALIZESHADERARB
+	gpStateCaptureNV                                 C.GPSTATECAPTURENV
+	gpStencilFillPathInstancedNV                     C.GPSTENCILFILLPATHINSTANCEDNV
+	gpStencilFillPathNV                              C.GPSTENCILFILLPATHNV
+	gpStencilFunc                                    C.GPSTENCILFUNC
+	gpStencilFuncSeparate                            C.GPSTENCILFUNCSEPARATE
+	gpStencilMask                                    C.GPSTENCILMASK
+	gpStencilMaskSeparate                            C.GPSTENCILMASKSEPARATE
+	gpStencilOp                                      C.GPSTENCILOP
+	gpStencilOpSeparate                              C.GPSTENCILOPSEPARATE
+	gpStencilStrokePathInstancedNV                   C.GPSTENCILSTROKEPATHINSTANCEDNV
+	gpStencilStrokePathNV                            C.GPSTENCILSTROKEPATHNV
+	gpStencilThenCoverFillPathInstancedNV            C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV
+	gpStencilThenCoverFillPathNV                     C.GPSTENCILTHENCOVERFILLPATHNV
+	gpStencilThenCoverStrokePathInstancedNV          C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV
+	gpStencilThenCoverStrokePathNV                   C.GPSTENCILTHENCOVERSTROKEPATHNV
+	gpSubpixelPrecisionBiasNV                        C.GPSUBPIXELPRECISIONBIASNV
+	gpTexBuffer                                      C.GPTEXBUFFER
+	gpTexBufferARB                                   C.GPTEXBUFFERARB
+	gpTexBufferRange                                 C.GPTEXBUFFERRANGE
+	gpTexCoord1d                                     C.GPTEXCOORD1D
+	gpTexCoord1dv                                    C.GPTEXCOORD1DV
+	gpTexCoord1f                                     C.GPTEXCOORD1F
+	gpTexCoord1fv                                    C.GPTEXCOORD1FV
+	gpTexCoord1i                                     C.GPTEXCOORD1I
+	gpTexCoord1iv                                    C.GPTEXCOORD1IV
+	gpTexCoord1s                                     C.GPTEXCOORD1S
+	gpTexCoord1sv                                    C.GPTEXCOORD1SV
+	gpTexCoord2d                                     C.GPTEXCOORD2D
+	gpTexCoord2dv                                    C.GPTEXCOORD2DV
+	gpTexCoord2f                                     C.GPTEXCOORD2F
+	gpTexCoord2fv                                    C.GPTEXCOORD2FV
+	gpTexCoord2i                                     C.GPTEXCOORD2I
+	gpTexCoord2iv                                    C.GPTEXCOORD2IV
+	gpTexCoord2s                                     C.GPTEXCOORD2S
+	gpTexCoord2sv                                    C.GPTEXCOORD2SV
+	gpTexCoord3d                                     C.GPTEXCOORD3D
+	gpTexCoord3dv                                    C.GPTEXCOORD3DV
+	gpTexCoord3f                                     C.GPTEXCOORD3F
+	gpTexCoord3fv                                    C.GPTEXCOORD3FV
+	gpTexCoord3i                                     C.GPTEXCOORD3I
+	gpTexCoord3iv                                    C.GPTEXCOORD3IV
+	gpTexCoord3s                                     C.GPTEXCOORD3S
+	gpTexCoord3sv                                    C.GPTEXCOORD3SV
+	gpTexCoord4d                                     C.GPTEXCOORD4D
+	gpTexCoord4dv                                    C.GPTEXCOORD4DV
+	gpTexCoord4f                                     C.GPTEXCOORD4F
+	gpTexCoord4fv                                    C.GPTEXCOORD4FV
+	gpTexCoord4i                                     C.GPTEXCOORD4I
+	gpTexCoord4iv                                    C.GPTEXCOORD4IV
+	gpTexCoord4s                                     C.GPTEXCOORD4S
+	gpTexCoord4sv                                    C.GPTEXCOORD4SV
+	gpTexCoordFormatNV                               C.GPTEXCOORDFORMATNV
+	gpTexCoordPointer                                C.GPTEXCOORDPOINTER
+	gpTexEnvf                                        C.GPTEXENVF
+	gpTexEnvfv                                       C.GPTEXENVFV
+	gpTexEnvi                                        C.GPTEXENVI
+	gpTexEnviv                                       C.GPTEXENVIV
+	gpTexGend                                        C.GPTEXGEND
+	gpTexGendv                                       C.GPTEXGENDV
+	gpTexGenf                                        C.GPTEXGENF
+	gpTexGenfv                                       C.GPTEXGENFV
+	gpTexGeni                                        C.GPTEXGENI
+	gpTexGeniv                                       C.GPTEXGENIV
+	gpTexImage1D                                     C.GPTEXIMAGE1D
+	gpTexImage2D                                     C.GPTEXIMAGE2D
+	gpTexImage2DMultisample                          C.GPTEXIMAGE2DMULTISAMPLE
+	gpTexImage3D                                     C.GPTEXIMAGE3D
+	gpTexImage3DMultisample                          C.GPTEXIMAGE3DMULTISAMPLE
+	gpTexPageCommitmentARB                           C.GPTEXPAGECOMMITMENTARB
+	gpTexParameterIiv                                C.GPTEXPARAMETERIIV
+	gpTexParameterIuiv                               C.GPTEXPARAMETERIUIV
+	gpTexParameterf                                  C.GPTEXPARAMETERF
+	gpTexParameterfv                                 C.GPTEXPARAMETERFV
+	gpTexParameteri                                  C.GPTEXPARAMETERI
+	gpTexParameteriv                                 C.GPTEXPARAMETERIV
+	gpTexStorage1D                                   C.GPTEXSTORAGE1D
+	gpTexStorage2D                                   C.GPTEXSTORAGE2D
+	gpTexStorage2DMultisample                        C.GPTEXSTORAGE2DMULTISAMPLE
+	gpTexStorage3D                                   C.GPTEXSTORAGE3D
+	gpTexStorage3DMultisample                        C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexSubImage1D                                  C.GPTEXSUBIMAGE1D
+	gpTexSubImage2D                                  C.GPTEXSUBIMAGE2D
+	gpTexSubImage3D                                  C.GPTEXSUBIMAGE3D
+	gpTextureBarrier                                 C.GPTEXTUREBARRIER
+	gpTextureBarrierNV                               C.GPTEXTUREBARRIERNV
+	gpTextureBuffer                                  C.GPTEXTUREBUFFER
+	gpTextureBufferEXT                               C.GPTEXTUREBUFFEREXT
+	gpTextureBufferRange                             C.GPTEXTUREBUFFERRANGE
+	gpTextureBufferRangeEXT                          C.GPTEXTUREBUFFERRANGEEXT
+	gpTextureImage1DEXT                              C.GPTEXTUREIMAGE1DEXT
+	gpTextureImage2DEXT                              C.GPTEXTUREIMAGE2DEXT
+	gpTextureImage3DEXT                              C.GPTEXTUREIMAGE3DEXT
+	gpTexturePageCommitmentEXT                       C.GPTEXTUREPAGECOMMITMENTEXT
+	gpTextureParameterIiv                            C.GPTEXTUREPARAMETERIIV
+	gpTextureParameterIivEXT                         C.GPTEXTUREPARAMETERIIVEXT
+	gpTextureParameterIuiv                           C.GPTEXTUREPARAMETERIUIV
+	gpTextureParameterIuivEXT                        C.GPTEXTUREPARAMETERIUIVEXT
+	gpTextureParameterf                              C.GPTEXTUREPARAMETERF
+	gpTextureParameterfEXT                           C.GPTEXTUREPARAMETERFEXT
+	gpTextureParameterfv                             C.GPTEXTUREPARAMETERFV
+	gpTextureParameterfvEXT                          C.GPTEXTUREPARAMETERFVEXT
+	gpTextureParameteri                              C.GPTEXTUREPARAMETERI
+	gpTextureParameteriEXT                           C.GPTEXTUREPARAMETERIEXT
+	gpTextureParameteriv                             C.GPTEXTUREPARAMETERIV
+	gpTextureParameterivEXT                          C.GPTEXTUREPARAMETERIVEXT
+	gpTextureRenderbufferEXT                         C.GPTEXTURERENDERBUFFEREXT
+	gpTextureStorage1D                               C.GPTEXTURESTORAGE1D
+	gpTextureStorage1DEXT                            C.GPTEXTURESTORAGE1DEXT
+	gpTextureStorage2D                               C.GPTEXTURESTORAGE2D
+	gpTextureStorage2DEXT                            C.GPTEXTURESTORAGE2DEXT
+	gpTextureStorage2DMultisample                    C.GPTEXTURESTORAGE2DMULTISAMPLE
+	gpTextureStorage2DMultisampleEXT                 C.GPTEXTURESTORAGE2DMULTISAMPLEEXT
+	gpTextureStorage3D                               C.GPTEXTURESTORAGE3D
+	gpTextureStorage3DEXT                            C.GPTEXTURESTORAGE3DEXT
+	gpTextureStorage3DMultisample                    C.GPTEXTURESTORAGE3DMULTISAMPLE
+	gpTextureStorage3DMultisampleEXT                 C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureSubImage1D                              C.GPTEXTURESUBIMAGE1D
+	gpTextureSubImage1DEXT                           C.GPTEXTURESUBIMAGE1DEXT
+	gpTextureSubImage2D                              C.GPTEXTURESUBIMAGE2D
+	gpTextureSubImage2DEXT                           C.GPTEXTURESUBIMAGE2DEXT
+	gpTextureSubImage3D                              C.GPTEXTURESUBIMAGE3D
+	gpTextureSubImage3DEXT                           C.GPTEXTURESUBIMAGE3DEXT
+	gpTextureView                                    C.GPTEXTUREVIEW
+	gpTransformFeedbackBufferBase                    C.GPTRANSFORMFEEDBACKBUFFERBASE
+	gpTransformFeedbackBufferRange                   C.GPTRANSFORMFEEDBACKBUFFERRANGE
+	gpTransformFeedbackVaryings                      C.GPTRANSFORMFEEDBACKVARYINGS
+	gpTransformPathNV                                C.GPTRANSFORMPATHNV
+	gpTranslated                                     C.GPTRANSLATED
+	gpTranslatef                                     C.GPTRANSLATEF
+	gpUniform1d                                      C.GPUNIFORM1D
+	gpUniform1dv                                     C.GPUNIFORM1DV
+	gpUniform1f                                      C.GPUNIFORM1F
+	gpUniform1fv                                     C.GPUNIFORM1FV
+	gpUniform1i                                      C.GPUNIFORM1I
+	gpUniform1i64ARB                                 C.GPUNIFORM1I64ARB
+	gpUniform1i64NV                                  C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                C.GPUNIFORM1I64VARB
+	gpUniform1i64vNV                                 C.GPUNIFORM1I64VNV
+	gpUniform1iv                                     C.GPUNIFORM1IV
+	gpUniform1ui                                     C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                C.GPUNIFORM1UI64ARB
+	gpUniform1ui64NV                                 C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                               C.GPUNIFORM1UI64VARB
+	gpUniform1ui64vNV                                C.GPUNIFORM1UI64VNV
+	gpUniform1uiv                                    C.GPUNIFORM1UIV
+	gpUniform2d                                      C.GPUNIFORM2D
+	gpUniform2dv                                     C.GPUNIFORM2DV
+	gpUniform2f                                      C.GPUNIFORM2F
+	gpUniform2fv                                     C.GPUNIFORM2FV
+	gpUniform2i                                      C.GPUNIFORM2I
+	gpUniform2i64ARB                                 C.GPUNIFORM2I64ARB
+	gpUniform2i64NV                                  C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                C.GPUNIFORM2I64VARB
+	gpUniform2i64vNV                                 C.GPUNIFORM2I64VNV
+	gpUniform2iv                                     C.GPUNIFORM2IV
+	gpUniform2ui                                     C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                C.GPUNIFORM2UI64ARB
+	gpUniform2ui64NV                                 C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                               C.GPUNIFORM2UI64VARB
+	gpUniform2ui64vNV                                C.GPUNIFORM2UI64VNV
+	gpUniform2uiv                                    C.GPUNIFORM2UIV
+	gpUniform3d                                      C.GPUNIFORM3D
+	gpUniform3dv                                     C.GPUNIFORM3DV
+	gpUniform3f                                      C.GPUNIFORM3F
+	gpUniform3fv                                     C.GPUNIFORM3FV
+	gpUniform3i                                      C.GPUNIFORM3I
+	gpUniform3i64ARB                                 C.GPUNIFORM3I64ARB
+	gpUniform3i64NV                                  C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                C.GPUNIFORM3I64VARB
+	gpUniform3i64vNV                                 C.GPUNIFORM3I64VNV
+	gpUniform3iv                                     C.GPUNIFORM3IV
+	gpUniform3ui                                     C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                C.GPUNIFORM3UI64ARB
+	gpUniform3ui64NV                                 C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                               C.GPUNIFORM3UI64VARB
+	gpUniform3ui64vNV                                C.GPUNIFORM3UI64VNV
+	gpUniform3uiv                                    C.GPUNIFORM3UIV
+	gpUniform4d                                      C.GPUNIFORM4D
+	gpUniform4dv                                     C.GPUNIFORM4DV
+	gpUniform4f                                      C.GPUNIFORM4F
+	gpUniform4fv                                     C.GPUNIFORM4FV
+	gpUniform4i                                      C.GPUNIFORM4I
+	gpUniform4i64ARB                                 C.GPUNIFORM4I64ARB
+	gpUniform4i64NV                                  C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                C.GPUNIFORM4I64VARB
+	gpUniform4i64vNV                                 C.GPUNIFORM4I64VNV
+	gpUniform4iv                                     C.GPUNIFORM4IV
+	gpUniform4ui                                     C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                C.GPUNIFORM4UI64ARB
+	gpUniform4ui64NV                                 C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                               C.GPUNIFORM4UI64VARB
+	gpUniform4ui64vNV                                C.GPUNIFORM4UI64VNV
+	gpUniform4uiv                                    C.GPUNIFORM4UIV
+	gpUniformBlockBinding                            C.GPUNIFORMBLOCKBINDING
+	gpUniformHandleui64ARB                           C.GPUNIFORMHANDLEUI64ARB
+	gpUniformHandleui64NV                            C.GPUNIFORMHANDLEUI64NV
+	gpUniformHandleui64vARB                          C.GPUNIFORMHANDLEUI64VARB
+	gpUniformHandleui64vNV                           C.GPUNIFORMHANDLEUI64VNV
+	gpUniformMatrix2dv                               C.GPUNIFORMMATRIX2DV
+	gpUniformMatrix2fv                               C.GPUNIFORMMATRIX2FV
+	gpUniformMatrix2x3dv                             C.GPUNIFORMMATRIX2X3DV
+	gpUniformMatrix2x3fv                             C.GPUNIFORMMATRIX2X3FV
+	gpUniformMatrix2x4dv                             C.GPUNIFORMMATRIX2X4DV
+	gpUniformMatrix2x4fv                             C.GPUNIFORMMATRIX2X4FV
+	gpUniformMatrix3dv                               C.GPUNIFORMMATRIX3DV
+	gpUniformMatrix3fv                               C.GPUNIFORMMATRIX3FV
+	gpUniformMatrix3x2dv                             C.GPUNIFORMMATRIX3X2DV
+	gpUniformMatrix3x2fv                             C.GPUNIFORMMATRIX3X2FV
+	gpUniformMatrix3x4dv                             C.GPUNIFORMMATRIX3X4DV
+	gpUniformMatrix3x4fv                             C.GPUNIFORMMATRIX3X4FV
+	gpUniformMatrix4dv                               C.GPUNIFORMMATRIX4DV
+	gpUniformMatrix4fv                               C.GPUNIFORMMATRIX4FV
+	gpUniformMatrix4x2dv                             C.GPUNIFORMMATRIX4X2DV
+	gpUniformMatrix4x2fv                             C.GPUNIFORMMATRIX4X2FV
+	gpUniformMatrix4x3dv                             C.GPUNIFORMMATRIX4X3DV
+	gpUniformMatrix4x3fv                             C.GPUNIFORMMATRIX4X3FV
+	gpUniformSubroutinesuiv                          C.GPUNIFORMSUBROUTINESUIV
+	gpUniformui64NV                                  C.GPUNIFORMUI64NV
+	gpUniformui64vNV                                 C.GPUNIFORMUI64VNV
+	gpUnmapBuffer                                    C.GPUNMAPBUFFER
+	gpUnmapNamedBuffer                               C.GPUNMAPNAMEDBUFFER
+	gpUnmapNamedBufferEXT                            C.GPUNMAPNAMEDBUFFEREXT
+	gpUseProgram                                     C.GPUSEPROGRAM
+	gpUseProgramStages                               C.GPUSEPROGRAMSTAGES
+	gpUseProgramStagesEXT                            C.GPUSEPROGRAMSTAGESEXT
+	gpUseShaderProgramEXT                            C.GPUSESHADERPROGRAMEXT
+	gpValidateProgram                                C.GPVALIDATEPROGRAM
+	gpValidateProgramPipeline                        C.GPVALIDATEPROGRAMPIPELINE
+	gpValidateProgramPipelineEXT                     C.GPVALIDATEPROGRAMPIPELINEEXT
+	gpVertex2d                                       C.GPVERTEX2D
+	gpVertex2dv                                      C.GPVERTEX2DV
+	gpVertex2f                                       C.GPVERTEX2F
+	gpVertex2fv                                      C.GPVERTEX2FV
+	gpVertex2i                                       C.GPVERTEX2I
+	gpVertex2iv                                      C.GPVERTEX2IV
+	gpVertex2s                                       C.GPVERTEX2S
+	gpVertex2sv                                      C.GPVERTEX2SV
+	gpVertex3d                                       C.GPVERTEX3D
+	gpVertex3dv                                      C.GPVERTEX3DV
+	gpVertex3f                                       C.GPVERTEX3F
+	gpVertex3fv                                      C.GPVERTEX3FV
+	gpVertex3i                                       C.GPVERTEX3I
+	gpVertex3iv                                      C.GPVERTEX3IV
+	gpVertex3s                                       C.GPVERTEX3S
+	gpVertex3sv                                      C.GPVERTEX3SV
+	gpVertex4d                                       C.GPVERTEX4D
+	gpVertex4dv                                      C.GPVERTEX4DV
+	gpVertex4f                                       C.GPVERTEX4F
+	gpVertex4fv                                      C.GPVERTEX4FV
+	gpVertex4i                                       C.GPVERTEX4I
+	gpVertex4iv                                      C.GPVERTEX4IV
+	gpVertex4s                                       C.GPVERTEX4S
+	gpVertex4sv                                      C.GPVERTEX4SV
+	gpVertexArrayAttribBinding                       C.GPVERTEXARRAYATTRIBBINDING
+	gpVertexArrayAttribFormat                        C.GPVERTEXARRAYATTRIBFORMAT
+	gpVertexArrayAttribIFormat                       C.GPVERTEXARRAYATTRIBIFORMAT
+	gpVertexArrayAttribLFormat                       C.GPVERTEXARRAYATTRIBLFORMAT
+	gpVertexArrayBindVertexBufferEXT                 C.GPVERTEXARRAYBINDVERTEXBUFFEREXT
+	gpVertexArrayBindingDivisor                      C.GPVERTEXARRAYBINDINGDIVISOR
+	gpVertexArrayColorOffsetEXT                      C.GPVERTEXARRAYCOLOROFFSETEXT
+	gpVertexArrayEdgeFlagOffsetEXT                   C.GPVERTEXARRAYEDGEFLAGOFFSETEXT
+	gpVertexArrayElementBuffer                       C.GPVERTEXARRAYELEMENTBUFFER
+	gpVertexArrayFogCoordOffsetEXT                   C.GPVERTEXARRAYFOGCOORDOFFSETEXT
+	gpVertexArrayIndexOffsetEXT                      C.GPVERTEXARRAYINDEXOFFSETEXT
+	gpVertexArrayMultiTexCoordOffsetEXT              C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT
+	gpVertexArrayNormalOffsetEXT                     C.GPVERTEXARRAYNORMALOFFSETEXT
+	gpVertexArraySecondaryColorOffsetEXT             C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT
+	gpVertexArrayTexCoordOffsetEXT                   C.GPVERTEXARRAYTEXCOORDOFFSETEXT
+	gpVertexArrayVertexAttribBindingEXT              C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT
+	gpVertexArrayVertexAttribDivisorEXT              C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT
+	gpVertexArrayVertexAttribFormatEXT               C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT
+	gpVertexArrayVertexAttribIFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT
+	gpVertexArrayVertexAttribIOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT
+	gpVertexArrayVertexAttribLFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT
+	gpVertexArrayVertexAttribLOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT
+	gpVertexArrayVertexAttribOffsetEXT               C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT
+	gpVertexArrayVertexBindingDivisorEXT             C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT
+	gpVertexArrayVertexBuffer                        C.GPVERTEXARRAYVERTEXBUFFER
+	gpVertexArrayVertexBuffers                       C.GPVERTEXARRAYVERTEXBUFFERS
+	gpVertexArrayVertexOffsetEXT                     C.GPVERTEXARRAYVERTEXOFFSETEXT
+	gpVertexAttrib1d                                 C.GPVERTEXATTRIB1D
+	gpVertexAttrib1dv                                C.GPVERTEXATTRIB1DV
+	gpVertexAttrib1f                                 C.GPVERTEXATTRIB1F
+	gpVertexAttrib1fv                                C.GPVERTEXATTRIB1FV
+	gpVertexAttrib1s                                 C.GPVERTEXATTRIB1S
+	gpVertexAttrib1sv                                C.GPVERTEXATTRIB1SV
+	gpVertexAttrib2d                                 C.GPVERTEXATTRIB2D
+	gpVertexAttrib2dv                                C.GPVERTEXATTRIB2DV
+	gpVertexAttrib2f                                 C.GPVERTEXATTRIB2F
+	gpVertexAttrib2fv                                C.GPVERTEXATTRIB2FV
+	gpVertexAttrib2s                                 C.GPVERTEXATTRIB2S
+	gpVertexAttrib2sv                                C.GPVERTEXATTRIB2SV
+	gpVertexAttrib3d                                 C.GPVERTEXATTRIB3D
+	gpVertexAttrib3dv                                C.GPVERTEXATTRIB3DV
+	gpVertexAttrib3f                                 C.GPVERTEXATTRIB3F
+	gpVertexAttrib3fv                                C.GPVERTEXATTRIB3FV
+	gpVertexAttrib3s                                 C.GPVERTEXATTRIB3S
+	gpVertexAttrib3sv                                C.GPVERTEXATTRIB3SV
+	gpVertexAttrib4Nbv                               C.GPVERTEXATTRIB4NBV
+	gpVertexAttrib4Niv                               C.GPVERTEXATTRIB4NIV
+	gpVertexAttrib4Nsv                               C.GPVERTEXATTRIB4NSV
+	gpVertexAttrib4Nub                               C.GPVERTEXATTRIB4NUB
+	gpVertexAttrib4Nubv                              C.GPVERTEXATTRIB4NUBV
+	gpVertexAttrib4Nuiv                              C.GPVERTEXATTRIB4NUIV
+	gpVertexAttrib4Nusv                              C.GPVERTEXATTRIB4NUSV
+	gpVertexAttrib4bv                                C.GPVERTEXATTRIB4BV
+	gpVertexAttrib4d                                 C.GPVERTEXATTRIB4D
+	gpVertexAttrib4dv                                C.GPVERTEXATTRIB4DV
+	gpVertexAttrib4f                                 C.GPVERTEXATTRIB4F
+	gpVertexAttrib4fv                                C.GPVERTEXATTRIB4FV
+	gpVertexAttrib4iv                                C.GPVERTEXATTRIB4IV
+	gpVertexAttrib4s                                 C.GPVERTEXATTRIB4S
+	gpVertexAttrib4sv                                C.GPVERTEXATTRIB4SV
+	gpVertexAttrib4ubv                               C.GPVERTEXATTRIB4UBV
+	gpVertexAttrib4uiv                               C.GPVERTEXATTRIB4UIV
+	gpVertexAttrib4usv                               C.GPVERTEXATTRIB4USV
+	gpVertexAttribBinding                            C.GPVERTEXATTRIBBINDING
+	gpVertexAttribDivisor                            C.GPVERTEXATTRIBDIVISOR
+	gpVertexAttribDivisorARB                         C.GPVERTEXATTRIBDIVISORARB
+	gpVertexAttribFormat                             C.GPVERTEXATTRIBFORMAT
+	gpVertexAttribFormatNV                           C.GPVERTEXATTRIBFORMATNV
+	gpVertexAttribI1i                                C.GPVERTEXATTRIBI1I
+	gpVertexAttribI1iv                               C.GPVERTEXATTRIBI1IV
+	gpVertexAttribI1ui                               C.GPVERTEXATTRIBI1UI
+	gpVertexAttribI1uiv                              C.GPVERTEXATTRIBI1UIV
+	gpVertexAttribI2i                                C.GPVERTEXATTRIBI2I
+	gpVertexAttribI2iv                               C.GPVERTEXATTRIBI2IV
+	gpVertexAttribI2ui                               C.GPVERTEXATTRIBI2UI
+	gpVertexAttribI2uiv                              C.GPVERTEXATTRIBI2UIV
+	gpVertexAttribI3i                                C.GPVERTEXATTRIBI3I
+	gpVertexAttribI3iv                               C.GPVERTEXATTRIBI3IV
+	gpVertexAttribI3ui                               C.GPVERTEXATTRIBI3UI
+	gpVertexAttribI3uiv                              C.GPVERTEXATTRIBI3UIV
+	gpVertexAttribI4bv                               C.GPVERTEXATTRIBI4BV
+	gpVertexAttribI4i                                C.GPVERTEXATTRIBI4I
+	gpVertexAttribI4iv                               C.GPVERTEXATTRIBI4IV
+	gpVertexAttribI4sv                               C.GPVERTEXATTRIBI4SV
+	gpVertexAttribI4ubv                              C.GPVERTEXATTRIBI4UBV
+	gpVertexAttribI4ui                               C.GPVERTEXATTRIBI4UI
+	gpVertexAttribI4uiv                              C.GPVERTEXATTRIBI4UIV
+	gpVertexAttribI4usv                              C.GPVERTEXATTRIBI4USV
+	gpVertexAttribIFormat                            C.GPVERTEXATTRIBIFORMAT
+	gpVertexAttribIFormatNV                          C.GPVERTEXATTRIBIFORMATNV
+	gpVertexAttribIPointer                           C.GPVERTEXATTRIBIPOINTER
+	gpVertexAttribL1d                                C.GPVERTEXATTRIBL1D
+	gpVertexAttribL1dv                               C.GPVERTEXATTRIBL1DV
+	gpVertexAttribL1i64NV                            C.GPVERTEXATTRIBL1I64NV
+	gpVertexAttribL1i64vNV                           C.GPVERTEXATTRIBL1I64VNV
+	gpVertexAttribL1ui64ARB                          C.GPVERTEXATTRIBL1UI64ARB
+	gpVertexAttribL1ui64NV                           C.GPVERTEXATTRIBL1UI64NV
+	gpVertexAttribL1ui64vARB                         C.GPVERTEXATTRIBL1UI64VARB
+	gpVertexAttribL1ui64vNV                          C.GPVERTEXATTRIBL1UI64VNV
+	gpVertexAttribL2d                                C.GPVERTEXATTRIBL2D
+	gpVertexAttribL2dv                               C.GPVERTEXATTRIBL2DV
+	gpVertexAttribL2i64NV                            C.GPVERTEXATTRIBL2I64NV
+	gpVertexAttribL2i64vNV                           C.GPVERTEXATTRIBL2I64VNV
+	gpVertexAttribL2ui64NV                           C.GPVERTEXATTRIBL2UI64NV
+	gpVertexAttribL2ui64vNV                          C.GPVERTEXATTRIBL2UI64VNV
+	gpVertexAttribL3d                                C.GPVERTEXATTRIBL3D
+	gpVertexAttribL3dv                               C.GPVERTEXATTRIBL3DV
+	gpVertexAttribL3i64NV                            C.GPVERTEXATTRIBL3I64NV
+	gpVertexAttribL3i64vNV                           C.GPVERTEXATTRIBL3I64VNV
+	gpVertexAttribL3ui64NV                           C.GPVERTEXATTRIBL3UI64NV
+	gpVertexAttribL3ui64vNV                          C.GPVERTEXATTRIBL3UI64VNV
+	gpVertexAttribL4d                                C.GPVERTEXATTRIBL4D
+	gpVertexAttribL4dv                               C.GPVERTEXATTRIBL4DV
+	gpVertexAttribL4i64NV                            C.GPVERTEXATTRIBL4I64NV
+	gpVertexAttribL4i64vNV                           C.GPVERTEXATTRIBL4I64VNV
+	gpVertexAttribL4ui64NV                           C.GPVERTEXATTRIBL4UI64NV
+	gpVertexAttribL4ui64vNV                          C.GPVERTEXATTRIBL4UI64VNV
+	gpVertexAttribLFormat                            C.GPVERTEXATTRIBLFORMAT
+	gpVertexAttribLFormatNV                          C.GPVERTEXATTRIBLFORMATNV
+	gpVertexAttribLPointer                           C.GPVERTEXATTRIBLPOINTER
+	gpVertexAttribP1ui                               C.GPVERTEXATTRIBP1UI
+	gpVertexAttribP1uiv                              C.GPVERTEXATTRIBP1UIV
+	gpVertexAttribP2ui                               C.GPVERTEXATTRIBP2UI
+	gpVertexAttribP2uiv                              C.GPVERTEXATTRIBP2UIV
+	gpVertexAttribP3ui                               C.GPVERTEXATTRIBP3UI
+	gpVertexAttribP3uiv                              C.GPVERTEXATTRIBP3UIV
+	gpVertexAttribP4ui                               C.GPVERTEXATTRIBP4UI
+	gpVertexAttribP4uiv                              C.GPVERTEXATTRIBP4UIV
+	gpVertexAttribPointer                            C.GPVERTEXATTRIBPOINTER
+	gpVertexBindingDivisor                           C.GPVERTEXBINDINGDIVISOR
+	gpVertexFormatNV                                 C.GPVERTEXFORMATNV
+	gpVertexPointer                                  C.GPVERTEXPOINTER
+	gpViewport                                       C.GPVIEWPORT
+	gpViewportArrayv                                 C.GPVIEWPORTARRAYV
+	gpViewportIndexedf                               C.GPVIEWPORTINDEXEDF
+	gpViewportIndexedfv                              C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                       C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                              C.GPVIEWPORTSWIZZLENV
+	gpWaitSync                                       C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                              C.GPWAITVKSEMAPHORENV
+	gpWeightPathsNV                                  C.GPWEIGHTPATHSNV
+	gpWindowPos2d                                    C.GPWINDOWPOS2D
+	gpWindowPos2dv                                   C.GPWINDOWPOS2DV
+	gpWindowPos2f                                    C.GPWINDOWPOS2F
+	gpWindowPos2fv                                   C.GPWINDOWPOS2FV
+	gpWindowPos2i                                    C.GPWINDOWPOS2I
+	gpWindowPos2iv                                   C.GPWINDOWPOS2IV
+	gpWindowPos2s                                    C.GPWINDOWPOS2S
+	gpWindowPos2sv                                   C.GPWINDOWPOS2SV
+	gpWindowPos3d                                    C.GPWINDOWPOS3D
+	gpWindowPos3dv                                   C.GPWINDOWPOS3DV
+	gpWindowPos3f                                    C.GPWINDOWPOS3F
+	gpWindowPos3fv                                   C.GPWINDOWPOS3FV
+	gpWindowPos3i                                    C.GPWINDOWPOS3I
+	gpWindowPos3iv                                   C.GPWINDOWPOS3IV
+	gpWindowPos3s                                    C.GPWINDOWPOS3S
+	gpWindowPos3sv                                   C.GPWINDOWPOS3SV
+	gpWindowRectanglesEXT                            C.GPWINDOWRECTANGLESEXT
 )
 
 // Helper functions
@@ -7344,10 +10654,16 @@ func boolToInt(b bool) int {
 func Accum(op uint32, value float32) {
 	C.glowAccum(gpAccum, (C.GLenum)(op), (C.GLfloat)(value))
 }
+func ActiveProgramEXT(program uint32) {
+	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
+}
 
 // set the active program object for a program pipeline object
 func ActiveShaderProgram(pipeline uint32, program uint32) {
 	C.glowActiveShaderProgram(gpActiveShaderProgram, (C.GLuint)(pipeline), (C.GLuint)(program))
+}
+func ActiveShaderProgramEXT(pipeline uint32, program uint32) {
+	C.glowActiveShaderProgramEXT(gpActiveShaderProgramEXT, (C.GLuint)(pipeline), (C.GLuint)(program))
 }
 
 // select active texture unit
@@ -7358,6 +10674,9 @@ func ActiveTexture(texture uint32) {
 // specify the alpha test function
 func AlphaFunc(xfunc uint32, ref float32) {
 	C.glowAlphaFunc(gpAlphaFunc, (C.GLenum)(xfunc), (C.GLfloat)(ref))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 
 // determine if textures are loaded in texture memory
@@ -7384,6 +10703,15 @@ func Begin(mode uint32) {
 // start conditional rendering
 func BeginConditionalRender(id uint32, mode uint32) {
 	C.glowBeginConditionalRender(gpBeginConditionalRender, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginConditionalRenderNV(id uint32, mode uint32) {
+	C.glowBeginConditionalRenderNV(gpBeginConditionalRenderNV, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginPerfMonitorAMD(monitor uint32) {
+	C.glowBeginPerfMonitorAMD(gpBeginPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func BeginPerfQueryINTEL(queryHandle uint32) {
+	C.glowBeginPerfQueryINTEL(gpBeginPerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // delimit the boundaries of a query object
@@ -7453,10 +10781,16 @@ func BindImageTexture(unit uint32, texture uint32, level int32, layered bool, la
 func BindImageTextures(first uint32, count int32, textures *uint32) {
 	C.glowBindImageTextures(gpBindImageTextures, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(textures)))
 }
+func BindMultiTextureEXT(texunit uint32, target uint32, texture uint32) {
+	C.glowBindMultiTextureEXT(gpBindMultiTextureEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(texture))
+}
 
 // bind a program pipeline to the current context
 func BindProgramPipeline(pipeline uint32) {
 	C.glowBindProgramPipeline(gpBindProgramPipeline, (C.GLuint)(pipeline))
+}
+func BindProgramPipelineEXT(pipeline uint32) {
+	C.glowBindProgramPipelineEXT(gpBindProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 
 // bind a renderbuffer to a renderbuffer target
@@ -7513,6 +10847,12 @@ func BindVertexBuffers(first uint32, count int32, buffers *uint32, offsets *int,
 func Bitmap(width int32, height int32, xorig float32, yorig float32, xmove float32, ymove float32, bitmap *uint8) {
 	C.glowBitmap(gpBitmap, (C.GLsizei)(width), (C.GLsizei)(height), (C.GLfloat)(xorig), (C.GLfloat)(yorig), (C.GLfloat)(xmove), (C.GLfloat)(ymove), (*C.GLubyte)(unsafe.Pointer(bitmap)))
 }
+func BlendBarrierKHR() {
+	C.glowBlendBarrierKHR(gpBlendBarrierKHR)
+}
+func BlendBarrierNV() {
+	C.glowBlendBarrierNV(gpBlendBarrierNV)
+}
 
 // set the blend color
 func BlendColor(red float32, green float32, blue float32, alpha float32) {
@@ -7562,6 +10902,9 @@ func BlendFunci(buf uint32, src uint32, dst uint32) {
 func BlendFunciARB(buf uint32, src uint32, dst uint32) {
 	C.glowBlendFunciARB(gpBlendFunciARB, (C.GLuint)(buf), (C.GLenum)(src), (C.GLenum)(dst))
 }
+func BlendParameteriNV(pname uint32, value int32) {
+	C.glowBlendParameteriNV(gpBlendParameteriNV, (C.GLenum)(pname), (C.GLint)(value))
+}
 
 // copy a block of pixels from one framebuffer object to another
 func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
@@ -7572,13 +10915,16 @@ func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 i
 func BlitNamedFramebuffer(readFramebuffer uint32, drawFramebuffer uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
 	C.glowBlitNamedFramebuffer(gpBlitNamedFramebuffer, (C.GLuint)(readFramebuffer), (C.GLuint)(drawFramebuffer), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
 }
+func BufferAddressRangeNV(pname uint32, index uint32, address uint64, length int) {
+	C.glowBufferAddressRangeNV(gpBufferAddressRangeNV, (C.GLenum)(pname), (C.GLuint)(index), (C.GLuint64EXT)(address), (C.GLsizeiptr)(length))
+}
 
 // creates and initializes a buffer object's data     store
 func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferData(gpBufferData, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
@@ -7589,6 +10935,9 @@ func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 // updates a subset of a buffer object's data store
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubData(gpBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
 }
 
 // execute a display list
@@ -7610,6 +10959,10 @@ func CheckFramebufferStatus(target uint32) uint32 {
 // check the completeness status of a framebuffer
 func CheckNamedFramebufferStatus(framebuffer uint32, target uint32) uint32 {
 	ret := C.glowCheckNamedFramebufferStatus(gpCheckNamedFramebufferStatus, (C.GLuint)(framebuffer), (C.GLenum)(target))
+	return (uint32)(ret)
+}
+func CheckNamedFramebufferStatusEXT(framebuffer uint32, target uint32) uint32 {
+	ret := C.glowCheckNamedFramebufferStatusEXT(gpCheckNamedFramebufferStatusEXT, (C.GLuint)(framebuffer), (C.GLenum)(target))
 	return (uint32)(ret)
 }
 
@@ -7659,6 +11012,8 @@ func ClearColor(red float32, green float32, blue float32, alpha float32) {
 func ClearDepth(depth float64) {
 	C.glowClearDepth(gpClearDepth, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -7672,13 +11027,19 @@ func ClearIndex(c float32) {
 func ClearNamedBufferData(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferData(gpClearNamedBufferData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferDataEXT(gpClearNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -7709,9 +11070,12 @@ func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32,
 func ClientActiveTexture(texture uint32) {
 	C.glowClientActiveTexture(gpClientActiveTexture, (C.GLenum)(texture))
 }
+func ClientAttribDefaultEXT(mask uint32) {
+	C.glowClientAttribDefaultEXT(gpClientAttribDefaultEXT, (C.GLbitfield)(mask))
+}
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -7821,6 +11185,9 @@ func Color4us(red uint16, green uint16, blue uint16, alpha uint16) {
 func Color4usv(v *uint16) {
 	C.glowColor4usv(gpColor4usv, (*C.GLushort)(unsafe.Pointer(v)))
 }
+func ColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowColorFormatNV(gpColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func ColorMask(red bool, green bool, blue bool, alpha bool) {
 	C.glowColorMask(gpColorMask, (C.GLboolean)(boolToInt(red)), (C.GLboolean)(boolToInt(green)), (C.GLboolean)(boolToInt(blue)), (C.GLboolean)(boolToInt(alpha)))
 }
@@ -7837,6 +11204,12 @@ func ColorMaterial(face uint32, mode uint32) {
 func ColorPointer(size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowColorPointer(gpColorPointer, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
 }
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
+}
 
 // Compiles a shader object
 func CompileShader(shader uint32) {
@@ -7844,6 +11217,24 @@ func CompileShader(shader uint32) {
 }
 func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
+}
+func CompressedMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage1DEXT(gpCompressedMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage2DEXT(gpCompressedMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage3DEXT(gpCompressedMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage1DEXT(gpCompressedMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage2DEXT(gpCompressedMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage3DEXT(gpCompressedMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a one-dimensional texture image in a compressed format
@@ -7875,20 +11266,44 @@ func CompressedTexSubImage2D(target uint32, level int32, xoffset int32, yoffset 
 func CompressedTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTexSubImage3D(gpCompressedTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage1DEXT(gpCompressedTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage2DEXT(gpCompressedTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage3DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage3DEXT(gpCompressedTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a one-dimensional texture subimage in a compressed     format
 func CompressedTextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage1D(gpCompressedTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage1DEXT(gpCompressedTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a two-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage2D(gpCompressedTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage2DEXT(gpCompressedTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a three-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3D(gpCompressedTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
@@ -7900,10 +11315,28 @@ func CopyBufferSubData(readTarget uint32, writeTarget uint32, readOffset int, wr
 func CopyImageSubData(srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
 	C.glowCopyImageSubData(gpCopyImageSubData, (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
 }
+func CopyMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyMultiTexImage1DEXT(gpCopyMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyMultiTexImage2DEXT(gpCopyMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
+func CopyMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyMultiTexSubImage1DEXT(gpCopyMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage2DEXT(gpCopyMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage3DEXT(gpCopyMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func CopyPathNV(resultPath uint32, srcPath uint32) {
+	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
 }
 
 // copy pixels in the frame buffer
@@ -7935,30 +11368,69 @@ func CopyTexSubImage2D(target uint32, level int32, xoffset int32, yoffset int32,
 func CopyTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTexSubImage3D(gpCopyTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyTextureImage1DEXT(gpCopyTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyTextureImage2DEXT(gpCopyTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
 
 // copy a one-dimensional texture subimage
 func CopyTextureSubImage1D(texture uint32, level int32, xoffset int32, x int32, y int32, width int32) {
 	C.glowCopyTextureSubImage1D(gpCopyTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyTextureSubImage1DEXT(gpCopyTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
 }
 
 // copy a two-dimensional texture subimage
 func CopyTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage2D(gpCopyTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage2DEXT(gpCopyTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy a three-dimensional texture subimage
 func CopyTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage3D(gpCopyTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage3DEXT(gpCopyTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverFillPathInstancedNV(gpCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverFillPathNV(path uint32, coverMode uint32) {
+	C.glowCoverFillPathNV(gpCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverStrokePathInstancedNV(gpCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverStrokePathNV(path uint32, coverMode uint32) {
+	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
+	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
 }
 
 // Creates a program object
@@ -7992,15 +11464,26 @@ func CreateShader(xtype uint32) uint32 {
 	ret := C.glowCreateShader(gpCreateShader, (C.GLenum)(xtype))
 	return (uint32)(ret)
 }
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
+	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
+	return (uint32)(ret)
+}
 
 // create a stand-alone program from an array of null-terminated source code strings
 func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
+	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
+	return (uint32)(ret)
+}
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -8063,6 +11546,9 @@ func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint
 func DeleteBuffers(n int32, buffers *uint32) {
 	C.glowDeleteBuffers(gpDeleteBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // delete framebuffer objects
 func DeleteFramebuffers(n int32, framebuffers *uint32) {
@@ -8076,6 +11562,15 @@ func DeleteLists(list uint32, xrange int32) {
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 }
+func DeletePathsNV(path uint32, xrange int32) {
+	C.glowDeletePathsNV(gpDeletePathsNV, (C.GLuint)(path), (C.GLsizei)(xrange))
+}
+func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowDeletePerfMonitorsAMD(gpDeletePerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
+func DeletePerfQueryINTEL(queryHandle uint32) {
+	C.glowDeletePerfQueryINTEL(gpDeletePerfQueryINTEL, (C.GLuint)(queryHandle))
+}
 
 // Deletes a program object
 func DeleteProgram(program uint32) {
@@ -8085,6 +11580,9 @@ func DeleteProgram(program uint32) {
 // delete program pipeline objects
 func DeleteProgramPipelines(n int32, pipelines *uint32) {
 	C.glowDeleteProgramPipelines(gpDeleteProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func DeleteProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowDeleteProgramPipelinesEXT(gpDeleteProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // delete named query objects
@@ -8106,9 +11604,12 @@ func DeleteSamplers(count int32, samplers *uint32) {
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -8149,6 +11650,8 @@ func DepthRangeArrayv(first uint32, count int32, v *float64) {
 func DepthRangeIndexed(index uint32, n float64, f float64) {
 	C.glowDepthRangeIndexed(gpDepthRangeIndexed, (C.GLuint)(index), (C.GLdouble)(n), (C.GLdouble)(f))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -8163,10 +11666,25 @@ func Disable(cap uint32) {
 func DisableClientState(array uint32) {
 	C.glowDisableClientState(gpDisableClientState, (C.GLenum)(array))
 }
+func DisableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowDisableClientStateIndexedEXT(gpDisableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableClientStateiEXT(array uint32, index uint32) {
+	C.glowDisableClientStateiEXT(gpDisableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableIndexedEXT(target uint32, index uint32) {
+	C.glowDisableIndexedEXT(gpDisableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func DisableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowDisableVertexArrayAttrib(gpDisableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowDisableVertexArrayAttribEXT(gpDisableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowDisableVertexArrayEXT(gpDisableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -8204,10 +11722,16 @@ func DrawArraysIndirect(mode uint32, indirect unsafe.Pointer) {
 func DrawArraysInstanced(mode uint32, first int32, count int32, instancecount int32) {
 	C.glowDrawArraysInstanced(gpDrawArraysInstanced, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount))
 }
+func DrawArraysInstancedARB(mode uint32, first int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedARB(gpDrawArraysInstancedARB, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a range of elements with offset applied to instanced attributes
 func DrawArraysInstancedBaseInstance(mode uint32, first int32, count int32, instancecount int32, baseinstance uint32) {
 	C.glowDrawArraysInstancedBaseInstance(gpDrawArraysInstancedBaseInstance, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount), (C.GLuint)(baseinstance))
+}
+func DrawArraysInstancedEXT(mode uint32, start int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedEXT(gpDrawArraysInstancedEXT, (C.GLenum)(mode), (C.GLint)(start), (C.GLsizei)(count), (C.GLsizei)(primcount))
 }
 
 // specify which color buffers are to be drawn into
@@ -8218,6 +11742,18 @@ func DrawBuffer(buf uint32) {
 // Specifies a list of color buffers to be drawn     into
 func DrawBuffers(n int32, bufs *uint32) {
 	C.glowDrawBuffers(gpDrawBuffers, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 
 // render primitives from array data
@@ -8239,6 +11775,9 @@ func DrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer) {
 func DrawElementsInstanced(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32) {
 	C.glowDrawElementsInstanced(gpDrawElementsInstanced, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount))
 }
+func DrawElementsInstancedARB(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedARB(gpDrawElementsInstancedARB, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a set of elements with offset applied to instanced attributes
 func DrawElementsInstancedBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, baseinstance uint32) {
@@ -8253,6 +11792,9 @@ func DrawElementsInstancedBaseVertex(mode uint32, count int32, xtype uint32, ind
 // render multiple instances of a set of primitives from array data with a per-element offset
 func DrawElementsInstancedBaseVertexBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, basevertex int32, baseinstance uint32) {
 	C.glowDrawElementsInstancedBaseVertexBaseInstance(gpDrawElementsInstancedBaseVertexBaseInstance, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount), (C.GLint)(basevertex), (C.GLuint)(baseinstance))
+}
+func DrawElementsInstancedEXT(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedEXT(gpDrawElementsInstancedEXT, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
 }
 
 // write a block of pixels to the frame buffer
@@ -8289,10 +11831,16 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
 }
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
+}
 
 // flag edges as either boundary or nonboundary
 func EdgeFlag(flag bool) {
 	C.glowEdgeFlag(gpEdgeFlag, (C.GLboolean)(boolToInt(flag)))
+}
+func EdgeFlagFormatNV(stride int32) {
+	C.glowEdgeFlagFormatNV(gpEdgeFlagFormatNV, (C.GLsizei)(stride))
 }
 
 // define an array of edge flags
@@ -8312,10 +11860,25 @@ func Enable(cap uint32) {
 func EnableClientState(array uint32) {
 	C.glowEnableClientState(gpEnableClientState, (C.GLenum)(array))
 }
+func EnableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowEnableClientStateIndexedEXT(gpEnableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableClientStateiEXT(array uint32, index uint32) {
+	C.glowEnableClientStateiEXT(gpEnableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableIndexedEXT(target uint32, index uint32) {
+	C.glowEnableIndexedEXT(gpEnableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func EnableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowEnableVertexArrayAttrib(gpEnableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowEnableVertexArrayAttribEXT(gpEnableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowEnableVertexArrayEXT(gpEnableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -8331,8 +11894,17 @@ func End() {
 func EndConditionalRender() {
 	C.glowEndConditionalRender(gpEndConditionalRender)
 }
+func EndConditionalRenderNV() {
+	C.glowEndConditionalRenderNV(gpEndConditionalRenderNV)
+}
 func EndList() {
 	C.glowEndList(gpEndList)
+}
+func EndPerfMonitorAMD(monitor uint32) {
+	C.glowEndPerfMonitorAMD(gpEndPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func EndPerfQueryINTEL(queryHandle uint32) {
+	C.glowEndPerfQueryINTEL(gpEndPerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 func EndQuery(target uint32) {
 	C.glowEndQuery(gpEndQuery, (C.GLenum)(target))
@@ -8379,6 +11951,9 @@ func EvalPoint1(i int32) {
 func EvalPoint2(i int32, j int32) {
 	C.glowEvalPoint2(gpEvalPoint2, (C.GLint)(i), (C.GLint)(j))
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 
 // controls feedback mode
 func FeedbackBuffer(size int32, xtype uint32, buffer *float32) {
@@ -8386,9 +11961,9 @@ func FeedbackBuffer(size int32, xtype uint32, buffer *float32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -8407,8 +11982,14 @@ func FlushMappedBufferRange(target uint32, offset int, length int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FogCoordFormatNV(xtype uint32, stride int32) {
+	C.glowFogCoordFormatNV(gpFogCoordFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // define an array of fog coordinates
@@ -8439,15 +12020,36 @@ func Fogi(pname uint32, param int32) {
 func Fogiv(pname uint32, params *int32) {
 	C.glowFogiv(gpFogiv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
+func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferDrawBufferEXT(gpFramebufferDrawBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
+func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
+	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
+}
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
 	C.glowFramebufferParameteri(gpFramebufferParameteri, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
 }
+func FramebufferReadBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferReadBufferEXT(gpFramebufferReadBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
 
 // attach a renderbuffer as a logical buffer of a framebuffer object
 func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbuffer(gpFramebufferRenderbuffer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
@@ -8457,16 +12059,30 @@ func FramebufferTexture(target uint32, attachment uint32, texture uint32, level 
 func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1D(gpFramebufferTexture1D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
 func FramebufferTexture3D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
 	C.glowFramebufferTexture3D(gpFramebufferTexture3D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
 }
+func FramebufferTextureARB(target uint32, attachment uint32, texture uint32, level int32) {
+	C.glowFramebufferTextureARB(gpFramebufferTextureARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func FramebufferTextureFaceARB(target uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowFramebufferTextureFaceARB(gpFramebufferTextureFaceARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
+}
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func FramebufferTextureLayer(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayer(gpFramebufferTextureLayer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowFramebufferTextureLayerARB(gpFramebufferTextureLayerARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 
 // define front- and back-facing polygons
@@ -8494,10 +12110,20 @@ func GenLists(xrange int32) uint32 {
 	ret := C.glowGenLists(gpGenLists, (C.GLsizei)(xrange))
 	return (uint32)(ret)
 }
+func GenPathsNV(xrange int32) uint32 {
+	ret := C.glowGenPathsNV(gpGenPathsNV, (C.GLsizei)(xrange))
+	return (uint32)(ret)
+}
+func GenPerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowGenPerfMonitorsAMD(gpGenPerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
 
 // reserve program pipeline object names
 func GenProgramPipelines(n int32, pipelines *uint32) {
 	C.glowGenProgramPipelines(gpGenProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func GenProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowGenProgramPipelinesEXT(gpGenProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // generate query object names
@@ -8534,10 +12160,16 @@ func GenVertexArrays(n int32, arrays *uint32) {
 func GenerateMipmap(target uint32) {
 	C.glowGenerateMipmap(gpGenerateMipmap, (C.GLenum)(target))
 }
+func GenerateMultiTexMipmapEXT(texunit uint32, target uint32) {
+	C.glowGenerateMultiTexMipmapEXT(gpGenerateMultiTexMipmapEXT, (C.GLenum)(texunit), (C.GLenum)(target))
+}
 
 // generate mipmaps for a specified texture object
 func GenerateTextureMipmap(texture uint32) {
 	C.glowGenerateTextureMipmap(gpGenerateTextureMipmap, (C.GLuint)(texture))
+}
+func GenerateTextureMipmapEXT(texture uint32, target uint32) {
+	C.glowGenerateTextureMipmapEXT(gpGenerateTextureMipmapEXT, (C.GLuint)(texture), (C.GLenum)(target))
 }
 
 // retrieve information about the set of active atomic counter buffers for a program
@@ -8572,6 +12204,8 @@ func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -8596,6 +12230,9 @@ func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
+func GetBooleanIndexedvEXT(target uint32, index uint32, data *bool) {
+	C.glowGetBooleanIndexedvEXT(gpGetBooleanIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
+}
 func GetBooleani_v(target uint32, index uint32, data *bool) {
 	C.glowGetBooleani_v(gpGetBooleani_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
 }
@@ -8612,6 +12249,9 @@ func GetBufferParameteri64v(target uint32, pname uint32, params *int64) {
 func GetBufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetBufferParameteriv(gpGetBufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetBufferParameterui64vNV(target uint32, pname uint32, params *uint64) {
+	C.glowGetBufferParameterui64vNV(gpGetBufferParameterui64vNV, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
@@ -8627,6 +12267,13 @@ func GetBufferSubData(target uint32, offset int, size int, data unsafe.Pointer) 
 func GetClipPlane(plane uint32, equation *float64) {
 	C.glowGetClipPlane(gpGetClipPlane, (C.GLenum)(plane), (*C.GLdouble)(unsafe.Pointer(equation)))
 }
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
+func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
+}
 
 // return a compressed texture image
 func GetCompressedTexImage(target uint32, level int32, img unsafe.Pointer) {
@@ -8637,10 +12284,16 @@ func GetCompressedTexImage(target uint32, level int32, img unsafe.Pointer) {
 func GetCompressedTextureImage(texture uint32, level int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureImage(gpGetCompressedTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLsizei)(bufSize), pixels)
 }
+func GetCompressedTextureImageEXT(texture uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedTextureImageEXT(gpGetCompressedTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(lod), img)
+}
 
 // retrieve a sub-region of a compressed texture image from a     compressed texture object
 func GetCompressedTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureSubImage(gpGetCompressedTextureSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(bufSize), pixels)
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -8656,8 +12309,14 @@ func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
+func GetDoubleIndexedvEXT(target uint32, index uint32, data *float64) {
+	C.glowGetDoubleIndexedvEXT(gpGetDoubleIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
 func GetDoublei_v(target uint32, index uint32, data *float64) {
 	C.glowGetDoublei_v(gpGetDoublei_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
+func GetDoublei_vEXT(pname uint32, index uint32, params *float64) {
+	C.glowGetDoublei_vEXT(gpGetDoublei_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
 }
 func GetDoublev(pname uint32, data *float64) {
 	C.glowGetDoublev(gpGetDoublev, (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(data)))
@@ -8668,8 +12327,17 @@ func GetError() uint32 {
 	ret := C.glowGetError(gpGetError)
 	return (uint32)(ret)
 }
+func GetFirstPerfQueryIdINTEL(queryId *uint32) {
+	C.glowGetFirstPerfQueryIdINTEL(gpGetFirstPerfQueryIdINTEL, (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetFloatIndexedvEXT(target uint32, index uint32, data *float32) {
+	C.glowGetFloatIndexedvEXT(gpGetFloatIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
 func GetFloati_v(target uint32, index uint32, data *float32) {
 	C.glowGetFloati_v(gpGetFloati_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
+func GetFloati_vEXT(pname uint32, index uint32, params *float32) {
+	C.glowGetFloati_vEXT(gpGetFloati_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetFloatv(pname uint32, data *float32) {
 	C.glowGetFloatv(gpGetFloatv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(data)))
@@ -8687,14 +12355,17 @@ func GetFragDataLocation(program uint32, name *uint8) int32 {
 	return (int32)(ret)
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetFramebufferParameterivEXT(gpGetFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // check if the rendering context has not been lost due to software or hardware issues
@@ -8714,21 +12385,39 @@ func GetImageHandleARB(texture uint32, level int32, layered bool, layer int32, f
 	ret := C.glowGetImageHandleARB(gpGetImageHandleARB, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
 	return (uint64)(ret)
 }
+func GetImageHandleNV(texture uint32, level int32, layered bool, layer int32, format uint32) uint64 {
+	ret := C.glowGetImageHandleNV(gpGetImageHandleNV, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
+	return (uint64)(ret)
+}
 func GetInteger64i_v(target uint32, index uint32, data *int64) {
 	C.glowGetInteger64i_v(gpGetInteger64i_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint64)(unsafe.Pointer(data)))
 }
 func GetInteger64v(pname uint32, data *int64) {
 	C.glowGetInteger64v(gpGetInteger64v, (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(data)))
 }
+func GetIntegerIndexedvEXT(target uint32, index uint32, data *int32) {
+	C.glowGetIntegerIndexedvEXT(gpGetIntegerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
 func GetIntegeri_v(target uint32, index uint32, data *int32) {
 	C.glowGetIntegeri_v(gpGetIntegeri_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
+func GetIntegerui64i_vNV(value uint32, index uint32, result *uint64) {
+	C.glowGetIntegerui64i_vNV(gpGetIntegerui64i_vNV, (C.GLenum)(value), (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(result)))
+}
+func GetIntegerui64vNV(value uint32, result *uint64) {
+	C.glowGetIntegerui64vNV(gpGetIntegerui64vNV, (C.GLenum)(value), (*C.GLuint64EXT)(unsafe.Pointer(result)))
 }
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -8753,6 +12442,42 @@ func GetMaterialfv(face uint32, pname uint32, params *float32) {
 func GetMaterialiv(face uint32, pname uint32, params *int32) {
 	C.glowGetMaterialiv(gpGetMaterialiv, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetMultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexEnvfvEXT(gpGetMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexEnvivEXT(gpGetMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowGetMultiTexGendvEXT(gpGetMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexGenfvEXT(gpGetMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexGenivEXT(gpGetMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexImageEXT(texunit uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetMultiTexImageEXT(gpGetMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func GetMultiTexLevelParameterfvEXT(texunit uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetMultiTexLevelParameterfvEXT(gpGetMultiTexLevelParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexLevelParameterivEXT(texunit uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetMultiTexLevelParameterivEXT(gpGetMultiTexLevelParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterIivEXT(gpGetMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetMultiTexParameterIuivEXT(gpGetMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexParameterfvEXT(gpGetMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterivEXT(gpGetMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // retrieve the location of a sample
 func GetMultisamplefv(pname uint32, index uint32, val *float32) {
@@ -8768,30 +12493,69 @@ func GetNamedBufferParameteri64v(buffer uint32, pname uint32, params *int64) {
 func GetNamedBufferParameteriv(buffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedBufferParameteriv(gpGetNamedBufferParameteriv, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedBufferParameterivEXT(buffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedBufferParameterivEXT(gpGetNamedBufferParameterivEXT, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedBufferParameterui64vNV(buffer uint32, pname uint32, params *uint64) {
+	C.glowGetNamedBufferParameterui64vNV(gpGetNamedBufferParameterui64vNV, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetNamedBufferPointerv(buffer uint32, pname uint32, params *unsafe.Pointer) {
 	C.glowGetNamedBufferPointerv(gpGetNamedBufferPointerv, (C.GLuint)(buffer), (C.GLenum)(pname), params)
 }
+func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Pointer) {
+	C.glowGetNamedBufferPointervEXT(gpGetNamedBufferPointervEXT, (C.GLuint)(buffer), (C.GLenum)(pname), params)
+}
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 
 // retrieve information about attachments of a framebuffer object
 func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameteriv(gpGetNamedFramebufferAttachmentParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a framebuffer object
 func GetNamedFramebufferParameteriv(framebuffer uint32, pname uint32, param *int32) {
 	C.glowGetNamedFramebufferParameteriv(gpGetNamedFramebufferParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
 }
+func GetNamedFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferParameterivEXT(gpGetNamedFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowGetNamedProgramLocalParameterIivEXT(gpGetNamedProgramLocalParameterIivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIuivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowGetNamedProgramLocalParameterIuivEXT(gpGetNamedProgramLocalParameterIuivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterdvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowGetNamedProgramLocalParameterdvEXT(gpGetNamedProgramLocalParameterdvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterfvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowGetNamedProgramLocalParameterfvEXT(gpGetNamedProgramLocalParameterfvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetNamedProgramStringEXT(program uint32, target uint32, pname uint32, xstring unsafe.Pointer) {
+	C.glowGetNamedProgramStringEXT(gpGetNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), xstring)
+}
+func GetNamedProgramivEXT(program uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetNamedProgramivEXT(gpGetNamedProgramivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a renderbuffer object
 func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameteriv(gpGetNamedRenderbufferParameteriv, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedRenderbufferParameterivEXT(renderbuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedRenderbufferParameterivEXT(gpGetNamedRenderbufferParameterivEXT, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
@@ -8799,10 +12563,16 @@ func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int
 func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
+	C.glowGetNextPerfQueryIdINTEL(gpGetNextPerfQueryIdINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(nextQueryId)))
+}
 
 // retrieve the label of a named object identified within a namespace
 func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
+	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
@@ -8815,6 +12585,64 @@ func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *
 func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
+func GetPathCommandsNV(path uint32, commands *uint8) {
+	C.glowGetPathCommandsNV(gpGetPathCommandsNV, (C.GLuint)(path), (*C.GLubyte)(unsafe.Pointer(commands)))
+}
+func GetPathCoordsNV(path uint32, coords *float32) {
+	C.glowGetPathCoordsNV(gpGetPathCoordsNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(coords)))
+}
+func GetPathDashArrayNV(path uint32, dashArray *float32) {
+	C.glowGetPathDashArrayNV(gpGetPathDashArrayNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func GetPathLengthNV(path uint32, startSegment int32, numSegments int32) float32 {
+	ret := C.glowGetPathLengthNV(gpGetPathLengthNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments))
+	return (float32)(ret)
+}
+func GetPathMetricRangeNV(metricQueryMask uint32, firstPathName uint32, numPaths int32, stride int32, metrics *float32) {
+	C.glowGetPathMetricRangeNV(gpGetPathMetricRangeNV, (C.GLbitfield)(metricQueryMask), (C.GLuint)(firstPathName), (C.GLsizei)(numPaths), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathMetricsNV(metricQueryMask uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, stride int32, metrics *float32) {
+	C.glowGetPathMetricsNV(gpGetPathMetricsNV, (C.GLbitfield)(metricQueryMask), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowGetPathParameterfvNV(gpGetPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func GetPathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowGetPathParameterivNV(gpGetPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func GetPathSpacingNV(pathListMode uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, advanceScale float32, kerningScale float32, transformType uint32, returnedSpacing *float32) {
+	C.glowGetPathSpacingNV(gpGetPathSpacingNV, (C.GLenum)(pathListMode), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLfloat)(advanceScale), (C.GLfloat)(kerningScale), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(returnedSpacing)))
+}
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
+}
+func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
+	C.glowGetPerfMonitorCounterDataAMD(gpGetPerfMonitorCounterDataAMD, (C.GLuint)(monitor), (C.GLenum)(pname), (C.GLsizei)(dataSize), (*C.GLuint)(unsafe.Pointer(data)), (*C.GLint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
+	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
+}
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
+	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
+}
+func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
+	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
+}
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
+	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
+}
+func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
+	C.glowGetPerfMonitorGroupsAMD(gpGetPerfMonitorGroupsAMD, (*C.GLint)(unsafe.Pointer(numGroups)), (C.GLsizei)(groupsSize), (*C.GLuint)(unsafe.Pointer(groups)))
+}
+func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
+	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
+	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
+}
 func GetPixelMapfv(xmap uint32, values *float32) {
 	C.glowGetPixelMapfv(gpGetPixelMapfv, (C.GLenum)(xmap), (*C.GLfloat)(unsafe.Pointer(values)))
 }
@@ -8823,6 +12651,12 @@ func GetPixelMapuiv(xmap uint32, values *uint32) {
 }
 func GetPixelMapusv(xmap uint32, values *uint16) {
 	C.glowGetPixelMapusv(gpGetPixelMapusv, (C.GLenum)(xmap), (*C.GLushort)(unsafe.Pointer(values)))
+}
+func GetPointerIndexedvEXT(target uint32, index uint32, data *unsafe.Pointer) {
+	C.glowGetPointerIndexedvEXT(gpGetPointerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), data)
+}
+func GetPointeri_vEXT(pname uint32, index uint32, params *unsafe.Pointer) {
+	C.glowGetPointeri_vEXT(gpGetPointeri_vEXT, (C.GLenum)(pname), (C.GLuint)(index), params)
 }
 
 // return the address of the specified pointer
@@ -8855,8 +12689,14 @@ func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32
 func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
+	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
+}
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
 	C.glowGetProgramPipelineiv(gpGetProgramPipelineiv, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
+	C.glowGetProgramPipelineivEXT(gpGetProgramPipelineivEXT, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // query the index of a named resource within a program
@@ -8881,6 +12721,9 @@ func GetProgramResourceLocationIndex(program uint32, programInterface uint32, na
 func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
+func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
+	C.glowGetProgramResourcefvNV(gpGetProgramResourcefvNV, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLfloat)(unsafe.Pointer(params)))
+}
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
 	C.glowGetProgramResourceiv(gpGetProgramResourceiv, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -8891,6 +12734,18 @@ func GetProgramStageiv(program uint32, shadertype uint32, pname uint32, values *
 // Returns a parameter from a program object
 func GetProgramiv(program uint32, pname uint32, params *int32) {
 	C.glowGetProgramiv(gpGetProgramiv, (C.GLuint)(program), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
 }
 
 // return parameters of an indexed query object target
@@ -8906,6 +12761,8 @@ func GetQueryObjectiv(id uint32, pname uint32, params *int32) {
 func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64v(gpGetQueryObjectui64v, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -8915,7 +12772,7 @@ func GetQueryiv(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryiv(gpGetQueryiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -8951,6 +12808,10 @@ func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8)
 func GetShaderiv(shader uint32, pname uint32, params *int32) {
 	C.glowGetShaderiv(gpGetShaderiv, (C.GLuint)(shader), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -8975,7 +12836,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexEnvfv(target uint32, pname uint32, params *float32) {
@@ -9020,31 +12881,60 @@ func GetTextureHandleARB(texture uint32) uint64 {
 	ret := C.glowGetTextureHandleARB(gpGetTextureHandleARB, (C.GLuint)(texture))
 	return (uint64)(ret)
 }
+func GetTextureHandleNV(texture uint32) uint64 {
+	ret := C.glowGetTextureHandleNV(gpGetTextureHandleNV, (C.GLuint)(texture))
+	return (uint64)(ret)
+}
 
 // return a texture image
 func GetTextureImage(texture uint32, level int32, format uint32, xtype uint32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetTextureImage(gpGetTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), pixels)
 }
+func GetTextureImageEXT(texture uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetTextureImageEXT(gpGetTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 func GetTextureLevelParameterfv(texture uint32, level int32, pname uint32, params *float32) {
 	C.glowGetTextureLevelParameterfv(gpGetTextureLevelParameterfv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureLevelParameterfvEXT(texture uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetTextureLevelParameterfvEXT(gpGetTextureLevelParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureLevelParameteriv(texture uint32, level int32, pname uint32, params *int32) {
 	C.glowGetTextureLevelParameteriv(gpGetTextureLevelParameteriv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureLevelParameterivEXT(texture uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetTextureLevelParameterivEXT(gpGetTextureLevelParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameterIiv(gpGetTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetTextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterIivEXT(gpGetTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetTextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowGetTextureParameterIuiv(gpGetTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetTextureParameterIuivEXT(gpGetTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterfv(texture uint32, pname uint32, params *float32) {
 	C.glowGetTextureParameterfv(gpGetTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetTextureParameterfvEXT(gpGetTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureParameteriv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameteriv(gpGetTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterivEXT(gpGetTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureSamplerHandleARB(texture uint32, sampler uint32) uint64 {
 	ret := C.glowGetTextureSamplerHandleARB(gpGetTextureSamplerHandleARB, (C.GLuint)(texture), (C.GLuint)(sampler))
+	return (uint64)(ret)
+}
+func GetTextureSamplerHandleNV(texture uint32, sampler uint32) uint64 {
+	ret := C.glowGetTextureSamplerHandleNV(gpGetTextureSamplerHandleNV, (C.GLuint)(texture), (C.GLuint)(sampler))
 	return (uint64)(ret)
 }
 
@@ -9096,10 +12986,22 @@ func GetUniformdv(program uint32, location int32, params *float64) {
 func GetUniformfv(program uint32, location int32, params *float32) {
 	C.glowGetUniformfv(gpGetUniformfv, (C.GLuint)(program), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func GetUniformi64vNV(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 
 // Returns the value of a uniform variable
 func GetUniformiv(program uint32, location int32, params *int32) {
 	C.glowGetUniformiv(gpGetUniformiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func GetUniformui64vNV(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 func GetUniformuiv(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuiv(gpGetUniformuiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
@@ -9109,6 +13011,18 @@ func GetVertexArrayIndexed64iv(vaobj uint32, index uint32, pname uint32, param *
 }
 func GetVertexArrayIndexediv(vaobj uint32, index uint32, pname uint32, param *int32) {
 	C.glowGetVertexArrayIndexediv(gpGetVertexArrayIndexediv, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegeri_vEXT(vaobj uint32, index uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegeri_vEXT(gpGetVertexArrayIntegeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegervEXT(vaobj uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegervEXT(gpGetVertexArrayIntegervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayPointeri_vEXT(vaobj uint32, index uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointeri_vEXT(gpGetVertexArrayPointeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), param)
+}
+func GetVertexArrayPointervEXT(vaobj uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointervEXT(gpGetVertexArrayPointervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), param)
 }
 
 // retrieve parameters of a vertex array object
@@ -9130,8 +13044,14 @@ func GetVertexAttribIuiv(index uint32, pname uint32, params *uint32) {
 func GetVertexAttribLdv(index uint32, pname uint32, params *float64) {
 	C.glowGetVertexAttribLdv(gpGetVertexAttribLdv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
 }
+func GetVertexAttribLi64vNV(index uint32, pname uint32, params *int64) {
+	C.glowGetVertexAttribLi64vNV(gpGetVertexAttribLi64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 func GetVertexAttribLui64vARB(index uint32, pname uint32, params *uint64) {
 	C.glowGetVertexAttribLui64vARB(gpGetVertexAttribLui64vARB, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
+func GetVertexAttribLui64vNV(index uint32, pname uint32, params *uint64) {
+	C.glowGetVertexAttribLui64vNV(gpGetVertexAttribLui64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 
 // return the address of the specified generic vertex attribute pointer
@@ -9152,6 +13072,10 @@ func GetVertexAttribfv(index uint32, pname uint32, params *float32) {
 // Return a generic vertex attribute parameter
 func GetVertexAttribiv(index uint32, pname uint32, params *int32) {
 	C.glowGetVertexAttribiv(gpGetVertexAttribiv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
 }
 
 // return a compressed texture image
@@ -9184,6 +13108,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -9192,6 +13119,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -9206,6 +13136,9 @@ func GetnUniformuivKHR(program uint32, location int32, bufSize int32, params *ui
 // specify implementation-specific hints
 func Hint(target uint32, mode uint32) {
 	C.glowHint(gpHint, (C.GLenum)(target), (C.GLenum)(mode))
+}
+func IndexFormatNV(xtype uint32, stride int32) {
+	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // control the writing of individual bits in the color index buffers
@@ -9252,10 +13185,16 @@ func Indexubv(c *uint8) {
 func InitNames() {
 	C.glowInitNames(gpInitNames)
 }
+func InsertEventMarkerEXT(length int32, marker *uint8) {
+	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
 
 // simultaneously specify and enable several interleaved arrays
 func InterleavedArrays(format uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowInterleavedArrays(gpInterleavedArrays, (C.GLenum)(format), (C.GLsizei)(stride), pointer)
+}
+func InterpolatePathsNV(resultPath uint32, pathA uint32, pathB uint32, weight float32) {
+	C.glowInterpolatePathsNV(gpInterpolatePathsNV, (C.GLuint)(resultPath), (C.GLuint)(pathA), (C.GLuint)(pathB), (C.GLfloat)(weight))
 }
 
 // invalidate the content of a buffer object's data store
@@ -9303,8 +13242,20 @@ func IsBuffer(buffer uint32) bool {
 	ret := C.glowIsBuffer(gpIsBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func IsBufferResidentNV(target uint32) bool {
+	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
+	return ret == TRUE
+}
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
+	return ret == TRUE
+}
+func IsEnabledIndexedEXT(target uint32, index uint32) bool {
+	ret := C.glowIsEnabledIndexedEXT(gpIsEnabledIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
 	return ret == TRUE
 }
 func IsEnabledi(target uint32, index uint32) bool {
@@ -9321,14 +13272,34 @@ func IsImageHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsImageHandleResidentARB(gpIsImageHandleResidentARB, (C.GLuint64)(handle))
 	return ret == TRUE
 }
+func IsImageHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsImageHandleResidentNV(gpIsImageHandleResidentNV, (C.GLuint64)(handle))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a display list
 func IsList(list uint32) bool {
 	ret := C.glowIsList(gpIsList, (C.GLuint)(list))
 	return ret == TRUE
 }
+func IsNamedBufferResidentNV(buffer uint32) bool {
+	ret := C.glowIsNamedBufferResidentNV(gpIsNamedBufferResidentNV, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+	return ret == TRUE
+}
+func IsPathNV(path uint32) bool {
+	ret := C.glowIsPathNV(gpIsPathNV, (C.GLuint)(path))
+	return ret == TRUE
+}
+func IsPointInFillPathNV(path uint32, mask uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInFillPathNV(gpIsPointInFillPathNV, (C.GLuint)(path), (C.GLuint)(mask), (C.GLfloat)(x), (C.GLfloat)(y))
+	return ret == TRUE
+}
+func IsPointInStrokePathNV(path uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInStrokePathNV(gpIsPointInStrokePathNV, (C.GLuint)(path), (C.GLfloat)(x), (C.GLfloat)(y))
 	return ret == TRUE
 }
 
@@ -9341,6 +13312,10 @@ func IsProgram(program uint32) bool {
 // determine if a name corresponds to a program pipeline object
 func IsProgramPipeline(pipeline uint32) bool {
 	ret := C.glowIsProgramPipeline(gpIsProgramPipeline, (C.GLuint)(pipeline))
+	return ret == TRUE
+}
+func IsProgramPipelineEXT(pipeline uint32) bool {
+	ret := C.glowIsProgramPipelineEXT(gpIsProgramPipelineEXT, (C.GLuint)(pipeline))
 	return ret == TRUE
 }
 
@@ -9367,9 +13342,13 @@ func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -9383,6 +13362,10 @@ func IsTextureHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsTextureHandleResidentARB(gpIsTextureHandleResidentARB, (C.GLuint64)(handle))
 	return ret == TRUE
 }
+func IsTextureHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsTextureHandleResidentNV(gpIsTextureHandleResidentNV, (C.GLuint64)(handle))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a transform feedback object
 func IsTransformFeedback(id uint32) bool {
@@ -9394,6 +13377,9 @@ func IsTransformFeedback(id uint32) bool {
 func IsVertexArray(array uint32) bool {
 	ret := C.glowIsVertexArray(gpIsVertexArray, (C.GLuint)(array))
 	return ret == TRUE
+}
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
+	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func LightModelf(pname uint32, param float32) {
 	C.glowLightModelf(gpLightModelf, (C.GLenum)(pname), (C.GLfloat)(param))
@@ -9439,6 +13425,9 @@ func LinkProgram(program uint32) {
 func ListBase(base uint32) {
 	C.glowListBase(gpListBase, (C.GLuint)(base))
 }
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 
 // replace the current matrix with the identity matrix
 func LoadIdentity() {
@@ -9466,17 +13455,41 @@ func LoadTransposeMatrixf(m *float32) {
 func LogicOp(opcode uint32) {
 	C.glowLogicOp(gpLogicOp, (C.GLenum)(opcode))
 }
+func MakeBufferNonResidentNV(target uint32) {
+	C.glowMakeBufferNonResidentNV(gpMakeBufferNonResidentNV, (C.GLenum)(target))
+}
+func MakeBufferResidentNV(target uint32, access uint32) {
+	C.glowMakeBufferResidentNV(gpMakeBufferResidentNV, (C.GLenum)(target), (C.GLenum)(access))
+}
 func MakeImageHandleNonResidentARB(handle uint64) {
 	C.glowMakeImageHandleNonResidentARB(gpMakeImageHandleNonResidentARB, (C.GLuint64)(handle))
+}
+func MakeImageHandleNonResidentNV(handle uint64) {
+	C.glowMakeImageHandleNonResidentNV(gpMakeImageHandleNonResidentNV, (C.GLuint64)(handle))
 }
 func MakeImageHandleResidentARB(handle uint64, access uint32) {
 	C.glowMakeImageHandleResidentARB(gpMakeImageHandleResidentARB, (C.GLuint64)(handle), (C.GLenum)(access))
 }
+func MakeImageHandleResidentNV(handle uint64, access uint32) {
+	C.glowMakeImageHandleResidentNV(gpMakeImageHandleResidentNV, (C.GLuint64)(handle), (C.GLenum)(access))
+}
+func MakeNamedBufferNonResidentNV(buffer uint32) {
+	C.glowMakeNamedBufferNonResidentNV(gpMakeNamedBufferNonResidentNV, (C.GLuint)(buffer))
+}
+func MakeNamedBufferResidentNV(buffer uint32, access uint32) {
+	C.glowMakeNamedBufferResidentNV(gpMakeNamedBufferResidentNV, (C.GLuint)(buffer), (C.GLenum)(access))
+}
 func MakeTextureHandleNonResidentARB(handle uint64) {
 	C.glowMakeTextureHandleNonResidentARB(gpMakeTextureHandleNonResidentARB, (C.GLuint64)(handle))
 }
+func MakeTextureHandleNonResidentNV(handle uint64) {
+	C.glowMakeTextureHandleNonResidentNV(gpMakeTextureHandleNonResidentNV, (C.GLuint64)(handle))
+}
 func MakeTextureHandleResidentARB(handle uint64) {
 	C.glowMakeTextureHandleResidentARB(gpMakeTextureHandleResidentARB, (C.GLuint64)(handle))
+}
+func MakeTextureHandleResidentNV(handle uint64) {
+	C.glowMakeTextureHandleResidentNV(gpMakeTextureHandleResidentNV, (C.GLuint64)(handle))
 }
 func Map1d(target uint32, u1 float64, u2 float64, stride int32, order int32, points *float64) {
 	C.glowMap1d(gpMap1d, (C.GLenum)(target), (C.GLdouble)(u1), (C.GLdouble)(u2), (C.GLint)(stride), (C.GLint)(order), (*C.GLdouble)(unsafe.Pointer(points)))
@@ -9520,10 +13533,18 @@ func MapNamedBuffer(buffer uint32, access uint32) unsafe.Pointer {
 	ret := C.glowMapNamedBuffer(gpMapNamedBuffer, (C.GLuint)(buffer), (C.GLenum)(access))
 	return (unsafe.Pointer)(ret)
 }
+func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferEXT(gpMapNamedBufferEXT, (C.GLuint)(buffer), (C.GLenum)(access))
+	return (unsafe.Pointer)(ret)
+}
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
+	return (unsafe.Pointer)(ret)
+}
+func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRangeEXT(gpMapNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
 }
 func Materialf(face uint32, pname uint32, param float32) {
@@ -9538,10 +13559,91 @@ func Materiali(face uint32, pname uint32, param int32) {
 func Materialiv(face uint32, pname uint32, params *int32) {
 	C.glowMaterialiv(gpMaterialiv, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func MatrixFrustumEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixFrustumEXT(gpMatrixFrustumEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixLoad3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x2fNV(gpMatrixLoad3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoad3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x3fNV(gpMatrixLoad3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadIdentityEXT(mode uint32) {
+	C.glowMatrixLoadIdentityEXT(gpMatrixLoadIdentityEXT, (C.GLenum)(mode))
+}
+func MatrixLoadTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoadTranspose3x3fNV(gpMatrixLoadTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixLoadTransposedEXT(gpMatrixLoadTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadTransposefEXT(gpMatrixLoadTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoaddEXT(mode uint32, m *float64) {
+	C.glowMatrixLoaddEXT(gpMatrixLoaddEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadfEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadfEXT(gpMatrixLoadfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
 
 // specify which matrix is the current matrix
 func MatrixMode(mode uint32) {
 	C.glowMatrixMode(gpMatrixMode, (C.GLenum)(mode))
+}
+func MatrixMult3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x2fNV(gpMatrixMult3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x3fNV(gpMatrixMult3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMultTranspose3x3fNV(gpMatrixMultTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixMultTransposedEXT(gpMatrixMultTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixMultTransposefEXT(gpMatrixMultTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultdEXT(mode uint32, m *float64) {
+	C.glowMatrixMultdEXT(gpMatrixMultdEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultfEXT(mode uint32, m *float32) {
+	C.glowMatrixMultfEXT(gpMatrixMultfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixOrthoEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixOrthoEXT(gpMatrixOrthoEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixPopEXT(mode uint32) {
+	C.glowMatrixPopEXT(gpMatrixPopEXT, (C.GLenum)(mode))
+}
+func MatrixPushEXT(mode uint32) {
+	C.glowMatrixPushEXT(gpMatrixPushEXT, (C.GLenum)(mode))
+}
+func MatrixRotatedEXT(mode uint32, angle float64, x float64, y float64, z float64) {
+	C.glowMatrixRotatedEXT(gpMatrixRotatedEXT, (C.GLenum)(mode), (C.GLdouble)(angle), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixRotatefEXT(mode uint32, angle float32, x float32, y float32, z float32) {
+	C.glowMatrixRotatefEXT(gpMatrixRotatefEXT, (C.GLenum)(mode), (C.GLfloat)(angle), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixScaledEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixScaledEXT(gpMatrixScaledEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixScalefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixScalefEXT(gpMatrixScalefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixTranslatedEXT(gpMatrixTranslatedEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
 }
 
 // defines a barrier ordering memory transactions
@@ -9581,8 +13683,17 @@ func MultiDrawArrays(mode uint32, first *int32, count *int32, drawcount int32) {
 func MultiDrawArraysIndirect(mode uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawArraysIndirect(gpMultiDrawArraysIndirect, (C.GLenum)(mode), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessCountNV(gpMultiDrawArraysIndirectBindlessCountNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectCount(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCount(gpMultiDrawArraysIndirectCount, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+}
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 
 // render multiple sets of primitives by specifying indices of array data elements
@@ -9599,8 +13710,20 @@ func MultiDrawElementsBaseVertex(mode uint32, count *int32, xtype uint32, indice
 func MultiDrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawElementsIndirect(gpMultiDrawElementsIndirect, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessCountNV(gpMultiDrawElementsIndirectBindlessCountNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectCount(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCount(gpMultiDrawElementsIndirectCount, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+}
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+}
+func MultiTexBufferEXT(texunit uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowMultiTexBufferEXT(gpMultiTexBufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
 func MultiTexCoord1d(target uint32, s float64) {
 	C.glowMultiTexCoord1d(gpMultiTexCoord1d, (C.GLenum)(target), (C.GLdouble)(s))
@@ -9698,26 +13821,110 @@ func MultiTexCoord4s(target uint32, s int16, t int16, r int16, q int16) {
 func MultiTexCoord4sv(target uint32, v *int16) {
 	C.glowMultiTexCoord4sv(gpMultiTexCoord4sv, (C.GLenum)(target), (*C.GLshort)(unsafe.Pointer(v)))
 }
+func MultiTexCoordPointerEXT(texunit uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
+	C.glowMultiTexCoordPointerEXT(gpMultiTexCoordPointerEXT, (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
+}
+func MultiTexEnvfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexEnvfEXT(gpMultiTexEnvfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexEnvfvEXT(gpMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexEnviEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexEnviEXT(gpMultiTexEnviEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexEnvivEXT(gpMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexGendEXT(texunit uint32, coord uint32, pname uint32, param float64) {
+	C.glowMultiTexGendEXT(gpMultiTexGendEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLdouble)(param))
+}
+func MultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowMultiTexGendvEXT(gpMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func MultiTexGenfEXT(texunit uint32, coord uint32, pname uint32, param float32) {
+	C.glowMultiTexGenfEXT(gpMultiTexGenfEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowMultiTexGenfvEXT(gpMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexGeniEXT(texunit uint32, coord uint32, pname uint32, param int32) {
+	C.glowMultiTexGeniEXT(gpMultiTexGeniEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowMultiTexGenivEXT(gpMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage1DEXT(gpMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage2DEXT(gpMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage3DEXT(gpMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterIivEXT(gpMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowMultiTexParameterIuivEXT(gpMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexParameterfEXT(gpMultiTexParameterfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexParameterfvEXT(gpMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexParameteriEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexParameteriEXT(gpMultiTexParameteriEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterivEXT(gpMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexRenderbufferEXT(texunit uint32, target uint32, renderbuffer uint32) {
+	C.glowMultiTexRenderbufferEXT(gpMultiTexRenderbufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(renderbuffer))
+}
+func MultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage1DEXT(gpMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage2DEXT(gpMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
+}
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
+}
+func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedCopyBufferSubDataEXT(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowNamedCopyBufferSubDataEXT(gpNamedCopyBufferSubDataEXT, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 
 // specify which color buffers are to be drawn into
@@ -9734,6 +13941,9 @@ func NamedFramebufferDrawBuffers(framebuffer uint32, n int32, bufs *uint32) {
 func NamedFramebufferParameteri(framebuffer uint32, pname uint32, param int32) {
 	C.glowNamedFramebufferParameteri(gpNamedFramebufferParameteri, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
 }
+func NamedFramebufferParameteriEXT(framebuffer uint32, pname uint32, param int32) {
+	C.glowNamedFramebufferParameteriEXT(gpNamedFramebufferParameteriEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // select a color buffer source for pixels
 func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
@@ -9744,23 +13954,95 @@ func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
 func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbuffer(gpNamedFramebufferRenderbuffer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
+	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture1DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture1DEXT(gpNamedFramebufferTexture1DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture2DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture2DEXT(gpNamedFramebufferTexture2DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture3DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
+	C.glowNamedFramebufferTexture3DEXT(gpNamedFramebufferTexture3DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
+}
+func NamedFramebufferTextureEXT(framebuffer uint32, attachment uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTextureEXT(gpNamedFramebufferTextureEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTextureFaceEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowNamedFramebufferTextureFaceEXT(gpNamedFramebufferTextureFaceEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
 }
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func NamedFramebufferTextureLayer(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowNamedFramebufferTextureLayer(gpNamedFramebufferTextureLayer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
 }
+func NamedFramebufferTextureLayerEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowNamedFramebufferTextureLayerEXT(gpNamedFramebufferTextureLayerEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func NamedProgramLocalParameter4dEXT(program uint32, target uint32, index uint32, x float64, y float64, z float64, w float64) {
+	C.glowNamedProgramLocalParameter4dEXT(gpNamedProgramLocalParameter4dEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
+func NamedProgramLocalParameter4dvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowNamedProgramLocalParameter4dvEXT(gpNamedProgramLocalParameter4dvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameter4fEXT(program uint32, target uint32, index uint32, x float32, y float32, z float32, w float32) {
+	C.glowNamedProgramLocalParameter4fEXT(gpNamedProgramLocalParameter4fEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z), (C.GLfloat)(w))
+}
+func NamedProgramLocalParameter4fvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowNamedProgramLocalParameter4fvEXT(gpNamedProgramLocalParameter4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4iEXT(program uint32, target uint32, index uint32, x int32, y int32, z int32, w int32) {
+	C.glowNamedProgramLocalParameterI4iEXT(gpNamedProgramLocalParameterI4iEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLint)(x), (C.GLint)(y), (C.GLint)(z), (C.GLint)(w))
+}
+func NamedProgramLocalParameterI4ivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowNamedProgramLocalParameterI4ivEXT(gpNamedProgramLocalParameterI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4uiEXT(program uint32, target uint32, index uint32, x uint32, y uint32, z uint32, w uint32) {
+	C.glowNamedProgramLocalParameterI4uiEXT(gpNamedProgramLocalParameterI4uiEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(x), (C.GLuint)(y), (C.GLuint)(z), (C.GLuint)(w))
+}
+func NamedProgramLocalParameterI4uivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowNamedProgramLocalParameterI4uivEXT(gpNamedProgramLocalParameterI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameters4fvEXT(program uint32, target uint32, index uint32, count int32, params *float32) {
+	C.glowNamedProgramLocalParameters4fvEXT(gpNamedProgramLocalParameters4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4ivEXT(program uint32, target uint32, index uint32, count int32, params *int32) {
+	C.glowNamedProgramLocalParametersI4ivEXT(gpNamedProgramLocalParametersI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4uivEXT(program uint32, target uint32, index uint32, count int32, params *uint32) {
+	C.glowNamedProgramLocalParametersI4uivEXT(gpNamedProgramLocalParametersI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramStringEXT(program uint32, target uint32, format uint32, len int32, xstring unsafe.Pointer) {
+	C.glowNamedProgramStringEXT(gpNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(format), (C.GLsizei)(len), xstring)
+}
 
 // establish data storage, format and dimensions of a     renderbuffer object's image
 func NamedRenderbufferStorage(renderbuffer uint32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorage(gpNamedRenderbufferStorage, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func NamedRenderbufferStorageEXT(renderbuffer uint32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageEXT(gpNamedRenderbufferStorageEXT, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func NamedRenderbufferStorageMultisample(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisample(gpNamedRenderbufferStorageMultisample, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageMultisampleCoverageEXT(renderbuffer uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleCoverageEXT(gpNamedRenderbufferStorageMultisampleCoverageEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageMultisampleEXT(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleEXT(gpNamedRenderbufferStorageMultisampleEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
@@ -9800,6 +14082,9 @@ func Normal3s(nx int16, ny int16, nz int16) {
 func Normal3sv(v *int16) {
 	C.glowNormal3sv(gpNormal3sv, (*C.GLshort)(unsafe.Pointer(v)))
 }
+func NormalFormatNV(xtype uint32, stride int32) {
+	C.glowNormalFormatNV(gpNormalFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 
 // define an array of normals
 func NormalPointer(xtype uint32, stride int32, pointer unsafe.Pointer) {
@@ -9834,8 +14119,67 @@ func PassThrough(token float32) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathCommandsNV(path uint32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCommandsNV(gpPathCommandsNV, (C.GLuint)(path), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoordsNV(path uint32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCoordsNV(gpPathCoordsNV, (C.GLuint)(path), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoverDepthFuncNV(xfunc uint32) {
+	C.glowPathCoverDepthFuncNV(gpPathCoverDepthFuncNV, (C.GLenum)(xfunc))
+}
+func PathDashArrayNV(path uint32, dashCount int32, dashArray *float32) {
+	C.glowPathDashArrayNV(gpPathDashArrayNV, (C.GLuint)(path), (C.GLsizei)(dashCount), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func PathGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathGlyphIndexArrayNV(gpPathGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathGlyphIndexRangeNV(fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, pathParameterTemplate uint32, emScale float32, baseAndCount *uint32) uint32 {
+	ret := C.glowPathGlyphIndexRangeNV(gpPathGlyphIndexRangeNV, (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale), (*C.GLuint)(unsafe.Pointer(baseAndCount)))
+	return (uint32)(ret)
+}
+func PathGlyphRangeNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyph uint32, numGlyphs int32, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphRangeNV(gpPathGlyphRangeNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyph), (C.GLsizei)(numGlyphs), (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathGlyphsNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, numGlyphs int32, xtype uint32, charcodes unsafe.Pointer, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphsNV(gpPathGlyphsNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLsizei)(numGlyphs), (C.GLenum)(xtype), charcodes, (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathMemoryGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontSize int, fontData unsafe.Pointer, faceIndex int32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathMemoryGlyphIndexArrayNV(gpPathMemoryGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), (C.GLsizeiptr)(fontSize), fontData, (C.GLsizei)(faceIndex), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathParameterfNV(path uint32, pname uint32, value float32) {
+	C.glowPathParameterfNV(gpPathParameterfNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func PathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowPathParameterfvNV(gpPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func PathParameteriNV(path uint32, pname uint32, value int32) {
+	C.glowPathParameteriNV(gpPathParameteriNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowPathParameterivNV(gpPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func PathStencilDepthOffsetNV(factor float32, units float32) {
+	C.glowPathStencilDepthOffsetNV(gpPathStencilDepthOffsetNV, (C.GLfloat)(factor), (C.GLfloat)(units))
+}
+func PathStencilFuncNV(xfunc uint32, ref int32, mask uint32) {
+	C.glowPathStencilFuncNV(gpPathStencilFuncNV, (C.GLenum)(xfunc), (C.GLint)(ref), (C.GLuint)(mask))
+}
+func PathStringNV(path uint32, format uint32, length int32, pathString unsafe.Pointer) {
+	C.glowPathStringNV(gpPathStringNV, (C.GLuint)(path), (C.GLenum)(format), (C.GLsizei)(length), pathString)
+}
+func PathSubCommandsNV(path uint32, commandStart int32, commandsToDelete int32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCommandsNV(gpPathSubCommandsNV, (C.GLuint)(path), (C.GLsizei)(commandStart), (C.GLsizei)(commandsToDelete), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathSubCoordsNV(path uint32, coordStart int32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCoordsNV(gpPathSubCoordsNV, (C.GLuint)(path), (C.GLsizei)(coordStart), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
 }
 
 // pause transform feedback operations
@@ -9854,6 +14198,8 @@ func PixelMapusv(xmap uint32, mapsize int32, values *uint16) {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
 }
@@ -9867,6 +14213,10 @@ func PixelTransferi(pname uint32, param int32) {
 // specify the pixel zoom factors
 func PixelZoom(xfactor float32, yfactor float32) {
 	C.glowPixelZoom(gpPixelZoom, (C.GLfloat)(xfactor), (C.GLfloat)(yfactor))
+}
+func PointAlongPathNV(path uint32, startSegment int32, numSegments int32, distance float32, x *float32, y *float32, tangentX *float32, tangentY *float32) bool {
+	ret := C.glowPointAlongPathNV(gpPointAlongPathNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments), (C.GLfloat)(distance), (*C.GLfloat)(unsafe.Pointer(x)), (*C.GLfloat)(unsafe.Pointer(y)), (*C.GLfloat)(unsafe.Pointer(tangentX)), (*C.GLfloat)(unsafe.Pointer(tangentY)))
+	return ret == TRUE
 }
 func PointParameterf(pname uint32, param float32) {
 	C.glowPointParameterf(gpPointParameterf, (C.GLenum)(pname), (C.GLfloat)(param))
@@ -9895,6 +14245,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 
 // set the polygon stippling pattern
 func PolygonStipple(mask *uint8) {
@@ -9914,11 +14270,17 @@ func PopDebugGroup() {
 func PopDebugGroupKHR() {
 	C.glowPopDebugGroupKHR(gpPopDebugGroupKHR)
 }
+func PopGroupMarkerEXT() {
+	C.glowPopGroupMarkerEXT(gpPopGroupMarkerEXT)
+}
 func PopMatrix() {
 	C.glowPopMatrix(gpPopMatrix)
 }
 func PopName() {
 	C.glowPopName(gpPopName)
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -9935,230 +14297,499 @@ func PrioritizeTextures(n int32, textures *uint32, priorities *float32) {
 func ProgramBinary(program uint32, binaryFormat uint32, binary unsafe.Pointer, length int32) {
 	C.glowProgramBinary(gpProgramBinary, (C.GLuint)(program), (C.GLenum)(binaryFormat), binary, (C.GLsizei)(length))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriARB(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriARB(gpProgramParameteriARB, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriEXT(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriEXT(gpProgramParameteriEXT, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramPathFragmentInputGenNV(program uint32, location int32, genMode uint32, components int32, coeffs *float32) {
+	C.glowProgramPathFragmentInputGenNV(gpProgramPathFragmentInputGenNV, (C.GLuint)(program), (C.GLint)(location), (C.GLenum)(genMode), (C.GLint)(components), (*C.GLfloat)(unsafe.Pointer(coeffs)))
 }
 func ProgramUniform1d(program uint32, location int32, v0 float64) {
 	C.glowProgramUniform1d(gpProgramUniform1d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0))
 }
+func ProgramUniform1dEXT(program uint32, location int32, x float64) {
+	C.glowProgramUniform1dEXT(gpProgramUniform1dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x))
+}
 func ProgramUniform1dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform1dv(gpProgramUniform1dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform1dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform1dvEXT(gpProgramUniform1dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1f(program uint32, location int32, v0 float32) {
 	C.glowProgramUniform1f(gpProgramUniform1f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
 }
+func ProgramUniform1fEXT(program uint32, location int32, v0 float32) {
+	C.glowProgramUniform1fEXT(gpProgramUniform1fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform1fv(gpProgramUniform1fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform1fvEXT(gpProgramUniform1fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
+func ProgramUniform1i64NV(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1iEXT(program uint32, location int32, v0 int32) {
+	C.glowProgramUniform1iEXT(gpProgramUniform1iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform1iv(gpProgramUniform1iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform1ivEXT(gpProgramUniform1ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
+func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1uiEXT(program uint32, location int32, v0 uint32) {
+	C.glowProgramUniform1uiEXT(gpProgramUniform1uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform1uiv(gpProgramUniform1uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform1uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform1uivEXT(gpProgramUniform1uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform2d(program uint32, location int32, v0 float64, v1 float64) {
 	C.glowProgramUniform2d(gpProgramUniform2d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1))
 }
+func ProgramUniform2dEXT(program uint32, location int32, x float64, y float64) {
+	C.glowProgramUniform2dEXT(gpProgramUniform2dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y))
+}
 func ProgramUniform2dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform2dv(gpProgramUniform2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform2dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform2dvEXT(gpProgramUniform2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2f(program uint32, location int32, v0 float32, v1 float32) {
 	C.glowProgramUniform2f(gpProgramUniform2f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
 }
+func ProgramUniform2fEXT(program uint32, location int32, v0 float32, v1 float32) {
+	C.glowProgramUniform2fEXT(gpProgramUniform2fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform2fv(gpProgramUniform2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform2fvEXT(gpProgramUniform2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2iEXT(program uint32, location int32, v0 int32, v1 int32) {
+	C.glowProgramUniform2iEXT(gpProgramUniform2iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform2iv(gpProgramUniform2iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform2ivEXT(gpProgramUniform2ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2uiEXT(program uint32, location int32, v0 uint32, v1 uint32) {
+	C.glowProgramUniform2uiEXT(gpProgramUniform2uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform2uiv(gpProgramUniform2uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform2uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform2uivEXT(gpProgramUniform2uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform3d(program uint32, location int32, v0 float64, v1 float64, v2 float64) {
 	C.glowProgramUniform3d(gpProgramUniform3d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2))
 }
+func ProgramUniform3dEXT(program uint32, location int32, x float64, y float64, z float64) {
+	C.glowProgramUniform3dEXT(gpProgramUniform3dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
 func ProgramUniform3dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform3dv(gpProgramUniform3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform3dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform3dvEXT(gpProgramUniform3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3f(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
 	C.glowProgramUniform3f(gpProgramUniform3f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
 }
+func ProgramUniform3fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
+	C.glowProgramUniform3fEXT(gpProgramUniform3fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform3fv(gpProgramUniform3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform3fvEXT(gpProgramUniform3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
+	C.glowProgramUniform3iEXT(gpProgramUniform3iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform3iv(gpProgramUniform3iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform3ivEXT(gpProgramUniform3ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
+	C.glowProgramUniform3uiEXT(gpProgramUniform3uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform3uiv(gpProgramUniform3uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform3uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform3uivEXT(gpProgramUniform3uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform4d(program uint32, location int32, v0 float64, v1 float64, v2 float64, v3 float64) {
 	C.glowProgramUniform4d(gpProgramUniform4d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2), (C.GLdouble)(v3))
 }
+func ProgramUniform4dEXT(program uint32, location int32, x float64, y float64, z float64, w float64) {
+	C.glowProgramUniform4dEXT(gpProgramUniform4dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
 func ProgramUniform4dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform4dv(gpProgramUniform4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform4dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform4dvEXT(gpProgramUniform4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4f(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
 	C.glowProgramUniform4f(gpProgramUniform4f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
 }
+func ProgramUniform4fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
+	C.glowProgramUniform4fEXT(gpProgramUniform4fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform4fv(gpProgramUniform4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform4fvEXT(gpProgramUniform4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
+	C.glowProgramUniform4iEXT(gpProgramUniform4iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform4iv(gpProgramUniform4iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform4ivEXT(gpProgramUniform4ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
+	C.glowProgramUniform4uiEXT(gpProgramUniform4uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform4uiv(gpProgramUniform4uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform4uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform4uivEXT(gpProgramUniform4uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniformHandleui64ARB(program uint32, location int32, value uint64) {
 	C.glowProgramUniformHandleui64ARB(gpProgramUniformHandleui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
+}
+func ProgramUniformHandleui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformHandleui64NV(gpProgramUniformHandleui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
 }
 func ProgramUniformHandleui64vARB(program uint32, location int32, count int32, values *uint64) {
 	C.glowProgramUniformHandleui64vARB(gpProgramUniformHandleui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
 }
+func ProgramUniformHandleui64vNV(program uint32, location int32, count int32, values *uint64) {
+	C.glowProgramUniformHandleui64vNV(gpProgramUniformHandleui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
+}
 func ProgramUniformMatrix2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2dv(gpProgramUniformMatrix2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2dvEXT(gpProgramUniformMatrix2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2fv(gpProgramUniformMatrix2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2fvEXT(gpProgramUniformMatrix2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x3dv(gpProgramUniformMatrix2x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x3dvEXT(gpProgramUniformMatrix2x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x3fv(gpProgramUniformMatrix2x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x3fvEXT(gpProgramUniformMatrix2x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x4dv(gpProgramUniformMatrix2x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x4dvEXT(gpProgramUniformMatrix2x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x4fv(gpProgramUniformMatrix2x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x4fvEXT(gpProgramUniformMatrix2x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3dv(gpProgramUniformMatrix3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3dvEXT(gpProgramUniformMatrix3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3fv(gpProgramUniformMatrix3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3fvEXT(gpProgramUniformMatrix3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x2dv(gpProgramUniformMatrix3x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x2dvEXT(gpProgramUniformMatrix3x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x2fv(gpProgramUniformMatrix3x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x2fvEXT(gpProgramUniformMatrix3x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x4dv(gpProgramUniformMatrix3x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x4dvEXT(gpProgramUniformMatrix3x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x4fv(gpProgramUniformMatrix3x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x4fvEXT(gpProgramUniformMatrix3x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4dv(gpProgramUniformMatrix4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4dvEXT(gpProgramUniformMatrix4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4fv(gpProgramUniformMatrix4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4fvEXT(gpProgramUniformMatrix4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x2dv(gpProgramUniformMatrix4x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x2dvEXT(gpProgramUniformMatrix4x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x2fv(gpProgramUniformMatrix4x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x2fvEXT(gpProgramUniformMatrix4x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x3dv(gpProgramUniformMatrix4x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x3dvEXT(gpProgramUniformMatrix4x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x3fv(gpProgramUniformMatrix4x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x3fvEXT(gpProgramUniformMatrix4x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniformui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformui64NV(gpProgramUniformui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func ProgramUniformui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniformui64vNV(gpProgramUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // specifiy the vertex to be used as the source of data for flat shaded varyings
@@ -10175,6 +14806,9 @@ func PushAttrib(mask uint32) {
 func PushClientAttrib(mask uint32) {
 	C.glowPushClientAttrib(gpPushClientAttrib, (C.GLbitfield)(mask))
 }
+func PushClientAttribDefaultEXT(mask uint32) {
+	C.glowPushClientAttribDefaultEXT(gpPushClientAttribDefaultEXT, (C.GLbitfield)(mask))
+}
 
 // push a named debug group into the command stream
 func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
@@ -10182,6 +14816,9 @@ func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 }
 func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
+}
+func PushGroupMarkerEXT(length int32, marker *uint8) {
+	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
 // push and pop the current matrix stack
@@ -10270,6 +14907,9 @@ func RasterPos4s(x int16, y int16, z int16, w int16) {
 func RasterPos4sv(v *int16) {
 	C.glowRasterPos4sv(gpRasterPos4sv, (*C.GLshort)(unsafe.Pointer(v)))
 }
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // select a color buffer source for pixels
 func ReadBuffer(src uint32) {
@@ -10335,6 +14975,12 @@ func RenderbufferStorage(target uint32, internalformat uint32, width int32, heig
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func RenderbufferStorageMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowRenderbufferStorageMultisample(gpRenderbufferStorageMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func RenderbufferStorageMultisampleCoverageNV(target uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowRenderbufferStorageMultisampleCoverageNV(gpRenderbufferStorageMultisampleCoverageNV, (C.GLenum)(target), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
 }
 
 // resume transform feedback operations
@@ -10445,6 +15091,9 @@ func SecondaryColor3us(red uint16, green uint16, blue uint16) {
 func SecondaryColor3usv(v *uint16) {
 	C.glowSecondaryColor3usv(gpSecondaryColor3usv, (*C.GLushort)(unsafe.Pointer(v)))
 }
+func SecondaryColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowSecondaryColorFormatNV(gpSecondaryColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 
 // define an array of secondary colors
 func SecondaryColorPointer(size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
@@ -10454,6 +15103,9 @@ func SecondaryColorPointer(size int32, xtype uint32, stride int32, pointer unsaf
 // establish a buffer for selection mode values
 func SelectBuffer(size int32, buffer *uint32) {
 	C.glowSelectBuffer(gpSelectBuffer, (C.GLsizei)(size), (*C.GLuint)(unsafe.Pointer(buffer)))
+}
+func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
+	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
 }
 
 // select flat or smooth shading
@@ -10474,6 +15126,27 @@ func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 // change an active shader storage block binding
 func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storageBlockBinding uint32) {
 	C.glowShaderStorageBlockBinding(gpShaderStorageBlockBinding, (C.GLuint)(program), (C.GLuint)(storageBlockIndex), (C.GLuint)(storageBlockBinding))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShader(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShader(gpSpecializeShader, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
+}
+func StencilFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilFillPathInstancedNV(gpStencilFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilFillPathNV(path uint32, fillMode uint32, mask uint32) {
+	C.glowStencilFillPathNV(gpStencilFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask))
 }
 
 // set front and back function and reference value for stencil testing
@@ -10505,10 +15178,34 @@ func StencilOp(fail uint32, zfail uint32, zpass uint32) {
 func StencilOpSeparate(face uint32, sfail uint32, dpfail uint32, dppass uint32) {
 	C.glowStencilOpSeparate(gpStencilOpSeparate, (C.GLenum)(face), (C.GLenum)(sfail), (C.GLenum)(dpfail), (C.GLenum)(dppass))
 }
+func StencilStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilStrokePathInstancedNV(gpStencilStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilStrokePathNV(path uint32, reference int32, mask uint32) {
+	C.glowStencilStrokePathNV(gpStencilStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask))
+}
+func StencilThenCoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverFillPathInstancedNV(gpStencilThenCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverFillPathNV(path uint32, fillMode uint32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverFillPathNV(gpStencilThenCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func StencilThenCoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverStrokePathInstancedNV(gpStencilThenCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverStrokePathNV(path uint32, reference int32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverStrokePathNV(gpStencilThenCoverStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TexBuffer(target uint32, internalformat uint32, buffer uint32) {
 	C.glowTexBuffer(gpTexBuffer, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
+func TexBufferARB(target uint32, internalformat uint32, buffer uint32) {
+	C.glowTexBufferARB(gpTexBufferARB, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
 
 // attach a range of a buffer object's data store to a buffer texture object
@@ -10611,6 +15308,9 @@ func TexCoord4s(s int16, t int16, r int16, q int16) {
 func TexCoord4sv(v *int16) {
 	C.glowTexCoord4sv(gpTexCoord4sv, (*C.GLshort)(unsafe.Pointer(v)))
 }
+func TexCoordFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowTexCoordFormatNV(gpTexCoordFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 
 // define an array of texture coordinates
 func TexCoordPointer(size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
@@ -10671,8 +15371,8 @@ func TexImage3D(target uint32, level int32, internalformat int32, width int32, h
 func TexImage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexImage3DMultisample(gpTexImage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -10737,73 +15437,139 @@ func TexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zof
 func TextureBarrier() {
 	C.glowTextureBarrier(gpTextureBarrier)
 }
+func TextureBarrierNV() {
+	C.glowTextureBarrierNV(gpTextureBarrierNV)
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TextureBuffer(texture uint32, internalformat uint32, buffer uint32) {
 	C.glowTextureBuffer(gpTextureBuffer, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowTextureBufferEXT(gpTextureBufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureImage1DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage1DEXT(gpTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage2DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage2DEXT(gpTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage3DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage3DEXT(gpTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func TextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterIivEXT(gpTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func TextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowTextureParameterIuiv(gpTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func TextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowTextureParameterIuivEXT(gpTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
 func TextureParameterf(texture uint32, pname uint32, param float32) {
 	C.glowTextureParameterf(gpTextureParameterf, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLfloat)(param))
 }
+func TextureParameterfEXT(texture uint32, target uint32, pname uint32, param float32) {
+	C.glowTextureParameterfEXT(gpTextureParameterfEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
 func TextureParameterfv(texture uint32, pname uint32, param *float32) {
 	C.glowTextureParameterfv(gpTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(param)))
+}
+func TextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowTextureParameterfvEXT(gpTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func TextureParameteri(texture uint32, pname uint32, param int32) {
 	C.glowTextureParameteri(gpTextureParameteri, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLint)(param))
 }
+func TextureParameteriEXT(texture uint32, target uint32, pname uint32, param int32) {
+	C.glowTextureParameteriEXT(gpTextureParameteriEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
 func TextureParameteriv(texture uint32, pname uint32, param *int32) {
 	C.glowTextureParameteriv(gpTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func TextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterivEXT(gpTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func TextureRenderbufferEXT(texture uint32, target uint32, renderbuffer uint32) {
+	C.glowTextureRenderbufferEXT(gpTextureRenderbufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLuint)(renderbuffer))
 }
 
 // simultaneously specify storage for all levels of a one-dimensional texture
 func TextureStorage1D(texture uint32, levels int32, internalformat uint32, width int32) {
 	C.glowTextureStorage1D(gpTextureStorage1D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
 }
+func TextureStorage1DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32) {
+	C.glowTextureStorage1DEXT(gpTextureStorage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
+}
 
 // simultaneously specify storage for all levels of a two-dimensional or one-dimensional array texture
 func TextureStorage2D(texture uint32, levels int32, internalformat uint32, width int32, height int32) {
 	C.glowTextureStorage2D(gpTextureStorage2D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func TextureStorage2DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32) {
+	C.glowTextureStorage2DEXT(gpTextureStorage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // specify storage for a two-dimensional multisample texture
 func TextureStorage2DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
 	C.glowTextureStorage2DMultisample(gpTextureStorage2DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage2DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
+	C.glowTextureStorage2DMultisampleEXT(gpTextureStorage2DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // simultaneously specify storage for all levels of a three-dimensional, two-dimensional array or cube-map array texture
 func TextureStorage3D(texture uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
 	C.glowTextureStorage3D(gpTextureStorage3D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func TextureStorage3DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
+	C.glowTextureStorage3DEXT(gpTextureStorage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
 }
 
 // specify storage for a two-dimensional multisample array texture
 func TextureStorage3DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisample(gpTextureStorage3DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
+	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // specify a one-dimensional texture subimage
 func TextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage1D(gpTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage1DEXT(gpTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // specify a two-dimensional texture subimage
 func TextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage2D(gpTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func TextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage2DEXT(gpTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 
 // specify a three-dimensional texture subimage
 func TextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage3D(gpTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage3DEXT(gpTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // initialize a texture as a data alias of another texture's data store
@@ -10817,13 +15583,16 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 
 // specify values to record in transform feedback buffers
 func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
+}
+func TransformPathNV(resultPath uint32, srcPath uint32, transformType uint32, transformValues *float32) {
+	C.glowTransformPathNV(gpTransformPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
 }
 func Translated(x float64, y float64, z float64) {
 	C.glowTranslated(gpTranslated, (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
@@ -10852,6 +15621,18 @@ func Uniform1fv(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
+func Uniform1i64NV(location int32, x int64) {
+	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform1i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform1iv(location int32, count int32, value *int32) {
@@ -10861,6 +15642,18 @@ func Uniform1iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
+}
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
+func Uniform1ui64NV(location int32, x uint64) {
+	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform1ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -10888,6 +15681,18 @@ func Uniform2fv(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func Uniform2i64NV(location int32, x int64, y int64) {
+	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform2i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform2iv(location int32, count int32, value *int32) {
@@ -10897,6 +15702,18 @@ func Uniform2iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func Uniform2ui64NV(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform2ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -10924,6 +15741,18 @@ func Uniform3fv(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func Uniform3i64NV(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform3i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform3iv(location int32, count int32, value *int32) {
@@ -10933,6 +15762,18 @@ func Uniform3iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform3ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -10960,6 +15801,18 @@ func Uniform4fv(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform4i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform4iv(location int32, count int32, value *int32) {
@@ -10969,6 +15822,18 @@ func Uniform4iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform4ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -10983,8 +15848,14 @@ func UniformBlockBinding(program uint32, uniformBlockIndex uint32, uniformBlockB
 func UniformHandleui64ARB(location int32, value uint64) {
 	C.glowUniformHandleui64ARB(gpUniformHandleui64ARB, (C.GLint)(location), (C.GLuint64)(value))
 }
+func UniformHandleui64NV(location int32, value uint64) {
+	C.glowUniformHandleui64NV(gpUniformHandleui64NV, (C.GLint)(location), (C.GLuint64)(value))
+}
 func UniformHandleui64vARB(location int32, count int32, value *uint64) {
 	C.glowUniformHandleui64vARB(gpUniformHandleui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func UniformHandleui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformHandleui64vNV(gpUniformHandleui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func UniformMatrix2dv(location int32, count int32, transpose bool, value *float64) {
 	C.glowUniformMatrix2dv(gpUniformMatrix2dv, (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
@@ -11061,6 +15932,12 @@ func UniformMatrix4x3fv(location int32, count int32, transpose bool, value *floa
 func UniformSubroutinesuiv(shadertype uint32, count int32, indices *uint32) {
 	C.glowUniformSubroutinesuiv(gpUniformSubroutinesuiv, (C.GLenum)(shadertype), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(indices)))
 }
+func Uniformui64NV(location int32, value uint64) {
+	C.glowUniformui64NV(gpUniformui64NV, (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func Uniformui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformui64vNV(gpUniformui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // release the mapping of a buffer object's data store into the client's address space
 func UnmapBuffer(target uint32) bool {
@@ -11073,6 +15950,10 @@ func UnmapNamedBuffer(buffer uint32) bool {
 	ret := C.glowUnmapNamedBuffer(gpUnmapNamedBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func UnmapNamedBufferEXT(buffer uint32) bool {
+	ret := C.glowUnmapNamedBufferEXT(gpUnmapNamedBufferEXT, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 
 // Installs a program object as part of current rendering state
 func UseProgram(program uint32) {
@@ -11083,6 +15964,12 @@ func UseProgram(program uint32) {
 func UseProgramStages(pipeline uint32, stages uint32, program uint32) {
 	C.glowUseProgramStages(gpUseProgramStages, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
 }
+func UseProgramStagesEXT(pipeline uint32, stages uint32, program uint32) {
+	C.glowUseProgramStagesEXT(gpUseProgramStagesEXT, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
+}
+func UseShaderProgramEXT(xtype uint32, program uint32) {
+	C.glowUseShaderProgramEXT(gpUseShaderProgramEXT, (C.GLenum)(xtype), (C.GLuint)(program))
+}
 
 // Validates a program object
 func ValidateProgram(program uint32) {
@@ -11092,6 +15979,9 @@ func ValidateProgram(program uint32) {
 // validate a program pipeline object against current GL state
 func ValidateProgramPipeline(pipeline uint32) {
 	C.glowValidateProgramPipeline(gpValidateProgramPipeline, (C.GLuint)(pipeline))
+}
+func ValidateProgramPipelineEXT(pipeline uint32) {
+	C.glowValidateProgramPipelineEXT(gpValidateProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 func Vertex2d(x float64, y float64) {
 	C.glowVertex2d(gpVertex2d, (C.GLdouble)(x), (C.GLdouble)(y))
@@ -11179,15 +16069,69 @@ func VertexArrayAttribIFormat(vaobj uint32, attribindex uint32, size int32, xtyp
 func VertexArrayAttribLFormat(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexArrayAttribLFormat(gpVertexArrayAttribLFormat, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexArrayBindVertexBufferEXT(vaobj uint32, bindingindex uint32, buffer uint32, offset int, stride int32) {
+	C.glowVertexArrayBindVertexBufferEXT(gpVertexArrayBindVertexBufferEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(stride))
+}
 
 // modify the rate at which generic vertex attributes     advance
 func VertexArrayBindingDivisor(vaobj uint32, bindingindex uint32, divisor uint32) {
 	C.glowVertexArrayBindingDivisor(gpVertexArrayBindingDivisor, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexArrayColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayColorOffsetEXT(gpVertexArrayColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayEdgeFlagOffsetEXT(vaobj uint32, buffer uint32, stride int32, offset int) {
+	C.glowVertexArrayEdgeFlagOffsetEXT(gpVertexArrayEdgeFlagOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
 
 // configures element array buffer binding of a vertex array object
 func VertexArrayElementBuffer(vaobj uint32, buffer uint32) {
 	C.glowVertexArrayElementBuffer(gpVertexArrayElementBuffer, (C.GLuint)(vaobj), (C.GLuint)(buffer))
+}
+func VertexArrayFogCoordOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayFogCoordOffsetEXT(gpVertexArrayFogCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayIndexOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayIndexOffsetEXT(gpVertexArrayIndexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayMultiTexCoordOffsetEXT(vaobj uint32, buffer uint32, texunit uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayMultiTexCoordOffsetEXT(gpVertexArrayMultiTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayNormalOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayNormalOffsetEXT(gpVertexArrayNormalOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArraySecondaryColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArraySecondaryColorOffsetEXT(gpVertexArraySecondaryColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayTexCoordOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayTexCoordOffsetEXT(gpVertexArrayTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribBindingEXT(vaobj uint32, attribindex uint32, bindingindex uint32) {
+	C.glowVertexArrayVertexAttribBindingEXT(gpVertexArrayVertexAttribBindingEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
+}
+func VertexArrayVertexAttribDivisorEXT(vaobj uint32, index uint32, divisor uint32) {
+	C.glowVertexArrayVertexAttribDivisorEXT(gpVertexArrayVertexAttribDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLuint)(divisor))
+}
+func VertexArrayVertexAttribFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribFormatEXT(gpVertexArrayVertexAttribFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribIFormatEXT(gpVertexArrayVertexAttribIFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribIOffsetEXT(gpVertexArrayVertexAttribIOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribLFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribLFormatEXT(gpVertexArrayVertexAttribLFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribLOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribLOffsetEXT(gpVertexArrayVertexAttribLOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, normalized bool, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribOffsetEXT(gpVertexArrayVertexAttribOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexBindingDivisorEXT(vaobj uint32, bindingindex uint32, divisor uint32) {
+	C.glowVertexArrayVertexBindingDivisorEXT(gpVertexArrayVertexBindingDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
 
 // bind a buffer to a vertex buffer bind point
@@ -11198,6 +16142,9 @@ func VertexArrayVertexBuffer(vaobj uint32, bindingindex uint32, buffer uint32, o
 // attach multiple buffer objects to a vertex array object
 func VertexArrayVertexBuffers(vaobj uint32, first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowVertexArrayVertexBuffers(gpVertexArrayVertexBuffers, (C.GLuint)(vaobj), (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
+}
+func VertexArrayVertexOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexOffsetEXT(gpVertexArrayVertexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
 }
 func VertexAttrib1d(index uint32, x float64) {
 	C.glowVertexAttrib1d(gpVertexAttrib1d, (C.GLuint)(index), (C.GLdouble)(x))
@@ -11317,10 +16264,16 @@ func VertexAttribBinding(attribindex uint32, bindingindex uint32) {
 func VertexAttribDivisor(index uint32, divisor uint32) {
 	C.glowVertexAttribDivisor(gpVertexAttribDivisor, (C.GLuint)(index), (C.GLuint)(divisor))
 }
+func VertexAttribDivisorARB(index uint32, divisor uint32) {
+	C.glowVertexAttribDivisorARB(gpVertexAttribDivisorARB, (C.GLuint)(index), (C.GLuint)(divisor))
+}
 
 // specify the organization of vertex arrays
 func VertexAttribFormat(attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
 	C.glowVertexAttribFormat(gpVertexAttribFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexAttribFormatNV(index uint32, size int32, xtype uint32, normalized bool, stride int32) {
+	C.glowVertexAttribFormatNV(gpVertexAttribFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride))
 }
 func VertexAttribI1i(index uint32, x int32) {
 	C.glowVertexAttribI1i(gpVertexAttribI1i, (C.GLuint)(index), (C.GLint)(x))
@@ -11385,6 +16338,9 @@ func VertexAttribI4usv(index uint32, v *uint16) {
 func VertexAttribIFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribIFormat(gpVertexAttribIFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexAttribIFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribIFormatNV(gpVertexAttribIFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func VertexAttribIPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribIPointer(gpVertexAttribIPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
 }
@@ -11394,11 +16350,23 @@ func VertexAttribL1d(index uint32, x float64) {
 func VertexAttribL1dv(index uint32, v *float64) {
 	C.glowVertexAttribL1dv(gpVertexAttribL1dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL1i64NV(index uint32, x int64) {
+	C.glowVertexAttribL1i64NV(gpVertexAttribL1i64NV, (C.GLuint)(index), (C.GLint64EXT)(x))
+}
+func VertexAttribL1i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL1i64vNV(gpVertexAttribL1i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL1ui64ARB(index uint32, x uint64) {
 	C.glowVertexAttribL1ui64ARB(gpVertexAttribL1ui64ARB, (C.GLuint)(index), (C.GLuint64EXT)(x))
 }
+func VertexAttribL1ui64NV(index uint32, x uint64) {
+	C.glowVertexAttribL1ui64NV(gpVertexAttribL1ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x))
+}
 func VertexAttribL1ui64vARB(index uint32, v *uint64) {
 	C.glowVertexAttribL1ui64vARB(gpVertexAttribL1ui64vARB, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL1ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL1ui64vNV(gpVertexAttribL1ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL2d(index uint32, x float64, y float64) {
 	C.glowVertexAttribL2d(gpVertexAttribL2d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y))
@@ -11406,11 +16374,35 @@ func VertexAttribL2d(index uint32, x float64, y float64) {
 func VertexAttribL2dv(index uint32, v *float64) {
 	C.glowVertexAttribL2dv(gpVertexAttribL2dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL2i64NV(index uint32, x int64, y int64) {
+	C.glowVertexAttribL2i64NV(gpVertexAttribL2i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func VertexAttribL2i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL2i64vNV(gpVertexAttribL2i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL2ui64NV(index uint32, x uint64, y uint64) {
+	C.glowVertexAttribL2ui64NV(gpVertexAttribL2ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func VertexAttribL2ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL2ui64vNV(gpVertexAttribL2ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL3d(index uint32, x float64, y float64, z float64) {
 	C.glowVertexAttribL3d(gpVertexAttribL3d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
 }
 func VertexAttribL3dv(index uint32, v *float64) {
 	C.glowVertexAttribL3dv(gpVertexAttribL3dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
+}
+func VertexAttribL3i64NV(index uint32, x int64, y int64, z int64) {
+	C.glowVertexAttribL3i64NV(gpVertexAttribL3i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func VertexAttribL3i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL3i64vNV(gpVertexAttribL3i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL3ui64NV(index uint32, x uint64, y uint64, z uint64) {
+	C.glowVertexAttribL3ui64NV(gpVertexAttribL3ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func VertexAttribL3ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL3ui64vNV(gpVertexAttribL3ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 	C.glowVertexAttribL4d(gpVertexAttribL4d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
@@ -11418,8 +16410,23 @@ func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 func VertexAttribL4dv(index uint32, v *float64) {
 	C.glowVertexAttribL4dv(gpVertexAttribL4dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL4i64NV(index uint32, x int64, y int64, z int64, w int64) {
+	C.glowVertexAttribL4i64NV(gpVertexAttribL4i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func VertexAttribL4i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL4i64vNV(gpVertexAttribL4i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL4ui64NV(index uint32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowVertexAttribL4ui64NV(gpVertexAttribL4ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func VertexAttribL4ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL4ui64vNV(gpVertexAttribL4ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribLFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribLFormat(gpVertexAttribLFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexAttribLFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribLFormatNV(gpVertexAttribLFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 func VertexAttribLPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribLPointer(gpVertexAttribLPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
@@ -11458,6 +16465,9 @@ func VertexAttribPointer(index uint32, size int32, xtype uint32, normalized bool
 func VertexBindingDivisor(bindingindex uint32, divisor uint32) {
 	C.glowVertexBindingDivisor(gpVertexBindingDivisor, (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowVertexFormatNV(gpVertexFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 
 // define an array of vertex data
 func VertexPointer(size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
@@ -11477,10 +16487,22 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
+	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
 }
 func WindowPos2d(x float64, y float64) {
 	C.glowWindowPos2d(gpWindowPos2d, (C.GLdouble)(x), (C.GLdouble)(y))
@@ -11530,6 +16552,9 @@ func WindowPos3s(x int16, y int16, z int16) {
 func WindowPos3sv(v *int16) {
 	C.glowWindowPos3sv(gpWindowPos3sv, (*C.GLshort)(unsafe.Pointer(v)))
 }
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
+}
 
 // Init initializes the OpenGL bindings by loading the function pointers (for
 // each OpenGL function) from the active OpenGL context.
@@ -11559,14 +16584,20 @@ func Init() error {
 // instead.
 func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpAccum = (C.GPACCUM)(getProcAddr("glAccum"))
+	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
+	gpActiveShaderProgramEXT = (C.GPACTIVESHADERPROGRAMEXT)(getProcAddr("glActiveShaderProgramEXT"))
 	gpActiveTexture = (C.GPACTIVETEXTURE)(getProcAddr("glActiveTexture"))
 	gpAlphaFunc = (C.GPALPHAFUNC)(getProcAddr("glAlphaFunc"))
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpAreTexturesResident = (C.GPARETEXTURESRESIDENT)(getProcAddr("glAreTexturesResident"))
 	gpArrayElement = (C.GPARRAYELEMENT)(getProcAddr("glArrayElement"))
 	gpAttachShader = (C.GPATTACHSHADER)(getProcAddr("glAttachShader"))
 	gpBegin = (C.GPBEGIN)(getProcAddr("glBegin"))
 	gpBeginConditionalRender = (C.GPBEGINCONDITIONALRENDER)(getProcAddr("glBeginConditionalRender"))
+	gpBeginConditionalRenderNV = (C.GPBEGINCONDITIONALRENDERNV)(getProcAddr("glBeginConditionalRenderNV"))
+	gpBeginPerfMonitorAMD = (C.GPBEGINPERFMONITORAMD)(getProcAddr("glBeginPerfMonitorAMD"))
+	gpBeginPerfQueryINTEL = (C.GPBEGINPERFQUERYINTEL)(getProcAddr("glBeginPerfQueryINTEL"))
 	gpBeginQuery = (C.GPBEGINQUERY)(getProcAddr("glBeginQuery"))
 	gpBeginQueryIndexed = (C.GPBEGINQUERYINDEXED)(getProcAddr("glBeginQueryIndexed"))
 	gpBeginTransformFeedback = (C.GPBEGINTRANSFORMFEEDBACK)(getProcAddr("glBeginTransformFeedback"))
@@ -11581,7 +16612,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpBindFramebuffer = (C.GPBINDFRAMEBUFFER)(getProcAddr("glBindFramebuffer"))
 	gpBindImageTexture = (C.GPBINDIMAGETEXTURE)(getProcAddr("glBindImageTexture"))
 	gpBindImageTextures = (C.GPBINDIMAGETEXTURES)(getProcAddr("glBindImageTextures"))
+	gpBindMultiTextureEXT = (C.GPBINDMULTITEXTUREEXT)(getProcAddr("glBindMultiTextureEXT"))
 	gpBindProgramPipeline = (C.GPBINDPROGRAMPIPELINE)(getProcAddr("glBindProgramPipeline"))
+	gpBindProgramPipelineEXT = (C.GPBINDPROGRAMPIPELINEEXT)(getProcAddr("glBindProgramPipelineEXT"))
 	gpBindRenderbuffer = (C.GPBINDRENDERBUFFER)(getProcAddr("glBindRenderbuffer"))
 	gpBindSampler = (C.GPBINDSAMPLER)(getProcAddr("glBindSampler"))
 	gpBindSamplers = (C.GPBINDSAMPLERS)(getProcAddr("glBindSamplers"))
@@ -11593,6 +16626,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpBindVertexBuffer = (C.GPBINDVERTEXBUFFER)(getProcAddr("glBindVertexBuffer"))
 	gpBindVertexBuffers = (C.GPBINDVERTEXBUFFERS)(getProcAddr("glBindVertexBuffers"))
 	gpBitmap = (C.GPBITMAP)(getProcAddr("glBitmap"))
+	gpBlendBarrierKHR = (C.GPBLENDBARRIERKHR)(getProcAddr("glBlendBarrierKHR"))
+	gpBlendBarrierNV = (C.GPBLENDBARRIERNV)(getProcAddr("glBlendBarrierNV"))
 	gpBlendColor = (C.GPBLENDCOLOR)(getProcAddr("glBlendColor"))
 	gpBlendEquation = (C.GPBLENDEQUATION)(getProcAddr("glBlendEquation"))
 	gpBlendEquationSeparate = (C.GPBLENDEQUATIONSEPARATE)(getProcAddr("glBlendEquationSeparate"))
@@ -11606,16 +16641,20 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpBlendFuncSeparateiARB = (C.GPBLENDFUNCSEPARATEIARB)(getProcAddr("glBlendFuncSeparateiARB"))
 	gpBlendFunci = (C.GPBLENDFUNCI)(getProcAddr("glBlendFunci"))
 	gpBlendFunciARB = (C.GPBLENDFUNCIARB)(getProcAddr("glBlendFunciARB"))
+	gpBlendParameteriNV = (C.GPBLENDPARAMETERINV)(getProcAddr("glBlendParameteriNV"))
 	gpBlitFramebuffer = (C.GPBLITFRAMEBUFFER)(getProcAddr("glBlitFramebuffer"))
 	gpBlitNamedFramebuffer = (C.GPBLITNAMEDFRAMEBUFFER)(getProcAddr("glBlitNamedFramebuffer"))
+	gpBufferAddressRangeNV = (C.GPBUFFERADDRESSRANGENV)(getProcAddr("glBufferAddressRangeNV"))
 	gpBufferData = (C.GPBUFFERDATA)(getProcAddr("glBufferData"))
 	gpBufferPageCommitmentARB = (C.GPBUFFERPAGECOMMITMENTARB)(getProcAddr("glBufferPageCommitmentARB"))
 	gpBufferStorage = (C.GPBUFFERSTORAGE)(getProcAddr("glBufferStorage"))
 	gpBufferSubData = (C.GPBUFFERSUBDATA)(getProcAddr("glBufferSubData"))
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCallList = (C.GPCALLLIST)(getProcAddr("glCallList"))
 	gpCallLists = (C.GPCALLLISTS)(getProcAddr("glCallLists"))
 	gpCheckFramebufferStatus = (C.GPCHECKFRAMEBUFFERSTATUS)(getProcAddr("glCheckFramebufferStatus"))
 	gpCheckNamedFramebufferStatus = (C.GPCHECKNAMEDFRAMEBUFFERSTATUS)(getProcAddr("glCheckNamedFramebufferStatus"))
+	gpCheckNamedFramebufferStatusEXT = (C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(getProcAddr("glCheckNamedFramebufferStatusEXT"))
 	gpClampColor = (C.GPCLAMPCOLOR)(getProcAddr("glClampColor"))
 	gpClear = (C.GPCLEAR)(getProcAddr("glClear"))
 	gpClearAccum = (C.GPCLEARACCUM)(getProcAddr("glClearAccum"))
@@ -11630,7 +16669,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpClearDepthf = (C.GPCLEARDEPTHF)(getProcAddr("glClearDepthf"))
 	gpClearIndex = (C.GPCLEARINDEX)(getProcAddr("glClearIndex"))
 	gpClearNamedBufferData = (C.GPCLEARNAMEDBUFFERDATA)(getProcAddr("glClearNamedBufferData"))
+	gpClearNamedBufferDataEXT = (C.GPCLEARNAMEDBUFFERDATAEXT)(getProcAddr("glClearNamedBufferDataEXT"))
 	gpClearNamedBufferSubData = (C.GPCLEARNAMEDBUFFERSUBDATA)(getProcAddr("glClearNamedBufferSubData"))
+	gpClearNamedBufferSubDataEXT = (C.GPCLEARNAMEDBUFFERSUBDATAEXT)(getProcAddr("glClearNamedBufferSubDataEXT"))
 	gpClearNamedFramebufferfi = (C.GPCLEARNAMEDFRAMEBUFFERFI)(getProcAddr("glClearNamedFramebufferfi"))
 	gpClearNamedFramebufferfv = (C.GPCLEARNAMEDFRAMEBUFFERFV)(getProcAddr("glClearNamedFramebufferfv"))
 	gpClearNamedFramebufferiv = (C.GPCLEARNAMEDFRAMEBUFFERIV)(getProcAddr("glClearNamedFramebufferiv"))
@@ -11639,6 +16680,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpClearTexImage = (C.GPCLEARTEXIMAGE)(getProcAddr("glClearTexImage"))
 	gpClearTexSubImage = (C.GPCLEARTEXSUBIMAGE)(getProcAddr("glClearTexSubImage"))
 	gpClientActiveTexture = (C.GPCLIENTACTIVETEXTURE)(getProcAddr("glClientActiveTexture"))
+	gpClientAttribDefaultEXT = (C.GPCLIENTATTRIBDEFAULTEXT)(getProcAddr("glClientAttribDefaultEXT"))
 	gpClientWaitSync = (C.GPCLIENTWAITSYNC)(getProcAddr("glClientWaitSync"))
 	gpClipControl = (C.GPCLIPCONTROL)(getProcAddr("glClipControl"))
 	gpClipPlane = (C.GPCLIPPLANE)(getProcAddr("glClipPlane"))
@@ -11674,42 +16716,81 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpColor4uiv = (C.GPCOLOR4UIV)(getProcAddr("glColor4uiv"))
 	gpColor4us = (C.GPCOLOR4US)(getProcAddr("glColor4us"))
 	gpColor4usv = (C.GPCOLOR4USV)(getProcAddr("glColor4usv"))
+	gpColorFormatNV = (C.GPCOLORFORMATNV)(getProcAddr("glColorFormatNV"))
 	gpColorMask = (C.GPCOLORMASK)(getProcAddr("glColorMask"))
 	gpColorMaski = (C.GPCOLORMASKI)(getProcAddr("glColorMaski"))
 	gpColorMaterial = (C.GPCOLORMATERIAL)(getProcAddr("glColorMaterial"))
 	gpColorPointer = (C.GPCOLORPOINTER)(getProcAddr("glColorPointer"))
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	gpCompileShaderIncludeARB = (C.GPCOMPILESHADERINCLUDEARB)(getProcAddr("glCompileShaderIncludeARB"))
+	gpCompressedMultiTexImage1DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE1DEXT)(getProcAddr("glCompressedMultiTexImage1DEXT"))
+	gpCompressedMultiTexImage2DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE2DEXT)(getProcAddr("glCompressedMultiTexImage2DEXT"))
+	gpCompressedMultiTexImage3DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE3DEXT)(getProcAddr("glCompressedMultiTexImage3DEXT"))
+	gpCompressedMultiTexSubImage1DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCompressedMultiTexSubImage1DEXT"))
+	gpCompressedMultiTexSubImage2DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCompressedMultiTexSubImage2DEXT"))
+	gpCompressedMultiTexSubImage3DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCompressedMultiTexSubImage3DEXT"))
 	gpCompressedTexImage1D = (C.GPCOMPRESSEDTEXIMAGE1D)(getProcAddr("glCompressedTexImage1D"))
 	gpCompressedTexImage2D = (C.GPCOMPRESSEDTEXIMAGE2D)(getProcAddr("glCompressedTexImage2D"))
 	gpCompressedTexImage3D = (C.GPCOMPRESSEDTEXIMAGE3D)(getProcAddr("glCompressedTexImage3D"))
 	gpCompressedTexSubImage1D = (C.GPCOMPRESSEDTEXSUBIMAGE1D)(getProcAddr("glCompressedTexSubImage1D"))
 	gpCompressedTexSubImage2D = (C.GPCOMPRESSEDTEXSUBIMAGE2D)(getProcAddr("glCompressedTexSubImage2D"))
 	gpCompressedTexSubImage3D = (C.GPCOMPRESSEDTEXSUBIMAGE3D)(getProcAddr("glCompressedTexSubImage3D"))
+	gpCompressedTextureImage1DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE1DEXT)(getProcAddr("glCompressedTextureImage1DEXT"))
+	gpCompressedTextureImage2DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE2DEXT)(getProcAddr("glCompressedTextureImage2DEXT"))
+	gpCompressedTextureImage3DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE3DEXT)(getProcAddr("glCompressedTextureImage3DEXT"))
 	gpCompressedTextureSubImage1D = (C.GPCOMPRESSEDTEXTURESUBIMAGE1D)(getProcAddr("glCompressedTextureSubImage1D"))
+	gpCompressedTextureSubImage1DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(getProcAddr("glCompressedTextureSubImage1DEXT"))
 	gpCompressedTextureSubImage2D = (C.GPCOMPRESSEDTEXTURESUBIMAGE2D)(getProcAddr("glCompressedTextureSubImage2D"))
+	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
+	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpCopyBufferSubData = (C.GPCOPYBUFFERSUBDATA)(getProcAddr("glCopyBufferSubData"))
 	gpCopyImageSubData = (C.GPCOPYIMAGESUBDATA)(getProcAddr("glCopyImageSubData"))
+	gpCopyMultiTexImage1DEXT = (C.GPCOPYMULTITEXIMAGE1DEXT)(getProcAddr("glCopyMultiTexImage1DEXT"))
+	gpCopyMultiTexImage2DEXT = (C.GPCOPYMULTITEXIMAGE2DEXT)(getProcAddr("glCopyMultiTexImage2DEXT"))
+	gpCopyMultiTexSubImage1DEXT = (C.GPCOPYMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCopyMultiTexSubImage1DEXT"))
+	gpCopyMultiTexSubImage2DEXT = (C.GPCOPYMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCopyMultiTexSubImage2DEXT"))
+	gpCopyMultiTexSubImage3DEXT = (C.GPCOPYMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCopyMultiTexSubImage3DEXT"))
 	gpCopyNamedBufferSubData = (C.GPCOPYNAMEDBUFFERSUBDATA)(getProcAddr("glCopyNamedBufferSubData"))
+	gpCopyPathNV = (C.GPCOPYPATHNV)(getProcAddr("glCopyPathNV"))
 	gpCopyPixels = (C.GPCOPYPIXELS)(getProcAddr("glCopyPixels"))
 	gpCopyTexImage1D = (C.GPCOPYTEXIMAGE1D)(getProcAddr("glCopyTexImage1D"))
 	gpCopyTexImage2D = (C.GPCOPYTEXIMAGE2D)(getProcAddr("glCopyTexImage2D"))
 	gpCopyTexSubImage1D = (C.GPCOPYTEXSUBIMAGE1D)(getProcAddr("glCopyTexSubImage1D"))
 	gpCopyTexSubImage2D = (C.GPCOPYTEXSUBIMAGE2D)(getProcAddr("glCopyTexSubImage2D"))
 	gpCopyTexSubImage3D = (C.GPCOPYTEXSUBIMAGE3D)(getProcAddr("glCopyTexSubImage3D"))
+	gpCopyTextureImage1DEXT = (C.GPCOPYTEXTUREIMAGE1DEXT)(getProcAddr("glCopyTextureImage1DEXT"))
+	gpCopyTextureImage2DEXT = (C.GPCOPYTEXTUREIMAGE2DEXT)(getProcAddr("glCopyTextureImage2DEXT"))
 	gpCopyTextureSubImage1D = (C.GPCOPYTEXTURESUBIMAGE1D)(getProcAddr("glCopyTextureSubImage1D"))
+	gpCopyTextureSubImage1DEXT = (C.GPCOPYTEXTURESUBIMAGE1DEXT)(getProcAddr("glCopyTextureSubImage1DEXT"))
 	gpCopyTextureSubImage2D = (C.GPCOPYTEXTURESUBIMAGE2D)(getProcAddr("glCopyTextureSubImage2D"))
+	gpCopyTextureSubImage2DEXT = (C.GPCOPYTEXTURESUBIMAGE2DEXT)(getProcAddr("glCopyTextureSubImage2DEXT"))
 	gpCopyTextureSubImage3D = (C.GPCOPYTEXTURESUBIMAGE3D)(getProcAddr("glCopyTextureSubImage3D"))
+	gpCopyTextureSubImage3DEXT = (C.GPCOPYTEXTURESUBIMAGE3DEXT)(getProcAddr("glCopyTextureSubImage3DEXT"))
+	gpCoverFillPathInstancedNV = (C.GPCOVERFILLPATHINSTANCEDNV)(getProcAddr("glCoverFillPathInstancedNV"))
+	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
+	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
+	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
+	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	gpCreateProgramPipelines = (C.GPCREATEPROGRAMPIPELINES)(getProcAddr("glCreateProgramPipelines"))
 	gpCreateQueries = (C.GPCREATEQUERIES)(getProcAddr("glCreateQueries"))
 	gpCreateRenderbuffers = (C.GPCREATERENDERBUFFERS)(getProcAddr("glCreateRenderbuffers"))
 	gpCreateSamplers = (C.GPCREATESAMPLERS)(getProcAddr("glCreateSamplers"))
 	gpCreateShader = (C.GPCREATESHADER)(getProcAddr("glCreateShader"))
+	gpCreateShaderProgramEXT = (C.GPCREATESHADERPROGRAMEXT)(getProcAddr("glCreateShaderProgramEXT"))
 	gpCreateShaderProgramv = (C.GPCREATESHADERPROGRAMV)(getProcAddr("glCreateShaderProgramv"))
+	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	gpCreateTransformFeedbacks = (C.GPCREATETRANSFORMFEEDBACKS)(getProcAddr("glCreateTransformFeedbacks"))
@@ -11725,15 +16806,21 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpDebugMessageInsertARB = (C.GPDEBUGMESSAGEINSERTARB)(getProcAddr("glDebugMessageInsertARB"))
 	gpDebugMessageInsertKHR = (C.GPDEBUGMESSAGEINSERTKHR)(getProcAddr("glDebugMessageInsertKHR"))
 	gpDeleteBuffers = (C.GPDELETEBUFFERS)(getProcAddr("glDeleteBuffers"))
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFramebuffers = (C.GPDELETEFRAMEBUFFERS)(getProcAddr("glDeleteFramebuffers"))
 	gpDeleteLists = (C.GPDELETELISTS)(getProcAddr("glDeleteLists"))
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
+	gpDeletePathsNV = (C.GPDELETEPATHSNV)(getProcAddr("glDeletePathsNV"))
+	gpDeletePerfMonitorsAMD = (C.GPDELETEPERFMONITORSAMD)(getProcAddr("glDeletePerfMonitorsAMD"))
+	gpDeletePerfQueryINTEL = (C.GPDELETEPERFQUERYINTEL)(getProcAddr("glDeletePerfQueryINTEL"))
 	gpDeleteProgram = (C.GPDELETEPROGRAM)(getProcAddr("glDeleteProgram"))
 	gpDeleteProgramPipelines = (C.GPDELETEPROGRAMPIPELINES)(getProcAddr("glDeleteProgramPipelines"))
+	gpDeleteProgramPipelinesEXT = (C.GPDELETEPROGRAMPIPELINESEXT)(getProcAddr("glDeleteProgramPipelinesEXT"))
 	gpDeleteQueries = (C.GPDELETEQUERIES)(getProcAddr("glDeleteQueries"))
 	gpDeleteRenderbuffers = (C.GPDELETERENDERBUFFERS)(getProcAddr("glDeleteRenderbuffers"))
 	gpDeleteSamplers = (C.GPDELETESAMPLERS)(getProcAddr("glDeleteSamplers"))
 	gpDeleteShader = (C.GPDELETESHADER)(getProcAddr("glDeleteShader"))
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	gpDeleteTextures = (C.GPDELETETEXTURES)(getProcAddr("glDeleteTextures"))
 	gpDeleteTransformFeedbacks = (C.GPDELETETRANSFORMFEEDBACKS)(getProcAddr("glDeleteTransformFeedbacks"))
@@ -11747,7 +16834,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpDetachShader = (C.GPDETACHSHADER)(getProcAddr("glDetachShader"))
 	gpDisable = (C.GPDISABLE)(getProcAddr("glDisable"))
 	gpDisableClientState = (C.GPDISABLECLIENTSTATE)(getProcAddr("glDisableClientState"))
+	gpDisableClientStateIndexedEXT = (C.GPDISABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glDisableClientStateIndexedEXT"))
+	gpDisableClientStateiEXT = (C.GPDISABLECLIENTSTATEIEXT)(getProcAddr("glDisableClientStateiEXT"))
+	gpDisableIndexedEXT = (C.GPDISABLEINDEXEDEXT)(getProcAddr("glDisableIndexedEXT"))
 	gpDisableVertexArrayAttrib = (C.GPDISABLEVERTEXARRAYATTRIB)(getProcAddr("glDisableVertexArrayAttrib"))
+	gpDisableVertexArrayAttribEXT = (C.GPDISABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glDisableVertexArrayAttribEXT"))
+	gpDisableVertexArrayEXT = (C.GPDISABLEVERTEXARRAYEXT)(getProcAddr("glDisableVertexArrayEXT"))
 	gpDisableVertexAttribArray = (C.GPDISABLEVERTEXATTRIBARRAY)(getProcAddr("glDisableVertexAttribArray"))
 	gpDisablei = (C.GPDISABLEI)(getProcAddr("glDisablei"))
 	gpDispatchCompute = (C.GPDISPATCHCOMPUTE)(getProcAddr("glDispatchCompute"))
@@ -11756,16 +16848,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpDrawArrays = (C.GPDRAWARRAYS)(getProcAddr("glDrawArrays"))
 	gpDrawArraysIndirect = (C.GPDRAWARRAYSINDIRECT)(getProcAddr("glDrawArraysIndirect"))
 	gpDrawArraysInstanced = (C.GPDRAWARRAYSINSTANCED)(getProcAddr("glDrawArraysInstanced"))
+	gpDrawArraysInstancedARB = (C.GPDRAWARRAYSINSTANCEDARB)(getProcAddr("glDrawArraysInstancedARB"))
 	gpDrawArraysInstancedBaseInstance = (C.GPDRAWARRAYSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawArraysInstancedBaseInstance"))
+	gpDrawArraysInstancedEXT = (C.GPDRAWARRAYSINSTANCEDEXT)(getProcAddr("glDrawArraysInstancedEXT"))
 	gpDrawBuffer = (C.GPDRAWBUFFER)(getProcAddr("glDrawBuffer"))
 	gpDrawBuffers = (C.GPDRAWBUFFERS)(getProcAddr("glDrawBuffers"))
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
 	gpDrawElementsBaseVertex = (C.GPDRAWELEMENTSBASEVERTEX)(getProcAddr("glDrawElementsBaseVertex"))
 	gpDrawElementsIndirect = (C.GPDRAWELEMENTSINDIRECT)(getProcAddr("glDrawElementsIndirect"))
 	gpDrawElementsInstanced = (C.GPDRAWELEMENTSINSTANCED)(getProcAddr("glDrawElementsInstanced"))
+	gpDrawElementsInstancedARB = (C.GPDRAWELEMENTSINSTANCEDARB)(getProcAddr("glDrawElementsInstancedARB"))
 	gpDrawElementsInstancedBaseInstance = (C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawElementsInstancedBaseInstance"))
 	gpDrawElementsInstancedBaseVertex = (C.GPDRAWELEMENTSINSTANCEDBASEVERTEX)(getProcAddr("glDrawElementsInstancedBaseVertex"))
 	gpDrawElementsInstancedBaseVertexBaseInstance = (C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE)(getProcAddr("glDrawElementsInstancedBaseVertexBaseInstance"))
+	gpDrawElementsInstancedEXT = (C.GPDRAWELEMENTSINSTANCEDEXT)(getProcAddr("glDrawElementsInstancedEXT"))
 	gpDrawPixels = (C.GPDRAWPIXELS)(getProcAddr("glDrawPixels"))
 	gpDrawRangeElements = (C.GPDRAWRANGEELEMENTS)(getProcAddr("glDrawRangeElements"))
 	gpDrawRangeElementsBaseVertex = (C.GPDRAWRANGEELEMENTSBASEVERTEX)(getProcAddr("glDrawRangeElementsBaseVertex"))
@@ -11773,17 +16873,27 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpDrawTransformFeedbackInstanced = (C.GPDRAWTRANSFORMFEEDBACKINSTANCED)(getProcAddr("glDrawTransformFeedbackInstanced"))
 	gpDrawTransformFeedbackStream = (C.GPDRAWTRANSFORMFEEDBACKSTREAM)(getProcAddr("glDrawTransformFeedbackStream"))
 	gpDrawTransformFeedbackStreamInstanced = (C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(getProcAddr("glDrawTransformFeedbackStreamInstanced"))
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
 	gpEdgeFlag = (C.GPEDGEFLAG)(getProcAddr("glEdgeFlag"))
+	gpEdgeFlagFormatNV = (C.GPEDGEFLAGFORMATNV)(getProcAddr("glEdgeFlagFormatNV"))
 	gpEdgeFlagPointer = (C.GPEDGEFLAGPOINTER)(getProcAddr("glEdgeFlagPointer"))
 	gpEdgeFlagv = (C.GPEDGEFLAGV)(getProcAddr("glEdgeFlagv"))
 	gpEnable = (C.GPENABLE)(getProcAddr("glEnable"))
 	gpEnableClientState = (C.GPENABLECLIENTSTATE)(getProcAddr("glEnableClientState"))
+	gpEnableClientStateIndexedEXT = (C.GPENABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glEnableClientStateIndexedEXT"))
+	gpEnableClientStateiEXT = (C.GPENABLECLIENTSTATEIEXT)(getProcAddr("glEnableClientStateiEXT"))
+	gpEnableIndexedEXT = (C.GPENABLEINDEXEDEXT)(getProcAddr("glEnableIndexedEXT"))
 	gpEnableVertexArrayAttrib = (C.GPENABLEVERTEXARRAYATTRIB)(getProcAddr("glEnableVertexArrayAttrib"))
+	gpEnableVertexArrayAttribEXT = (C.GPENABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glEnableVertexArrayAttribEXT"))
+	gpEnableVertexArrayEXT = (C.GPENABLEVERTEXARRAYEXT)(getProcAddr("glEnableVertexArrayEXT"))
 	gpEnableVertexAttribArray = (C.GPENABLEVERTEXATTRIBARRAY)(getProcAddr("glEnableVertexAttribArray"))
 	gpEnablei = (C.GPENABLEI)(getProcAddr("glEnablei"))
 	gpEnd = (C.GPEND)(getProcAddr("glEnd"))
 	gpEndConditionalRender = (C.GPENDCONDITIONALRENDER)(getProcAddr("glEndConditionalRender"))
+	gpEndConditionalRenderNV = (C.GPENDCONDITIONALRENDERNV)(getProcAddr("glEndConditionalRenderNV"))
 	gpEndList = (C.GPENDLIST)(getProcAddr("glEndList"))
+	gpEndPerfMonitorAMD = (C.GPENDPERFMONITORAMD)(getProcAddr("glEndPerfMonitorAMD"))
+	gpEndPerfQueryINTEL = (C.GPENDPERFQUERYINTEL)(getProcAddr("glEndPerfQueryINTEL"))
 	gpEndQuery = (C.GPENDQUERY)(getProcAddr("glEndQuery"))
 	gpEndQueryIndexed = (C.GPENDQUERYINDEXED)(getProcAddr("glEndQueryIndexed"))
 	gpEndTransformFeedback = (C.GPENDTRANSFORMFEEDBACK)(getProcAddr("glEndTransformFeedback"))
@@ -11799,12 +16909,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpEvalMesh2 = (C.GPEVALMESH2)(getProcAddr("glEvalMesh2"))
 	gpEvalPoint1 = (C.GPEVALPOINT1)(getProcAddr("glEvalPoint1"))
 	gpEvalPoint2 = (C.GPEVALPOINT2)(getProcAddr("glEvalPoint2"))
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpFeedbackBuffer = (C.GPFEEDBACKBUFFER)(getProcAddr("glFeedbackBuffer"))
 	gpFenceSync = (C.GPFENCESYNC)(getProcAddr("glFenceSync"))
 	gpFinish = (C.GPFINISH)(getProcAddr("glFinish"))
 	gpFlush = (C.GPFLUSH)(getProcAddr("glFlush"))
 	gpFlushMappedBufferRange = (C.GPFLUSHMAPPEDBUFFERRANGE)(getProcAddr("glFlushMappedBufferRange"))
 	gpFlushMappedNamedBufferRange = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGE)(getProcAddr("glFlushMappedNamedBufferRange"))
+	gpFlushMappedNamedBufferRangeEXT = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(getProcAddr("glFlushMappedNamedBufferRangeEXT"))
+	gpFogCoordFormatNV = (C.GPFOGCOORDFORMATNV)(getProcAddr("glFogCoordFormatNV"))
 	gpFogCoordPointer = (C.GPFOGCOORDPOINTER)(getProcAddr("glFogCoordPointer"))
 	gpFogCoordd = (C.GPFOGCOORDD)(getProcAddr("glFogCoordd"))
 	gpFogCoorddv = (C.GPFOGCOORDDV)(getProcAddr("glFogCoorddv"))
@@ -11814,19 +16927,33 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFogfv = (C.GPFOGFV)(getProcAddr("glFogfv"))
 	gpFogi = (C.GPFOGI)(getProcAddr("glFogi"))
 	gpFogiv = (C.GPFOGIV)(getProcAddr("glFogiv"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
+	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
+	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
+	gpFramebufferReadBufferEXT = (C.GPFRAMEBUFFERREADBUFFEREXT)(getProcAddr("glFramebufferReadBufferEXT"))
 	gpFramebufferRenderbuffer = (C.GPFRAMEBUFFERRENDERBUFFER)(getProcAddr("glFramebufferRenderbuffer"))
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	gpFramebufferTexture1D = (C.GPFRAMEBUFFERTEXTURE1D)(getProcAddr("glFramebufferTexture1D"))
 	gpFramebufferTexture2D = (C.GPFRAMEBUFFERTEXTURE2D)(getProcAddr("glFramebufferTexture2D"))
 	gpFramebufferTexture3D = (C.GPFRAMEBUFFERTEXTURE3D)(getProcAddr("glFramebufferTexture3D"))
+	gpFramebufferTextureARB = (C.GPFRAMEBUFFERTEXTUREARB)(getProcAddr("glFramebufferTextureARB"))
+	gpFramebufferTextureFaceARB = (C.GPFRAMEBUFFERTEXTUREFACEARB)(getProcAddr("glFramebufferTextureFaceARB"))
 	gpFramebufferTextureLayer = (C.GPFRAMEBUFFERTEXTURELAYER)(getProcAddr("glFramebufferTextureLayer"))
+	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	gpFrustum = (C.GPFRUSTUM)(getProcAddr("glFrustum"))
 	gpGenBuffers = (C.GPGENBUFFERS)(getProcAddr("glGenBuffers"))
 	gpGenFramebuffers = (C.GPGENFRAMEBUFFERS)(getProcAddr("glGenFramebuffers"))
 	gpGenLists = (C.GPGENLISTS)(getProcAddr("glGenLists"))
+	gpGenPathsNV = (C.GPGENPATHSNV)(getProcAddr("glGenPathsNV"))
+	gpGenPerfMonitorsAMD = (C.GPGENPERFMONITORSAMD)(getProcAddr("glGenPerfMonitorsAMD"))
 	gpGenProgramPipelines = (C.GPGENPROGRAMPIPELINES)(getProcAddr("glGenProgramPipelines"))
+	gpGenProgramPipelinesEXT = (C.GPGENPROGRAMPIPELINESEXT)(getProcAddr("glGenProgramPipelinesEXT"))
 	gpGenQueries = (C.GPGENQUERIES)(getProcAddr("glGenQueries"))
 	gpGenRenderbuffers = (C.GPGENRENDERBUFFERS)(getProcAddr("glGenRenderbuffers"))
 	gpGenSamplers = (C.GPGENSAMPLERS)(getProcAddr("glGenSamplers"))
@@ -11834,7 +16961,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGenTransformFeedbacks = (C.GPGENTRANSFORMFEEDBACKS)(getProcAddr("glGenTransformFeedbacks"))
 	gpGenVertexArrays = (C.GPGENVERTEXARRAYS)(getProcAddr("glGenVertexArrays"))
 	gpGenerateMipmap = (C.GPGENERATEMIPMAP)(getProcAddr("glGenerateMipmap"))
+	gpGenerateMultiTexMipmapEXT = (C.GPGENERATEMULTITEXMIPMAPEXT)(getProcAddr("glGenerateMultiTexMipmapEXT"))
 	gpGenerateTextureMipmap = (C.GPGENERATETEXTUREMIPMAP)(getProcAddr("glGenerateTextureMipmap"))
+	gpGenerateTextureMipmapEXT = (C.GPGENERATETEXTUREMIPMAPEXT)(getProcAddr("glGenerateTextureMipmapEXT"))
 	gpGetActiveAtomicCounterBufferiv = (C.GPGETACTIVEATOMICCOUNTERBUFFERIV)(getProcAddr("glGetActiveAtomicCounterBufferiv"))
 	gpGetActiveAttrib = (C.GPGETACTIVEATTRIB)(getProcAddr("glGetActiveAttrib"))
 	gpGetActiveSubroutineName = (C.GPGETACTIVESUBROUTINENAME)(getProcAddr("glGetActiveSubroutineName"))
@@ -11847,36 +16976,53 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetActiveUniformsiv = (C.GPGETACTIVEUNIFORMSIV)(getProcAddr("glGetActiveUniformsiv"))
 	gpGetAttachedShaders = (C.GPGETATTACHEDSHADERS)(getProcAddr("glGetAttachedShaders"))
 	gpGetAttribLocation = (C.GPGETATTRIBLOCATION)(getProcAddr("glGetAttribLocation"))
+	gpGetBooleanIndexedvEXT = (C.GPGETBOOLEANINDEXEDVEXT)(getProcAddr("glGetBooleanIndexedvEXT"))
 	gpGetBooleani_v = (C.GPGETBOOLEANI_V)(getProcAddr("glGetBooleani_v"))
 	gpGetBooleanv = (C.GPGETBOOLEANV)(getProcAddr("glGetBooleanv"))
 	gpGetBufferParameteri64v = (C.GPGETBUFFERPARAMETERI64V)(getProcAddr("glGetBufferParameteri64v"))
 	gpGetBufferParameteriv = (C.GPGETBUFFERPARAMETERIV)(getProcAddr("glGetBufferParameteriv"))
+	gpGetBufferParameterui64vNV = (C.GPGETBUFFERPARAMETERUI64VNV)(getProcAddr("glGetBufferParameterui64vNV"))
 	gpGetBufferPointerv = (C.GPGETBUFFERPOINTERV)(getProcAddr("glGetBufferPointerv"))
 	gpGetBufferSubData = (C.GPGETBUFFERSUBDATA)(getProcAddr("glGetBufferSubData"))
 	gpGetClipPlane = (C.GPGETCLIPPLANE)(getProcAddr("glGetClipPlane"))
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
+	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	gpGetCompressedTextureImage = (C.GPGETCOMPRESSEDTEXTUREIMAGE)(getProcAddr("glGetCompressedTextureImage"))
+	gpGetCompressedTextureImageEXT = (C.GPGETCOMPRESSEDTEXTUREIMAGEEXT)(getProcAddr("glGetCompressedTextureImageEXT"))
 	gpGetCompressedTextureSubImage = (C.GPGETCOMPRESSEDTEXTURESUBIMAGE)(getProcAddr("glGetCompressedTextureSubImage"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	gpGetDebugMessageLogARB = (C.GPGETDEBUGMESSAGELOGARB)(getProcAddr("glGetDebugMessageLogARB"))
 	gpGetDebugMessageLogKHR = (C.GPGETDEBUGMESSAGELOGKHR)(getProcAddr("glGetDebugMessageLogKHR"))
+	gpGetDoubleIndexedvEXT = (C.GPGETDOUBLEINDEXEDVEXT)(getProcAddr("glGetDoubleIndexedvEXT"))
 	gpGetDoublei_v = (C.GPGETDOUBLEI_V)(getProcAddr("glGetDoublei_v"))
+	gpGetDoublei_vEXT = (C.GPGETDOUBLEI_VEXT)(getProcAddr("glGetDoublei_vEXT"))
 	gpGetDoublev = (C.GPGETDOUBLEV)(getProcAddr("glGetDoublev"))
 	gpGetError = (C.GPGETERROR)(getProcAddr("glGetError"))
+	gpGetFirstPerfQueryIdINTEL = (C.GPGETFIRSTPERFQUERYIDINTEL)(getProcAddr("glGetFirstPerfQueryIdINTEL"))
+	gpGetFloatIndexedvEXT = (C.GPGETFLOATINDEXEDVEXT)(getProcAddr("glGetFloatIndexedvEXT"))
 	gpGetFloati_v = (C.GPGETFLOATI_V)(getProcAddr("glGetFloati_v"))
+	gpGetFloati_vEXT = (C.GPGETFLOATI_VEXT)(getProcAddr("glGetFloati_vEXT"))
 	gpGetFloatv = (C.GPGETFLOATV)(getProcAddr("glGetFloatv"))
 	gpGetFragDataIndex = (C.GPGETFRAGDATAINDEX)(getProcAddr("glGetFragDataIndex"))
 	gpGetFragDataLocation = (C.GPGETFRAGDATALOCATION)(getProcAddr("glGetFragDataLocation"))
 	gpGetFramebufferAttachmentParameteriv = (C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetFramebufferAttachmentParameteriv"))
 	gpGetFramebufferParameteriv = (C.GPGETFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetFramebufferParameteriv"))
+	gpGetFramebufferParameterivEXT = (C.GPGETFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetFramebufferParameterivEXT"))
 	gpGetGraphicsResetStatus = (C.GPGETGRAPHICSRESETSTATUS)(getProcAddr("glGetGraphicsResetStatus"))
 	gpGetGraphicsResetStatusARB = (C.GPGETGRAPHICSRESETSTATUSARB)(getProcAddr("glGetGraphicsResetStatusARB"))
 	gpGetGraphicsResetStatusKHR = (C.GPGETGRAPHICSRESETSTATUSKHR)(getProcAddr("glGetGraphicsResetStatusKHR"))
 	gpGetImageHandleARB = (C.GPGETIMAGEHANDLEARB)(getProcAddr("glGetImageHandleARB"))
+	gpGetImageHandleNV = (C.GPGETIMAGEHANDLENV)(getProcAddr("glGetImageHandleNV"))
 	gpGetInteger64i_v = (C.GPGETINTEGER64I_V)(getProcAddr("glGetInteger64i_v"))
 	gpGetInteger64v = (C.GPGETINTEGER64V)(getProcAddr("glGetInteger64v"))
+	gpGetIntegerIndexedvEXT = (C.GPGETINTEGERINDEXEDVEXT)(getProcAddr("glGetIntegerIndexedvEXT"))
 	gpGetIntegeri_v = (C.GPGETINTEGERI_V)(getProcAddr("glGetIntegeri_v"))
+	gpGetIntegerui64i_vNV = (C.GPGETINTEGERUI64I_VNV)(getProcAddr("glGetIntegerui64i_vNV"))
+	gpGetIntegerui64vNV = (C.GPGETINTEGERUI64VNV)(getProcAddr("glGetIntegerui64vNV"))
 	gpGetIntegerv = (C.GPGETINTEGERV)(getProcAddr("glGetIntegerv"))
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	gpGetInternalformativ = (C.GPGETINTERNALFORMATIV)(getProcAddr("glGetInternalformativ"))
 	gpGetLightfv = (C.GPGETLIGHTFV)(getProcAddr("glGetLightfv"))
@@ -11886,23 +17032,71 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetMapiv = (C.GPGETMAPIV)(getProcAddr("glGetMapiv"))
 	gpGetMaterialfv = (C.GPGETMATERIALFV)(getProcAddr("glGetMaterialfv"))
 	gpGetMaterialiv = (C.GPGETMATERIALIV)(getProcAddr("glGetMaterialiv"))
+	gpGetMultiTexEnvfvEXT = (C.GPGETMULTITEXENVFVEXT)(getProcAddr("glGetMultiTexEnvfvEXT"))
+	gpGetMultiTexEnvivEXT = (C.GPGETMULTITEXENVIVEXT)(getProcAddr("glGetMultiTexEnvivEXT"))
+	gpGetMultiTexGendvEXT = (C.GPGETMULTITEXGENDVEXT)(getProcAddr("glGetMultiTexGendvEXT"))
+	gpGetMultiTexGenfvEXT = (C.GPGETMULTITEXGENFVEXT)(getProcAddr("glGetMultiTexGenfvEXT"))
+	gpGetMultiTexGenivEXT = (C.GPGETMULTITEXGENIVEXT)(getProcAddr("glGetMultiTexGenivEXT"))
+	gpGetMultiTexImageEXT = (C.GPGETMULTITEXIMAGEEXT)(getProcAddr("glGetMultiTexImageEXT"))
+	gpGetMultiTexLevelParameterfvEXT = (C.GPGETMULTITEXLEVELPARAMETERFVEXT)(getProcAddr("glGetMultiTexLevelParameterfvEXT"))
+	gpGetMultiTexLevelParameterivEXT = (C.GPGETMULTITEXLEVELPARAMETERIVEXT)(getProcAddr("glGetMultiTexLevelParameterivEXT"))
+	gpGetMultiTexParameterIivEXT = (C.GPGETMULTITEXPARAMETERIIVEXT)(getProcAddr("glGetMultiTexParameterIivEXT"))
+	gpGetMultiTexParameterIuivEXT = (C.GPGETMULTITEXPARAMETERIUIVEXT)(getProcAddr("glGetMultiTexParameterIuivEXT"))
+	gpGetMultiTexParameterfvEXT = (C.GPGETMULTITEXPARAMETERFVEXT)(getProcAddr("glGetMultiTexParameterfvEXT"))
+	gpGetMultiTexParameterivEXT = (C.GPGETMULTITEXPARAMETERIVEXT)(getProcAddr("glGetMultiTexParameterivEXT"))
 	gpGetMultisamplefv = (C.GPGETMULTISAMPLEFV)(getProcAddr("glGetMultisamplefv"))
 	gpGetNamedBufferParameteri64v = (C.GPGETNAMEDBUFFERPARAMETERI64V)(getProcAddr("glGetNamedBufferParameteri64v"))
 	gpGetNamedBufferParameteriv = (C.GPGETNAMEDBUFFERPARAMETERIV)(getProcAddr("glGetNamedBufferParameteriv"))
+	gpGetNamedBufferParameterivEXT = (C.GPGETNAMEDBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedBufferParameterivEXT"))
+	gpGetNamedBufferParameterui64vNV = (C.GPGETNAMEDBUFFERPARAMETERUI64VNV)(getProcAddr("glGetNamedBufferParameterui64vNV"))
 	gpGetNamedBufferPointerv = (C.GPGETNAMEDBUFFERPOINTERV)(getProcAddr("glGetNamedBufferPointerv"))
+	gpGetNamedBufferPointervEXT = (C.GPGETNAMEDBUFFERPOINTERVEXT)(getProcAddr("glGetNamedBufferPointervEXT"))
 	gpGetNamedBufferSubData = (C.GPGETNAMEDBUFFERSUBDATA)(getProcAddr("glGetNamedBufferSubData"))
+	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
+	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
+	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
+	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
+	gpGetNamedProgramLocalParameterIuivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIuivEXT"))
+	gpGetNamedProgramLocalParameterdvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(getProcAddr("glGetNamedProgramLocalParameterdvEXT"))
+	gpGetNamedProgramLocalParameterfvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(getProcAddr("glGetNamedProgramLocalParameterfvEXT"))
+	gpGetNamedProgramStringEXT = (C.GPGETNAMEDPROGRAMSTRINGEXT)(getProcAddr("glGetNamedProgramStringEXT"))
+	gpGetNamedProgramivEXT = (C.GPGETNAMEDPROGRAMIVEXT)(getProcAddr("glGetNamedProgramivEXT"))
 	gpGetNamedRenderbufferParameteriv = (C.GPGETNAMEDRENDERBUFFERPARAMETERIV)(getProcAddr("glGetNamedRenderbufferParameteriv"))
+	gpGetNamedRenderbufferParameterivEXT = (C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedRenderbufferParameterivEXT"))
 	gpGetNamedStringARB = (C.GPGETNAMEDSTRINGARB)(getProcAddr("glGetNamedStringARB"))
 	gpGetNamedStringivARB = (C.GPGETNAMEDSTRINGIVARB)(getProcAddr("glGetNamedStringivARB"))
+	gpGetNextPerfQueryIdINTEL = (C.GPGETNEXTPERFQUERYIDINTEL)(getProcAddr("glGetNextPerfQueryIdINTEL"))
 	gpGetObjectLabel = (C.GPGETOBJECTLABEL)(getProcAddr("glGetObjectLabel"))
+	gpGetObjectLabelEXT = (C.GPGETOBJECTLABELEXT)(getProcAddr("glGetObjectLabelEXT"))
 	gpGetObjectLabelKHR = (C.GPGETOBJECTLABELKHR)(getProcAddr("glGetObjectLabelKHR"))
 	gpGetObjectPtrLabel = (C.GPGETOBJECTPTRLABEL)(getProcAddr("glGetObjectPtrLabel"))
 	gpGetObjectPtrLabelKHR = (C.GPGETOBJECTPTRLABELKHR)(getProcAddr("glGetObjectPtrLabelKHR"))
+	gpGetPathCommandsNV = (C.GPGETPATHCOMMANDSNV)(getProcAddr("glGetPathCommandsNV"))
+	gpGetPathCoordsNV = (C.GPGETPATHCOORDSNV)(getProcAddr("glGetPathCoordsNV"))
+	gpGetPathDashArrayNV = (C.GPGETPATHDASHARRAYNV)(getProcAddr("glGetPathDashArrayNV"))
+	gpGetPathLengthNV = (C.GPGETPATHLENGTHNV)(getProcAddr("glGetPathLengthNV"))
+	gpGetPathMetricRangeNV = (C.GPGETPATHMETRICRANGENV)(getProcAddr("glGetPathMetricRangeNV"))
+	gpGetPathMetricsNV = (C.GPGETPATHMETRICSNV)(getProcAddr("glGetPathMetricsNV"))
+	gpGetPathParameterfvNV = (C.GPGETPATHPARAMETERFVNV)(getProcAddr("glGetPathParameterfvNV"))
+	gpGetPathParameterivNV = (C.GPGETPATHPARAMETERIVNV)(getProcAddr("glGetPathParameterivNV"))
+	gpGetPathSpacingNV = (C.GPGETPATHSPACINGNV)(getProcAddr("glGetPathSpacingNV"))
+	gpGetPerfCounterInfoINTEL = (C.GPGETPERFCOUNTERINFOINTEL)(getProcAddr("glGetPerfCounterInfoINTEL"))
+	gpGetPerfMonitorCounterDataAMD = (C.GPGETPERFMONITORCOUNTERDATAAMD)(getProcAddr("glGetPerfMonitorCounterDataAMD"))
+	gpGetPerfMonitorCounterInfoAMD = (C.GPGETPERFMONITORCOUNTERINFOAMD)(getProcAddr("glGetPerfMonitorCounterInfoAMD"))
+	gpGetPerfMonitorCounterStringAMD = (C.GPGETPERFMONITORCOUNTERSTRINGAMD)(getProcAddr("glGetPerfMonitorCounterStringAMD"))
+	gpGetPerfMonitorCountersAMD = (C.GPGETPERFMONITORCOUNTERSAMD)(getProcAddr("glGetPerfMonitorCountersAMD"))
+	gpGetPerfMonitorGroupStringAMD = (C.GPGETPERFMONITORGROUPSTRINGAMD)(getProcAddr("glGetPerfMonitorGroupStringAMD"))
+	gpGetPerfMonitorGroupsAMD = (C.GPGETPERFMONITORGROUPSAMD)(getProcAddr("glGetPerfMonitorGroupsAMD"))
+	gpGetPerfQueryDataINTEL = (C.GPGETPERFQUERYDATAINTEL)(getProcAddr("glGetPerfQueryDataINTEL"))
+	gpGetPerfQueryIdByNameINTEL = (C.GPGETPERFQUERYIDBYNAMEINTEL)(getProcAddr("glGetPerfQueryIdByNameINTEL"))
+	gpGetPerfQueryInfoINTEL = (C.GPGETPERFQUERYINFOINTEL)(getProcAddr("glGetPerfQueryInfoINTEL"))
 	gpGetPixelMapfv = (C.GPGETPIXELMAPFV)(getProcAddr("glGetPixelMapfv"))
 	gpGetPixelMapuiv = (C.GPGETPIXELMAPUIV)(getProcAddr("glGetPixelMapuiv"))
 	gpGetPixelMapusv = (C.GPGETPIXELMAPUSV)(getProcAddr("glGetPixelMapusv"))
+	gpGetPointerIndexedvEXT = (C.GPGETPOINTERINDEXEDVEXT)(getProcAddr("glGetPointerIndexedvEXT"))
+	gpGetPointeri_vEXT = (C.GPGETPOINTERI_VEXT)(getProcAddr("glGetPointeri_vEXT"))
 	gpGetPointerv = (C.GPGETPOINTERV)(getProcAddr("glGetPointerv"))
 	gpGetPointervKHR = (C.GPGETPOINTERVKHR)(getProcAddr("glGetPointervKHR"))
 	gpGetPolygonStipple = (C.GPGETPOLYGONSTIPPLE)(getProcAddr("glGetPolygonStipple"))
@@ -11910,14 +17104,21 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetProgramInfoLog = (C.GPGETPROGRAMINFOLOG)(getProcAddr("glGetProgramInfoLog"))
 	gpGetProgramInterfaceiv = (C.GPGETPROGRAMINTERFACEIV)(getProcAddr("glGetProgramInterfaceiv"))
 	gpGetProgramPipelineInfoLog = (C.GPGETPROGRAMPIPELINEINFOLOG)(getProcAddr("glGetProgramPipelineInfoLog"))
+	gpGetProgramPipelineInfoLogEXT = (C.GPGETPROGRAMPIPELINEINFOLOGEXT)(getProcAddr("glGetProgramPipelineInfoLogEXT"))
 	gpGetProgramPipelineiv = (C.GPGETPROGRAMPIPELINEIV)(getProcAddr("glGetProgramPipelineiv"))
+	gpGetProgramPipelineivEXT = (C.GPGETPROGRAMPIPELINEIVEXT)(getProcAddr("glGetProgramPipelineivEXT"))
 	gpGetProgramResourceIndex = (C.GPGETPROGRAMRESOURCEINDEX)(getProcAddr("glGetProgramResourceIndex"))
 	gpGetProgramResourceLocation = (C.GPGETPROGRAMRESOURCELOCATION)(getProcAddr("glGetProgramResourceLocation"))
 	gpGetProgramResourceLocationIndex = (C.GPGETPROGRAMRESOURCELOCATIONINDEX)(getProcAddr("glGetProgramResourceLocationIndex"))
 	gpGetProgramResourceName = (C.GPGETPROGRAMRESOURCENAME)(getProcAddr("glGetProgramResourceName"))
+	gpGetProgramResourcefvNV = (C.GPGETPROGRAMRESOURCEFVNV)(getProcAddr("glGetProgramResourcefvNV"))
 	gpGetProgramResourceiv = (C.GPGETPROGRAMRESOURCEIV)(getProcAddr("glGetProgramResourceiv"))
 	gpGetProgramStageiv = (C.GPGETPROGRAMSTAGEIV)(getProcAddr("glGetProgramStageiv"))
 	gpGetProgramiv = (C.GPGETPROGRAMIV)(getProcAddr("glGetProgramiv"))
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	gpGetQueryObjecti64v = (C.GPGETQUERYOBJECTI64V)(getProcAddr("glGetQueryObjecti64v"))
 	gpGetQueryObjectiv = (C.GPGETQUERYOBJECTIV)(getProcAddr("glGetQueryObjectiv"))
@@ -11933,6 +17134,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetShaderPrecisionFormat = (C.GPGETSHADERPRECISIONFORMAT)(getProcAddr("glGetShaderPrecisionFormat"))
 	gpGetShaderSource = (C.GPGETSHADERSOURCE)(getProcAddr("glGetShaderSource"))
 	gpGetShaderiv = (C.GPGETSHADERIV)(getProcAddr("glGetShaderiv"))
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	gpGetStringi = (C.GPGETSTRINGI)(getProcAddr("glGetStringi"))
 	gpGetSubroutineIndex = (C.GPGETSUBROUTINEINDEX)(getProcAddr("glGetSubroutineIndex"))
@@ -11951,14 +17153,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetTexParameterfv = (C.GPGETTEXPARAMETERFV)(getProcAddr("glGetTexParameterfv"))
 	gpGetTexParameteriv = (C.GPGETTEXPARAMETERIV)(getProcAddr("glGetTexParameteriv"))
 	gpGetTextureHandleARB = (C.GPGETTEXTUREHANDLEARB)(getProcAddr("glGetTextureHandleARB"))
+	gpGetTextureHandleNV = (C.GPGETTEXTUREHANDLENV)(getProcAddr("glGetTextureHandleNV"))
 	gpGetTextureImage = (C.GPGETTEXTUREIMAGE)(getProcAddr("glGetTextureImage"))
+	gpGetTextureImageEXT = (C.GPGETTEXTUREIMAGEEXT)(getProcAddr("glGetTextureImageEXT"))
 	gpGetTextureLevelParameterfv = (C.GPGETTEXTURELEVELPARAMETERFV)(getProcAddr("glGetTextureLevelParameterfv"))
+	gpGetTextureLevelParameterfvEXT = (C.GPGETTEXTURELEVELPARAMETERFVEXT)(getProcAddr("glGetTextureLevelParameterfvEXT"))
 	gpGetTextureLevelParameteriv = (C.GPGETTEXTURELEVELPARAMETERIV)(getProcAddr("glGetTextureLevelParameteriv"))
+	gpGetTextureLevelParameterivEXT = (C.GPGETTEXTURELEVELPARAMETERIVEXT)(getProcAddr("glGetTextureLevelParameterivEXT"))
 	gpGetTextureParameterIiv = (C.GPGETTEXTUREPARAMETERIIV)(getProcAddr("glGetTextureParameterIiv"))
+	gpGetTextureParameterIivEXT = (C.GPGETTEXTUREPARAMETERIIVEXT)(getProcAddr("glGetTextureParameterIivEXT"))
 	gpGetTextureParameterIuiv = (C.GPGETTEXTUREPARAMETERIUIV)(getProcAddr("glGetTextureParameterIuiv"))
+	gpGetTextureParameterIuivEXT = (C.GPGETTEXTUREPARAMETERIUIVEXT)(getProcAddr("glGetTextureParameterIuivEXT"))
 	gpGetTextureParameterfv = (C.GPGETTEXTUREPARAMETERFV)(getProcAddr("glGetTextureParameterfv"))
+	gpGetTextureParameterfvEXT = (C.GPGETTEXTUREPARAMETERFVEXT)(getProcAddr("glGetTextureParameterfvEXT"))
 	gpGetTextureParameteriv = (C.GPGETTEXTUREPARAMETERIV)(getProcAddr("glGetTextureParameteriv"))
+	gpGetTextureParameterivEXT = (C.GPGETTEXTUREPARAMETERIVEXT)(getProcAddr("glGetTextureParameterivEXT"))
 	gpGetTextureSamplerHandleARB = (C.GPGETTEXTURESAMPLERHANDLEARB)(getProcAddr("glGetTextureSamplerHandleARB"))
+	gpGetTextureSamplerHandleNV = (C.GPGETTEXTURESAMPLERHANDLENV)(getProcAddr("glGetTextureSamplerHandleNV"))
 	gpGetTextureSubImage = (C.GPGETTEXTURESUBIMAGE)(getProcAddr("glGetTextureSubImage"))
 	gpGetTransformFeedbackVarying = (C.GPGETTRANSFORMFEEDBACKVARYING)(getProcAddr("glGetTransformFeedbackVarying"))
 	gpGetTransformFeedbacki64_v = (C.GPGETTRANSFORMFEEDBACKI64_V)(getProcAddr("glGetTransformFeedbacki64_v"))
@@ -11970,19 +17181,30 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetUniformSubroutineuiv = (C.GPGETUNIFORMSUBROUTINEUIV)(getProcAddr("glGetUniformSubroutineuiv"))
 	gpGetUniformdv = (C.GPGETUNIFORMDV)(getProcAddr("glGetUniformdv"))
 	gpGetUniformfv = (C.GPGETUNIFORMFV)(getProcAddr("glGetUniformfv"))
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
+	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
+	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	gpGetVertexArrayIndexed64iv = (C.GPGETVERTEXARRAYINDEXED64IV)(getProcAddr("glGetVertexArrayIndexed64iv"))
 	gpGetVertexArrayIndexediv = (C.GPGETVERTEXARRAYINDEXEDIV)(getProcAddr("glGetVertexArrayIndexediv"))
+	gpGetVertexArrayIntegeri_vEXT = (C.GPGETVERTEXARRAYINTEGERI_VEXT)(getProcAddr("glGetVertexArrayIntegeri_vEXT"))
+	gpGetVertexArrayIntegervEXT = (C.GPGETVERTEXARRAYINTEGERVEXT)(getProcAddr("glGetVertexArrayIntegervEXT"))
+	gpGetVertexArrayPointeri_vEXT = (C.GPGETVERTEXARRAYPOINTERI_VEXT)(getProcAddr("glGetVertexArrayPointeri_vEXT"))
+	gpGetVertexArrayPointervEXT = (C.GPGETVERTEXARRAYPOINTERVEXT)(getProcAddr("glGetVertexArrayPointervEXT"))
 	gpGetVertexArrayiv = (C.GPGETVERTEXARRAYIV)(getProcAddr("glGetVertexArrayiv"))
 	gpGetVertexAttribIiv = (C.GPGETVERTEXATTRIBIIV)(getProcAddr("glGetVertexAttribIiv"))
 	gpGetVertexAttribIuiv = (C.GPGETVERTEXATTRIBIUIV)(getProcAddr("glGetVertexAttribIuiv"))
 	gpGetVertexAttribLdv = (C.GPGETVERTEXATTRIBLDV)(getProcAddr("glGetVertexAttribLdv"))
+	gpGetVertexAttribLi64vNV = (C.GPGETVERTEXATTRIBLI64VNV)(getProcAddr("glGetVertexAttribLi64vNV"))
 	gpGetVertexAttribLui64vARB = (C.GPGETVERTEXATTRIBLUI64VARB)(getProcAddr("glGetVertexAttribLui64vARB"))
+	gpGetVertexAttribLui64vNV = (C.GPGETVERTEXATTRIBLUI64VNV)(getProcAddr("glGetVertexAttribLui64vNV"))
 	gpGetVertexAttribPointerv = (C.GPGETVERTEXATTRIBPOINTERV)(getProcAddr("glGetVertexAttribPointerv"))
 	gpGetVertexAttribdv = (C.GPGETVERTEXATTRIBDV)(getProcAddr("glGetVertexAttribdv"))
 	gpGetVertexAttribfv = (C.GPGETVERTEXATTRIBFV)(getProcAddr("glGetVertexAttribfv"))
 	gpGetVertexAttribiv = (C.GPGETVERTEXATTRIBIV)(getProcAddr("glGetVertexAttribiv"))
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnCompressedTexImage = (C.GPGETNCOMPRESSEDTEXIMAGE)(getProcAddr("glGetnCompressedTexImage"))
 	gpGetnCompressedTexImageARB = (C.GPGETNCOMPRESSEDTEXIMAGEARB)(getProcAddr("glGetnCompressedTexImageARB"))
 	gpGetnTexImage = (C.GPGETNTEXIMAGE)(getProcAddr("glGetnTexImage"))
@@ -11992,13 +17214,16 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	gpGetnUniformuivARB = (C.GPGETNUNIFORMUIVARB)(getProcAddr("glGetnUniformuivARB"))
 	gpGetnUniformuivKHR = (C.GPGETNUNIFORMUIVKHR)(getProcAddr("glGetnUniformuivKHR"))
 	gpHint = (C.GPHINT)(getProcAddr("glHint"))
+	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
 	gpIndexMask = (C.GPINDEXMASK)(getProcAddr("glIndexMask"))
 	gpIndexPointer = (C.GPINDEXPOINTER)(getProcAddr("glIndexPointer"))
 	gpIndexd = (C.GPINDEXD)(getProcAddr("glIndexd"))
@@ -12012,7 +17237,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpIndexub = (C.GPINDEXUB)(getProcAddr("glIndexub"))
 	gpIndexubv = (C.GPINDEXUBV)(getProcAddr("glIndexubv"))
 	gpInitNames = (C.GPINITNAMES)(getProcAddr("glInitNames"))
+	gpInsertEventMarkerEXT = (C.GPINSERTEVENTMARKEREXT)(getProcAddr("glInsertEventMarkerEXT"))
 	gpInterleavedArrays = (C.GPINTERLEAVEDARRAYS)(getProcAddr("glInterleavedArrays"))
+	gpInterpolatePathsNV = (C.GPINTERPOLATEPATHSNV)(getProcAddr("glInterpolatePathsNV"))
 	gpInvalidateBufferData = (C.GPINVALIDATEBUFFERDATA)(getProcAddr("glInvalidateBufferData"))
 	gpInvalidateBufferSubData = (C.GPINVALIDATEBUFFERSUBDATA)(getProcAddr("glInvalidateBufferSubData"))
 	gpInvalidateFramebuffer = (C.GPINVALIDATEFRAMEBUFFER)(getProcAddr("glInvalidateFramebuffer"))
@@ -12022,23 +17249,35 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpInvalidateTexImage = (C.GPINVALIDATETEXIMAGE)(getProcAddr("glInvalidateTexImage"))
 	gpInvalidateTexSubImage = (C.GPINVALIDATETEXSUBIMAGE)(getProcAddr("glInvalidateTexSubImage"))
 	gpIsBuffer = (C.GPISBUFFER)(getProcAddr("glIsBuffer"))
+	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
+	gpIsEnabledIndexedEXT = (C.GPISENABLEDINDEXEDEXT)(getProcAddr("glIsEnabledIndexedEXT"))
 	gpIsEnabledi = (C.GPISENABLEDI)(getProcAddr("glIsEnabledi"))
 	gpIsFramebuffer = (C.GPISFRAMEBUFFER)(getProcAddr("glIsFramebuffer"))
 	gpIsImageHandleResidentARB = (C.GPISIMAGEHANDLERESIDENTARB)(getProcAddr("glIsImageHandleResidentARB"))
+	gpIsImageHandleResidentNV = (C.GPISIMAGEHANDLERESIDENTNV)(getProcAddr("glIsImageHandleResidentNV"))
 	gpIsList = (C.GPISLIST)(getProcAddr("glIsList"))
+	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
+	gpIsPathNV = (C.GPISPATHNV)(getProcAddr("glIsPathNV"))
+	gpIsPointInFillPathNV = (C.GPISPOINTINFILLPATHNV)(getProcAddr("glIsPointInFillPathNV"))
+	gpIsPointInStrokePathNV = (C.GPISPOINTINSTROKEPATHNV)(getProcAddr("glIsPointInStrokePathNV"))
 	gpIsProgram = (C.GPISPROGRAM)(getProcAddr("glIsProgram"))
 	gpIsProgramPipeline = (C.GPISPROGRAMPIPELINE)(getProcAddr("glIsProgramPipeline"))
+	gpIsProgramPipelineEXT = (C.GPISPROGRAMPIPELINEEXT)(getProcAddr("glIsProgramPipelineEXT"))
 	gpIsQuery = (C.GPISQUERY)(getProcAddr("glIsQuery"))
 	gpIsRenderbuffer = (C.GPISRENDERBUFFER)(getProcAddr("glIsRenderbuffer"))
 	gpIsSampler = (C.GPISSAMPLER)(getProcAddr("glIsSampler"))
 	gpIsShader = (C.GPISSHADER)(getProcAddr("glIsShader"))
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	gpIsTexture = (C.GPISTEXTURE)(getProcAddr("glIsTexture"))
 	gpIsTextureHandleResidentARB = (C.GPISTEXTUREHANDLERESIDENTARB)(getProcAddr("glIsTextureHandleResidentARB"))
+	gpIsTextureHandleResidentNV = (C.GPISTEXTUREHANDLERESIDENTNV)(getProcAddr("glIsTextureHandleResidentNV"))
 	gpIsTransformFeedback = (C.GPISTRANSFORMFEEDBACK)(getProcAddr("glIsTransformFeedback"))
 	gpIsVertexArray = (C.GPISVERTEXARRAY)(getProcAddr("glIsVertexArray"))
+	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLightModelf = (C.GPLIGHTMODELF)(getProcAddr("glLightModelf"))
 	gpLightModelfv = (C.GPLIGHTMODELFV)(getProcAddr("glLightModelfv"))
 	gpLightModeli = (C.GPLIGHTMODELI)(getProcAddr("glLightModeli"))
@@ -12051,6 +17290,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpLineWidth = (C.GPLINEWIDTH)(getProcAddr("glLineWidth"))
 	gpLinkProgram = (C.GPLINKPROGRAM)(getProcAddr("glLinkProgram"))
 	gpListBase = (C.GPLISTBASE)(getProcAddr("glListBase"))
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpLoadIdentity = (C.GPLOADIDENTITY)(getProcAddr("glLoadIdentity"))
 	gpLoadMatrixd = (C.GPLOADMATRIXD)(getProcAddr("glLoadMatrixd"))
 	gpLoadMatrixf = (C.GPLOADMATRIXF)(getProcAddr("glLoadMatrixf"))
@@ -12058,10 +17298,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpLoadTransposeMatrixd = (C.GPLOADTRANSPOSEMATRIXD)(getProcAddr("glLoadTransposeMatrixd"))
 	gpLoadTransposeMatrixf = (C.GPLOADTRANSPOSEMATRIXF)(getProcAddr("glLoadTransposeMatrixf"))
 	gpLogicOp = (C.GPLOGICOP)(getProcAddr("glLogicOp"))
+	gpMakeBufferNonResidentNV = (C.GPMAKEBUFFERNONRESIDENTNV)(getProcAddr("glMakeBufferNonResidentNV"))
+	gpMakeBufferResidentNV = (C.GPMAKEBUFFERRESIDENTNV)(getProcAddr("glMakeBufferResidentNV"))
 	gpMakeImageHandleNonResidentARB = (C.GPMAKEIMAGEHANDLENONRESIDENTARB)(getProcAddr("glMakeImageHandleNonResidentARB"))
+	gpMakeImageHandleNonResidentNV = (C.GPMAKEIMAGEHANDLENONRESIDENTNV)(getProcAddr("glMakeImageHandleNonResidentNV"))
 	gpMakeImageHandleResidentARB = (C.GPMAKEIMAGEHANDLERESIDENTARB)(getProcAddr("glMakeImageHandleResidentARB"))
+	gpMakeImageHandleResidentNV = (C.GPMAKEIMAGEHANDLERESIDENTNV)(getProcAddr("glMakeImageHandleResidentNV"))
+	gpMakeNamedBufferNonResidentNV = (C.GPMAKENAMEDBUFFERNONRESIDENTNV)(getProcAddr("glMakeNamedBufferNonResidentNV"))
+	gpMakeNamedBufferResidentNV = (C.GPMAKENAMEDBUFFERRESIDENTNV)(getProcAddr("glMakeNamedBufferResidentNV"))
 	gpMakeTextureHandleNonResidentARB = (C.GPMAKETEXTUREHANDLENONRESIDENTARB)(getProcAddr("glMakeTextureHandleNonResidentARB"))
+	gpMakeTextureHandleNonResidentNV = (C.GPMAKETEXTUREHANDLENONRESIDENTNV)(getProcAddr("glMakeTextureHandleNonResidentNV"))
 	gpMakeTextureHandleResidentARB = (C.GPMAKETEXTUREHANDLERESIDENTARB)(getProcAddr("glMakeTextureHandleResidentARB"))
+	gpMakeTextureHandleResidentNV = (C.GPMAKETEXTUREHANDLERESIDENTNV)(getProcAddr("glMakeTextureHandleResidentNV"))
 	gpMap1d = (C.GPMAP1D)(getProcAddr("glMap1d"))
 	gpMap1f = (C.GPMAP1F)(getProcAddr("glMap1f"))
 	gpMap2d = (C.GPMAP2D)(getProcAddr("glMap2d"))
@@ -12073,12 +17321,41 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMapGrid2d = (C.GPMAPGRID2D)(getProcAddr("glMapGrid2d"))
 	gpMapGrid2f = (C.GPMAPGRID2F)(getProcAddr("glMapGrid2f"))
 	gpMapNamedBuffer = (C.GPMAPNAMEDBUFFER)(getProcAddr("glMapNamedBuffer"))
+	gpMapNamedBufferEXT = (C.GPMAPNAMEDBUFFEREXT)(getProcAddr("glMapNamedBufferEXT"))
 	gpMapNamedBufferRange = (C.GPMAPNAMEDBUFFERRANGE)(getProcAddr("glMapNamedBufferRange"))
+	gpMapNamedBufferRangeEXT = (C.GPMAPNAMEDBUFFERRANGEEXT)(getProcAddr("glMapNamedBufferRangeEXT"))
 	gpMaterialf = (C.GPMATERIALF)(getProcAddr("glMaterialf"))
 	gpMaterialfv = (C.GPMATERIALFV)(getProcAddr("glMaterialfv"))
 	gpMateriali = (C.GPMATERIALI)(getProcAddr("glMateriali"))
 	gpMaterialiv = (C.GPMATERIALIV)(getProcAddr("glMaterialiv"))
+	gpMatrixFrustumEXT = (C.GPMATRIXFRUSTUMEXT)(getProcAddr("glMatrixFrustumEXT"))
+	gpMatrixLoad3x2fNV = (C.GPMATRIXLOAD3X2FNV)(getProcAddr("glMatrixLoad3x2fNV"))
+	gpMatrixLoad3x3fNV = (C.GPMATRIXLOAD3X3FNV)(getProcAddr("glMatrixLoad3x3fNV"))
+	gpMatrixLoadIdentityEXT = (C.GPMATRIXLOADIDENTITYEXT)(getProcAddr("glMatrixLoadIdentityEXT"))
+	gpMatrixLoadTranspose3x3fNV = (C.GPMATRIXLOADTRANSPOSE3X3FNV)(getProcAddr("glMatrixLoadTranspose3x3fNV"))
+	gpMatrixLoadTransposedEXT = (C.GPMATRIXLOADTRANSPOSEDEXT)(getProcAddr("glMatrixLoadTransposedEXT"))
+	gpMatrixLoadTransposefEXT = (C.GPMATRIXLOADTRANSPOSEFEXT)(getProcAddr("glMatrixLoadTransposefEXT"))
+	gpMatrixLoaddEXT = (C.GPMATRIXLOADDEXT)(getProcAddr("glMatrixLoaddEXT"))
+	gpMatrixLoadfEXT = (C.GPMATRIXLOADFEXT)(getProcAddr("glMatrixLoadfEXT"))
 	gpMatrixMode = (C.GPMATRIXMODE)(getProcAddr("glMatrixMode"))
+	gpMatrixMult3x2fNV = (C.GPMATRIXMULT3X2FNV)(getProcAddr("glMatrixMult3x2fNV"))
+	gpMatrixMult3x3fNV = (C.GPMATRIXMULT3X3FNV)(getProcAddr("glMatrixMult3x3fNV"))
+	gpMatrixMultTranspose3x3fNV = (C.GPMATRIXMULTTRANSPOSE3X3FNV)(getProcAddr("glMatrixMultTranspose3x3fNV"))
+	gpMatrixMultTransposedEXT = (C.GPMATRIXMULTTRANSPOSEDEXT)(getProcAddr("glMatrixMultTransposedEXT"))
+	gpMatrixMultTransposefEXT = (C.GPMATRIXMULTTRANSPOSEFEXT)(getProcAddr("glMatrixMultTransposefEXT"))
+	gpMatrixMultdEXT = (C.GPMATRIXMULTDEXT)(getProcAddr("glMatrixMultdEXT"))
+	gpMatrixMultfEXT = (C.GPMATRIXMULTFEXT)(getProcAddr("glMatrixMultfEXT"))
+	gpMatrixOrthoEXT = (C.GPMATRIXORTHOEXT)(getProcAddr("glMatrixOrthoEXT"))
+	gpMatrixPopEXT = (C.GPMATRIXPOPEXT)(getProcAddr("glMatrixPopEXT"))
+	gpMatrixPushEXT = (C.GPMATRIXPUSHEXT)(getProcAddr("glMatrixPushEXT"))
+	gpMatrixRotatedEXT = (C.GPMATRIXROTATEDEXT)(getProcAddr("glMatrixRotatedEXT"))
+	gpMatrixRotatefEXT = (C.GPMATRIXROTATEFEXT)(getProcAddr("glMatrixRotatefEXT"))
+	gpMatrixScaledEXT = (C.GPMATRIXSCALEDEXT)(getProcAddr("glMatrixScaledEXT"))
+	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
+	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
+	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	gpMemoryBarrierByRegion = (C.GPMEMORYBARRIERBYREGION)(getProcAddr("glMemoryBarrierByRegion"))
 	gpMinSampleShading = (C.GPMINSAMPLESHADING)(getProcAddr("glMinSampleShading"))
@@ -12089,11 +17366,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMultTransposeMatrixf = (C.GPMULTTRANSPOSEMATRIXF)(getProcAddr("glMultTransposeMatrixf"))
 	gpMultiDrawArrays = (C.GPMULTIDRAWARRAYS)(getProcAddr("glMultiDrawArrays"))
 	gpMultiDrawArraysIndirect = (C.GPMULTIDRAWARRAYSINDIRECT)(getProcAddr("glMultiDrawArraysIndirect"))
+	gpMultiDrawArraysIndirectBindlessCountNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawArraysIndirectBindlessCountNV"))
+	gpMultiDrawArraysIndirectBindlessNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawArraysIndirectBindlessNV"))
+	gpMultiDrawArraysIndirectCount = (C.GPMULTIDRAWARRAYSINDIRECTCOUNT)(getProcAddr("glMultiDrawArraysIndirectCount"))
 	gpMultiDrawArraysIndirectCountARB = (C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawArraysIndirectCountARB"))
 	gpMultiDrawElements = (C.GPMULTIDRAWELEMENTS)(getProcAddr("glMultiDrawElements"))
 	gpMultiDrawElementsBaseVertex = (C.GPMULTIDRAWELEMENTSBASEVERTEX)(getProcAddr("glMultiDrawElementsBaseVertex"))
 	gpMultiDrawElementsIndirect = (C.GPMULTIDRAWELEMENTSINDIRECT)(getProcAddr("glMultiDrawElementsIndirect"))
+	gpMultiDrawElementsIndirectBindlessCountNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawElementsIndirectBindlessCountNV"))
+	gpMultiDrawElementsIndirectBindlessNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawElementsIndirectBindlessNV"))
+	gpMultiDrawElementsIndirectCount = (C.GPMULTIDRAWELEMENTSINDIRECTCOUNT)(getProcAddr("glMultiDrawElementsIndirectCount"))
 	gpMultiDrawElementsIndirectCountARB = (C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawElementsIndirectCountARB"))
+	gpMultiTexBufferEXT = (C.GPMULTITEXBUFFEREXT)(getProcAddr("glMultiTexBufferEXT"))
 	gpMultiTexCoord1d = (C.GPMULTITEXCOORD1D)(getProcAddr("glMultiTexCoord1d"))
 	gpMultiTexCoord1dv = (C.GPMULTITEXCOORD1DV)(getProcAddr("glMultiTexCoord1dv"))
 	gpMultiTexCoord1f = (C.GPMULTITEXCOORD1F)(getProcAddr("glMultiTexCoord1f"))
@@ -12126,20 +17410,73 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMultiTexCoord4iv = (C.GPMULTITEXCOORD4IV)(getProcAddr("glMultiTexCoord4iv"))
 	gpMultiTexCoord4s = (C.GPMULTITEXCOORD4S)(getProcAddr("glMultiTexCoord4s"))
 	gpMultiTexCoord4sv = (C.GPMULTITEXCOORD4SV)(getProcAddr("glMultiTexCoord4sv"))
+	gpMultiTexCoordPointerEXT = (C.GPMULTITEXCOORDPOINTEREXT)(getProcAddr("glMultiTexCoordPointerEXT"))
+	gpMultiTexEnvfEXT = (C.GPMULTITEXENVFEXT)(getProcAddr("glMultiTexEnvfEXT"))
+	gpMultiTexEnvfvEXT = (C.GPMULTITEXENVFVEXT)(getProcAddr("glMultiTexEnvfvEXT"))
+	gpMultiTexEnviEXT = (C.GPMULTITEXENVIEXT)(getProcAddr("glMultiTexEnviEXT"))
+	gpMultiTexEnvivEXT = (C.GPMULTITEXENVIVEXT)(getProcAddr("glMultiTexEnvivEXT"))
+	gpMultiTexGendEXT = (C.GPMULTITEXGENDEXT)(getProcAddr("glMultiTexGendEXT"))
+	gpMultiTexGendvEXT = (C.GPMULTITEXGENDVEXT)(getProcAddr("glMultiTexGendvEXT"))
+	gpMultiTexGenfEXT = (C.GPMULTITEXGENFEXT)(getProcAddr("glMultiTexGenfEXT"))
+	gpMultiTexGenfvEXT = (C.GPMULTITEXGENFVEXT)(getProcAddr("glMultiTexGenfvEXT"))
+	gpMultiTexGeniEXT = (C.GPMULTITEXGENIEXT)(getProcAddr("glMultiTexGeniEXT"))
+	gpMultiTexGenivEXT = (C.GPMULTITEXGENIVEXT)(getProcAddr("glMultiTexGenivEXT"))
+	gpMultiTexImage1DEXT = (C.GPMULTITEXIMAGE1DEXT)(getProcAddr("glMultiTexImage1DEXT"))
+	gpMultiTexImage2DEXT = (C.GPMULTITEXIMAGE2DEXT)(getProcAddr("glMultiTexImage2DEXT"))
+	gpMultiTexImage3DEXT = (C.GPMULTITEXIMAGE3DEXT)(getProcAddr("glMultiTexImage3DEXT"))
+	gpMultiTexParameterIivEXT = (C.GPMULTITEXPARAMETERIIVEXT)(getProcAddr("glMultiTexParameterIivEXT"))
+	gpMultiTexParameterIuivEXT = (C.GPMULTITEXPARAMETERIUIVEXT)(getProcAddr("glMultiTexParameterIuivEXT"))
+	gpMultiTexParameterfEXT = (C.GPMULTITEXPARAMETERFEXT)(getProcAddr("glMultiTexParameterfEXT"))
+	gpMultiTexParameterfvEXT = (C.GPMULTITEXPARAMETERFVEXT)(getProcAddr("glMultiTexParameterfvEXT"))
+	gpMultiTexParameteriEXT = (C.GPMULTITEXPARAMETERIEXT)(getProcAddr("glMultiTexParameteriEXT"))
+	gpMultiTexParameterivEXT = (C.GPMULTITEXPARAMETERIVEXT)(getProcAddr("glMultiTexParameterivEXT"))
+	gpMultiTexRenderbufferEXT = (C.GPMULTITEXRENDERBUFFEREXT)(getProcAddr("glMultiTexRenderbufferEXT"))
+	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
+	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
+	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
+	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
+	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
+	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
+	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
 	gpNamedFramebufferDrawBuffer = (C.GPNAMEDFRAMEBUFFERDRAWBUFFER)(getProcAddr("glNamedFramebufferDrawBuffer"))
 	gpNamedFramebufferDrawBuffers = (C.GPNAMEDFRAMEBUFFERDRAWBUFFERS)(getProcAddr("glNamedFramebufferDrawBuffers"))
 	gpNamedFramebufferParameteri = (C.GPNAMEDFRAMEBUFFERPARAMETERI)(getProcAddr("glNamedFramebufferParameteri"))
+	gpNamedFramebufferParameteriEXT = (C.GPNAMEDFRAMEBUFFERPARAMETERIEXT)(getProcAddr("glNamedFramebufferParameteriEXT"))
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	gpNamedFramebufferRenderbuffer = (C.GPNAMEDFRAMEBUFFERRENDERBUFFER)(getProcAddr("glNamedFramebufferRenderbuffer"))
+	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
+	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
+	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
+	gpNamedFramebufferTexture3DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(getProcAddr("glNamedFramebufferTexture3DEXT"))
+	gpNamedFramebufferTextureEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREEXT)(getProcAddr("glNamedFramebufferTextureEXT"))
+	gpNamedFramebufferTextureFaceEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(getProcAddr("glNamedFramebufferTextureFaceEXT"))
 	gpNamedFramebufferTextureLayer = (C.GPNAMEDFRAMEBUFFERTEXTURELAYER)(getProcAddr("glNamedFramebufferTextureLayer"))
+	gpNamedFramebufferTextureLayerEXT = (C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glNamedFramebufferTextureLayerEXT"))
+	gpNamedProgramLocalParameter4dEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(getProcAddr("glNamedProgramLocalParameter4dEXT"))
+	gpNamedProgramLocalParameter4dvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(getProcAddr("glNamedProgramLocalParameter4dvEXT"))
+	gpNamedProgramLocalParameter4fEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(getProcAddr("glNamedProgramLocalParameter4fEXT"))
+	gpNamedProgramLocalParameter4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(getProcAddr("glNamedProgramLocalParameter4fvEXT"))
+	gpNamedProgramLocalParameterI4iEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(getProcAddr("glNamedProgramLocalParameterI4iEXT"))
+	gpNamedProgramLocalParameterI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(getProcAddr("glNamedProgramLocalParameterI4ivEXT"))
+	gpNamedProgramLocalParameterI4uiEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(getProcAddr("glNamedProgramLocalParameterI4uiEXT"))
+	gpNamedProgramLocalParameterI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(getProcAddr("glNamedProgramLocalParameterI4uivEXT"))
+	gpNamedProgramLocalParameters4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(getProcAddr("glNamedProgramLocalParameters4fvEXT"))
+	gpNamedProgramLocalParametersI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(getProcAddr("glNamedProgramLocalParametersI4ivEXT"))
+	gpNamedProgramLocalParametersI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(getProcAddr("glNamedProgramLocalParametersI4uivEXT"))
+	gpNamedProgramStringEXT = (C.GPNAMEDPROGRAMSTRINGEXT)(getProcAddr("glNamedProgramStringEXT"))
 	gpNamedRenderbufferStorage = (C.GPNAMEDRENDERBUFFERSTORAGE)(getProcAddr("glNamedRenderbufferStorage"))
+	gpNamedRenderbufferStorageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEEXT)(getProcAddr("glNamedRenderbufferStorageEXT"))
 	gpNamedRenderbufferStorageMultisample = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(getProcAddr("glNamedRenderbufferStorageMultisample"))
+	gpNamedRenderbufferStorageMultisampleCoverageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleCoverageEXT"))
+	gpNamedRenderbufferStorageMultisampleEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleEXT"))
 	gpNamedStringARB = (C.GPNAMEDSTRINGARB)(getProcAddr("glNamedStringARB"))
 	gpNewList = (C.GPNEWLIST)(getProcAddr("glNewList"))
 	gpNormal3b = (C.GPNORMAL3B)(getProcAddr("glNormal3b"))
@@ -12152,6 +17489,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpNormal3iv = (C.GPNORMAL3IV)(getProcAddr("glNormal3iv"))
 	gpNormal3s = (C.GPNORMAL3S)(getProcAddr("glNormal3s"))
 	gpNormal3sv = (C.GPNORMAL3SV)(getProcAddr("glNormal3sv"))
+	gpNormalFormatNV = (C.GPNORMALFORMATNV)(getProcAddr("glNormalFormatNV"))
 	gpNormalPointer = (C.GPNORMALPOINTER)(getProcAddr("glNormalPointer"))
 	gpObjectLabel = (C.GPOBJECTLABEL)(getProcAddr("glObjectLabel"))
 	gpObjectLabelKHR = (C.GPOBJECTLABELKHR)(getProcAddr("glObjectLabelKHR"))
@@ -12161,6 +17499,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpPassThrough = (C.GPPASSTHROUGH)(getProcAddr("glPassThrough"))
 	gpPatchParameterfv = (C.GPPATCHPARAMETERFV)(getProcAddr("glPatchParameterfv"))
 	gpPatchParameteri = (C.GPPATCHPARAMETERI)(getProcAddr("glPatchParameteri"))
+	gpPathCommandsNV = (C.GPPATHCOMMANDSNV)(getProcAddr("glPathCommandsNV"))
+	gpPathCoordsNV = (C.GPPATHCOORDSNV)(getProcAddr("glPathCoordsNV"))
+	gpPathCoverDepthFuncNV = (C.GPPATHCOVERDEPTHFUNCNV)(getProcAddr("glPathCoverDepthFuncNV"))
+	gpPathDashArrayNV = (C.GPPATHDASHARRAYNV)(getProcAddr("glPathDashArrayNV"))
+	gpPathGlyphIndexArrayNV = (C.GPPATHGLYPHINDEXARRAYNV)(getProcAddr("glPathGlyphIndexArrayNV"))
+	gpPathGlyphIndexRangeNV = (C.GPPATHGLYPHINDEXRANGENV)(getProcAddr("glPathGlyphIndexRangeNV"))
+	gpPathGlyphRangeNV = (C.GPPATHGLYPHRANGENV)(getProcAddr("glPathGlyphRangeNV"))
+	gpPathGlyphsNV = (C.GPPATHGLYPHSNV)(getProcAddr("glPathGlyphsNV"))
+	gpPathMemoryGlyphIndexArrayNV = (C.GPPATHMEMORYGLYPHINDEXARRAYNV)(getProcAddr("glPathMemoryGlyphIndexArrayNV"))
+	gpPathParameterfNV = (C.GPPATHPARAMETERFNV)(getProcAddr("glPathParameterfNV"))
+	gpPathParameterfvNV = (C.GPPATHPARAMETERFVNV)(getProcAddr("glPathParameterfvNV"))
+	gpPathParameteriNV = (C.GPPATHPARAMETERINV)(getProcAddr("glPathParameteriNV"))
+	gpPathParameterivNV = (C.GPPATHPARAMETERIVNV)(getProcAddr("glPathParameterivNV"))
+	gpPathStencilDepthOffsetNV = (C.GPPATHSTENCILDEPTHOFFSETNV)(getProcAddr("glPathStencilDepthOffsetNV"))
+	gpPathStencilFuncNV = (C.GPPATHSTENCILFUNCNV)(getProcAddr("glPathStencilFuncNV"))
+	gpPathStringNV = (C.GPPATHSTRINGNV)(getProcAddr("glPathStringNV"))
+	gpPathSubCommandsNV = (C.GPPATHSUBCOMMANDSNV)(getProcAddr("glPathSubCommandsNV"))
+	gpPathSubCoordsNV = (C.GPPATHSUBCOORDSNV)(getProcAddr("glPathSubCoordsNV"))
 	gpPauseTransformFeedback = (C.GPPAUSETRANSFORMFEEDBACK)(getProcAddr("glPauseTransformFeedback"))
 	gpPixelMapfv = (C.GPPIXELMAPFV)(getProcAddr("glPixelMapfv"))
 	gpPixelMapuiv = (C.GPPIXELMAPUIV)(getProcAddr("glPixelMapuiv"))
@@ -12170,6 +17526,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpPixelTransferf = (C.GPPIXELTRANSFERF)(getProcAddr("glPixelTransferf"))
 	gpPixelTransferi = (C.GPPIXELTRANSFERI)(getProcAddr("glPixelTransferi"))
 	gpPixelZoom = (C.GPPIXELZOOM)(getProcAddr("glPixelZoom"))
+	gpPointAlongPathNV = (C.GPPOINTALONGPATHNV)(getProcAddr("glPointAlongPathNV"))
 	gpPointParameterf = (C.GPPOINTPARAMETERF)(getProcAddr("glPointParameterf"))
 	gpPointParameterfv = (C.GPPOINTPARAMETERFV)(getProcAddr("glPointParameterfv"))
 	gpPointParameteri = (C.GPPOINTPARAMETERI)(getProcAddr("glPointParameteri"))
@@ -12177,74 +17534,169 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpPointSize = (C.GPPOINTSIZE)(getProcAddr("glPointSize"))
 	gpPolygonMode = (C.GPPOLYGONMODE)(getProcAddr("glPolygonMode"))
 	gpPolygonOffset = (C.GPPOLYGONOFFSET)(getProcAddr("glPolygonOffset"))
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPolygonStipple = (C.GPPOLYGONSTIPPLE)(getProcAddr("glPolygonStipple"))
 	gpPopAttrib = (C.GPPOPATTRIB)(getProcAddr("glPopAttrib"))
 	gpPopClientAttrib = (C.GPPOPCLIENTATTRIB)(getProcAddr("glPopClientAttrib"))
 	gpPopDebugGroup = (C.GPPOPDEBUGGROUP)(getProcAddr("glPopDebugGroup"))
 	gpPopDebugGroupKHR = (C.GPPOPDEBUGGROUPKHR)(getProcAddr("glPopDebugGroupKHR"))
+	gpPopGroupMarkerEXT = (C.GPPOPGROUPMARKEREXT)(getProcAddr("glPopGroupMarkerEXT"))
 	gpPopMatrix = (C.GPPOPMATRIX)(getProcAddr("glPopMatrix"))
 	gpPopName = (C.GPPOPNAME)(getProcAddr("glPopName"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	gpPrioritizeTextures = (C.GPPRIORITIZETEXTURES)(getProcAddr("glPrioritizeTextures"))
 	gpProgramBinary = (C.GPPROGRAMBINARY)(getProcAddr("glProgramBinary"))
 	gpProgramParameteri = (C.GPPROGRAMPARAMETERI)(getProcAddr("glProgramParameteri"))
+	gpProgramParameteriARB = (C.GPPROGRAMPARAMETERIARB)(getProcAddr("glProgramParameteriARB"))
+	gpProgramParameteriEXT = (C.GPPROGRAMPARAMETERIEXT)(getProcAddr("glProgramParameteriEXT"))
+	gpProgramPathFragmentInputGenNV = (C.GPPROGRAMPATHFRAGMENTINPUTGENNV)(getProcAddr("glProgramPathFragmentInputGenNV"))
 	gpProgramUniform1d = (C.GPPROGRAMUNIFORM1D)(getProcAddr("glProgramUniform1d"))
+	gpProgramUniform1dEXT = (C.GPPROGRAMUNIFORM1DEXT)(getProcAddr("glProgramUniform1dEXT"))
 	gpProgramUniform1dv = (C.GPPROGRAMUNIFORM1DV)(getProcAddr("glProgramUniform1dv"))
+	gpProgramUniform1dvEXT = (C.GPPROGRAMUNIFORM1DVEXT)(getProcAddr("glProgramUniform1dvEXT"))
 	gpProgramUniform1f = (C.GPPROGRAMUNIFORM1F)(getProcAddr("glProgramUniform1f"))
+	gpProgramUniform1fEXT = (C.GPPROGRAMUNIFORM1FEXT)(getProcAddr("glProgramUniform1fEXT"))
 	gpProgramUniform1fv = (C.GPPROGRAMUNIFORM1FV)(getProcAddr("glProgramUniform1fv"))
+	gpProgramUniform1fvEXT = (C.GPPROGRAMUNIFORM1FVEXT)(getProcAddr("glProgramUniform1fvEXT"))
 	gpProgramUniform1i = (C.GPPROGRAMUNIFORM1I)(getProcAddr("glProgramUniform1i"))
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
+	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
+	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
+	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
+	gpProgramUniform1ivEXT = (C.GPPROGRAMUNIFORM1IVEXT)(getProcAddr("glProgramUniform1ivEXT"))
 	gpProgramUniform1ui = (C.GPPROGRAMUNIFORM1UI)(getProcAddr("glProgramUniform1ui"))
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
+	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
+	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
+	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
+	gpProgramUniform1uivEXT = (C.GPPROGRAMUNIFORM1UIVEXT)(getProcAddr("glProgramUniform1uivEXT"))
 	gpProgramUniform2d = (C.GPPROGRAMUNIFORM2D)(getProcAddr("glProgramUniform2d"))
+	gpProgramUniform2dEXT = (C.GPPROGRAMUNIFORM2DEXT)(getProcAddr("glProgramUniform2dEXT"))
 	gpProgramUniform2dv = (C.GPPROGRAMUNIFORM2DV)(getProcAddr("glProgramUniform2dv"))
+	gpProgramUniform2dvEXT = (C.GPPROGRAMUNIFORM2DVEXT)(getProcAddr("glProgramUniform2dvEXT"))
 	gpProgramUniform2f = (C.GPPROGRAMUNIFORM2F)(getProcAddr("glProgramUniform2f"))
+	gpProgramUniform2fEXT = (C.GPPROGRAMUNIFORM2FEXT)(getProcAddr("glProgramUniform2fEXT"))
 	gpProgramUniform2fv = (C.GPPROGRAMUNIFORM2FV)(getProcAddr("glProgramUniform2fv"))
+	gpProgramUniform2fvEXT = (C.GPPROGRAMUNIFORM2FVEXT)(getProcAddr("glProgramUniform2fvEXT"))
 	gpProgramUniform2i = (C.GPPROGRAMUNIFORM2I)(getProcAddr("glProgramUniform2i"))
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
+	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
+	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
+	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
+	gpProgramUniform2ivEXT = (C.GPPROGRAMUNIFORM2IVEXT)(getProcAddr("glProgramUniform2ivEXT"))
 	gpProgramUniform2ui = (C.GPPROGRAMUNIFORM2UI)(getProcAddr("glProgramUniform2ui"))
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
+	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
+	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
+	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
+	gpProgramUniform2uivEXT = (C.GPPROGRAMUNIFORM2UIVEXT)(getProcAddr("glProgramUniform2uivEXT"))
 	gpProgramUniform3d = (C.GPPROGRAMUNIFORM3D)(getProcAddr("glProgramUniform3d"))
+	gpProgramUniform3dEXT = (C.GPPROGRAMUNIFORM3DEXT)(getProcAddr("glProgramUniform3dEXT"))
 	gpProgramUniform3dv = (C.GPPROGRAMUNIFORM3DV)(getProcAddr("glProgramUniform3dv"))
+	gpProgramUniform3dvEXT = (C.GPPROGRAMUNIFORM3DVEXT)(getProcAddr("glProgramUniform3dvEXT"))
 	gpProgramUniform3f = (C.GPPROGRAMUNIFORM3F)(getProcAddr("glProgramUniform3f"))
+	gpProgramUniform3fEXT = (C.GPPROGRAMUNIFORM3FEXT)(getProcAddr("glProgramUniform3fEXT"))
 	gpProgramUniform3fv = (C.GPPROGRAMUNIFORM3FV)(getProcAddr("glProgramUniform3fv"))
+	gpProgramUniform3fvEXT = (C.GPPROGRAMUNIFORM3FVEXT)(getProcAddr("glProgramUniform3fvEXT"))
 	gpProgramUniform3i = (C.GPPROGRAMUNIFORM3I)(getProcAddr("glProgramUniform3i"))
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
+	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
+	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
+	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
+	gpProgramUniform3ivEXT = (C.GPPROGRAMUNIFORM3IVEXT)(getProcAddr("glProgramUniform3ivEXT"))
 	gpProgramUniform3ui = (C.GPPROGRAMUNIFORM3UI)(getProcAddr("glProgramUniform3ui"))
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
+	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
+	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
+	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
+	gpProgramUniform3uivEXT = (C.GPPROGRAMUNIFORM3UIVEXT)(getProcAddr("glProgramUniform3uivEXT"))
 	gpProgramUniform4d = (C.GPPROGRAMUNIFORM4D)(getProcAddr("glProgramUniform4d"))
+	gpProgramUniform4dEXT = (C.GPPROGRAMUNIFORM4DEXT)(getProcAddr("glProgramUniform4dEXT"))
 	gpProgramUniform4dv = (C.GPPROGRAMUNIFORM4DV)(getProcAddr("glProgramUniform4dv"))
+	gpProgramUniform4dvEXT = (C.GPPROGRAMUNIFORM4DVEXT)(getProcAddr("glProgramUniform4dvEXT"))
 	gpProgramUniform4f = (C.GPPROGRAMUNIFORM4F)(getProcAddr("glProgramUniform4f"))
+	gpProgramUniform4fEXT = (C.GPPROGRAMUNIFORM4FEXT)(getProcAddr("glProgramUniform4fEXT"))
 	gpProgramUniform4fv = (C.GPPROGRAMUNIFORM4FV)(getProcAddr("glProgramUniform4fv"))
+	gpProgramUniform4fvEXT = (C.GPPROGRAMUNIFORM4FVEXT)(getProcAddr("glProgramUniform4fvEXT"))
 	gpProgramUniform4i = (C.GPPROGRAMUNIFORM4I)(getProcAddr("glProgramUniform4i"))
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
+	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
+	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
+	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
+	gpProgramUniform4ivEXT = (C.GPPROGRAMUNIFORM4IVEXT)(getProcAddr("glProgramUniform4ivEXT"))
 	gpProgramUniform4ui = (C.GPPROGRAMUNIFORM4UI)(getProcAddr("glProgramUniform4ui"))
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
+	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
+	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
+	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
+	gpProgramUniform4uivEXT = (C.GPPROGRAMUNIFORM4UIVEXT)(getProcAddr("glProgramUniform4uivEXT"))
 	gpProgramUniformHandleui64ARB = (C.GPPROGRAMUNIFORMHANDLEUI64ARB)(getProcAddr("glProgramUniformHandleui64ARB"))
+	gpProgramUniformHandleui64NV = (C.GPPROGRAMUNIFORMHANDLEUI64NV)(getProcAddr("glProgramUniformHandleui64NV"))
 	gpProgramUniformHandleui64vARB = (C.GPPROGRAMUNIFORMHANDLEUI64VARB)(getProcAddr("glProgramUniformHandleui64vARB"))
+	gpProgramUniformHandleui64vNV = (C.GPPROGRAMUNIFORMHANDLEUI64VNV)(getProcAddr("glProgramUniformHandleui64vNV"))
 	gpProgramUniformMatrix2dv = (C.GPPROGRAMUNIFORMMATRIX2DV)(getProcAddr("glProgramUniformMatrix2dv"))
+	gpProgramUniformMatrix2dvEXT = (C.GPPROGRAMUNIFORMMATRIX2DVEXT)(getProcAddr("glProgramUniformMatrix2dvEXT"))
 	gpProgramUniformMatrix2fv = (C.GPPROGRAMUNIFORMMATRIX2FV)(getProcAddr("glProgramUniformMatrix2fv"))
+	gpProgramUniformMatrix2fvEXT = (C.GPPROGRAMUNIFORMMATRIX2FVEXT)(getProcAddr("glProgramUniformMatrix2fvEXT"))
 	gpProgramUniformMatrix2x3dv = (C.GPPROGRAMUNIFORMMATRIX2X3DV)(getProcAddr("glProgramUniformMatrix2x3dv"))
+	gpProgramUniformMatrix2x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3DVEXT)(getProcAddr("glProgramUniformMatrix2x3dvEXT"))
 	gpProgramUniformMatrix2x3fv = (C.GPPROGRAMUNIFORMMATRIX2X3FV)(getProcAddr("glProgramUniformMatrix2x3fv"))
+	gpProgramUniformMatrix2x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3FVEXT)(getProcAddr("glProgramUniformMatrix2x3fvEXT"))
 	gpProgramUniformMatrix2x4dv = (C.GPPROGRAMUNIFORMMATRIX2X4DV)(getProcAddr("glProgramUniformMatrix2x4dv"))
+	gpProgramUniformMatrix2x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4DVEXT)(getProcAddr("glProgramUniformMatrix2x4dvEXT"))
 	gpProgramUniformMatrix2x4fv = (C.GPPROGRAMUNIFORMMATRIX2X4FV)(getProcAddr("glProgramUniformMatrix2x4fv"))
+	gpProgramUniformMatrix2x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4FVEXT)(getProcAddr("glProgramUniformMatrix2x4fvEXT"))
 	gpProgramUniformMatrix3dv = (C.GPPROGRAMUNIFORMMATRIX3DV)(getProcAddr("glProgramUniformMatrix3dv"))
+	gpProgramUniformMatrix3dvEXT = (C.GPPROGRAMUNIFORMMATRIX3DVEXT)(getProcAddr("glProgramUniformMatrix3dvEXT"))
 	gpProgramUniformMatrix3fv = (C.GPPROGRAMUNIFORMMATRIX3FV)(getProcAddr("glProgramUniformMatrix3fv"))
+	gpProgramUniformMatrix3fvEXT = (C.GPPROGRAMUNIFORMMATRIX3FVEXT)(getProcAddr("glProgramUniformMatrix3fvEXT"))
 	gpProgramUniformMatrix3x2dv = (C.GPPROGRAMUNIFORMMATRIX3X2DV)(getProcAddr("glProgramUniformMatrix3x2dv"))
+	gpProgramUniformMatrix3x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2DVEXT)(getProcAddr("glProgramUniformMatrix3x2dvEXT"))
 	gpProgramUniformMatrix3x2fv = (C.GPPROGRAMUNIFORMMATRIX3X2FV)(getProcAddr("glProgramUniformMatrix3x2fv"))
+	gpProgramUniformMatrix3x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2FVEXT)(getProcAddr("glProgramUniformMatrix3x2fvEXT"))
 	gpProgramUniformMatrix3x4dv = (C.GPPROGRAMUNIFORMMATRIX3X4DV)(getProcAddr("glProgramUniformMatrix3x4dv"))
+	gpProgramUniformMatrix3x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4DVEXT)(getProcAddr("glProgramUniformMatrix3x4dvEXT"))
 	gpProgramUniformMatrix3x4fv = (C.GPPROGRAMUNIFORMMATRIX3X4FV)(getProcAddr("glProgramUniformMatrix3x4fv"))
+	gpProgramUniformMatrix3x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4FVEXT)(getProcAddr("glProgramUniformMatrix3x4fvEXT"))
 	gpProgramUniformMatrix4dv = (C.GPPROGRAMUNIFORMMATRIX4DV)(getProcAddr("glProgramUniformMatrix4dv"))
+	gpProgramUniformMatrix4dvEXT = (C.GPPROGRAMUNIFORMMATRIX4DVEXT)(getProcAddr("glProgramUniformMatrix4dvEXT"))
 	gpProgramUniformMatrix4fv = (C.GPPROGRAMUNIFORMMATRIX4FV)(getProcAddr("glProgramUniformMatrix4fv"))
+	gpProgramUniformMatrix4fvEXT = (C.GPPROGRAMUNIFORMMATRIX4FVEXT)(getProcAddr("glProgramUniformMatrix4fvEXT"))
 	gpProgramUniformMatrix4x2dv = (C.GPPROGRAMUNIFORMMATRIX4X2DV)(getProcAddr("glProgramUniformMatrix4x2dv"))
+	gpProgramUniformMatrix4x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2DVEXT)(getProcAddr("glProgramUniformMatrix4x2dvEXT"))
 	gpProgramUniformMatrix4x2fv = (C.GPPROGRAMUNIFORMMATRIX4X2FV)(getProcAddr("glProgramUniformMatrix4x2fv"))
+	gpProgramUniformMatrix4x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2FVEXT)(getProcAddr("glProgramUniformMatrix4x2fvEXT"))
 	gpProgramUniformMatrix4x3dv = (C.GPPROGRAMUNIFORMMATRIX4X3DV)(getProcAddr("glProgramUniformMatrix4x3dv"))
+	gpProgramUniformMatrix4x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3DVEXT)(getProcAddr("glProgramUniformMatrix4x3dvEXT"))
 	gpProgramUniformMatrix4x3fv = (C.GPPROGRAMUNIFORMMATRIX4X3FV)(getProcAddr("glProgramUniformMatrix4x3fv"))
+	gpProgramUniformMatrix4x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3FVEXT)(getProcAddr("glProgramUniformMatrix4x3fvEXT"))
+	gpProgramUniformui64NV = (C.GPPROGRAMUNIFORMUI64NV)(getProcAddr("glProgramUniformui64NV"))
+	gpProgramUniformui64vNV = (C.GPPROGRAMUNIFORMUI64VNV)(getProcAddr("glProgramUniformui64vNV"))
 	gpProvokingVertex = (C.GPPROVOKINGVERTEX)(getProcAddr("glProvokingVertex"))
 	gpPushAttrib = (C.GPPUSHATTRIB)(getProcAddr("glPushAttrib"))
 	gpPushClientAttrib = (C.GPPUSHCLIENTATTRIB)(getProcAddr("glPushClientAttrib"))
+	gpPushClientAttribDefaultEXT = (C.GPPUSHCLIENTATTRIBDEFAULTEXT)(getProcAddr("glPushClientAttribDefaultEXT"))
 	gpPushDebugGroup = (C.GPPUSHDEBUGGROUP)(getProcAddr("glPushDebugGroup"))
 	gpPushDebugGroupKHR = (C.GPPUSHDEBUGGROUPKHR)(getProcAddr("glPushDebugGroupKHR"))
+	gpPushGroupMarkerEXT = (C.GPPUSHGROUPMARKEREXT)(getProcAddr("glPushGroupMarkerEXT"))
 	gpPushMatrix = (C.GPPUSHMATRIX)(getProcAddr("glPushMatrix"))
 	gpPushName = (C.GPPUSHNAME)(getProcAddr("glPushName"))
 	gpQueryCounter = (C.GPQUERYCOUNTER)(getProcAddr("glQueryCounter"))
@@ -12272,6 +17724,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpRasterPos4iv = (C.GPRASTERPOS4IV)(getProcAddr("glRasterPos4iv"))
 	gpRasterPos4s = (C.GPRASTERPOS4S)(getProcAddr("glRasterPos4s"))
 	gpRasterPos4sv = (C.GPRASTERPOS4SV)(getProcAddr("glRasterPos4sv"))
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	gpReadPixels = (C.GPREADPIXELS)(getProcAddr("glReadPixels"))
 	gpReadnPixels = (C.GPREADNPIXELS)(getProcAddr("glReadnPixels"))
@@ -12289,6 +17742,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpRenderMode = (C.GPRENDERMODE)(getProcAddr("glRenderMode"))
 	gpRenderbufferStorage = (C.GPRENDERBUFFERSTORAGE)(getProcAddr("glRenderbufferStorage"))
 	gpRenderbufferStorageMultisample = (C.GPRENDERBUFFERSTORAGEMULTISAMPLE)(getProcAddr("glRenderbufferStorageMultisample"))
+	gpRenderbufferStorageMultisampleCoverageNV = (C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(getProcAddr("glRenderbufferStorageMultisampleCoverageNV"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	gpRotated = (C.GPROTATED)(getProcAddr("glRotated"))
 	gpRotatef = (C.GPROTATEF)(getProcAddr("glRotatef"))
@@ -12322,19 +17777,36 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpSecondaryColor3uiv = (C.GPSECONDARYCOLOR3UIV)(getProcAddr("glSecondaryColor3uiv"))
 	gpSecondaryColor3us = (C.GPSECONDARYCOLOR3US)(getProcAddr("glSecondaryColor3us"))
 	gpSecondaryColor3usv = (C.GPSECONDARYCOLOR3USV)(getProcAddr("glSecondaryColor3usv"))
+	gpSecondaryColorFormatNV = (C.GPSECONDARYCOLORFORMATNV)(getProcAddr("glSecondaryColorFormatNV"))
 	gpSecondaryColorPointer = (C.GPSECONDARYCOLORPOINTER)(getProcAddr("glSecondaryColorPointer"))
 	gpSelectBuffer = (C.GPSELECTBUFFER)(getProcAddr("glSelectBuffer"))
+	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
 	gpShadeModel = (C.GPSHADEMODEL)(getProcAddr("glShadeModel"))
 	gpShaderBinary = (C.GPSHADERBINARY)(getProcAddr("glShaderBinary"))
 	gpShaderSource = (C.GPSHADERSOURCE)(getProcAddr("glShaderSource"))
 	gpShaderStorageBlockBinding = (C.GPSHADERSTORAGEBLOCKBINDING)(getProcAddr("glShaderStorageBlockBinding"))
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShader = (C.GPSPECIALIZESHADER)(getProcAddr("glSpecializeShader"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
+	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
+	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
 	gpStencilFunc = (C.GPSTENCILFUNC)(getProcAddr("glStencilFunc"))
 	gpStencilFuncSeparate = (C.GPSTENCILFUNCSEPARATE)(getProcAddr("glStencilFuncSeparate"))
 	gpStencilMask = (C.GPSTENCILMASK)(getProcAddr("glStencilMask"))
 	gpStencilMaskSeparate = (C.GPSTENCILMASKSEPARATE)(getProcAddr("glStencilMaskSeparate"))
 	gpStencilOp = (C.GPSTENCILOP)(getProcAddr("glStencilOp"))
 	gpStencilOpSeparate = (C.GPSTENCILOPSEPARATE)(getProcAddr("glStencilOpSeparate"))
+	gpStencilStrokePathInstancedNV = (C.GPSTENCILSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilStrokePathInstancedNV"))
+	gpStencilStrokePathNV = (C.GPSTENCILSTROKEPATHNV)(getProcAddr("glStencilStrokePathNV"))
+	gpStencilThenCoverFillPathInstancedNV = (C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverFillPathInstancedNV"))
+	gpStencilThenCoverFillPathNV = (C.GPSTENCILTHENCOVERFILLPATHNV)(getProcAddr("glStencilThenCoverFillPathNV"))
+	gpStencilThenCoverStrokePathInstancedNV = (C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverStrokePathInstancedNV"))
+	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpTexBuffer = (C.GPTEXBUFFER)(getProcAddr("glTexBuffer"))
+	gpTexBufferARB = (C.GPTEXBUFFERARB)(getProcAddr("glTexBufferARB"))
 	gpTexBufferRange = (C.GPTEXBUFFERRANGE)(getProcAddr("glTexBufferRange"))
 	gpTexCoord1d = (C.GPTEXCOORD1D)(getProcAddr("glTexCoord1d"))
 	gpTexCoord1dv = (C.GPTEXCOORD1DV)(getProcAddr("glTexCoord1dv"))
@@ -12368,6 +17840,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpTexCoord4iv = (C.GPTEXCOORD4IV)(getProcAddr("glTexCoord4iv"))
 	gpTexCoord4s = (C.GPTEXCOORD4S)(getProcAddr("glTexCoord4s"))
 	gpTexCoord4sv = (C.GPTEXCOORD4SV)(getProcAddr("glTexCoord4sv"))
+	gpTexCoordFormatNV = (C.GPTEXCOORDFORMATNV)(getProcAddr("glTexCoordFormatNV"))
 	gpTexCoordPointer = (C.GPTEXCOORDPOINTER)(getProcAddr("glTexCoordPointer"))
 	gpTexEnvf = (C.GPTEXENVF)(getProcAddr("glTexEnvf"))
 	gpTexEnvfv = (C.GPTEXENVFV)(getProcAddr("glTexEnvfv"))
@@ -12400,26 +17873,49 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpTexSubImage2D = (C.GPTEXSUBIMAGE2D)(getProcAddr("glTexSubImage2D"))
 	gpTexSubImage3D = (C.GPTEXSUBIMAGE3D)(getProcAddr("glTexSubImage3D"))
 	gpTextureBarrier = (C.GPTEXTUREBARRIER)(getProcAddr("glTextureBarrier"))
+	gpTextureBarrierNV = (C.GPTEXTUREBARRIERNV)(getProcAddr("glTextureBarrierNV"))
 	gpTextureBuffer = (C.GPTEXTUREBUFFER)(getProcAddr("glTextureBuffer"))
+	gpTextureBufferEXT = (C.GPTEXTUREBUFFEREXT)(getProcAddr("glTextureBufferEXT"))
 	gpTextureBufferRange = (C.GPTEXTUREBUFFERRANGE)(getProcAddr("glTextureBufferRange"))
+	gpTextureBufferRangeEXT = (C.GPTEXTUREBUFFERRANGEEXT)(getProcAddr("glTextureBufferRangeEXT"))
+	gpTextureImage1DEXT = (C.GPTEXTUREIMAGE1DEXT)(getProcAddr("glTextureImage1DEXT"))
+	gpTextureImage2DEXT = (C.GPTEXTUREIMAGE2DEXT)(getProcAddr("glTextureImage2DEXT"))
+	gpTextureImage3DEXT = (C.GPTEXTUREIMAGE3DEXT)(getProcAddr("glTextureImage3DEXT"))
+	gpTexturePageCommitmentEXT = (C.GPTEXTUREPAGECOMMITMENTEXT)(getProcAddr("glTexturePageCommitmentEXT"))
 	gpTextureParameterIiv = (C.GPTEXTUREPARAMETERIIV)(getProcAddr("glTextureParameterIiv"))
+	gpTextureParameterIivEXT = (C.GPTEXTUREPARAMETERIIVEXT)(getProcAddr("glTextureParameterIivEXT"))
 	gpTextureParameterIuiv = (C.GPTEXTUREPARAMETERIUIV)(getProcAddr("glTextureParameterIuiv"))
+	gpTextureParameterIuivEXT = (C.GPTEXTUREPARAMETERIUIVEXT)(getProcAddr("glTextureParameterIuivEXT"))
 	gpTextureParameterf = (C.GPTEXTUREPARAMETERF)(getProcAddr("glTextureParameterf"))
+	gpTextureParameterfEXT = (C.GPTEXTUREPARAMETERFEXT)(getProcAddr("glTextureParameterfEXT"))
 	gpTextureParameterfv = (C.GPTEXTUREPARAMETERFV)(getProcAddr("glTextureParameterfv"))
+	gpTextureParameterfvEXT = (C.GPTEXTUREPARAMETERFVEXT)(getProcAddr("glTextureParameterfvEXT"))
 	gpTextureParameteri = (C.GPTEXTUREPARAMETERI)(getProcAddr("glTextureParameteri"))
+	gpTextureParameteriEXT = (C.GPTEXTUREPARAMETERIEXT)(getProcAddr("glTextureParameteriEXT"))
 	gpTextureParameteriv = (C.GPTEXTUREPARAMETERIV)(getProcAddr("glTextureParameteriv"))
+	gpTextureParameterivEXT = (C.GPTEXTUREPARAMETERIVEXT)(getProcAddr("glTextureParameterivEXT"))
+	gpTextureRenderbufferEXT = (C.GPTEXTURERENDERBUFFEREXT)(getProcAddr("glTextureRenderbufferEXT"))
 	gpTextureStorage1D = (C.GPTEXTURESTORAGE1D)(getProcAddr("glTextureStorage1D"))
+	gpTextureStorage1DEXT = (C.GPTEXTURESTORAGE1DEXT)(getProcAddr("glTextureStorage1DEXT"))
 	gpTextureStorage2D = (C.GPTEXTURESTORAGE2D)(getProcAddr("glTextureStorage2D"))
+	gpTextureStorage2DEXT = (C.GPTEXTURESTORAGE2DEXT)(getProcAddr("glTextureStorage2DEXT"))
 	gpTextureStorage2DMultisample = (C.GPTEXTURESTORAGE2DMULTISAMPLE)(getProcAddr("glTextureStorage2DMultisample"))
+	gpTextureStorage2DMultisampleEXT = (C.GPTEXTURESTORAGE2DMULTISAMPLEEXT)(getProcAddr("glTextureStorage2DMultisampleEXT"))
 	gpTextureStorage3D = (C.GPTEXTURESTORAGE3D)(getProcAddr("glTextureStorage3D"))
+	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
+	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
+	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
 	gpTextureSubImage2D = (C.GPTEXTURESUBIMAGE2D)(getProcAddr("glTextureSubImage2D"))
+	gpTextureSubImage2DEXT = (C.GPTEXTURESUBIMAGE2DEXT)(getProcAddr("glTextureSubImage2DEXT"))
 	gpTextureSubImage3D = (C.GPTEXTURESUBIMAGE3D)(getProcAddr("glTextureSubImage3D"))
+	gpTextureSubImage3DEXT = (C.GPTEXTURESUBIMAGE3DEXT)(getProcAddr("glTextureSubImage3DEXT"))
 	gpTextureView = (C.GPTEXTUREVIEW)(getProcAddr("glTextureView"))
 	gpTransformFeedbackBufferBase = (C.GPTRANSFORMFEEDBACKBUFFERBASE)(getProcAddr("glTransformFeedbackBufferBase"))
 	gpTransformFeedbackBufferRange = (C.GPTRANSFORMFEEDBACKBUFFERRANGE)(getProcAddr("glTransformFeedbackBufferRange"))
 	gpTransformFeedbackVaryings = (C.GPTRANSFORMFEEDBACKVARYINGS)(getProcAddr("glTransformFeedbackVaryings"))
+	gpTransformPathNV = (C.GPTRANSFORMPATHNV)(getProcAddr("glTransformPathNV"))
 	gpTranslated = (C.GPTRANSLATED)(getProcAddr("glTranslated"))
 	gpTranslatef = (C.GPTRANSLATEF)(getProcAddr("glTranslatef"))
 	gpUniform1d = (C.GPUNIFORM1D)(getProcAddr("glUniform1d"))
@@ -12427,36 +17923,70 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpUniform1f = (C.GPUNIFORM1F)(getProcAddr("glUniform1f"))
 	gpUniform1fv = (C.GPUNIFORM1FV)(getProcAddr("glUniform1fv"))
 	gpUniform1i = (C.GPUNIFORM1I)(getProcAddr("glUniform1i"))
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
+	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
+	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
 	gpUniform1ui = (C.GPUNIFORM1UI)(getProcAddr("glUniform1ui"))
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
+	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
+	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
 	gpUniform2d = (C.GPUNIFORM2D)(getProcAddr("glUniform2d"))
 	gpUniform2dv = (C.GPUNIFORM2DV)(getProcAddr("glUniform2dv"))
 	gpUniform2f = (C.GPUNIFORM2F)(getProcAddr("glUniform2f"))
 	gpUniform2fv = (C.GPUNIFORM2FV)(getProcAddr("glUniform2fv"))
 	gpUniform2i = (C.GPUNIFORM2I)(getProcAddr("glUniform2i"))
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
+	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
+	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
 	gpUniform2ui = (C.GPUNIFORM2UI)(getProcAddr("glUniform2ui"))
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
+	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
+	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
 	gpUniform3d = (C.GPUNIFORM3D)(getProcAddr("glUniform3d"))
 	gpUniform3dv = (C.GPUNIFORM3DV)(getProcAddr("glUniform3dv"))
 	gpUniform3f = (C.GPUNIFORM3F)(getProcAddr("glUniform3f"))
 	gpUniform3fv = (C.GPUNIFORM3FV)(getProcAddr("glUniform3fv"))
 	gpUniform3i = (C.GPUNIFORM3I)(getProcAddr("glUniform3i"))
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
+	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
+	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
 	gpUniform3ui = (C.GPUNIFORM3UI)(getProcAddr("glUniform3ui"))
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
+	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
+	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
 	gpUniform4d = (C.GPUNIFORM4D)(getProcAddr("glUniform4d"))
 	gpUniform4dv = (C.GPUNIFORM4DV)(getProcAddr("glUniform4dv"))
 	gpUniform4f = (C.GPUNIFORM4F)(getProcAddr("glUniform4f"))
 	gpUniform4fv = (C.GPUNIFORM4FV)(getProcAddr("glUniform4fv"))
 	gpUniform4i = (C.GPUNIFORM4I)(getProcAddr("glUniform4i"))
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
+	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
+	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
 	gpUniform4ui = (C.GPUNIFORM4UI)(getProcAddr("glUniform4ui"))
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
+	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
+	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
 	gpUniformBlockBinding = (C.GPUNIFORMBLOCKBINDING)(getProcAddr("glUniformBlockBinding"))
 	gpUniformHandleui64ARB = (C.GPUNIFORMHANDLEUI64ARB)(getProcAddr("glUniformHandleui64ARB"))
+	gpUniformHandleui64NV = (C.GPUNIFORMHANDLEUI64NV)(getProcAddr("glUniformHandleui64NV"))
 	gpUniformHandleui64vARB = (C.GPUNIFORMHANDLEUI64VARB)(getProcAddr("glUniformHandleui64vARB"))
+	gpUniformHandleui64vNV = (C.GPUNIFORMHANDLEUI64VNV)(getProcAddr("glUniformHandleui64vNV"))
 	gpUniformMatrix2dv = (C.GPUNIFORMMATRIX2DV)(getProcAddr("glUniformMatrix2dv"))
 	gpUniformMatrix2fv = (C.GPUNIFORMMATRIX2FV)(getProcAddr("glUniformMatrix2fv"))
 	gpUniformMatrix2x3dv = (C.GPUNIFORMMATRIX2X3DV)(getProcAddr("glUniformMatrix2x3dv"))
@@ -12476,12 +18006,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpUniformMatrix4x3dv = (C.GPUNIFORMMATRIX4X3DV)(getProcAddr("glUniformMatrix4x3dv"))
 	gpUniformMatrix4x3fv = (C.GPUNIFORMMATRIX4X3FV)(getProcAddr("glUniformMatrix4x3fv"))
 	gpUniformSubroutinesuiv = (C.GPUNIFORMSUBROUTINESUIV)(getProcAddr("glUniformSubroutinesuiv"))
+	gpUniformui64NV = (C.GPUNIFORMUI64NV)(getProcAddr("glUniformui64NV"))
+	gpUniformui64vNV = (C.GPUNIFORMUI64VNV)(getProcAddr("glUniformui64vNV"))
 	gpUnmapBuffer = (C.GPUNMAPBUFFER)(getProcAddr("glUnmapBuffer"))
 	gpUnmapNamedBuffer = (C.GPUNMAPNAMEDBUFFER)(getProcAddr("glUnmapNamedBuffer"))
+	gpUnmapNamedBufferEXT = (C.GPUNMAPNAMEDBUFFEREXT)(getProcAddr("glUnmapNamedBufferEXT"))
 	gpUseProgram = (C.GPUSEPROGRAM)(getProcAddr("glUseProgram"))
 	gpUseProgramStages = (C.GPUSEPROGRAMSTAGES)(getProcAddr("glUseProgramStages"))
+	gpUseProgramStagesEXT = (C.GPUSEPROGRAMSTAGESEXT)(getProcAddr("glUseProgramStagesEXT"))
+	gpUseShaderProgramEXT = (C.GPUSESHADERPROGRAMEXT)(getProcAddr("glUseShaderProgramEXT"))
 	gpValidateProgram = (C.GPVALIDATEPROGRAM)(getProcAddr("glValidateProgram"))
 	gpValidateProgramPipeline = (C.GPVALIDATEPROGRAMPIPELINE)(getProcAddr("glValidateProgramPipeline"))
+	gpValidateProgramPipelineEXT = (C.GPVALIDATEPROGRAMPIPELINEEXT)(getProcAddr("glValidateProgramPipelineEXT"))
 	gpVertex2d = (C.GPVERTEX2D)(getProcAddr("glVertex2d"))
 	gpVertex2dv = (C.GPVERTEX2DV)(getProcAddr("glVertex2dv"))
 	gpVertex2f = (C.GPVERTEX2F)(getProcAddr("glVertex2f"))
@@ -12510,10 +18046,29 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpVertexArrayAttribFormat = (C.GPVERTEXARRAYATTRIBFORMAT)(getProcAddr("glVertexArrayAttribFormat"))
 	gpVertexArrayAttribIFormat = (C.GPVERTEXARRAYATTRIBIFORMAT)(getProcAddr("glVertexArrayAttribIFormat"))
 	gpVertexArrayAttribLFormat = (C.GPVERTEXARRAYATTRIBLFORMAT)(getProcAddr("glVertexArrayAttribLFormat"))
+	gpVertexArrayBindVertexBufferEXT = (C.GPVERTEXARRAYBINDVERTEXBUFFEREXT)(getProcAddr("glVertexArrayBindVertexBufferEXT"))
 	gpVertexArrayBindingDivisor = (C.GPVERTEXARRAYBINDINGDIVISOR)(getProcAddr("glVertexArrayBindingDivisor"))
+	gpVertexArrayColorOffsetEXT = (C.GPVERTEXARRAYCOLOROFFSETEXT)(getProcAddr("glVertexArrayColorOffsetEXT"))
+	gpVertexArrayEdgeFlagOffsetEXT = (C.GPVERTEXARRAYEDGEFLAGOFFSETEXT)(getProcAddr("glVertexArrayEdgeFlagOffsetEXT"))
 	gpVertexArrayElementBuffer = (C.GPVERTEXARRAYELEMENTBUFFER)(getProcAddr("glVertexArrayElementBuffer"))
+	gpVertexArrayFogCoordOffsetEXT = (C.GPVERTEXARRAYFOGCOORDOFFSETEXT)(getProcAddr("glVertexArrayFogCoordOffsetEXT"))
+	gpVertexArrayIndexOffsetEXT = (C.GPVERTEXARRAYINDEXOFFSETEXT)(getProcAddr("glVertexArrayIndexOffsetEXT"))
+	gpVertexArrayMultiTexCoordOffsetEXT = (C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayMultiTexCoordOffsetEXT"))
+	gpVertexArrayNormalOffsetEXT = (C.GPVERTEXARRAYNORMALOFFSETEXT)(getProcAddr("glVertexArrayNormalOffsetEXT"))
+	gpVertexArraySecondaryColorOffsetEXT = (C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(getProcAddr("glVertexArraySecondaryColorOffsetEXT"))
+	gpVertexArrayTexCoordOffsetEXT = (C.GPVERTEXARRAYTEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayTexCoordOffsetEXT"))
+	gpVertexArrayVertexAttribBindingEXT = (C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(getProcAddr("glVertexArrayVertexAttribBindingEXT"))
+	gpVertexArrayVertexAttribDivisorEXT = (C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(getProcAddr("glVertexArrayVertexAttribDivisorEXT"))
+	gpVertexArrayVertexAttribFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(getProcAddr("glVertexArrayVertexAttribFormatEXT"))
+	gpVertexArrayVertexAttribIFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(getProcAddr("glVertexArrayVertexAttribIFormatEXT"))
+	gpVertexArrayVertexAttribIOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribIOffsetEXT"))
+	gpVertexArrayVertexAttribLFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(getProcAddr("glVertexArrayVertexAttribLFormatEXT"))
+	gpVertexArrayVertexAttribLOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribLOffsetEXT"))
+	gpVertexArrayVertexAttribOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribOffsetEXT"))
+	gpVertexArrayVertexBindingDivisorEXT = (C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(getProcAddr("glVertexArrayVertexBindingDivisorEXT"))
 	gpVertexArrayVertexBuffer = (C.GPVERTEXARRAYVERTEXBUFFER)(getProcAddr("glVertexArrayVertexBuffer"))
 	gpVertexArrayVertexBuffers = (C.GPVERTEXARRAYVERTEXBUFFERS)(getProcAddr("glVertexArrayVertexBuffers"))
+	gpVertexArrayVertexOffsetEXT = (C.GPVERTEXARRAYVERTEXOFFSETEXT)(getProcAddr("glVertexArrayVertexOffsetEXT"))
 	gpVertexAttrib1d = (C.GPVERTEXATTRIB1D)(getProcAddr("glVertexAttrib1d"))
 	gpVertexAttrib1dv = (C.GPVERTEXATTRIB1DV)(getProcAddr("glVertexAttrib1dv"))
 	gpVertexAttrib1f = (C.GPVERTEXATTRIB1F)(getProcAddr("glVertexAttrib1f"))
@@ -12552,7 +18107,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpVertexAttrib4usv = (C.GPVERTEXATTRIB4USV)(getProcAddr("glVertexAttrib4usv"))
 	gpVertexAttribBinding = (C.GPVERTEXATTRIBBINDING)(getProcAddr("glVertexAttribBinding"))
 	gpVertexAttribDivisor = (C.GPVERTEXATTRIBDIVISOR)(getProcAddr("glVertexAttribDivisor"))
+	gpVertexAttribDivisorARB = (C.GPVERTEXATTRIBDIVISORARB)(getProcAddr("glVertexAttribDivisorARB"))
 	gpVertexAttribFormat = (C.GPVERTEXATTRIBFORMAT)(getProcAddr("glVertexAttribFormat"))
+	gpVertexAttribFormatNV = (C.GPVERTEXATTRIBFORMATNV)(getProcAddr("glVertexAttribFormatNV"))
 	gpVertexAttribI1i = (C.GPVERTEXATTRIBI1I)(getProcAddr("glVertexAttribI1i"))
 	gpVertexAttribI1iv = (C.GPVERTEXATTRIBI1IV)(getProcAddr("glVertexAttribI1iv"))
 	gpVertexAttribI1ui = (C.GPVERTEXATTRIBI1UI)(getProcAddr("glVertexAttribI1ui"))
@@ -12574,18 +18131,36 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpVertexAttribI4uiv = (C.GPVERTEXATTRIBI4UIV)(getProcAddr("glVertexAttribI4uiv"))
 	gpVertexAttribI4usv = (C.GPVERTEXATTRIBI4USV)(getProcAddr("glVertexAttribI4usv"))
 	gpVertexAttribIFormat = (C.GPVERTEXATTRIBIFORMAT)(getProcAddr("glVertexAttribIFormat"))
+	gpVertexAttribIFormatNV = (C.GPVERTEXATTRIBIFORMATNV)(getProcAddr("glVertexAttribIFormatNV"))
 	gpVertexAttribIPointer = (C.GPVERTEXATTRIBIPOINTER)(getProcAddr("glVertexAttribIPointer"))
 	gpVertexAttribL1d = (C.GPVERTEXATTRIBL1D)(getProcAddr("glVertexAttribL1d"))
 	gpVertexAttribL1dv = (C.GPVERTEXATTRIBL1DV)(getProcAddr("glVertexAttribL1dv"))
+	gpVertexAttribL1i64NV = (C.GPVERTEXATTRIBL1I64NV)(getProcAddr("glVertexAttribL1i64NV"))
+	gpVertexAttribL1i64vNV = (C.GPVERTEXATTRIBL1I64VNV)(getProcAddr("glVertexAttribL1i64vNV"))
 	gpVertexAttribL1ui64ARB = (C.GPVERTEXATTRIBL1UI64ARB)(getProcAddr("glVertexAttribL1ui64ARB"))
+	gpVertexAttribL1ui64NV = (C.GPVERTEXATTRIBL1UI64NV)(getProcAddr("glVertexAttribL1ui64NV"))
 	gpVertexAttribL1ui64vARB = (C.GPVERTEXATTRIBL1UI64VARB)(getProcAddr("glVertexAttribL1ui64vARB"))
+	gpVertexAttribL1ui64vNV = (C.GPVERTEXATTRIBL1UI64VNV)(getProcAddr("glVertexAttribL1ui64vNV"))
 	gpVertexAttribL2d = (C.GPVERTEXATTRIBL2D)(getProcAddr("glVertexAttribL2d"))
 	gpVertexAttribL2dv = (C.GPVERTEXATTRIBL2DV)(getProcAddr("glVertexAttribL2dv"))
+	gpVertexAttribL2i64NV = (C.GPVERTEXATTRIBL2I64NV)(getProcAddr("glVertexAttribL2i64NV"))
+	gpVertexAttribL2i64vNV = (C.GPVERTEXATTRIBL2I64VNV)(getProcAddr("glVertexAttribL2i64vNV"))
+	gpVertexAttribL2ui64NV = (C.GPVERTEXATTRIBL2UI64NV)(getProcAddr("glVertexAttribL2ui64NV"))
+	gpVertexAttribL2ui64vNV = (C.GPVERTEXATTRIBL2UI64VNV)(getProcAddr("glVertexAttribL2ui64vNV"))
 	gpVertexAttribL3d = (C.GPVERTEXATTRIBL3D)(getProcAddr("glVertexAttribL3d"))
 	gpVertexAttribL3dv = (C.GPVERTEXATTRIBL3DV)(getProcAddr("glVertexAttribL3dv"))
+	gpVertexAttribL3i64NV = (C.GPVERTEXATTRIBL3I64NV)(getProcAddr("glVertexAttribL3i64NV"))
+	gpVertexAttribL3i64vNV = (C.GPVERTEXATTRIBL3I64VNV)(getProcAddr("glVertexAttribL3i64vNV"))
+	gpVertexAttribL3ui64NV = (C.GPVERTEXATTRIBL3UI64NV)(getProcAddr("glVertexAttribL3ui64NV"))
+	gpVertexAttribL3ui64vNV = (C.GPVERTEXATTRIBL3UI64VNV)(getProcAddr("glVertexAttribL3ui64vNV"))
 	gpVertexAttribL4d = (C.GPVERTEXATTRIBL4D)(getProcAddr("glVertexAttribL4d"))
 	gpVertexAttribL4dv = (C.GPVERTEXATTRIBL4DV)(getProcAddr("glVertexAttribL4dv"))
+	gpVertexAttribL4i64NV = (C.GPVERTEXATTRIBL4I64NV)(getProcAddr("glVertexAttribL4i64NV"))
+	gpVertexAttribL4i64vNV = (C.GPVERTEXATTRIBL4I64VNV)(getProcAddr("glVertexAttribL4i64vNV"))
+	gpVertexAttribL4ui64NV = (C.GPVERTEXATTRIBL4UI64NV)(getProcAddr("glVertexAttribL4ui64NV"))
+	gpVertexAttribL4ui64vNV = (C.GPVERTEXATTRIBL4UI64VNV)(getProcAddr("glVertexAttribL4ui64vNV"))
 	gpVertexAttribLFormat = (C.GPVERTEXATTRIBLFORMAT)(getProcAddr("glVertexAttribLFormat"))
+	gpVertexAttribLFormatNV = (C.GPVERTEXATTRIBLFORMATNV)(getProcAddr("glVertexAttribLFormatNV"))
 	gpVertexAttribLPointer = (C.GPVERTEXATTRIBLPOINTER)(getProcAddr("glVertexAttribLPointer"))
 	gpVertexAttribP1ui = (C.GPVERTEXATTRIBP1UI)(getProcAddr("glVertexAttribP1ui"))
 	gpVertexAttribP1uiv = (C.GPVERTEXATTRIBP1UIV)(getProcAddr("glVertexAttribP1uiv"))
@@ -12597,12 +18172,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpVertexAttribP4uiv = (C.GPVERTEXATTRIBP4UIV)(getProcAddr("glVertexAttribP4uiv"))
 	gpVertexAttribPointer = (C.GPVERTEXATTRIBPOINTER)(getProcAddr("glVertexAttribPointer"))
 	gpVertexBindingDivisor = (C.GPVERTEXBINDINGDIVISOR)(getProcAddr("glVertexBindingDivisor"))
+	gpVertexFormatNV = (C.GPVERTEXFORMATNV)(getProcAddr("glVertexFormatNV"))
 	gpVertexPointer = (C.GPVERTEXPOINTER)(getProcAddr("glVertexPointer"))
 	gpViewport = (C.GPVIEWPORT)(getProcAddr("glViewport"))
 	gpViewportArrayv = (C.GPVIEWPORTARRAYV)(getProcAddr("glViewportArrayv"))
 	gpViewportIndexedf = (C.GPVIEWPORTINDEXEDF)(getProcAddr("glViewportIndexedf"))
 	gpViewportIndexedfv = (C.GPVIEWPORTINDEXEDFV)(getProcAddr("glViewportIndexedfv"))
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
+	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
 	gpWindowPos2d = (C.GPWINDOWPOS2D)(getProcAddr("glWindowPos2d"))
 	gpWindowPos2dv = (C.GPWINDOWPOS2DV)(getProcAddr("glWindowPos2dv"))
 	gpWindowPos2f = (C.GPWINDOWPOS2F)(getProcAddr("glWindowPos2f"))
@@ -12619,5 +18199,6 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpWindowPos3iv = (C.GPWINDOWPOS3IV)(getProcAddr("glWindowPos3iv"))
 	gpWindowPos3s = (C.GPWINDOWPOS3S)(getProcAddr("glWindowPos3s"))
 	gpWindowPos3sv = (C.GPWINDOWPOS3SV)(getProcAddr("glWindowPos3sv"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	return nil
 }

--- a/all-core/gl/procaddr.go
+++ b/all-core/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcoreall(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v2.1/gl/package.go
+++ b/v2.1/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -75,7 +73,6 @@ package gl
 // typedef unsigned int GLenum;
 // typedef unsigned char GLboolean;
 // typedef unsigned int GLbitfield;
-// typedef void GLvoid;
 // typedef signed char GLbyte;
 // typedef short GLshort;
 // typedef int GLint;
@@ -88,6 +85,7 @@ package gl
 // typedef float GLclampf;
 // typedef double GLdouble;
 // typedef double GLclampd;
+// typedef void *GLeglClientBufferEXT;
 // typedef char GLchar;
 // typedef char GLcharARB;
 // #ifdef __APPLE__
@@ -104,7 +102,7 @@ package gl
 // typedef ptrdiff_t GLsizeiptrARB;
 // typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
@@ -113,12 +111,14 @@ package gl
 // typedef void (APIENTRY *GLDEBUGPROCAMD)(GLuint id,GLenum category,GLenum severity,GLsizei length,const GLchar *message,void *userParam);
 // typedef unsigned short GLhalfNV;
 // typedef GLintptr GLvdpauSurfaceNV;
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_gl21(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_gl21(source, type, id, severity, length, message, userParam);
 // }
 // typedef void  (APIENTRYP GPACCUM)(GLenum  op, GLfloat  value);
 // typedef void  (APIENTRYP GPACCUMXOES)(GLenum  op, GLfixed  value);
+// typedef GLboolean  (APIENTRYP GPACQUIREKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key, GLuint  timeout);
 // typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
@@ -131,6 +131,8 @@ package gl
 // typedef void  (APIENTRYP GPALPHAFRAGMENTOP3ATI)(GLenum  op, GLuint  dst, GLuint  dstMod, GLuint  arg1, GLuint  arg1Rep, GLuint  arg1Mod, GLuint  arg2, GLuint  arg2Rep, GLuint  arg2Mod, GLuint  arg3, GLuint  arg3Rep, GLuint  arg3Mod);
 // typedef void  (APIENTRYP GPALPHAFUNC)(GLenum  func, GLfloat  ref);
 // typedef void  (APIENTRYP GPALPHAFUNCXOES)(GLenum  func, GLfixed  ref);
+// typedef void  (APIENTRYP GPALPHATOCOVERAGEDITHERCONTROLNV)(GLenum  mode);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPAPPLYTEXTUREEXT)(GLenum  mode);
 // typedef GLboolean  (APIENTRYP GPAREPROGRAMSRESIDENTNV)(GLsizei  n, const GLuint * programs, GLboolean * residences);
 // typedef GLboolean  (APIENTRYP GPARETEXTURESRESIDENT)(GLsizei  n, const GLuint * textures, GLboolean * residences);
@@ -159,10 +161,12 @@ package gl
 // typedef void  (APIENTRYP GPBINDATTRIBLOCATIONARB)(GLhandleARB  programObj, GLuint  index, const GLcharARB * name);
 // typedef void  (APIENTRYP GPBINDBUFFER)(GLenum  target, GLuint  buffer);
 // typedef void  (APIENTRYP GPBINDBUFFERARB)(GLenum  target, GLuint  buffer);
+// typedef void  (APIENTRYP GPBINDBUFFERBASE)(GLenum  target, GLuint  index, GLuint  buffer);
 // typedef void  (APIENTRYP GPBINDBUFFERBASEEXT)(GLenum  target, GLuint  index, GLuint  buffer);
 // typedef void  (APIENTRYP GPBINDBUFFERBASENV)(GLenum  target, GLuint  index, GLuint  buffer);
 // typedef void  (APIENTRYP GPBINDBUFFEROFFSETEXT)(GLenum  target, GLuint  index, GLuint  buffer, GLintptr  offset);
 // typedef void  (APIENTRYP GPBINDBUFFEROFFSETNV)(GLenum  target, GLuint  index, GLuint  buffer, GLintptr  offset);
+// typedef void  (APIENTRYP GPBINDBUFFERRANGE)(GLenum  target, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPBINDBUFFERRANGEEXT)(GLenum  target, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPBINDBUFFERRANGENV)(GLenum  target, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPBINDBUFFERSBASE)(GLenum  target, GLuint  first, GLsizei  count, const GLuint * buffers);
@@ -243,11 +247,14 @@ package gl
 // typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPBUFFERDATAARB)(GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERPARAMETERIAPPLE)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEEXTERNALEXT)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEMEMEXT)(GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPBUFFERSUBDATAARB)(GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLIST)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLISTS)(GLsizei  n, GLenum  type, const void * lists);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
@@ -272,9 +279,9 @@ package gl
 // typedef void  (APIENTRYP GPCLEARINDEX)(GLfloat  c);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
@@ -361,6 +368,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERIVNV)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERARB)(GLhandleARB  shaderObj);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
@@ -391,6 +400,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER2DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONPARAMETERFEXT)(GLenum  target, GLenum  pname, GLfloat  params);
@@ -411,7 +422,7 @@ package gl
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  type);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
@@ -436,8 +447,12 @@ package gl
 // typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEMEMORYOBJECTSEXT)(GLsizei  n, GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef GLhandleARB  (APIENTRYP GPCREATEPROGRAMOBJECTARB)();
@@ -450,6 +465,7 @@ package gl
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -476,12 +492,14 @@ package gl
 // typedef void  (APIENTRYP GPDELETEASYNCMARKERSSGIX)(GLuint  marker, GLsizei  range);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
 // typedef void  (APIENTRYP GPDELETEBUFFERSARB)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFENCESAPPLE)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFENCESNV)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFRAGMENTSHADERATI)(GLuint  id);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERSEXT)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETELISTS)(GLuint  list, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEMEMORYOBJECTSEXT)(GLsizei  n, const GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
 // typedef void  (APIENTRYP GPDELETENAMESAMD)(GLenum  identifier, GLuint  num, const GLuint * names);
 // typedef void  (APIENTRYP GPDELETEOBJECTARB)(GLhandleARB  obj);
@@ -496,10 +514,13 @@ package gl
 // typedef void  (APIENTRYP GPDELETEPROGRAMSNV)(GLsizei  n, const GLuint * programs);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETEQUERIESARB)(GLsizei  n, const GLuint * ids);
+// typedef void  (APIENTRYP GPDELETEQUERYRESOURCETAGNV)(GLsizei  n, const GLint * tagIds);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERSEXT)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
+// typedef void  (APIENTRYP GPDELETESEMAPHORESEXT)(GLsizei  n, const GLuint * semaphores);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETEXTURESEXT)(GLsizei  n, const GLuint * textures);
@@ -547,6 +568,10 @@ package gl
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSARB)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSATI)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYAPPLE)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYATI)(GLenum  mode, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
@@ -570,6 +595,7 @@ package gl
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKNV)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
 // typedef void  (APIENTRYP GPEDGEFLAG)(GLboolean  flag);
 // typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPEDGEFLAGPOINTER)(GLsizei  stride, const void * pointer);
@@ -622,6 +648,7 @@ package gl
 // typedef void  (APIENTRYP GPEVALMESH2)(GLenum  mode, GLint  i1, GLint  i2, GLint  j1, GLint  j2);
 // typedef void  (APIENTRYP GPEVALPOINT1)(GLint  i);
 // typedef void  (APIENTRYP GPEVALPOINT2)(GLint  i, GLint  j);
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef void  (APIENTRYP GPEXECUTEPROGRAMNV)(GLenum  target, GLuint  id, const GLfloat * params);
 // typedef void  (APIENTRYP GPEXTRACTCOMPONENTEXT)(GLuint  res, GLuint  src, GLuint  num);
 // typedef void  (APIENTRYP GPFEEDBACKBUFFER)(GLsizei  size, GLenum  type, GLfloat * buffer);
@@ -637,7 +664,7 @@ package gl
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGEAPPLE)(GLenum  target, GLintptr  offset, GLsizeiptr  size);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHPIXELDATARANGENV)(GLenum  target);
 // typedef void  (APIENTRYP GPFLUSHRASTERSGIX)();
@@ -666,6 +693,7 @@ package gl
 // typedef void  (APIENTRYP GPFOGXOES)(GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPFOGXVOES)(GLenum  pname, const GLfixed * param);
 // typedef void  (APIENTRYP GPFRAGMENTCOLORMATERIALSGIX)(GLenum  face, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELISGIX)(GLenum  pname, GLint  param);
@@ -682,10 +710,14 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEZOOMSGIX)(GLint  factor);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFEREXT)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1DEXT)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE2D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -699,6 +731,7 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYEREXT)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFREEOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPFRUSTUM)(GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
@@ -723,9 +756,11 @@ package gl
 // typedef void  (APIENTRYP GPGENPROGRAMSNV)(GLsizei  n, GLuint * programs);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENQUERIESARB)(GLsizei  n, GLuint * ids);
+// typedef void  (APIENTRYP GPGENQUERYRESOURCETAGNV)(GLsizei  n, GLint * tagIds);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERSEXT)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
+// typedef void  (APIENTRYP GPGENSEMAPHORESEXT)(GLsizei  n, GLuint * semaphores);
 // typedef GLuint  (APIENTRYP GPGENSYMBOLSEXT)(GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components);
 // typedef void  (APIENTRYP GPGENTEXTURES)(GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPGENTEXTURESEXT)(GLsizei  n, GLuint * textures);
@@ -781,6 +816,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERFVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERIVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, GLfloat * params);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  level, void * img);
@@ -791,6 +827,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERFVEXT)(GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIVEXT)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERXVOES)(GLenum  target, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGAMD)(GLuint  count, GLsizei  bufsize, GLenum * categories, GLuint * severities, GLuint * ids, GLsizei * lengths, GLchar * message);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
@@ -819,6 +856,7 @@ package gl
 // typedef void  (APIENTRYP GPGETFRAGMENTMATERIALIVSGIX)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERFVAMD)(GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
@@ -837,9 +875,11 @@ package gl
 // typedef GLint  (APIENTRYP GPGETINSTRUMENTSSGIX)();
 // typedef void  (APIENTRYP GPGETINTEGER64V)(GLenum  pname, GLint64 * data);
 // typedef void  (APIENTRYP GPGETINTEGERINDEXEDVEXT)(GLenum  target, GLuint  index, GLint * data);
+// typedef void  (APIENTRYP GPGETINTEGERI_V)(GLenum  target, GLuint  index, GLint * data);
 // typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -867,6 +907,7 @@ package gl
 // typedef void  (APIENTRYP GPGETMATERIALIV)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMATERIALXOES)(GLenum  face, GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPGETMATERIALXVOES)(GLenum  face, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMINMAXEXT)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXPARAMETERFVEXT)(GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETMINMAXPARAMETERIVEXT)(GLenum  target, GLenum  pname, GLint * params);
@@ -890,10 +931,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
@@ -919,8 +961,6 @@ package gl
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABELKHR)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOCCLUSIONQUERYIVNV)(GLuint  id, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETOCCLUSIONQUERYUIVNV)(GLuint  id, GLenum  pname, GLuint * params);
-// typedef void  (APIENTRYP GPGETPATHCOLORGENFVNV)(GLenum  color, GLenum  pname, GLfloat * value);
-// typedef void  (APIENTRYP GPGETPATHCOLORGENIVNV)(GLenum  color, GLenum  pname, GLint * value);
 // typedef void  (APIENTRYP GPGETPATHCOMMANDSNV)(GLuint  path, GLubyte * commands);
 // typedef void  (APIENTRYP GPGETPATHCOORDSNV)(GLuint  path, GLfloat * coords);
 // typedef void  (APIENTRYP GPGETPATHDASHARRAYNV)(GLuint  path, GLfloat * dashArray);
@@ -930,8 +970,6 @@ package gl
 // typedef void  (APIENTRYP GPGETPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, GLfloat * value);
 // typedef void  (APIENTRYP GPGETPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, GLint * value);
 // typedef void  (APIENTRYP GPGETPATHSPACINGNV)(GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing);
-// typedef void  (APIENTRYP GPGETPATHTEXGENFVNV)(GLenum  texCoordSet, GLenum  pname, GLfloat * value);
-// typedef void  (APIENTRYP GPGETPATHTEXGENIVNV)(GLenum  texCoordSet, GLenum  pname, GLint * value);
 // typedef void  (APIENTRYP GPGETPERFCOUNTERINFOINTEL)(GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue);
 // typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERDATAAMD)(GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten);
 // typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERINFOAMD)(GLuint  group, GLuint  counter, GLenum  pname, void * data);
@@ -939,7 +977,7 @@ package gl
 // typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
-// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
 // typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
 // typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
 // typedef void  (APIENTRYP GPGETPIXELMAPFV)(GLenum  map, GLfloat * values);
@@ -988,6 +1026,10 @@ package gl
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVARB)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVNV)(GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64VEXT)(GLuint  id, GLenum  pname, GLint64 * params);
@@ -1005,6 +1047,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIUIV)(GLuint  sampler, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERFV)(GLuint  sampler, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIV)(GLuint  sampler, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTEREXT)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSHADERINFOLOG)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETSHADERPRECISIONFORMAT)(GLenum  shadertype, GLenum  precisiontype, GLint * range, GLint * precision);
@@ -1012,6 +1055,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERSOURCEARB)(GLhandleARB  obj, GLsizei  maxLength, GLsizei * length, GLcharARB * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETSHARPENTEXFUNCSGIS)(GLenum  target, GLfloat * points);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETSUBROUTINEUNIFORMLOCATION)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -1071,11 +1115,15 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFVARB)(GLhandleARB  programObj, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIVARB)(GLhandleARB  programObj, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIVEXT)(GLuint  program, GLint  location, GLuint * params);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEI_VEXT)(GLenum  target, GLuint  index, GLubyte * data);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEVEXT)(GLenum  pname, GLubyte * data);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTFVATI)(GLuint  id, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTIVATI)(GLuint  id, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -1119,15 +1167,18 @@ package gl
 // typedef void  (APIENTRYP GPGETVIDEOIVNV)(GLuint  video_slot, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVIDEOUI64VNV)(GLuint  video_slot, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVIDEOUIVNV)(GLuint  video_slot, GLenum  pname, GLuint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNTEXIMAGEARB)(GLenum  target, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNUNIFORMDVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLdouble * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
@@ -1147,6 +1198,12 @@ package gl
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERFVHP)(GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIHP)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIVHP)(GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPIMPORTMEMORYFDEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32HANDLEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32NAMEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, const void * name);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREFDEXT)(GLuint  semaphore, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32HANDLEEXT)(GLuint  semaphore, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32NAMEEXT)(GLuint  semaphore, GLenum  handleType, const void * name);
 // typedef GLsync  (APIENTRYP GPIMPORTSYNCEXT)(GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags);
 // typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPINDEXFUNCEXT)(GLenum  func, GLclampf  ref);
@@ -1185,6 +1242,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERARB)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
 // typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISFENCEAPPLE)(GLuint  fence);
@@ -1194,6 +1252,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISLIST)(GLuint  list);
+// typedef GLboolean  (APIENTRYP GPISMEMORYOBJECTEXT)(GLuint  memoryObject);
 // typedef GLboolean  (APIENTRYP GPISNAMEAMD)(GLenum  identifier, GLuint  name);
 // typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
@@ -1212,7 +1271,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFEREXT)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
+// typedef GLboolean  (APIENTRYP GPISSEMAPHOREEXT)(GLuint  semaphore);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREEXT)(GLuint  texture);
@@ -1224,6 +1285,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAYAPPLE)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXATTRIBENABLEDAPPLE)(GLuint  index, GLenum  pname);
+// typedef void  (APIENTRYP GPLGPUCOPYIMAGESUBDATANVX)(GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPLGPUINTERLOCKNVX)();
+// typedef void  (APIENTRYP GPLGPUNAMEDBUFFERSUBDATANVX)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLIGHTENVISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPLIGHTMODELF)(GLenum  pname, GLfloat  param);
@@ -1244,6 +1308,7 @@ package gl
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPLINKPROGRAMARB)(GLhandleARB  programObj);
 // typedef void  (APIENTRYP GPLISTBASE)(GLuint  base);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLISTPARAMETERFSGIX)(GLuint  list, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPLISTPARAMETERFVSGIX)(GLuint  list, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPLISTPARAMETERISGIX)(GLuint  list, GLenum  pname, GLint  param);
@@ -1292,7 +1357,7 @@ package gl
 // typedef void  (APIENTRYP GPMAPGRID2XOES)(GLint  n, GLfixed  u1, GLfixed  u2, GLfixed  v1, GLfixed  v2);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPMAPPARAMETERFVNV)(GLenum  target, GLenum  pname, const GLfloat * params);
@@ -1338,9 +1403,12 @@ package gl
 // typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIEREXT)(GLbitfield  barriers);
+// typedef void  (APIENTRYP GPMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINMAXEXT)(GLenum  target, GLenum  internalformat, GLboolean  sink);
 // typedef void  (APIENTRYP GPMULTMATRIXD)(const GLdouble * m);
@@ -1357,7 +1425,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTAMD)(GLenum  mode, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTARRAYAPPLE)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
@@ -1366,7 +1434,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTAMD)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWRANGEELEMENTARRAYAPPLE)(GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWARRAYSIBM)(const GLenum * mode, const GLint * first, const GLsizei * count, GLsizei  primcount, GLint  modestride);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWELEMENTSIBM)(const GLenum * mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  primcount, GLint  modestride);
@@ -1483,13 +1551,26 @@ package gl
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPMULTICASTBARRIERNV)();
+// typedef void  (APIENTRYP GPMULTICASTBLITFRAMEBUFFERNV)(GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPMULTICASTBUFFERSUBDATANV)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPMULTICASTCOPYBUFFERSUBDATANV)(GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPMULTICASTCOPYIMAGESUBDATANV)(GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
+// typedef void  (APIENTRYP GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPMULTICASTWAITSYNCNV)(GLuint  signalGpu, GLbitfield  waitGpuMask);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXTERNALEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEMEMEXT)(GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
@@ -1499,6 +1580,9 @@ package gl
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -1574,12 +1658,10 @@ package gl
 // typedef void  (APIENTRYP GPPASSTHROUGHXOES)(GLfixed  token);
 // typedef void  (APIENTRYP GPPATCHPARAMETERFV)(GLenum  pname, const GLfloat * values);
 // typedef void  (APIENTRYP GPPATCHPARAMETERI)(GLenum  pname, GLint  value);
-// typedef void  (APIENTRYP GPPATHCOLORGENNV)(GLenum  color, GLenum  genMode, GLenum  colorFormat, const GLfloat * coeffs);
 // typedef void  (APIENTRYP GPPATHCOMMANDSNV)(GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
 // typedef void  (APIENTRYP GPPATHCOORDSNV)(GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords);
 // typedef void  (APIENTRYP GPPATHCOVERDEPTHFUNCNV)(GLenum  func);
 // typedef void  (APIENTRYP GPPATHDASHARRAYNV)(GLuint  path, GLsizei  dashCount, const GLfloat * dashArray);
-// typedef void  (APIENTRYP GPPATHFOGGENNV)(GLenum  genMode);
 // typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
 // typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXRANGENV)(GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount);
 // typedef void  (APIENTRYP GPPATHGLYPHRANGENV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
@@ -1594,7 +1676,6 @@ package gl
 // typedef void  (APIENTRYP GPPATHSTRINGNV)(GLuint  path, GLenum  format, GLsizei  length, const void * pathString);
 // typedef void  (APIENTRYP GPPATHSUBCOMMANDSNV)(GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
 // typedef void  (APIENTRYP GPPATHSUBCOORDSNV)(GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords);
-// typedef void  (APIENTRYP GPPATHTEXGENNV)(GLenum  texCoordSet, GLenum  genMode, GLint  components, const GLfloat * coeffs);
 // typedef void  (APIENTRYP GPPAUSETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPPAUSETRANSFORMFEEDBACKNV)();
 // typedef void  (APIENTRYP GPPIXELDATARANGENV)(GLenum  target, GLsizei  length, const void * pointer);
@@ -1640,6 +1721,8 @@ package gl
 // typedef GLint  (APIENTRYP GPPOLLINSTRUMENTSSGIX)(GLint * marker_p);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETEXT)(GLfloat  factor, GLfloat  bias);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETXOES)(GLfixed  factor, GLfixed  units);
 // typedef void  (APIENTRYP GPPOLYGONSTIPPLE)(const GLubyte * mask);
@@ -1652,6 +1735,7 @@ package gl
 // typedef void  (APIENTRYP GPPOPNAME)();
 // typedef void  (APIENTRYP GPPRESENTFRAMEDUALFILLNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLenum  target1, GLuint  fill1, GLenum  target2, GLuint  fill2, GLenum  target3, GLuint  fill3);
 // typedef void  (APIENTRYP GPPRESENTFRAMEKEYEDNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1);
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEXNV)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTNV)();
 // typedef void  (APIENTRYP GPPRIORITIZETEXTURES)(GLsizei  n, const GLuint * textures, const GLfloat * priorities);
@@ -1708,13 +1792,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1728,13 +1816,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1748,13 +1840,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1768,13 +1864,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1835,6 +1935,8 @@ package gl
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
 // typedef GLbitfield  (APIENTRYP GPQUERYMATRIXXOES)(GLfixed * mantissa, GLint * exponent);
 // typedef void  (APIENTRYP GPQUERYOBJECTPARAMETERUIAMD)(GLenum  target, GLuint  id, GLenum  pname, GLuint  param);
+// typedef GLint  (APIENTRYP GPQUERYRESOURCENV)(GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer);
+// typedef void  (APIENTRYP GPQUERYRESOURCETAGNV)(GLint  tagId, const GLchar * tagString);
 // typedef void  (APIENTRYP GPRASTERPOS2D)(GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPRASTERPOS2DV)(const GLdouble * v);
 // typedef void  (APIENTRYP GPRASTERPOS2F)(GLfloat  x, GLfloat  y);
@@ -1865,6 +1967,7 @@ package gl
 // typedef void  (APIENTRYP GPRASTERPOS4SV)(const GLshort * v);
 // typedef void  (APIENTRYP GPRASTERPOS4XOES)(GLfixed  x, GLfixed  y, GLfixed  z, GLfixed  w);
 // typedef void  (APIENTRYP GPRASTERPOS4XVOES)(const GLfixed * coords);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
@@ -1882,7 +1985,9 @@ package gl
 // typedef void  (APIENTRYP GPRECTXOES)(GLfixed  x1, GLfixed  y1, GLfixed  x2, GLfixed  y2);
 // typedef void  (APIENTRYP GPRECTXVOES)(const GLfixed * v1, const GLfixed * v2);
 // typedef void  (APIENTRYP GPREFERENCEPLANESGIX)(const GLdouble * equation);
+// typedef GLboolean  (APIENTRYP GPRELEASEKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key);
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
+// typedef void  (APIENTRYP GPRENDERGPUMASKNV)(GLbitfield  mask);
 // typedef GLint  (APIENTRYP GPRENDERMODE)(GLenum  mode);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
@@ -1916,6 +2021,7 @@ package gl
 // typedef void  (APIENTRYP GPRESETHISTOGRAMEXT)(GLenum  target);
 // typedef void  (APIENTRYP GPRESETMINMAXEXT)(GLenum  target);
 // typedef void  (APIENTRYP GPRESIZEBUFFERSMESA)();
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACKNV)();
 // typedef void  (APIENTRYP GPROTATED)(GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
@@ -1923,7 +2029,6 @@ package gl
 // typedef void  (APIENTRYP GPROTATEXOES)(GLfixed  angle, GLfixed  x, GLfixed  y, GLfixed  z);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEARB)(GLfloat  value, GLboolean  invert);
-// typedef void  (APIENTRYP GPSAMPLECOVERAGEOES)(GLfixed  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEXOES)(GLclampx  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMAPATI)(GLuint  dst, GLuint  interp, GLenum  swizzle);
 // typedef void  (APIENTRYP GPSAMPLEMASKEXT)(GLclampf  value, GLboolean  invert);
@@ -1985,6 +2090,7 @@ package gl
 // typedef void  (APIENTRYP GPSECONDARYCOLORPOINTERLISTIBM)(GLint  size, GLenum  type, GLint  stride, const void ** pointer, GLint  ptrstride);
 // typedef void  (APIENTRYP GPSELECTBUFFER)(GLsizei  size, GLuint * buffer);
 // typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
+// typedef void  (APIENTRYP GPSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, const GLuint64 * params);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSETFENCEAPPLE)(GLuint  fence);
 // typedef void  (APIENTRYP GPSETFENCENV)(GLuint  fence, GLenum  condition);
@@ -2001,11 +2107,16 @@ package gl
 // typedef void  (APIENTRYP GPSHADERSOURCEARB)(GLhandleARB  shaderObj, GLsizei  count, const GLcharARB ** string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
 // typedef void  (APIENTRYP GPSHARPENTEXFUNCSGIS)(GLenum  target, GLsizei  n, const GLfloat * points);
+// typedef void  (APIENTRYP GPSIGNALSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERIVSGIX)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPSTARTINSTRUMENTSSGIX)();
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
 // typedef void  (APIENTRYP GPSTENCILCLEARTAGEXT)(GLsizei  stencilTagBits, GLuint  stencilClearTag);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
@@ -2026,6 +2137,7 @@ package gl
 // typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
 // typedef void  (APIENTRYP GPSTOPINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPSTRINGMARKERGREMEDY)(GLsizei  len, const void * string);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPSWIZZLEEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // typedef void  (APIENTRYP GPSYNCTEXTUREINTEL)(GLuint  texture);
 // typedef void  (APIENTRYP GPTAGSAMPLEBUFFERSGIX)();
@@ -2150,7 +2262,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLint  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations);
 // typedef void  (APIENTRYP GPTEXIMAGE4DSGIS)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIVEXT)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIVEXT)(GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERF)(GLenum  target, GLenum  pname, GLfloat  param);
@@ -2165,6 +2277,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXSTORAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXSTORAGE3D)(GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXSTORAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM1DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXSTORAGESPARSEAMD)(GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1DEXT)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2177,7 +2294,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTURECOLORMASKSGIS)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
@@ -2190,7 +2307,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURELIGHTEXT)(GLenum  pname);
 // typedef void  (APIENTRYP GPTEXTUREMATERIALEXT)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPTEXTURENORMALEXT)(GLenum  mode);
-// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
@@ -2215,6 +2332,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM1DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXTURESTORAGESPARSEAMD)(GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2226,7 +2348,7 @@ package gl
 // typedef void  (APIENTRYP GPTRACKMATRIXNV)(GLenum  target, GLuint  address, GLenum  matrix, GLenum  transform);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKATTRIBSNV)(GLsizei  count, const GLint * attribs, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKSTREAMATTRIBSNV)(GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGSEXT)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGSNV)(GLuint  program, GLsizei  count, const GLint * locations, GLenum  bufferMode);
@@ -2241,12 +2363,16 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IARB)(GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1IVARB)(GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIEXT)(GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1UIVEXT)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2257,12 +2383,16 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IARB)(GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2IVARB)(GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIEXT)(GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2UIVEXT)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2273,12 +2403,16 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3IVARB)(GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3UIVEXT)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2289,12 +2423,16 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4IVARB)(GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4UIVEXT)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2692,7 +2830,11 @@ package gl
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
+// typedef void  (APIENTRYP GPWAITSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
 // typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
 // typedef void  (APIENTRYP GPWEIGHTPOINTERARB)(GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPWEIGHTBVARB)(GLint  size, const GLbyte * weights);
@@ -2759,12 +2901,16 @@ package gl
 // typedef void  (APIENTRYP GPWINDOWPOS4IVMESA)(const GLint * v);
 // typedef void  (APIENTRYP GPWINDOWPOS4SMESA)(GLshort  x, GLshort  y, GLshort  z, GLshort  w);
 // typedef void  (APIENTRYP GPWINDOWPOS4SVMESA)(const GLshort * v);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
 // typedef void  (APIENTRYP GPWRITEMASKEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // static void  glowAccum(GPACCUM fnptr, GLenum  op, GLfloat  value) {
 //   (*fnptr)(op, value);
 // }
 // static void  glowAccumxOES(GPACCUMXOES fnptr, GLenum  op, GLfixed  value) {
 //   (*fnptr)(op, value);
+// }
+// static GLboolean  glowAcquireKeyedMutexWin32EXT(GPACQUIREKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key, GLuint  timeout) {
+//   return (*fnptr)(memory, key, timeout);
 // }
 // static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
 //   (*fnptr)(program);
@@ -2801,6 +2947,12 @@ package gl
 // }
 // static void  glowAlphaFuncxOES(GPALPHAFUNCXOES fnptr, GLenum  func, GLfixed  ref) {
 //   (*fnptr)(func, ref);
+// }
+// static void  glowAlphaToCoverageDitherControlNV(GPALPHATOCOVERAGEDITHERCONTROLNV fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowApplyTextureEXT(GPAPPLYTEXTUREEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -2886,6 +3038,9 @@ package gl
 // static void  glowBindBufferARB(GPBINDBUFFERARB fnptr, GLenum  target, GLuint  buffer) {
 //   (*fnptr)(target, buffer);
 // }
+// static void  glowBindBufferBase(GPBINDBUFFERBASE fnptr, GLenum  target, GLuint  index, GLuint  buffer) {
+//   (*fnptr)(target, index, buffer);
+// }
 // static void  glowBindBufferBaseEXT(GPBINDBUFFERBASEEXT fnptr, GLenum  target, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(target, index, buffer);
 // }
@@ -2897,6 +3052,9 @@ package gl
 // }
 // static void  glowBindBufferOffsetNV(GPBINDBUFFEROFFSETNV fnptr, GLenum  target, GLuint  index, GLuint  buffer, GLintptr  offset) {
 //   (*fnptr)(target, index, buffer, offset);
+// }
+// static void  glowBindBufferRange(GPBINDBUFFERRANGE fnptr, GLenum  target, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
+//   (*fnptr)(target, index, buffer, offset, size);
 // }
 // static void  glowBindBufferRangeEXT(GPBINDBUFFERRANGEEXT fnptr, GLenum  target, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, index, buffer, offset, size);
@@ -3138,7 +3296,7 @@ package gl
 // static void  glowBufferDataARB(GPBUFFERDATAARB fnptr, GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferParameteriAPPLE(GPBUFFERPARAMETERIAPPLE fnptr, GLenum  target, GLenum  pname, GLint  param) {
@@ -3147,11 +3305,20 @@ package gl
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(target, size, data, flags);
 // }
+// static void  glowBufferStorageExternalEXT(GPBUFFERSTORAGEEXTERNALEXT fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(target, offset, size, clientBuffer, flags);
+// }
+// static void  glowBufferStorageMemEXT(GPBUFFERSTORAGEMEMEXT fnptr, GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, size, memory, offset);
+// }
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
 // static void  glowBufferSubDataARB(GPBUFFERSUBDATAARB fnptr, GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
 // }
 // static void  glowCallList(GPCALLLIST fnptr, GLuint  list) {
 //   (*fnptr)(list);
@@ -3225,14 +3392,14 @@ package gl
 // static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
 // static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -3492,6 +3659,12 @@ package gl
 // static void  glowCombinerStageParameterfvNV(GPCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, const GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
@@ -3582,6 +3755,12 @@ package gl
 // static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
 //   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
 // }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
+// }
 // static void  glowConvolutionFilter1DEXT(GPCONVOLUTIONFILTER1DEXT fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image) {
 //   (*fnptr)(target, internalformat, width, format, type, image);
 // }
@@ -3642,7 +3821,7 @@ package gl
 // static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
@@ -3717,11 +3896,23 @@ package gl
 // static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
 //   (*fnptr)(path, coverMode);
 // }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
+// }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreateMemoryObjectsEXT(GPCREATEMEMORYOBJECTSEXT fnptr, GLsizei  n, GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
 //   (*fnptr)(queryId, queryHandle);
@@ -3758,6 +3949,9 @@ package gl
 // }
 // static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -3837,6 +4031,9 @@ package gl
 // static void  glowDeleteBuffersARB(GPDELETEBUFFERSARB fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFencesAPPLE(GPDELETEFENCESAPPLE fnptr, GLsizei  n, const GLuint * fences) {
 //   (*fnptr)(n, fences);
 // }
@@ -3854,6 +4051,9 @@ package gl
 // }
 // static void  glowDeleteLists(GPDELETELISTS fnptr, GLuint  list, GLsizei  range) {
 //   (*fnptr)(list, range);
+// }
+// static void  glowDeleteMemoryObjectsEXT(GPDELETEMEMORYOBJECTSEXT fnptr, GLsizei  n, const GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
@@ -3897,6 +4097,9 @@ package gl
 // static void  glowDeleteQueriesARB(GPDELETEQUERIESARB fnptr, GLsizei  n, const GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowDeleteQueryResourceTagNV(GPDELETEQUERYRESOURCETAGNV fnptr, GLsizei  n, const GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowDeleteRenderbuffers(GPDELETERENDERBUFFERS fnptr, GLsizei  n, const GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -3906,8 +4109,14 @@ package gl
 // static void  glowDeleteSamplers(GPDELETESAMPLERS fnptr, GLsizei  count, const GLuint * samplers) {
 //   (*fnptr)(count, samplers);
 // }
+// static void  glowDeleteSemaphoresEXT(GPDELETESEMAPHORESEXT fnptr, GLsizei  n, const GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
+// }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -4050,6 +4259,18 @@ package gl
 // static void  glowDrawBuffersATI(GPDRAWBUFFERSATI fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
 // }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
+// }
 // static void  glowDrawElementArrayAPPLE(GPDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, GLint  first, GLsizei  count) {
 //   (*fnptr)(mode, first, count);
 // }
@@ -4118,6 +4339,9 @@ package gl
 // }
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
+// }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
 // }
 // static void  glowEdgeFlag(GPEDGEFLAG fnptr, GLboolean  flag) {
 //   (*fnptr)(flag);
@@ -4275,6 +4499,9 @@ package gl
 // static void  glowEvalPoint2(GPEVALPOINT2 fnptr, GLint  i, GLint  j) {
 //   (*fnptr)(i, j);
 // }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowExecuteProgramNV(GPEXECUTEPROGRAMNV fnptr, GLenum  target, GLuint  id, const GLfloat * params) {
 //   (*fnptr)(target, id, params);
 // }
@@ -4320,7 +4547,7 @@ package gl
 // static void  glowFlushMappedBufferRangeAPPLE(GPFLUSHMAPPEDBUFFERRANGEAPPLE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, offset, size);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
 // }
 // static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
@@ -4407,6 +4634,9 @@ package gl
 // static void  glowFragmentColorMaterialSGIX(GPFRAGMENTCOLORMATERIALSGIX fnptr, GLenum  face, GLenum  mode) {
 //   (*fnptr)(face, mode);
 // }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
 // static void  glowFragmentLightModelfSGIX(GPFRAGMENTLIGHTMODELFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -4455,6 +4685,9 @@ package gl
 // static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(framebuffer, n, bufs);
 // }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
@@ -4466,6 +4699,15 @@ package gl
 // }
 // static void  glowFramebufferRenderbufferEXT(GPFRAMEBUFFERRENDERBUFFEREXT fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSamplePositionsfvAMD(GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(target, numsamples, pixelindex, values);
 // }
 // static void  glowFramebufferTexture1D(GPFRAMEBUFFERTEXTURE1D fnptr, GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, textarget, texture, level);
@@ -4505,6 +4747,9 @@ package gl
 // }
 // static void  glowFramebufferTextureLayerEXT(GPFRAMEBUFFERTEXTURELAYEREXT fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFreeObjectBufferATI(GPFREEOBJECTBUFFERATI fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -4578,6 +4823,9 @@ package gl
 // static void  glowGenQueriesARB(GPGENQUERIESARB fnptr, GLsizei  n, GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowGenQueryResourceTagNV(GPGENQUERYRESOURCETAGNV fnptr, GLsizei  n, GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowGenRenderbuffers(GPGENRENDERBUFFERS fnptr, GLsizei  n, GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4586,6 +4834,9 @@ package gl
 // }
 // static void  glowGenSamplers(GPGENSAMPLERS fnptr, GLsizei  count, GLuint * samplers) {
 //   (*fnptr)(count, samplers);
+// }
+// static void  glowGenSemaphoresEXT(GPGENSEMAPHORESEXT fnptr, GLsizei  n, GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
 // }
 // static GLuint  glowGenSymbolsEXT(GPGENSYMBOLSEXT fnptr, GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components) {
 //   return (*fnptr)(datatype, storagetype, range, components);
@@ -4752,6 +5003,9 @@ package gl
 // static void  glowGetCombinerStageParameterfvNV(GPGETCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
 // static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
 //   (*fnptr)(texunit, target, lod, img);
 // }
@@ -4781,6 +5035,9 @@ package gl
 // }
 // static void  glowGetConvolutionParameterxvOES(GPGETCONVOLUTIONPARAMETERXVOES fnptr, GLenum  target, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -4866,6 +5123,9 @@ package gl
 // static void  glowGetFramebufferAttachmentParameterivEXT(GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLenum  target, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, attachment, pname, params);
 // }
+// static void  glowGetFramebufferParameterfvAMD(GPGETFRAMEBUFFERPARAMETERFVAMD fnptr, GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(target, pname, numsamples, pixelindex, size, values);
+// }
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
@@ -4920,6 +5180,9 @@ package gl
 // static void  glowGetIntegerIndexedvEXT(GPGETINTEGERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLint * data) {
 //   (*fnptr)(target, index, data);
 // }
+// static void  glowGetIntegeri_v(GPGETINTEGERI_V fnptr, GLenum  target, GLuint  index, GLint * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetIntegerui64i_vNV(GPGETINTEGERUI64I_VNV fnptr, GLenum  value, GLuint  index, GLuint64EXT * result) {
 //   (*fnptr)(value, index, result);
 // }
@@ -4928,6 +5191,9 @@ package gl
 // }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
@@ -5010,6 +5276,9 @@ package gl
 // static void  glowGetMaterialxvOES(GPGETMATERIALXVOES fnptr, GLenum  face, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(face, pname, params);
 // }
+// static void  glowGetMemoryObjectParameterivEXT(GPGETMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
+// }
 // static void  glowGetMinmaxEXT(GPGETMINMAXEXT fnptr, GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values) {
 //   (*fnptr)(target, reset, format, type, values);
 // }
@@ -5079,7 +5348,7 @@ package gl
 // static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
@@ -5090,6 +5359,9 @@ package gl
 // }
 // static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
+// }
+// static void  glowGetNamedFramebufferParameterfvAMD(GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD fnptr, GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(framebuffer, pname, numsamples, pixelindex, size, values);
 // }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
@@ -5166,12 +5438,6 @@ package gl
 // static void  glowGetOcclusionQueryuivNV(GPGETOCCLUSIONQUERYUIVNV fnptr, GLuint  id, GLenum  pname, GLuint * params) {
 //   (*fnptr)(id, pname, params);
 // }
-// static void  glowGetPathColorGenfvNV(GPGETPATHCOLORGENFVNV fnptr, GLenum  color, GLenum  pname, GLfloat * value) {
-//   (*fnptr)(color, pname, value);
-// }
-// static void  glowGetPathColorGenivNV(GPGETPATHCOLORGENIVNV fnptr, GLenum  color, GLenum  pname, GLint * value) {
-//   (*fnptr)(color, pname, value);
-// }
 // static void  glowGetPathCommandsNV(GPGETPATHCOMMANDSNV fnptr, GLuint  path, GLubyte * commands) {
 //   (*fnptr)(path, commands);
 // }
@@ -5199,12 +5465,6 @@ package gl
 // static void  glowGetPathSpacingNV(GPGETPATHSPACINGNV fnptr, GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing) {
 //   (*fnptr)(pathListMode, numPaths, pathNameType, paths, pathBase, advanceScale, kerningScale, transformType, returnedSpacing);
 // }
-// static void  glowGetPathTexGenfvNV(GPGETPATHTEXGENFVNV fnptr, GLenum  texCoordSet, GLenum  pname, GLfloat * value) {
-//   (*fnptr)(texCoordSet, pname, value);
-// }
-// static void  glowGetPathTexGenivNV(GPGETPATHTEXGENIVNV fnptr, GLenum  texCoordSet, GLenum  pname, GLint * value) {
-//   (*fnptr)(texCoordSet, pname, value);
-// }
 // static void  glowGetPerfCounterInfoINTEL(GPGETPERFCOUNTERINFOINTEL fnptr, GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue) {
 //   (*fnptr)(queryId, counterId, counterNameLength, counterName, counterDescLength, counterDesc, counterOffset, counterDataSize, counterTypeEnum, counterDataTypeEnum, rawCounterMaxValue);
 // }
@@ -5226,7 +5486,7 @@ package gl
 // static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
 //   (*fnptr)(numGroups, groupsSize, groups);
 // }
-// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten) {
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
 //   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
 // }
 // static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
@@ -5373,6 +5633,18 @@ package gl
 // static void  glowGetProgramivNV(GPGETPROGRAMIVNV fnptr, GLuint  id, GLenum  pname, GLint * params) {
 //   (*fnptr)(id, pname, params);
 // }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
 // }
@@ -5424,6 +5696,9 @@ package gl
 // static void  glowGetSamplerParameteriv(GPGETSAMPLERPARAMETERIV fnptr, GLuint  sampler, GLenum  pname, GLint * params) {
 //   (*fnptr)(sampler, pname, params);
 // }
+// static void  glowGetSemaphoreParameterui64vEXT(GPGETSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowGetSeparableFilterEXT(GPGETSEPARABLEFILTEREXT fnptr, GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span) {
 //   (*fnptr)(target, format, type, row, column, span);
 // }
@@ -5444,6 +5719,9 @@ package gl
 // }
 // static void  glowGetSharpenTexFuncSGIS(GPGETSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLfloat * points) {
 //   (*fnptr)(target, points);
+// }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
 // }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
@@ -5622,6 +5900,9 @@ package gl
 // static void  glowGetUniformfvARB(GPGETUNIFORMFVARB fnptr, GLhandleARB  programObj, GLint  location, GLfloat * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5631,11 +5912,20 @@ package gl
 // static void  glowGetUniformivARB(GPGETUNIFORMIVARB fnptr, GLhandleARB  programObj, GLint  location, GLint * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
 // static void  glowGetUniformuivEXT(GPGETUNIFORMUIVEXT fnptr, GLuint  program, GLint  location, GLuint * params) {
 //   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUnsignedBytei_vEXT(GPGETUNSIGNEDBYTEI_VEXT fnptr, GLenum  target, GLuint  index, GLubyte * data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetUnsignedBytevEXT(GPGETUNSIGNEDBYTEVEXT fnptr, GLenum  pname, GLubyte * data) {
+//   (*fnptr)(pname, data);
 // }
 // static void  glowGetVariantArrayObjectfvATI(GPGETVARIANTARRAYOBJECTFVATI fnptr, GLuint  id, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(id, pname, params);
@@ -5766,6 +6056,9 @@ package gl
 // static void  glowGetVideouivNV(GPGETVIDEOUIVNV fnptr, GLuint  video_slot, GLenum  pname, GLuint * params) {
 //   (*fnptr)(video_slot, pname, params);
 // }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
+// }
 // static void  glowGetnCompressedTexImageARB(GPGETNCOMPRESSEDTEXIMAGEARB fnptr, GLenum  target, GLint  lod, GLsizei  bufSize, void * img) {
 //   (*fnptr)(target, lod, bufSize, img);
 // }
@@ -5784,6 +6077,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -5791,6 +6087,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -5849,6 +6148,24 @@ package gl
 // }
 // static void  glowImageTransformParameterivHP(GPIMAGETRANSFORMPARAMETERIVHP fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowImportMemoryFdEXT(GPIMPORTMEMORYFDEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(memory, size, handleType, fd);
+// }
+// static void  glowImportMemoryWin32HandleEXT(GPIMPORTMEMORYWIN32HANDLEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, void * handle) {
+//   (*fnptr)(memory, size, handleType, handle);
+// }
+// static void  glowImportMemoryWin32NameEXT(GPIMPORTMEMORYWIN32NAMEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, const void * name) {
+//   (*fnptr)(memory, size, handleType, name);
+// }
+// static void  glowImportSemaphoreFdEXT(GPIMPORTSEMAPHOREFDEXT fnptr, GLuint  semaphore, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(semaphore, handleType, fd);
+// }
+// static void  glowImportSemaphoreWin32HandleEXT(GPIMPORTSEMAPHOREWIN32HANDLEEXT fnptr, GLuint  semaphore, GLenum  handleType, void * handle) {
+//   (*fnptr)(semaphore, handleType, handle);
+// }
+// static void  glowImportSemaphoreWin32NameEXT(GPIMPORTSEMAPHOREWIN32NAMEEXT fnptr, GLuint  semaphore, GLenum  handleType, const void * name) {
+//   (*fnptr)(semaphore, handleType, name);
 // }
 // static GLsync  glowImportSyncEXT(GPIMPORTSYNCEXT fnptr, GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags) {
 //   return (*fnptr)(external_sync_type, external_sync, flags);
@@ -5964,6 +6281,9 @@ package gl
 // static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
 // }
@@ -5990,6 +6310,9 @@ package gl
 // }
 // static GLboolean  glowIsList(GPISLIST fnptr, GLuint  list) {
 //   return (*fnptr)(list);
+// }
+// static GLboolean  glowIsMemoryObjectEXT(GPISMEMORYOBJECTEXT fnptr, GLuint  memoryObject) {
+//   return (*fnptr)(memoryObject);
 // }
 // static GLboolean  glowIsNameAMD(GPISNAMEAMD fnptr, GLenum  identifier, GLuint  name) {
 //   return (*fnptr)(identifier, name);
@@ -6045,8 +6368,14 @@ package gl
 // static GLboolean  glowIsSampler(GPISSAMPLER fnptr, GLuint  sampler) {
 //   return (*fnptr)(sampler);
 // }
+// static GLboolean  glowIsSemaphoreEXT(GPISSEMAPHOREEXT fnptr, GLuint  semaphore) {
+//   return (*fnptr)(semaphore);
+// }
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
+// }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
 // }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
@@ -6080,6 +6409,15 @@ package gl
 // }
 // static GLboolean  glowIsVertexAttribEnabledAPPLE(GPISVERTEXATTRIBENABLEDAPPLE fnptr, GLuint  index, GLenum  pname) {
 //   return (*fnptr)(index, pname);
+// }
+// static void  glowLGPUCopyImageSubDataNVX(GPLGPUCOPYIMAGESUBDATANVX fnptr, GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(sourceGpu, destinationGpuMask, srcName, srcTarget, srcLevel, srcX, srxY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, width, height, depth);
+// }
+// static void  glowLGPUInterlockNVX(GPLGPUINTERLOCKNVX fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowLGPUNamedBufferSubDataNVX(GPLGPUNAMEDBUFFERSUBDATANVX fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
 // }
 // static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(type, object, length, label);
@@ -6140,6 +6478,9 @@ package gl
 // }
 // static void  glowListBase(GPLISTBASE fnptr, GLuint  base) {
 //   (*fnptr)(base);
+// }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
 // }
 // static void  glowListParameterfSGIX(GPLISTPARAMETERFSGIX fnptr, GLuint  list, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(list, pname, param);
@@ -6285,7 +6626,7 @@ package gl
 // static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
 // }
 // static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
@@ -6423,6 +6764,12 @@ package gl
 // static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
 //   (*fnptr)(mode, x, y, z);
 // }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
 // }
@@ -6431,6 +6778,9 @@ package gl
 // }
 // static void  glowMemoryBarrierEXT(GPMEMORYBARRIEREXT fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
+// }
+// static void  glowMemoryObjectParameterivEXT(GPMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, const GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
 // }
 // static void  glowMinSampleShadingARB(GPMINSAMPLESHADINGARB fnptr, GLfloat  value) {
 //   (*fnptr)(value);
@@ -6480,7 +6830,7 @@ package gl
 // static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElementArrayAPPLE(GPMULTIDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -6507,7 +6857,7 @@ package gl
 // static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawRangeElementArrayAPPLE(GPMULTIDRAWRANGEELEMENTARRAYAPPLE fnptr, GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -6858,25 +7208,64 @@ package gl
 // static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMulticastBarrierNV(GPMULTICASTBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowMulticastBlitFramebufferNV(GPMULTICASTBLITFRAMEBUFFERNV fnptr, GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
+//   (*fnptr)(srcGpu, dstGpu, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+// }
+// static void  glowMulticastBufferSubDataNV(GPMULTICASTBUFFERSUBDATANV fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
+// }
+// static void  glowMulticastCopyBufferSubDataNV(GPMULTICASTCOPYBUFFERSUBDATANV fnptr, GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readGpu, writeGpuMask, readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowMulticastCopyImageSubDataNV(GPMULTICASTCOPYIMAGESUBDATANV fnptr, GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
+//   (*fnptr)(srcGpu, dstGpuMask, srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
+// }
+// static void  glowMulticastFramebufferSampleLocationsfvNV(GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(gpu, framebuffer, start, count, v);
+// }
+// static void  glowMulticastGetQueryObjecti64vNV(GPMULTICASTGETQUERYOBJECTI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectivNV(GPMULTICASTGETQUERYOBJECTIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectui64vNV(GPMULTICASTGETQUERYOBJECTUI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectuivNV(GPMULTICASTGETQUERYOBJECTUIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastWaitSyncNV(GPMULTICASTWAITSYNCNV fnptr, GLuint  signalGpu, GLbitfield  waitGpuMask) {
+//   (*fnptr)(signalGpu, waitGpuMask);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
 // static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
 // static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageExternalEXT(GPNAMEDBUFFERSTORAGEEXTERNALEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(buffer, offset, size, clientBuffer, flags);
+// }
+// static void  glowNamedBufferStorageMemEXT(GPNAMEDBUFFERSTORAGEMEMEXT fnptr, GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(buffer, size, memory, offset);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
@@ -6905,6 +7294,15 @@ package gl
 // }
 // static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSamplePositionsfvAMD(GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(framebuffer, numsamples, pixelindex, values);
 // }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
@@ -7131,9 +7529,6 @@ package gl
 // static void  glowPatchParameteri(GPPATCHPARAMETERI fnptr, GLenum  pname, GLint  value) {
 //   (*fnptr)(pname, value);
 // }
-// static void  glowPathColorGenNV(GPPATHCOLORGENNV fnptr, GLenum  color, GLenum  genMode, GLenum  colorFormat, const GLfloat * coeffs) {
-//   (*fnptr)(color, genMode, colorFormat, coeffs);
-// }
 // static void  glowPathCommandsNV(GPPATHCOMMANDSNV fnptr, GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
 //   (*fnptr)(path, numCommands, commands, numCoords, coordType, coords);
 // }
@@ -7145,9 +7540,6 @@ package gl
 // }
 // static void  glowPathDashArrayNV(GPPATHDASHARRAYNV fnptr, GLuint  path, GLsizei  dashCount, const GLfloat * dashArray) {
 //   (*fnptr)(path, dashCount, dashArray);
-// }
-// static void  glowPathFogGenNV(GPPATHFOGGENNV fnptr, GLenum  genMode) {
-//   (*fnptr)(genMode);
 // }
 // static GLenum  glowPathGlyphIndexArrayNV(GPPATHGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
 //   return (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
@@ -7190,9 +7582,6 @@ package gl
 // }
 // static void  glowPathSubCoordsNV(GPPATHSUBCOORDSNV fnptr, GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords) {
 //   (*fnptr)(path, coordStart, numCoords, coordType, coords);
-// }
-// static void  glowPathTexGenNV(GPPATHTEXGENNV fnptr, GLenum  texCoordSet, GLenum  genMode, GLint  components, const GLfloat * coeffs) {
-//   (*fnptr)(texCoordSet, genMode, components, coeffs);
 // }
 // static void  glowPauseTransformFeedback(GPPAUSETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
@@ -7329,6 +7718,12 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPolygonOffsetEXT(GPPOLYGONOFFSETEXT fnptr, GLfloat  factor, GLfloat  bias) {
 //   (*fnptr)(factor, bias);
 // }
@@ -7364,6 +7759,9 @@ package gl
 // }
 // static void  glowPresentFrameKeyedNV(GPPRESENTFRAMEKEYEDNV fnptr, GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1) {
 //   (*fnptr)(video_slot, minPresentTime, beginPresentTimeId, presentDurationId, type, target0, fill0, key0, target1, fill1, key1);
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndexNV(GPPRIMITIVERESTARTINDEXNV fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -7533,8 +7931,14 @@ package gl
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7551,8 +7955,14 @@ package gl
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7593,8 +8003,14 @@ package gl
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7611,8 +8027,14 @@ package gl
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7653,8 +8075,14 @@ package gl
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7671,8 +8099,14 @@ package gl
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7713,8 +8147,14 @@ package gl
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7731,8 +8171,14 @@ package gl
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7914,6 +8360,12 @@ package gl
 // static void  glowQueryObjectParameteruiAMD(GPQUERYOBJECTPARAMETERUIAMD fnptr, GLenum  target, GLuint  id, GLenum  pname, GLuint  param) {
 //   (*fnptr)(target, id, pname, param);
 // }
+// static GLint  glowQueryResourceNV(GPQUERYRESOURCENV fnptr, GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer) {
+//   return (*fnptr)(queryType, tagId, bufSize, buffer);
+// }
+// static void  glowQueryResourceTagNV(GPQUERYRESOURCETAGNV fnptr, GLint  tagId, const GLchar * tagString) {
+//   (*fnptr)(tagId, tagString);
+// }
 // static void  glowRasterPos2d(GPRASTERPOS2D fnptr, GLdouble  x, GLdouble  y) {
 //   (*fnptr)(x, y);
 // }
@@ -8004,6 +8456,9 @@ package gl
 // static void  glowRasterPos4xvOES(GPRASTERPOS4XVOES fnptr, const GLfixed * coords) {
 //   (*fnptr)(coords);
 // }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
+// }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
 // }
@@ -8055,8 +8510,14 @@ package gl
 // static void  glowReferencePlaneSGIX(GPREFERENCEPLANESGIX fnptr, const GLdouble * equation) {
 //   (*fnptr)(equation);
 // }
+// static GLboolean  glowReleaseKeyedMutexWin32EXT(GPRELEASEKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key) {
+//   return (*fnptr)(memory, key);
+// }
 // static void  glowReleaseShaderCompiler(GPRELEASESHADERCOMPILER fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowRenderGpuMaskNV(GPRENDERGPUMASKNV fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static GLint  glowRenderMode(GPRENDERMODE fnptr, GLenum  mode) {
 //   return (*fnptr)(mode);
@@ -8157,6 +8618,9 @@ package gl
 // static void  glowResizeBuffersMESA(GPRESIZEBUFFERSMESA fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -8176,9 +8640,6 @@ package gl
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoverageARB(GPSAMPLECOVERAGEARB fnptr, GLfloat  value, GLboolean  invert) {
-//   (*fnptr)(value, invert);
-// }
-// static void  glowSampleCoverageOES(GPSAMPLECOVERAGEOES fnptr, GLfixed  value, GLboolean  invert) {
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoveragexOES(GPSAMPLECOVERAGEXOES fnptr, GLclampx  value, GLboolean  invert) {
@@ -8364,6 +8825,9 @@ package gl
 // static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
 //   (*fnptr)(monitor, enable, group, numCounters, counterList);
 // }
+// static void  glowSemaphoreParameterui64vEXT(GPSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, const GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowSeparableFilter2DEXT(GPSEPARABLEFILTER2DEXT fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column) {
 //   (*fnptr)(target, internalformat, width, height, format, type, row, column);
 // }
@@ -8412,6 +8876,18 @@ package gl
 // static void  glowSharpenTexFuncSGIS(GPSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLsizei  n, const GLfloat * points) {
 //   (*fnptr)(target, n, points);
 // }
+// static void  glowSignalSemaphoreEXT(GPSIGNALSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, dstLayouts);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
 // static void  glowSpriteParameterfSGIX(GPSPRITEPARAMETERFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -8426,6 +8902,9 @@ package gl
 // }
 // static void  glowStartInstrumentsSGIX(GPSTARTINSTRUMENTSSGIX fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
 // }
 // static void  glowStencilClearTagEXT(GPSTENCILCLEARTAGEXT fnptr, GLsizei  stencilTagBits, GLuint  stencilClearTag) {
 //   (*fnptr)(stencilTagBits, stencilClearTag);
@@ -8486,6 +8965,9 @@ package gl
 // }
 // static void  glowStringMarkerGREMEDY(GPSTRINGMARKERGREMEDY fnptr, GLsizei  len, const void * string) {
 //   (*fnptr)(len, string);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
 // }
 // static void  glowSwizzleEXT(GPSWIZZLEEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
@@ -8859,8 +9341,8 @@ package gl
 // static void  glowTexImage4DSGIS(GPTEXIMAGE4DSGIS fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, height, depth, size4d, border, format, type, pixels);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIivEXT(GPTEXPARAMETERIIVEXT fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -8904,6 +9386,21 @@ package gl
 // static void  glowTexStorage3DMultisample(GPTEXSTORAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTexStorageMem1DEXT(GPTEXSTORAGEMEM1DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTexStorageMem2DEXT(GPTEXSTORAGEMEM2DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTexStorageMem2DMultisampleEXT(GPTEXSTORAGEMEM2DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTexStorageMem3DEXT(GPTEXSTORAGEMEM3DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTexStorageMem3DMultisampleEXT(GPTEXSTORAGEMEM3DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTexStorageSparseAMD(GPTEXSTORAGESPARSEAMD fnptr, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -8940,7 +9437,7 @@ package gl
 // static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, target, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
 // }
 // static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
@@ -8979,8 +9476,8 @@ package gl
 // static void  glowTextureNormalEXT(GPTEXTURENORMALEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
 // }
-// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
@@ -9054,6 +9551,21 @@ package gl
 // static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorageMem1DEXT(GPTEXTURESTORAGEMEM1DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTextureStorageMem2DEXT(GPTEXTURESTORAGEMEM2DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTextureStorageMem2DMultisampleEXT(GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTextureStorageMem3DEXT(GPTEXTURESTORAGEMEM3DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTextureStorageMem3DMultisampleEXT(GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTextureStorageSparseAMD(GPTEXTURESTORAGESPARSEAMD fnptr, GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(texture, target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9087,7 +9599,7 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackStreamAttribsNV(GPTRANSFORMFEEDBACKSTREAMATTRIBSNV fnptr, GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode) {
@@ -9132,8 +9644,14 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9147,8 +9665,14 @@ package gl
 // static void  glowUniform1ivARB(GPUNIFORM1IVARB fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9180,8 +9704,14 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9195,8 +9725,14 @@ package gl
 // static void  glowUniform2ivARB(GPUNIFORM2IVARB fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9228,8 +9764,14 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9243,8 +9785,14 @@ package gl
 // static void  glowUniform3ivARB(GPUNIFORM3IVARB fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9276,8 +9824,14 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9291,8 +9845,14 @@ package gl
 // static void  glowUniform4ivARB(GPUNIFORM4IVARB fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -10485,8 +11045,20 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
+// static void  glowWaitSemaphoreEXT(GPWAITSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, srcLayouts);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
 // }
 // static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
 //   (*fnptr)(resultPath, numPaths, paths, weights);
@@ -10686,6 +11258,9 @@ package gl
 // static void  glowWindowPos4svMESA(GPWINDOWPOS4SVMESA fnptr, const GLshort * v) {
 //   (*fnptr)(v);
 // }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
+// }
 // static void  glowWriteMaskEXT(GPWRITEMASKEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
 // }
@@ -10774,6 +11349,7 @@ const (
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_BARRIER_BITS_EXT                                       = 0xFFFFFFFF
 	ALL_COMPLETED_NV                                           = 0x84F2
+	ALL_PIXELS_AMD                                             = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
 	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALL_STATIC_DATA_IBM                                        = 103060
@@ -10807,11 +11383,16 @@ const (
 	ALPHA_MAX_SGIX                                             = 0x8321
 	ALPHA_MIN_CLAMP_INGR                                       = 0x8563
 	ALPHA_MIN_SGIX                                             = 0x8320
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALPHA_SCALE                                                = 0x0D1C
 	ALPHA_SNORM                                                = 0x9010
 	ALPHA_TEST                                                 = 0x0BC0
 	ALPHA_TEST_FUNC                                            = 0x0BC1
 	ALPHA_TEST_REF                                             = 0x0BC2
+	ALPHA_TO_COVERAGE_DITHER_DEFAULT_NV                        = 0x934D
+	ALPHA_TO_COVERAGE_DITHER_DISABLE_NV                        = 0x934F
+	ALPHA_TO_COVERAGE_DITHER_ENABLE_NV                         = 0x934E
+	ALPHA_TO_COVERAGE_DITHER_MODE_NV                           = 0x92BF
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	ALWAYS_FAST_HINT_PGI                                       = 0x1A20C
@@ -10857,6 +11438,7 @@ const (
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
 	ATTENUATION_EXT                                            = 0x834D
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	ATTRIB_ARRAY_POINTER_NV                                    = 0x8645
 	ATTRIB_ARRAY_SIZE_NV                                       = 0x8623
 	ATTRIB_ARRAY_STRIDE_NV                                     = 0x8624
@@ -10897,6 +11479,7 @@ const (
 	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
 	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_COLOR_EXT                                            = 0x8005
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
@@ -11152,6 +11735,8 @@ const (
 	COMPILE                                                    = 0x1300
 	COMPILE_AND_EXECUTE                                        = 0x1301
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_ALPHA                                           = 0x84E9
 	COMPRESSED_ALPHA_ARB                                       = 0x84E9
 	COMPRESSED_INTENSITY                                       = 0x84EC
@@ -11249,8 +11834,18 @@ const (
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	COMP_BIT_ATI                                               = 0x00000002
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
 	CONIC_CURVE_TO_NV                                          = 0x1A
 	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSERVE_MEMORY_HINT_PGI                                   = 0x1A1FD
 	CONSTANT                                                   = 0x8576
 	CONSTANT_ALPHA                                             = 0x8003
@@ -11266,6 +11861,7 @@ const (
 	CONST_EYE_NV                                               = 0x86E5
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
 	CONTEXT_LOST_KHR                                           = 0x0507
@@ -11327,13 +11923,14 @@ const (
 	COPY_INVERTED                                              = 0x150C
 	COPY_PIXEL_TOKEN                                           = 0x0706
 	COPY_READ_BUFFER                                           = 0x8F36
-	COPY_READ_BUFFER_BINDING                                   = 0x8F36
 	COPY_WRITE_BUFFER                                          = 0x8F37
-	COPY_WRITE_BUFFER_BINDING                                  = 0x8F37
 	COUNTER_RANGE_AMD                                          = 0x8BC1
 	COUNTER_TYPE_AMD                                           = 0x8BC0
 	COUNT_DOWN_NV                                              = 0x9089
 	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
 	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CUBIC_EXT                                                  = 0x8334
 	CUBIC_HP                                                   = 0x815F
@@ -11383,6 +11980,7 @@ const (
 	CURRENT_VERTEX_WEIGHT_EXT                                  = 0x850B
 	CURRENT_WEIGHT_ARB                                         = 0x86A8
 	CW                                                         = 0x0900
+	D3D12_FENCE_VALUE_EXT                                      = 0x9595
 	DARKEN_KHR                                                 = 0x9297
 	DARKEN_NV                                                  = 0x9297
 	DATA_BUFFER_AMD                                            = 0x9151
@@ -11475,6 +12073,7 @@ const (
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DECR_WRAP_EXT                                              = 0x8508
+	DEDICATED_MEMORY_OBJECT_EXT                                = 0x9581
 	DEFORMATIONS_MASK_SGIX                                     = 0x8196
 	DELETE_STATUS                                              = 0x8B80
 	DEPENDENT_AR_TEXTURE_2D_NV                                 = 0x86E9
@@ -11516,6 +12115,7 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_SCALE                                                = 0x0D1E
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
@@ -11533,6 +12133,9 @@ const (
 	DETAIL_TEXTURE_FUNC_POINTS_SGIS                            = 0x809C
 	DETAIL_TEXTURE_LEVEL_SGIS                                  = 0x809A
 	DETAIL_TEXTURE_MODE_SGIS                                   = 0x809B
+	DEVICE_LUID_EXT                                            = 0x9599
+	DEVICE_NODE_MASK_EXT                                       = 0x959A
+	DEVICE_UUID_EXT                                            = 0x9597
 	DIFFERENCE_KHR                                             = 0x929E
 	DIFFERENCE_NV                                              = 0x929E
 	DIFFUSE                                                    = 0x1201
@@ -11594,6 +12197,9 @@ const (
 	DOUBLE_VEC3_EXT                                            = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
 	DOUBLE_VEC4_EXT                                            = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER0_ARB                                           = 0x8825
@@ -11643,6 +12249,9 @@ const (
 	DRAW_BUFFER9                                               = 0x882E
 	DRAW_BUFFER9_ARB                                           = 0x882E
 	DRAW_BUFFER9_ATI                                           = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
 	DRAW_FRAMEBUFFER_BINDING_EXT                               = 0x8CA6
@@ -11654,6 +12263,7 @@ const (
 	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DRAW_PIXELS_APPLE                                          = 0x8A0A
 	DRAW_PIXEL_TOKEN                                           = 0x0705
+	DRIVER_UUID_EXT                                            = 0x9598
 	DSDT8_MAG8_INTENSITY8_NV                                   = 0x870B
 	DSDT8_MAG8_NV                                              = 0x870A
 	DSDT8_NV                                                   = 0x8709
@@ -11714,7 +12324,9 @@ const (
 	EDGE_FLAG_ARRAY_POINTER_EXT                                = 0x8093
 	EDGE_FLAG_ARRAY_STRIDE                                     = 0x808C
 	EDGE_FLAG_ARRAY_STRIDE_EXT                                 = 0x808C
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
 	EIGHTH_BIT_ATI                                             = 0x00000020
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
 	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_APPLE                                        = 0x8A0C
 	ELEMENT_ARRAY_ATI                                          = 0x8768
@@ -11759,6 +12371,7 @@ const (
 	EVAL_VERTEX_ATTRIB9_NV                                     = 0x86CF
 	EXCLUSION_KHR                                              = 0x92A0
 	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXP                                                        = 0x0800
 	EXP2                                                       = 0x0801
 	EXPAND_NEGATE_NV                                           = 0x8539
@@ -11791,6 +12404,7 @@ const (
 	FIELD_UPPER_NV                                             = 0x9022
 	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
 	FILTER4_SGIS                                               = 0x8146
 	FIRST_TO_REST_NV                                           = 0x90AF
@@ -11801,6 +12415,15 @@ const (
 	FIXED_ONLY_ARB                                             = 0x891D
 	FLAT                                                       = 0x1D00
 	FLOAT                                                      = 0x1406
+	FLOAT16_MAT2_AMD                                           = 0x91C5
+	FLOAT16_MAT2x3_AMD                                         = 0x91C8
+	FLOAT16_MAT2x4_AMD                                         = 0x91C9
+	FLOAT16_MAT3_AMD                                           = 0x91C6
+	FLOAT16_MAT3x2_AMD                                         = 0x91CA
+	FLOAT16_MAT3x4_AMD                                         = 0x91CB
+	FLOAT16_MAT4_AMD                                           = 0x91C7
+	FLOAT16_MAT4x2_AMD                                         = 0x91CC
+	FLOAT16_MAT4x3_AMD                                         = 0x91CD
 	FLOAT16_NV                                                 = 0x8FF8
 	FLOAT16_VEC2_NV                                            = 0x8FF9
 	FLOAT16_VEC3_NV                                            = 0x8FFA
@@ -11906,6 +12529,8 @@ const (
 	FRAGMENT_COLOR_MATERIAL_FACE_SGIX                          = 0x8402
 	FRAGMENT_COLOR_MATERIAL_PARAMETER_SGIX                     = 0x8403
 	FRAGMENT_COLOR_MATERIAL_SGIX                               = 0x8401
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
 	FRAGMENT_DEPTH                                             = 0x8452
 	FRAGMENT_DEPTH_EXT                                         = 0x8452
 	FRAGMENT_INPUT_NV                                          = 0x936D
@@ -11937,6 +12562,7 @@ const (
 	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
 	FRAGMENT_SHADER_DERIVATIVE_HINT_ARB                        = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -11957,12 +12583,14 @@ const (
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_3D_ZOFFSET_EXT              = 0x8CD4
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE_EXT           = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER_EXT                   = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL_EXT                   = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BARRIER_BIT_EXT                                = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
@@ -11993,8 +12621,13 @@ const (
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_EXT                     = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER_EXT                     = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_SRGB_CAPABLE_EXT                               = 0x8DBA
 	FRAMEBUFFER_SRGB_EXT                                       = 0x8DB9
@@ -12007,6 +12640,7 @@ const (
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_RANGE_EXT                                             = 0x87E1
@@ -12081,6 +12715,14 @@ const (
 	HALF_FLOAT                                                 = 0x140B
 	HALF_FLOAT_ARB                                             = 0x140B
 	HALF_FLOAT_NV                                              = 0x140B
+	HANDLE_TYPE_D3D11_IMAGE_EXT                                = 0x958B
+	HANDLE_TYPE_D3D11_IMAGE_KMT_EXT                            = 0x958C
+	HANDLE_TYPE_D3D12_FENCE_EXT                                = 0x9594
+	HANDLE_TYPE_D3D12_RESOURCE_EXT                             = 0x958A
+	HANDLE_TYPE_D3D12_TILEPOOL_EXT                             = 0x9589
+	HANDLE_TYPE_OPAQUE_FD_EXT                                  = 0x9586
+	HANDLE_TYPE_OPAQUE_WIN32_EXT                               = 0x9587
+	HANDLE_TYPE_OPAQUE_WIN32_KMT_EXT                           = 0x9588
 	HARDLIGHT_KHR                                              = 0x929B
 	HARDLIGHT_NV                                               = 0x929B
 	HARDMIX_NV                                                 = 0x92A9
@@ -12179,6 +12821,7 @@ const (
 	IMPLEMENTATION_COLOR_READ_FORMAT_OES                       = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
 	IMPLEMENTATION_COLOR_READ_TYPE_OES                         = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
 	INCR_WRAP_EXT                                              = 0x8507
@@ -12222,9 +12865,13 @@ const (
 	INT16_VEC2_NV                                              = 0x8FE5
 	INT16_VEC3_NV                                              = 0x8FE6
 	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
 	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
 	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
 	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
 	INT64_VEC4_NV                                              = 0x8FEB
 	INT8_NV                                                    = 0x8FE0
 	INT8_VEC2_NV                                               = 0x8FE1
@@ -12353,13 +13000,23 @@ const (
 	LAST_VIDEO_CAPTURE_STATUS_NV                               = 0x9027
 	LAYER_NV                                                   = 0x8DAA
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
+	LAYOUT_COLOR_ATTACHMENT_EXT                                = 0x958E
 	LAYOUT_DEFAULT_INTEL                                       = 0
+	LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT              = 0x9531
+	LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT              = 0x9530
+	LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT                        = 0x958F
+	LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT                         = 0x9590
+	LAYOUT_GENERAL_EXT                                         = 0x958D
 	LAYOUT_LINEAR_CPU_CACHED_INTEL                             = 2
 	LAYOUT_LINEAR_INTEL                                        = 1
+	LAYOUT_SHADER_READ_ONLY_EXT                                = 0x9591
+	LAYOUT_TRANSFER_DST_EXT                                    = 0x9593
+	LAYOUT_TRANSFER_SRC_EXT                                    = 0x9592
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LERP_ATI                                                   = 0x8969
 	LESS                                                       = 0x0201
+	LGPU_SEPARATE_STORAGE_BIT_NVX                              = 0x0800
 	LIGHT0                                                     = 0x4000
 	LIGHT1                                                     = 0x4001
 	LIGHT2                                                     = 0x4002
@@ -12395,6 +13052,7 @@ const (
 	LINEAR_SHARPEN_ALPHA_SGIS                                  = 0x80AE
 	LINEAR_SHARPEN_COLOR_SGIS                                  = 0x80AF
 	LINEAR_SHARPEN_SGIS                                        = 0x80AD
+	LINEAR_TILING_EXT                                          = 0x9585
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY_ARB                                        = 0x000A
 	LINES_ADJACENCY_EXT                                        = 0x000A
@@ -12412,6 +13070,7 @@ const (
 	LINE_TOKEN                                                 = 0x0702
 	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -12438,6 +13097,7 @@ const (
 	LOW_INT                                                    = 0x8DF3
 	LO_BIAS_NV                                                 = 0x8715
 	LO_SCALE_NV                                                = 0x870F
+	LUID_SIZE_EXT                                              = 8
 	LUMINANCE                                                  = 0x1909
 	LUMINANCE12                                                = 0x8041
 	LUMINANCE12_ALPHA12                                        = 0x8047
@@ -12758,6 +13418,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_LGPU_GPUS_NVX                                          = 0x92BA
 	MAX_LIGHTS                                                 = 0x0D31
 	MAX_LIST_NESTING                                           = 0x0B31
 	MAX_MAP_TESSELLATION_NV                                    = 0x86D6
@@ -12820,6 +13481,7 @@ const (
 	MAX_PROGRAM_TEX_INSTRUCTIONS_ARB                           = 0x880C
 	MAX_PROGRAM_TOTAL_OUTPUT_COMPONENTS_NV                     = 0x8C28
 	MAX_PROJECTION_STACK_DEPTH                                 = 0x0D38
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RATIONAL_EVAL_ORDER_NV                                 = 0x86D7
 	MAX_RECTANGLE_TEXTURE_SIZE_ARB                             = 0x84F8
 	MAX_RECTANGLE_TEXTURE_SIZE_NV                              = 0x84F8
@@ -12831,6 +13493,8 @@ const (
 	MAX_SAMPLE_MASK_WORDS_NV                                   = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
 	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SHININESS_NV                                           = 0x8504
@@ -12841,6 +13505,7 @@ const (
 	MAX_SPARSE_TEXTURE_SIZE_AMD                                = 0x9198
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
 	MAX_SPOT_EXPONENT_NV                                       = 0x8505
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -12874,6 +13539,7 @@ const (
 	MAX_TEXTURE_IMAGE_UNITS_NV                                 = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
 	MAX_TEXTURE_LOD_BIAS_EXT                                   = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_MAX_ANISOTROPY_EXT                             = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TEXTURE_STACK_DEPTH                                    = 0x0D39
@@ -12925,7 +13591,9 @@ const (
 	MAX_VERTEX_VARYING_COMPONENTS_EXT                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
@@ -12945,7 +13613,6 @@ const (
 	MIN_PROGRAM_TEXTURE_GATHER_OFFSET_NV                       = 0x8E5E
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
 	MIN_SPARSE_LEVEL_AMD                                       = 0x919B
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
 	MIRRORED_REPEAT_ARB                                        = 0x8370
@@ -12958,6 +13625,8 @@ const (
 	MIRROR_CLAMP_TO_EDGE_EXT                                   = 0x8743
 	MITER_REVERT_NV                                            = 0x90A7
 	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
 	MODELVIEW                                                  = 0x1700
 	MODELVIEW0_ARB                                             = 0x1700
 	MODELVIEW0_EXT                                             = 0x1700
@@ -13009,9 +13678,12 @@ const (
 	MOVE_TO_RESETS_NV                                          = 0x90B5
 	MOV_ATI                                                    = 0x8961
 	MULT                                                       = 0x0103
+	MULTICAST_GPUS_NV                                          = 0x92BA
+	MULTICAST_PROGRAMMABLE_SAMPLE_LOCATION_NV                  = 0x9549
 	MULTIPLY_KHR                                               = 0x9294
 	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
 	MULTISAMPLE_3DFX                                           = 0x86B2
 	MULTISAMPLE_ARB                                            = 0x809D
 	MULTISAMPLE_BIT                                            = 0x20000000
@@ -13021,6 +13693,9 @@ const (
 	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
 	MULTISAMPLE_EXT                                            = 0x809D
 	MULTISAMPLE_FILTER_HINT_NV                                 = 0x8534
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	MULTISAMPLE_SGIS                                           = 0x809D
 	MUL_ATI                                                    = 0x8964
 	MVP_MATRIX_EXT                                             = 0x87E3
@@ -13051,6 +13726,7 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
 	NORMALIZE                                                  = 0x0BA1
 	NORMALIZED_RANGE_EXT                                       = 0x87E0
@@ -13084,6 +13760,7 @@ const (
 	NUM_COMPATIBLE_SUBROUTINES                                 = 0x8E4A
 	NUM_COMPRESSED_TEXTURE_FORMATS                             = 0x86A2
 	NUM_COMPRESSED_TEXTURE_FORMATS_ARB                         = 0x86A2
+	NUM_DEVICE_UUIDS_EXT                                       = 0x9596
 	NUM_FILL_STREAMS_NV                                        = 0x8E29
 	NUM_FRAGMENT_CONSTANTS_ATI                                 = 0x896F
 	NUM_FRAGMENT_REGISTERS_ATI                                 = 0x896E
@@ -13096,8 +13773,12 @@ const (
 	NUM_PROGRAM_BINARY_FORMATS                                 = 0x87FE
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
+	NUM_TILING_TYPES_EXT                                       = 0x9582
 	NUM_VIDEO_CAPTURE_STREAMS_NV                               = 0x9024
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_ACTIVE_ATTRIBUTES_ARB                               = 0x8B89
 	OBJECT_ACTIVE_ATTRIBUTE_MAX_LENGTH_ARB                     = 0x8B8A
 	OBJECT_ACTIVE_UNIFORMS_ARB                                 = 0x8B86
@@ -13173,6 +13854,7 @@ const (
 	OPERAND2_RGB_EXT                                           = 0x8592
 	OPERAND3_ALPHA_NV                                          = 0x859B
 	OPERAND3_RGB_NV                                            = 0x8593
+	OPTIMAL_TILING_EXT                                         = 0x9584
 	OP_ADD_EXT                                                 = 0x8787
 	OP_CLAMP_EXT                                               = 0x878E
 	OP_CROSS_PRODUCT_EXT                                       = 0x8797
@@ -13252,7 +13934,7 @@ const (
 	PACK_INVERT_MESA                                           = 0x8758
 	PACK_LSB_FIRST                                             = 0x0D01
 	PACK_RESAMPLE_OML                                          = 0x8984
-	PACK_RESAMPLE_SGIX                                         = 0x842C
+	PACK_RESAMPLE_SGIX                                         = 0x842E
 	PACK_ROW_BYTES_APPLE                                       = 0x8A15
 	PACK_ROW_LENGTH                                            = 0x0D02
 	PACK_SKIP_IMAGES                                           = 0x806B
@@ -13297,11 +13979,9 @@ const (
 	PATH_FILL_COVER_MODE_NV                                    = 0x9082
 	PATH_FILL_MASK_NV                                          = 0x9081
 	PATH_FILL_MODE_NV                                          = 0x9080
-	PATH_FOG_GEN_MODE_NV                                       = 0x90AC
 	PATH_FORMAT_PS_NV                                          = 0x9071
 	PATH_FORMAT_SVG_NV                                         = 0x9070
 	PATH_GEN_COEFF_NV                                          = 0x90B1
-	PATH_GEN_COLOR_FORMAT_NV                                   = 0x90B2
 	PATH_GEN_COMPONENTS_NV                                     = 0x90B3
 	PATH_GEN_MODE_NV                                           = 0x90B0
 	PATH_INITIAL_DASH_CAP_NV                                   = 0x907C
@@ -13357,10 +14037,14 @@ const (
 	PERFQUERY_WAIT_INTEL                                       = 0x83FB
 	PERSPECTIVE_CORRECTION_HINT                                = 0x0C50
 	PERTURB_EXT                                                = 0x85AE
+	PER_GPU_STORAGE_BIT_NV                                     = 0x0800
+	PER_GPU_STORAGE_NV                                         = 0x9548
 	PER_STAGE_CONSTANTS_NV                                     = 0x8535
 	PHONG_HINT_WIN                                             = 0x80EB
 	PHONG_WIN                                                  = 0x80EA
 	PINLIGHT_NV                                                = 0x92A8
+	PIXELS_PER_SAMPLE_PATTERN_X_AMD                            = 0x91AE
+	PIXELS_PER_SAMPLE_PATTERN_Y_AMD                            = 0x91AF
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_BUFFER_BARRIER_BIT_EXT                               = 0x00000080
 	PIXEL_COUNTER_BITS_NV                                      = 0x8864
@@ -13466,6 +14150,9 @@ const (
 	POLYGON_BIT                                                = 0x00000008
 	POLYGON_MODE                                               = 0x0B40
 	POLYGON_OFFSET_BIAS_EXT                                    = 0x8039
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_EXT                                         = 0x8037
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FACTOR_EXT                                  = 0x8038
@@ -13517,16 +14204,22 @@ const (
 	PRIMITIVES_GENERATED_EXT                                   = 0x8C87
 	PRIMITIVES_GENERATED_NV                                    = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_ID_NV                                            = 0x8C7C
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
 	PRIMITIVE_RESTART_INDEX_NV                                 = 0x8559
 	PRIMITIVE_RESTART_NV                                       = 0x8558
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_ADDRESS_REGISTERS_ARB                              = 0x88B0
 	PROGRAM_ALU_INSTRUCTIONS_ARB                               = 0x8805
 	PROGRAM_ATTRIBS_ARB                                        = 0x88AC
 	PROGRAM_ATTRIB_COMPONENTS_NV                               = 0x8906
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
+	PROGRAM_BINARY_FORMAT_MESA                                 = 0x875F
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_BINDING_ARB                                        = 0x8677
@@ -13559,6 +14252,7 @@ const (
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
 	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
 	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
 	PROGRAM_POINT_SIZE_EXT                                     = 0x8642
@@ -13576,6 +14270,7 @@ const (
 	PROJECTION                                                 = 0x1701
 	PROJECTION_MATRIX                                          = 0x0BA7
 	PROJECTION_STACK_DEPTH                                     = 0x0BA4
+	PROTECTED_MEMORY_OBJECT_EXT                                = 0x959B
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROVOKING_VERTEX_EXT                                       = 0x8E4F
 	PROXY_COLOR_TABLE_SGI                                      = 0x80D3
@@ -13604,6 +14299,7 @@ const (
 	PROXY_TEXTURE_RECTANGLE_ARB                                = 0x84F7
 	PROXY_TEXTURE_RECTANGLE_NV                                 = 0x84F7
 	PURGEABLE_APPLE                                            = 0x8A1D
+	PURGED_CONTEXT_RESET_NV                                    = 0x92BB
 	Q                                                          = 0x2003
 	QUADRATIC_ATTENUATION                                      = 0x1209
 	QUADRATIC_CURVE_TO_NV                                      = 0x0A
@@ -13641,6 +14337,12 @@ const (
 	QUERY_NO_WAIT_NV                                           = 0x8E14
 	QUERY_OBJECT_AMD                                           = 0x9153
 	QUERY_OBJECT_EXT                                           = 0x9153
+	QUERY_RESOURCE_BUFFEROBJECT_NV                             = 0x9547
+	QUERY_RESOURCE_MEMTYPE_VIDMEM_NV                           = 0x9542
+	QUERY_RESOURCE_RENDERBUFFER_NV                             = 0x9546
+	QUERY_RESOURCE_SYS_RESERVED_NV                             = 0x9544
+	QUERY_RESOURCE_TEXTURE_NV                                  = 0x9545
+	QUERY_RESOURCE_TYPE_VIDMEM_ALLOC_NV                        = 0x9540
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_ARB                                           = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
@@ -13676,7 +14378,10 @@ const (
 	R8_SNORM                                                   = 0x8F94
 	RASTERIZER_DISCARD_EXT                                     = 0x8C89
 	RASTERIZER_DISCARD_NV                                      = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
 	RASTER_POSITION_UNCLIPPED_IBM                              = 0x19262
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -13799,6 +14504,7 @@ const (
 	RENDERBUFFER_WIDTH                                         = 0x8D42
 	RENDERBUFFER_WIDTH_EXT                                     = 0x8D42
 	RENDERER                                                   = 0x1F01
+	RENDER_GPU_MASK_NV                                         = 0x9558
 	RENDER_MODE                                                = 0x0C40
 	REPEAT                                                     = 0x2901
 	REPLACE                                                    = 0x1E01
@@ -13816,9 +14522,9 @@ const (
 	RESAMPLE_DECIMATE_OML                                      = 0x8989
 	RESAMPLE_DECIMATE_SGIX                                     = 0x8430
 	RESAMPLE_REPLICATE_OML                                     = 0x8986
-	RESAMPLE_REPLICATE_SGIX                                    = 0x842E
+	RESAMPLE_REPLICATE_SGIX                                    = 0x8433
 	RESAMPLE_ZERO_FILL_OML                                     = 0x8987
-	RESAMPLE_ZERO_FILL_SGIX                                    = 0x842F
+	RESAMPLE_ZERO_FILL_SGIX                                    = 0x8434
 	RESCALE_NORMAL                                             = 0x803A
 	RESCALE_NORMAL_EXT                                         = 0x803A
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
@@ -13991,6 +14697,14 @@ const (
 	SAMPLE_COVERAGE_INVERT_ARB                                 = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
 	SAMPLE_COVERAGE_VALUE_ARB                                  = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_EXT                                            = 0x80A0
 	SAMPLE_MASK_INVERT_EXT                                     = 0x80AB
@@ -14016,6 +14730,7 @@ const (
 	SCALE_BY_TWO_NV                                            = 0x853E
 	SCISSOR_BIT                                                = 0x00080000
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
 	SCREEN_COORDINATES_REND                                    = 0x8490
 	SCREEN_KHR                                                 = 0x9295
@@ -14050,6 +14765,7 @@ const (
 	SET_AMD                                                    = 0x874A
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
 	SHADER_CONSISTENT_NV                                       = 0x86DD
 	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
@@ -14077,6 +14793,7 @@ const (
 	SHADING_LANGUAGE_VERSION_ARB                               = 0x8B8C
 	SHADOW_AMBIENT_SGIX                                        = 0x80BF
 	SHADOW_ATTENUATION_EXT                                     = 0x834E
+	SHARED_EDGE_NV                                             = 0xC0
 	SHARED_TEXTURE_PALETTE_EXT                                 = 0x81FB
 	SHARPEN_TEXTURE_FUNC_POINTS_SGIS                           = 0x80B0
 	SHININESS                                                  = 0x1601
@@ -14163,6 +14880,8 @@ const (
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
 	SPECULAR                                                   = 0x1202
 	SPHERE_MAP                                                 = 0x2402
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
 	SPOT_CUTOFF                                                = 0x1206
 	SPOT_DIRECTION                                             = 0x1204
 	SPOT_EXPONENT                                              = 0x1205
@@ -14249,7 +14968,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TAG_BITS_EXT                                       = 0x88F2
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_TEST_TWO_SIDE_EXT                                  = 0x8910
@@ -14271,11 +14992,15 @@ const (
 	STRICT_LIGHTING_HINT_PGI                                   = 0x1A217
 	STRICT_SCISSOR_HINT_PGI                                    = 0x1A218
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
 	SUBSAMPLE_DISTANCE_AMD                                     = 0x883F
 	SUBTRACT                                                   = 0x84E7
 	SUBTRACT_ARB                                               = 0x84E7
 	SUB_ATI                                                    = 0x8965
 	SUCCESS_NV                                                 = 0x902F
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SURFACE_MAPPED_NV                                          = 0x8700
 	SURFACE_REGISTERED_NV                                      = 0x86FD
 	SURFACE_STATE_NV                                           = 0x86EB
@@ -14312,6 +15037,7 @@ const (
 	TANGENT_ARRAY_POINTER_EXT                                  = 0x8442
 	TANGENT_ARRAY_STRIDE_EXT                                   = 0x843F
 	TANGENT_ARRAY_TYPE_EXT                                     = 0x843E
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESSELLATION_FACTOR_AMD                                    = 0x9005
 	TESSELLATION_MODE_AMD                                      = 0x9004
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
@@ -14426,12 +15152,10 @@ const (
 	TEXTURE_4D_SGIS                                            = 0x8134
 	TEXTURE_ALPHA_SIZE                                         = 0x805F
 	TEXTURE_ALPHA_SIZE_EXT                                     = 0x805F
-	TEXTURE_ALPHA_TYPE                                         = 0x8C13
 	TEXTURE_ALPHA_TYPE_ARB                                     = 0x8C13
 	TEXTURE_APPLICATION_MODE_EXT                               = 0x834F
 	TEXTURE_BASE_LEVEL                                         = 0x813C
 	TEXTURE_BASE_LEVEL_SGIS                                    = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_1D_ARRAY_EXT                               = 0x8C1C
@@ -14456,7 +15180,6 @@ const (
 	TEXTURE_BIT                                                = 0x00040000
 	TEXTURE_BLUE_SIZE                                          = 0x805E
 	TEXTURE_BLUE_SIZE_EXT                                      = 0x805E
-	TEXTURE_BLUE_TYPE                                          = 0x8C12
 	TEXTURE_BLUE_TYPE_ARB                                      = 0x8C12
 	TEXTURE_BORDER                                             = 0x1005
 	TEXTURE_BORDER_COLOR                                       = 0x1004
@@ -14548,7 +15271,6 @@ const (
 	TEXTURE_DEPTH_EXT                                          = 0x8071
 	TEXTURE_DEPTH_SIZE                                         = 0x884A
 	TEXTURE_DEPTH_SIZE_ARB                                     = 0x884A
-	TEXTURE_DEPTH_TYPE                                         = 0x8C16
 	TEXTURE_DEPTH_TYPE_ARB                                     = 0x8C16
 	TEXTURE_DS_SIZE_NV                                         = 0x871D
 	TEXTURE_DT_SIZE_NV                                         = 0x871E
@@ -14574,7 +15296,6 @@ const (
 	TEXTURE_GEQUAL_R_SGIX                                      = 0x819D
 	TEXTURE_GREEN_SIZE                                         = 0x805D
 	TEXTURE_GREEN_SIZE_EXT                                     = 0x805D
-	TEXTURE_GREEN_TYPE                                         = 0x8C11
 	TEXTURE_GREEN_TYPE_ARB                                     = 0x8C11
 	TEXTURE_HEIGHT                                             = 0x1001
 	TEXTURE_HI_SIZE_NV                                         = 0x871B
@@ -14604,6 +15325,7 @@ const (
 	TEXTURE_MATERIAL_FACE_EXT                                  = 0x8351
 	TEXTURE_MATERIAL_PARAMETER_EXT                             = 0x8352
 	TEXTURE_MATRIX                                             = 0x0BA8
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_ANISOTROPY_EXT                                 = 0x84FE
 	TEXTURE_MAX_CLAMP_R_SGIX                                   = 0x836B
 	TEXTURE_MAX_CLAMP_S_SGIX                                   = 0x8369
@@ -14627,9 +15349,10 @@ const (
 	TEXTURE_RECTANGLE                                          = 0x84F5
 	TEXTURE_RECTANGLE_ARB                                      = 0x84F5
 	TEXTURE_RECTANGLE_NV                                       = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_SIZE_EXT                                       = 0x805C
-	TEXTURE_RED_TYPE                                           = 0x8C10
 	TEXTURE_RED_TYPE_ARB                                       = 0x8C10
 	TEXTURE_RENDERBUFFER_DATA_STORE_BINDING_NV                 = 0x8E54
 	TEXTURE_RENDERBUFFER_NV                                    = 0x8E55
@@ -14657,6 +15380,7 @@ const (
 	TEXTURE_SWIZZLE_RGBA_EXT                                   = 0x8E46
 	TEXTURE_SWIZZLE_R_EXT                                      = 0x8E42
 	TEXTURE_TARGET                                             = 0x1006
+	TEXTURE_TILING_EXT                                         = 0x9580
 	TEXTURE_TOO_LARGE_EXT                                      = 0x8065
 	TEXTURE_UNSIGNED_REMAP_MODE_NV                             = 0x888F
 	TEXTURE_UPDATE_BARRIER_BIT                                 = 0x00000100
@@ -14673,6 +15397,10 @@ const (
 	TEXTURE_WRAP_S                                             = 0x2802
 	TEXTURE_WRAP_T                                             = 0x2803
 	TEXT_FRAGMENT_SHADER_ATI                                   = 0x8200
+	TILE_RASTER_ORDER_FIXED_MESA                               = 0x8BB8
+	TILE_RASTER_ORDER_INCREASING_X_MESA                        = 0x8BB9
+	TILE_RASTER_ORDER_INCREASING_Y_MESA                        = 0x8BBA
+	TILING_TYPES_EXT                                           = 0x9583
 	TIMEOUT_EXPIRED                                            = 0x911B
 	TIMEOUT_IGNORED                                            = 0xFFFFFFFFFFFFFFFF
 	TIMESTAMP                                                  = 0x8E28
@@ -14684,7 +15412,6 @@ const (
 	TRACK_MATRIX_TRANSFORM_NV                                  = 0x8649
 	TRANSFORM_BIT                                              = 0x00001000
 	TRANSFORM_FEEDBACK                                         = 0x8E22
-	TRANSFORM_FEEDBACK_ACTIVE                                  = 0x8E24
 	TRANSFORM_FEEDBACK_ATTRIBS_NV                              = 0x8C7E
 	TRANSFORM_FEEDBACK_BARRIER_BIT                             = 0x00000800
 	TRANSFORM_FEEDBACK_BARRIER_BIT_EXT                         = 0x00000800
@@ -14709,7 +15436,6 @@ const (
 	TRANSFORM_FEEDBACK_BUFFER_STRIDE                           = 0x934C
 	TRANSFORM_FEEDBACK_NV                                      = 0x8E22
 	TRANSFORM_FEEDBACK_OVERFLOW_ARB                            = 0x82EC
-	TRANSFORM_FEEDBACK_PAUSED                                  = 0x8E23
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN_EXT                  = 0x8C88
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN_NV                   = 0x8C88
 	TRANSFORM_FEEDBACK_RECORD_NV                               = 0x8C86
@@ -14752,6 +15478,7 @@ const (
 	UNDEFINED_APPLE                                            = 0x8A1C
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -14770,12 +15497,15 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
 	UNIFORM_BUFFER_BINDING_EXT                                 = 0x8DEF
 	UNIFORM_BUFFER_EXT                                         = 0x8DEE
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -14798,7 +15528,7 @@ const (
 	UNPACK_IMAGE_HEIGHT_EXT                                    = 0x806E
 	UNPACK_LSB_FIRST                                           = 0x0CF1
 	UNPACK_RESAMPLE_OML                                        = 0x8985
-	UNPACK_RESAMPLE_SGIX                                       = 0x842D
+	UNPACK_RESAMPLE_SGIX                                       = 0x842F
 	UNPACK_ROW_BYTES_APPLE                                     = 0x8A16
 	UNPACK_ROW_LENGTH                                          = 0x0CF2
 	UNPACK_SKIP_IMAGES                                         = 0x806D
@@ -14822,8 +15552,11 @@ const (
 	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
 	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
 	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
 	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
 	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
 	UNSIGNED_INT8_NV                                           = 0x8FEC
 	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
@@ -14902,6 +15635,7 @@ const (
 	USE_MISSING_GLYPH_NV                                       = 0x90AA
 	UTF16_NV                                                   = 0x909B
 	UTF8_NV                                                    = 0x909A
+	UUID_SIZE_EXT                                              = 16
 	V2F                                                        = 0x2A20
 	V3F                                                        = 0x2A21
 	VALIDATE_STATUS                                            = 0x8B83
@@ -15081,8 +15815,24 @@ const (
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BIT                                               = 0x00000800
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -15112,6 +15862,8 @@ const (
 	WAIT_FAILED                                                = 0x911D
 	WARPS_PER_SM_NV                                            = 0x933A
 	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
 	WEIGHT_ARRAY_ARB                                           = 0x86AD
 	WEIGHT_ARRAY_BUFFER_BINDING                                = 0x889E
 	WEIGHT_ARRAY_BUFFER_BINDING_ARB                            = 0x889E
@@ -15121,6 +15873,8 @@ const (
 	WEIGHT_ARRAY_TYPE_ARB                                      = 0x86A9
 	WEIGHT_SUM_UNITY_ARB                                       = 0x86A6
 	WIDE_LINE_HINT_PGI                                         = 0x1A222
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRAP_BORDER_SUN                                            = 0x81D4
 	WRITE_DISCARD_NV                                           = 0x88BE
 	WRITE_ONLY                                                 = 0x88B9
@@ -15157,6 +15911,7 @@ const (
 var (
 	gpAccum                                                  C.GPACCUM
 	gpAccumxOES                                              C.GPACCUMXOES
+	gpAcquireKeyedMutexWin32EXT                              C.GPACQUIREKEYEDMUTEXWIN32EXT
 	gpActiveProgramEXT                                       C.GPACTIVEPROGRAMEXT
 	gpActiveShaderProgram                                    C.GPACTIVESHADERPROGRAM
 	gpActiveShaderProgramEXT                                 C.GPACTIVESHADERPROGRAMEXT
@@ -15169,6 +15924,8 @@ var (
 	gpAlphaFragmentOp3ATI                                    C.GPALPHAFRAGMENTOP3ATI
 	gpAlphaFunc                                              C.GPALPHAFUNC
 	gpAlphaFuncxOES                                          C.GPALPHAFUNCXOES
+	gpAlphaToCoverageDitherControlNV                         C.GPALPHATOCOVERAGEDITHERCONTROLNV
+	gpApplyFramebufferAttachmentCMAAINTEL                    C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
 	gpApplyTextureEXT                                        C.GPAPPLYTEXTUREEXT
 	gpAreProgramsResidentNV                                  C.GPAREPROGRAMSRESIDENTNV
 	gpAreTexturesResident                                    C.GPARETEXTURESRESIDENT
@@ -15197,10 +15954,12 @@ var (
 	gpBindAttribLocationARB                                  C.GPBINDATTRIBLOCATIONARB
 	gpBindBuffer                                             C.GPBINDBUFFER
 	gpBindBufferARB                                          C.GPBINDBUFFERARB
+	gpBindBufferBase                                         C.GPBINDBUFFERBASE
 	gpBindBufferBaseEXT                                      C.GPBINDBUFFERBASEEXT
 	gpBindBufferBaseNV                                       C.GPBINDBUFFERBASENV
 	gpBindBufferOffsetEXT                                    C.GPBINDBUFFEROFFSETEXT
 	gpBindBufferOffsetNV                                     C.GPBINDBUFFEROFFSETNV
+	gpBindBufferRange                                        C.GPBINDBUFFERRANGE
 	gpBindBufferRangeEXT                                     C.GPBINDBUFFERRANGEEXT
 	gpBindBufferRangeNV                                      C.GPBINDBUFFERRANGENV
 	gpBindBuffersBase                                        C.GPBINDBUFFERSBASE
@@ -15284,8 +16043,11 @@ var (
 	gpBufferPageCommitmentARB                                C.GPBUFFERPAGECOMMITMENTARB
 	gpBufferParameteriAPPLE                                  C.GPBUFFERPARAMETERIAPPLE
 	gpBufferStorage                                          C.GPBUFFERSTORAGE
+	gpBufferStorageExternalEXT                               C.GPBUFFERSTORAGEEXTERNALEXT
+	gpBufferStorageMemEXT                                    C.GPBUFFERSTORAGEMEMEXT
 	gpBufferSubData                                          C.GPBUFFERSUBDATA
 	gpBufferSubDataARB                                       C.GPBUFFERSUBDATAARB
+	gpCallCommandListNV                                      C.GPCALLCOMMANDLISTNV
 	gpCallList                                               C.GPCALLLIST
 	gpCallLists                                              C.GPCALLLISTS
 	gpCheckFramebufferStatus                                 C.GPCHECKFRAMEBUFFERSTATUS
@@ -15399,6 +16161,8 @@ var (
 	gpCombinerParameteriNV                                   C.GPCOMBINERPARAMETERINV
 	gpCombinerParameterivNV                                  C.GPCOMBINERPARAMETERIVNV
 	gpCombinerStageParameterfvNV                             C.GPCOMBINERSTAGEPARAMETERFVNV
+	gpCommandListSegmentsNV                                  C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                                   C.GPCOMPILECOMMANDLISTNV
 	gpCompileShader                                          C.GPCOMPILESHADER
 	gpCompileShaderARB                                       C.GPCOMPILESHADERARB
 	gpCompileShaderIncludeARB                                C.GPCOMPILESHADERINCLUDEARB
@@ -15429,6 +16193,8 @@ var (
 	gpCompressedTextureSubImage2DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
 	gpCompressedTextureSubImage3D                            C.GPCOMPRESSEDTEXTURESUBIMAGE3D
 	gpCompressedTextureSubImage3DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                         C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                         C.GPCONSERVATIVERASTERPARAMETERINV
 	gpConvolutionFilter1DEXT                                 C.GPCONVOLUTIONFILTER1DEXT
 	gpConvolutionFilter2DEXT                                 C.GPCONVOLUTIONFILTER2DEXT
 	gpConvolutionParameterfEXT                               C.GPCONVOLUTIONPARAMETERFEXT
@@ -15474,8 +16240,12 @@ var (
 	gpCoverFillPathNV                                        C.GPCOVERFILLPATHNV
 	gpCoverStrokePathInstancedNV                             C.GPCOVERSTROKEPATHINSTANCEDNV
 	gpCoverStrokePathNV                                      C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                                   C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                              C.GPCOVERAGEMODULATIONTABLENV
 	gpCreateBuffers                                          C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                                   C.GPCREATECOMMANDLISTSNV
 	gpCreateFramebuffers                                     C.GPCREATEFRAMEBUFFERS
+	gpCreateMemoryObjectsEXT                                 C.GPCREATEMEMORYOBJECTSEXT
 	gpCreatePerfQueryINTEL                                   C.GPCREATEPERFQUERYINTEL
 	gpCreateProgram                                          C.GPCREATEPROGRAM
 	gpCreateProgramObjectARB                                 C.GPCREATEPROGRAMOBJECTARB
@@ -15488,6 +16258,7 @@ var (
 	gpCreateShaderProgramEXT                                 C.GPCREATESHADERPROGRAMEXT
 	gpCreateShaderProgramv                                   C.GPCREATESHADERPROGRAMV
 	gpCreateShaderProgramvEXT                                C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                         C.GPCREATESTATESNV
 	gpCreateSyncFromCLeventARB                               C.GPCREATESYNCFROMCLEVENTARB
 	gpCreateTextures                                         C.GPCREATETEXTURES
 	gpCreateTransformFeedbacks                               C.GPCREATETRANSFORMFEEDBACKS
@@ -15514,12 +16285,14 @@ var (
 	gpDeleteAsyncMarkersSGIX                                 C.GPDELETEASYNCMARKERSSGIX
 	gpDeleteBuffers                                          C.GPDELETEBUFFERS
 	gpDeleteBuffersARB                                       C.GPDELETEBUFFERSARB
+	gpDeleteCommandListsNV                                   C.GPDELETECOMMANDLISTSNV
 	gpDeleteFencesAPPLE                                      C.GPDELETEFENCESAPPLE
 	gpDeleteFencesNV                                         C.GPDELETEFENCESNV
 	gpDeleteFragmentShaderATI                                C.GPDELETEFRAGMENTSHADERATI
 	gpDeleteFramebuffers                                     C.GPDELETEFRAMEBUFFERS
 	gpDeleteFramebuffersEXT                                  C.GPDELETEFRAMEBUFFERSEXT
 	gpDeleteLists                                            C.GPDELETELISTS
+	gpDeleteMemoryObjectsEXT                                 C.GPDELETEMEMORYOBJECTSEXT
 	gpDeleteNamedStringARB                                   C.GPDELETENAMEDSTRINGARB
 	gpDeleteNamesAMD                                         C.GPDELETENAMESAMD
 	gpDeleteObjectARB                                        C.GPDELETEOBJECTARB
@@ -15534,10 +16307,13 @@ var (
 	gpDeleteProgramsNV                                       C.GPDELETEPROGRAMSNV
 	gpDeleteQueries                                          C.GPDELETEQUERIES
 	gpDeleteQueriesARB                                       C.GPDELETEQUERIESARB
+	gpDeleteQueryResourceTagNV                               C.GPDELETEQUERYRESOURCETAGNV
 	gpDeleteRenderbuffers                                    C.GPDELETERENDERBUFFERS
 	gpDeleteRenderbuffersEXT                                 C.GPDELETERENDERBUFFERSEXT
 	gpDeleteSamplers                                         C.GPDELETESAMPLERS
+	gpDeleteSemaphoresEXT                                    C.GPDELETESEMAPHORESEXT
 	gpDeleteShader                                           C.GPDELETESHADER
+	gpDeleteStatesNV                                         C.GPDELETESTATESNV
 	gpDeleteSync                                             C.GPDELETESYNC
 	gpDeleteTextures                                         C.GPDELETETEXTURES
 	gpDeleteTexturesEXT                                      C.GPDELETETEXTURESEXT
@@ -15585,6 +16361,10 @@ var (
 	gpDrawBuffers                                            C.GPDRAWBUFFERS
 	gpDrawBuffersARB                                         C.GPDRAWBUFFERSARB
 	gpDrawBuffersATI                                         C.GPDRAWBUFFERSATI
+	gpDrawCommandsAddressNV                                  C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                         C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                            C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                                   C.GPDRAWCOMMANDSSTATESNV
 	gpDrawElementArrayAPPLE                                  C.GPDRAWELEMENTARRAYAPPLE
 	gpDrawElementArrayATI                                    C.GPDRAWELEMENTARRAYATI
 	gpDrawElements                                           C.GPDRAWELEMENTS
@@ -15608,6 +16388,7 @@ var (
 	gpDrawTransformFeedbackNV                                C.GPDRAWTRANSFORMFEEDBACKNV
 	gpDrawTransformFeedbackStream                            C.GPDRAWTRANSFORMFEEDBACKSTREAM
 	gpDrawTransformFeedbackStreamInstanced                   C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                          C.GPDRAWVKIMAGENV
 	gpEdgeFlag                                               C.GPEDGEFLAG
 	gpEdgeFlagFormatNV                                       C.GPEDGEFLAGFORMATNV
 	gpEdgeFlagPointer                                        C.GPEDGEFLAGPOINTER
@@ -15660,6 +16441,7 @@ var (
 	gpEvalMesh2                                              C.GPEVALMESH2
 	gpEvalPoint1                                             C.GPEVALPOINT1
 	gpEvalPoint2                                             C.GPEVALPOINT2
+	gpEvaluateDepthValuesARB                                 C.GPEVALUATEDEPTHVALUESARB
 	gpExecuteProgramNV                                       C.GPEXECUTEPROGRAMNV
 	gpExtractComponentEXT                                    C.GPEXTRACTCOMPONENTEXT
 	gpFeedbackBuffer                                         C.GPFEEDBACKBUFFER
@@ -15704,6 +16486,7 @@ var (
 	gpFogxOES                                                C.GPFOGXOES
 	gpFogxvOES                                               C.GPFOGXVOES
 	gpFragmentColorMaterialSGIX                              C.GPFRAGMENTCOLORMATERIALSGIX
+	gpFragmentCoverageColorNV                                C.GPFRAGMENTCOVERAGECOLORNV
 	gpFragmentLightModelfSGIX                                C.GPFRAGMENTLIGHTMODELFSGIX
 	gpFragmentLightModelfvSGIX                               C.GPFRAGMENTLIGHTMODELFVSGIX
 	gpFragmentLightModeliSGIX                                C.GPFRAGMENTLIGHTMODELISGIX
@@ -15720,10 +16503,14 @@ var (
 	gpFrameZoomSGIX                                          C.GPFRAMEZOOMSGIX
 	gpFramebufferDrawBufferEXT                               C.GPFRAMEBUFFERDRAWBUFFEREXT
 	gpFramebufferDrawBuffersEXT                              C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                             C.GPFRAMEBUFFERFETCHBARRIEREXT
 	gpFramebufferParameteri                                  C.GPFRAMEBUFFERPARAMETERI
 	gpFramebufferReadBufferEXT                               C.GPFRAMEBUFFERREADBUFFEREXT
 	gpFramebufferRenderbuffer                                C.GPFRAMEBUFFERRENDERBUFFER
 	gpFramebufferRenderbufferEXT                             C.GPFRAMEBUFFERRENDERBUFFEREXT
+	gpFramebufferSampleLocationsfvARB                        C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                         C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferSamplePositionsfvAMD                        C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpFramebufferTexture1D                                   C.GPFRAMEBUFFERTEXTURE1D
 	gpFramebufferTexture1DEXT                                C.GPFRAMEBUFFERTEXTURE1DEXT
 	gpFramebufferTexture2D                                   C.GPFRAMEBUFFERTEXTURE2D
@@ -15737,6 +16524,7 @@ var (
 	gpFramebufferTextureLayer                                C.GPFRAMEBUFFERTEXTURELAYER
 	gpFramebufferTextureLayerARB                             C.GPFRAMEBUFFERTEXTURELAYERARB
 	gpFramebufferTextureLayerEXT                             C.GPFRAMEBUFFERTEXTURELAYEREXT
+	gpFramebufferTextureMultiviewOVR                         C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
 	gpFreeObjectBufferATI                                    C.GPFREEOBJECTBUFFERATI
 	gpFrontFace                                              C.GPFRONTFACE
 	gpFrustum                                                C.GPFRUSTUM
@@ -15761,9 +16549,11 @@ var (
 	gpGenProgramsNV                                          C.GPGENPROGRAMSNV
 	gpGenQueries                                             C.GPGENQUERIES
 	gpGenQueriesARB                                          C.GPGENQUERIESARB
+	gpGenQueryResourceTagNV                                  C.GPGENQUERYRESOURCETAGNV
 	gpGenRenderbuffers                                       C.GPGENRENDERBUFFERS
 	gpGenRenderbuffersEXT                                    C.GPGENRENDERBUFFERSEXT
 	gpGenSamplers                                            C.GPGENSAMPLERS
+	gpGenSemaphoresEXT                                       C.GPGENSEMAPHORESEXT
 	gpGenSymbolsEXT                                          C.GPGENSYMBOLSEXT
 	gpGenTextures                                            C.GPGENTEXTURES
 	gpGenTexturesEXT                                         C.GPGENTEXTURESEXT
@@ -15819,6 +16609,7 @@ var (
 	gpGetCombinerOutputParameterfvNV                         C.GPGETCOMBINEROUTPUTPARAMETERFVNV
 	gpGetCombinerOutputParameterivNV                         C.GPGETCOMBINEROUTPUTPARAMETERIVNV
 	gpGetCombinerStageParameterfvNV                          C.GPGETCOMBINERSTAGEPARAMETERFVNV
+	gpGetCommandHeaderNV                                     C.GPGETCOMMANDHEADERNV
 	gpGetCompressedMultiTexImageEXT                          C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
 	gpGetCompressedTexImage                                  C.GPGETCOMPRESSEDTEXIMAGE
 	gpGetCompressedTexImageARB                               C.GPGETCOMPRESSEDTEXIMAGEARB
@@ -15829,6 +16620,7 @@ var (
 	gpGetConvolutionParameterfvEXT                           C.GPGETCONVOLUTIONPARAMETERFVEXT
 	gpGetConvolutionParameterivEXT                           C.GPGETCONVOLUTIONPARAMETERIVEXT
 	gpGetConvolutionParameterxvOES                           C.GPGETCONVOLUTIONPARAMETERXVOES
+	gpGetCoverageModulationTableNV                           C.GPGETCOVERAGEMODULATIONTABLENV
 	gpGetDebugMessageLog                                     C.GPGETDEBUGMESSAGELOG
 	gpGetDebugMessageLogAMD                                  C.GPGETDEBUGMESSAGELOGAMD
 	gpGetDebugMessageLogARB                                  C.GPGETDEBUGMESSAGELOGARB
@@ -15857,6 +16649,7 @@ var (
 	gpGetFragmentMaterialivSGIX                              C.GPGETFRAGMENTMATERIALIVSGIX
 	gpGetFramebufferAttachmentParameteriv                    C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetFramebufferAttachmentParameterivEXT                 C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetFramebufferParameterfvAMD                           C.GPGETFRAMEBUFFERPARAMETERFVAMD
 	gpGetFramebufferParameteriv                              C.GPGETFRAMEBUFFERPARAMETERIV
 	gpGetFramebufferParameterivEXT                           C.GPGETFRAMEBUFFERPARAMETERIVEXT
 	gpGetGraphicsResetStatus                                 C.GPGETGRAPHICSRESETSTATUS
@@ -15875,9 +16668,11 @@ var (
 	gpGetInstrumentsSGIX                                     C.GPGETINSTRUMENTSSGIX
 	gpGetInteger64v                                          C.GPGETINTEGER64V
 	gpGetIntegerIndexedvEXT                                  C.GPGETINTEGERINDEXEDVEXT
+	gpGetIntegeri_v                                          C.GPGETINTEGERI_V
 	gpGetIntegerui64i_vNV                                    C.GPGETINTEGERUI64I_VNV
 	gpGetIntegerui64vNV                                      C.GPGETINTEGERUI64VNV
 	gpGetIntegerv                                            C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                            C.GPGETINTERNALFORMATSAMPLEIVNV
 	gpGetInternalformati64v                                  C.GPGETINTERNALFORMATI64V
 	gpGetInternalformativ                                    C.GPGETINTERNALFORMATIV
 	gpGetInvariantBooleanvEXT                                C.GPGETINVARIANTBOOLEANVEXT
@@ -15905,6 +16700,7 @@ var (
 	gpGetMaterialiv                                          C.GPGETMATERIALIV
 	gpGetMaterialxOES                                        C.GPGETMATERIALXOES
 	gpGetMaterialxvOES                                       C.GPGETMATERIALXVOES
+	gpGetMemoryObjectParameterivEXT                          C.GPGETMEMORYOBJECTPARAMETERIVEXT
 	gpGetMinmaxEXT                                           C.GPGETMINMAXEXT
 	gpGetMinmaxParameterfvEXT                                C.GPGETMINMAXPARAMETERFVEXT
 	gpGetMinmaxParameterivEXT                                C.GPGETMINMAXPARAMETERIVEXT
@@ -15932,6 +16728,7 @@ var (
 	gpGetNamedBufferSubDataEXT                               C.GPGETNAMEDBUFFERSUBDATAEXT
 	gpGetNamedFramebufferAttachmentParameteriv               C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetNamedFramebufferAttachmentParameterivEXT            C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameterfvAMD                      C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD
 	gpGetNamedFramebufferParameteriv                         C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
 	gpGetNamedFramebufferParameterivEXT                      C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
 	gpGetNamedProgramLocalParameterIivEXT                    C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
@@ -15957,8 +16754,6 @@ var (
 	gpGetObjectPtrLabelKHR                                   C.GPGETOBJECTPTRLABELKHR
 	gpGetOcclusionQueryivNV                                  C.GPGETOCCLUSIONQUERYIVNV
 	gpGetOcclusionQueryuivNV                                 C.GPGETOCCLUSIONQUERYUIVNV
-	gpGetPathColorGenfvNV                                    C.GPGETPATHCOLORGENFVNV
-	gpGetPathColorGenivNV                                    C.GPGETPATHCOLORGENIVNV
 	gpGetPathCommandsNV                                      C.GPGETPATHCOMMANDSNV
 	gpGetPathCoordsNV                                        C.GPGETPATHCOORDSNV
 	gpGetPathDashArrayNV                                     C.GPGETPATHDASHARRAYNV
@@ -15968,8 +16763,6 @@ var (
 	gpGetPathParameterfvNV                                   C.GPGETPATHPARAMETERFVNV
 	gpGetPathParameterivNV                                   C.GPGETPATHPARAMETERIVNV
 	gpGetPathSpacingNV                                       C.GPGETPATHSPACINGNV
-	gpGetPathTexGenfvNV                                      C.GPGETPATHTEXGENFVNV
-	gpGetPathTexGenivNV                                      C.GPGETPATHTEXGENIVNV
 	gpGetPerfCounterInfoINTEL                                C.GPGETPERFCOUNTERINFOINTEL
 	gpGetPerfMonitorCounterDataAMD                           C.GPGETPERFMONITORCOUNTERDATAAMD
 	gpGetPerfMonitorCounterInfoAMD                           C.GPGETPERFMONITORCOUNTERINFOAMD
@@ -16026,6 +16819,10 @@ var (
 	gpGetProgramiv                                           C.GPGETPROGRAMIV
 	gpGetProgramivARB                                        C.GPGETPROGRAMIVARB
 	gpGetProgramivNV                                         C.GPGETPROGRAMIVNV
+	gpGetQueryBufferObjecti64v                               C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                                 C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                              C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                                C.GPGETQUERYBUFFEROBJECTUIV
 	gpGetQueryIndexediv                                      C.GPGETQUERYINDEXEDIV
 	gpGetQueryObjecti64v                                     C.GPGETQUERYOBJECTI64V
 	gpGetQueryObjecti64vEXT                                  C.GPGETQUERYOBJECTI64VEXT
@@ -16043,6 +16840,7 @@ var (
 	gpGetSamplerParameterIuiv                                C.GPGETSAMPLERPARAMETERIUIV
 	gpGetSamplerParameterfv                                  C.GPGETSAMPLERPARAMETERFV
 	gpGetSamplerParameteriv                                  C.GPGETSAMPLERPARAMETERIV
+	gpGetSemaphoreParameterui64vEXT                          C.GPGETSEMAPHOREPARAMETERUI64VEXT
 	gpGetSeparableFilterEXT                                  C.GPGETSEPARABLEFILTEREXT
 	gpGetShaderInfoLog                                       C.GPGETSHADERINFOLOG
 	gpGetShaderPrecisionFormat                               C.GPGETSHADERPRECISIONFORMAT
@@ -16050,6 +16848,7 @@ var (
 	gpGetShaderSourceARB                                     C.GPGETSHADERSOURCEARB
 	gpGetShaderiv                                            C.GPGETSHADERIV
 	gpGetSharpenTexFuncSGIS                                  C.GPGETSHARPENTEXFUNCSGIS
+	gpGetStageIndexNV                                        C.GPGETSTAGEINDEXNV
 	gpGetString                                              C.GPGETSTRING
 	gpGetSubroutineIndex                                     C.GPGETSUBROUTINEINDEX
 	gpGetSubroutineUniformLocation                           C.GPGETSUBROUTINEUNIFORMLOCATION
@@ -16109,11 +16908,15 @@ var (
 	gpGetUniformdv                                           C.GPGETUNIFORMDV
 	gpGetUniformfv                                           C.GPGETUNIFORMFV
 	gpGetUniformfvARB                                        C.GPGETUNIFORMFVARB
+	gpGetUniformi64vARB                                      C.GPGETUNIFORMI64VARB
 	gpGetUniformi64vNV                                       C.GPGETUNIFORMI64VNV
 	gpGetUniformiv                                           C.GPGETUNIFORMIV
 	gpGetUniformivARB                                        C.GPGETUNIFORMIVARB
+	gpGetUniformui64vARB                                     C.GPGETUNIFORMUI64VARB
 	gpGetUniformui64vNV                                      C.GPGETUNIFORMUI64VNV
 	gpGetUniformuivEXT                                       C.GPGETUNIFORMUIVEXT
+	gpGetUnsignedBytei_vEXT                                  C.GPGETUNSIGNEDBYTEI_VEXT
+	gpGetUnsignedBytevEXT                                    C.GPGETUNSIGNEDBYTEVEXT
 	gpGetVariantArrayObjectfvATI                             C.GPGETVARIANTARRAYOBJECTFVATI
 	gpGetVariantArrayObjectivATI                             C.GPGETVARIANTARRAYOBJECTIVATI
 	gpGetVariantBooleanvEXT                                  C.GPGETVARIANTBOOLEANVEXT
@@ -16157,15 +16960,18 @@ var (
 	gpGetVideoivNV                                           C.GPGETVIDEOIVNV
 	gpGetVideoui64vNV                                        C.GPGETVIDEOUI64VNV
 	gpGetVideouivNV                                          C.GPGETVIDEOUIVNV
+	gpGetVkProcAddrNV                                        C.GPGETVKPROCADDRNV
 	gpGetnCompressedTexImageARB                              C.GPGETNCOMPRESSEDTEXIMAGEARB
 	gpGetnTexImageARB                                        C.GPGETNTEXIMAGEARB
 	gpGetnUniformdvARB                                       C.GPGETNUNIFORMDVARB
 	gpGetnUniformfv                                          C.GPGETNUNIFORMFV
 	gpGetnUniformfvARB                                       C.GPGETNUNIFORMFVARB
 	gpGetnUniformfvKHR                                       C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                                     C.GPGETNUNIFORMI64VARB
 	gpGetnUniformiv                                          C.GPGETNUNIFORMIV
 	gpGetnUniformivARB                                       C.GPGETNUNIFORMIVARB
 	gpGetnUniformivKHR                                       C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                                    C.GPGETNUNIFORMUI64VARB
 	gpGetnUniformuiv                                         C.GPGETNUNIFORMUIV
 	gpGetnUniformuivARB                                      C.GPGETNUNIFORMUIVARB
 	gpGetnUniformuivKHR                                      C.GPGETNUNIFORMUIVKHR
@@ -16185,6 +16991,12 @@ var (
 	gpImageTransformParameterfvHP                            C.GPIMAGETRANSFORMPARAMETERFVHP
 	gpImageTransformParameteriHP                             C.GPIMAGETRANSFORMPARAMETERIHP
 	gpImageTransformParameterivHP                            C.GPIMAGETRANSFORMPARAMETERIVHP
+	gpImportMemoryFdEXT                                      C.GPIMPORTMEMORYFDEXT
+	gpImportMemoryWin32HandleEXT                             C.GPIMPORTMEMORYWIN32HANDLEEXT
+	gpImportMemoryWin32NameEXT                               C.GPIMPORTMEMORYWIN32NAMEEXT
+	gpImportSemaphoreFdEXT                                   C.GPIMPORTSEMAPHOREFDEXT
+	gpImportSemaphoreWin32HandleEXT                          C.GPIMPORTSEMAPHOREWIN32HANDLEEXT
+	gpImportSemaphoreWin32NameEXT                            C.GPIMPORTSEMAPHOREWIN32NAMEEXT
 	gpImportSyncEXT                                          C.GPIMPORTSYNCEXT
 	gpIndexFormatNV                                          C.GPINDEXFORMATNV
 	gpIndexFuncEXT                                           C.GPINDEXFUNCEXT
@@ -16223,6 +17035,7 @@ var (
 	gpIsBuffer                                               C.GPISBUFFER
 	gpIsBufferARB                                            C.GPISBUFFERARB
 	gpIsBufferResidentNV                                     C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                        C.GPISCOMMANDLISTNV
 	gpIsEnabled                                              C.GPISENABLED
 	gpIsEnabledIndexedEXT                                    C.GPISENABLEDINDEXEDEXT
 	gpIsFenceAPPLE                                           C.GPISFENCEAPPLE
@@ -16232,6 +17045,7 @@ var (
 	gpIsImageHandleResidentARB                               C.GPISIMAGEHANDLERESIDENTARB
 	gpIsImageHandleResidentNV                                C.GPISIMAGEHANDLERESIDENTNV
 	gpIsList                                                 C.GPISLIST
+	gpIsMemoryObjectEXT                                      C.GPISMEMORYOBJECTEXT
 	gpIsNameAMD                                              C.GPISNAMEAMD
 	gpIsNamedBufferResidentNV                                C.GPISNAMEDBUFFERRESIDENTNV
 	gpIsNamedStringARB                                       C.GPISNAMEDSTRINGARB
@@ -16250,7 +17064,9 @@ var (
 	gpIsRenderbuffer                                         C.GPISRENDERBUFFER
 	gpIsRenderbufferEXT                                      C.GPISRENDERBUFFEREXT
 	gpIsSampler                                              C.GPISSAMPLER
+	gpIsSemaphoreEXT                                         C.GPISSEMAPHOREEXT
 	gpIsShader                                               C.GPISSHADER
+	gpIsStateNV                                              C.GPISSTATENV
 	gpIsSync                                                 C.GPISSYNC
 	gpIsTexture                                              C.GPISTEXTURE
 	gpIsTextureEXT                                           C.GPISTEXTUREEXT
@@ -16262,6 +17078,9 @@ var (
 	gpIsVertexArray                                          C.GPISVERTEXARRAY
 	gpIsVertexArrayAPPLE                                     C.GPISVERTEXARRAYAPPLE
 	gpIsVertexAttribEnabledAPPLE                             C.GPISVERTEXATTRIBENABLEDAPPLE
+	gpLGPUCopyImageSubDataNVX                                C.GPLGPUCOPYIMAGESUBDATANVX
+	gpLGPUInterlockNVX                                       C.GPLGPUINTERLOCKNVX
+	gpLGPUNamedBufferSubDataNVX                              C.GPLGPUNAMEDBUFFERSUBDATANVX
 	gpLabelObjectEXT                                         C.GPLABELOBJECTEXT
 	gpLightEnviSGIX                                          C.GPLIGHTENVISGIX
 	gpLightModelf                                            C.GPLIGHTMODELF
@@ -16282,6 +17101,7 @@ var (
 	gpLinkProgram                                            C.GPLINKPROGRAM
 	gpLinkProgramARB                                         C.GPLINKPROGRAMARB
 	gpListBase                                               C.GPLISTBASE
+	gpListDrawCommandsStatesClientNV                         C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
 	gpListParameterfSGIX                                     C.GPLISTPARAMETERFSGIX
 	gpListParameterfvSGIX                                    C.GPLISTPARAMETERFVSGIX
 	gpListParameteriSGIX                                     C.GPLISTPARAMETERISGIX
@@ -16376,9 +17196,12 @@ var (
 	gpMatrixScalefEXT                                        C.GPMATRIXSCALEFEXT
 	gpMatrixTranslatedEXT                                    C.GPMATRIXTRANSLATEDEXT
 	gpMatrixTranslatefEXT                                    C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                            C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                            C.GPMAXSHADERCOMPILERTHREADSKHR
 	gpMemoryBarrier                                          C.GPMEMORYBARRIER
 	gpMemoryBarrierByRegion                                  C.GPMEMORYBARRIERBYREGION
 	gpMemoryBarrierEXT                                       C.GPMEMORYBARRIEREXT
+	gpMemoryObjectParameterivEXT                             C.GPMEMORYOBJECTPARAMETERIVEXT
 	gpMinSampleShadingARB                                    C.GPMINSAMPLESHADINGARB
 	gpMinmaxEXT                                              C.GPMINMAXEXT
 	gpMultMatrixd                                            C.GPMULTMATRIXD
@@ -16521,12 +17344,25 @@ var (
 	gpMultiTexSubImage1DEXT                                  C.GPMULTITEXSUBIMAGE1DEXT
 	gpMultiTexSubImage2DEXT                                  C.GPMULTITEXSUBIMAGE2DEXT
 	gpMultiTexSubImage3DEXT                                  C.GPMULTITEXSUBIMAGE3DEXT
+	gpMulticastBarrierNV                                     C.GPMULTICASTBARRIERNV
+	gpMulticastBlitFramebufferNV                             C.GPMULTICASTBLITFRAMEBUFFERNV
+	gpMulticastBufferSubDataNV                               C.GPMULTICASTBUFFERSUBDATANV
+	gpMulticastCopyBufferSubDataNV                           C.GPMULTICASTCOPYBUFFERSUBDATANV
+	gpMulticastCopyImageSubDataNV                            C.GPMULTICASTCOPYIMAGESUBDATANV
+	gpMulticastFramebufferSampleLocationsfvNV                C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpMulticastGetQueryObjecti64vNV                          C.GPMULTICASTGETQUERYOBJECTI64VNV
+	gpMulticastGetQueryObjectivNV                            C.GPMULTICASTGETQUERYOBJECTIVNV
+	gpMulticastGetQueryObjectui64vNV                         C.GPMULTICASTGETQUERYOBJECTUI64VNV
+	gpMulticastGetQueryObjectuivNV                           C.GPMULTICASTGETQUERYOBJECTUIVNV
+	gpMulticastWaitSyncNV                                    C.GPMULTICASTWAITSYNCNV
 	gpNamedBufferData                                        C.GPNAMEDBUFFERDATA
 	gpNamedBufferDataEXT                                     C.GPNAMEDBUFFERDATAEXT
 	gpNamedBufferPageCommitmentARB                           C.GPNAMEDBUFFERPAGECOMMITMENTARB
 	gpNamedBufferPageCommitmentEXT                           C.GPNAMEDBUFFERPAGECOMMITMENTEXT
 	gpNamedBufferStorage                                     C.GPNAMEDBUFFERSTORAGE
 	gpNamedBufferStorageEXT                                  C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferStorageExternalEXT                          C.GPNAMEDBUFFERSTORAGEEXTERNALEXT
+	gpNamedBufferStorageMemEXT                               C.GPNAMEDBUFFERSTORAGEMEMEXT
 	gpNamedBufferSubData                                     C.GPNAMEDBUFFERSUBDATA
 	gpNamedBufferSubDataEXT                                  C.GPNAMEDBUFFERSUBDATAEXT
 	gpNamedCopyBufferSubDataEXT                              C.GPNAMEDCOPYBUFFERSUBDATAEXT
@@ -16537,6 +17373,9 @@ var (
 	gpNamedFramebufferReadBuffer                             C.GPNAMEDFRAMEBUFFERREADBUFFER
 	gpNamedFramebufferRenderbuffer                           C.GPNAMEDFRAMEBUFFERRENDERBUFFER
 	gpNamedFramebufferRenderbufferEXT                        C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB                   C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV                    C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferSamplePositionsfvAMD                   C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpNamedFramebufferTexture                                C.GPNAMEDFRAMEBUFFERTEXTURE
 	gpNamedFramebufferTexture1DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
 	gpNamedFramebufferTexture2DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
@@ -16612,12 +17451,10 @@ var (
 	gpPassThroughxOES                                        C.GPPASSTHROUGHXOES
 	gpPatchParameterfv                                       C.GPPATCHPARAMETERFV
 	gpPatchParameteri                                        C.GPPATCHPARAMETERI
-	gpPathColorGenNV                                         C.GPPATHCOLORGENNV
 	gpPathCommandsNV                                         C.GPPATHCOMMANDSNV
 	gpPathCoordsNV                                           C.GPPATHCOORDSNV
 	gpPathCoverDepthFuncNV                                   C.GPPATHCOVERDEPTHFUNCNV
 	gpPathDashArrayNV                                        C.GPPATHDASHARRAYNV
-	gpPathFogGenNV                                           C.GPPATHFOGGENNV
 	gpPathGlyphIndexArrayNV                                  C.GPPATHGLYPHINDEXARRAYNV
 	gpPathGlyphIndexRangeNV                                  C.GPPATHGLYPHINDEXRANGENV
 	gpPathGlyphRangeNV                                       C.GPPATHGLYPHRANGENV
@@ -16632,7 +17469,6 @@ var (
 	gpPathStringNV                                           C.GPPATHSTRINGNV
 	gpPathSubCommandsNV                                      C.GPPATHSUBCOMMANDSNV
 	gpPathSubCoordsNV                                        C.GPPATHSUBCOORDSNV
-	gpPathTexGenNV                                           C.GPPATHTEXGENNV
 	gpPauseTransformFeedback                                 C.GPPAUSETRANSFORMFEEDBACK
 	gpPauseTransformFeedbackNV                               C.GPPAUSETRANSFORMFEEDBACKNV
 	gpPixelDataRangeNV                                       C.GPPIXELDATARANGENV
@@ -16678,6 +17514,8 @@ var (
 	gpPollInstrumentsSGIX                                    C.GPPOLLINSTRUMENTSSGIX
 	gpPolygonMode                                            C.GPPOLYGONMODE
 	gpPolygonOffset                                          C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                                     C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                                  C.GPPOLYGONOFFSETCLAMPEXT
 	gpPolygonOffsetEXT                                       C.GPPOLYGONOFFSETEXT
 	gpPolygonOffsetxOES                                      C.GPPOLYGONOFFSETXOES
 	gpPolygonStipple                                         C.GPPOLYGONSTIPPLE
@@ -16690,6 +17528,7 @@ var (
 	gpPopName                                                C.GPPOPNAME
 	gpPresentFrameDualFillNV                                 C.GPPRESENTFRAMEDUALFILLNV
 	gpPresentFrameKeyedNV                                    C.GPPRESENTFRAMEKEYEDNV
+	gpPrimitiveBoundingBoxARB                                C.GPPRIMITIVEBOUNDINGBOXARB
 	gpPrimitiveRestartIndexNV                                C.GPPRIMITIVERESTARTINDEXNV
 	gpPrimitiveRestartNV                                     C.GPPRIMITIVERESTARTNV
 	gpPrioritizeTextures                                     C.GPPRIORITIZETEXTURES
@@ -16746,13 +17585,17 @@ var (
 	gpProgramUniform1fv                                      C.GPPROGRAMUNIFORM1FV
 	gpProgramUniform1fvEXT                                   C.GPPROGRAMUNIFORM1FVEXT
 	gpProgramUniform1i                                       C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                                  C.GPPROGRAMUNIFORM1I64ARB
 	gpProgramUniform1i64NV                                   C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                                 C.GPPROGRAMUNIFORM1I64VARB
 	gpProgramUniform1i64vNV                                  C.GPPROGRAMUNIFORM1I64VNV
 	gpProgramUniform1iEXT                                    C.GPPROGRAMUNIFORM1IEXT
 	gpProgramUniform1iv                                      C.GPPROGRAMUNIFORM1IV
 	gpProgramUniform1ivEXT                                   C.GPPROGRAMUNIFORM1IVEXT
 	gpProgramUniform1ui                                      C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                                 C.GPPROGRAMUNIFORM1UI64ARB
 	gpProgramUniform1ui64NV                                  C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                                C.GPPROGRAMUNIFORM1UI64VARB
 	gpProgramUniform1ui64vNV                                 C.GPPROGRAMUNIFORM1UI64VNV
 	gpProgramUniform1uiEXT                                   C.GPPROGRAMUNIFORM1UIEXT
 	gpProgramUniform1uiv                                     C.GPPROGRAMUNIFORM1UIV
@@ -16766,13 +17609,17 @@ var (
 	gpProgramUniform2fv                                      C.GPPROGRAMUNIFORM2FV
 	gpProgramUniform2fvEXT                                   C.GPPROGRAMUNIFORM2FVEXT
 	gpProgramUniform2i                                       C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                                  C.GPPROGRAMUNIFORM2I64ARB
 	gpProgramUniform2i64NV                                   C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                                 C.GPPROGRAMUNIFORM2I64VARB
 	gpProgramUniform2i64vNV                                  C.GPPROGRAMUNIFORM2I64VNV
 	gpProgramUniform2iEXT                                    C.GPPROGRAMUNIFORM2IEXT
 	gpProgramUniform2iv                                      C.GPPROGRAMUNIFORM2IV
 	gpProgramUniform2ivEXT                                   C.GPPROGRAMUNIFORM2IVEXT
 	gpProgramUniform2ui                                      C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                                 C.GPPROGRAMUNIFORM2UI64ARB
 	gpProgramUniform2ui64NV                                  C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                                C.GPPROGRAMUNIFORM2UI64VARB
 	gpProgramUniform2ui64vNV                                 C.GPPROGRAMUNIFORM2UI64VNV
 	gpProgramUniform2uiEXT                                   C.GPPROGRAMUNIFORM2UIEXT
 	gpProgramUniform2uiv                                     C.GPPROGRAMUNIFORM2UIV
@@ -16786,13 +17633,17 @@ var (
 	gpProgramUniform3fv                                      C.GPPROGRAMUNIFORM3FV
 	gpProgramUniform3fvEXT                                   C.GPPROGRAMUNIFORM3FVEXT
 	gpProgramUniform3i                                       C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                                  C.GPPROGRAMUNIFORM3I64ARB
 	gpProgramUniform3i64NV                                   C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                                 C.GPPROGRAMUNIFORM3I64VARB
 	gpProgramUniform3i64vNV                                  C.GPPROGRAMUNIFORM3I64VNV
 	gpProgramUniform3iEXT                                    C.GPPROGRAMUNIFORM3IEXT
 	gpProgramUniform3iv                                      C.GPPROGRAMUNIFORM3IV
 	gpProgramUniform3ivEXT                                   C.GPPROGRAMUNIFORM3IVEXT
 	gpProgramUniform3ui                                      C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                                 C.GPPROGRAMUNIFORM3UI64ARB
 	gpProgramUniform3ui64NV                                  C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                                C.GPPROGRAMUNIFORM3UI64VARB
 	gpProgramUniform3ui64vNV                                 C.GPPROGRAMUNIFORM3UI64VNV
 	gpProgramUniform3uiEXT                                   C.GPPROGRAMUNIFORM3UIEXT
 	gpProgramUniform3uiv                                     C.GPPROGRAMUNIFORM3UIV
@@ -16806,13 +17657,17 @@ var (
 	gpProgramUniform4fv                                      C.GPPROGRAMUNIFORM4FV
 	gpProgramUniform4fvEXT                                   C.GPPROGRAMUNIFORM4FVEXT
 	gpProgramUniform4i                                       C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                                  C.GPPROGRAMUNIFORM4I64ARB
 	gpProgramUniform4i64NV                                   C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                                 C.GPPROGRAMUNIFORM4I64VARB
 	gpProgramUniform4i64vNV                                  C.GPPROGRAMUNIFORM4I64VNV
 	gpProgramUniform4iEXT                                    C.GPPROGRAMUNIFORM4IEXT
 	gpProgramUniform4iv                                      C.GPPROGRAMUNIFORM4IV
 	gpProgramUniform4ivEXT                                   C.GPPROGRAMUNIFORM4IVEXT
 	gpProgramUniform4ui                                      C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                                 C.GPPROGRAMUNIFORM4UI64ARB
 	gpProgramUniform4ui64NV                                  C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                                C.GPPROGRAMUNIFORM4UI64VARB
 	gpProgramUniform4ui64vNV                                 C.GPPROGRAMUNIFORM4UI64VNV
 	gpProgramUniform4uiEXT                                   C.GPPROGRAMUNIFORM4UIEXT
 	gpProgramUniform4uiv                                     C.GPPROGRAMUNIFORM4UIV
@@ -16873,6 +17728,8 @@ var (
 	gpQueryCounter                                           C.GPQUERYCOUNTER
 	gpQueryMatrixxOES                                        C.GPQUERYMATRIXXOES
 	gpQueryObjectParameteruiAMD                              C.GPQUERYOBJECTPARAMETERUIAMD
+	gpQueryResourceNV                                        C.GPQUERYRESOURCENV
+	gpQueryResourceTagNV                                     C.GPQUERYRESOURCETAGNV
 	gpRasterPos2d                                            C.GPRASTERPOS2D
 	gpRasterPos2dv                                           C.GPRASTERPOS2DV
 	gpRasterPos2f                                            C.GPRASTERPOS2F
@@ -16903,6 +17760,7 @@ var (
 	gpRasterPos4sv                                           C.GPRASTERPOS4SV
 	gpRasterPos4xOES                                         C.GPRASTERPOS4XOES
 	gpRasterPos4xvOES                                        C.GPRASTERPOS4XVOES
+	gpRasterSamplesEXT                                       C.GPRASTERSAMPLESEXT
 	gpReadBuffer                                             C.GPREADBUFFER
 	gpReadInstrumentsSGIX                                    C.GPREADINSTRUMENTSSGIX
 	gpReadPixels                                             C.GPREADPIXELS
@@ -16920,7 +17778,9 @@ var (
 	gpRectxOES                                               C.GPRECTXOES
 	gpRectxvOES                                              C.GPRECTXVOES
 	gpReferencePlaneSGIX                                     C.GPREFERENCEPLANESGIX
+	gpReleaseKeyedMutexWin32EXT                              C.GPRELEASEKEYEDMUTEXWIN32EXT
 	gpReleaseShaderCompiler                                  C.GPRELEASESHADERCOMPILER
+	gpRenderGpuMaskNV                                        C.GPRENDERGPUMASKNV
 	gpRenderMode                                             C.GPRENDERMODE
 	gpRenderbufferStorage                                    C.GPRENDERBUFFERSTORAGE
 	gpRenderbufferStorageEXT                                 C.GPRENDERBUFFERSTORAGEEXT
@@ -16954,6 +17814,7 @@ var (
 	gpResetHistogramEXT                                      C.GPRESETHISTOGRAMEXT
 	gpResetMinmaxEXT                                         C.GPRESETMINMAXEXT
 	gpResizeBuffersMESA                                      C.GPRESIZEBUFFERSMESA
+	gpResolveDepthValuesNV                                   C.GPRESOLVEDEPTHVALUESNV
 	gpResumeTransformFeedback                                C.GPRESUMETRANSFORMFEEDBACK
 	gpResumeTransformFeedbackNV                              C.GPRESUMETRANSFORMFEEDBACKNV
 	gpRotated                                                C.GPROTATED
@@ -16961,7 +17822,6 @@ var (
 	gpRotatexOES                                             C.GPROTATEXOES
 	gpSampleCoverage                                         C.GPSAMPLECOVERAGE
 	gpSampleCoverageARB                                      C.GPSAMPLECOVERAGEARB
-	gpSampleCoverageOES                                      C.GPSAMPLECOVERAGEOES
 	gpSampleCoveragexOES                                     C.GPSAMPLECOVERAGEXOES
 	gpSampleMapATI                                           C.GPSAMPLEMAPATI
 	gpSampleMaskEXT                                          C.GPSAMPLEMASKEXT
@@ -17023,6 +17883,7 @@ var (
 	gpSecondaryColorPointerListIBM                           C.GPSECONDARYCOLORPOINTERLISTIBM
 	gpSelectBuffer                                           C.GPSELECTBUFFER
 	gpSelectPerfMonitorCountersAMD                           C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpSemaphoreParameterui64vEXT                             C.GPSEMAPHOREPARAMETERUI64VEXT
 	gpSeparableFilter2DEXT                                   C.GPSEPARABLEFILTER2DEXT
 	gpSetFenceAPPLE                                          C.GPSETFENCEAPPLE
 	gpSetFenceNV                                             C.GPSETFENCENV
@@ -17039,11 +17900,16 @@ var (
 	gpShaderSourceARB                                        C.GPSHADERSOURCEARB
 	gpShaderStorageBlockBinding                              C.GPSHADERSTORAGEBLOCKBINDING
 	gpSharpenTexFuncSGIS                                     C.GPSHARPENTEXFUNCSGIS
+	gpSignalSemaphoreEXT                                     C.GPSIGNALSEMAPHOREEXT
+	gpSignalVkFenceNV                                        C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                                    C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                                    C.GPSPECIALIZESHADERARB
 	gpSpriteParameterfSGIX                                   C.GPSPRITEPARAMETERFSGIX
 	gpSpriteParameterfvSGIX                                  C.GPSPRITEPARAMETERFVSGIX
 	gpSpriteParameteriSGIX                                   C.GPSPRITEPARAMETERISGIX
 	gpSpriteParameterivSGIX                                  C.GPSPRITEPARAMETERIVSGIX
 	gpStartInstrumentsSGIX                                   C.GPSTARTINSTRUMENTSSGIX
+	gpStateCaptureNV                                         C.GPSTATECAPTURENV
 	gpStencilClearTagEXT                                     C.GPSTENCILCLEARTAGEXT
 	gpStencilFillPathInstancedNV                             C.GPSTENCILFILLPATHINSTANCEDNV
 	gpStencilFillPathNV                                      C.GPSTENCILFILLPATHNV
@@ -17064,6 +17930,7 @@ var (
 	gpStencilThenCoverStrokePathNV                           C.GPSTENCILTHENCOVERSTROKEPATHNV
 	gpStopInstrumentsSGIX                                    C.GPSTOPINSTRUMENTSSGIX
 	gpStringMarkerGREMEDY                                    C.GPSTRINGMARKERGREMEDY
+	gpSubpixelPrecisionBiasNV                                C.GPSUBPIXELPRECISIONBIASNV
 	gpSwizzleEXT                                             C.GPSWIZZLEEXT
 	gpSyncTextureINTEL                                       C.GPSYNCTEXTUREINTEL
 	gpTagSampleBufferSGIX                                    C.GPTAGSAMPLEBUFFERSGIX
@@ -17203,6 +18070,11 @@ var (
 	gpTexStorage2DMultisample                                C.GPTEXSTORAGE2DMULTISAMPLE
 	gpTexStorage3D                                           C.GPTEXSTORAGE3D
 	gpTexStorage3DMultisample                                C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexStorageMem1DEXT                                     C.GPTEXSTORAGEMEM1DEXT
+	gpTexStorageMem2DEXT                                     C.GPTEXSTORAGEMEM2DEXT
+	gpTexStorageMem2DMultisampleEXT                          C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT
+	gpTexStorageMem3DEXT                                     C.GPTEXSTORAGEMEM3DEXT
+	gpTexStorageMem3DMultisampleEXT                          C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT
 	gpTexStorageSparseAMD                                    C.GPTEXSTORAGESPARSEAMD
 	gpTexSubImage1D                                          C.GPTEXSUBIMAGE1D
 	gpTexSubImage1DEXT                                       C.GPTEXSUBIMAGE1DEXT
@@ -17253,6 +18125,11 @@ var (
 	gpTextureStorage3DEXT                                    C.GPTEXTURESTORAGE3DEXT
 	gpTextureStorage3DMultisample                            C.GPTEXTURESTORAGE3DMULTISAMPLE
 	gpTextureStorage3DMultisampleEXT                         C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureStorageMem1DEXT                                 C.GPTEXTURESTORAGEMEM1DEXT
+	gpTextureStorageMem2DEXT                                 C.GPTEXTURESTORAGEMEM2DEXT
+	gpTextureStorageMem2DMultisampleEXT                      C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT
+	gpTextureStorageMem3DEXT                                 C.GPTEXTURESTORAGEMEM3DEXT
+	gpTextureStorageMem3DMultisampleEXT                      C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT
 	gpTextureStorageSparseAMD                                C.GPTEXTURESTORAGESPARSEAMD
 	gpTextureSubImage1D                                      C.GPTEXTURESUBIMAGE1D
 	gpTextureSubImage1DEXT                                   C.GPTEXTURESUBIMAGE1DEXT
@@ -17279,12 +18156,16 @@ var (
 	gpUniform1fv                                             C.GPUNIFORM1FV
 	gpUniform1fvARB                                          C.GPUNIFORM1FVARB
 	gpUniform1i                                              C.GPUNIFORM1I
+	gpUniform1i64ARB                                         C.GPUNIFORM1I64ARB
 	gpUniform1i64NV                                          C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                        C.GPUNIFORM1I64VARB
 	gpUniform1i64vNV                                         C.GPUNIFORM1I64VNV
 	gpUniform1iARB                                           C.GPUNIFORM1IARB
 	gpUniform1iv                                             C.GPUNIFORM1IV
 	gpUniform1ivARB                                          C.GPUNIFORM1IVARB
+	gpUniform1ui64ARB                                        C.GPUNIFORM1UI64ARB
 	gpUniform1ui64NV                                         C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                                       C.GPUNIFORM1UI64VARB
 	gpUniform1ui64vNV                                        C.GPUNIFORM1UI64VNV
 	gpUniform1uiEXT                                          C.GPUNIFORM1UIEXT
 	gpUniform1uivEXT                                         C.GPUNIFORM1UIVEXT
@@ -17295,12 +18176,16 @@ var (
 	gpUniform2fv                                             C.GPUNIFORM2FV
 	gpUniform2fvARB                                          C.GPUNIFORM2FVARB
 	gpUniform2i                                              C.GPUNIFORM2I
+	gpUniform2i64ARB                                         C.GPUNIFORM2I64ARB
 	gpUniform2i64NV                                          C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                        C.GPUNIFORM2I64VARB
 	gpUniform2i64vNV                                         C.GPUNIFORM2I64VNV
 	gpUniform2iARB                                           C.GPUNIFORM2IARB
 	gpUniform2iv                                             C.GPUNIFORM2IV
 	gpUniform2ivARB                                          C.GPUNIFORM2IVARB
+	gpUniform2ui64ARB                                        C.GPUNIFORM2UI64ARB
 	gpUniform2ui64NV                                         C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                                       C.GPUNIFORM2UI64VARB
 	gpUniform2ui64vNV                                        C.GPUNIFORM2UI64VNV
 	gpUniform2uiEXT                                          C.GPUNIFORM2UIEXT
 	gpUniform2uivEXT                                         C.GPUNIFORM2UIVEXT
@@ -17311,12 +18196,16 @@ var (
 	gpUniform3fv                                             C.GPUNIFORM3FV
 	gpUniform3fvARB                                          C.GPUNIFORM3FVARB
 	gpUniform3i                                              C.GPUNIFORM3I
+	gpUniform3i64ARB                                         C.GPUNIFORM3I64ARB
 	gpUniform3i64NV                                          C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                        C.GPUNIFORM3I64VARB
 	gpUniform3i64vNV                                         C.GPUNIFORM3I64VNV
 	gpUniform3iARB                                           C.GPUNIFORM3IARB
 	gpUniform3iv                                             C.GPUNIFORM3IV
 	gpUniform3ivARB                                          C.GPUNIFORM3IVARB
+	gpUniform3ui64ARB                                        C.GPUNIFORM3UI64ARB
 	gpUniform3ui64NV                                         C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                                       C.GPUNIFORM3UI64VARB
 	gpUniform3ui64vNV                                        C.GPUNIFORM3UI64VNV
 	gpUniform3uiEXT                                          C.GPUNIFORM3UIEXT
 	gpUniform3uivEXT                                         C.GPUNIFORM3UIVEXT
@@ -17327,12 +18216,16 @@ var (
 	gpUniform4fv                                             C.GPUNIFORM4FV
 	gpUniform4fvARB                                          C.GPUNIFORM4FVARB
 	gpUniform4i                                              C.GPUNIFORM4I
+	gpUniform4i64ARB                                         C.GPUNIFORM4I64ARB
 	gpUniform4i64NV                                          C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                        C.GPUNIFORM4I64VARB
 	gpUniform4i64vNV                                         C.GPUNIFORM4I64VNV
 	gpUniform4iARB                                           C.GPUNIFORM4IARB
 	gpUniform4iv                                             C.GPUNIFORM4IV
 	gpUniform4ivARB                                          C.GPUNIFORM4IVARB
+	gpUniform4ui64ARB                                        C.GPUNIFORM4UI64ARB
 	gpUniform4ui64NV                                         C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                                       C.GPUNIFORM4UI64VARB
 	gpUniform4ui64vNV                                        C.GPUNIFORM4UI64VNV
 	gpUniform4uiEXT                                          C.GPUNIFORM4UIEXT
 	gpUniform4uivEXT                                         C.GPUNIFORM4UIVEXT
@@ -17730,7 +18623,11 @@ var (
 	gpViewportArrayv                                         C.GPVIEWPORTARRAYV
 	gpViewportIndexedf                                       C.GPVIEWPORTINDEXEDF
 	gpViewportIndexedfv                                      C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                               C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                                      C.GPVIEWPORTSWIZZLENV
+	gpWaitSemaphoreEXT                                       C.GPWAITSEMAPHOREEXT
 	gpWaitSync                                               C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                                      C.GPWAITVKSEMAPHORENV
 	gpWeightPathsNV                                          C.GPWEIGHTPATHSNV
 	gpWeightPointerARB                                       C.GPWEIGHTPOINTERARB
 	gpWeightbvARB                                            C.GPWEIGHTBVARB
@@ -17797,6 +18694,7 @@ var (
 	gpWindowPos4ivMESA                                       C.GPWINDOWPOS4IVMESA
 	gpWindowPos4sMESA                                        C.GPWINDOWPOS4SMESA
 	gpWindowPos4svMESA                                       C.GPWINDOWPOS4SVMESA
+	gpWindowRectanglesEXT                                    C.GPWINDOWRECTANGLESEXT
 	gpWriteMaskEXT                                           C.GPWRITEMASKEXT
 )
 
@@ -17814,6 +18712,10 @@ func Accum(op uint32, value float32) {
 }
 func AccumxOES(op uint32, value int32) {
 	C.glowAccumxOES(gpAccumxOES, (C.GLenum)(op), (C.GLfixed)(value))
+}
+func AcquireKeyedMutexWin32EXT(memory uint32, key uint64, timeout uint32) bool {
+	ret := C.glowAcquireKeyedMutexWin32EXT(gpAcquireKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key), (C.GLuint)(timeout))
+	return ret == TRUE
 }
 func ActiveProgramEXT(program uint32) {
 	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
@@ -17856,6 +18758,12 @@ func AlphaFunc(xfunc uint32, ref float32) {
 }
 func AlphaFuncxOES(xfunc uint32, ref int32) {
 	C.glowAlphaFuncxOES(gpAlphaFuncxOES, (C.GLenum)(xfunc), (C.GLfixed)(ref))
+}
+func AlphaToCoverageDitherControlNV(mode uint32) {
+	C.glowAlphaToCoverageDitherControlNV(gpAlphaToCoverageDitherControlNV, (C.GLenum)(mode))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 func ApplyTextureEXT(mode uint32) {
 	C.glowApplyTextureEXT(gpApplyTextureEXT, (C.GLenum)(mode))
@@ -17958,6 +18866,11 @@ func BindBuffer(target uint32, buffer uint32) {
 func BindBufferARB(target uint32, buffer uint32) {
 	C.glowBindBufferARB(gpBindBufferARB, (C.GLenum)(target), (C.GLuint)(buffer))
 }
+
+// bind a buffer object to an indexed buffer target
+func BindBufferBase(target uint32, index uint32, buffer uint32) {
+	C.glowBindBufferBase(gpBindBufferBase, (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(buffer))
+}
 func BindBufferBaseEXT(target uint32, index uint32, buffer uint32) {
 	C.glowBindBufferBaseEXT(gpBindBufferBaseEXT, (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(buffer))
 }
@@ -17969,6 +18882,11 @@ func BindBufferOffsetEXT(target uint32, index uint32, buffer uint32, offset int)
 }
 func BindBufferOffsetNV(target uint32, index uint32, buffer uint32, offset int) {
 	C.glowBindBufferOffsetNV(gpBindBufferOffsetNV, (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset))
+}
+
+// bind a range within a buffer object to an indexed buffer target
+func BindBufferRange(target uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowBindBufferRange(gpBindBufferRange, (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func BindBufferRangeEXT(target uint32, index uint32, buffer uint32, offset int, size int) {
 	C.glowBindBufferRangeEXT(gpBindBufferRangeEXT, (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
@@ -18267,8 +19185,8 @@ func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 func BufferDataARB(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferDataARB(gpBufferDataARB, (C.GLenum)(target), (C.GLsizeiptrARB)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 	C.glowBufferParameteriAPPLE(gpBufferParameteriAPPLE, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
@@ -18278,6 +19196,12 @@ func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowBufferStorage(gpBufferStorage, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func BufferStorageExternalEXT(target uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowBufferStorageExternalEXT(gpBufferStorageExternalEXT, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func BufferStorageMemEXT(target uint32, size int, memory uint32, offset uint64) {
+	C.glowBufferStorageMemEXT(gpBufferStorageMemEXT, (C.GLenum)(target), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
@@ -18285,6 +19209,9 @@ func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 }
 func BufferSubDataARB(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubDataARB(gpBufferSubDataARB, (C.GLenum)(target), (C.GLintptrARB)(offset), (C.GLsizeiptrARB)(size), data)
+}
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
 }
 
 // execute a display list
@@ -18364,6 +19291,8 @@ func ClearDepth(depth float64) {
 func ClearDepthdNV(depth float64) {
 	C.glowClearDepthdNV(gpClearDepthdNV, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -18388,14 +19317,14 @@ func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32
 }
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
 func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -18437,7 +19366,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -18674,6 +19603,12 @@ func CombinerParameterivNV(pname uint32, params *int32) {
 func CombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowCombinerStageParameterfvNV(gpCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
+}
 
 // Compiles a shader object
 func CompileShader(shader uint32) {
@@ -18784,6 +19719,12 @@ func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yof
 func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
+}
 func ConvolutionFilter1DEXT(target uint32, internalformat uint32, width int32, format uint32, xtype uint32, image unsafe.Pointer) {
 	C.glowConvolutionFilter1DEXT(gpConvolutionFilter1DEXT, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), image)
 }
@@ -18850,8 +19791,8 @@ func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffs
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 func CopyPathNV(resultPath uint32, srcPath uint32) {
 	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
@@ -18943,15 +19884,27 @@ func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsaf
 func CoverStrokePathNV(path uint32, coverMode uint32) {
 	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
 }
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreateMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowCreateMemoryObjectsEXT(gpCreateMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
 	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
@@ -19010,9 +19963,12 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -19108,6 +20064,9 @@ func DeleteBuffers(n int32, buffers *uint32) {
 func DeleteBuffersARB(n int32, buffers *uint32) {
 	C.glowDeleteBuffersARB(gpDeleteBuffersARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 func DeleteFencesAPPLE(n int32, fences *uint32) {
 	C.glowDeleteFencesAPPLE(gpDeleteFencesAPPLE, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(fences)))
 }
@@ -19129,6 +20088,9 @@ func DeleteFramebuffersEXT(n int32, framebuffers *uint32) {
 // delete a contiguous group of display lists
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
+}
+func DeleteMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowDeleteMemoryObjectsEXT(gpDeleteMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
@@ -19178,6 +20140,9 @@ func DeleteQueries(n int32, ids *uint32) {
 func DeleteQueriesARB(n int32, ids *uint32) {
 	C.glowDeleteQueriesARB(gpDeleteQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func DeleteQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowDeleteQueryResourceTagNV(gpDeleteQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // delete renderbuffer objects
 func DeleteRenderbuffers(n int32, renderbuffers *uint32) {
@@ -19191,14 +20156,20 @@ func DeleteRenderbuffersEXT(n int32, renderbuffers *uint32) {
 func DeleteSamplers(count int32, samplers *uint32) {
 	C.glowDeleteSamplers(gpDeleteSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
 }
+func DeleteSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowDeleteSemaphoresEXT(gpDeleteSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
+}
 
 // Deletes a shader object
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -19260,6 +20231,8 @@ func DepthRangeIndexed(index uint32, n float64, f float64) {
 func DepthRangedNV(zNear float64, zFar float64) {
 	C.glowDepthRangedNV(gpDepthRangedNV, (C.GLdouble)(zNear), (C.GLdouble)(zFar))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -19373,6 +20346,18 @@ func DrawBuffersARB(n int32, bufs *uint32) {
 func DrawBuffersATI(n int32, bufs *uint32) {
 	C.glowDrawBuffersATI(gpDrawBuffersATI, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 func DrawElementArrayAPPLE(mode uint32, first int32, count int32) {
 	C.glowDrawElementArrayAPPLE(gpDrawElementArrayAPPLE, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count))
 }
@@ -19467,6 +20452,9 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 // render multiple instances of primitives using a count derived from a specifed stream of a transform feedback object
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
+}
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
 }
 
 // flag edges as either boundary or nonboundary
@@ -19636,6 +20624,9 @@ func EvalPoint1(i int32) {
 func EvalPoint2(i int32, j int32) {
 	C.glowEvalPoint2(gpEvalPoint2, (C.GLint)(i), (C.GLint)(j))
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 func ExecuteProgramNV(target uint32, id uint32, params *float32) {
 	C.glowExecuteProgramNV(gpExecuteProgramNV, (C.GLenum)(target), (C.GLuint)(id), (*C.GLfloat)(unsafe.Pointer(params)))
 }
@@ -19652,9 +20643,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -19695,8 +20686,8 @@ func FlushMappedBufferRangeAPPLE(target uint32, offset int, size int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
 }
 func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
 	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
@@ -19784,6 +20775,9 @@ func FogxvOES(pname uint32, param *int32) {
 func FragmentColorMaterialSGIX(face uint32, mode uint32) {
 	C.glowFragmentColorMaterialSGIX(gpFragmentColorMaterialSGIX, (C.GLenum)(face), (C.GLenum)(mode))
 }
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
 func FragmentLightModelfSGIX(pname uint32, param float32) {
 	C.glowFragmentLightModelfSGIX(gpFragmentLightModelfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -19832,6 +20826,9 @@ func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
 func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
 	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
+}
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
@@ -19848,12 +20845,23 @@ func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarge
 func FramebufferRenderbufferEXT(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbufferEXT(gpFramebufferRenderbufferEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSamplePositionsfvAMD(target uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowFramebufferSamplePositionsfvAMD(gpFramebufferSamplePositionsfvAMD, (C.GLenum)(target), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1D(gpFramebufferTexture1D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
 func FramebufferTexture1DEXT(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1DEXT(gpFramebufferTexture1DEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
@@ -19888,6 +20896,9 @@ func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32
 }
 func FramebufferTextureLayerEXT(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayerEXT(gpFramebufferTextureLayerEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 func FreeObjectBufferATI(buffer uint32) {
 	C.glowFreeObjectBufferATI(gpFreeObjectBufferATI, (C.GLuint)(buffer))
@@ -19979,6 +20990,9 @@ func GenQueries(n int32, ids *uint32) {
 func GenQueriesARB(n int32, ids *uint32) {
 	C.glowGenQueriesARB(gpGenQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func GenQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowGenQueryResourceTagNV(gpGenQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // generate renderbuffer object names
 func GenRenderbuffers(n int32, renderbuffers *uint32) {
@@ -19991,6 +21005,9 @@ func GenRenderbuffersEXT(n int32, renderbuffers *uint32) {
 // generate sampler object names
 func GenSamplers(count int32, samplers *uint32) {
 	C.glowGenSamplers(gpGenSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
+}
+func GenSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowGenSemaphoresEXT(gpGenSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
 }
 func GenSymbolsEXT(datatype uint32, storagetype uint32, xrange uint32, components uint32) uint32 {
 	ret := C.glowGenSymbolsEXT(gpGenSymbolsEXT, (C.GLenum)(datatype), (C.GLenum)(storagetype), (C.GLenum)(xrange), (C.GLuint)(components))
@@ -20082,6 +21099,8 @@ func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, leng
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -20199,6 +21218,10 @@ func GetCombinerOutputParameterivNV(stage uint32, portion uint32, pname uint32, 
 func GetCombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowGetCombinerStageParameterfvNV(gpGetCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
 func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
 	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
@@ -20234,6 +21257,9 @@ func GetConvolutionParameterivEXT(target uint32, pname uint32, params *int32) {
 }
 func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 	C.glowGetConvolutionParameterxvOES(gpGetConvolutionParameterxvOES, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -20327,15 +21353,18 @@ func GetFragmentMaterialivSGIX(face uint32, pname uint32, params *int32) {
 	C.glowGetFragmentMaterialivSGIX(gpGetFragmentMaterialivSGIX, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetFramebufferAttachmentParameterivEXT(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameterivEXT(gpGetFramebufferAttachmentParameterivEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetFramebufferParameterfvAMD(target uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetFramebufferParameterfvAMD(gpGetFramebufferParameterfvAMD, (C.GLenum)(target), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -20399,6 +21428,9 @@ func GetInteger64v(pname uint32, data *int64) {
 func GetIntegerIndexedvEXT(target uint32, index uint32, data *int32) {
 	C.glowGetIntegerIndexedvEXT(gpGetIntegerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetIntegeri_v(target uint32, index uint32, data *int32) {
+	C.glowGetIntegeri_v(gpGetIntegeri_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
 func GetIntegerui64i_vNV(value uint32, index uint32, result *uint64) {
 	C.glowGetIntegerui64i_vNV(gpGetIntegerui64i_vNV, (C.GLenum)(value), (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(result)))
 }
@@ -20408,9 +21440,14 @@ func GetIntegerui64vNV(value uint32, result *uint64) {
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -20488,6 +21525,9 @@ func GetMaterialxOES(face uint32, pname uint32, param int32) {
 }
 func GetMaterialxvOES(face uint32, pname uint32, params *int32) {
 	C.glowGetMaterialxvOES(gpGetMaterialxvOES, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetMemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowGetMemoryObjectParameterivEXT(gpGetMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetMinmaxEXT(target uint32, reset bool, format uint32, xtype uint32, values unsafe.Pointer) {
 	C.glowGetMinmaxEXT(gpGetMinmaxEXT, (C.GLenum)(target), (C.GLboolean)(boolToInt(reset)), (C.GLenum)(format), (C.GLenum)(xtype), values)
@@ -20568,8 +21608,8 @@ func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Point
 }
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -20581,6 +21621,9 @@ func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uin
 }
 func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedFramebufferParameterfvAMD(framebuffer uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetNamedFramebufferParameterfvAMD(gpGetNamedFramebufferParameterfvAMD, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 
 // query a named parameter of a framebuffer object
@@ -20665,12 +21708,6 @@ func GetOcclusionQueryivNV(id uint32, pname uint32, params *int32) {
 func GetOcclusionQueryuivNV(id uint32, pname uint32, params *uint32) {
 	C.glowGetOcclusionQueryuivNV(gpGetOcclusionQueryuivNV, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
-func GetPathColorGenfvNV(color uint32, pname uint32, value *float32) {
-	C.glowGetPathColorGenfvNV(gpGetPathColorGenfvNV, (C.GLenum)(color), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
-}
-func GetPathColorGenivNV(color uint32, pname uint32, value *int32) {
-	C.glowGetPathColorGenivNV(gpGetPathColorGenivNV, (C.GLenum)(color), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
-}
 func GetPathCommandsNV(path uint32, commands *uint8) {
 	C.glowGetPathCommandsNV(gpGetPathCommandsNV, (C.GLuint)(path), (*C.GLubyte)(unsafe.Pointer(commands)))
 }
@@ -20698,12 +21735,6 @@ func GetPathParameterivNV(path uint32, pname uint32, value *int32) {
 }
 func GetPathSpacingNV(pathListMode uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, advanceScale float32, kerningScale float32, transformType uint32, returnedSpacing *float32) {
 	C.glowGetPathSpacingNV(gpGetPathSpacingNV, (C.GLenum)(pathListMode), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLfloat)(advanceScale), (C.GLfloat)(kerningScale), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(returnedSpacing)))
-}
-func GetPathTexGenfvNV(texCoordSet uint32, pname uint32, value *float32) {
-	C.glowGetPathTexGenfvNV(gpGetPathTexGenfvNV, (C.GLenum)(texCoordSet), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
-}
-func GetPathTexGenivNV(texCoordSet uint32, pname uint32, value *int32) {
-	C.glowGetPathTexGenivNV(gpGetPathTexGenivNV, (C.GLenum)(texCoordSet), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
 }
 func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
 	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
@@ -20896,6 +21927,18 @@ func GetProgramivARB(target uint32, pname uint32, params *int32) {
 func GetProgramivNV(id uint32, pname uint32, params *int32) {
 	C.glowGetProgramivNV(gpGetProgramivNV, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
 
 // return parameters of an indexed query object target
 func GetQueryIndexediv(target uint32, index uint32, pname uint32, params *int32) {
@@ -20919,6 +21962,8 @@ func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 func GetQueryObjectui64vEXT(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64vEXT(gpGetQueryObjectui64vEXT, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -20934,7 +21979,7 @@ func GetQueryivARB(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryivARB(gpGetQueryivARB, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -20952,6 +21997,9 @@ func GetSamplerParameterfv(sampler uint32, pname uint32, params *float32) {
 }
 func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 	C.glowGetSamplerParameteriv(gpGetSamplerParameteriv, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetSemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowGetSemaphoreParameterui64vEXT(gpGetSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetSeparableFilterEXT(target uint32, format uint32, xtype uint32, row unsafe.Pointer, column unsafe.Pointer, span unsafe.Pointer) {
 	C.glowGetSeparableFilterEXT(gpGetSeparableFilterEXT, (C.GLenum)(target), (C.GLenum)(format), (C.GLenum)(xtype), row, column, span)
@@ -20982,6 +22030,10 @@ func GetShaderiv(shader uint32, pname uint32, params *int32) {
 func GetSharpenTexFuncSGIS(target uint32, points *float32) {
 	C.glowGetSharpenTexFuncSGIS(gpGetSharpenTexFuncSGIS, (C.GLenum)(target), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -21002,7 +22054,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -21195,6 +22247,9 @@ func GetUniformfv(program uint32, location int32, params *float32) {
 func GetUniformfvARB(programObj uintptr, location int32, params *float32) {
 	C.glowGetUniformfvARB(gpGetUniformfvARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetUniformi64vNV(program uint32, location int32, params *int64) {
 	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
 }
@@ -21206,11 +22261,20 @@ func GetUniformiv(program uint32, location int32, params *int32) {
 func GetUniformivARB(programObj uintptr, location int32, params *int32) {
 	C.glowGetUniformivARB(gpGetUniformivARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 func GetUniformui64vNV(program uint32, location int32, params *uint64) {
 	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 func GetUniformuivEXT(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuivEXT(gpGetUniformuivEXT, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetUnsignedBytei_vEXT(target uint32, index uint32, data *uint8) {
+	C.glowGetUnsignedBytei_vEXT(gpGetUnsignedBytei_vEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLubyte)(unsafe.Pointer(data)))
+}
+func GetUnsignedBytevEXT(pname uint32, data *uint8) {
+	C.glowGetUnsignedBytevEXT(gpGetUnsignedBytevEXT, (C.GLenum)(pname), (*C.GLubyte)(unsafe.Pointer(data)))
 }
 func GetVariantArrayObjectfvATI(id uint32, pname uint32, params *float32) {
 	C.glowGetVariantArrayObjectfvATI(gpGetVariantArrayObjectfvATI, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
@@ -21354,6 +22418,10 @@ func GetVideoui64vNV(video_slot uint32, pname uint32, params *uint64) {
 func GetVideouivNV(video_slot uint32, pname uint32, params *uint32) {
 	C.glowGetVideouivNV(gpGetVideouivNV, (C.GLuint)(video_slot), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
+}
 func GetnCompressedTexImageARB(target uint32, lod int32, bufSize int32, img unsafe.Pointer) {
 	C.glowGetnCompressedTexImageARB(gpGetnCompressedTexImageARB, (C.GLenum)(target), (C.GLint)(lod), (C.GLsizei)(bufSize), img)
 }
@@ -21372,6 +22440,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21380,6 +22451,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -21440,9 +22514,27 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportMemoryFdEXT(memory uint32, size uint64, handleType uint32, fd int32) {
+	C.glowImportMemoryFdEXT(gpImportMemoryFdEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportMemoryWin32HandleEXT(memory uint32, size uint64, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportMemoryWin32HandleEXT(gpImportMemoryWin32HandleEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), handle)
+}
+func ImportMemoryWin32NameEXT(memory uint32, size uint64, handleType uint32, name unsafe.Pointer) {
+	C.glowImportMemoryWin32NameEXT(gpImportMemoryWin32NameEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), name)
+}
+func ImportSemaphoreFdEXT(semaphore uint32, handleType uint32, fd int32) {
+	C.glowImportSemaphoreFdEXT(gpImportSemaphoreFdEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportSemaphoreWin32HandleEXT(semaphore uint32, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportSemaphoreWin32HandleEXT(gpImportSemaphoreWin32HandleEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), handle)
+}
+func ImportSemaphoreWin32NameEXT(semaphore uint32, handleType uint32, name unsafe.Pointer) {
+	C.glowImportSemaphoreWin32NameEXT(gpImportSemaphoreWin32NameEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), name)
+}
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -21585,6 +22677,10 @@ func IsBufferResidentNV(target uint32) bool {
 	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
 	return ret == TRUE
 }
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
 	return ret == TRUE
@@ -21623,6 +22719,10 @@ func IsImageHandleResidentNV(handle uint64) bool {
 // determine if a name corresponds to a display list
 func IsList(list uint32) bool {
 	ret := C.glowIsList(gpIsList, (C.GLuint)(list))
+	return ret == TRUE
+}
+func IsMemoryObjectEXT(memoryObject uint32) bool {
+	ret := C.glowIsMemoryObjectEXT(gpIsMemoryObjectEXT, (C.GLuint)(memoryObject))
 	return ret == TRUE
 }
 func IsNameAMD(identifier uint32, name uint32) bool {
@@ -21707,15 +22807,23 @@ func IsSampler(sampler uint32) bool {
 	ret := C.glowIsSampler(gpIsSampler, (C.GLuint)(sampler))
 	return ret == TRUE
 }
+func IsSemaphoreEXT(semaphore uint32) bool {
+	ret := C.glowIsSemaphoreEXT(gpIsSemaphoreEXT, (C.GLuint)(semaphore))
+	return ret == TRUE
+}
 
 // Determines if a name corresponds to a shader object
 func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -21764,6 +22872,15 @@ func IsVertexArrayAPPLE(array uint32) bool {
 func IsVertexAttribEnabledAPPLE(index uint32, pname uint32) bool {
 	ret := C.glowIsVertexAttribEnabledAPPLE(gpIsVertexAttribEnabledAPPLE, (C.GLuint)(index), (C.GLenum)(pname))
 	return ret == TRUE
+}
+func LGPUCopyImageSubDataNVX(sourceGpu uint32, destinationGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srxY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, width int32, height int32, depth int32) {
+	C.glowLGPUCopyImageSubDataNVX(gpLGPUCopyImageSubDataNVX, (C.GLuint)(sourceGpu), (C.GLbitfield)(destinationGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srxY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func LGPUInterlockNVX() {
+	C.glowLGPUInterlockNVX(gpLGPUInterlockNVX)
+}
+func LGPUNamedBufferSubDataNVX(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowLGPUNamedBufferSubDataNVX(gpLGPUNamedBufferSubDataNVX, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
@@ -21832,6 +22949,9 @@ func LinkProgramARB(programObj uintptr) {
 // set the display-list base for
 func ListBase(base uint32) {
 	C.glowListBase(gpListBase, (C.GLuint)(base))
+}
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 func ListParameterfSGIX(list uint32, pname uint32, param float32) {
 	C.glowListParameterfSGIX(gpListParameterfSGIX, (C.GLuint)(list), (C.GLenum)(pname), (C.GLfloat)(param))
@@ -21996,8 +23116,8 @@ func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
 }
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
 }
 func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
@@ -22140,6 +23260,12 @@ func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
 func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
 	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
 }
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
+}
 
 // defines a barrier ordering memory transactions
 func MemoryBarrier(barriers uint32) {
@@ -22150,6 +23276,9 @@ func MemoryBarrierByRegion(barriers uint32) {
 }
 func MemoryBarrierEXT(barriers uint32) {
 	C.glowMemoryBarrierEXT(gpMemoryBarrierEXT, (C.GLbitfield)(barriers))
+}
+func MemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowMemoryObjectParameterivEXT(gpMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func MinSampleShadingARB(value float32) {
 	C.glowMinSampleShadingARB(gpMinSampleShadingARB, (C.GLfloat)(value))
@@ -22203,8 +23332,8 @@ func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer
 func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawElementArrayAPPLE(mode uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawElementArrayAPPLE(gpMultiDrawElementArrayAPPLE, (C.GLenum)(mode), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -22236,8 +23365,8 @@ func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirec
 func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawRangeElementArrayAPPLE(mode uint32, start uint32, end uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawRangeElementArrayAPPLE(gpMultiDrawRangeElementArrayAPPLE, (C.GLenum)(mode), (C.GLuint)(start), (C.GLuint)(end), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -22587,32 +23716,71 @@ func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset i
 func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func MulticastBarrierNV() {
+	C.glowMulticastBarrierNV(gpMulticastBarrierNV)
+}
+func MulticastBlitFramebufferNV(srcGpu uint32, dstGpu uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
+	C.glowMulticastBlitFramebufferNV(gpMulticastBlitFramebufferNV, (C.GLuint)(srcGpu), (C.GLuint)(dstGpu), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
+}
+func MulticastBufferSubDataNV(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowMulticastBufferSubDataNV(gpMulticastBufferSubDataNV, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func MulticastCopyBufferSubDataNV(readGpu uint32, writeGpuMask uint32, readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowMulticastCopyBufferSubDataNV(gpMulticastCopyBufferSubDataNV, (C.GLuint)(readGpu), (C.GLbitfield)(writeGpuMask), (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func MulticastCopyImageSubDataNV(srcGpu uint32, dstGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
+	C.glowMulticastCopyImageSubDataNV(gpMulticastCopyImageSubDataNV, (C.GLuint)(srcGpu), (C.GLbitfield)(dstGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
+}
+func MulticastFramebufferSampleLocationsfvNV(gpu uint32, framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowMulticastFramebufferSampleLocationsfvNV(gpMulticastFramebufferSampleLocationsfvNV, (C.GLuint)(gpu), (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func MulticastGetQueryObjecti64vNV(gpu uint32, id uint32, pname uint32, params *int64) {
+	C.glowMulticastGetQueryObjecti64vNV(gpMulticastGetQueryObjecti64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectivNV(gpu uint32, id uint32, pname uint32, params *int32) {
+	C.glowMulticastGetQueryObjectivNV(gpMulticastGetQueryObjectivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectui64vNV(gpu uint32, id uint32, pname uint32, params *uint64) {
+	C.glowMulticastGetQueryObjectui64vNV(gpMulticastGetQueryObjectui64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectuivNV(gpu uint32, id uint32, pname uint32, params *uint32) {
+	C.glowMulticastGetQueryObjectuivNV(gpMulticastGetQueryObjectuivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MulticastWaitSyncNV(signalGpu uint32, waitGpuMask uint32) {
+	C.glowMulticastWaitSyncNV(gpMulticastWaitSyncNV, (C.GLuint)(signalGpu), (C.GLbitfield)(waitGpuMask))
+}
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
 func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func NamedBufferStorageExternalEXT(buffer uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowNamedBufferStorageExternalEXT(gpNamedBufferStorageExternalEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func NamedBufferStorageMemEXT(buffer uint32, size int, memory uint32, offset uint64) {
+	C.glowNamedBufferStorageMemEXT(gpNamedBufferStorageMemEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -22650,6 +23818,15 @@ func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderb
 }
 func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSamplePositionsfvAMD(framebuffer uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowNamedFramebufferSamplePositionsfvAMD(gpNamedFramebufferSamplePositionsfvAMD, (C.GLuint)(framebuffer), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
@@ -22894,11 +24071,10 @@ func PassThroughxOES(token int32) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
-}
-func PathColorGenNV(color uint32, genMode uint32, colorFormat uint32, coeffs *float32) {
-	C.glowPathColorGenNV(gpPathColorGenNV, (C.GLenum)(color), (C.GLenum)(genMode), (C.GLenum)(colorFormat), (*C.GLfloat)(unsafe.Pointer(coeffs)))
 }
 func PathCommandsNV(path uint32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
 	C.glowPathCommandsNV(gpPathCommandsNV, (C.GLuint)(path), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
@@ -22911,9 +24087,6 @@ func PathCoverDepthFuncNV(xfunc uint32) {
 }
 func PathDashArrayNV(path uint32, dashCount int32, dashArray *float32) {
 	C.glowPathDashArrayNV(gpPathDashArrayNV, (C.GLuint)(path), (C.GLsizei)(dashCount), (*C.GLfloat)(unsafe.Pointer(dashArray)))
-}
-func PathFogGenNV(genMode uint32) {
-	C.glowPathFogGenNV(gpPathFogGenNV, (C.GLenum)(genMode))
 }
 func PathGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
 	ret := C.glowPathGlyphIndexArrayNV(gpPathGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
@@ -22960,9 +24133,6 @@ func PathSubCommandsNV(path uint32, commandStart int32, commandsToDelete int32, 
 func PathSubCoordsNV(path uint32, coordStart int32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
 	C.glowPathSubCoordsNV(gpPathSubCoordsNV, (C.GLuint)(path), (C.GLsizei)(coordStart), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
 }
-func PathTexGenNV(texCoordSet uint32, genMode uint32, components int32, coeffs *float32) {
-	C.glowPathTexGenNV(gpPathTexGenNV, (C.GLenum)(texCoordSet), (C.GLenum)(genMode), (C.GLint)(components), (*C.GLfloat)(unsafe.Pointer(coeffs)))
-}
 
 // pause transform feedback operations
 func PauseTransformFeedback() {
@@ -22989,6 +24159,8 @@ func PixelMapx(xmap uint32, size int32, values *int32) {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
 }
@@ -23111,6 +24283,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 func PolygonOffsetEXT(factor float32, bias float32) {
 	C.glowPolygonOffsetEXT(gpPolygonOffsetEXT, (C.GLfloat)(factor), (C.GLfloat)(bias))
 }
@@ -23150,6 +24328,9 @@ func PresentFrameDualFillNV(video_slot uint32, minPresentTime uint64, beginPrese
 }
 func PresentFrameKeyedNV(video_slot uint32, minPresentTime uint64, beginPresentTimeId uint32, presentDurationId uint32, xtype uint32, target0 uint32, fill0 uint32, key0 uint32, target1 uint32, fill1 uint32, key1 uint32) {
 	C.glowPresentFrameKeyedNV(gpPresentFrameKeyedNV, (C.GLuint)(video_slot), (C.GLuint64EXT)(minPresentTime), (C.GLuint)(beginPresentTimeId), (C.GLuint)(presentDurationId), (C.GLenum)(xtype), (C.GLenum)(target0), (C.GLuint)(fill0), (C.GLuint)(key0), (C.GLenum)(target1), (C.GLuint)(fill1), (C.GLuint)(key1))
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 func PrimitiveRestartIndexNV(index uint32) {
 	C.glowPrimitiveRestartIndexNV(gpPrimitiveRestartIndexNV, (C.GLuint)(index))
@@ -23272,6 +24453,8 @@ func ProgramParameter4fNV(target uint32, index uint32, x float32, y float32, z f
 func ProgramParameter4fvNV(target uint32, index uint32, v *float32) {
 	C.glowProgramParameter4fvNV(gpProgramParameter4fvNV, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -23329,8 +24512,14 @@ func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
 func ProgramUniform1i64NV(program uint32, location int32, x int64) {
 	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -23351,8 +24540,14 @@ func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
 func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
 	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -23401,8 +24596,14 @@ func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
 	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -23423,8 +24624,14 @@ func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
 	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -23473,8 +24680,14 @@ func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
 	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -23495,8 +24708,14 @@ func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
 	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -23545,8 +24764,14 @@ func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
 	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -23567,8 +24792,14 @@ func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -23778,12 +25009,21 @@ func PushName(name uint32) {
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
 }
+
+// return the values of the current matrix
 func QueryMatrixxOES(mantissa *int32, exponent *int32) uint32 {
 	ret := C.glowQueryMatrixxOES(gpQueryMatrixxOES, (*C.GLfixed)(unsafe.Pointer(mantissa)), (*C.GLint)(unsafe.Pointer(exponent)))
 	return (uint32)(ret)
 }
 func QueryObjectParameteruiAMD(target uint32, id uint32, pname uint32, param uint32) {
 	C.glowQueryObjectParameteruiAMD(gpQueryObjectParameteruiAMD, (C.GLenum)(target), (C.GLuint)(id), (C.GLenum)(pname), (C.GLuint)(param))
+}
+func QueryResourceNV(queryType uint32, tagId int32, bufSize uint32, buffer *int32) int32 {
+	ret := C.glowQueryResourceNV(gpQueryResourceNV, (C.GLenum)(queryType), (C.GLint)(tagId), (C.GLuint)(bufSize), (*C.GLint)(unsafe.Pointer(buffer)))
+	return (int32)(ret)
+}
+func QueryResourceTagNV(tagId int32, tagString *uint8) {
+	C.glowQueryResourceTagNV(gpQueryResourceTagNV, (C.GLint)(tagId), (*C.GLchar)(unsafe.Pointer(tagString)))
 }
 func RasterPos2d(x float64, y float64) {
 	C.glowRasterPos2d(gpRasterPos2d, (C.GLdouble)(x), (C.GLdouble)(y))
@@ -23875,6 +25115,9 @@ func RasterPos4xOES(x int32, y int32, z int32, w int32) {
 func RasterPos4xvOES(coords *int32) {
 	C.glowRasterPos4xvOES(gpRasterPos4xvOES, (*C.GLfixed)(unsafe.Pointer(coords)))
 }
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // select a color buffer source for pixels
 func ReadBuffer(src uint32) {
@@ -23932,10 +25175,17 @@ func RectxvOES(v1 *int32, v2 *int32) {
 func ReferencePlaneSGIX(equation *float64) {
 	C.glowReferencePlaneSGIX(gpReferencePlaneSGIX, (*C.GLdouble)(unsafe.Pointer(equation)))
 }
+func ReleaseKeyedMutexWin32EXT(memory uint32, key uint64) bool {
+	ret := C.glowReleaseKeyedMutexWin32EXT(gpReleaseKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key))
+	return ret == TRUE
+}
 
 // release resources consumed by the implementation's shader compiler
 func ReleaseShaderCompiler() {
 	C.glowReleaseShaderCompiler(gpReleaseShaderCompiler)
+}
+func RenderGpuMaskNV(mask uint32) {
+	C.glowRenderGpuMaskNV(gpRenderGpuMaskNV, (C.GLbitfield)(mask))
 }
 
 // set rasterization mode
@@ -24043,6 +25293,9 @@ func ResetMinmaxEXT(target uint32) {
 func ResizeBuffersMESA() {
 	C.glowResizeBuffersMESA(gpResizeBuffersMESA)
 }
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
+}
 
 // resume transform feedback operations
 func ResumeTransformFeedback() {
@@ -24067,9 +25320,6 @@ func SampleCoverage(value float32, invert bool) {
 }
 func SampleCoverageARB(value float32, invert bool) {
 	C.glowSampleCoverageARB(gpSampleCoverageARB, (C.GLfloat)(value), (C.GLboolean)(boolToInt(invert)))
-}
-func SampleCoverageOES(value int32, invert bool) {
-	C.glowSampleCoverageOES(gpSampleCoverageOES, (C.GLfixed)(value), (C.GLboolean)(boolToInt(invert)))
 }
 func SampleCoveragexOES(value int32, invert bool) {
 	C.glowSampleCoveragexOES(gpSampleCoveragexOES, (C.GLclampx)(value), (C.GLboolean)(boolToInt(invert)))
@@ -24264,6 +25514,9 @@ func SelectBuffer(size int32, buffer *uint32) {
 func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
 	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
 }
+func SemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowSemaphoreParameterui64vEXT(gpSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 func SeparableFilter2DEXT(target uint32, internalformat uint32, width int32, height int32, format uint32, xtype uint32, row unsafe.Pointer, column unsafe.Pointer) {
 	C.glowSeparableFilter2DEXT(gpSeparableFilter2DEXT, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), row, column)
 }
@@ -24320,6 +25573,18 @@ func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storage
 func SharpenTexFuncSGIS(target uint32, n int32, points *float32) {
 	C.glowSharpenTexFuncSGIS(gpSharpenTexFuncSGIS, (C.GLenum)(target), (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func SignalSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, dstLayouts *uint32) {
+	C.glowSignalSemaphoreEXT(gpSignalSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(dstLayouts)))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
 func SpriteParameterfSGIX(pname uint32, param float32) {
 	C.glowSpriteParameterfSGIX(gpSpriteParameterfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -24334,6 +25599,9 @@ func SpriteParameterivSGIX(pname uint32, params *int32) {
 }
 func StartInstrumentsSGIX() {
 	C.glowStartInstrumentsSGIX(gpStartInstrumentsSGIX)
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
 }
 func StencilClearTagEXT(stencilTagBits int32, stencilClearTag uint32) {
 	C.glowStencilClearTagEXT(gpStencilClearTagEXT, (C.GLsizei)(stencilTagBits), (C.GLuint)(stencilClearTag))
@@ -24406,6 +25674,9 @@ func StopInstrumentsSGIX(marker int32) {
 }
 func StringMarkerGREMEDY(len int32, xstring unsafe.Pointer) {
 	C.glowStringMarkerGREMEDY(gpStringMarkerGREMEDY, (C.GLsizei)(len), xstring)
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
 }
 func SwizzleEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowSwizzleEXT(gpSwizzleEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
@@ -24796,8 +26067,8 @@ func TexImage3DMultisampleCoverageNV(target uint32, coverageSamples int32, color
 func TexImage4DSGIS(target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, size4d int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTexImage4DSGIS(gpTexImage4DSGIS, (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(size4d), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIivEXT(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIivEXT(gpTexParameterIivEXT, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -24851,6 +26122,21 @@ func TexStorage3D(target uint32, levels int32, internalformat uint32, width int3
 func TexStorage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexStorage3DMultisample(gpTexStorage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TexStorageMem1DEXT(target uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem1DEXT(gpTexStorageMem1DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DEXT(gpTexStorageMem2DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DMultisampleEXT(gpTexStorageMem2DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DEXT(gpTexStorageMem3DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DMultisampleEXT(gpTexStorageMem3DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TexStorageSparseAMD(target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTexStorageSparseAMD(gpTexStorageSparseAMD, (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -24899,8 +26185,8 @@ func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buff
 }
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
@@ -24938,8 +26224,8 @@ func TextureMaterialEXT(face uint32, mode uint32) {
 func TextureNormalEXT(mode uint32) {
 	C.glowTextureNormalEXT(gpTextureNormalEXT, (C.GLenum)(mode))
 }
-func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -25023,6 +26309,21 @@ func TextureStorage3DMultisample(texture uint32, samples int32, internalformat u
 func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorageMem1DEXT(texture uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem1DEXT(gpTextureStorageMem1DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DEXT(gpTextureStorageMem2DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DMultisampleEXT(gpTextureStorageMem2DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DEXT(gpTextureStorageMem3DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DMultisampleEXT(gpTextureStorageMem3DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TextureStorageSparseAMD(texture uint32, target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTextureStorageSparseAMD(gpTextureStorageSparseAMD, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -25068,8 +26369,8 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TransformFeedbackStreamAttribsNV(count int32, attribs *int32, nbuffers int32, bufstreams *int32, bufferMode uint32) {
 	C.glowTransformFeedbackStreamAttribsNV(gpTransformFeedbackStreamAttribsNV, (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(attribs)), (C.GLsizei)(nbuffers), (*C.GLint)(unsafe.Pointer(bufstreams)), (C.GLenum)(bufferMode))
@@ -25119,8 +26420,14 @@ func Uniform1fvARB(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
 func Uniform1i64NV(location int32, x int64) {
 	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform1i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -25136,8 +26443,14 @@ func Uniform1iv(location int32, count int32, value *int32) {
 func Uniform1ivARB(location int32, count int32, value *int32) {
 	C.glowUniform1ivARB(gpUniform1ivARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
 func Uniform1ui64NV(location int32, x uint64) {
 	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform1ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -25175,8 +26488,14 @@ func Uniform2fvARB(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func Uniform2i64NV(location int32, x int64, y int64) {
 	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform2i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -25192,8 +26511,14 @@ func Uniform2iv(location int32, count int32, value *int32) {
 func Uniform2ivARB(location int32, count int32, value *int32) {
 	C.glowUniform2ivARB(gpUniform2ivARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func Uniform2ui64NV(location int32, x uint64, y uint64) {
 	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform2ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -25231,8 +26556,14 @@ func Uniform3fvARB(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func Uniform3i64NV(location int32, x int64, y int64, z int64) {
 	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform3i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -25248,8 +26579,14 @@ func Uniform3iv(location int32, count int32, value *int32) {
 func Uniform3ivARB(location int32, count int32, value *int32) {
 	C.glowUniform3ivARB(gpUniform3ivARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
 	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform3ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -25287,8 +26624,14 @@ func Uniform4fvARB(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
 	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform4i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -25304,8 +26647,14 @@ func Uniform4iv(location int32, count int32, value *int32) {
 func Uniform4ivARB(location int32, count int32, value *int32) {
 	C.glowUniform4ivARB(gpUniform4ivARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform4ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26560,10 +27909,22 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
+func WaitSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, srcLayouts *uint32) {
+	C.glowWaitSemaphoreEXT(gpWaitSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(srcLayouts)))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
 	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
@@ -26763,6 +28124,9 @@ func WindowPos4sMESA(x int16, y int16, z int16, w int16) {
 func WindowPos4svMESA(v *int16) {
 	C.glowWindowPos4svMESA(gpWindowPos4svMESA, (*C.GLshort)(unsafe.Pointer(v)))
 }
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
+}
 func WriteMaskEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowWriteMaskEXT(gpWriteMaskEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
 }
@@ -26799,6 +28163,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAccum")
 	}
 	gpAccumxOES = (C.GPACCUMXOES)(getProcAddr("glAccumxOES"))
+	gpAcquireKeyedMutexWin32EXT = (C.GPACQUIREKEYEDMUTEXWIN32EXT)(getProcAddr("glAcquireKeyedMutexWin32EXT"))
 	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
 	gpActiveShaderProgramEXT = (C.GPACTIVESHADERPROGRAMEXT)(getProcAddr("glActiveShaderProgramEXT"))
@@ -26817,6 +28182,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAlphaFunc")
 	}
 	gpAlphaFuncxOES = (C.GPALPHAFUNCXOES)(getProcAddr("glAlphaFuncxOES"))
+	gpAlphaToCoverageDitherControlNV = (C.GPALPHATOCOVERAGEDITHERCONTROLNV)(getProcAddr("glAlphaToCoverageDitherControlNV"))
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpApplyTextureEXT = (C.GPAPPLYTEXTUREEXT)(getProcAddr("glApplyTextureEXT"))
 	gpAreProgramsResidentNV = (C.GPAREPROGRAMSRESIDENTNV)(getProcAddr("glAreProgramsResidentNV"))
 	gpAreTexturesResident = (C.GPARETEXTURESRESIDENT)(getProcAddr("glAreTexturesResident"))
@@ -26866,10 +28233,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glBindBuffer")
 	}
 	gpBindBufferARB = (C.GPBINDBUFFERARB)(getProcAddr("glBindBufferARB"))
+	gpBindBufferBase = (C.GPBINDBUFFERBASE)(getProcAddr("glBindBufferBase"))
 	gpBindBufferBaseEXT = (C.GPBINDBUFFERBASEEXT)(getProcAddr("glBindBufferBaseEXT"))
 	gpBindBufferBaseNV = (C.GPBINDBUFFERBASENV)(getProcAddr("glBindBufferBaseNV"))
 	gpBindBufferOffsetEXT = (C.GPBINDBUFFEROFFSETEXT)(getProcAddr("glBindBufferOffsetEXT"))
 	gpBindBufferOffsetNV = (C.GPBINDBUFFEROFFSETNV)(getProcAddr("glBindBufferOffsetNV"))
+	gpBindBufferRange = (C.GPBINDBUFFERRANGE)(getProcAddr("glBindBufferRange"))
 	gpBindBufferRangeEXT = (C.GPBINDBUFFERRANGEEXT)(getProcAddr("glBindBufferRangeEXT"))
 	gpBindBufferRangeNV = (C.GPBINDBUFFERRANGENV)(getProcAddr("glBindBufferRangeNV"))
 	gpBindBuffersBase = (C.GPBINDBUFFERSBASE)(getProcAddr("glBindBuffersBase"))
@@ -26977,11 +28346,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpBufferPageCommitmentARB = (C.GPBUFFERPAGECOMMITMENTARB)(getProcAddr("glBufferPageCommitmentARB"))
 	gpBufferParameteriAPPLE = (C.GPBUFFERPARAMETERIAPPLE)(getProcAddr("glBufferParameteriAPPLE"))
 	gpBufferStorage = (C.GPBUFFERSTORAGE)(getProcAddr("glBufferStorage"))
+	gpBufferStorageExternalEXT = (C.GPBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glBufferStorageExternalEXT"))
+	gpBufferStorageMemEXT = (C.GPBUFFERSTORAGEMEMEXT)(getProcAddr("glBufferStorageMemEXT"))
 	gpBufferSubData = (C.GPBUFFERSUBDATA)(getProcAddr("glBufferSubData"))
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
 	gpBufferSubDataARB = (C.GPBUFFERSUBDATAARB)(getProcAddr("glBufferSubDataARB"))
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCallList = (C.GPCALLLIST)(getProcAddr("glCallList"))
 	if gpCallList == nil {
 		return errors.New("glCallList")
@@ -27230,6 +28602,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCombinerParameteriNV = (C.GPCOMBINERPARAMETERINV)(getProcAddr("glCombinerParameteriNV"))
 	gpCombinerParameterivNV = (C.GPCOMBINERPARAMETERIVNV)(getProcAddr("glCombinerParameterivNV"))
 	gpCombinerStageParameterfvNV = (C.GPCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glCombinerStageParameterfvNV"))
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
@@ -27281,6 +28655,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
 	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpConvolutionFilter1DEXT = (C.GPCONVOLUTIONFILTER1DEXT)(getProcAddr("glConvolutionFilter1DEXT"))
 	gpConvolutionFilter2DEXT = (C.GPCONVOLUTIONFILTER2DEXT)(getProcAddr("glConvolutionFilter2DEXT"))
 	gpConvolutionParameterfEXT = (C.GPCONVOLUTIONPARAMETERFEXT)(getProcAddr("glConvolutionParameterfEXT"))
@@ -27344,8 +28720,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
 	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
 	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
+	gpCreateMemoryObjectsEXT = (C.GPCREATEMEMORYOBJECTSEXT)(getProcAddr("glCreateMemoryObjectsEXT"))
 	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
@@ -27364,6 +28744,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCreateShaderProgramEXT = (C.GPCREATESHADERPROGRAMEXT)(getProcAddr("glCreateShaderProgramEXT"))
 	gpCreateShaderProgramv = (C.GPCREATESHADERPROGRAMV)(getProcAddr("glCreateShaderProgramv"))
 	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	gpCreateTransformFeedbacks = (C.GPCREATETRANSFORMFEEDBACKS)(getProcAddr("glCreateTransformFeedbacks"))
@@ -27396,6 +28777,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteBuffers")
 	}
 	gpDeleteBuffersARB = (C.GPDELETEBUFFERSARB)(getProcAddr("glDeleteBuffersARB"))
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFencesAPPLE = (C.GPDELETEFENCESAPPLE)(getProcAddr("glDeleteFencesAPPLE"))
 	gpDeleteFencesNV = (C.GPDELETEFENCESNV)(getProcAddr("glDeleteFencesNV"))
 	gpDeleteFragmentShaderATI = (C.GPDELETEFRAGMENTSHADERATI)(getProcAddr("glDeleteFragmentShaderATI"))
@@ -27405,6 +28787,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteLists == nil {
 		return errors.New("glDeleteLists")
 	}
+	gpDeleteMemoryObjectsEXT = (C.GPDELETEMEMORYOBJECTSEXT)(getProcAddr("glDeleteMemoryObjectsEXT"))
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
 	gpDeleteNamesAMD = (C.GPDELETENAMESAMD)(getProcAddr("glDeleteNamesAMD"))
 	gpDeleteObjectARB = (C.GPDELETEOBJECTARB)(getProcAddr("glDeleteObjectARB"))
@@ -27425,13 +28808,16 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteQueries")
 	}
 	gpDeleteQueriesARB = (C.GPDELETEQUERIESARB)(getProcAddr("glDeleteQueriesARB"))
+	gpDeleteQueryResourceTagNV = (C.GPDELETEQUERYRESOURCETAGNV)(getProcAddr("glDeleteQueryResourceTagNV"))
 	gpDeleteRenderbuffers = (C.GPDELETERENDERBUFFERS)(getProcAddr("glDeleteRenderbuffers"))
 	gpDeleteRenderbuffersEXT = (C.GPDELETERENDERBUFFERSEXT)(getProcAddr("glDeleteRenderbuffersEXT"))
 	gpDeleteSamplers = (C.GPDELETESAMPLERS)(getProcAddr("glDeleteSamplers"))
+	gpDeleteSemaphoresEXT = (C.GPDELETESEMAPHORESEXT)(getProcAddr("glDeleteSemaphoresEXT"))
 	gpDeleteShader = (C.GPDELETESHADER)(getProcAddr("glDeleteShader"))
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	gpDeleteTextures = (C.GPDELETETEXTURES)(getProcAddr("glDeleteTextures"))
 	if gpDeleteTextures == nil {
@@ -27512,6 +28898,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpDrawBuffersARB = (C.GPDRAWBUFFERSARB)(getProcAddr("glDrawBuffersARB"))
 	gpDrawBuffersATI = (C.GPDRAWBUFFERSATI)(getProcAddr("glDrawBuffersATI"))
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElementArrayAPPLE = (C.GPDRAWELEMENTARRAYAPPLE)(getProcAddr("glDrawElementArrayAPPLE"))
 	gpDrawElementArrayATI = (C.GPDRAWELEMENTARRAYATI)(getProcAddr("glDrawElementArrayATI"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
@@ -27544,6 +28934,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpDrawTransformFeedbackNV = (C.GPDRAWTRANSFORMFEEDBACKNV)(getProcAddr("glDrawTransformFeedbackNV"))
 	gpDrawTransformFeedbackStream = (C.GPDRAWTRANSFORMFEEDBACKSTREAM)(getProcAddr("glDrawTransformFeedbackStream"))
 	gpDrawTransformFeedbackStreamInstanced = (C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(getProcAddr("glDrawTransformFeedbackStreamInstanced"))
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
 	gpEdgeFlag = (C.GPEDGEFLAG)(getProcAddr("glEdgeFlag"))
 	if gpEdgeFlag == nil {
 		return errors.New("glEdgeFlag")
@@ -27659,6 +29050,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEvalPoint2 == nil {
 		return errors.New("glEvalPoint2")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpExecuteProgramNV = (C.GPEXECUTEPROGRAMNV)(getProcAddr("glExecuteProgramNV"))
 	gpExtractComponentEXT = (C.GPEXTRACTCOMPONENTEXT)(getProcAddr("glExtractComponentEXT"))
 	gpFeedbackBuffer = (C.GPFEEDBACKBUFFER)(getProcAddr("glFeedbackBuffer"))
@@ -27739,6 +29131,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFogxOES = (C.GPFOGXOES)(getProcAddr("glFogxOES"))
 	gpFogxvOES = (C.GPFOGXVOES)(getProcAddr("glFogxvOES"))
 	gpFragmentColorMaterialSGIX = (C.GPFRAGMENTCOLORMATERIALSGIX)(getProcAddr("glFragmentColorMaterialSGIX"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
 	gpFragmentLightModelfSGIX = (C.GPFRAGMENTLIGHTMODELFSGIX)(getProcAddr("glFragmentLightModelfSGIX"))
 	gpFragmentLightModelfvSGIX = (C.GPFRAGMENTLIGHTMODELFVSGIX)(getProcAddr("glFragmentLightModelfvSGIX"))
 	gpFragmentLightModeliSGIX = (C.GPFRAGMENTLIGHTMODELISGIX)(getProcAddr("glFragmentLightModeliSGIX"))
@@ -27755,10 +29148,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFrameZoomSGIX = (C.GPFRAMEZOOMSGIX)(getProcAddr("glFrameZoomSGIX"))
 	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
 	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
 	gpFramebufferReadBufferEXT = (C.GPFRAMEBUFFERREADBUFFEREXT)(getProcAddr("glFramebufferReadBufferEXT"))
 	gpFramebufferRenderbuffer = (C.GPFRAMEBUFFERRENDERBUFFER)(getProcAddr("glFramebufferRenderbuffer"))
 	gpFramebufferRenderbufferEXT = (C.GPFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glFramebufferRenderbufferEXT"))
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
+	gpFramebufferSamplePositionsfvAMD = (C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glFramebufferSamplePositionsfvAMD"))
 	gpFramebufferTexture1D = (C.GPFRAMEBUFFERTEXTURE1D)(getProcAddr("glFramebufferTexture1D"))
 	gpFramebufferTexture1DEXT = (C.GPFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glFramebufferTexture1DEXT"))
 	gpFramebufferTexture2D = (C.GPFRAMEBUFFERTEXTURE2D)(getProcAddr("glFramebufferTexture2D"))
@@ -27772,6 +29169,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFramebufferTextureLayer = (C.GPFRAMEBUFFERTEXTURELAYER)(getProcAddr("glFramebufferTextureLayer"))
 	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
 	gpFramebufferTextureLayerEXT = (C.GPFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glFramebufferTextureLayerEXT"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFreeObjectBufferATI = (C.GPFREEOBJECTBUFFERATI)(getProcAddr("glFreeObjectBufferATI"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
@@ -27811,9 +29209,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGenQueries")
 	}
 	gpGenQueriesARB = (C.GPGENQUERIESARB)(getProcAddr("glGenQueriesARB"))
+	gpGenQueryResourceTagNV = (C.GPGENQUERYRESOURCETAGNV)(getProcAddr("glGenQueryResourceTagNV"))
 	gpGenRenderbuffers = (C.GPGENRENDERBUFFERS)(getProcAddr("glGenRenderbuffers"))
 	gpGenRenderbuffersEXT = (C.GPGENRENDERBUFFERSEXT)(getProcAddr("glGenRenderbuffersEXT"))
 	gpGenSamplers = (C.GPGENSAMPLERS)(getProcAddr("glGenSamplers"))
+	gpGenSemaphoresEXT = (C.GPGENSEMAPHORESEXT)(getProcAddr("glGenSemaphoresEXT"))
 	gpGenSymbolsEXT = (C.GPGENSYMBOLSEXT)(getProcAddr("glGenSymbolsEXT"))
 	gpGenTextures = (C.GPGENTEXTURES)(getProcAddr("glGenTextures"))
 	if gpGenTextures == nil {
@@ -27899,6 +29299,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetCombinerOutputParameterfvNV = (C.GPGETCOMBINEROUTPUTPARAMETERFVNV)(getProcAddr("glGetCombinerOutputParameterfvNV"))
 	gpGetCombinerOutputParameterivNV = (C.GPGETCOMBINEROUTPUTPARAMETERIVNV)(getProcAddr("glGetCombinerOutputParameterivNV"))
 	gpGetCombinerStageParameterfvNV = (C.GPGETCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glGetCombinerStageParameterfvNV"))
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
 	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
@@ -27912,6 +29313,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetConvolutionParameterfvEXT = (C.GPGETCONVOLUTIONPARAMETERFVEXT)(getProcAddr("glGetConvolutionParameterfvEXT"))
 	gpGetConvolutionParameterivEXT = (C.GPGETCONVOLUTIONPARAMETERIVEXT)(getProcAddr("glGetConvolutionParameterivEXT"))
 	gpGetConvolutionParameterxvOES = (C.GPGETCONVOLUTIONPARAMETERXVOES)(getProcAddr("glGetConvolutionParameterxvOES"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	gpGetDebugMessageLogAMD = (C.GPGETDEBUGMESSAGELOGAMD)(getProcAddr("glGetDebugMessageLogAMD"))
 	gpGetDebugMessageLogARB = (C.GPGETDEBUGMESSAGELOGARB)(getProcAddr("glGetDebugMessageLogARB"))
@@ -27949,6 +29351,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetFragmentMaterialivSGIX = (C.GPGETFRAGMENTMATERIALIVSGIX)(getProcAddr("glGetFragmentMaterialivSGIX"))
 	gpGetFramebufferAttachmentParameteriv = (C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetFramebufferAttachmentParameteriv"))
 	gpGetFramebufferAttachmentParameterivEXT = (C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetFramebufferAttachmentParameterivEXT"))
+	gpGetFramebufferParameterfvAMD = (C.GPGETFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetFramebufferParameterfvAMD"))
 	gpGetFramebufferParameteriv = (C.GPGETFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetFramebufferParameteriv"))
 	gpGetFramebufferParameterivEXT = (C.GPGETFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetFramebufferParameterivEXT"))
 	gpGetGraphicsResetStatus = (C.GPGETGRAPHICSRESETSTATUS)(getProcAddr("glGetGraphicsResetStatus"))
@@ -27967,12 +29370,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetInstrumentsSGIX = (C.GPGETINSTRUMENTSSGIX)(getProcAddr("glGetInstrumentsSGIX"))
 	gpGetInteger64v = (C.GPGETINTEGER64V)(getProcAddr("glGetInteger64v"))
 	gpGetIntegerIndexedvEXT = (C.GPGETINTEGERINDEXEDVEXT)(getProcAddr("glGetIntegerIndexedvEXT"))
+	gpGetIntegeri_v = (C.GPGETINTEGERI_V)(getProcAddr("glGetIntegeri_v"))
 	gpGetIntegerui64i_vNV = (C.GPGETINTEGERUI64I_VNV)(getProcAddr("glGetIntegerui64i_vNV"))
 	gpGetIntegerui64vNV = (C.GPGETINTEGERUI64VNV)(getProcAddr("glGetIntegerui64vNV"))
 	gpGetIntegerv = (C.GPGETINTEGERV)(getProcAddr("glGetIntegerv"))
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	gpGetInternalformativ = (C.GPGETINTERNALFORMATIV)(getProcAddr("glGetInternalformativ"))
 	gpGetInvariantBooleanvEXT = (C.GPGETINVARIANTBOOLEANVEXT)(getProcAddr("glGetInvariantBooleanvEXT"))
@@ -28021,6 +29426,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetMaterialxOES = (C.GPGETMATERIALXOES)(getProcAddr("glGetMaterialxOES"))
 	gpGetMaterialxvOES = (C.GPGETMATERIALXVOES)(getProcAddr("glGetMaterialxvOES"))
+	gpGetMemoryObjectParameterivEXT = (C.GPGETMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glGetMemoryObjectParameterivEXT"))
 	gpGetMinmaxEXT = (C.GPGETMINMAXEXT)(getProcAddr("glGetMinmaxEXT"))
 	gpGetMinmaxParameterfvEXT = (C.GPGETMINMAXPARAMETERFVEXT)(getProcAddr("glGetMinmaxParameterfvEXT"))
 	gpGetMinmaxParameterivEXT = (C.GPGETMINMAXPARAMETERIVEXT)(getProcAddr("glGetMinmaxParameterivEXT"))
@@ -28048,6 +29454,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
 	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
+	gpGetNamedFramebufferParameterfvAMD = (C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetNamedFramebufferParameterfvAMD"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
 	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
 	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
@@ -28073,8 +29480,6 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetObjectPtrLabelKHR = (C.GPGETOBJECTPTRLABELKHR)(getProcAddr("glGetObjectPtrLabelKHR"))
 	gpGetOcclusionQueryivNV = (C.GPGETOCCLUSIONQUERYIVNV)(getProcAddr("glGetOcclusionQueryivNV"))
 	gpGetOcclusionQueryuivNV = (C.GPGETOCCLUSIONQUERYUIVNV)(getProcAddr("glGetOcclusionQueryuivNV"))
-	gpGetPathColorGenfvNV = (C.GPGETPATHCOLORGENFVNV)(getProcAddr("glGetPathColorGenfvNV"))
-	gpGetPathColorGenivNV = (C.GPGETPATHCOLORGENIVNV)(getProcAddr("glGetPathColorGenivNV"))
 	gpGetPathCommandsNV = (C.GPGETPATHCOMMANDSNV)(getProcAddr("glGetPathCommandsNV"))
 	gpGetPathCoordsNV = (C.GPGETPATHCOORDSNV)(getProcAddr("glGetPathCoordsNV"))
 	gpGetPathDashArrayNV = (C.GPGETPATHDASHARRAYNV)(getProcAddr("glGetPathDashArrayNV"))
@@ -28084,8 +29489,6 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetPathParameterfvNV = (C.GPGETPATHPARAMETERFVNV)(getProcAddr("glGetPathParameterfvNV"))
 	gpGetPathParameterivNV = (C.GPGETPATHPARAMETERIVNV)(getProcAddr("glGetPathParameterivNV"))
 	gpGetPathSpacingNV = (C.GPGETPATHSPACINGNV)(getProcAddr("glGetPathSpacingNV"))
-	gpGetPathTexGenfvNV = (C.GPGETPATHTEXGENFVNV)(getProcAddr("glGetPathTexGenfvNV"))
-	gpGetPathTexGenivNV = (C.GPGETPATHTEXGENIVNV)(getProcAddr("glGetPathTexGenivNV"))
 	gpGetPerfCounterInfoINTEL = (C.GPGETPERFCOUNTERINFOINTEL)(getProcAddr("glGetPerfCounterInfoINTEL"))
 	gpGetPerfMonitorCounterDataAMD = (C.GPGETPERFMONITORCOUNTERDATAAMD)(getProcAddr("glGetPerfMonitorCounterDataAMD"))
 	gpGetPerfMonitorCounterInfoAMD = (C.GPGETPERFMONITORCOUNTERINFOAMD)(getProcAddr("glGetPerfMonitorCounterInfoAMD"))
@@ -28163,6 +29566,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetProgramivARB = (C.GPGETPROGRAMIVARB)(getProcAddr("glGetProgramivARB"))
 	gpGetProgramivNV = (C.GPGETPROGRAMIVNV)(getProcAddr("glGetProgramivNV"))
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	gpGetQueryObjecti64v = (C.GPGETQUERYOBJECTI64V)(getProcAddr("glGetQueryObjecti64v"))
 	gpGetQueryObjecti64vEXT = (C.GPGETQUERYOBJECTI64VEXT)(getProcAddr("glGetQueryObjecti64vEXT"))
@@ -28189,6 +29596,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetSamplerParameterIuiv = (C.GPGETSAMPLERPARAMETERIUIV)(getProcAddr("glGetSamplerParameterIuiv"))
 	gpGetSamplerParameterfv = (C.GPGETSAMPLERPARAMETERFV)(getProcAddr("glGetSamplerParameterfv"))
 	gpGetSamplerParameteriv = (C.GPGETSAMPLERPARAMETERIV)(getProcAddr("glGetSamplerParameteriv"))
+	gpGetSemaphoreParameterui64vEXT = (C.GPGETSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glGetSemaphoreParameterui64vEXT"))
 	gpGetSeparableFilterEXT = (C.GPGETSEPARABLEFILTEREXT)(getProcAddr("glGetSeparableFilterEXT"))
 	gpGetShaderInfoLog = (C.GPGETSHADERINFOLOG)(getProcAddr("glGetShaderInfoLog"))
 	if gpGetShaderInfoLog == nil {
@@ -28205,6 +29613,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetShaderiv")
 	}
 	gpGetSharpenTexFuncSGIS = (C.GPGETSHARPENTEXFUNCSGIS)(getProcAddr("glGetSharpenTexFuncSGIS"))
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -28303,14 +29712,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetUniformfv")
 	}
 	gpGetUniformfvARB = (C.GPGETUNIFORMFVARB)(getProcAddr("glGetUniformfvARB"))
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
 	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
 	gpGetUniformivARB = (C.GPGETUNIFORMIVARB)(getProcAddr("glGetUniformivARB"))
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
 	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuivEXT = (C.GPGETUNIFORMUIVEXT)(getProcAddr("glGetUniformuivEXT"))
+	gpGetUnsignedBytei_vEXT = (C.GPGETUNSIGNEDBYTEI_VEXT)(getProcAddr("glGetUnsignedBytei_vEXT"))
+	gpGetUnsignedBytevEXT = (C.GPGETUNSIGNEDBYTEVEXT)(getProcAddr("glGetUnsignedBytevEXT"))
 	gpGetVariantArrayObjectfvATI = (C.GPGETVARIANTARRAYOBJECTFVATI)(getProcAddr("glGetVariantArrayObjectfvATI"))
 	gpGetVariantArrayObjectivATI = (C.GPGETVARIANTARRAYOBJECTIVATI)(getProcAddr("glGetVariantArrayObjectivATI"))
 	gpGetVariantBooleanvEXT = (C.GPGETVARIANTBOOLEANVEXT)(getProcAddr("glGetVariantBooleanvEXT"))
@@ -28366,15 +29779,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetVideoivNV = (C.GPGETVIDEOIVNV)(getProcAddr("glGetVideoivNV"))
 	gpGetVideoui64vNV = (C.GPGETVIDEOUI64VNV)(getProcAddr("glGetVideoui64vNV"))
 	gpGetVideouivNV = (C.GPGETVIDEOUIVNV)(getProcAddr("glGetVideouivNV"))
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnCompressedTexImageARB = (C.GPGETNCOMPRESSEDTEXIMAGEARB)(getProcAddr("glGetnCompressedTexImageARB"))
 	gpGetnTexImageARB = (C.GPGETNTEXIMAGEARB)(getProcAddr("glGetnTexImageARB"))
 	gpGetnUniformdvARB = (C.GPGETNUNIFORMDVARB)(getProcAddr("glGetnUniformdvARB"))
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	gpGetnUniformuivARB = (C.GPGETNUNIFORMUIVARB)(getProcAddr("glGetnUniformuivARB"))
 	gpGetnUniformuivKHR = (C.GPGETNUNIFORMUIVKHR)(getProcAddr("glGetnUniformuivKHR"))
@@ -28397,6 +29813,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpImageTransformParameterfvHP = (C.GPIMAGETRANSFORMPARAMETERFVHP)(getProcAddr("glImageTransformParameterfvHP"))
 	gpImageTransformParameteriHP = (C.GPIMAGETRANSFORMPARAMETERIHP)(getProcAddr("glImageTransformParameteriHP"))
 	gpImageTransformParameterivHP = (C.GPIMAGETRANSFORMPARAMETERIVHP)(getProcAddr("glImageTransformParameterivHP"))
+	gpImportMemoryFdEXT = (C.GPIMPORTMEMORYFDEXT)(getProcAddr("glImportMemoryFdEXT"))
+	gpImportMemoryWin32HandleEXT = (C.GPIMPORTMEMORYWIN32HANDLEEXT)(getProcAddr("glImportMemoryWin32HandleEXT"))
+	gpImportMemoryWin32NameEXT = (C.GPIMPORTMEMORYWIN32NAMEEXT)(getProcAddr("glImportMemoryWin32NameEXT"))
+	gpImportSemaphoreFdEXT = (C.GPIMPORTSEMAPHOREFDEXT)(getProcAddr("glImportSemaphoreFdEXT"))
+	gpImportSemaphoreWin32HandleEXT = (C.GPIMPORTSEMAPHOREWIN32HANDLEEXT)(getProcAddr("glImportSemaphoreWin32HandleEXT"))
+	gpImportSemaphoreWin32NameEXT = (C.GPIMPORTSEMAPHOREWIN32NAMEEXT)(getProcAddr("glImportSemaphoreWin32NameEXT"))
 	gpImportSyncEXT = (C.GPIMPORTSYNCEXT)(getProcAddr("glImportSyncEXT"))
 	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
 	gpIndexFuncEXT = (C.GPINDEXFUNCEXT)(getProcAddr("glIndexFuncEXT"))
@@ -28480,6 +29902,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsBufferARB = (C.GPISBUFFERARB)(getProcAddr("glIsBufferARB"))
 	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
@@ -28495,6 +29918,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsList == nil {
 		return errors.New("glIsList")
 	}
+	gpIsMemoryObjectEXT = (C.GPISMEMORYOBJECTEXT)(getProcAddr("glIsMemoryObjectEXT"))
 	gpIsNameAMD = (C.GPISNAMEAMD)(getProcAddr("glIsNameAMD"))
 	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
@@ -28519,10 +29943,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpIsRenderbuffer = (C.GPISRENDERBUFFER)(getProcAddr("glIsRenderbuffer"))
 	gpIsRenderbufferEXT = (C.GPISRENDERBUFFEREXT)(getProcAddr("glIsRenderbufferEXT"))
 	gpIsSampler = (C.GPISSAMPLER)(getProcAddr("glIsSampler"))
+	gpIsSemaphoreEXT = (C.GPISSEMAPHOREEXT)(getProcAddr("glIsSemaphoreEXT"))
 	gpIsShader = (C.GPISSHADER)(getProcAddr("glIsShader"))
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	gpIsTexture = (C.GPISTEXTURE)(getProcAddr("glIsTexture"))
 	if gpIsTexture == nil {
@@ -28537,6 +29963,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpIsVertexArray = (C.GPISVERTEXARRAY)(getProcAddr("glIsVertexArray"))
 	gpIsVertexArrayAPPLE = (C.GPISVERTEXARRAYAPPLE)(getProcAddr("glIsVertexArrayAPPLE"))
 	gpIsVertexAttribEnabledAPPLE = (C.GPISVERTEXATTRIBENABLEDAPPLE)(getProcAddr("glIsVertexAttribEnabledAPPLE"))
+	gpLGPUCopyImageSubDataNVX = (C.GPLGPUCOPYIMAGESUBDATANVX)(getProcAddr("glLGPUCopyImageSubDataNVX"))
+	gpLGPUInterlockNVX = (C.GPLGPUINTERLOCKNVX)(getProcAddr("glLGPUInterlockNVX"))
+	gpLGPUNamedBufferSubDataNVX = (C.GPLGPUNAMEDBUFFERSUBDATANVX)(getProcAddr("glLGPUNamedBufferSubDataNVX"))
 	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLightEnviSGIX = (C.GPLIGHTENVISGIX)(getProcAddr("glLightEnviSGIX"))
 	gpLightModelf = (C.GPLIGHTMODELF)(getProcAddr("glLightModelf"))
@@ -28593,6 +30022,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpListBase == nil {
 		return errors.New("glListBase")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpListParameterfSGIX = (C.GPLISTPARAMETERFSGIX)(getProcAddr("glListParameterfSGIX"))
 	gpListParameterfvSGIX = (C.GPLISTPARAMETERFVSGIX)(getProcAddr("glListParameterfvSGIX"))
 	gpListParameteriSGIX = (C.GPLISTPARAMETERISGIX)(getProcAddr("glListParameteriSGIX"))
@@ -28750,9 +30180,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
 	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
 	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	gpMemoryBarrierByRegion = (C.GPMEMORYBARRIERBYREGION)(getProcAddr("glMemoryBarrierByRegion"))
 	gpMemoryBarrierEXT = (C.GPMEMORYBARRIEREXT)(getProcAddr("glMemoryBarrierEXT"))
+	gpMemoryObjectParameterivEXT = (C.GPMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glMemoryObjectParameterivEXT"))
 	gpMinSampleShadingARB = (C.GPMINSAMPLESHADINGARB)(getProcAddr("glMinSampleShadingARB"))
 	gpMinmaxEXT = (C.GPMINMAXEXT)(getProcAddr("glMinmaxEXT"))
 	gpMultMatrixd = (C.GPMULTMATRIXD)(getProcAddr("glMultMatrixd"))
@@ -29009,12 +30442,25 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
 	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
 	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
+	gpMulticastBarrierNV = (C.GPMULTICASTBARRIERNV)(getProcAddr("glMulticastBarrierNV"))
+	gpMulticastBlitFramebufferNV = (C.GPMULTICASTBLITFRAMEBUFFERNV)(getProcAddr("glMulticastBlitFramebufferNV"))
+	gpMulticastBufferSubDataNV = (C.GPMULTICASTBUFFERSUBDATANV)(getProcAddr("glMulticastBufferSubDataNV"))
+	gpMulticastCopyBufferSubDataNV = (C.GPMULTICASTCOPYBUFFERSUBDATANV)(getProcAddr("glMulticastCopyBufferSubDataNV"))
+	gpMulticastCopyImageSubDataNV = (C.GPMULTICASTCOPYIMAGESUBDATANV)(getProcAddr("glMulticastCopyImageSubDataNV"))
+	gpMulticastFramebufferSampleLocationsfvNV = (C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glMulticastFramebufferSampleLocationsfvNV"))
+	gpMulticastGetQueryObjecti64vNV = (C.GPMULTICASTGETQUERYOBJECTI64VNV)(getProcAddr("glMulticastGetQueryObjecti64vNV"))
+	gpMulticastGetQueryObjectivNV = (C.GPMULTICASTGETQUERYOBJECTIVNV)(getProcAddr("glMulticastGetQueryObjectivNV"))
+	gpMulticastGetQueryObjectui64vNV = (C.GPMULTICASTGETQUERYOBJECTUI64VNV)(getProcAddr("glMulticastGetQueryObjectui64vNV"))
+	gpMulticastGetQueryObjectuivNV = (C.GPMULTICASTGETQUERYOBJECTUIVNV)(getProcAddr("glMulticastGetQueryObjectuivNV"))
+	gpMulticastWaitSyncNV = (C.GPMULTICASTWAITSYNCNV)(getProcAddr("glMulticastWaitSyncNV"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
 	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
 	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
+	gpNamedBufferStorageExternalEXT = (C.GPNAMEDBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glNamedBufferStorageExternalEXT"))
+	gpNamedBufferStorageMemEXT = (C.GPNAMEDBUFFERSTORAGEMEMEXT)(getProcAddr("glNamedBufferStorageMemEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
 	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
 	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
@@ -29025,6 +30471,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	gpNamedFramebufferRenderbuffer = (C.GPNAMEDFRAMEBUFFERRENDERBUFFER)(getProcAddr("glNamedFramebufferRenderbuffer"))
 	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
+	gpNamedFramebufferSamplePositionsfvAMD = (C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glNamedFramebufferSamplePositionsfvAMD"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
 	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
 	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
@@ -29142,12 +30591,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpPassThroughxOES = (C.GPPASSTHROUGHXOES)(getProcAddr("glPassThroughxOES"))
 	gpPatchParameterfv = (C.GPPATCHPARAMETERFV)(getProcAddr("glPatchParameterfv"))
 	gpPatchParameteri = (C.GPPATCHPARAMETERI)(getProcAddr("glPatchParameteri"))
-	gpPathColorGenNV = (C.GPPATHCOLORGENNV)(getProcAddr("glPathColorGenNV"))
 	gpPathCommandsNV = (C.GPPATHCOMMANDSNV)(getProcAddr("glPathCommandsNV"))
 	gpPathCoordsNV = (C.GPPATHCOORDSNV)(getProcAddr("glPathCoordsNV"))
 	gpPathCoverDepthFuncNV = (C.GPPATHCOVERDEPTHFUNCNV)(getProcAddr("glPathCoverDepthFuncNV"))
 	gpPathDashArrayNV = (C.GPPATHDASHARRAYNV)(getProcAddr("glPathDashArrayNV"))
-	gpPathFogGenNV = (C.GPPATHFOGGENNV)(getProcAddr("glPathFogGenNV"))
 	gpPathGlyphIndexArrayNV = (C.GPPATHGLYPHINDEXARRAYNV)(getProcAddr("glPathGlyphIndexArrayNV"))
 	gpPathGlyphIndexRangeNV = (C.GPPATHGLYPHINDEXRANGENV)(getProcAddr("glPathGlyphIndexRangeNV"))
 	gpPathGlyphRangeNV = (C.GPPATHGLYPHRANGENV)(getProcAddr("glPathGlyphRangeNV"))
@@ -29162,7 +30609,6 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpPathStringNV = (C.GPPATHSTRINGNV)(getProcAddr("glPathStringNV"))
 	gpPathSubCommandsNV = (C.GPPATHSUBCOMMANDSNV)(getProcAddr("glPathSubCommandsNV"))
 	gpPathSubCoordsNV = (C.GPPATHSUBCOORDSNV)(getProcAddr("glPathSubCoordsNV"))
-	gpPathTexGenNV = (C.GPPATHTEXGENNV)(getProcAddr("glPathTexGenNV"))
 	gpPauseTransformFeedback = (C.GPPAUSETRANSFORMFEEDBACK)(getProcAddr("glPauseTransformFeedback"))
 	gpPauseTransformFeedbackNV = (C.GPPAUSETRANSFORMFEEDBACKNV)(getProcAddr("glPauseTransformFeedbackNV"))
 	gpPixelDataRangeNV = (C.GPPIXELDATARANGENV)(getProcAddr("glPixelDataRangeNV"))
@@ -29253,6 +30699,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPolygonOffsetEXT = (C.GPPOLYGONOFFSETEXT)(getProcAddr("glPolygonOffsetEXT"))
 	gpPolygonOffsetxOES = (C.GPPOLYGONOFFSETXOES)(getProcAddr("glPolygonOffsetxOES"))
 	gpPolygonStipple = (C.GPPOLYGONSTIPPLE)(getProcAddr("glPolygonStipple"))
@@ -29280,6 +30728,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpPresentFrameDualFillNV = (C.GPPRESENTFRAMEDUALFILLNV)(getProcAddr("glPresentFrameDualFillNV"))
 	gpPresentFrameKeyedNV = (C.GPPRESENTFRAMEKEYEDNV)(getProcAddr("glPresentFrameKeyedNV"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndexNV = (C.GPPRIMITIVERESTARTINDEXNV)(getProcAddr("glPrimitiveRestartIndexNV"))
 	gpPrimitiveRestartNV = (C.GPPRIMITIVERESTARTNV)(getProcAddr("glPrimitiveRestartNV"))
 	gpPrioritizeTextures = (C.GPPRIORITIZETEXTURES)(getProcAddr("glPrioritizeTextures"))
@@ -29339,13 +30788,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpProgramUniform1fv = (C.GPPROGRAMUNIFORM1FV)(getProcAddr("glProgramUniform1fv"))
 	gpProgramUniform1fvEXT = (C.GPPROGRAMUNIFORM1FVEXT)(getProcAddr("glProgramUniform1fvEXT"))
 	gpProgramUniform1i = (C.GPPROGRAMUNIFORM1I)(getProcAddr("glProgramUniform1i"))
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
 	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
 	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
 	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
 	gpProgramUniform1ivEXT = (C.GPPROGRAMUNIFORM1IVEXT)(getProcAddr("glProgramUniform1ivEXT"))
 	gpProgramUniform1ui = (C.GPPROGRAMUNIFORM1UI)(getProcAddr("glProgramUniform1ui"))
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
 	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
 	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
 	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
@@ -29359,13 +30812,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpProgramUniform2fv = (C.GPPROGRAMUNIFORM2FV)(getProcAddr("glProgramUniform2fv"))
 	gpProgramUniform2fvEXT = (C.GPPROGRAMUNIFORM2FVEXT)(getProcAddr("glProgramUniform2fvEXT"))
 	gpProgramUniform2i = (C.GPPROGRAMUNIFORM2I)(getProcAddr("glProgramUniform2i"))
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
 	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
 	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
 	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
 	gpProgramUniform2ivEXT = (C.GPPROGRAMUNIFORM2IVEXT)(getProcAddr("glProgramUniform2ivEXT"))
 	gpProgramUniform2ui = (C.GPPROGRAMUNIFORM2UI)(getProcAddr("glProgramUniform2ui"))
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
 	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
 	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
 	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
@@ -29379,13 +30836,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpProgramUniform3fv = (C.GPPROGRAMUNIFORM3FV)(getProcAddr("glProgramUniform3fv"))
 	gpProgramUniform3fvEXT = (C.GPPROGRAMUNIFORM3FVEXT)(getProcAddr("glProgramUniform3fvEXT"))
 	gpProgramUniform3i = (C.GPPROGRAMUNIFORM3I)(getProcAddr("glProgramUniform3i"))
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
 	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
 	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
 	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
 	gpProgramUniform3ivEXT = (C.GPPROGRAMUNIFORM3IVEXT)(getProcAddr("glProgramUniform3ivEXT"))
 	gpProgramUniform3ui = (C.GPPROGRAMUNIFORM3UI)(getProcAddr("glProgramUniform3ui"))
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
 	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
 	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
 	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
@@ -29399,13 +30860,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpProgramUniform4fv = (C.GPPROGRAMUNIFORM4FV)(getProcAddr("glProgramUniform4fv"))
 	gpProgramUniform4fvEXT = (C.GPPROGRAMUNIFORM4FVEXT)(getProcAddr("glProgramUniform4fvEXT"))
 	gpProgramUniform4i = (C.GPPROGRAMUNIFORM4I)(getProcAddr("glProgramUniform4i"))
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
 	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
 	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
 	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
 	gpProgramUniform4ivEXT = (C.GPPROGRAMUNIFORM4IVEXT)(getProcAddr("glProgramUniform4ivEXT"))
 	gpProgramUniform4ui = (C.GPPROGRAMUNIFORM4UI)(getProcAddr("glProgramUniform4ui"))
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
 	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
 	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
 	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
@@ -29478,6 +30943,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpQueryCounter = (C.GPQUERYCOUNTER)(getProcAddr("glQueryCounter"))
 	gpQueryMatrixxOES = (C.GPQUERYMATRIXXOES)(getProcAddr("glQueryMatrixxOES"))
 	gpQueryObjectParameteruiAMD = (C.GPQUERYOBJECTPARAMETERUIAMD)(getProcAddr("glQueryObjectParameteruiAMD"))
+	gpQueryResourceNV = (C.GPQUERYRESOURCENV)(getProcAddr("glQueryResourceNV"))
+	gpQueryResourceTagNV = (C.GPQUERYRESOURCETAGNV)(getProcAddr("glQueryResourceTagNV"))
 	gpRasterPos2d = (C.GPRASTERPOS2D)(getProcAddr("glRasterPos2d"))
 	if gpRasterPos2d == nil {
 		return errors.New("glRasterPos2d")
@@ -29580,6 +31047,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpRasterPos4xOES = (C.GPRASTERPOS4XOES)(getProcAddr("glRasterPos4xOES"))
 	gpRasterPos4xvOES = (C.GPRASTERPOS4XVOES)(getProcAddr("glRasterPos4xvOES"))
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -29627,7 +31095,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpRectxOES = (C.GPRECTXOES)(getProcAddr("glRectxOES"))
 	gpRectxvOES = (C.GPRECTXVOES)(getProcAddr("glRectxvOES"))
 	gpReferencePlaneSGIX = (C.GPREFERENCEPLANESGIX)(getProcAddr("glReferencePlaneSGIX"))
+	gpReleaseKeyedMutexWin32EXT = (C.GPRELEASEKEYEDMUTEXWIN32EXT)(getProcAddr("glReleaseKeyedMutexWin32EXT"))
 	gpReleaseShaderCompiler = (C.GPRELEASESHADERCOMPILER)(getProcAddr("glReleaseShaderCompiler"))
+	gpRenderGpuMaskNV = (C.GPRENDERGPUMASKNV)(getProcAddr("glRenderGpuMaskNV"))
 	gpRenderMode = (C.GPRENDERMODE)(getProcAddr("glRenderMode"))
 	if gpRenderMode == nil {
 		return errors.New("glRenderMode")
@@ -29664,6 +31134,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpResetHistogramEXT = (C.GPRESETHISTOGRAMEXT)(getProcAddr("glResetHistogramEXT"))
 	gpResetMinmaxEXT = (C.GPRESETMINMAXEXT)(getProcAddr("glResetMinmaxEXT"))
 	gpResizeBuffersMESA = (C.GPRESIZEBUFFERSMESA)(getProcAddr("glResizeBuffersMESA"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	gpResumeTransformFeedbackNV = (C.GPRESUMETRANSFORMFEEDBACKNV)(getProcAddr("glResumeTransformFeedbackNV"))
 	gpRotated = (C.GPROTATED)(getProcAddr("glRotated"))
@@ -29680,7 +31151,6 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSampleCoverage")
 	}
 	gpSampleCoverageARB = (C.GPSAMPLECOVERAGEARB)(getProcAddr("glSampleCoverageARB"))
-	gpSampleCoverageOES = (C.GPSAMPLECOVERAGEOES)(getProcAddr("glSampleCoverageOES"))
 	gpSampleCoveragexOES = (C.GPSAMPLECOVERAGEXOES)(getProcAddr("glSampleCoveragexOES"))
 	gpSampleMapATI = (C.GPSAMPLEMAPATI)(getProcAddr("glSampleMapATI"))
 	gpSampleMaskEXT = (C.GPSAMPLEMASKEXT)(getProcAddr("glSampleMaskEXT"))
@@ -29805,6 +31275,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSelectBuffer")
 	}
 	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
+	gpSemaphoreParameterui64vEXT = (C.GPSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glSemaphoreParameterui64vEXT"))
 	gpSeparableFilter2DEXT = (C.GPSEPARABLEFILTER2DEXT)(getProcAddr("glSeparableFilter2DEXT"))
 	gpSetFenceAPPLE = (C.GPSETFENCEAPPLE)(getProcAddr("glSetFenceAPPLE"))
 	gpSetFenceNV = (C.GPSETFENCENV)(getProcAddr("glSetFenceNV"))
@@ -29827,11 +31298,16 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpShaderSourceARB = (C.GPSHADERSOURCEARB)(getProcAddr("glShaderSourceARB"))
 	gpShaderStorageBlockBinding = (C.GPSHADERSTORAGEBLOCKBINDING)(getProcAddr("glShaderStorageBlockBinding"))
 	gpSharpenTexFuncSGIS = (C.GPSHARPENTEXFUNCSGIS)(getProcAddr("glSharpenTexFuncSGIS"))
+	gpSignalSemaphoreEXT = (C.GPSIGNALSEMAPHOREEXT)(getProcAddr("glSignalSemaphoreEXT"))
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
 	gpSpriteParameterfSGIX = (C.GPSPRITEPARAMETERFSGIX)(getProcAddr("glSpriteParameterfSGIX"))
 	gpSpriteParameterfvSGIX = (C.GPSPRITEPARAMETERFVSGIX)(getProcAddr("glSpriteParameterfvSGIX"))
 	gpSpriteParameteriSGIX = (C.GPSPRITEPARAMETERISGIX)(getProcAddr("glSpriteParameteriSGIX"))
 	gpSpriteParameterivSGIX = (C.GPSPRITEPARAMETERIVSGIX)(getProcAddr("glSpriteParameterivSGIX"))
 	gpStartInstrumentsSGIX = (C.GPSTARTINSTRUMENTSSGIX)(getProcAddr("glStartInstrumentsSGIX"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
 	gpStencilClearTagEXT = (C.GPSTENCILCLEARTAGEXT)(getProcAddr("glStencilClearTagEXT"))
 	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
 	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
@@ -29870,6 +31346,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
 	gpStopInstrumentsSGIX = (C.GPSTOPINSTRUMENTSSGIX)(getProcAddr("glStopInstrumentsSGIX"))
 	gpStringMarkerGREMEDY = (C.GPSTRINGMARKERGREMEDY)(getProcAddr("glStringMarkerGREMEDY"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpSwizzleEXT = (C.GPSWIZZLEEXT)(getProcAddr("glSwizzleEXT"))
 	gpSyncTextureINTEL = (C.GPSYNCTEXTUREINTEL)(getProcAddr("glSyncTextureINTEL"))
 	gpTagSampleBufferSGIX = (C.GPTAGSAMPLEBUFFERSGIX)(getProcAddr("glTagSampleBufferSGIX"))
@@ -30159,6 +31636,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpTexStorage2DMultisample = (C.GPTEXSTORAGE2DMULTISAMPLE)(getProcAddr("glTexStorage2DMultisample"))
 	gpTexStorage3D = (C.GPTEXSTORAGE3D)(getProcAddr("glTexStorage3D"))
 	gpTexStorage3DMultisample = (C.GPTEXSTORAGE3DMULTISAMPLE)(getProcAddr("glTexStorage3DMultisample"))
+	gpTexStorageMem1DEXT = (C.GPTEXSTORAGEMEM1DEXT)(getProcAddr("glTexStorageMem1DEXT"))
+	gpTexStorageMem2DEXT = (C.GPTEXSTORAGEMEM2DEXT)(getProcAddr("glTexStorageMem2DEXT"))
+	gpTexStorageMem2DMultisampleEXT = (C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem2DMultisampleEXT"))
+	gpTexStorageMem3DEXT = (C.GPTEXSTORAGEMEM3DEXT)(getProcAddr("glTexStorageMem3DEXT"))
+	gpTexStorageMem3DMultisampleEXT = (C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem3DMultisampleEXT"))
 	gpTexStorageSparseAMD = (C.GPTEXSTORAGESPARSEAMD)(getProcAddr("glTexStorageSparseAMD"))
 	gpTexSubImage1D = (C.GPTEXSUBIMAGE1D)(getProcAddr("glTexSubImage1D"))
 	if gpTexSubImage1D == nil {
@@ -30218,6 +31700,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
 	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
+	gpTextureStorageMem1DEXT = (C.GPTEXTURESTORAGEMEM1DEXT)(getProcAddr("glTextureStorageMem1DEXT"))
+	gpTextureStorageMem2DEXT = (C.GPTEXTURESTORAGEMEM2DEXT)(getProcAddr("glTextureStorageMem2DEXT"))
+	gpTextureStorageMem2DMultisampleEXT = (C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem2DMultisampleEXT"))
+	gpTextureStorageMem3DEXT = (C.GPTEXTURESTORAGEMEM3DEXT)(getProcAddr("glTextureStorageMem3DEXT"))
+	gpTextureStorageMem3DMultisampleEXT = (C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem3DMultisampleEXT"))
 	gpTextureStorageSparseAMD = (C.GPTEXTURESTORAGESPARSEAMD)(getProcAddr("glTextureStorageSparseAMD"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
 	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
@@ -30259,7 +31746,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
 	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
 	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iARB = (C.GPUNIFORM1IARB)(getProcAddr("glUniform1iARB"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
@@ -30267,7 +31756,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glUniform1iv")
 	}
 	gpUniform1ivARB = (C.GPUNIFORM1IVARB)(getProcAddr("glUniform1ivARB"))
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
 	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
 	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiEXT = (C.GPUNIFORM1UIEXT)(getProcAddr("glUniform1uiEXT"))
 	gpUniform1uivEXT = (C.GPUNIFORM1UIVEXT)(getProcAddr("glUniform1uivEXT"))
@@ -30287,7 +31778,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
 	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
 	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iARB = (C.GPUNIFORM2IARB)(getProcAddr("glUniform2iARB"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
@@ -30295,7 +31788,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glUniform2iv")
 	}
 	gpUniform2ivARB = (C.GPUNIFORM2IVARB)(getProcAddr("glUniform2ivARB"))
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
 	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
 	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiEXT = (C.GPUNIFORM2UIEXT)(getProcAddr("glUniform2uiEXT"))
 	gpUniform2uivEXT = (C.GPUNIFORM2UIVEXT)(getProcAddr("glUniform2uivEXT"))
@@ -30315,7 +31810,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
 	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
 	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iARB = (C.GPUNIFORM3IARB)(getProcAddr("glUniform3iARB"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
@@ -30323,7 +31820,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glUniform3iv")
 	}
 	gpUniform3ivARB = (C.GPUNIFORM3IVARB)(getProcAddr("glUniform3ivARB"))
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
 	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
 	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiEXT = (C.GPUNIFORM3UIEXT)(getProcAddr("glUniform3uiEXT"))
 	gpUniform3uivEXT = (C.GPUNIFORM3UIVEXT)(getProcAddr("glUniform3uivEXT"))
@@ -30343,7 +31842,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
 	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
 	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iARB = (C.GPUNIFORM4IARB)(getProcAddr("glUniform4iARB"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
@@ -30351,7 +31852,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glUniform4iv")
 	}
 	gpUniform4ivARB = (C.GPUNIFORM4IVARB)(getProcAddr("glUniform4ivARB"))
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
 	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
 	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiEXT = (C.GPUNIFORM4UIEXT)(getProcAddr("glUniform4uiEXT"))
 	gpUniform4uivEXT = (C.GPUNIFORM4UIVEXT)(getProcAddr("glUniform4uivEXT"))
@@ -30974,7 +32477,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpViewportArrayv = (C.GPVIEWPORTARRAYV)(getProcAddr("glViewportArrayv"))
 	gpViewportIndexedf = (C.GPVIEWPORTINDEXEDF)(getProcAddr("glViewportIndexedf"))
 	gpViewportIndexedfv = (C.GPVIEWPORTINDEXEDFV)(getProcAddr("glViewportIndexedfv"))
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
+	gpWaitSemaphoreEXT = (C.GPWAITSEMAPHOREEXT)(getProcAddr("glWaitSemaphoreEXT"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
 	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
 	gpWeightPointerARB = (C.GPWEIGHTPOINTERARB)(getProcAddr("glWeightPointerARB"))
 	gpWeightbvARB = (C.GPWEIGHTBVARB)(getProcAddr("glWeightbvARB"))
@@ -31089,6 +32596,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpWindowPos4ivMESA = (C.GPWINDOWPOS4IVMESA)(getProcAddr("glWindowPos4ivMESA"))
 	gpWindowPos4sMESA = (C.GPWINDOWPOS4SMESA)(getProcAddr("glWindowPos4sMESA"))
 	gpWindowPos4svMESA = (C.GPWINDOWPOS4SVMESA)(getProcAddr("glWindowPos4svMESA"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	gpWriteMaskEXT = (C.GPWRITEMASKEXT)(getProcAddr("glWriteMaskEXT"))
 	return nil
 }

--- a/v2.1/gl/procaddr.go
+++ b/v2.1/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_gl21(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v3.1/gles2/package.go
+++ b/v3.1/gles2/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gles2
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -38,13 +36,14 @@ package gles2
 // typedef unsigned int GLenum;
 // typedef unsigned char GLboolean;
 // typedef unsigned int GLbitfield;
-// typedef void GLvoid;
 // typedef int GLint;
 // typedef unsigned int GLuint;
 // typedef int GLsizei;
+// typedef double GLdouble;
+// typedef void *GLeglClientBufferEXT;
 // typedef void *GLeglImageOES;
 // typedef char GLchar;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCKHR)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef khronos_uint8_t GLubyte;
@@ -52,18 +51,24 @@ package gles2
 // typedef khronos_float_t GLclampf;
 // typedef khronos_int64_t GLint64;
 // typedef khronos_uint64_t GLuint64;
+// typedef khronos_int64_t GLint64EXT;
+// typedef khronos_uint64_t GLuint64EXT;
 // typedef khronos_intptr_t GLintptr;
 // typedef khronos_ssize_t GLsizeiptr;
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_gles231(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_gles231(source, type, id, severity, length, message, userParam);
 // }
+// typedef GLboolean  (APIENTRYP GPACQUIREKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key, GLuint  timeout);
 // typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVETEXTURE)(GLenum  texture);
 // typedef void  (APIENTRYP GPALPHAFUNCQCOM)(GLenum  func, GLclampf  ref);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPATTACHSHADER)(GLuint  program, GLuint  shader);
+// typedef void  (APIENTRYP GPBEGINCONDITIONALRENDERNV)(GLuint  id, GLenum  mode);
 // typedef void  (APIENTRYP GPBEGINPERFMONITORAMD)(GLuint  monitor);
 // typedef void  (APIENTRYP GPBEGINPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPBEGINQUERY)(GLenum  target, GLuint  id);
@@ -73,6 +78,8 @@ package gles2
 // typedef void  (APIENTRYP GPBINDBUFFER)(GLenum  target, GLuint  buffer);
 // typedef void  (APIENTRYP GPBINDBUFFERBASE)(GLenum  target, GLuint  index, GLuint  buffer);
 // typedef void  (APIENTRYP GPBINDBUFFERRANGE)(GLenum  target, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPBINDFRAGDATALOCATIONEXT)(GLuint  program, GLuint  color, const GLchar * name);
+// typedef void  (APIENTRYP GPBINDFRAGDATALOCATIONINDEXEDEXT)(GLuint  program, GLuint  colorNumber, GLuint  index, const GLchar * name);
 // typedef void  (APIENTRYP GPBINDFRAMEBUFFER)(GLenum  target, GLuint  framebuffer);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURE)(GLuint  unit, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  access, GLenum  format);
 // typedef void  (APIENTRYP GPBINDPROGRAMPIPELINE)(GLuint  pipeline);
@@ -91,16 +98,23 @@ package gles2
 // typedef void  (APIENTRYP GPBLENDEQUATIONEXT)(GLenum  mode);
 // typedef void  (APIENTRYP GPBLENDEQUATIONSEPARATE)(GLenum  modeRGB, GLenum  modeAlpha);
 // typedef void  (APIENTRYP GPBLENDEQUATIONSEPARATEIEXT)(GLuint  buf, GLenum  modeRGB, GLenum  modeAlpha);
+// typedef void  (APIENTRYP GPBLENDEQUATIONSEPARATEIOES)(GLuint  buf, GLenum  modeRGB, GLenum  modeAlpha);
 // typedef void  (APIENTRYP GPBLENDEQUATIONIEXT)(GLuint  buf, GLenum  mode);
+// typedef void  (APIENTRYP GPBLENDEQUATIONIOES)(GLuint  buf, GLenum  mode);
 // typedef void  (APIENTRYP GPBLENDFUNC)(GLenum  sfactor, GLenum  dfactor);
 // typedef void  (APIENTRYP GPBLENDFUNCSEPARATE)(GLenum  sfactorRGB, GLenum  dfactorRGB, GLenum  sfactorAlpha, GLenum  dfactorAlpha);
 // typedef void  (APIENTRYP GPBLENDFUNCSEPARATEIEXT)(GLuint  buf, GLenum  srcRGB, GLenum  dstRGB, GLenum  srcAlpha, GLenum  dstAlpha);
+// typedef void  (APIENTRYP GPBLENDFUNCSEPARATEIOES)(GLuint  buf, GLenum  srcRGB, GLenum  dstRGB, GLenum  srcAlpha, GLenum  dstAlpha);
 // typedef void  (APIENTRYP GPBLENDFUNCIEXT)(GLuint  buf, GLenum  src, GLenum  dst);
+// typedef void  (APIENTRYP GPBLENDFUNCIOES)(GLuint  buf, GLenum  src, GLenum  dst);
 // typedef void  (APIENTRYP GPBLENDPARAMETERINV)(GLenum  pname, GLint  value);
 // typedef void  (APIENTRYP GPBLITFRAMEBUFFER)(GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
 // typedef void  (APIENTRYP GPBLITFRAMEBUFFERANGLE)(GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
 // typedef void  (APIENTRYP GPBLITFRAMEBUFFERNV)(GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEEXT)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEEXTERNALEXT)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEMEMEXT)(GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
 // typedef void  (APIENTRYP GPCLEAR)(GLbitfield  mask);
@@ -110,11 +124,16 @@ package gles2
 // typedef void  (APIENTRYP GPCLEARBUFFERUIV)(GLenum  buffer, GLint  drawbuffer, const GLuint * value);
 // typedef void  (APIENTRYP GPCLEARCOLOR)(GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha);
 // typedef void  (APIENTRYP GPCLEARDEPTHF)(GLfloat  d);
+// typedef void  (APIENTRYP GPCLEARPIXELLOCALSTORAGEUIEXT)(GLsizei  offset, GLsizei  n, const GLuint * values);
 // typedef void  (APIENTRYP GPCLEARSTENCIL)(GLint  s);
+// typedef void  (APIENTRYP GPCLEARTEXIMAGEEXT)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARTEXSUBIMAGEEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data);
 // typedef GLenum  (APIENTRYP GPCLIENTWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
 // typedef GLenum  (APIENTRYP GPCLIENTWAITSYNCAPPLE)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPCLIPCONTROLEXT)(GLenum  origin, GLenum  depth);
 // typedef void  (APIENTRYP GPCOLORMASK)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPCOLORMASKIEXT)(GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a);
+// typedef void  (APIENTRYP GPCOLORMASKIOES)(GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE3D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * data);
@@ -122,16 +141,26 @@ package gles2
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE3DOES)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOPYBUFFERSUBDATA)(GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYBUFFERSUBDATANV)(GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYIMAGESUBDATAEXT)(GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
+// typedef void  (APIENTRYP GPCOPYIMAGESUBDATAOES)(GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
+// typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE3DOES)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXTURELEVELSAPPLE)(GLuint  destinationTexture, GLuint  sourceTexture, GLint  sourceBaseLevel, GLsizei  sourceLevelCount);
+// typedef void  (APIENTRYP GPCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
 // typedef void  (APIENTRYP GPCOVERAGEMASKNV)(GLboolean  mask);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCOVERAGEOPERATIONNV)(GLenum  operation);
+// typedef void  (APIENTRYP GPCREATEMEMORYOBJECTSEXT)(GLsizei  n, GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef GLuint  (APIENTRYP GPCREATESHADER)(GLenum  type);
@@ -148,6 +177,8 @@ package gles2
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
 // typedef void  (APIENTRYP GPDELETEFENCESNV)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
+// typedef void  (APIENTRYP GPDELETEMEMORYOBJECTSEXT)(GLsizei  n, const GLuint * memoryObjects);
+// typedef void  (APIENTRYP GPDELETEPATHSNV)(GLuint  path, GLsizei  range);
 // typedef void  (APIENTRYP GPDELETEPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
 // typedef void  (APIENTRYP GPDELETEPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPDELETEPROGRAM)(GLuint  program);
@@ -157,6 +188,7 @@ package gles2
 // typedef void  (APIENTRYP GPDELETEQUERIESEXT)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
+// typedef void  (APIENTRYP GPDELETESEMAPHORESEXT)(GLsizei  n, const GLuint * semaphores);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETESYNCAPPLE)(GLsync  sync);
@@ -166,12 +198,18 @@ package gles2
 // typedef void  (APIENTRYP GPDELETEVERTEXARRAYSOES)(GLsizei  n, const GLuint * arrays);
 // typedef void  (APIENTRYP GPDEPTHFUNC)(GLenum  func);
 // typedef void  (APIENTRYP GPDEPTHMASK)(GLboolean  flag);
+// typedef void  (APIENTRYP GPDEPTHRANGEARRAYFVNV)(GLuint  first, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPDEPTHRANGEARRAYFVOES)(GLuint  first, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPDEPTHRANGEINDEXEDFNV)(GLuint  index, GLfloat  n, GLfloat  f);
+// typedef void  (APIENTRYP GPDEPTHRANGEINDEXEDFOES)(GLuint  index, GLfloat  n, GLfloat  f);
 // typedef void  (APIENTRYP GPDEPTHRANGEF)(GLfloat  n, GLfloat  f);
 // typedef void  (APIENTRYP GPDETACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPDISABLE)(GLenum  cap);
 // typedef void  (APIENTRYP GPDISABLEDRIVERCONTROLQCOM)(GLuint  driverControl);
 // typedef void  (APIENTRYP GPDISABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEIEXT)(GLenum  target, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEINV)(GLenum  target, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEIOES)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISCARDFRAMEBUFFEREXT)(GLenum  target, GLsizei  numAttachments, const GLenum * attachments);
 // typedef void  (APIENTRYP GPDISPATCHCOMPUTE)(GLuint  num_groups_x, GLuint  num_groups_y, GLuint  num_groups_z);
 // typedef void  (APIENTRYP GPDISPATCHCOMPUTEINDIRECT)(GLintptr  indirect);
@@ -179,6 +217,7 @@ package gles2
 // typedef void  (APIENTRYP GPDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCED)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDANGLE)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDBASEINSTANCEEXT)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDEXT)(GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDNV)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
@@ -186,18 +225,32 @@ package gles2
 // typedef void  (APIENTRYP GPDRAWBUFFERSINDEXEDEXT)(GLint  n, const GLenum * location, const GLint * indices);
 // typedef void  (APIENTRYP GPDRAWBUFFERSNV)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
+// typedef void  (APIENTRYP GPDRAWELEMENTSBASEVERTEXEXT)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
+// typedef void  (APIENTRYP GPDRAWELEMENTSBASEVERTEXOES)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCED)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDANGLE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEINSTANCEEXT)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCEEXT)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEXEXT)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEXOES)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDEXT)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDNV)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTS)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices);
+// typedef void  (APIENTRYP GPDRAWRANGEELEMENTSBASEVERTEXEXT)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
+// typedef void  (APIENTRYP GPDRAWRANGEELEMENTSBASEVERTEXOES)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
+// typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKEXT)(GLenum  mode, GLuint  id);
+// typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKINSTANCEDEXT)(GLenum  mode, GLuint  id, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
 // typedef void  (APIENTRYP GPEGLIMAGETARGETRENDERBUFFERSTORAGEOES)(GLenum  target, GLeglImageOES  image);
 // typedef void  (APIENTRYP GPEGLIMAGETARGETTEXTURE2DOES)(GLenum  target, GLeglImageOES  image);
 // typedef void  (APIENTRYP GPENABLE)(GLenum  cap);
 // typedef void  (APIENTRYP GPENABLEDRIVERCONTROLQCOM)(GLuint  driverControl);
 // typedef void  (APIENTRYP GPENABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPENABLEIEXT)(GLenum  target, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEINV)(GLenum  target, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEIOES)(GLenum  target, GLuint  index);
+// typedef void  (APIENTRYP GPENDCONDITIONALRENDERNV)();
 // typedef void  (APIENTRYP GPENDPERFMONITORAMD)(GLuint  monitor);
 // typedef void  (APIENTRYP GPENDPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPENDQUERY)(GLenum  target);
@@ -223,18 +276,31 @@ package gles2
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGEEXT)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIERQCOM)();
+// typedef void  (APIENTRYP GPFRAMEBUFFERFOVEATIONCONFIGQCOM)(GLuint  framebuffer, GLuint  numLayers, GLuint  focalPointsPerLayer, GLuint  requestedFeatures, GLuint * providedFeatures);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFOVEATIONPARAMETERSQCOM)(GLuint  framebuffer, GLuint  layer, GLuint  focalPoint, GLfloat  focalX, GLfloat  focalY, GLfloat  gainX, GLfloat  gainY, GLfloat  foveaArea);
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPFRAMEBUFFERPIXELLOCALSTORAGESIZEEXT)(GLuint  target, GLsizei  size);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE2D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE2DDOWNSAMPLEIMG)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  xscale, GLint  yscale);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE2DMULTISAMPLEEXT)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLsizei  samples);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE2DMULTISAMPLEIMG)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLsizei  samples);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE3DOES)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREEXT)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERDOWNSAMPLEIMG)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer, GLint  xscale, GLint  yscale);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTISAMPLEMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLsizei  samples, GLint  baseViewIndex, GLsizei  numViews);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREOES)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPGENBUFFERS)(GLsizei  n, GLuint * buffers);
 // typedef void  (APIENTRYP GPGENFENCESNV)(GLsizei  n, GLuint * fences);
 // typedef void  (APIENTRYP GPGENFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef GLuint  (APIENTRYP GPGENPATHSNV)(GLsizei  range);
 // typedef void  (APIENTRYP GPGENPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
 // typedef void  (APIENTRYP GPGENPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPGENPROGRAMPIPELINESEXT)(GLsizei  n, GLuint * pipelines);
@@ -242,6 +308,7 @@ package gles2
 // typedef void  (APIENTRYP GPGENQUERIESEXT)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
+// typedef void  (APIENTRYP GPGENSEMAPHORESEXT)(GLsizei  n, GLuint * semaphores);
 // typedef void  (APIENTRYP GPGENTEXTURES)(GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPGENTRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENVERTEXARRAYS)(GLsizei  n, GLuint * arrays);
@@ -260,6 +327,7 @@ package gles2
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETBUFFERPOINTERV)(GLenum  target, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETBUFFERPOINTERVOES)(GLenum  target, GLenum  pname, void ** params);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGKHR)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef void  (APIENTRYP GPGETDRIVERCONTROLSTRINGQCOM)(GLuint  driverControl, GLsizei  bufSize, GLsizei * length, GLchar * driverControlString);
@@ -267,20 +335,27 @@ package gles2
 // typedef GLenum  (APIENTRYP GPGETERROR)();
 // typedef void  (APIENTRYP GPGETFENCEIVNV)(GLuint  fence, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFIRSTPERFQUERYIDINTEL)(GLuint * queryId);
+// typedef void  (APIENTRYP GPGETFLOATI_VNV)(GLenum  target, GLuint  index, GLfloat * data);
+// typedef void  (APIENTRYP GPGETFLOATI_VOES)(GLenum  target, GLuint  index, GLfloat * data);
 // typedef void  (APIENTRYP GPGETFLOATV)(GLenum  pname, GLfloat * data);
+// typedef GLint  (APIENTRYP GPGETFRAGDATAINDEXEXT)(GLuint  program, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETFRAGDATALOCATION)(GLuint  program, const GLchar * name);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef GLsizei  (APIENTRYP GPGETFRAMEBUFFERPIXELLOCALSTORAGESIZEEXT)(GLuint  target);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSEXT)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSKHR)();
+// typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLENV)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
 // typedef void  (APIENTRYP GPGETINTEGER64I_V)(GLenum  target, GLuint  index, GLint64 * data);
 // typedef void  (APIENTRYP GPGETINTEGER64V)(GLenum  pname, GLint64 * data);
 // typedef void  (APIENTRYP GPGETINTEGER64VAPPLE)(GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTEGERI_V)(GLenum  target, GLuint  index, GLint * data);
 // typedef void  (APIENTRYP GPGETINTEGERI_VEXT)(GLenum  target, GLuint  index, GLint * data);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMULTISAMPLEFV)(GLenum  pname, GLuint  index, GLfloat * val);
 // typedef void  (APIENTRYP GPGETNEXTPERFQUERYIDINTEL)(GLuint  queryId, GLuint * nextQueryId);
 // typedef void  (APIENTRYP GPGETOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
@@ -288,6 +363,15 @@ package gles2
 // typedef void  (APIENTRYP GPGETOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABEL)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABELKHR)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETPATHCOMMANDSNV)(GLuint  path, GLubyte * commands);
+// typedef void  (APIENTRYP GPGETPATHCOORDSNV)(GLuint  path, GLfloat * coords);
+// typedef void  (APIENTRYP GPGETPATHDASHARRAYNV)(GLuint  path, GLfloat * dashArray);
+// typedef GLfloat  (APIENTRYP GPGETPATHLENGTHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments);
+// typedef void  (APIENTRYP GPGETPATHMETRICRANGENV)(GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHMETRICSNV)(GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, GLfloat * value);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, GLint * value);
+// typedef void  (APIENTRYP GPGETPATHSPACINGNV)(GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing);
 // typedef void  (APIENTRYP GPGETPERFCOUNTERINFOINTEL)(GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue);
 // typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERDATAAMD)(GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten);
 // typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERINFOAMD)(GLuint  group, GLuint  counter, GLenum  pname, void * data);
@@ -295,7 +379,7 @@ package gles2
 // typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
-// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
 // typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
 // typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
 // typedef void  (APIENTRYP GPGETPOINTERV)(GLenum  pname, void ** params);
@@ -310,7 +394,9 @@ package gles2
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIVEXT)(GLuint  pipeline, GLenum  pname, GLint * params);
 // typedef GLuint  (APIENTRYP GPGETPROGRAMRESOURCEINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATION)(GLuint  program, GLenum  programInterface, const GLchar * name);
+// typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATIONINDEXEXT)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCENAME)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name);
+// typedef void  (APIENTRYP GPGETPROGRAMRESOURCEFVNV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCEIV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64VEXT)(GLuint  id, GLenum  pname, GLint64 * params);
@@ -322,9 +408,12 @@ package gles2
 // typedef void  (APIENTRYP GPGETQUERYIVEXT)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETRENDERBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIIVEXT)(GLuint  sampler, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIIVOES)(GLuint  sampler, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIUIVEXT)(GLuint  sampler, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIUIVOES)(GLuint  sampler, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERFV)(GLuint  sampler, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIV)(GLuint  sampler, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETSHADERINFOLOG)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETSHADERPRECISIONFORMAT)(GLenum  shadertype, GLenum  precisiontype, GLint * range, GLint * precision);
 // typedef void  (APIENTRYP GPGETSHADERSOURCE)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * source);
@@ -336,22 +425,32 @@ package gles2
 // typedef void  (APIENTRYP GPGETTEXLEVELPARAMETERFV)(GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXLEVELPARAMETERIV)(GLenum  target, GLint  level, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXPARAMETERIIVEXT)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXPARAMETERIIVOES)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXPARAMETERIUIVEXT)(GLenum  target, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETTEXPARAMETERIUIVOES)(GLenum  target, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETTEXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLEIMG)(GLuint  texture);
+// typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLENV)(GLuint  texture);
+// typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLEIMG)(GLuint  texture, GLuint  sampler);
+// typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLENV)(GLuint  texture, GLuint  sampler);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKVARYING)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLsizei * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETTRANSLATEDSHADERSOURCEANGLE)(GLuint  shader, GLsizei  bufsize, GLsizei * length, GLchar * source);
 // typedef GLuint  (APIENTRYP GPGETUNIFORMBLOCKINDEX)(GLuint  program, const GLchar * uniformBlockName);
 // typedef void  (APIENTRYP GPGETUNIFORMINDICES)(GLuint  program, GLsizei  uniformCount, const GLchar *const* uniformNames, GLuint * uniformIndices);
 // typedef GLint  (APIENTRYP GPGETUNIFORMLOCATION)(GLuint  program, const GLchar * name);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEI_VEXT)(GLenum  target, GLuint  index, GLubyte * data);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEVEXT)(GLenum  pname, GLubyte * data);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIIV)(GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIUIV)(GLuint  index, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBPOINTERV)(GLuint  index, GLenum  pname, void ** pointer);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBFV)(GLuint  index, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIV)(GLuint  index, GLenum  pname, GLint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVEXT)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
@@ -361,14 +460,28 @@ package gles2
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPHINT)(GLenum  target, GLenum  mode);
+// typedef void  (APIENTRYP GPIMPORTMEMORYFDEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32HANDLEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32NAMEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, const void * name);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREFDEXT)(GLuint  semaphore, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32HANDLEEXT)(GLuint  semaphore, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32NAMEEXT)(GLuint  semaphore, GLenum  handleType, const void * name);
 // typedef void  (APIENTRYP GPINSERTEVENTMARKEREXT)(GLsizei  length, const GLchar * marker);
+// typedef void  (APIENTRYP GPINTERPOLATEPATHSNV)(GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight);
 // typedef void  (APIENTRYP GPINVALIDATEFRAMEBUFFER)(GLenum  target, GLsizei  numAttachments, const GLenum * attachments);
 // typedef void  (APIENTRYP GPINVALIDATESUBFRAMEBUFFER)(GLenum  target, GLsizei  numAttachments, const GLenum * attachments, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
 // typedef GLboolean  (APIENTRYP GPISENABLEDIEXT)(GLenum  target, GLuint  index);
+// typedef GLboolean  (APIENTRYP GPISENABLEDINV)(GLenum  target, GLuint  index);
+// typedef GLboolean  (APIENTRYP GPISENABLEDIOES)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISFENCENV)(GLuint  fence);
 // typedef GLboolean  (APIENTRYP GPISFRAMEBUFFER)(GLuint  framebuffer);
+// typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISMEMORYOBJECTEXT)(GLuint  memoryObject);
+// typedef GLboolean  (APIENTRYP GPISPATHNV)(GLuint  path);
+// typedef GLboolean  (APIENTRYP GPISPOINTINFILLPATHNV)(GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y);
+// typedef GLboolean  (APIENTRYP GPISPOINTINSTROKEPATHNV)(GLuint  path, GLfloat  x, GLfloat  y);
 // typedef GLboolean  (APIENTRYP GPISPROGRAM)(GLuint  program);
 // typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINE)(GLuint  pipeline);
 // typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINEEXT)(GLuint  pipeline);
@@ -376,49 +489,116 @@ package gles2
 // typedef GLboolean  (APIENTRYP GPISQUERYEXT)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
+// typedef GLboolean  (APIENTRYP GPISSEMAPHOREEXT)(GLuint  semaphore);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISSYNCAPPLE)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
+// typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISTRANSFORMFEEDBACK)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAYOES)(GLuint  array);
 // typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLINEWIDTH)(GLfloat  width);
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTNV)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTNV)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTNV)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef void * (APIENTRYP GPMAPBUFFEROES)(GLenum  target, GLenum  access);
 // typedef void * (APIENTRYP GPMAPBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPBUFFERRANGEEXT)(GLenum  target, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void  (APIENTRYP GPMATRIXFRUSTUMEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADIDENTITYEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXORTHOEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXPOPEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXPUSHEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXROTATEDEXT)(GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXROTATEFEXT)(GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
+// typedef void  (APIENTRYP GPMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGOES)(GLfloat  value);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSEXT)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTEXT)(GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEXEXT)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  primcount, const GLint * basevertex);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSEXT)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  primcount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTEXT)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXTERNALEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEMEMEXT)(GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABEL)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABELKHR)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPPATCHPARAMETERIEXT)(GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATCHPARAMETERIOES)(GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHCOMMANDSNV)(GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOORDSNV)(GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOVERDEPTHFUNCNV)(GLenum  func);
+// typedef void  (APIENTRYP GPPATHDASHARRAYNV)(GLuint  path, GLsizei  dashCount, const GLfloat * dashArray);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXRANGENV)(GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount);
+// typedef void  (APIENTRYP GPPATHGLYPHRANGENV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHGLYPHSNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHMEMORYGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHPARAMETERFNV)(GLuint  path, GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, const GLfloat * value);
+// typedef void  (APIENTRYP GPPATHPARAMETERINV)(GLuint  path, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, const GLint * value);
+// typedef void  (APIENTRYP GPPATHSTENCILDEPTHOFFSETNV)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPATHSTENCILFUNCNV)(GLenum  func, GLint  ref, GLuint  mask);
+// typedef void  (APIENTRYP GPPATHSTRINGNV)(GLuint  path, GLenum  format, GLsizei  length, const void * pathString);
+// typedef void  (APIENTRYP GPPATHSUBCOMMANDSNV)(GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHSUBCOORDSNV)(GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords);
 // typedef void  (APIENTRYP GPPAUSETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPPIXELSTOREI)(GLenum  pname, GLint  param);
+// typedef GLboolean  (APIENTRYP GPPOINTALONGPATHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY);
+// typedef void  (APIENTRYP GPPOLYGONMODENV)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOPDEBUGGROUP)();
 // typedef void  (APIENTRYP GPPOPDEBUGGROUPKHR)();
 // typedef void  (APIENTRYP GPPOPGROUPMARKEREXT)();
 // typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXEXT)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXOES)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPROGRAMBINARY)(GLuint  program, GLenum  binaryFormat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPPROGRAMBINARYOES)(GLuint  program, GLenum  binaryFormat, const void * binary, GLint  length);
 // typedef void  (APIENTRYP GPPROGRAMPARAMETERI)(GLuint  program, GLenum  pname, GLint  value);
 // typedef void  (APIENTRYP GPPROGRAMPARAMETERIEXT)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPATHFRAGMENTINPUTGENNV)(GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1F)(GLuint  program, GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FEXT)(GLuint  program, GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -427,10 +607,14 @@ package gles2
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -439,10 +623,14 @@ package gles2
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -451,13 +639,21 @@ package gles2
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64IMG)(GLuint  program, GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64NV)(GLuint  program, GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VIMG)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
@@ -480,6 +676,7 @@ package gles2
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUPKHR)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
 // typedef void  (APIENTRYP GPPUSHGROUPMARKEREXT)(GLsizei  length, const GLchar * marker);
 // typedef void  (APIENTRYP GPQUERYCOUNTEREXT)(GLuint  id, GLenum  target);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADBUFFERINDEXEDEXT)(GLenum  src, GLint  index);
 // typedef void  (APIENTRYP GPREADBUFFERNV)(GLenum  mode);
@@ -487,6 +684,7 @@ package gles2
 // typedef void  (APIENTRYP GPREADNPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, GLsizei  bufSize, void * data);
 // typedef void  (APIENTRYP GPREADNPIXELSEXT)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, GLsizei  bufSize, void * data);
 // typedef void  (APIENTRYP GPREADNPIXELSKHR)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, GLsizei  bufSize, void * data);
+// typedef GLboolean  (APIENTRYP GPRELEASEKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key);
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
@@ -495,36 +693,63 @@ package gles2
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLEIMG)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLENV)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESOLVEMULTISAMPLEFRAMEBUFFERAPPLE)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMASKI)(GLuint  maskNumber, GLbitfield  mask);
 // typedef void  (APIENTRYP GPSAMPLERPARAMETERIIVEXT)(GLuint  sampler, GLenum  pname, const GLint * param);
+// typedef void  (APIENTRYP GPSAMPLERPARAMETERIIVOES)(GLuint  sampler, GLenum  pname, const GLint * param);
 // typedef void  (APIENTRYP GPSAMPLERPARAMETERIUIVEXT)(GLuint  sampler, GLenum  pname, const GLuint * param);
+// typedef void  (APIENTRYP GPSAMPLERPARAMETERIUIVOES)(GLuint  sampler, GLenum  pname, const GLuint * param);
 // typedef void  (APIENTRYP GPSAMPLERPARAMETERF)(GLuint  sampler, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPSAMPLERPARAMETERFV)(GLuint  sampler, GLenum  pname, const GLfloat * param);
 // typedef void  (APIENTRYP GPSAMPLERPARAMETERI)(GLuint  sampler, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPSAMPLERPARAMETERIV)(GLuint  sampler, GLenum  pname, const GLint * param);
 // typedef void  (APIENTRYP GPSCISSOR)(GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPSCISSORARRAYVNV)(GLuint  first, GLsizei  count, const GLint * v);
+// typedef void  (APIENTRYP GPSCISSORARRAYVOES)(GLuint  first, GLsizei  count, const GLint * v);
+// typedef void  (APIENTRYP GPSCISSORINDEXEDNV)(GLuint  index, GLint  left, GLint  bottom, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPSCISSORINDEXEDOES)(GLuint  index, GLint  left, GLint  bottom, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPSCISSORINDEXEDVNV)(GLuint  index, const GLint * v);
+// typedef void  (APIENTRYP GPSCISSORINDEXEDVOES)(GLuint  index, const GLint * v);
 // typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
+// typedef void  (APIENTRYP GPSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, const GLuint64 * params);
 // typedef void  (APIENTRYP GPSETFENCENV)(GLuint  fence, GLenum  condition);
 // typedef void  (APIENTRYP GPSHADERBINARY)(GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPSHADERSOURCE)(GLuint  shader, GLsizei  count, const GLchar *const* string, const GLint * length);
+// typedef void  (APIENTRYP GPSIGNALSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
 // typedef void  (APIENTRYP GPSTARTTILINGQCOM)(GLuint  x, GLuint  y, GLuint  width, GLuint  height, GLbitfield  preserveMask);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNC)(GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNCSEPARATE)(GLenum  face, GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASK)(GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASKSEPARATE)(GLenum  face, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILOP)(GLenum  fail, GLenum  zfail, GLenum  zpass);
 // typedef void  (APIENTRYP GPSTENCILOPSEPARATE)(GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef GLboolean  (APIENTRYP GPTESTFENCENV)(GLuint  fence);
 // typedef void  (APIENTRYP GPTEXBUFFEREXT)(GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXBUFFEROES)(GLenum  target, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXBUFFERRANGEEXT)(GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXBUFFERRANGEOES)(GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXIMAGE2D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE3D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE3DOES)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTEXT)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIVEXT)(GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXPARAMETERIIVOES)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIVEXT)(GLenum  target, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPTEXPARAMETERIUIVOES)(GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERF)(GLenum  target, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPTEXPARAMETERFV)(GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
@@ -536,39 +761,72 @@ package gles2
 // typedef void  (APIENTRYP GPTEXSTORAGE3D)(GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXSTORAGE3DEXT)(GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXSTORAGE3DMULTISAMPLEOES)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM1DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE3DOES)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREFOVEATIONPARAMETERSQCOM)(GLuint  texture, GLuint  layer, GLuint  focalPoint, GLfloat  focalX, GLfloat  focalY, GLfloat  gainX, GLfloat  gainY, GLfloat  foveaArea);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE1DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM1DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXTUREVIEWEXT)(GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers);
+// typedef void  (APIENTRYP GPTEXTUREVIEWOES)(GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
+// typedef void  (APIENTRYP GPTRANSFORMPATHNV)(GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPUNIFORM1F)(GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM2F)(GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM3F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM4F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORMBLOCKBINDING)(GLuint  program, GLuint  uniformBlockIndex, GLuint  uniformBlockBinding);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64IMG)(GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64NV)(GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VIMG)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VNV)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2X3FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2X3FVNV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
@@ -616,8 +874,23 @@ package gles2
 // typedef void  (APIENTRYP GPVERTEXATTRIBPOINTER)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXBINDINGDIVISOR)(GLuint  bindingindex, GLuint  divisor);
 // typedef void  (APIENTRYP GPVIEWPORT)(GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPVIEWPORTARRAYVNV)(GLuint  first, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTARRAYVOES)(GLuint  first, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTINDEXEDFNV)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
+// typedef void  (APIENTRYP GPVIEWPORTINDEXEDFOES)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
+// typedef void  (APIENTRYP GPVIEWPORTINDEXEDFVNV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTINDEXEDFVOES)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
+// typedef void  (APIENTRYP GPWAITSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
 // typedef void  (APIENTRYP GPWAITSYNCAPPLE)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
+// static GLboolean  glowAcquireKeyedMutexWin32EXT(GPACQUIREKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key, GLuint  timeout) {
+//   return (*fnptr)(memory, key, timeout);
+// }
 // static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
@@ -633,8 +906,14 @@ package gles2
 // static void  glowAlphaFuncQCOM(GPALPHAFUNCQCOM fnptr, GLenum  func, GLclampf  ref) {
 //   (*fnptr)(func, ref);
 // }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowAttachShader(GPATTACHSHADER fnptr, GLuint  program, GLuint  shader) {
 //   (*fnptr)(program, shader);
+// }
+// static void  glowBeginConditionalRenderNV(GPBEGINCONDITIONALRENDERNV fnptr, GLuint  id, GLenum  mode) {
+//   (*fnptr)(id, mode);
 // }
 // static void  glowBeginPerfMonitorAMD(GPBEGINPERFMONITORAMD fnptr, GLuint  monitor) {
 //   (*fnptr)(monitor);
@@ -662,6 +941,12 @@ package gles2
 // }
 // static void  glowBindBufferRange(GPBINDBUFFERRANGE fnptr, GLenum  target, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, index, buffer, offset, size);
+// }
+// static void  glowBindFragDataLocationEXT(GPBINDFRAGDATALOCATIONEXT fnptr, GLuint  program, GLuint  color, const GLchar * name) {
+//   (*fnptr)(program, color, name);
+// }
+// static void  glowBindFragDataLocationIndexedEXT(GPBINDFRAGDATALOCATIONINDEXEDEXT fnptr, GLuint  program, GLuint  colorNumber, GLuint  index, const GLchar * name) {
+//   (*fnptr)(program, colorNumber, index, name);
 // }
 // static void  glowBindFramebuffer(GPBINDFRAMEBUFFER fnptr, GLenum  target, GLuint  framebuffer) {
 //   (*fnptr)(target, framebuffer);
@@ -717,7 +1002,13 @@ package gles2
 // static void  glowBlendEquationSeparateiEXT(GPBLENDEQUATIONSEPARATEIEXT fnptr, GLuint  buf, GLenum  modeRGB, GLenum  modeAlpha) {
 //   (*fnptr)(buf, modeRGB, modeAlpha);
 // }
+// static void  glowBlendEquationSeparateiOES(GPBLENDEQUATIONSEPARATEIOES fnptr, GLuint  buf, GLenum  modeRGB, GLenum  modeAlpha) {
+//   (*fnptr)(buf, modeRGB, modeAlpha);
+// }
 // static void  glowBlendEquationiEXT(GPBLENDEQUATIONIEXT fnptr, GLuint  buf, GLenum  mode) {
+//   (*fnptr)(buf, mode);
+// }
+// static void  glowBlendEquationiOES(GPBLENDEQUATIONIOES fnptr, GLuint  buf, GLenum  mode) {
 //   (*fnptr)(buf, mode);
 // }
 // static void  glowBlendFunc(GPBLENDFUNC fnptr, GLenum  sfactor, GLenum  dfactor) {
@@ -729,7 +1020,13 @@ package gles2
 // static void  glowBlendFuncSeparateiEXT(GPBLENDFUNCSEPARATEIEXT fnptr, GLuint  buf, GLenum  srcRGB, GLenum  dstRGB, GLenum  srcAlpha, GLenum  dstAlpha) {
 //   (*fnptr)(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
 // }
+// static void  glowBlendFuncSeparateiOES(GPBLENDFUNCSEPARATEIOES fnptr, GLuint  buf, GLenum  srcRGB, GLenum  dstRGB, GLenum  srcAlpha, GLenum  dstAlpha) {
+//   (*fnptr)(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
+// }
 // static void  glowBlendFunciEXT(GPBLENDFUNCIEXT fnptr, GLuint  buf, GLenum  src, GLenum  dst) {
+//   (*fnptr)(buf, src, dst);
+// }
+// static void  glowBlendFunciOES(GPBLENDFUNCIOES fnptr, GLuint  buf, GLenum  src, GLenum  dst) {
 //   (*fnptr)(buf, src, dst);
 // }
 // static void  glowBlendParameteriNV(GPBLENDPARAMETERINV fnptr, GLenum  pname, GLint  value) {
@@ -746,6 +1043,15 @@ package gles2
 // }
 // static void  glowBufferData(GPBUFFERDATA fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
+// }
+// static void  glowBufferStorageEXT(GPBUFFERSTORAGEEXT fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
+//   (*fnptr)(target, size, data, flags);
+// }
+// static void  glowBufferStorageExternalEXT(GPBUFFERSTORAGEEXTERNALEXT fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(target, offset, size, clientBuffer, flags);
+// }
+// static void  glowBufferStorageMemEXT(GPBUFFERSTORAGEMEMEXT fnptr, GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, size, memory, offset);
 // }
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
@@ -774,8 +1080,17 @@ package gles2
 // static void  glowClearDepthf(GPCLEARDEPTHF fnptr, GLfloat  d) {
 //   (*fnptr)(d);
 // }
+// static void  glowClearPixelLocalStorageuiEXT(GPCLEARPIXELLOCALSTORAGEUIEXT fnptr, GLsizei  offset, GLsizei  n, const GLuint * values) {
+//   (*fnptr)(offset, n, values);
+// }
 // static void  glowClearStencil(GPCLEARSTENCIL fnptr, GLint  s) {
 //   (*fnptr)(s);
+// }
+// static void  glowClearTexImageEXT(GPCLEARTEXIMAGEEXT fnptr, GLuint  texture, GLint  level, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(texture, level, format, type, data);
+// }
+// static void  glowClearTexSubImageEXT(GPCLEARTEXSUBIMAGEEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data);
 // }
 // static GLenum  glowClientWaitSync(GPCLIENTWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   return (*fnptr)(sync, flags, timeout);
@@ -783,10 +1098,16 @@ package gles2
 // static GLenum  glowClientWaitSyncAPPLE(GPCLIENTWAITSYNCAPPLE fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   return (*fnptr)(sync, flags, timeout);
 // }
+// static void  glowClipControlEXT(GPCLIPCONTROLEXT fnptr, GLenum  origin, GLenum  depth) {
+//   (*fnptr)(origin, depth);
+// }
 // static void  glowColorMask(GPCOLORMASK fnptr, GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
 // }
 // static void  glowColorMaskiEXT(GPCOLORMASKIEXT fnptr, GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a) {
+//   (*fnptr)(index, r, g, b, a);
+// }
+// static void  glowColorMaskiOES(GPCOLORMASKIOES fnptr, GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a) {
 //   (*fnptr)(index, r, g, b, a);
 // }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
@@ -810,6 +1131,9 @@ package gles2
 // static void  glowCompressedTexSubImage3DOES(GPCOMPRESSEDTEXSUBIMAGE3DOES fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
 // }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
+// }
 // static void  glowCopyBufferSubData(GPCOPYBUFFERSUBDATA fnptr, GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readTarget, writeTarget, readOffset, writeOffset, size);
 // }
@@ -818,6 +1142,12 @@ package gles2
 // }
 // static void  glowCopyImageSubDataEXT(GPCOPYIMAGESUBDATAEXT fnptr, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
 //   (*fnptr)(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
+// }
+// static void  glowCopyImageSubDataOES(GPCOPYIMAGESUBDATAOES fnptr, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
+//   (*fnptr)(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
+// }
+// static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
+//   (*fnptr)(resultPath, srcPath);
 // }
 // static void  glowCopyTexImage2D(GPCOPYTEXIMAGE2D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
 //   (*fnptr)(target, level, internalformat, x, y, width, height, border);
@@ -834,11 +1164,32 @@ package gles2
 // static void  glowCopyTextureLevelsAPPLE(GPCOPYTEXTURELEVELSAPPLE fnptr, GLuint  destinationTexture, GLuint  sourceTexture, GLint  sourceBaseLevel, GLsizei  sourceLevelCount) {
 //   (*fnptr)(destinationTexture, sourceTexture, sourceBaseLevel, sourceLevelCount);
 // }
+// static void  glowCoverFillPathInstancedNV(GPCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverFillPathNV(GPCOVERFILLPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverStrokePathInstancedNV(GPCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
 // static void  glowCoverageMaskNV(GPCOVERAGEMASKNV fnptr, GLboolean  mask) {
 //   (*fnptr)(mask);
 // }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
+// }
 // static void  glowCoverageOperationNV(GPCOVERAGEOPERATIONNV fnptr, GLenum  operation) {
 //   (*fnptr)(operation);
+// }
+// static void  glowCreateMemoryObjectsEXT(GPCREATEMEMORYOBJECTSEXT fnptr, GLsizei  n, GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
 //   (*fnptr)(queryId, queryHandle);
@@ -888,6 +1239,12 @@ package gles2
 // static void  glowDeleteFramebuffers(GPDELETEFRAMEBUFFERS fnptr, GLsizei  n, const GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
+// static void  glowDeleteMemoryObjectsEXT(GPDELETEMEMORYOBJECTSEXT fnptr, GLsizei  n, const GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
+// }
+// static void  glowDeletePathsNV(GPDELETEPATHSNV fnptr, GLuint  path, GLsizei  range) {
+//   (*fnptr)(path, range);
+// }
 // static void  glowDeletePerfMonitorsAMD(GPDELETEPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
 //   (*fnptr)(n, monitors);
 // }
@@ -914,6 +1271,9 @@ package gles2
 // }
 // static void  glowDeleteSamplers(GPDELETESAMPLERS fnptr, GLsizei  count, const GLuint * samplers) {
 //   (*fnptr)(count, samplers);
+// }
+// static void  glowDeleteSemaphoresEXT(GPDELETESEMAPHORESEXT fnptr, GLsizei  n, const GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
 // }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
@@ -942,6 +1302,18 @@ package gles2
 // static void  glowDepthMask(GPDEPTHMASK fnptr, GLboolean  flag) {
 //   (*fnptr)(flag);
 // }
+// static void  glowDepthRangeArrayfvNV(GPDEPTHRANGEARRAYFVNV fnptr, GLuint  first, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(first, count, v);
+// }
+// static void  glowDepthRangeArrayfvOES(GPDEPTHRANGEARRAYFVOES fnptr, GLuint  first, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(first, count, v);
+// }
+// static void  glowDepthRangeIndexedfNV(GPDEPTHRANGEINDEXEDFNV fnptr, GLuint  index, GLfloat  n, GLfloat  f) {
+//   (*fnptr)(index, n, f);
+// }
+// static void  glowDepthRangeIndexedfOES(GPDEPTHRANGEINDEXEDFOES fnptr, GLuint  index, GLfloat  n, GLfloat  f) {
+//   (*fnptr)(index, n, f);
+// }
 // static void  glowDepthRangef(GPDEPTHRANGEF fnptr, GLfloat  n, GLfloat  f) {
 //   (*fnptr)(n, f);
 // }
@@ -958,6 +1330,12 @@ package gles2
 //   (*fnptr)(index);
 // }
 // static void  glowDisableiEXT(GPDISABLEIEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
+// static void  glowDisableiNV(GPDISABLEINV fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
+// static void  glowDisableiOES(GPDISABLEIOES fnptr, GLenum  target, GLuint  index) {
 //   (*fnptr)(target, index);
 // }
 // static void  glowDiscardFramebufferEXT(GPDISCARDFRAMEBUFFEREXT fnptr, GLenum  target, GLsizei  numAttachments, const GLenum * attachments) {
@@ -981,6 +1359,9 @@ package gles2
 // static void  glowDrawArraysInstancedANGLE(GPDRAWARRAYSINSTANCEDANGLE fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount) {
 //   (*fnptr)(mode, first, count, primcount);
 // }
+// static void  glowDrawArraysInstancedBaseInstanceEXT(GPDRAWARRAYSINSTANCEDBASEINSTANCEEXT fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance) {
+//   (*fnptr)(mode, first, count, instancecount, baseinstance);
+// }
 // static void  glowDrawArraysInstancedEXT(GPDRAWARRAYSINSTANCEDEXT fnptr, GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount) {
 //   (*fnptr)(mode, start, count, primcount);
 // }
@@ -1002,6 +1383,12 @@ package gles2
 // static void  glowDrawElements(GPDRAWELEMENTS fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, count, type, indices);
 // }
+// static void  glowDrawElementsBaseVertexEXT(GPDRAWELEMENTSBASEVERTEXEXT fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex) {
+//   (*fnptr)(mode, count, type, indices, basevertex);
+// }
+// static void  glowDrawElementsBaseVertexOES(GPDRAWELEMENTSBASEVERTEXOES fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex) {
+//   (*fnptr)(mode, count, type, indices, basevertex);
+// }
 // static void  glowDrawElementsIndirect(GPDRAWELEMENTSINDIRECT fnptr, GLenum  mode, GLenum  type, const void * indirect) {
 //   (*fnptr)(mode, type, indirect);
 // }
@@ -1011,6 +1398,18 @@ package gles2
 // static void  glowDrawElementsInstancedANGLE(GPDRAWELEMENTSINSTANCEDANGLE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
 //   (*fnptr)(mode, count, type, indices, primcount);
 // }
+// static void  glowDrawElementsInstancedBaseInstanceEXT(GPDRAWELEMENTSINSTANCEDBASEINSTANCEEXT fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance) {
+//   (*fnptr)(mode, count, type, indices, instancecount, baseinstance);
+// }
+// static void  glowDrawElementsInstancedBaseVertexBaseInstanceEXT(GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCEEXT fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance) {
+//   (*fnptr)(mode, count, type, indices, instancecount, basevertex, baseinstance);
+// }
+// static void  glowDrawElementsInstancedBaseVertexEXT(GPDRAWELEMENTSINSTANCEDBASEVERTEXEXT fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex) {
+//   (*fnptr)(mode, count, type, indices, instancecount, basevertex);
+// }
+// static void  glowDrawElementsInstancedBaseVertexOES(GPDRAWELEMENTSINSTANCEDBASEVERTEXOES fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex) {
+//   (*fnptr)(mode, count, type, indices, instancecount, basevertex);
+// }
 // static void  glowDrawElementsInstancedEXT(GPDRAWELEMENTSINSTANCEDEXT fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
 //   (*fnptr)(mode, count, type, indices, primcount);
 // }
@@ -1019,6 +1418,21 @@ package gles2
 // }
 // static void  glowDrawRangeElements(GPDRAWRANGEELEMENTS fnptr, GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, start, end, count, type, indices);
+// }
+// static void  glowDrawRangeElementsBaseVertexEXT(GPDRAWRANGEELEMENTSBASEVERTEXEXT fnptr, GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex) {
+//   (*fnptr)(mode, start, end, count, type, indices, basevertex);
+// }
+// static void  glowDrawRangeElementsBaseVertexOES(GPDRAWRANGEELEMENTSBASEVERTEXOES fnptr, GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex) {
+//   (*fnptr)(mode, start, end, count, type, indices, basevertex);
+// }
+// static void  glowDrawTransformFeedbackEXT(GPDRAWTRANSFORMFEEDBACKEXT fnptr, GLenum  mode, GLuint  id) {
+//   (*fnptr)(mode, id);
+// }
+// static void  glowDrawTransformFeedbackInstancedEXT(GPDRAWTRANSFORMFEEDBACKINSTANCEDEXT fnptr, GLenum  mode, GLuint  id, GLsizei  instancecount) {
+//   (*fnptr)(mode, id, instancecount);
+// }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
 // }
 // static void  glowEGLImageTargetRenderbufferStorageOES(GPEGLIMAGETARGETRENDERBUFFERSTORAGEOES fnptr, GLenum  target, GLeglImageOES  image) {
 //   (*fnptr)(target, image);
@@ -1037,6 +1451,15 @@ package gles2
 // }
 // static void  glowEnableiEXT(GPENABLEIEXT fnptr, GLenum  target, GLuint  index) {
 //   (*fnptr)(target, index);
+// }
+// static void  glowEnableiNV(GPENABLEINV fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
+// static void  glowEnableiOES(GPENABLEIOES fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
+// static void  glowEndConditionalRenderNV(GPENDCONDITIONALRENDERNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowEndPerfMonitorAMD(GPENDPERFMONITORAMD fnptr, GLuint  monitor) {
 //   (*fnptr)(monitor);
@@ -1113,14 +1536,38 @@ package gles2
 // static void  glowFlushMappedBufferRangeEXT(GPFLUSHMAPPEDBUFFERRANGEEXT fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(target, offset, length);
 // }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowFramebufferFetchBarrierQCOM(GPFRAMEBUFFERFETCHBARRIERQCOM fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowFramebufferFoveationConfigQCOM(GPFRAMEBUFFERFOVEATIONCONFIGQCOM fnptr, GLuint  framebuffer, GLuint  numLayers, GLuint  focalPointsPerLayer, GLuint  requestedFeatures, GLuint * providedFeatures) {
+//   (*fnptr)(framebuffer, numLayers, focalPointsPerLayer, requestedFeatures, providedFeatures);
+// }
+// static void  glowFramebufferFoveationParametersQCOM(GPFRAMEBUFFERFOVEATIONPARAMETERSQCOM fnptr, GLuint  framebuffer, GLuint  layer, GLuint  focalPoint, GLfloat  focalX, GLfloat  focalY, GLfloat  gainX, GLfloat  gainY, GLfloat  foveaArea) {
+//   (*fnptr)(framebuffer, layer, focalPoint, focalX, focalY, gainX, gainY, foveaArea);
+// }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
+// }
+// static void  glowFramebufferPixelLocalStorageSizeEXT(GPFRAMEBUFFERPIXELLOCALSTORAGESIZEEXT fnptr, GLuint  target, GLsizei  size) {
+//   (*fnptr)(target, size);
 // }
 // static void  glowFramebufferRenderbuffer(GPFRAMEBUFFERRENDERBUFFER fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
 // }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
 // static void  glowFramebufferTexture2D(GPFRAMEBUFFERTEXTURE2D fnptr, GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, textarget, texture, level);
+// }
+// static void  glowFramebufferTexture2DDownsampleIMG(GPFRAMEBUFFERTEXTURE2DDOWNSAMPLEIMG fnptr, GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  xscale, GLint  yscale) {
+//   (*fnptr)(target, attachment, textarget, texture, level, xscale, yscale);
 // }
 // static void  glowFramebufferTexture2DMultisampleEXT(GPFRAMEBUFFERTEXTURE2DMULTISAMPLEEXT fnptr, GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLsizei  samples) {
 //   (*fnptr)(target, attachment, textarget, texture, level, samples);
@@ -1137,6 +1584,18 @@ package gles2
 // static void  glowFramebufferTextureLayer(GPFRAMEBUFFERTEXTURELAYER fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
 // }
+// static void  glowFramebufferTextureLayerDownsampleIMG(GPFRAMEBUFFERTEXTURELAYERDOWNSAMPLEIMG fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer, GLint  xscale, GLint  yscale) {
+//   (*fnptr)(target, attachment, texture, level, layer, xscale, yscale);
+// }
+// static void  glowFramebufferTextureMultisampleMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTISAMPLEMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLsizei  samples, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, samples, baseViewIndex, numViews);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
+// }
+// static void  glowFramebufferTextureOES(GPFRAMEBUFFERTEXTUREOES fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(target, attachment, texture, level);
+// }
 // static void  glowFrontFace(GPFRONTFACE fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
 // }
@@ -1148,6 +1607,9 @@ package gles2
 // }
 // static void  glowGenFramebuffers(GPGENFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static GLuint  glowGenPathsNV(GPGENPATHSNV fnptr, GLsizei  range) {
+//   return (*fnptr)(range);
 // }
 // static void  glowGenPerfMonitorsAMD(GPGENPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
 //   (*fnptr)(n, monitors);
@@ -1169,6 +1631,9 @@ package gles2
 // }
 // static void  glowGenSamplers(GPGENSAMPLERS fnptr, GLsizei  count, GLuint * samplers) {
 //   (*fnptr)(count, samplers);
+// }
+// static void  glowGenSemaphoresEXT(GPGENSEMAPHORESEXT fnptr, GLsizei  n, GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
 // }
 // static void  glowGenTextures(GPGENTEXTURES fnptr, GLsizei  n, GLuint * textures) {
 //   (*fnptr)(n, textures);
@@ -1224,6 +1689,9 @@ package gles2
 // static void  glowGetBufferPointervOES(GPGETBUFFERPOINTERVOES fnptr, GLenum  target, GLenum  pname, void ** params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
+// }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
 // }
@@ -1245,8 +1713,17 @@ package gles2
 // static void  glowGetFirstPerfQueryIdINTEL(GPGETFIRSTPERFQUERYIDINTEL fnptr, GLuint * queryId) {
 //   (*fnptr)(queryId);
 // }
+// static void  glowGetFloati_vNV(GPGETFLOATI_VNV fnptr, GLenum  target, GLuint  index, GLfloat * data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetFloati_vOES(GPGETFLOATI_VOES fnptr, GLenum  target, GLuint  index, GLfloat * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetFloatv(GPGETFLOATV fnptr, GLenum  pname, GLfloat * data) {
 //   (*fnptr)(pname, data);
+// }
+// static GLint  glowGetFragDataIndexEXT(GPGETFRAGDATAINDEXEXT fnptr, GLuint  program, const GLchar * name) {
+//   return (*fnptr)(program, name);
 // }
 // static GLint  glowGetFragDataLocation(GPGETFRAGDATALOCATION fnptr, GLuint  program, const GLchar * name) {
 //   return (*fnptr)(program, name);
@@ -1257,6 +1734,9 @@ package gles2
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static GLsizei  glowGetFramebufferPixelLocalStorageSizeEXT(GPGETFRAMEBUFFERPIXELLOCALSTORAGESIZEEXT fnptr, GLuint  target) {
+//   return (*fnptr)(target);
+// }
 // static GLenum  glowGetGraphicsResetStatus(GPGETGRAPHICSRESETSTATUS fnptr) {
 //   return (*fnptr)();
 // }
@@ -1265,6 +1745,9 @@ package gles2
 // }
 // static GLenum  glowGetGraphicsResetStatusKHR(GPGETGRAPHICSRESETSTATUSKHR fnptr) {
 //   return (*fnptr)();
+// }
+// static GLuint64  glowGetImageHandleNV(GPGETIMAGEHANDLENV fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
+//   return (*fnptr)(texture, level, layered, layer, format);
 // }
 // static void  glowGetInteger64i_v(GPGETINTEGER64I_V fnptr, GLenum  target, GLuint  index, GLint64 * data) {
 //   (*fnptr)(target, index, data);
@@ -1284,8 +1767,14 @@ package gles2
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
 // }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
+// }
 // static void  glowGetInternalformativ(GPGETINTERNALFORMATIV fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
+// }
+// static void  glowGetMemoryObjectParameterivEXT(GPGETMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
 // }
 // static void  glowGetMultisamplefv(GPGETMULTISAMPLEFV fnptr, GLenum  pname, GLuint  index, GLfloat * val) {
 //   (*fnptr)(pname, index, val);
@@ -1308,6 +1797,33 @@ package gles2
 // static void  glowGetObjectPtrLabelKHR(GPGETOBJECTPTRLABELKHR fnptr, const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(ptr, bufSize, length, label);
 // }
+// static void  glowGetPathCommandsNV(GPGETPATHCOMMANDSNV fnptr, GLuint  path, GLubyte * commands) {
+//   (*fnptr)(path, commands);
+// }
+// static void  glowGetPathCoordsNV(GPGETPATHCOORDSNV fnptr, GLuint  path, GLfloat * coords) {
+//   (*fnptr)(path, coords);
+// }
+// static void  glowGetPathDashArrayNV(GPGETPATHDASHARRAYNV fnptr, GLuint  path, GLfloat * dashArray) {
+//   (*fnptr)(path, dashArray);
+// }
+// static GLfloat  glowGetPathLengthNV(GPGETPATHLENGTHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments) {
+//   return (*fnptr)(path, startSegment, numSegments);
+// }
+// static void  glowGetPathMetricRangeNV(GPGETPATHMETRICRANGENV fnptr, GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, firstPathName, numPaths, stride, metrics);
+// }
+// static void  glowGetPathMetricsNV(GPGETPATHMETRICSNV fnptr, GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, numPaths, pathNameType, paths, pathBase, stride, metrics);
+// }
+// static void  glowGetPathParameterfvNV(GPGETPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathParameterivNV(GPGETPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathSpacingNV(GPGETPATHSPACINGNV fnptr, GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing) {
+//   (*fnptr)(pathListMode, numPaths, pathNameType, paths, pathBase, advanceScale, kerningScale, transformType, returnedSpacing);
+// }
 // static void  glowGetPerfCounterInfoINTEL(GPGETPERFCOUNTERINFOINTEL fnptr, GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue) {
 //   (*fnptr)(queryId, counterId, counterNameLength, counterName, counterDescLength, counterDesc, counterOffset, counterDataSize, counterTypeEnum, counterDataTypeEnum, rawCounterMaxValue);
 // }
@@ -1329,7 +1845,7 @@ package gles2
 // static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
 //   (*fnptr)(numGroups, groupsSize, groups);
 // }
-// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten) {
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
 //   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
 // }
 // static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
@@ -1374,8 +1890,14 @@ package gles2
 // static GLint  glowGetProgramResourceLocation(GPGETPROGRAMRESOURCELOCATION fnptr, GLuint  program, GLenum  programInterface, const GLchar * name) {
 //   return (*fnptr)(program, programInterface, name);
 // }
+// static GLint  glowGetProgramResourceLocationIndexEXT(GPGETPROGRAMRESOURCELOCATIONINDEXEXT fnptr, GLuint  program, GLenum  programInterface, const GLchar * name) {
+//   return (*fnptr)(program, programInterface, name);
+// }
 // static void  glowGetProgramResourceName(GPGETPROGRAMRESOURCENAME fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name) {
 //   (*fnptr)(program, programInterface, index, bufSize, length, name);
+// }
+// static void  glowGetProgramResourcefvNV(GPGETPROGRAMRESOURCEFVNV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params) {
+//   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
 // }
 // static void  glowGetProgramResourceiv(GPGETPROGRAMRESOURCEIV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params) {
 //   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
@@ -1410,7 +1932,13 @@ package gles2
 // static void  glowGetSamplerParameterIivEXT(GPGETSAMPLERPARAMETERIIVEXT fnptr, GLuint  sampler, GLenum  pname, GLint * params) {
 //   (*fnptr)(sampler, pname, params);
 // }
+// static void  glowGetSamplerParameterIivOES(GPGETSAMPLERPARAMETERIIVOES fnptr, GLuint  sampler, GLenum  pname, GLint * params) {
+//   (*fnptr)(sampler, pname, params);
+// }
 // static void  glowGetSamplerParameterIuivEXT(GPGETSAMPLERPARAMETERIUIVEXT fnptr, GLuint  sampler, GLenum  pname, GLuint * params) {
+//   (*fnptr)(sampler, pname, params);
+// }
+// static void  glowGetSamplerParameterIuivOES(GPGETSAMPLERPARAMETERIUIVOES fnptr, GLuint  sampler, GLenum  pname, GLuint * params) {
 //   (*fnptr)(sampler, pname, params);
 // }
 // static void  glowGetSamplerParameterfv(GPGETSAMPLERPARAMETERFV fnptr, GLuint  sampler, GLenum  pname, GLfloat * params) {
@@ -1418,6 +1946,9 @@ package gles2
 // }
 // static void  glowGetSamplerParameteriv(GPGETSAMPLERPARAMETERIV fnptr, GLuint  sampler, GLenum  pname, GLint * params) {
 //   (*fnptr)(sampler, pname, params);
+// }
+// static void  glowGetSemaphoreParameterui64vEXT(GPGETSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
 // }
 // static void  glowGetShaderInfoLog(GPGETSHADERINFOLOG fnptr, GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
 //   (*fnptr)(shader, bufSize, length, infoLog);
@@ -1452,7 +1983,13 @@ package gles2
 // static void  glowGetTexParameterIivEXT(GPGETTEXPARAMETERIIVEXT fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetTexParameterIivOES(GPGETTEXPARAMETERIIVOES fnptr, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(target, pname, params);
+// }
 // static void  glowGetTexParameterIuivEXT(GPGETTEXPARAMETERIUIVEXT fnptr, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(target, pname, params);
+// }
+// static void  glowGetTexParameterIuivOES(GPGETTEXPARAMETERIUIVOES fnptr, GLenum  target, GLenum  pname, GLuint * params) {
 //   (*fnptr)(target, pname, params);
 // }
 // static void  glowGetTexParameterfv(GPGETTEXPARAMETERFV fnptr, GLenum  target, GLenum  pname, GLfloat * params) {
@@ -1460,6 +1997,18 @@ package gles2
 // }
 // static void  glowGetTexParameteriv(GPGETTEXPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static GLuint64  glowGetTextureHandleIMG(GPGETTEXTUREHANDLEIMG fnptr, GLuint  texture) {
+//   return (*fnptr)(texture);
+// }
+// static GLuint64  glowGetTextureHandleNV(GPGETTEXTUREHANDLENV fnptr, GLuint  texture) {
+//   return (*fnptr)(texture);
+// }
+// static GLuint64  glowGetTextureSamplerHandleIMG(GPGETTEXTURESAMPLERHANDLEIMG fnptr, GLuint  texture, GLuint  sampler) {
+//   return (*fnptr)(texture, sampler);
+// }
+// static GLuint64  glowGetTextureSamplerHandleNV(GPGETTEXTURESAMPLERHANDLENV fnptr, GLuint  texture, GLuint  sampler) {
+//   return (*fnptr)(texture, sampler);
 // }
 // static void  glowGetTransformFeedbackVarying(GPGETTRANSFORMFEEDBACKVARYING fnptr, GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLsizei * size, GLenum * type, GLchar * name) {
 //   (*fnptr)(program, index, bufSize, length, size, type, name);
@@ -1479,11 +2028,20 @@ package gles2
 // static void  glowGetUniformfv(GPGETUNIFORMFV fnptr, GLuint  program, GLint  location, GLfloat * params) {
 //   (*fnptr)(program, location, params);
 // }
+// static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformiv(GPGETUNIFORMIV fnptr, GLuint  program, GLint  location, GLint * params) {
 //   (*fnptr)(program, location, params);
 // }
 // static void  glowGetUniformuiv(GPGETUNIFORMUIV fnptr, GLuint  program, GLint  location, GLuint * params) {
 //   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUnsignedBytei_vEXT(GPGETUNSIGNEDBYTEI_VEXT fnptr, GLenum  target, GLuint  index, GLubyte * data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetUnsignedBytevEXT(GPGETUNSIGNEDBYTEVEXT fnptr, GLenum  pname, GLubyte * data) {
+//   (*fnptr)(pname, data);
 // }
 // static void  glowGetVertexAttribIiv(GPGETVERTEXATTRIBIIV fnptr, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(index, pname, params);
@@ -1499,6 +2057,9 @@ package gles2
 // }
 // static void  glowGetVertexAttribiv(GPGETVERTEXATTRIBIV fnptr, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(index, pname, params);
+// }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
 // }
 // static void  glowGetnUniformfv(GPGETNUNIFORMFV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
@@ -1527,8 +2088,29 @@ package gles2
 // static void  glowHint(GPHINT fnptr, GLenum  target, GLenum  mode) {
 //   (*fnptr)(target, mode);
 // }
+// static void  glowImportMemoryFdEXT(GPIMPORTMEMORYFDEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(memory, size, handleType, fd);
+// }
+// static void  glowImportMemoryWin32HandleEXT(GPIMPORTMEMORYWIN32HANDLEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, void * handle) {
+//   (*fnptr)(memory, size, handleType, handle);
+// }
+// static void  glowImportMemoryWin32NameEXT(GPIMPORTMEMORYWIN32NAMEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, const void * name) {
+//   (*fnptr)(memory, size, handleType, name);
+// }
+// static void  glowImportSemaphoreFdEXT(GPIMPORTSEMAPHOREFDEXT fnptr, GLuint  semaphore, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(semaphore, handleType, fd);
+// }
+// static void  glowImportSemaphoreWin32HandleEXT(GPIMPORTSEMAPHOREWIN32HANDLEEXT fnptr, GLuint  semaphore, GLenum  handleType, void * handle) {
+//   (*fnptr)(semaphore, handleType, handle);
+// }
+// static void  glowImportSemaphoreWin32NameEXT(GPIMPORTSEMAPHOREWIN32NAMEEXT fnptr, GLuint  semaphore, GLenum  handleType, const void * name) {
+//   (*fnptr)(semaphore, handleType, name);
+// }
 // static void  glowInsertEventMarkerEXT(GPINSERTEVENTMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
 //   (*fnptr)(length, marker);
+// }
+// static void  glowInterpolatePathsNV(GPINTERPOLATEPATHSNV fnptr, GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight) {
+//   (*fnptr)(resultPath, pathA, pathB, weight);
 // }
 // static void  glowInvalidateFramebuffer(GPINVALIDATEFRAMEBUFFER fnptr, GLenum  target, GLsizei  numAttachments, const GLenum * attachments) {
 //   (*fnptr)(target, numAttachments, attachments);
@@ -1545,11 +2127,32 @@ package gles2
 // static GLboolean  glowIsEnablediEXT(GPISENABLEDIEXT fnptr, GLenum  target, GLuint  index) {
 //   return (*fnptr)(target, index);
 // }
+// static GLboolean  glowIsEnablediNV(GPISENABLEDINV fnptr, GLenum  target, GLuint  index) {
+//   return (*fnptr)(target, index);
+// }
+// static GLboolean  glowIsEnablediOES(GPISENABLEDIOES fnptr, GLenum  target, GLuint  index) {
+//   return (*fnptr)(target, index);
+// }
 // static GLboolean  glowIsFenceNV(GPISFENCENV fnptr, GLuint  fence) {
 //   return (*fnptr)(fence);
 // }
 // static GLboolean  glowIsFramebuffer(GPISFRAMEBUFFER fnptr, GLuint  framebuffer) {
 //   return (*fnptr)(framebuffer);
+// }
+// static GLboolean  glowIsImageHandleResidentNV(GPISIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
+// static GLboolean  glowIsMemoryObjectEXT(GPISMEMORYOBJECTEXT fnptr, GLuint  memoryObject) {
+//   return (*fnptr)(memoryObject);
+// }
+// static GLboolean  glowIsPathNV(GPISPATHNV fnptr, GLuint  path) {
+//   return (*fnptr)(path);
+// }
+// static GLboolean  glowIsPointInFillPathNV(GPISPOINTINFILLPATHNV fnptr, GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, mask, x, y);
+// }
+// static GLboolean  glowIsPointInStrokePathNV(GPISPOINTINSTROKEPATHNV fnptr, GLuint  path, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, x, y);
 // }
 // static GLboolean  glowIsProgram(GPISPROGRAM fnptr, GLuint  program) {
 //   return (*fnptr)(program);
@@ -1572,6 +2175,9 @@ package gles2
 // static GLboolean  glowIsSampler(GPISSAMPLER fnptr, GLuint  sampler) {
 //   return (*fnptr)(sampler);
 // }
+// static GLboolean  glowIsSemaphoreEXT(GPISSEMAPHOREEXT fnptr, GLuint  semaphore) {
+//   return (*fnptr)(semaphore);
+// }
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
 // }
@@ -1583,6 +2189,9 @@ package gles2
 // }
 // static GLboolean  glowIsTexture(GPISTEXTURE fnptr, GLuint  texture) {
 //   return (*fnptr)(texture);
+// }
+// static GLboolean  glowIsTextureHandleResidentNV(GPISTEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
 // }
 // static GLboolean  glowIsTransformFeedback(GPISTRANSFORMFEEDBACK fnptr, GLuint  id) {
 //   return (*fnptr)(id);
@@ -1602,6 +2211,18 @@ package gles2
 // static void  glowLinkProgram(GPLINKPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
+// static void  glowMakeImageHandleNonResidentNV(GPMAKEIMAGEHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeImageHandleResidentNV(GPMAKEIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle, GLenum  access) {
+//   (*fnptr)(handle, access);
+// }
+// static void  glowMakeTextureHandleNonResidentNV(GPMAKETEXTUREHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeTextureHandleResidentNV(GPMAKETEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
 // static void * glowMapBufferOES(GPMAPBUFFEROES fnptr, GLenum  target, GLenum  access) {
 //   return (*fnptr)(target, access);
 // }
@@ -1611,11 +2232,92 @@ package gles2
 // static void * glowMapBufferRangeEXT(GPMAPBUFFERRANGEEXT fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(target, offset, length, access);
 // }
+// static void  glowMatrixFrustumEXT(GPMATRIXFRUSTUMEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixLoad3x2fNV(GPMATRIXLOAD3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoad3x3fNV(GPMATRIXLOAD3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadIdentityEXT(GPMATRIXLOADIDENTITYEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixLoadTranspose3x3fNV(GPMATRIXLOADTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadTransposedEXT(GPMATRIXLOADTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadTransposefEXT(GPMATRIXLOADTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoaddEXT(GPMATRIXLOADDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadfEXT(GPMATRIXLOADFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMult3x2fNV(GPMATRIXMULT3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMult3x3fNV(GPMATRIXMULT3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTranspose3x3fNV(GPMATRIXMULTTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTransposedEXT(GPMATRIXMULTTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultTransposefEXT(GPMATRIXMULTTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultdEXT(GPMATRIXMULTDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultfEXT(GPMATRIXMULTFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixOrthoEXT(GPMATRIXORTHOEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixPopEXT(GPMATRIXPOPEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixPushEXT(GPMATRIXPUSHEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixRotatedEXT(GPMATRIXROTATEDEXT fnptr, GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixRotatefEXT(GPMATRIXROTATEFEXT fnptr, GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixScaledEXT(GPMATRIXSCALEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixScalefEXT(GPMATRIXSCALEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatedEXT(GPMATRIXTRANSLATEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
 // }
 // static void  glowMemoryBarrierByRegion(GPMEMORYBARRIERBYREGION fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
+// }
+// static void  glowMemoryObjectParameterivEXT(GPMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, const GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
 // }
 // static void  glowMinSampleShadingOES(GPMINSAMPLESHADINGOES fnptr, GLfloat  value) {
 //   (*fnptr)(value);
@@ -1623,8 +2325,26 @@ package gles2
 // static void  glowMultiDrawArraysEXT(GPMULTIDRAWARRAYSEXT fnptr, GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount) {
 //   (*fnptr)(mode, first, count, primcount);
 // }
+// static void  glowMultiDrawArraysIndirectEXT(GPMULTIDRAWARRAYSINDIRECTEXT fnptr, GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
+//   (*fnptr)(mode, indirect, drawcount, stride);
+// }
+// static void  glowMultiDrawElementsBaseVertexEXT(GPMULTIDRAWELEMENTSBASEVERTEXEXT fnptr, GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  primcount, const GLint * basevertex) {
+//   (*fnptr)(mode, count, type, indices, primcount, basevertex);
+// }
 // static void  glowMultiDrawElementsEXT(GPMULTIDRAWELEMENTSEXT fnptr, GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  primcount) {
 //   (*fnptr)(mode, count, type, indices, primcount);
+// }
+// static void  glowMultiDrawElementsIndirectEXT(GPMULTIDRAWELEMENTSINDIRECTEXT fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
+//   (*fnptr)(mode, type, indirect, drawcount, stride);
+// }
+// static void  glowNamedBufferStorageExternalEXT(GPNAMEDBUFFERSTORAGEEXTERNALEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(buffer, offset, size, clientBuffer, flags);
+// }
+// static void  glowNamedBufferStorageMemEXT(GPNAMEDBUFFERSTORAGEMEMEXT fnptr, GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(buffer, size, memory, offset);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
 // }
 // static void  glowObjectLabel(GPOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(identifier, name, length, label);
@@ -1641,14 +2361,80 @@ package gles2
 // static void  glowPatchParameteriEXT(GPPATCHPARAMETERIEXT fnptr, GLenum  pname, GLint  value) {
 //   (*fnptr)(pname, value);
 // }
+// static void  glowPatchParameteriOES(GPPATCHPARAMETERIOES fnptr, GLenum  pname, GLint  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowPathCommandsNV(GPPATHCOMMANDSNV fnptr, GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathCoordsNV(GPPATHCOORDSNV fnptr, GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCoords, coordType, coords);
+// }
+// static void  glowPathCoverDepthFuncNV(GPPATHCOVERDEPTHFUNCNV fnptr, GLenum  func) {
+//   (*fnptr)(func);
+// }
+// static void  glowPathDashArrayNV(GPPATHDASHARRAYNV fnptr, GLuint  path, GLsizei  dashCount, const GLfloat * dashArray) {
+//   (*fnptr)(path, dashCount, dashArray);
+// }
+// static GLenum  glowPathGlyphIndexArrayNV(GPPATHGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathGlyphIndexRangeNV(GPPATHGLYPHINDEXRANGENV fnptr, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount) {
+//   return (*fnptr)(fontTarget, fontName, fontStyle, pathParameterTemplate, emScale, baseAndCount);
+// }
+// static void  glowPathGlyphRangeNV(GPPATHGLYPHRANGENV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyph, numGlyphs, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathGlyphsNV(GPPATHGLYPHSNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, numGlyphs, type, charcodes, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathMemoryGlyphIndexArrayNV(GPPATHMEMORYGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontSize, fontData, faceIndex, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathParameterfNV(GPPATHPARAMETERFNV fnptr, GLuint  path, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterfvNV(GPPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, const GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameteriNV(GPPATHPARAMETERINV fnptr, GLuint  path, GLenum  pname, GLint  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterivNV(GPPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, const GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathStencilDepthOffsetNV(GPPATHSTENCILDEPTHOFFSETNV fnptr, GLfloat  factor, GLfloat  units) {
+//   (*fnptr)(factor, units);
+// }
+// static void  glowPathStencilFuncNV(GPPATHSTENCILFUNCNV fnptr, GLenum  func, GLint  ref, GLuint  mask) {
+//   (*fnptr)(func, ref, mask);
+// }
+// static void  glowPathStringNV(GPPATHSTRINGNV fnptr, GLuint  path, GLenum  format, GLsizei  length, const void * pathString) {
+//   (*fnptr)(path, format, length, pathString);
+// }
+// static void  glowPathSubCommandsNV(GPPATHSUBCOMMANDSNV fnptr, GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, commandStart, commandsToDelete, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathSubCoordsNV(GPPATHSUBCOORDSNV fnptr, GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, coordStart, numCoords, coordType, coords);
+// }
 // static void  glowPauseTransformFeedback(GPPAUSETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
 // static void  glowPixelStorei(GPPIXELSTOREI fnptr, GLenum  pname, GLint  param) {
 //   (*fnptr)(pname, param);
 // }
+// static GLboolean  glowPointAlongPathNV(GPPOINTALONGPATHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY) {
+//   return (*fnptr)(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
+// }
+// static void  glowPolygonModeNV(GPPOLYGONMODENV fnptr, GLenum  face, GLenum  mode) {
+//   (*fnptr)(face, mode);
+// }
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
 // }
 // static void  glowPopDebugGroup(GPPOPDEBUGGROUP fnptr) {
 //   (*fnptr)();
@@ -1662,6 +2448,9 @@ package gles2
 // static void  glowPrimitiveBoundingBoxEXT(GPPRIMITIVEBOUNDINGBOXEXT fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
 //   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
+// static void  glowPrimitiveBoundingBoxOES(GPPRIMITIVEBOUNDINGBOXOES fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
+// }
 // static void  glowProgramBinary(GPPROGRAMBINARY fnptr, GLuint  program, GLenum  binaryFormat, const void * binary, GLsizei  length) {
 //   (*fnptr)(program, binaryFormat, binary, length);
 // }
@@ -1673,6 +2462,9 @@ package gles2
 // }
 // static void  glowProgramParameteriEXT(GPPROGRAMPARAMETERIEXT fnptr, GLuint  program, GLenum  pname, GLint  value) {
 //   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramPathFragmentInputGenNV(GPPROGRAMPATHFRAGMENTINPUTGENNV fnptr, GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs) {
+//   (*fnptr)(program, location, genMode, components, coeffs);
 // }
 // static void  glowProgramUniform1f(GPPROGRAMUNIFORM1F fnptr, GLuint  program, GLint  location, GLfloat  v0) {
 //   (*fnptr)(program, location, v0);
@@ -1689,6 +2481,12 @@ package gles2
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
 // static void  glowProgramUniform1iEXT(GPPROGRAMUNIFORM1IEXT fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
@@ -1700,6 +2498,12 @@ package gles2
 // }
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
+// }
+// static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1uiEXT(GPPROGRAMUNIFORM1UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
@@ -1725,6 +2529,12 @@ package gles2
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
 // static void  glowProgramUniform2iEXT(GPPROGRAMUNIFORM2IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
@@ -1736,6 +2546,12 @@ package gles2
 // }
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
+// }
+// static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2uiEXT(GPPROGRAMUNIFORM2UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
@@ -1761,6 +2577,12 @@ package gles2
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
 // static void  glowProgramUniform3iEXT(GPPROGRAMUNIFORM3IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
@@ -1772,6 +2594,12 @@ package gles2
 // }
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
+// }
+// static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3uiEXT(GPPROGRAMUNIFORM3UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
@@ -1797,6 +2625,12 @@ package gles2
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
 // static void  glowProgramUniform4iEXT(GPPROGRAMUNIFORM4IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
@@ -1809,6 +2643,12 @@ package gles2
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
 // static void  glowProgramUniform4uiEXT(GPPROGRAMUNIFORM4UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
@@ -1817,6 +2657,18 @@ package gles2
 // }
 // static void  glowProgramUniform4uivEXT(GPPROGRAMUNIFORM4UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniformHandleui64IMG(GPPROGRAMUNIFORMHANDLEUI64IMG fnptr, GLuint  program, GLint  location, GLuint64  value) {
+//   (*fnptr)(program, location, value);
+// }
+// static void  glowProgramUniformHandleui64NV(GPPROGRAMUNIFORMHANDLEUI64NV fnptr, GLuint  program, GLint  location, GLuint64  value) {
+//   (*fnptr)(program, location, value);
+// }
+// static void  glowProgramUniformHandleui64vIMG(GPPROGRAMUNIFORMHANDLEUI64VIMG fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
+//   (*fnptr)(program, location, count, values);
+// }
+// static void  glowProgramUniformHandleui64vNV(GPPROGRAMUNIFORMHANDLEUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
+//   (*fnptr)(program, location, count, values);
 // }
 // static void  glowProgramUniformMatrix2fv(GPPROGRAMUNIFORMMATRIX2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
@@ -1884,6 +2736,9 @@ package gles2
 // static void  glowQueryCounterEXT(GPQUERYCOUNTEREXT fnptr, GLuint  id, GLenum  target) {
 //   (*fnptr)(id, target);
 // }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
+// }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
 // }
@@ -1904,6 +2759,9 @@ package gles2
 // }
 // static void  glowReadnPixelsKHR(GPREADNPIXELSKHR fnptr, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, GLsizei  bufSize, void * data) {
 //   (*fnptr)(x, y, width, height, format, type, bufSize, data);
+// }
+// static GLboolean  glowReleaseKeyedMutexWin32EXT(GPRELEASEKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key) {
+//   return (*fnptr)(memory, key);
 // }
 // static void  glowReleaseShaderCompiler(GPRELEASESHADERCOMPILER fnptr) {
 //   (*fnptr)();
@@ -1929,6 +2787,9 @@ package gles2
 // static void  glowRenderbufferStorageMultisampleNV(GPRENDERBUFFERSTORAGEMULTISAMPLENV fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, samples, internalformat, width, height);
 // }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowResolveMultisampleFramebufferAPPLE(GPRESOLVEMULTISAMPLEFRAMEBUFFERAPPLE fnptr) {
 //   (*fnptr)();
 // }
@@ -1944,7 +2805,13 @@ package gles2
 // static void  glowSamplerParameterIivEXT(GPSAMPLERPARAMETERIIVEXT fnptr, GLuint  sampler, GLenum  pname, const GLint * param) {
 //   (*fnptr)(sampler, pname, param);
 // }
+// static void  glowSamplerParameterIivOES(GPSAMPLERPARAMETERIIVOES fnptr, GLuint  sampler, GLenum  pname, const GLint * param) {
+//   (*fnptr)(sampler, pname, param);
+// }
 // static void  glowSamplerParameterIuivEXT(GPSAMPLERPARAMETERIUIVEXT fnptr, GLuint  sampler, GLenum  pname, const GLuint * param) {
+//   (*fnptr)(sampler, pname, param);
+// }
+// static void  glowSamplerParameterIuivOES(GPSAMPLERPARAMETERIUIVOES fnptr, GLuint  sampler, GLenum  pname, const GLuint * param) {
 //   (*fnptr)(sampler, pname, param);
 // }
 // static void  glowSamplerParameterf(GPSAMPLERPARAMETERF fnptr, GLuint  sampler, GLenum  pname, GLfloat  param) {
@@ -1962,8 +2829,29 @@ package gles2
 // static void  glowScissor(GPSCISSOR fnptr, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(x, y, width, height);
 // }
+// static void  glowScissorArrayvNV(GPSCISSORARRAYVNV fnptr, GLuint  first, GLsizei  count, const GLint * v) {
+//   (*fnptr)(first, count, v);
+// }
+// static void  glowScissorArrayvOES(GPSCISSORARRAYVOES fnptr, GLuint  first, GLsizei  count, const GLint * v) {
+//   (*fnptr)(first, count, v);
+// }
+// static void  glowScissorIndexedNV(GPSCISSORINDEXEDNV fnptr, GLuint  index, GLint  left, GLint  bottom, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(index, left, bottom, width, height);
+// }
+// static void  glowScissorIndexedOES(GPSCISSORINDEXEDOES fnptr, GLuint  index, GLint  left, GLint  bottom, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(index, left, bottom, width, height);
+// }
+// static void  glowScissorIndexedvNV(GPSCISSORINDEXEDVNV fnptr, GLuint  index, const GLint * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowScissorIndexedvOES(GPSCISSORINDEXEDVOES fnptr, GLuint  index, const GLint * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
 //   (*fnptr)(monitor, enable, group, numCounters, counterList);
+// }
+// static void  glowSemaphoreParameterui64vEXT(GPSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, const GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
 // }
 // static void  glowSetFenceNV(GPSETFENCENV fnptr, GLuint  fence, GLenum  condition) {
 //   (*fnptr)(fence, condition);
@@ -1974,8 +2862,23 @@ package gles2
 // static void  glowShaderSource(GPSHADERSOURCE fnptr, GLuint  shader, GLsizei  count, const GLchar *const* string, const GLint * length) {
 //   (*fnptr)(shader, count, string, length);
 // }
+// static void  glowSignalSemaphoreEXT(GPSIGNALSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, dstLayouts);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
 // static void  glowStartTilingQCOM(GPSTARTTILINGQCOM fnptr, GLuint  x, GLuint  y, GLuint  width, GLuint  height, GLbitfield  preserveMask) {
 //   (*fnptr)(x, y, width, height, preserveMask);
+// }
+// static void  glowStencilFillPathInstancedNV(GPSTENCILFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, transformType, transformValues);
+// }
+// static void  glowStencilFillPathNV(GPSTENCILFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask) {
+//   (*fnptr)(path, fillMode, mask);
 // }
 // static void  glowStencilFunc(GPSTENCILFUNC fnptr, GLenum  func, GLint  ref, GLuint  mask) {
 //   (*fnptr)(func, ref, mask);
@@ -1995,13 +2898,40 @@ package gles2
 // static void  glowStencilOpSeparate(GPSTENCILOPSEPARATE fnptr, GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass) {
 //   (*fnptr)(face, sfail, dpfail, dppass);
 // }
+// static void  glowStencilStrokePathInstancedNV(GPSTENCILSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, transformType, transformValues);
+// }
+// static void  glowStencilStrokePathNV(GPSTENCILSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask) {
+//   (*fnptr)(path, reference, mask);
+// }
+// static void  glowStencilThenCoverFillPathInstancedNV(GPSTENCILTHENCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverFillPathNV(GPSTENCILTHENCOVERFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, fillMode, mask, coverMode);
+// }
+// static void  glowStencilThenCoverStrokePathInstancedNV(GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverStrokePathNV(GPSTENCILTHENCOVERSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, reference, mask, coverMode);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
+// }
 // static GLboolean  glowTestFenceNV(GPTESTFENCENV fnptr, GLuint  fence) {
 //   return (*fnptr)(fence);
 // }
 // static void  glowTexBufferEXT(GPTEXBUFFEREXT fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(target, internalformat, buffer);
 // }
+// static void  glowTexBufferOES(GPTEXBUFFEROES fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(target, internalformat, buffer);
+// }
 // static void  glowTexBufferRangeEXT(GPTEXBUFFERRANGEEXT fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
+//   (*fnptr)(target, internalformat, buffer, offset, size);
+// }
+// static void  glowTexBufferRangeOES(GPTEXBUFFERRANGEOES fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, internalformat, buffer, offset, size);
 // }
 // static void  glowTexImage2D(GPTEXIMAGE2D fnptr, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
@@ -2013,10 +2943,19 @@ package gles2
 // static void  glowTexImage3DOES(GPTEXIMAGE3DOES fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, height, depth, border, format, type, pixels);
 // }
+// static void  glowTexPageCommitmentEXT(GPTEXPAGECOMMITMENTEXT fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
+// }
 // static void  glowTexParameterIivEXT(GPTEXPARAMETERIIVEXT fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowTexParameterIivOES(GPTEXPARAMETERIIVOES fnptr, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(target, pname, params);
+// }
 // static void  glowTexParameterIuivEXT(GPTEXPARAMETERIUIVEXT fnptr, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(target, pname, params);
+// }
+// static void  glowTexParameterIuivOES(GPTEXPARAMETERIUIVOES fnptr, GLenum  target, GLenum  pname, const GLuint * params) {
 //   (*fnptr)(target, pname, params);
 // }
 // static void  glowTexParameterf(GPTEXPARAMETERF fnptr, GLenum  target, GLenum  pname, GLfloat  param) {
@@ -2052,6 +2991,21 @@ package gles2
 // static void  glowTexStorage3DMultisampleOES(GPTEXSTORAGE3DMULTISAMPLEOES fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTexStorageMem1DEXT(GPTEXSTORAGEMEM1DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTexStorageMem2DEXT(GPTEXSTORAGEMEM2DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTexStorageMem2DMultisampleEXT(GPTEXSTORAGEMEM2DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTexStorageMem3DEXT(GPTEXSTORAGEMEM3DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTexStorageMem3DMultisampleEXT(GPTEXSTORAGEMEM3DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTexSubImage2D(GPTEXSUBIMAGE2D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, xoffset, yoffset, width, height, format, type, pixels);
 // }
@@ -2060,6 +3014,9 @@ package gles2
 // }
 // static void  glowTexSubImage3DOES(GPTEXSUBIMAGE3DOES fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowTextureFoveationParametersQCOM(GPTEXTUREFOVEATIONPARAMETERSQCOM fnptr, GLuint  texture, GLuint  layer, GLuint  focalPoint, GLfloat  focalX, GLfloat  focalY, GLfloat  gainX, GLfloat  gainY, GLfloat  foveaArea) {
+//   (*fnptr)(texture, layer, focalPoint, focalX, focalY, gainX, gainY, foveaArea);
 // }
 // static void  glowTextureStorage1DEXT(GPTEXTURESTORAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
 //   (*fnptr)(texture, target, levels, internalformat, width);
@@ -2070,11 +3027,32 @@ package gles2
 // static void  glowTextureStorage3DEXT(GPTEXTURESTORAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
 //   (*fnptr)(texture, target, levels, internalformat, width, height, depth);
 // }
+// static void  glowTextureStorageMem1DEXT(GPTEXTURESTORAGEMEM1DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTextureStorageMem2DEXT(GPTEXTURESTORAGEMEM2DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTextureStorageMem2DMultisampleEXT(GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTextureStorageMem3DEXT(GPTEXTURESTORAGEMEM3DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTextureStorageMem3DMultisampleEXT(GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTextureViewEXT(GPTEXTUREVIEWEXT fnptr, GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers) {
+//   (*fnptr)(texture, target, origtexture, internalformat, minlevel, numlevels, minlayer, numlayers);
+// }
+// static void  glowTextureViewOES(GPTEXTUREVIEWOES fnptr, GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers) {
 //   (*fnptr)(texture, target, origtexture, internalformat, minlevel, numlevels, minlayer, numlayers);
 // }
 // static void  glowTransformFeedbackVaryings(GPTRANSFORMFEEDBACKVARYINGS fnptr, GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode) {
 //   (*fnptr)(program, count, varyings, bufferMode);
+// }
+// static void  glowTransformPathNV(GPTRANSFORMPATHNV fnptr, GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(resultPath, srcPath, transformType, transformValues);
 // }
 // static void  glowUniform1f(GPUNIFORM1F fnptr, GLint  location, GLfloat  v0) {
 //   (*fnptr)(location, v0);
@@ -2085,11 +3063,23 @@ package gles2
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform1iv(GPUNIFORM1IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
+// }
+// static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1uiv(GPUNIFORM1UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2103,11 +3093,23 @@ package gles2
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform2iv(GPUNIFORM2IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
+// }
+// static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2uiv(GPUNIFORM2UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2121,11 +3123,23 @@ package gles2
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform3iv(GPUNIFORM3IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
+// }
+// static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3uiv(GPUNIFORM3UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2139,17 +3153,41 @@ package gles2
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform4iv(GPUNIFORM4IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform4uiv(GPUNIFORM4UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniformBlockBinding(GPUNIFORMBLOCKBINDING fnptr, GLuint  program, GLuint  uniformBlockIndex, GLuint  uniformBlockBinding) {
 //   (*fnptr)(program, uniformBlockIndex, uniformBlockBinding);
+// }
+// static void  glowUniformHandleui64IMG(GPUNIFORMHANDLEUI64IMG fnptr, GLint  location, GLuint64  value) {
+//   (*fnptr)(location, value);
+// }
+// static void  glowUniformHandleui64NV(GPUNIFORMHANDLEUI64NV fnptr, GLint  location, GLuint64  value) {
+//   (*fnptr)(location, value);
+// }
+// static void  glowUniformHandleui64vIMG(GPUNIFORMHANDLEUI64VIMG fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniformHandleui64vNV(GPUNIFORMHANDLEUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniformMatrix2fv(GPUNIFORMMATRIX2FV fnptr, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(location, count, transpose, value);
@@ -2292,11 +3330,47 @@ package gles2
 // static void  glowViewport(GPVIEWPORT fnptr, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(x, y, width, height);
 // }
+// static void  glowViewportArrayvNV(GPVIEWPORTARRAYVNV fnptr, GLuint  first, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(first, count, v);
+// }
+// static void  glowViewportArrayvOES(GPVIEWPORTARRAYVOES fnptr, GLuint  first, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(first, count, v);
+// }
+// static void  glowViewportIndexedfNV(GPVIEWPORTINDEXEDFNV fnptr, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h) {
+//   (*fnptr)(index, x, y, w, h);
+// }
+// static void  glowViewportIndexedfOES(GPVIEWPORTINDEXEDFOES fnptr, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h) {
+//   (*fnptr)(index, x, y, w, h);
+// }
+// static void  glowViewportIndexedfvNV(GPVIEWPORTINDEXEDFVNV fnptr, GLuint  index, const GLfloat * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowViewportIndexedfvOES(GPVIEWPORTINDEXEDFVOES fnptr, GLuint  index, const GLfloat * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
+// static void  glowWaitSemaphoreEXT(GPWAITSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, srcLayouts);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
 // }
 // static void  glowWaitSyncAPPLE(GPWAITSYNCAPPLE fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
+//   (*fnptr)(resultPath, numPaths, paths, weights);
+// }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
 // }
 import "C"
 import (
@@ -2305,2104 +3379,2911 @@ import (
 )
 
 const (
-	GL_3DC_XY_AMD                                       = 0x87FA
-	GL_3DC_X_AMD                                        = 0x87F9
-	ACTIVE_ATOMIC_COUNTER_BUFFERS                       = 0x92D9
-	ACTIVE_ATTRIBUTES                                   = 0x8B89
-	ACTIVE_ATTRIBUTE_MAX_LENGTH                         = 0x8B8A
-	ACTIVE_PROGRAM                                      = 0x8259
-	ACTIVE_PROGRAM_EXT                                  = 0x8259
-	ACTIVE_RESOURCES                                    = 0x92F5
-	ACTIVE_TEXTURE                                      = 0x84E0
-	ACTIVE_UNIFORMS                                     = 0x8B86
-	ACTIVE_UNIFORM_BLOCKS                               = 0x8A36
-	ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH                = 0x8A35
-	ACTIVE_UNIFORM_MAX_LENGTH                           = 0x8B87
-	ACTIVE_VARIABLES                                    = 0x9305
-	ALIASED_LINE_WIDTH_RANGE                            = 0x846E
-	ALIASED_POINT_SIZE_RANGE                            = 0x846D
-	ALL_BARRIER_BITS                                    = 0xFFFFFFFF
-	ALL_COMPLETED_NV                                    = 0x84F2
-	ALL_SHADER_BITS                                     = 0xFFFFFFFF
-	ALL_SHADER_BITS_EXT                                 = 0xFFFFFFFF
-	ALPHA                                               = 0x1906
-	ALPHA16F_EXT                                        = 0x881C
-	ALPHA32F_EXT                                        = 0x8816
-	ALPHA8_EXT                                          = 0x803C
-	ALPHA8_OES                                          = 0x803C
-	ALPHA_BITS                                          = 0x0D55
-	ALPHA_TEST_FUNC_QCOM                                = 0x0BC1
-	ALPHA_TEST_QCOM                                     = 0x0BC0
-	ALPHA_TEST_REF_QCOM                                 = 0x0BC2
-	ALREADY_SIGNALED                                    = 0x911A
-	ALREADY_SIGNALED_APPLE                              = 0x911A
-	ALWAYS                                              = 0x0207
-	ANY_SAMPLES_PASSED                                  = 0x8C2F
-	ANY_SAMPLES_PASSED_CONSERVATIVE                     = 0x8D6A
-	ANY_SAMPLES_PASSED_CONSERVATIVE_EXT                 = 0x8D6A
-	ANY_SAMPLES_PASSED_EXT                              = 0x8C2F
-	ARRAY_BUFFER                                        = 0x8892
-	ARRAY_BUFFER_BINDING                                = 0x8894
-	ARRAY_SIZE                                          = 0x92FB
-	ARRAY_STRIDE                                        = 0x92FE
-	ATC_RGBA_EXPLICIT_ALPHA_AMD                         = 0x8C93
-	ATC_RGBA_INTERPOLATED_ALPHA_AMD                     = 0x87EE
-	ATC_RGB_AMD                                         = 0x8C92
-	ATOMIC_COUNTER_BARRIER_BIT                          = 0x00001000
-	ATOMIC_COUNTER_BUFFER                               = 0x92C0
-	ATOMIC_COUNTER_BUFFER_BINDING                       = 0x92C1
-	ATOMIC_COUNTER_BUFFER_INDEX                         = 0x9301
-	ATOMIC_COUNTER_BUFFER_SIZE                          = 0x92C3
-	ATOMIC_COUNTER_BUFFER_START                         = 0x92C2
-	ATTACHED_SHADERS                                    = 0x8B85
-	BACK                                                = 0x0405
-	BGRA8_EXT                                           = 0x93A1
-	BGRA_EXT                                            = 0x80E1
-	BGRA_IMG                                            = 0x80E1
-	BINNING_CONTROL_HINT_QCOM                           = 0x8FB0
-	BLEND                                               = 0x0BE2
-	BLEND_ADVANCED_COHERENT_KHR                         = 0x9285
-	BLEND_ADVANCED_COHERENT_NV                          = 0x9285
-	BLEND_COLOR                                         = 0x8005
-	BLEND_DST_ALPHA                                     = 0x80CA
-	BLEND_DST_RGB                                       = 0x80C8
-	BLEND_EQUATION                                      = 0x8009
-	BLEND_EQUATION_ALPHA                                = 0x883D
-	BLEND_EQUATION_EXT                                  = 0x8009
-	BLEND_EQUATION_RGB                                  = 0x8009
-	BLEND_OVERLAP_NV                                    = 0x9281
-	BLEND_PREMULTIPLIED_SRC_NV                          = 0x9280
-	BLEND_SRC_ALPHA                                     = 0x80CB
-	BLEND_SRC_RGB                                       = 0x80C9
-	BLOCK_INDEX                                         = 0x92FD
-	BLUE                                                = 0x1905
-	BLUE_BITS                                           = 0x0D54
-	BLUE_NV                                             = 0x1905
-	BOOL                                                = 0x8B56
-	BOOL_VEC2                                           = 0x8B57
-	BOOL_VEC3                                           = 0x8B58
-	BOOL_VEC4                                           = 0x8B59
-	BUFFER                                              = 0x82E0
-	BUFFER_ACCESS_FLAGS                                 = 0x911F
-	BUFFER_ACCESS_OES                                   = 0x88BB
-	BUFFER_BINDING                                      = 0x9302
-	BUFFER_DATA_SIZE                                    = 0x9303
-	BUFFER_KHR                                          = 0x82E0
-	BUFFER_MAPPED                                       = 0x88BC
-	BUFFER_MAPPED_OES                                   = 0x88BC
-	BUFFER_MAP_LENGTH                                   = 0x9120
-	BUFFER_MAP_OFFSET                                   = 0x9121
-	BUFFER_MAP_POINTER                                  = 0x88BD
-	BUFFER_MAP_POINTER_OES                              = 0x88BD
-	BUFFER_OBJECT_EXT                                   = 0x9151
-	BUFFER_SIZE                                         = 0x8764
-	BUFFER_UPDATE_BARRIER_BIT                           = 0x00000200
-	BUFFER_USAGE                                        = 0x8765
-	BUFFER_VARIABLE                                     = 0x92E5
-	BYTE                                                = 0x1400
-	CCW                                                 = 0x0901
-	CLAMP_TO_BORDER_EXT                                 = 0x812D
-	CLAMP_TO_BORDER_NV                                  = 0x812D
-	CLAMP_TO_EDGE                                       = 0x812F
-	COLOR                                               = 0x1800
-	COLORBURN_KHR                                       = 0x929A
-	COLORBURN_NV                                        = 0x929A
-	COLORDODGE_KHR                                      = 0x9299
-	COLORDODGE_NV                                       = 0x9299
-	COLOR_ATTACHMENT0                                   = 0x8CE0
-	COLOR_ATTACHMENT0_EXT                               = 0x8CE0
-	COLOR_ATTACHMENT0_NV                                = 0x8CE0
-	COLOR_ATTACHMENT1                                   = 0x8CE1
-	COLOR_ATTACHMENT10                                  = 0x8CEA
-	COLOR_ATTACHMENT10_EXT                              = 0x8CEA
-	COLOR_ATTACHMENT10_NV                               = 0x8CEA
-	COLOR_ATTACHMENT11                                  = 0x8CEB
-	COLOR_ATTACHMENT11_EXT                              = 0x8CEB
-	COLOR_ATTACHMENT11_NV                               = 0x8CEB
-	COLOR_ATTACHMENT12                                  = 0x8CEC
-	COLOR_ATTACHMENT12_EXT                              = 0x8CEC
-	COLOR_ATTACHMENT12_NV                               = 0x8CEC
-	COLOR_ATTACHMENT13                                  = 0x8CED
-	COLOR_ATTACHMENT13_EXT                              = 0x8CED
-	COLOR_ATTACHMENT13_NV                               = 0x8CED
-	COLOR_ATTACHMENT14                                  = 0x8CEE
-	COLOR_ATTACHMENT14_EXT                              = 0x8CEE
-	COLOR_ATTACHMENT14_NV                               = 0x8CEE
-	COLOR_ATTACHMENT15                                  = 0x8CEF
-	COLOR_ATTACHMENT15_EXT                              = 0x8CEF
-	COLOR_ATTACHMENT15_NV                               = 0x8CEF
-	COLOR_ATTACHMENT1_EXT                               = 0x8CE1
-	COLOR_ATTACHMENT1_NV                                = 0x8CE1
-	COLOR_ATTACHMENT2                                   = 0x8CE2
-	COLOR_ATTACHMENT2_EXT                               = 0x8CE2
-	COLOR_ATTACHMENT2_NV                                = 0x8CE2
-	COLOR_ATTACHMENT3                                   = 0x8CE3
-	COLOR_ATTACHMENT3_EXT                               = 0x8CE3
-	COLOR_ATTACHMENT3_NV                                = 0x8CE3
-	COLOR_ATTACHMENT4                                   = 0x8CE4
-	COLOR_ATTACHMENT4_EXT                               = 0x8CE4
-	COLOR_ATTACHMENT4_NV                                = 0x8CE4
-	COLOR_ATTACHMENT5                                   = 0x8CE5
-	COLOR_ATTACHMENT5_EXT                               = 0x8CE5
-	COLOR_ATTACHMENT5_NV                                = 0x8CE5
-	COLOR_ATTACHMENT6                                   = 0x8CE6
-	COLOR_ATTACHMENT6_EXT                               = 0x8CE6
-	COLOR_ATTACHMENT6_NV                                = 0x8CE6
-	COLOR_ATTACHMENT7                                   = 0x8CE7
-	COLOR_ATTACHMENT7_EXT                               = 0x8CE7
-	COLOR_ATTACHMENT7_NV                                = 0x8CE7
-	COLOR_ATTACHMENT8                                   = 0x8CE8
-	COLOR_ATTACHMENT8_EXT                               = 0x8CE8
-	COLOR_ATTACHMENT8_NV                                = 0x8CE8
-	COLOR_ATTACHMENT9                                   = 0x8CE9
-	COLOR_ATTACHMENT9_EXT                               = 0x8CE9
-	COLOR_ATTACHMENT9_NV                                = 0x8CE9
-	COLOR_ATTACHMENT_EXT                                = 0x90F0
-	COLOR_BUFFER_BIT                                    = 0x00004000
-	COLOR_BUFFER_BIT0_QCOM                              = 0x00000001
-	COLOR_BUFFER_BIT1_QCOM                              = 0x00000002
-	COLOR_BUFFER_BIT2_QCOM                              = 0x00000004
-	COLOR_BUFFER_BIT3_QCOM                              = 0x00000008
-	COLOR_BUFFER_BIT4_QCOM                              = 0x00000010
-	COLOR_BUFFER_BIT5_QCOM                              = 0x00000020
-	COLOR_BUFFER_BIT6_QCOM                              = 0x00000040
-	COLOR_BUFFER_BIT7_QCOM                              = 0x00000080
-	COLOR_CLEAR_VALUE                                   = 0x0C22
-	COLOR_EXT                                           = 0x1800
-	COLOR_WRITEMASK                                     = 0x0C23
-	COMMAND_BARRIER_BIT                                 = 0x00000040
-	COMPARE_REF_TO_TEXTURE                              = 0x884E
-	COMPARE_REF_TO_TEXTURE_EXT                          = 0x884E
-	COMPILE_STATUS                                      = 0x8B81
-	COMPRESSED_R11_EAC                                  = 0x9270
-	COMPRESSED_RG11_EAC                                 = 0x9272
-	COMPRESSED_RGB8_ETC2                                = 0x9274
-	COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2            = 0x9276
-	COMPRESSED_RGBA8_ETC2_EAC                           = 0x9278
-	COMPRESSED_RGBA_ASTC_10x10_KHR                      = 0x93BB
-	COMPRESSED_RGBA_ASTC_10x5_KHR                       = 0x93B8
-	COMPRESSED_RGBA_ASTC_10x6_KHR                       = 0x93B9
-	COMPRESSED_RGBA_ASTC_10x8_KHR                       = 0x93BA
-	COMPRESSED_RGBA_ASTC_12x10_KHR                      = 0x93BC
-	COMPRESSED_RGBA_ASTC_12x12_KHR                      = 0x93BD
-	COMPRESSED_RGBA_ASTC_3x3x3_OES                      = 0x93C0
-	COMPRESSED_RGBA_ASTC_4x3x3_OES                      = 0x93C1
-	COMPRESSED_RGBA_ASTC_4x4_KHR                        = 0x93B0
-	COMPRESSED_RGBA_ASTC_4x4x3_OES                      = 0x93C2
-	COMPRESSED_RGBA_ASTC_4x4x4_OES                      = 0x93C3
-	COMPRESSED_RGBA_ASTC_5x4_KHR                        = 0x93B1
-	COMPRESSED_RGBA_ASTC_5x4x4_OES                      = 0x93C4
-	COMPRESSED_RGBA_ASTC_5x5_KHR                        = 0x93B2
-	COMPRESSED_RGBA_ASTC_5x5x4_OES                      = 0x93C5
-	COMPRESSED_RGBA_ASTC_5x5x5_OES                      = 0x93C6
-	COMPRESSED_RGBA_ASTC_6x5_KHR                        = 0x93B3
-	COMPRESSED_RGBA_ASTC_6x5x5_OES                      = 0x93C7
-	COMPRESSED_RGBA_ASTC_6x6_KHR                        = 0x93B4
-	COMPRESSED_RGBA_ASTC_6x6x5_OES                      = 0x93C8
-	COMPRESSED_RGBA_ASTC_6x6x6_OES                      = 0x93C9
-	COMPRESSED_RGBA_ASTC_8x5_KHR                        = 0x93B5
-	COMPRESSED_RGBA_ASTC_8x6_KHR                        = 0x93B6
-	COMPRESSED_RGBA_ASTC_8x8_KHR                        = 0x93B7
-	COMPRESSED_RGBA_PVRTC_2BPPV1_IMG                    = 0x8C03
-	COMPRESSED_RGBA_PVRTC_2BPPV2_IMG                    = 0x9137
-	COMPRESSED_RGBA_PVRTC_4BPPV1_IMG                    = 0x8C02
-	COMPRESSED_RGBA_PVRTC_4BPPV2_IMG                    = 0x9138
-	COMPRESSED_RGBA_S3TC_DXT1_EXT                       = 0x83F1
-	COMPRESSED_RGBA_S3TC_DXT3_ANGLE                     = 0x83F2
-	COMPRESSED_RGBA_S3TC_DXT3_EXT                       = 0x83F2
-	COMPRESSED_RGBA_S3TC_DXT5_ANGLE                     = 0x83F3
-	COMPRESSED_RGBA_S3TC_DXT5_EXT                       = 0x83F3
-	COMPRESSED_RGB_PVRTC_2BPPV1_IMG                     = 0x8C01
-	COMPRESSED_RGB_PVRTC_4BPPV1_IMG                     = 0x8C00
-	COMPRESSED_RGB_S3TC_DXT1_EXT                        = 0x83F0
-	COMPRESSED_SIGNED_R11_EAC                           = 0x9271
-	COMPRESSED_SIGNED_RG11_EAC                          = 0x9273
-	COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR              = 0x93DB
-	COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR               = 0x93D8
-	COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR               = 0x93D9
-	COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR               = 0x93DA
-	COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR              = 0x93DC
-	COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR              = 0x93DD
-	COMPRESSED_SRGB8_ALPHA8_ASTC_3x3x3_OES              = 0x93E0
-	COMPRESSED_SRGB8_ALPHA8_ASTC_4x3x3_OES              = 0x93E1
-	COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR                = 0x93D0
-	COMPRESSED_SRGB8_ALPHA8_ASTC_4x4x3_OES              = 0x93E2
-	COMPRESSED_SRGB8_ALPHA8_ASTC_4x4x4_OES              = 0x93E3
-	COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR                = 0x93D1
-	COMPRESSED_SRGB8_ALPHA8_ASTC_5x4x4_OES              = 0x93E4
-	COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR                = 0x93D2
-	COMPRESSED_SRGB8_ALPHA8_ASTC_5x5x4_OES              = 0x93E5
-	COMPRESSED_SRGB8_ALPHA8_ASTC_5x5x5_OES              = 0x93E6
-	COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR                = 0x93D3
-	COMPRESSED_SRGB8_ALPHA8_ASTC_6x5x5_OES              = 0x93E7
-	COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR                = 0x93D4
-	COMPRESSED_SRGB8_ALPHA8_ASTC_6x6x5_OES              = 0x93E8
-	COMPRESSED_SRGB8_ALPHA8_ASTC_6x6x6_OES              = 0x93E9
-	COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR                = 0x93D5
-	COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR                = 0x93D6
-	COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR                = 0x93D7
-	COMPRESSED_SRGB8_ALPHA8_ETC2_EAC                    = 0x9279
-	COMPRESSED_SRGB8_ETC2                               = 0x9275
-	COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2           = 0x9277
-	COMPRESSED_SRGB_ALPHA_PVRTC_2BPPV1_EXT              = 0x8A56
-	COMPRESSED_SRGB_ALPHA_PVRTC_2BPPV2_IMG              = 0x93F0
-	COMPRESSED_SRGB_ALPHA_PVRTC_4BPPV1_EXT              = 0x8A57
-	COMPRESSED_SRGB_ALPHA_PVRTC_4BPPV2_IMG              = 0x93F1
-	COMPRESSED_SRGB_ALPHA_S3TC_DXT1_NV                  = 0x8C4D
-	COMPRESSED_SRGB_ALPHA_S3TC_DXT3_NV                  = 0x8C4E
-	COMPRESSED_SRGB_ALPHA_S3TC_DXT5_NV                  = 0x8C4F
-	COMPRESSED_SRGB_PVRTC_2BPPV1_EXT                    = 0x8A54
-	COMPRESSED_SRGB_PVRTC_4BPPV1_EXT                    = 0x8A55
-	COMPRESSED_SRGB_S3TC_DXT1_NV                        = 0x8C4C
-	COMPRESSED_TEXTURE_FORMATS                          = 0x86A3
-	COMPUTE_SHADER                                      = 0x91B9
-	COMPUTE_SHADER_BIT                                  = 0x00000020
-	COMPUTE_WORK_GROUP_SIZE                             = 0x8267
-	CONDITION_SATISFIED                                 = 0x911C
-	CONDITION_SATISFIED_APPLE                           = 0x911C
-	CONJOINT_NV                                         = 0x9284
-	CONSTANT_ALPHA                                      = 0x8003
-	CONSTANT_COLOR                                      = 0x8001
-	CONTEXT_FLAG_DEBUG_BIT                              = 0x00000002
-	CONTEXT_FLAG_DEBUG_BIT_KHR                          = 0x00000002
-	CONTEXT_LOST                                        = 0x0507
-	CONTEXT_LOST_KHR                                    = 0x0507
-	CONTEXT_RELEASE_BEHAVIOR                            = 0x82FB
-	CONTEXT_RELEASE_BEHAVIOR_FLUSH                      = 0x82FC
-	CONTEXT_RELEASE_BEHAVIOR_FLUSH_KHR                  = 0x82FC
-	CONTEXT_RELEASE_BEHAVIOR_KHR                        = 0x82FB
-	CONTEXT_ROBUST_ACCESS                               = 0x90F3
-	CONTEXT_ROBUST_ACCESS_EXT                           = 0x90F3
-	CONTEXT_ROBUST_ACCESS_KHR                           = 0x90F3
-	CONTRAST_NV                                         = 0x92A1
-	COPY_READ_BUFFER                                    = 0x8F36
-	COPY_READ_BUFFER_BINDING                            = 0x8F36
-	COPY_READ_BUFFER_NV                                 = 0x8F36
-	COPY_WRITE_BUFFER                                   = 0x8F37
-	COPY_WRITE_BUFFER_BINDING                           = 0x8F37
-	COPY_WRITE_BUFFER_NV                                = 0x8F37
-	COUNTER_RANGE_AMD                                   = 0x8BC1
-	COUNTER_TYPE_AMD                                    = 0x8BC0
-	COVERAGE_ALL_FRAGMENTS_NV                           = 0x8ED5
-	COVERAGE_ATTACHMENT_NV                              = 0x8ED2
-	COVERAGE_AUTOMATIC_NV                               = 0x8ED7
-	COVERAGE_BUFFERS_NV                                 = 0x8ED3
-	COVERAGE_BUFFER_BIT_NV                              = 0x00008000
-	COVERAGE_COMPONENT4_NV                              = 0x8ED1
-	COVERAGE_COMPONENT_NV                               = 0x8ED0
-	COVERAGE_EDGE_FRAGMENTS_NV                          = 0x8ED6
-	COVERAGE_SAMPLES_NV                                 = 0x8ED4
-	CPU_OPTIMIZED_QCOM                                  = 0x8FB1
-	CULL_FACE                                           = 0x0B44
-	CULL_FACE_MODE                                      = 0x0B45
-	CURRENT_PROGRAM                                     = 0x8B8D
-	CURRENT_QUERY                                       = 0x8865
-	CURRENT_QUERY_EXT                                   = 0x8865
-	CURRENT_VERTEX_ATTRIB                               = 0x8626
-	CW                                                  = 0x0900
-	DARKEN_KHR                                          = 0x9297
-	DARKEN_NV                                           = 0x9297
-	DEBUG_CALLBACK_FUNCTION                             = 0x8244
-	DEBUG_CALLBACK_FUNCTION_KHR                         = 0x8244
-	DEBUG_CALLBACK_USER_PARAM                           = 0x8245
-	DEBUG_CALLBACK_USER_PARAM_KHR                       = 0x8245
-	DEBUG_GROUP_STACK_DEPTH                             = 0x826D
-	DEBUG_GROUP_STACK_DEPTH_KHR                         = 0x826D
-	DEBUG_LOGGED_MESSAGES                               = 0x9145
-	DEBUG_LOGGED_MESSAGES_KHR                           = 0x9145
-	DEBUG_NEXT_LOGGED_MESSAGE_LENGTH                    = 0x8243
-	DEBUG_NEXT_LOGGED_MESSAGE_LENGTH_KHR                = 0x8243
-	DEBUG_OUTPUT                                        = 0x92E0
-	DEBUG_OUTPUT_KHR                                    = 0x92E0
-	DEBUG_OUTPUT_SYNCHRONOUS                            = 0x8242
-	DEBUG_OUTPUT_SYNCHRONOUS_KHR                        = 0x8242
-	DEBUG_SEVERITY_HIGH                                 = 0x9146
-	DEBUG_SEVERITY_HIGH_KHR                             = 0x9146
-	DEBUG_SEVERITY_LOW                                  = 0x9148
-	DEBUG_SEVERITY_LOW_KHR                              = 0x9148
-	DEBUG_SEVERITY_MEDIUM                               = 0x9147
-	DEBUG_SEVERITY_MEDIUM_KHR                           = 0x9147
-	DEBUG_SEVERITY_NOTIFICATION                         = 0x826B
-	DEBUG_SEVERITY_NOTIFICATION_KHR                     = 0x826B
-	DEBUG_SOURCE_API                                    = 0x8246
-	DEBUG_SOURCE_API_KHR                                = 0x8246
-	DEBUG_SOURCE_APPLICATION                            = 0x824A
-	DEBUG_SOURCE_APPLICATION_KHR                        = 0x824A
-	DEBUG_SOURCE_OTHER                                  = 0x824B
-	DEBUG_SOURCE_OTHER_KHR                              = 0x824B
-	DEBUG_SOURCE_SHADER_COMPILER                        = 0x8248
-	DEBUG_SOURCE_SHADER_COMPILER_KHR                    = 0x8248
-	DEBUG_SOURCE_THIRD_PARTY                            = 0x8249
-	DEBUG_SOURCE_THIRD_PARTY_KHR                        = 0x8249
-	DEBUG_SOURCE_WINDOW_SYSTEM                          = 0x8247
-	DEBUG_SOURCE_WINDOW_SYSTEM_KHR                      = 0x8247
-	DEBUG_TYPE_DEPRECATED_BEHAVIOR                      = 0x824D
-	DEBUG_TYPE_DEPRECATED_BEHAVIOR_KHR                  = 0x824D
-	DEBUG_TYPE_ERROR                                    = 0x824C
-	DEBUG_TYPE_ERROR_KHR                                = 0x824C
-	DEBUG_TYPE_MARKER                                   = 0x8268
-	DEBUG_TYPE_MARKER_KHR                               = 0x8268
-	DEBUG_TYPE_OTHER                                    = 0x8251
-	DEBUG_TYPE_OTHER_KHR                                = 0x8251
-	DEBUG_TYPE_PERFORMANCE                              = 0x8250
-	DEBUG_TYPE_PERFORMANCE_KHR                          = 0x8250
-	DEBUG_TYPE_POP_GROUP                                = 0x826A
-	DEBUG_TYPE_POP_GROUP_KHR                            = 0x826A
-	DEBUG_TYPE_PORTABILITY                              = 0x824F
-	DEBUG_TYPE_PORTABILITY_KHR                          = 0x824F
-	DEBUG_TYPE_PUSH_GROUP                               = 0x8269
-	DEBUG_TYPE_PUSH_GROUP_KHR                           = 0x8269
-	DEBUG_TYPE_UNDEFINED_BEHAVIOR                       = 0x824E
-	DEBUG_TYPE_UNDEFINED_BEHAVIOR_KHR                   = 0x824E
-	DECODE_EXT                                          = 0x8A49
-	DECR                                                = 0x1E03
-	DECR_WRAP                                           = 0x8508
-	DELETE_STATUS                                       = 0x8B80
-	DEPTH                                               = 0x1801
-	DEPTH24_STENCIL8                                    = 0x88F0
-	DEPTH24_STENCIL8_OES                                = 0x88F0
-	DEPTH32F_STENCIL8                                   = 0x8CAD
-	DEPTH_ATTACHMENT                                    = 0x8D00
-	DEPTH_BITS                                          = 0x0D56
-	DEPTH_BUFFER_BIT                                    = 0x00000100
-	DEPTH_BUFFER_BIT0_QCOM                              = 0x00000100
-	DEPTH_BUFFER_BIT1_QCOM                              = 0x00000200
-	DEPTH_BUFFER_BIT2_QCOM                              = 0x00000400
-	DEPTH_BUFFER_BIT3_QCOM                              = 0x00000800
-	DEPTH_BUFFER_BIT4_QCOM                              = 0x00001000
-	DEPTH_BUFFER_BIT5_QCOM                              = 0x00002000
-	DEPTH_BUFFER_BIT6_QCOM                              = 0x00004000
-	DEPTH_BUFFER_BIT7_QCOM                              = 0x00008000
-	DEPTH_CLEAR_VALUE                                   = 0x0B73
-	DEPTH_COMPONENT                                     = 0x1902
-	DEPTH_COMPONENT16                                   = 0x81A5
-	DEPTH_COMPONENT16_NONLINEAR_NV                      = 0x8E2C
-	DEPTH_COMPONENT16_OES                               = 0x81A5
-	DEPTH_COMPONENT24                                   = 0x81A6
-	DEPTH_COMPONENT24_OES                               = 0x81A6
-	DEPTH_COMPONENT32F                                  = 0x8CAC
-	DEPTH_COMPONENT32_OES                               = 0x81A7
-	DEPTH_EXT                                           = 0x1801
-	DEPTH_FUNC                                          = 0x0B74
-	DEPTH_RANGE                                         = 0x0B70
-	DEPTH_STENCIL                                       = 0x84F9
-	DEPTH_STENCIL_ATTACHMENT                            = 0x821A
-	DEPTH_STENCIL_OES                                   = 0x84F9
-	DEPTH_STENCIL_TEXTURE_MODE                          = 0x90EA
-	DEPTH_TEST                                          = 0x0B71
-	DEPTH_WRITEMASK                                     = 0x0B72
-	DIFFERENCE_KHR                                      = 0x929E
-	DIFFERENCE_NV                                       = 0x929E
-	DISJOINT_NV                                         = 0x9283
-	DISPATCH_INDIRECT_BUFFER                            = 0x90EE
-	DISPATCH_INDIRECT_BUFFER_BINDING                    = 0x90EF
-	DITHER                                              = 0x0BD0
-	DONT_CARE                                           = 0x1100
-	DRAW_BUFFER0                                        = 0x8825
-	DRAW_BUFFER0_EXT                                    = 0x8825
-	DRAW_BUFFER0_NV                                     = 0x8825
-	DRAW_BUFFER1                                        = 0x8826
-	DRAW_BUFFER10                                       = 0x882F
-	DRAW_BUFFER10_EXT                                   = 0x882F
-	DRAW_BUFFER10_NV                                    = 0x882F
-	DRAW_BUFFER11                                       = 0x8830
-	DRAW_BUFFER11_EXT                                   = 0x8830
-	DRAW_BUFFER11_NV                                    = 0x8830
-	DRAW_BUFFER12                                       = 0x8831
-	DRAW_BUFFER12_EXT                                   = 0x8831
-	DRAW_BUFFER12_NV                                    = 0x8831
-	DRAW_BUFFER13                                       = 0x8832
-	DRAW_BUFFER13_EXT                                   = 0x8832
-	DRAW_BUFFER13_NV                                    = 0x8832
-	DRAW_BUFFER14                                       = 0x8833
-	DRAW_BUFFER14_EXT                                   = 0x8833
-	DRAW_BUFFER14_NV                                    = 0x8833
-	DRAW_BUFFER15                                       = 0x8834
-	DRAW_BUFFER15_EXT                                   = 0x8834
-	DRAW_BUFFER15_NV                                    = 0x8834
-	DRAW_BUFFER1_EXT                                    = 0x8826
-	DRAW_BUFFER1_NV                                     = 0x8826
-	DRAW_BUFFER2                                        = 0x8827
-	DRAW_BUFFER2_EXT                                    = 0x8827
-	DRAW_BUFFER2_NV                                     = 0x8827
-	DRAW_BUFFER3                                        = 0x8828
-	DRAW_BUFFER3_EXT                                    = 0x8828
-	DRAW_BUFFER3_NV                                     = 0x8828
-	DRAW_BUFFER4                                        = 0x8829
-	DRAW_BUFFER4_EXT                                    = 0x8829
-	DRAW_BUFFER4_NV                                     = 0x8829
-	DRAW_BUFFER5                                        = 0x882A
-	DRAW_BUFFER5_EXT                                    = 0x882A
-	DRAW_BUFFER5_NV                                     = 0x882A
-	DRAW_BUFFER6                                        = 0x882B
-	DRAW_BUFFER6_EXT                                    = 0x882B
-	DRAW_BUFFER6_NV                                     = 0x882B
-	DRAW_BUFFER7                                        = 0x882C
-	DRAW_BUFFER7_EXT                                    = 0x882C
-	DRAW_BUFFER7_NV                                     = 0x882C
-	DRAW_BUFFER8                                        = 0x882D
-	DRAW_BUFFER8_EXT                                    = 0x882D
-	DRAW_BUFFER8_NV                                     = 0x882D
-	DRAW_BUFFER9                                        = 0x882E
-	DRAW_BUFFER9_EXT                                    = 0x882E
-	DRAW_BUFFER9_NV                                     = 0x882E
-	DRAW_BUFFER_EXT                                     = 0x0C01
-	DRAW_FRAMEBUFFER                                    = 0x8CA9
-	DRAW_FRAMEBUFFER_ANGLE                              = 0x8CA9
-	DRAW_FRAMEBUFFER_APPLE                              = 0x8CA9
-	DRAW_FRAMEBUFFER_BINDING                            = 0x8CA6
-	DRAW_FRAMEBUFFER_BINDING_ANGLE                      = 0x8CA6
-	DRAW_FRAMEBUFFER_BINDING_APPLE                      = 0x8CA6
-	DRAW_FRAMEBUFFER_BINDING_NV                         = 0x8CA6
-	DRAW_FRAMEBUFFER_NV                                 = 0x8CA9
-	DRAW_INDIRECT_BUFFER                                = 0x8F3F
-	DRAW_INDIRECT_BUFFER_BINDING                        = 0x8F43
-	DST_ALPHA                                           = 0x0304
-	DST_ATOP_NV                                         = 0x928F
-	DST_COLOR                                           = 0x0306
-	DST_IN_NV                                           = 0x928B
-	DST_NV                                              = 0x9287
-	DST_OUT_NV                                          = 0x928D
-	DST_OVER_NV                                         = 0x9289
-	DYNAMIC_COPY                                        = 0x88EA
-	DYNAMIC_DRAW                                        = 0x88E8
-	DYNAMIC_READ                                        = 0x88E9
-	ELEMENT_ARRAY_BARRIER_BIT                           = 0x00000002
-	ELEMENT_ARRAY_BUFFER                                = 0x8893
-	ELEMENT_ARRAY_BUFFER_BINDING                        = 0x8895
-	EQUAL                                               = 0x0202
-	ETC1_RGB8_OES                                       = 0x8D64
-	ETC1_SRGB8_NV                                       = 0x88EE
-	EXCLUSION_KHR                                       = 0x92A0
-	EXCLUSION_NV                                        = 0x92A0
-	EXTENSIONS                                          = 0x1F03
-	FALSE                                               = 0
-	FASTEST                                             = 0x1101
-	FENCE_CONDITION_NV                                  = 0x84F4
-	FENCE_STATUS_NV                                     = 0x84F3
-	FETCH_PER_SAMPLE_ARM                                = 0x8F65
-	FIRST_VERTEX_CONVENTION_EXT                         = 0x8E4D
-	FIXED                                               = 0x140C
-	FLOAT                                               = 0x1406
-	FLOAT_32_UNSIGNED_INT_24_8_REV                      = 0x8DAD
-	FLOAT_MAT2                                          = 0x8B5A
-	FLOAT_MAT2x3                                        = 0x8B65
-	FLOAT_MAT2x3_NV                                     = 0x8B65
-	FLOAT_MAT2x4                                        = 0x8B66
-	FLOAT_MAT2x4_NV                                     = 0x8B66
-	FLOAT_MAT3                                          = 0x8B5B
-	FLOAT_MAT3x2                                        = 0x8B67
-	FLOAT_MAT3x2_NV                                     = 0x8B67
-	FLOAT_MAT3x4                                        = 0x8B68
-	FLOAT_MAT3x4_NV                                     = 0x8B68
-	FLOAT_MAT4                                          = 0x8B5C
-	FLOAT_MAT4x2                                        = 0x8B69
-	FLOAT_MAT4x2_NV                                     = 0x8B69
-	FLOAT_MAT4x3                                        = 0x8B6A
-	FLOAT_MAT4x3_NV                                     = 0x8B6A
-	FLOAT_VEC2                                          = 0x8B50
-	FLOAT_VEC3                                          = 0x8B51
-	FLOAT_VEC4                                          = 0x8B52
-	FRACTIONAL_EVEN_EXT                                 = 0x8E7C
-	FRACTIONAL_ODD_EXT                                  = 0x8E7B
-	FRAGMENT_INTERPOLATION_OFFSET_BITS_OES              = 0x8E5D
-	FRAGMENT_SHADER                                     = 0x8B30
-	FRAGMENT_SHADER_BIT                                 = 0x00000002
-	FRAGMENT_SHADER_BIT_EXT                             = 0x00000002
-	FRAGMENT_SHADER_DERIVATIVE_HINT                     = 0x8B8B
-	FRAGMENT_SHADER_DERIVATIVE_HINT_OES                 = 0x8B8B
-	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                = 0x8A52
-	FRAGMENT_SHADER_FRAMEBUFFER_FETCH_MRT_ARM           = 0x8F66
-	FRAMEBUFFER                                         = 0x8D40
-	FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE                   = 0x8215
-	FRAMEBUFFER_ATTACHMENT_ANGLE                        = 0x93A3
-	FRAMEBUFFER_ATTACHMENT_BLUE_SIZE                    = 0x8214
-	FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING               = 0x8210
-	FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT           = 0x8210
-	FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE               = 0x8211
-	FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT           = 0x8211
-	FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE                   = 0x8216
-	FRAMEBUFFER_ATTACHMENT_GREEN_SIZE                   = 0x8213
-	FRAMEBUFFER_ATTACHMENT_LAYERED_EXT                  = 0x8DA7
-	FRAMEBUFFER_ATTACHMENT_OBJECT_NAME                  = 0x8CD1
-	FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE                  = 0x8CD0
-	FRAMEBUFFER_ATTACHMENT_RED_SIZE                     = 0x8212
-	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                 = 0x8217
-	FRAMEBUFFER_ATTACHMENT_TEXTURE_3D_ZOFFSET_OES       = 0x8CD4
-	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE        = 0x8CD3
-	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                = 0x8CD4
-	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                = 0x8CD2
-	FRAMEBUFFER_ATTACHMENT_TEXTURE_SAMPLES_EXT          = 0x8D6C
-	FRAMEBUFFER_BARRIER_BIT                             = 0x00000400
-	FRAMEBUFFER_BINDING                                 = 0x8CA6
-	FRAMEBUFFER_COMPLETE                                = 0x8CD5
-	FRAMEBUFFER_DEFAULT                                 = 0x8218
-	FRAMEBUFFER_DEFAULT_FIXED_SAMPLE_LOCATIONS          = 0x9314
-	FRAMEBUFFER_DEFAULT_HEIGHT                          = 0x9311
-	FRAMEBUFFER_DEFAULT_LAYERS_EXT                      = 0x9312
-	FRAMEBUFFER_DEFAULT_SAMPLES                         = 0x9313
-	FRAMEBUFFER_DEFAULT_WIDTH                           = 0x9310
-	FRAMEBUFFER_INCOMPLETE_ATTACHMENT                   = 0x8CD6
-	FRAMEBUFFER_INCOMPLETE_DIMENSIONS                   = 0x8CD9
-	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS_EXT            = 0x8DA8
-	FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT           = 0x8CD7
-	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE                  = 0x8D56
-	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_ANGLE            = 0x8D56
-	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_APPLE            = 0x8D56
-	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_EXT              = 0x8D56
-	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_IMG              = 0x9134
-	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_NV               = 0x8D56
-	FRAMEBUFFER_SRGB_EXT                                = 0x8DB9
-	FRAMEBUFFER_UNDEFINED                               = 0x8219
-	FRAMEBUFFER_UNDEFINED_OES                           = 0x8219
-	FRAMEBUFFER_UNSUPPORTED                             = 0x8CDD
-	FRONT                                               = 0x0404
-	FRONT_AND_BACK                                      = 0x0408
-	FRONT_FACE                                          = 0x0B46
-	FUNC_ADD                                            = 0x8006
-	FUNC_ADD_EXT                                        = 0x8006
-	FUNC_REVERSE_SUBTRACT                               = 0x800B
-	FUNC_SUBTRACT                                       = 0x800A
-	GCCSO_SHADER_BINARY_FJ                              = 0x9260
-	GENERATE_MIPMAP_HINT                                = 0x8192
-	GEOMETRY_LINKED_INPUT_TYPE_EXT                      = 0x8917
-	GEOMETRY_LINKED_OUTPUT_TYPE_EXT                     = 0x8918
-	GEOMETRY_LINKED_VERTICES_OUT_EXT                    = 0x8916
-	GEOMETRY_SHADER_BIT_EXT                             = 0x00000004
-	GEOMETRY_SHADER_EXT                                 = 0x8DD9
-	GEOMETRY_SHADER_INVOCATIONS_EXT                     = 0x887F
-	GEQUAL                                              = 0x0206
-	GPU_DISJOINT_EXT                                    = 0x8FBB
-	GPU_OPTIMIZED_QCOM                                  = 0x8FB2
-	GREATER                                             = 0x0204
-	GREEN                                               = 0x1904
-	GREEN_BITS                                          = 0x0D53
-	GREEN_NV                                            = 0x1904
-	GUILTY_CONTEXT_RESET                                = 0x8253
-	GUILTY_CONTEXT_RESET_EXT                            = 0x8253
-	GUILTY_CONTEXT_RESET_KHR                            = 0x8253
-	HALF_FLOAT                                          = 0x140B
-	HALF_FLOAT_OES                                      = 0x8D61
-	HARDLIGHT_KHR                                       = 0x929B
-	HARDLIGHT_NV                                        = 0x929B
-	HARDMIX_NV                                          = 0x92A9
-	HIGH_FLOAT                                          = 0x8DF2
-	HIGH_INT                                            = 0x8DF5
-	HSL_COLOR_KHR                                       = 0x92AF
-	HSL_COLOR_NV                                        = 0x92AF
-	HSL_HUE_KHR                                         = 0x92AD
-	HSL_HUE_NV                                          = 0x92AD
-	HSL_LUMINOSITY_KHR                                  = 0x92B0
-	HSL_LUMINOSITY_NV                                   = 0x92B0
-	HSL_SATURATION_KHR                                  = 0x92AE
-	HSL_SATURATION_NV                                   = 0x92AE
-	IMAGE_2D                                            = 0x904D
-	IMAGE_2D_ARRAY                                      = 0x9053
-	IMAGE_3D                                            = 0x904E
-	IMAGE_BINDING_ACCESS                                = 0x8F3E
-	IMAGE_BINDING_FORMAT                                = 0x906E
-	IMAGE_BINDING_LAYER                                 = 0x8F3D
-	IMAGE_BINDING_LAYERED                               = 0x8F3C
-	IMAGE_BINDING_LEVEL                                 = 0x8F3B
-	IMAGE_BINDING_NAME                                  = 0x8F3A
-	IMAGE_BUFFER_EXT                                    = 0x9051
-	IMAGE_CUBE                                          = 0x9050
-	IMAGE_CUBE_MAP_ARRAY_EXT                            = 0x9054
-	IMAGE_FORMAT_COMPATIBILITY_BY_CLASS                 = 0x90C9
-	IMAGE_FORMAT_COMPATIBILITY_BY_SIZE                  = 0x90C8
-	IMAGE_FORMAT_COMPATIBILITY_TYPE                     = 0x90C7
-	IMPLEMENTATION_COLOR_READ_FORMAT                    = 0x8B9B
-	IMPLEMENTATION_COLOR_READ_TYPE                      = 0x8B9A
-	INCR                                                = 0x1E02
-	INCR_WRAP                                           = 0x8507
-	INFO_LOG_LENGTH                                     = 0x8B84
-	INNOCENT_CONTEXT_RESET                              = 0x8254
-	INNOCENT_CONTEXT_RESET_EXT                          = 0x8254
-	INNOCENT_CONTEXT_RESET_KHR                          = 0x8254
-	INT                                                 = 0x1404
-	INTERLEAVED_ATTRIBS                                 = 0x8C8C
-	INT_10_10_10_2_OES                                  = 0x8DF7
-	INT_2_10_10_10_REV                                  = 0x8D9F
-	INT_IMAGE_2D                                        = 0x9058
-	INT_IMAGE_2D_ARRAY                                  = 0x905E
-	INT_IMAGE_3D                                        = 0x9059
-	INT_IMAGE_BUFFER_EXT                                = 0x905C
-	INT_IMAGE_CUBE                                      = 0x905B
-	INT_IMAGE_CUBE_MAP_ARRAY_EXT                        = 0x905F
-	INT_SAMPLER_2D                                      = 0x8DCA
-	INT_SAMPLER_2D_ARRAY                                = 0x8DCF
-	INT_SAMPLER_2D_MULTISAMPLE                          = 0x9109
-	INT_SAMPLER_2D_MULTISAMPLE_ARRAY_OES                = 0x910C
-	INT_SAMPLER_3D                                      = 0x8DCB
-	INT_SAMPLER_BUFFER_EXT                              = 0x8DD0
-	INT_SAMPLER_CUBE                                    = 0x8DCC
-	INT_SAMPLER_CUBE_MAP_ARRAY_EXT                      = 0x900E
-	INT_VEC2                                            = 0x8B53
-	INT_VEC3                                            = 0x8B54
-	INT_VEC4                                            = 0x8B55
-	INVALID_ENUM                                        = 0x0500
-	INVALID_FRAMEBUFFER_OPERATION                       = 0x0506
-	INVALID_INDEX                                       = 0xFFFFFFFF
-	INVALID_OPERATION                                   = 0x0502
-	INVALID_VALUE                                       = 0x0501
-	INVERT                                              = 0x150A
-	INVERT_OVG_NV                                       = 0x92B4
-	INVERT_RGB_NV                                       = 0x92A3
-	ISOLINES_EXT                                        = 0x8E7A
-	IS_PER_PATCH_EXT                                    = 0x92E7
-	IS_ROW_MAJOR                                        = 0x9300
-	KEEP                                                = 0x1E00
-	LAST_VERTEX_CONVENTION_EXT                          = 0x8E4E
-	LAYER_PROVOKING_VERTEX_EXT                          = 0x825E
-	LEQUAL                                              = 0x0203
-	LESS                                                = 0x0201
-	LIGHTEN_KHR                                         = 0x9298
-	LIGHTEN_NV                                          = 0x9298
-	LINEAR                                              = 0x2601
-	LINEARBURN_NV                                       = 0x92A5
-	LINEARDODGE_NV                                      = 0x92A4
-	LINEARLIGHT_NV                                      = 0x92A7
-	LINEAR_MIPMAP_LINEAR                                = 0x2703
-	LINEAR_MIPMAP_NEAREST                               = 0x2701
-	LINES                                               = 0x0001
-	LINES_ADJACENCY_EXT                                 = 0x000A
-	LINE_LOOP                                           = 0x0002
-	LINE_STRIP                                          = 0x0003
-	LINE_STRIP_ADJACENCY_EXT                            = 0x000B
-	LINE_WIDTH                                          = 0x0B21
-	LINK_STATUS                                         = 0x8B82
-	LOCATION                                            = 0x930E
-	LOSE_CONTEXT_ON_RESET                               = 0x8252
-	LOSE_CONTEXT_ON_RESET_EXT                           = 0x8252
-	LOSE_CONTEXT_ON_RESET_KHR                           = 0x8252
-	LOW_FLOAT                                           = 0x8DF0
-	LOW_INT                                             = 0x8DF3
-	LUMINANCE                                           = 0x1909
-	LUMINANCE16F_EXT                                    = 0x881E
-	LUMINANCE32F_EXT                                    = 0x8818
-	LUMINANCE4_ALPHA4_OES                               = 0x8043
-	LUMINANCE8_ALPHA8_EXT                               = 0x8045
-	LUMINANCE8_ALPHA8_OES                               = 0x8045
-	LUMINANCE8_EXT                                      = 0x8040
-	LUMINANCE8_OES                                      = 0x8040
-	LUMINANCE_ALPHA                                     = 0x190A
-	LUMINANCE_ALPHA16F_EXT                              = 0x881F
-	LUMINANCE_ALPHA32F_EXT                              = 0x8819
-	MAJOR_VERSION                                       = 0x821B
-	MALI_PROGRAM_BINARY_ARM                             = 0x8F61
-	MALI_SHADER_BINARY_ARM                              = 0x8F60
-	MAP_FLUSH_EXPLICIT_BIT                              = 0x0010
-	MAP_FLUSH_EXPLICIT_BIT_EXT                          = 0x0010
-	MAP_INVALIDATE_BUFFER_BIT                           = 0x0008
-	MAP_INVALIDATE_BUFFER_BIT_EXT                       = 0x0008
-	MAP_INVALIDATE_RANGE_BIT                            = 0x0004
-	MAP_INVALIDATE_RANGE_BIT_EXT                        = 0x0004
-	MAP_READ_BIT                                        = 0x0001
-	MAP_READ_BIT_EXT                                    = 0x0001
-	MAP_UNSYNCHRONIZED_BIT                              = 0x0020
-	MAP_UNSYNCHRONIZED_BIT_EXT                          = 0x0020
-	MAP_WRITE_BIT                                       = 0x0002
-	MAP_WRITE_BIT_EXT                                   = 0x0002
-	MATRIX_STRIDE                                       = 0x92FF
-	MAX                                                 = 0x8008
-	MAX_3D_TEXTURE_SIZE                                 = 0x8073
-	MAX_3D_TEXTURE_SIZE_OES                             = 0x8073
-	MAX_ARRAY_TEXTURE_LAYERS                            = 0x88FF
-	MAX_ATOMIC_COUNTER_BUFFER_BINDINGS                  = 0x92DC
-	MAX_ATOMIC_COUNTER_BUFFER_SIZE                      = 0x92D8
-	MAX_COLOR_ATTACHMENTS                               = 0x8CDF
-	MAX_COLOR_ATTACHMENTS_EXT                           = 0x8CDF
-	MAX_COLOR_ATTACHMENTS_NV                            = 0x8CDF
-	MAX_COLOR_TEXTURE_SAMPLES                           = 0x910E
-	MAX_COMBINED_ATOMIC_COUNTERS                        = 0x92D7
-	MAX_COMBINED_ATOMIC_COUNTER_BUFFERS                 = 0x92D1
-	MAX_COMBINED_COMPUTE_UNIFORM_COMPONENTS             = 0x8266
-	MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS            = 0x8A33
-	MAX_COMBINED_GEOMETRY_UNIFORM_COMPONENTS_EXT        = 0x8A32
-	MAX_COMBINED_IMAGE_UNIFORMS                         = 0x90CF
-	MAX_COMBINED_SHADER_OUTPUT_RESOURCES                = 0x8F39
-	MAX_COMBINED_SHADER_STORAGE_BLOCKS                  = 0x90DC
-	MAX_COMBINED_TESS_CONTROL_UNIFORM_COMPONENTS_EXT    = 0x8E1E
-	MAX_COMBINED_TESS_EVALUATION_UNIFORM_COMPONENTS_EXT = 0x8E1F
-	MAX_COMBINED_TEXTURE_IMAGE_UNITS                    = 0x8B4D
-	MAX_COMBINED_UNIFORM_BLOCKS                         = 0x8A2E
-	MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS              = 0x8A31
-	MAX_COMPUTE_ATOMIC_COUNTERS                         = 0x8265
-	MAX_COMPUTE_ATOMIC_COUNTER_BUFFERS                  = 0x8264
-	MAX_COMPUTE_IMAGE_UNIFORMS                          = 0x91BD
-	MAX_COMPUTE_SHADER_STORAGE_BLOCKS                   = 0x90DB
-	MAX_COMPUTE_SHARED_MEMORY_SIZE                      = 0x8262
-	MAX_COMPUTE_TEXTURE_IMAGE_UNITS                     = 0x91BC
-	MAX_COMPUTE_UNIFORM_BLOCKS                          = 0x91BB
-	MAX_COMPUTE_UNIFORM_COMPONENTS                      = 0x8263
-	MAX_COMPUTE_WORK_GROUP_COUNT                        = 0x91BE
-	MAX_COMPUTE_WORK_GROUP_INVOCATIONS                  = 0x90EB
-	MAX_COMPUTE_WORK_GROUP_SIZE                         = 0x91BF
-	MAX_CUBE_MAP_TEXTURE_SIZE                           = 0x851C
-	MAX_DEBUG_GROUP_STACK_DEPTH                         = 0x826C
-	MAX_DEBUG_GROUP_STACK_DEPTH_KHR                     = 0x826C
-	MAX_DEBUG_LOGGED_MESSAGES                           = 0x9144
-	MAX_DEBUG_LOGGED_MESSAGES_KHR                       = 0x9144
-	MAX_DEBUG_MESSAGE_LENGTH                            = 0x9143
-	MAX_DEBUG_MESSAGE_LENGTH_KHR                        = 0x9143
-	MAX_DEPTH_TEXTURE_SAMPLES                           = 0x910F
-	MAX_DRAW_BUFFERS                                    = 0x8824
-	MAX_DRAW_BUFFERS_EXT                                = 0x8824
-	MAX_DRAW_BUFFERS_NV                                 = 0x8824
-	MAX_ELEMENTS_INDICES                                = 0x80E9
-	MAX_ELEMENTS_VERTICES                               = 0x80E8
-	MAX_ELEMENT_INDEX                                   = 0x8D6B
-	MAX_EXT                                             = 0x8008
-	MAX_FRAGMENT_ATOMIC_COUNTERS                        = 0x92D6
-	MAX_FRAGMENT_ATOMIC_COUNTER_BUFFERS                 = 0x92D0
-	MAX_FRAGMENT_IMAGE_UNIFORMS                         = 0x90CE
-	MAX_FRAGMENT_INPUT_COMPONENTS                       = 0x9125
-	MAX_FRAGMENT_INTERPOLATION_OFFSET_OES               = 0x8E5C
-	MAX_FRAGMENT_SHADER_STORAGE_BLOCKS                  = 0x90DA
-	MAX_FRAGMENT_UNIFORM_BLOCKS                         = 0x8A2D
-	MAX_FRAGMENT_UNIFORM_COMPONENTS                     = 0x8B49
-	MAX_FRAGMENT_UNIFORM_VECTORS                        = 0x8DFD
-	MAX_FRAMEBUFFER_HEIGHT                              = 0x9316
-	MAX_FRAMEBUFFER_LAYERS_EXT                          = 0x9317
-	MAX_FRAMEBUFFER_SAMPLES                             = 0x9318
-	MAX_FRAMEBUFFER_WIDTH                               = 0x9315
-	MAX_GEOMETRY_ATOMIC_COUNTERS_EXT                    = 0x92D5
-	MAX_GEOMETRY_ATOMIC_COUNTER_BUFFERS_EXT             = 0x92CF
-	MAX_GEOMETRY_IMAGE_UNIFORMS_EXT                     = 0x90CD
-	MAX_GEOMETRY_INPUT_COMPONENTS_EXT                   = 0x9123
-	MAX_GEOMETRY_OUTPUT_COMPONENTS_EXT                  = 0x9124
-	MAX_GEOMETRY_OUTPUT_VERTICES_EXT                    = 0x8DE0
-	MAX_GEOMETRY_SHADER_INVOCATIONS_EXT                 = 0x8E5A
-	MAX_GEOMETRY_SHADER_STORAGE_BLOCKS_EXT              = 0x90D7
-	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS_EXT                = 0x8C29
-	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS_EXT            = 0x8DE1
-	MAX_GEOMETRY_UNIFORM_BLOCKS_EXT                     = 0x8A2C
-	MAX_GEOMETRY_UNIFORM_COMPONENTS_EXT                 = 0x8DDF
-	MAX_IMAGE_UNITS                                     = 0x8F38
-	MAX_INTEGER_SAMPLES                                 = 0x9110
-	MAX_LABEL_LENGTH                                    = 0x82E8
-	MAX_LABEL_LENGTH_KHR                                = 0x82E8
-	MAX_MULTIVIEW_BUFFERS_EXT                           = 0x90F2
-	MAX_NAME_LENGTH                                     = 0x92F6
-	MAX_NUM_ACTIVE_VARIABLES                            = 0x92F7
-	MAX_PATCH_VERTICES_EXT                              = 0x8E7D
-	MAX_PROGRAM_TEXEL_OFFSET                            = 0x8905
-	MAX_PROGRAM_TEXTURE_GATHER_OFFSET                   = 0x8E5F
-	MAX_RENDERBUFFER_SIZE                               = 0x84E8
-	MAX_SAMPLES                                         = 0x8D57
-	MAX_SAMPLES_ANGLE                                   = 0x8D57
-	MAX_SAMPLES_APPLE                                   = 0x8D57
-	MAX_SAMPLES_EXT                                     = 0x8D57
-	MAX_SAMPLES_IMG                                     = 0x9135
-	MAX_SAMPLES_NV                                      = 0x8D57
-	MAX_SAMPLE_MASK_WORDS                               = 0x8E59
-	MAX_SERVER_WAIT_TIMEOUT                             = 0x9111
-	MAX_SERVER_WAIT_TIMEOUT_APPLE                       = 0x9111
-	MAX_SHADER_PIXEL_LOCAL_STORAGE_FAST_SIZE_EXT        = 0x8F63
-	MAX_SHADER_PIXEL_LOCAL_STORAGE_SIZE_EXT             = 0x8F67
-	MAX_SHADER_STORAGE_BLOCK_SIZE                       = 0x90DE
-	MAX_SHADER_STORAGE_BUFFER_BINDINGS                  = 0x90DD
-	MAX_TESS_CONTROL_ATOMIC_COUNTERS_EXT                = 0x92D3
-	MAX_TESS_CONTROL_ATOMIC_COUNTER_BUFFERS_EXT         = 0x92CD
-	MAX_TESS_CONTROL_IMAGE_UNIFORMS_EXT                 = 0x90CB
-	MAX_TESS_CONTROL_INPUT_COMPONENTS_EXT               = 0x886C
-	MAX_TESS_CONTROL_OUTPUT_COMPONENTS_EXT              = 0x8E83
-	MAX_TESS_CONTROL_SHADER_STORAGE_BLOCKS_EXT          = 0x90D8
-	MAX_TESS_CONTROL_TEXTURE_IMAGE_UNITS_EXT            = 0x8E81
-	MAX_TESS_CONTROL_TOTAL_OUTPUT_COMPONENTS_EXT        = 0x8E85
-	MAX_TESS_CONTROL_UNIFORM_BLOCKS_EXT                 = 0x8E89
-	MAX_TESS_CONTROL_UNIFORM_COMPONENTS_EXT             = 0x8E7F
-	MAX_TESS_EVALUATION_ATOMIC_COUNTERS_EXT             = 0x92D4
-	MAX_TESS_EVALUATION_ATOMIC_COUNTER_BUFFERS_EXT      = 0x92CE
-	MAX_TESS_EVALUATION_IMAGE_UNIFORMS_EXT              = 0x90CC
-	MAX_TESS_EVALUATION_INPUT_COMPONENTS_EXT            = 0x886D
-	MAX_TESS_EVALUATION_OUTPUT_COMPONENTS_EXT           = 0x8E86
-	MAX_TESS_EVALUATION_SHADER_STORAGE_BLOCKS_EXT       = 0x90D9
-	MAX_TESS_EVALUATION_TEXTURE_IMAGE_UNITS_EXT         = 0x8E82
-	MAX_TESS_EVALUATION_UNIFORM_BLOCKS_EXT              = 0x8E8A
-	MAX_TESS_EVALUATION_UNIFORM_COMPONENTS_EXT          = 0x8E80
-	MAX_TESS_GEN_LEVEL_EXT                              = 0x8E7E
-	MAX_TESS_PATCH_COMPONENTS_EXT                       = 0x8E84
-	MAX_TEXTURE_BUFFER_SIZE_EXT                         = 0x8C2B
-	MAX_TEXTURE_IMAGE_UNITS                             = 0x8872
-	MAX_TEXTURE_LOD_BIAS                                = 0x84FD
-	MAX_TEXTURE_MAX_ANISOTROPY_EXT                      = 0x84FF
-	MAX_TEXTURE_SIZE                                    = 0x0D33
-	MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS       = 0x8C8A
-	MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS             = 0x8C8B
-	MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS          = 0x8C80
-	MAX_UNIFORM_BLOCK_SIZE                              = 0x8A30
-	MAX_UNIFORM_BUFFER_BINDINGS                         = 0x8A2F
-	MAX_UNIFORM_LOCATIONS                               = 0x826E
-	MAX_VARYING_COMPONENTS                              = 0x8B4B
-	MAX_VARYING_VECTORS                                 = 0x8DFC
-	MAX_VERTEX_ATOMIC_COUNTERS                          = 0x92D2
-	MAX_VERTEX_ATOMIC_COUNTER_BUFFERS                   = 0x92CC
-	MAX_VERTEX_ATTRIBS                                  = 0x8869
-	MAX_VERTEX_ATTRIB_BINDINGS                          = 0x82DA
-	MAX_VERTEX_ATTRIB_RELATIVE_OFFSET                   = 0x82D9
-	MAX_VERTEX_ATTRIB_STRIDE                            = 0x82E5
-	MAX_VERTEX_IMAGE_UNIFORMS                           = 0x90CA
-	MAX_VERTEX_OUTPUT_COMPONENTS                        = 0x9122
-	MAX_VERTEX_SHADER_STORAGE_BLOCKS                    = 0x90D6
-	MAX_VERTEX_TEXTURE_IMAGE_UNITS                      = 0x8B4C
-	MAX_VERTEX_UNIFORM_BLOCKS                           = 0x8A2B
-	MAX_VERTEX_UNIFORM_COMPONENTS                       = 0x8B4A
-	MAX_VERTEX_UNIFORM_VECTORS                          = 0x8DFB
-	MAX_VIEWPORT_DIMS                                   = 0x0D3A
-	MEDIUM_FLOAT                                        = 0x8DF1
-	MEDIUM_INT                                          = 0x8DF4
-	MIN                                                 = 0x8007
-	MINOR_VERSION                                       = 0x821C
-	MINUS_CLAMPED_NV                                    = 0x92B3
-	MINUS_NV                                            = 0x929F
-	MIN_EXT                                             = 0x8007
-	MIN_FRAGMENT_INTERPOLATION_OFFSET_OES               = 0x8E5B
-	MIN_PROGRAM_TEXEL_OFFSET                            = 0x8904
-	MIN_PROGRAM_TEXTURE_GATHER_OFFSET                   = 0x8E5E
-	MIN_SAMPLE_SHADING_VALUE_OES                        = 0x8C37
-	MIRRORED_REPEAT                                     = 0x8370
-	MULTIPLY_KHR                                        = 0x9294
-	MULTIPLY_NV                                         = 0x9294
-	MULTISAMPLE_BUFFER_BIT0_QCOM                        = 0x01000000
-	MULTISAMPLE_BUFFER_BIT1_QCOM                        = 0x02000000
-	MULTISAMPLE_BUFFER_BIT2_QCOM                        = 0x04000000
-	MULTISAMPLE_BUFFER_BIT3_QCOM                        = 0x08000000
-	MULTISAMPLE_BUFFER_BIT4_QCOM                        = 0x10000000
-	MULTISAMPLE_BUFFER_BIT5_QCOM                        = 0x20000000
-	MULTISAMPLE_BUFFER_BIT6_QCOM                        = 0x40000000
-	MULTISAMPLE_BUFFER_BIT7_QCOM                        = 0x80000000
-	MULTIVIEW_EXT                                       = 0x90F1
-	NAME_LENGTH                                         = 0x92F9
-	NEAREST                                             = 0x2600
-	NEAREST_MIPMAP_LINEAR                               = 0x2702
-	NEAREST_MIPMAP_NEAREST                              = 0x2700
-	NEVER                                               = 0x0200
-	NICEST                                              = 0x1102
-	NONE                                                = 0
-	NOTEQUAL                                            = 0x0205
-	NO_ERROR                                            = 0
-	NO_RESET_NOTIFICATION                               = 0x8261
-	NO_RESET_NOTIFICATION_EXT                           = 0x8261
-	NO_RESET_NOTIFICATION_KHR                           = 0x8261
-	NUM_ACTIVE_VARIABLES                                = 0x9304
-	NUM_COMPRESSED_TEXTURE_FORMATS                      = 0x86A2
-	NUM_EXTENSIONS                                      = 0x821D
-	NUM_PROGRAM_BINARY_FORMATS                          = 0x87FE
-	NUM_PROGRAM_BINARY_FORMATS_OES                      = 0x87FE
-	NUM_SAMPLE_COUNTS                                   = 0x9380
-	NUM_SHADER_BINARY_FORMATS                           = 0x8DF9
-	OBJECT_TYPE                                         = 0x9112
-	OBJECT_TYPE_APPLE                                   = 0x9112
-	OFFSET                                              = 0x92FC
-	ONE                                                 = 1
-	ONE_MINUS_CONSTANT_ALPHA                            = 0x8004
-	ONE_MINUS_CONSTANT_COLOR                            = 0x8002
-	ONE_MINUS_DST_ALPHA                                 = 0x0305
-	ONE_MINUS_DST_COLOR                                 = 0x0307
-	ONE_MINUS_SRC_ALPHA                                 = 0x0303
-	ONE_MINUS_SRC_COLOR                                 = 0x0301
-	OUT_OF_MEMORY                                       = 0x0505
-	OVERLAY_KHR                                         = 0x9296
-	OVERLAY_NV                                          = 0x9296
-	PACK_ALIGNMENT                                      = 0x0D05
-	PACK_REVERSE_ROW_ORDER_ANGLE                        = 0x93A4
-	PACK_ROW_LENGTH                                     = 0x0D02
-	PACK_SKIP_PIXELS                                    = 0x0D04
-	PACK_SKIP_ROWS                                      = 0x0D03
-	PALETTE4_R5_G6_B5_OES                               = 0x8B92
-	PALETTE4_RGB5_A1_OES                                = 0x8B94
-	PALETTE4_RGB8_OES                                   = 0x8B90
-	PALETTE4_RGBA4_OES                                  = 0x8B93
-	PALETTE4_RGBA8_OES                                  = 0x8B91
-	PALETTE8_R5_G6_B5_OES                               = 0x8B97
-	PALETTE8_RGB5_A1_OES                                = 0x8B99
-	PALETTE8_RGB8_OES                                   = 0x8B95
-	PALETTE8_RGBA4_OES                                  = 0x8B98
-	PALETTE8_RGBA8_OES                                  = 0x8B96
-	PATCHES_EXT                                         = 0x000E
-	PATCH_VERTICES_EXT                                  = 0x8E72
-	PERCENTAGE_AMD                                      = 0x8BC3
-	PERFMON_GLOBAL_MODE_QCOM                            = 0x8FA0
-	PERFMON_RESULT_AMD                                  = 0x8BC6
-	PERFMON_RESULT_AVAILABLE_AMD                        = 0x8BC4
-	PERFMON_RESULT_SIZE_AMD                             = 0x8BC5
-	PERFQUERY_COUNTER_DATA_BOOL32_INTEL                 = 0x94FC
-	PERFQUERY_COUNTER_DATA_DOUBLE_INTEL                 = 0x94FB
-	PERFQUERY_COUNTER_DATA_FLOAT_INTEL                  = 0x94FA
-	PERFQUERY_COUNTER_DATA_UINT32_INTEL                 = 0x94F8
-	PERFQUERY_COUNTER_DATA_UINT64_INTEL                 = 0x94F9
-	PERFQUERY_COUNTER_DESC_LENGTH_MAX_INTEL             = 0x94FF
-	PERFQUERY_COUNTER_DURATION_NORM_INTEL               = 0x94F1
-	PERFQUERY_COUNTER_DURATION_RAW_INTEL                = 0x94F2
-	PERFQUERY_COUNTER_EVENT_INTEL                       = 0x94F0
-	PERFQUERY_COUNTER_NAME_LENGTH_MAX_INTEL             = 0x94FE
-	PERFQUERY_COUNTER_RAW_INTEL                         = 0x94F4
-	PERFQUERY_COUNTER_THROUGHPUT_INTEL                  = 0x94F3
-	PERFQUERY_COUNTER_TIMESTAMP_INTEL                   = 0x94F5
-	PERFQUERY_DONOT_FLUSH_INTEL                         = 0x83F9
-	PERFQUERY_FLUSH_INTEL                               = 0x83FA
-	PERFQUERY_GLOBAL_CONTEXT_INTEL                      = 0x00000001
-	PERFQUERY_GPA_EXTENDED_COUNTERS_INTEL               = 0x9500
-	PERFQUERY_QUERY_NAME_LENGTH_MAX_INTEL               = 0x94FD
-	PERFQUERY_SINGLE_CONTEXT_INTEL                      = 0x00000000
-	PERFQUERY_WAIT_INTEL                                = 0x83FB
-	PINLIGHT_NV                                         = 0x92A8
-	PIXEL_BUFFER_BARRIER_BIT                            = 0x00000080
-	PIXEL_PACK_BUFFER                                   = 0x88EB
-	PIXEL_PACK_BUFFER_BINDING                           = 0x88ED
-	PIXEL_UNPACK_BUFFER                                 = 0x88EC
-	PIXEL_UNPACK_BUFFER_BINDING                         = 0x88EF
-	PLUS_CLAMPED_ALPHA_NV                               = 0x92B2
-	PLUS_CLAMPED_NV                                     = 0x92B1
-	PLUS_DARKER_NV                                      = 0x9292
-	PLUS_NV                                             = 0x9291
-	POINTS                                              = 0x0000
-	POLYGON_OFFSET_FACTOR                               = 0x8038
-	POLYGON_OFFSET_FILL                                 = 0x8037
-	POLYGON_OFFSET_UNITS                                = 0x2A00
-	PRIMITIVES_GENERATED_EXT                            = 0x8C87
-	PRIMITIVE_BOUNDING_BOX_EXT                          = 0x92BE
-	PRIMITIVE_RESTART_FIXED_INDEX                       = 0x8D69
-	PRIMITIVE_RESTART_FOR_PATCHES_SUPPORTED             = 0x8221
-	PROGRAM                                             = 0x82E2
-	PROGRAM_BINARY_ANGLE                                = 0x93A6
-	PROGRAM_BINARY_FORMATS                              = 0x87FF
-	PROGRAM_BINARY_FORMATS_OES                          = 0x87FF
-	PROGRAM_BINARY_LENGTH                               = 0x8741
-	PROGRAM_BINARY_LENGTH_OES                           = 0x8741
-	PROGRAM_BINARY_RETRIEVABLE_HINT                     = 0x8257
-	PROGRAM_INPUT                                       = 0x92E3
-	PROGRAM_KHR                                         = 0x82E2
-	PROGRAM_OBJECT_EXT                                  = 0x8B40
-	PROGRAM_OUTPUT                                      = 0x92E4
-	PROGRAM_PIPELINE                                    = 0x82E4
-	PROGRAM_PIPELINE_BINDING                            = 0x825A
-	PROGRAM_PIPELINE_BINDING_EXT                        = 0x825A
-	PROGRAM_PIPELINE_OBJECT_EXT                         = 0x8A4F
-	PROGRAM_SEPARABLE                                   = 0x8258
-	PROGRAM_SEPARABLE_EXT                               = 0x8258
-	QUADS_EXT                                           = 0x0007
-	QUERY                                               = 0x82E3
-	QUERY_COUNTER_BITS_EXT                              = 0x8864
-	QUERY_KHR                                           = 0x82E3
-	QUERY_OBJECT_EXT                                    = 0x9153
-	QUERY_RESULT                                        = 0x8866
-	QUERY_RESULT_AVAILABLE                              = 0x8867
-	QUERY_RESULT_AVAILABLE_EXT                          = 0x8867
-	QUERY_RESULT_EXT                                    = 0x8866
-	R11F_G11F_B10F                                      = 0x8C3A
-	R16F                                                = 0x822D
-	R16F_EXT                                            = 0x822D
-	R16I                                                = 0x8233
-	R16UI                                               = 0x8234
-	R32F                                                = 0x822E
-	R32F_EXT                                            = 0x822E
-	R32I                                                = 0x8235
-	R32UI                                               = 0x8236
-	R8                                                  = 0x8229
-	R8I                                                 = 0x8231
-	R8UI                                                = 0x8232
-	R8_EXT                                              = 0x8229
-	R8_SNORM                                            = 0x8F94
-	RASTERIZER_DISCARD                                  = 0x8C89
-	READ_BUFFER                                         = 0x0C02
-	READ_BUFFER_EXT                                     = 0x0C02
-	READ_BUFFER_NV                                      = 0x0C02
-	READ_FRAMEBUFFER                                    = 0x8CA8
-	READ_FRAMEBUFFER_ANGLE                              = 0x8CA8
-	READ_FRAMEBUFFER_APPLE                              = 0x8CA8
-	READ_FRAMEBUFFER_BINDING                            = 0x8CAA
-	READ_FRAMEBUFFER_BINDING_ANGLE                      = 0x8CAA
-	READ_FRAMEBUFFER_BINDING_APPLE                      = 0x8CAA
-	READ_FRAMEBUFFER_BINDING_NV                         = 0x8CAA
-	READ_FRAMEBUFFER_NV                                 = 0x8CA8
-	READ_ONLY                                           = 0x88B8
-	READ_WRITE                                          = 0x88BA
-	RED                                                 = 0x1903
-	RED_BITS                                            = 0x0D52
-	RED_EXT                                             = 0x1903
-	RED_INTEGER                                         = 0x8D94
-	RED_NV                                              = 0x1903
-	REFERENCED_BY_COMPUTE_SHADER                        = 0x930B
-	REFERENCED_BY_FRAGMENT_SHADER                       = 0x930A
-	REFERENCED_BY_GEOMETRY_SHADER_EXT                   = 0x9309
-	REFERENCED_BY_TESS_CONTROL_SHADER_EXT               = 0x9307
-	REFERENCED_BY_TESS_EVALUATION_SHADER_EXT            = 0x9308
-	REFERENCED_BY_VERTEX_SHADER                         = 0x9306
-	RENDERBUFFER                                        = 0x8D41
-	RENDERBUFFER_ALPHA_SIZE                             = 0x8D53
-	RENDERBUFFER_BINDING                                = 0x8CA7
-	RENDERBUFFER_BLUE_SIZE                              = 0x8D52
-	RENDERBUFFER_DEPTH_SIZE                             = 0x8D54
-	RENDERBUFFER_GREEN_SIZE                             = 0x8D51
-	RENDERBUFFER_HEIGHT                                 = 0x8D43
-	RENDERBUFFER_INTERNAL_FORMAT                        = 0x8D44
-	RENDERBUFFER_RED_SIZE                               = 0x8D50
-	RENDERBUFFER_SAMPLES                                = 0x8CAB
-	RENDERBUFFER_SAMPLES_ANGLE                          = 0x8CAB
-	RENDERBUFFER_SAMPLES_APPLE                          = 0x8CAB
-	RENDERBUFFER_SAMPLES_EXT                            = 0x8CAB
-	RENDERBUFFER_SAMPLES_IMG                            = 0x9133
-	RENDERBUFFER_SAMPLES_NV                             = 0x8CAB
-	RENDERBUFFER_STENCIL_SIZE                           = 0x8D55
-	RENDERBUFFER_WIDTH                                  = 0x8D42
-	RENDERER                                            = 0x1F01
-	RENDER_DIRECT_TO_FRAMEBUFFER_QCOM                   = 0x8FB3
-	REPEAT                                              = 0x2901
-	REPLACE                                             = 0x1E01
-	REQUIRED_TEXTURE_IMAGE_UNITS_OES                    = 0x8D68
-	RESET_NOTIFICATION_STRATEGY                         = 0x8256
-	RESET_NOTIFICATION_STRATEGY_EXT                     = 0x8256
-	RESET_NOTIFICATION_STRATEGY_KHR                     = 0x8256
-	RG                                                  = 0x8227
-	RG16F                                               = 0x822F
-	RG16F_EXT                                           = 0x822F
-	RG16I                                               = 0x8239
-	RG16UI                                              = 0x823A
-	RG32F                                               = 0x8230
-	RG32F_EXT                                           = 0x8230
-	RG32I                                               = 0x823B
-	RG32UI                                              = 0x823C
-	RG8                                                 = 0x822B
-	RG8I                                                = 0x8237
-	RG8UI                                               = 0x8238
-	RG8_EXT                                             = 0x822B
-	RG8_SNORM                                           = 0x8F95
-	RGB                                                 = 0x1907
-	RGB10_A2                                            = 0x8059
-	RGB10_A2UI                                          = 0x906F
-	RGB10_A2_EXT                                        = 0x8059
-	RGB10_EXT                                           = 0x8052
-	RGB16F                                              = 0x881B
-	RGB16F_EXT                                          = 0x881B
-	RGB16I                                              = 0x8D89
-	RGB16UI                                             = 0x8D77
-	RGB32F                                              = 0x8815
-	RGB32F_EXT                                          = 0x8815
-	RGB32I                                              = 0x8D83
-	RGB32UI                                             = 0x8D71
-	RGB565                                              = 0x8D62
-	RGB565_OES                                          = 0x8D62
-	RGB5_A1                                             = 0x8057
-	RGB5_A1_OES                                         = 0x8057
-	RGB8                                                = 0x8051
-	RGB8I                                               = 0x8D8F
-	RGB8UI                                              = 0x8D7D
-	RGB8_OES                                            = 0x8051
-	RGB8_SNORM                                          = 0x8F96
-	RGB9_E5                                             = 0x8C3D
-	RGBA                                                = 0x1908
-	RGBA16F                                             = 0x881A
-	RGBA16F_EXT                                         = 0x881A
-	RGBA16I                                             = 0x8D88
-	RGBA16UI                                            = 0x8D76
-	RGBA32F                                             = 0x8814
-	RGBA32F_EXT                                         = 0x8814
-	RGBA32I                                             = 0x8D82
-	RGBA32UI                                            = 0x8D70
-	RGBA4                                               = 0x8056
-	RGBA4_OES                                           = 0x8056
-	RGBA8                                               = 0x8058
-	RGBA8I                                              = 0x8D8E
-	RGBA8UI                                             = 0x8D7C
-	RGBA8_OES                                           = 0x8058
-	RGBA8_SNORM                                         = 0x8F97
-	RGBA_INTEGER                                        = 0x8D99
-	RGB_422_APPLE                                       = 0x8A1F
-	RGB_INTEGER                                         = 0x8D98
-	RGB_RAW_422_APPLE                                   = 0x8A51
-	RG_EXT                                              = 0x8227
-	RG_INTEGER                                          = 0x8228
-	SAMPLER                                             = 0x82E6
-	SAMPLER_2D                                          = 0x8B5E
-	SAMPLER_2D_ARRAY                                    = 0x8DC1
-	SAMPLER_2D_ARRAY_SHADOW                             = 0x8DC4
-	SAMPLER_2D_ARRAY_SHADOW_NV                          = 0x8DC4
-	SAMPLER_2D_MULTISAMPLE                              = 0x9108
-	SAMPLER_2D_MULTISAMPLE_ARRAY_OES                    = 0x910B
-	SAMPLER_2D_SHADOW                                   = 0x8B62
-	SAMPLER_2D_SHADOW_EXT                               = 0x8B62
-	SAMPLER_3D                                          = 0x8B5F
-	SAMPLER_3D_OES                                      = 0x8B5F
-	SAMPLER_BINDING                                     = 0x8919
-	SAMPLER_BUFFER_EXT                                  = 0x8DC2
-	SAMPLER_CUBE                                        = 0x8B60
-	SAMPLER_CUBE_MAP_ARRAY_EXT                          = 0x900C
-	SAMPLER_CUBE_MAP_ARRAY_SHADOW_EXT                   = 0x900D
-	SAMPLER_CUBE_SHADOW                                 = 0x8DC5
-	SAMPLER_CUBE_SHADOW_NV                              = 0x8DC5
-	SAMPLER_EXTERNAL_OES                                = 0x8D66
-	SAMPLER_KHR                                         = 0x82E6
-	SAMPLES                                             = 0x80A9
-	SAMPLE_ALPHA_TO_COVERAGE                            = 0x809E
-	SAMPLE_BUFFERS                                      = 0x80A8
-	SAMPLE_COVERAGE                                     = 0x80A0
-	SAMPLE_COVERAGE_INVERT                              = 0x80AB
-	SAMPLE_COVERAGE_VALUE                               = 0x80AA
-	SAMPLE_MASK                                         = 0x8E51
-	SAMPLE_MASK_VALUE                                   = 0x8E52
-	SAMPLE_POSITION                                     = 0x8E50
-	SAMPLE_SHADING_OES                                  = 0x8C36
-	SCISSOR_BOX                                         = 0x0C10
-	SCISSOR_TEST                                        = 0x0C11
-	SCREEN_KHR                                          = 0x9295
-	SCREEN_NV                                           = 0x9295
-	SEPARATE_ATTRIBS                                    = 0x8C8D
-	SGX_BINARY_IMG                                      = 0x8C0A
-	SGX_PROGRAM_BINARY_IMG                              = 0x9130
-	SHADER                                              = 0x82E1
-	SHADER_BINARY_DMP                                   = 0x9250
-	SHADER_BINARY_FORMATS                               = 0x8DF8
-	SHADER_BINARY_VIV                                   = 0x8FC4
-	SHADER_COMPILER                                     = 0x8DFA
-	SHADER_IMAGE_ACCESS_BARRIER_BIT                     = 0x00000020
-	SHADER_KHR                                          = 0x82E1
-	SHADER_OBJECT_EXT                                   = 0x8B48
-	SHADER_PIXEL_LOCAL_STORAGE_EXT                      = 0x8F64
-	SHADER_SOURCE_LENGTH                                = 0x8B88
-	SHADER_STORAGE_BARRIER_BIT                          = 0x00002000
-	SHADER_STORAGE_BLOCK                                = 0x92E6
-	SHADER_STORAGE_BUFFER                               = 0x90D2
-	SHADER_STORAGE_BUFFER_BINDING                       = 0x90D3
-	SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT              = 0x90DF
-	SHADER_STORAGE_BUFFER_SIZE                          = 0x90D5
-	SHADER_STORAGE_BUFFER_START                         = 0x90D4
-	SHADER_TYPE                                         = 0x8B4F
-	SHADING_LANGUAGE_VERSION                            = 0x8B8C
-	SHORT                                               = 0x1402
-	SIGNALED                                            = 0x9119
-	SIGNALED_APPLE                                      = 0x9119
-	SIGNED_NORMALIZED                                   = 0x8F9C
-	SKIP_DECODE_EXT                                     = 0x8A4A
-	SLUMINANCE8_ALPHA8_NV                               = 0x8C45
-	SLUMINANCE8_NV                                      = 0x8C47
-	SLUMINANCE_ALPHA_NV                                 = 0x8C44
-	SLUMINANCE_NV                                       = 0x8C46
-	SOFTLIGHT_KHR                                       = 0x929C
-	SOFTLIGHT_NV                                        = 0x929C
-	SRC_ALPHA                                           = 0x0302
-	SRC_ALPHA_SATURATE                                  = 0x0308
-	SRC_ATOP_NV                                         = 0x928E
-	SRC_COLOR                                           = 0x0300
-	SRC_IN_NV                                           = 0x928A
-	SRC_NV                                              = 0x9286
-	SRC_OUT_NV                                          = 0x928C
-	SRC_OVER_NV                                         = 0x9288
-	SRGB                                                = 0x8C40
-	SRGB8                                               = 0x8C41
-	SRGB8_ALPHA8                                        = 0x8C43
-	SRGB8_ALPHA8_EXT                                    = 0x8C43
-	SRGB8_NV                                            = 0x8C41
-	SRGB_ALPHA_EXT                                      = 0x8C42
-	SRGB_EXT                                            = 0x8C40
-	STACK_OVERFLOW                                      = 0x0503
-	STACK_OVERFLOW_KHR                                  = 0x0503
-	STACK_UNDERFLOW                                     = 0x0504
-	STACK_UNDERFLOW_KHR                                 = 0x0504
-	STATE_RESTORE                                       = 0x8BDC
-	STATIC_COPY                                         = 0x88E6
-	STATIC_DRAW                                         = 0x88E4
-	STATIC_READ                                         = 0x88E5
-	STENCIL                                             = 0x1802
-	STENCIL_ATTACHMENT                                  = 0x8D20
-	STENCIL_BACK_FAIL                                   = 0x8801
-	STENCIL_BACK_FUNC                                   = 0x8800
-	STENCIL_BACK_PASS_DEPTH_FAIL                        = 0x8802
-	STENCIL_BACK_PASS_DEPTH_PASS                        = 0x8803
-	STENCIL_BACK_REF                                    = 0x8CA3
-	STENCIL_BACK_VALUE_MASK                             = 0x8CA4
-	STENCIL_BACK_WRITEMASK                              = 0x8CA5
-	STENCIL_BITS                                        = 0x0D57
-	STENCIL_BUFFER_BIT                                  = 0x00000400
-	STENCIL_BUFFER_BIT0_QCOM                            = 0x00010000
-	STENCIL_BUFFER_BIT1_QCOM                            = 0x00020000
-	STENCIL_BUFFER_BIT2_QCOM                            = 0x00040000
-	STENCIL_BUFFER_BIT3_QCOM                            = 0x00080000
-	STENCIL_BUFFER_BIT4_QCOM                            = 0x00100000
-	STENCIL_BUFFER_BIT5_QCOM                            = 0x00200000
-	STENCIL_BUFFER_BIT6_QCOM                            = 0x00400000
-	STENCIL_BUFFER_BIT7_QCOM                            = 0x00800000
-	STENCIL_CLEAR_VALUE                                 = 0x0B91
-	STENCIL_EXT                                         = 0x1802
-	STENCIL_FAIL                                        = 0x0B94
-	STENCIL_FUNC                                        = 0x0B92
-	STENCIL_INDEX                                       = 0x1901
-	STENCIL_INDEX1_OES                                  = 0x8D46
-	STENCIL_INDEX4_OES                                  = 0x8D47
-	STENCIL_INDEX8                                      = 0x8D48
-	STENCIL_INDEX8_OES                                  = 0x8D48
-	STENCIL_INDEX_OES                                   = 0x1901
-	STENCIL_PASS_DEPTH_FAIL                             = 0x0B95
-	STENCIL_PASS_DEPTH_PASS                             = 0x0B96
-	STENCIL_REF                                         = 0x0B97
-	STENCIL_TEST                                        = 0x0B90
-	STENCIL_VALUE_MASK                                  = 0x0B93
-	STENCIL_WRITEMASK                                   = 0x0B98
-	STREAM_COPY                                         = 0x88E2
-	STREAM_DRAW                                         = 0x88E0
-	STREAM_READ                                         = 0x88E1
-	SUBPIXEL_BITS                                       = 0x0D50
-	SYNC_CONDITION                                      = 0x9113
-	SYNC_CONDITION_APPLE                                = 0x9113
-	SYNC_FENCE                                          = 0x9116
-	SYNC_FENCE_APPLE                                    = 0x9116
-	SYNC_FLAGS                                          = 0x9115
-	SYNC_FLAGS_APPLE                                    = 0x9115
-	SYNC_FLUSH_COMMANDS_BIT                             = 0x00000001
-	SYNC_FLUSH_COMMANDS_BIT_APPLE                       = 0x00000001
-	SYNC_GPU_COMMANDS_COMPLETE                          = 0x9117
-	SYNC_GPU_COMMANDS_COMPLETE_APPLE                    = 0x9117
-	SYNC_OBJECT_APPLE                                   = 0x8A53
-	SYNC_STATUS                                         = 0x9114
-	SYNC_STATUS_APPLE                                   = 0x9114
-	TESS_CONTROL_OUTPUT_VERTICES_EXT                    = 0x8E75
-	TESS_CONTROL_SHADER_BIT_EXT                         = 0x00000008
-	TESS_CONTROL_SHADER_EXT                             = 0x8E88
-	TESS_EVALUATION_SHADER_BIT_EXT                      = 0x00000010
-	TESS_EVALUATION_SHADER_EXT                          = 0x8E87
-	TESS_GEN_MODE_EXT                                   = 0x8E76
-	TESS_GEN_POINT_MODE_EXT                             = 0x8E79
-	TESS_GEN_SPACING_EXT                                = 0x8E77
-	TESS_GEN_VERTEX_ORDER_EXT                           = 0x8E78
-	TEXTURE                                             = 0x1702
-	TEXTURE0                                            = 0x84C0
-	TEXTURE1                                            = 0x84C1
-	TEXTURE10                                           = 0x84CA
-	TEXTURE11                                           = 0x84CB
-	TEXTURE12                                           = 0x84CC
-	TEXTURE13                                           = 0x84CD
-	TEXTURE14                                           = 0x84CE
-	TEXTURE15                                           = 0x84CF
-	TEXTURE16                                           = 0x84D0
-	TEXTURE17                                           = 0x84D1
-	TEXTURE18                                           = 0x84D2
-	TEXTURE19                                           = 0x84D3
-	TEXTURE2                                            = 0x84C2
-	TEXTURE20                                           = 0x84D4
-	TEXTURE21                                           = 0x84D5
-	TEXTURE22                                           = 0x84D6
-	TEXTURE23                                           = 0x84D7
-	TEXTURE24                                           = 0x84D8
-	TEXTURE25                                           = 0x84D9
-	TEXTURE26                                           = 0x84DA
-	TEXTURE27                                           = 0x84DB
-	TEXTURE28                                           = 0x84DC
-	TEXTURE29                                           = 0x84DD
-	TEXTURE3                                            = 0x84C3
-	TEXTURE30                                           = 0x84DE
-	TEXTURE31                                           = 0x84DF
-	TEXTURE4                                            = 0x84C4
-	TEXTURE5                                            = 0x84C5
-	TEXTURE6                                            = 0x84C6
-	TEXTURE7                                            = 0x84C7
-	TEXTURE8                                            = 0x84C8
-	TEXTURE9                                            = 0x84C9
-	TEXTURE_2D                                          = 0x0DE1
-	TEXTURE_2D_ARRAY                                    = 0x8C1A
-	TEXTURE_2D_MULTISAMPLE                              = 0x9100
-	TEXTURE_2D_MULTISAMPLE_ARRAY_OES                    = 0x9102
-	TEXTURE_3D                                          = 0x806F
-	TEXTURE_3D_OES                                      = 0x806F
-	TEXTURE_ALPHA_SIZE                                  = 0x805F
-	TEXTURE_ALPHA_TYPE                                  = 0x8C13
-	TEXTURE_BASE_LEVEL                                  = 0x813C
-	TEXTURE_BINDING_2D                                  = 0x8069
-	TEXTURE_BINDING_2D_ARRAY                            = 0x8C1D
-	TEXTURE_BINDING_2D_MULTISAMPLE                      = 0x9104
-	TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY_OES            = 0x9105
-	TEXTURE_BINDING_3D                                  = 0x806A
-	TEXTURE_BINDING_3D_OES                              = 0x806A
-	TEXTURE_BINDING_BUFFER_EXT                          = 0x8C2C
-	TEXTURE_BINDING_CUBE_MAP                            = 0x8514
-	TEXTURE_BINDING_CUBE_MAP_ARRAY_EXT                  = 0x900A
-	TEXTURE_BINDING_EXTERNAL_OES                        = 0x8D67
-	TEXTURE_BLUE_SIZE                                   = 0x805E
-	TEXTURE_BLUE_TYPE                                   = 0x8C12
-	TEXTURE_BORDER_COLOR_EXT                            = 0x1004
-	TEXTURE_BORDER_COLOR_NV                             = 0x1004
-	TEXTURE_BUFFER_BINDING_EXT                          = 0x8C2A
-	TEXTURE_BUFFER_DATA_STORE_BINDING_EXT               = 0x8C2D
-	TEXTURE_BUFFER_EXT                                  = 0x8C2A
-	TEXTURE_BUFFER_OFFSET_ALIGNMENT_EXT                 = 0x919F
-	TEXTURE_BUFFER_OFFSET_EXT                           = 0x919D
-	TEXTURE_BUFFER_SIZE_EXT                             = 0x919E
-	TEXTURE_COMPARE_FUNC                                = 0x884D
-	TEXTURE_COMPARE_FUNC_EXT                            = 0x884D
-	TEXTURE_COMPARE_MODE                                = 0x884C
-	TEXTURE_COMPARE_MODE_EXT                            = 0x884C
-	TEXTURE_COMPRESSED                                  = 0x86A1
-	TEXTURE_CUBE_MAP                                    = 0x8513
-	TEXTURE_CUBE_MAP_ARRAY_EXT                          = 0x9009
-	TEXTURE_CUBE_MAP_NEGATIVE_X                         = 0x8516
-	TEXTURE_CUBE_MAP_NEGATIVE_Y                         = 0x8518
-	TEXTURE_CUBE_MAP_NEGATIVE_Z                         = 0x851A
-	TEXTURE_CUBE_MAP_POSITIVE_X                         = 0x8515
-	TEXTURE_CUBE_MAP_POSITIVE_Y                         = 0x8517
-	TEXTURE_CUBE_MAP_POSITIVE_Z                         = 0x8519
-	TEXTURE_DEPTH                                       = 0x8071
-	TEXTURE_DEPTH_QCOM                                  = 0x8BD4
-	TEXTURE_DEPTH_SIZE                                  = 0x884A
-	TEXTURE_DEPTH_TYPE                                  = 0x8C16
-	TEXTURE_EXTERNAL_OES                                = 0x8D65
-	TEXTURE_FETCH_BARRIER_BIT                           = 0x00000008
-	TEXTURE_FIXED_SAMPLE_LOCATIONS                      = 0x9107
-	TEXTURE_FORMAT_QCOM                                 = 0x8BD6
-	TEXTURE_GREEN_SIZE                                  = 0x805D
-	TEXTURE_GREEN_TYPE                                  = 0x8C11
-	TEXTURE_HEIGHT                                      = 0x1001
-	TEXTURE_HEIGHT_QCOM                                 = 0x8BD3
-	TEXTURE_IMAGE_VALID_QCOM                            = 0x8BD8
-	TEXTURE_IMMUTABLE_FORMAT                            = 0x912F
-	TEXTURE_IMMUTABLE_FORMAT_EXT                        = 0x912F
-	TEXTURE_IMMUTABLE_LEVELS                            = 0x82DF
-	TEXTURE_INTERNAL_FORMAT                             = 0x1003
-	TEXTURE_INTERNAL_FORMAT_QCOM                        = 0x8BD5
-	TEXTURE_MAG_FILTER                                  = 0x2800
-	TEXTURE_MAX_ANISOTROPY_EXT                          = 0x84FE
-	TEXTURE_MAX_LEVEL                                   = 0x813D
-	TEXTURE_MAX_LEVEL_APPLE                             = 0x813D
-	TEXTURE_MAX_LOD                                     = 0x813B
-	TEXTURE_MIN_FILTER                                  = 0x2801
-	TEXTURE_MIN_LOD                                     = 0x813A
-	TEXTURE_NUM_LEVELS_QCOM                             = 0x8BD9
-	TEXTURE_OBJECT_VALID_QCOM                           = 0x8BDB
-	TEXTURE_RED_SIZE                                    = 0x805C
-	TEXTURE_RED_TYPE                                    = 0x8C10
-	TEXTURE_SAMPLES                                     = 0x9106
-	TEXTURE_SAMPLES_IMG                                 = 0x9136
-	TEXTURE_SHARED_SIZE                                 = 0x8C3F
-	TEXTURE_SRGB_DECODE_EXT                             = 0x8A48
-	TEXTURE_STENCIL_SIZE                                = 0x88F1
-	TEXTURE_SWIZZLE_A                                   = 0x8E45
-	TEXTURE_SWIZZLE_B                                   = 0x8E44
-	TEXTURE_SWIZZLE_G                                   = 0x8E43
-	TEXTURE_SWIZZLE_R                                   = 0x8E42
-	TEXTURE_TARGET_QCOM                                 = 0x8BDA
-	TEXTURE_TYPE_QCOM                                   = 0x8BD7
-	TEXTURE_UPDATE_BARRIER_BIT                          = 0x00000100
-	TEXTURE_USAGE_ANGLE                                 = 0x93A2
-	TEXTURE_VIEW_MIN_LAYER_EXT                          = 0x82DD
-	TEXTURE_VIEW_MIN_LEVEL_EXT                          = 0x82DB
-	TEXTURE_VIEW_NUM_LAYERS_EXT                         = 0x82DE
-	TEXTURE_VIEW_NUM_LEVELS_EXT                         = 0x82DC
-	TEXTURE_WIDTH                                       = 0x1000
-	TEXTURE_WIDTH_QCOM                                  = 0x8BD2
-	TEXTURE_WRAP_R                                      = 0x8072
-	TEXTURE_WRAP_R_OES                                  = 0x8072
-	TEXTURE_WRAP_S                                      = 0x2802
-	TEXTURE_WRAP_T                                      = 0x2803
-	TIMEOUT_EXPIRED                                     = 0x911B
-	TIMEOUT_EXPIRED_APPLE                               = 0x911B
-	TIMEOUT_IGNORED                                     = 0xFFFFFFFFFFFFFFFF
-	TIMEOUT_IGNORED_APPLE                               = 0xFFFFFFFFFFFFFFFF
-	TIMESTAMP_EXT                                       = 0x8E28
-	TIME_ELAPSED_EXT                                    = 0x88BF
-	TOP_LEVEL_ARRAY_SIZE                                = 0x930C
-	TOP_LEVEL_ARRAY_STRIDE                              = 0x930D
-	TRANSFORM_FEEDBACK                                  = 0x8E22
-	TRANSFORM_FEEDBACK_ACTIVE                           = 0x8E24
-	TRANSFORM_FEEDBACK_BARRIER_BIT                      = 0x00000800
-	TRANSFORM_FEEDBACK_BINDING                          = 0x8E25
-	TRANSFORM_FEEDBACK_BUFFER                           = 0x8C8E
-	TRANSFORM_FEEDBACK_BUFFER_BINDING                   = 0x8C8F
-	TRANSFORM_FEEDBACK_BUFFER_MODE                      = 0x8C7F
-	TRANSFORM_FEEDBACK_BUFFER_SIZE                      = 0x8C85
-	TRANSFORM_FEEDBACK_BUFFER_START                     = 0x8C84
-	TRANSFORM_FEEDBACK_PAUSED                           = 0x8E23
-	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN               = 0x8C88
-	TRANSFORM_FEEDBACK_VARYING                          = 0x92F4
-	TRANSFORM_FEEDBACK_VARYINGS                         = 0x8C83
-	TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH               = 0x8C76
-	TRANSLATED_SHADER_SOURCE_LENGTH_ANGLE               = 0x93A0
-	TRIANGLES                                           = 0x0004
-	TRIANGLES_ADJACENCY_EXT                             = 0x000C
-	TRIANGLE_FAN                                        = 0x0006
-	TRIANGLE_STRIP                                      = 0x0005
-	TRIANGLE_STRIP_ADJACENCY_EXT                        = 0x000D
-	TRUE                                                = 1
-	TYPE                                                = 0x92FA
-	UNCORRELATED_NV                                     = 0x9282
-	UNDEFINED_VERTEX_EXT                                = 0x8260
-	UNIFORM                                             = 0x92E1
-	UNIFORM_ARRAY_STRIDE                                = 0x8A3C
-	UNIFORM_BARRIER_BIT                                 = 0x00000004
-	UNIFORM_BLOCK                                       = 0x92E2
-	UNIFORM_BLOCK_ACTIVE_UNIFORMS                       = 0x8A42
-	UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES                = 0x8A43
-	UNIFORM_BLOCK_BINDING                               = 0x8A3F
-	UNIFORM_BLOCK_DATA_SIZE                             = 0x8A40
-	UNIFORM_BLOCK_INDEX                                 = 0x8A3A
-	UNIFORM_BLOCK_NAME_LENGTH                           = 0x8A41
-	UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER         = 0x8A46
-	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER           = 0x8A44
-	UNIFORM_BUFFER                                      = 0x8A11
-	UNIFORM_BUFFER_BINDING                              = 0x8A28
-	UNIFORM_BUFFER_OFFSET_ALIGNMENT                     = 0x8A34
-	UNIFORM_BUFFER_SIZE                                 = 0x8A2A
-	UNIFORM_BUFFER_START                                = 0x8A29
-	UNIFORM_IS_ROW_MAJOR                                = 0x8A3E
-	UNIFORM_MATRIX_STRIDE                               = 0x8A3D
-	UNIFORM_NAME_LENGTH                                 = 0x8A39
-	UNIFORM_OFFSET                                      = 0x8A3B
-	UNIFORM_SIZE                                        = 0x8A38
-	UNIFORM_TYPE                                        = 0x8A37
-	UNKNOWN_CONTEXT_RESET                               = 0x8255
-	UNKNOWN_CONTEXT_RESET_EXT                           = 0x8255
-	UNKNOWN_CONTEXT_RESET_KHR                           = 0x8255
-	UNPACK_ALIGNMENT                                    = 0x0CF5
-	UNPACK_IMAGE_HEIGHT                                 = 0x806E
-	UNPACK_ROW_LENGTH                                   = 0x0CF2
-	UNPACK_ROW_LENGTH_EXT                               = 0x0CF2
-	UNPACK_SKIP_IMAGES                                  = 0x806D
-	UNPACK_SKIP_PIXELS                                  = 0x0CF4
-	UNPACK_SKIP_PIXELS_EXT                              = 0x0CF4
-	UNPACK_SKIP_ROWS                                    = 0x0CF3
-	UNPACK_SKIP_ROWS_EXT                                = 0x0CF3
-	UNSIGNALED                                          = 0x9118
-	UNSIGNALED_APPLE                                    = 0x9118
-	UNSIGNED_BYTE                                       = 0x1401
-	UNSIGNED_INT                                        = 0x1405
-	UNSIGNED_INT64_AMD                                  = 0x8BC2
-	UNSIGNED_INT_10F_11F_11F_REV                        = 0x8C3B
-	UNSIGNED_INT_10_10_10_2_OES                         = 0x8DF6
-	UNSIGNED_INT_24_8                                   = 0x84FA
-	UNSIGNED_INT_24_8_OES                               = 0x84FA
-	UNSIGNED_INT_2_10_10_10_REV                         = 0x8368
-	UNSIGNED_INT_2_10_10_10_REV_EXT                     = 0x8368
-	UNSIGNED_INT_5_9_9_9_REV                            = 0x8C3E
-	UNSIGNED_INT_ATOMIC_COUNTER                         = 0x92DB
-	UNSIGNED_INT_IMAGE_2D                               = 0x9063
-	UNSIGNED_INT_IMAGE_2D_ARRAY                         = 0x9069
-	UNSIGNED_INT_IMAGE_3D                               = 0x9064
-	UNSIGNED_INT_IMAGE_BUFFER_EXT                       = 0x9067
-	UNSIGNED_INT_IMAGE_CUBE                             = 0x9066
-	UNSIGNED_INT_IMAGE_CUBE_MAP_ARRAY_EXT               = 0x906A
-	UNSIGNED_INT_SAMPLER_2D                             = 0x8DD2
-	UNSIGNED_INT_SAMPLER_2D_ARRAY                       = 0x8DD7
-	UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE                 = 0x910A
-	UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE_ARRAY_OES       = 0x910D
-	UNSIGNED_INT_SAMPLER_3D                             = 0x8DD3
-	UNSIGNED_INT_SAMPLER_BUFFER_EXT                     = 0x8DD8
-	UNSIGNED_INT_SAMPLER_CUBE                           = 0x8DD4
-	UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY_EXT             = 0x900F
-	UNSIGNED_INT_VEC2                                   = 0x8DC6
-	UNSIGNED_INT_VEC3                                   = 0x8DC7
-	UNSIGNED_INT_VEC4                                   = 0x8DC8
-	UNSIGNED_NORMALIZED                                 = 0x8C17
-	UNSIGNED_NORMALIZED_EXT                             = 0x8C17
-	UNSIGNED_SHORT                                      = 0x1403
-	UNSIGNED_SHORT_1_5_5_5_REV_EXT                      = 0x8366
-	UNSIGNED_SHORT_4_4_4_4                              = 0x8033
-	UNSIGNED_SHORT_4_4_4_4_REV_EXT                      = 0x8365
-	UNSIGNED_SHORT_4_4_4_4_REV_IMG                      = 0x8365
-	UNSIGNED_SHORT_5_5_5_1                              = 0x8034
-	UNSIGNED_SHORT_5_6_5                                = 0x8363
-	UNSIGNED_SHORT_8_8_APPLE                            = 0x85BA
-	UNSIGNED_SHORT_8_8_REV_APPLE                        = 0x85BB
-	VALIDATE_STATUS                                     = 0x8B83
-	VENDOR                                              = 0x1F00
-	VERSION                                             = 0x1F02
-	VERTEX_ARRAY                                        = 0x8074
-	VERTEX_ARRAY_BINDING                                = 0x85B5
-	VERTEX_ARRAY_BINDING_OES                            = 0x85B5
-	VERTEX_ARRAY_KHR                                    = 0x8074
-	VERTEX_ARRAY_OBJECT_EXT                             = 0x9154
-	VERTEX_ATTRIB_ARRAY_BARRIER_BIT                     = 0x00000001
-	VERTEX_ATTRIB_ARRAY_BUFFER_BINDING                  = 0x889F
-	VERTEX_ATTRIB_ARRAY_DIVISOR                         = 0x88FE
-	VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE                   = 0x88FE
-	VERTEX_ATTRIB_ARRAY_DIVISOR_EXT                     = 0x88FE
-	VERTEX_ATTRIB_ARRAY_DIVISOR_NV                      = 0x88FE
-	VERTEX_ATTRIB_ARRAY_ENABLED                         = 0x8622
-	VERTEX_ATTRIB_ARRAY_INTEGER                         = 0x88FD
-	VERTEX_ATTRIB_ARRAY_NORMALIZED                      = 0x886A
-	VERTEX_ATTRIB_ARRAY_POINTER                         = 0x8645
-	VERTEX_ATTRIB_ARRAY_SIZE                            = 0x8623
-	VERTEX_ATTRIB_ARRAY_STRIDE                          = 0x8624
-	VERTEX_ATTRIB_ARRAY_TYPE                            = 0x8625
-	VERTEX_ATTRIB_BINDING                               = 0x82D4
-	VERTEX_ATTRIB_RELATIVE_OFFSET                       = 0x82D5
-	VERTEX_BINDING_BUFFER                               = 0x8F4F
-	VERTEX_BINDING_DIVISOR                              = 0x82D6
-	VERTEX_BINDING_OFFSET                               = 0x82D7
-	VERTEX_BINDING_STRIDE                               = 0x82D8
-	VERTEX_SHADER                                       = 0x8B31
-	VERTEX_SHADER_BIT                                   = 0x00000001
-	VERTEX_SHADER_BIT_EXT                               = 0x00000001
-	VIEWPORT                                            = 0x0BA2
-	VIVIDLIGHT_NV                                       = 0x92A6
-	WAIT_FAILED                                         = 0x911D
-	WAIT_FAILED_APPLE                                   = 0x911D
-	WRITEONLY_RENDERING_QCOM                            = 0x8823
-	WRITE_ONLY                                          = 0x88B9
-	WRITE_ONLY_OES                                      = 0x88B9
-	XOR_NV                                              = 0x1506
-	Z400_BINARY_AMD                                     = 0x8740
-	ZERO                                                = 0
+	GL_3DC_XY_AMD                                                         = 0x87FA
+	GL_3DC_X_AMD                                                          = 0x87F9
+	ACCUM_ADJACENT_PAIRS_NV                                               = 0x90AD
+	ACTIVE_ATOMIC_COUNTER_BUFFERS                                         = 0x92D9
+	ACTIVE_ATTRIBUTES                                                     = 0x8B89
+	ACTIVE_ATTRIBUTE_MAX_LENGTH                                           = 0x8B8A
+	ACTIVE_PROGRAM                                                        = 0x8259
+	ACTIVE_PROGRAM_EXT                                                    = 0x8259
+	ACTIVE_RESOURCES                                                      = 0x92F5
+	ACTIVE_TEXTURE                                                        = 0x84E0
+	ACTIVE_UNIFORMS                                                       = 0x8B86
+	ACTIVE_UNIFORM_BLOCKS                                                 = 0x8A36
+	ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH                                  = 0x8A35
+	ACTIVE_UNIFORM_MAX_LENGTH                                             = 0x8B87
+	ACTIVE_VARIABLES                                                      = 0x9305
+	ADJACENT_PAIRS_NV                                                     = 0x90AE
+	AFFINE_2D_NV                                                          = 0x9092
+	AFFINE_3D_NV                                                          = 0x9094
+	ALIASED_LINE_WIDTH_RANGE                                              = 0x846E
+	ALIASED_POINT_SIZE_RANGE                                              = 0x846D
+	ALL_BARRIER_BITS                                                      = 0xFFFFFFFF
+	ALL_COMPLETED_NV                                                      = 0x84F2
+	ALL_SHADER_BITS                                                       = 0xFFFFFFFF
+	ALL_SHADER_BITS_EXT                                                   = 0xFFFFFFFF
+	ALPHA                                                                 = 0x1906
+	ALPHA16F_EXT                                                          = 0x881C
+	ALPHA32F_EXT                                                          = 0x8816
+	ALPHA8_EXT                                                            = 0x803C
+	ALPHA8_OES                                                            = 0x803C
+	ALPHA_BITS                                                            = 0x0D55
+	ALPHA_TEST_FUNC_QCOM                                                  = 0x0BC1
+	ALPHA_TEST_QCOM                                                       = 0x0BC0
+	ALPHA_TEST_REF_QCOM                                                   = 0x0BC2
+	ALREADY_SIGNALED                                                      = 0x911A
+	ALREADY_SIGNALED_APPLE                                                = 0x911A
+	ALWAYS                                                                = 0x0207
+	ANY_SAMPLES_PASSED                                                    = 0x8C2F
+	ANY_SAMPLES_PASSED_CONSERVATIVE                                       = 0x8D6A
+	ANY_SAMPLES_PASSED_CONSERVATIVE_EXT                                   = 0x8D6A
+	ANY_SAMPLES_PASSED_EXT                                                = 0x8C2F
+	ARC_TO_NV                                                             = 0xFE
+	ARRAY_BUFFER                                                          = 0x8892
+	ARRAY_BUFFER_BINDING                                                  = 0x8894
+	ARRAY_SIZE                                                            = 0x92FB
+	ARRAY_STRIDE                                                          = 0x92FE
+	ATC_RGBA_EXPLICIT_ALPHA_AMD                                           = 0x8C93
+	ATC_RGBA_INTERPOLATED_ALPHA_AMD                                       = 0x87EE
+	ATC_RGB_AMD                                                           = 0x8C92
+	ATOMIC_COUNTER_BARRIER_BIT                                            = 0x00001000
+	ATOMIC_COUNTER_BUFFER                                                 = 0x92C0
+	ATOMIC_COUNTER_BUFFER_BINDING                                         = 0x92C1
+	ATOMIC_COUNTER_BUFFER_INDEX                                           = 0x9301
+	ATOMIC_COUNTER_BUFFER_SIZE                                            = 0x92C3
+	ATOMIC_COUNTER_BUFFER_START                                           = 0x92C2
+	ATTACHED_SHADERS                                                      = 0x8B85
+	BACK                                                                  = 0x0405
+	BEVEL_NV                                                              = 0x90A6
+	BGRA8_EXT                                                             = 0x93A1
+	BGRA_EXT                                                              = 0x80E1
+	BGRA_IMG                                                              = 0x80E1
+	BINNING_CONTROL_HINT_QCOM                                             = 0x8FB0
+	BLEND                                                                 = 0x0BE2
+	BLEND_ADVANCED_COHERENT_KHR                                           = 0x9285
+	BLEND_ADVANCED_COHERENT_NV                                            = 0x9285
+	BLEND_COLOR                                                           = 0x8005
+	BLEND_DST_ALPHA                                                       = 0x80CA
+	BLEND_DST_RGB                                                         = 0x80C8
+	BLEND_EQUATION                                                        = 0x8009
+	BLEND_EQUATION_ALPHA                                                  = 0x883D
+	BLEND_EQUATION_EXT                                                    = 0x8009
+	BLEND_EQUATION_RGB                                                    = 0x8009
+	BLEND_OVERLAP_NV                                                      = 0x9281
+	BLEND_PREMULTIPLIED_SRC_NV                                            = 0x9280
+	BLEND_SRC_ALPHA                                                       = 0x80CB
+	BLEND_SRC_RGB                                                         = 0x80C9
+	BLOCK_INDEX                                                           = 0x92FD
+	BLUE                                                                  = 0x1905
+	BLUE_BITS                                                             = 0x0D54
+	BLUE_NV                                                               = 0x1905
+	BOLD_BIT_NV                                                           = 0x01
+	BOOL                                                                  = 0x8B56
+	BOOL_VEC2                                                             = 0x8B57
+	BOOL_VEC3                                                             = 0x8B58
+	BOOL_VEC4                                                             = 0x8B59
+	BOUNDING_BOX_NV                                                       = 0x908D
+	BOUNDING_BOX_OF_BOUNDING_BOXES_NV                                     = 0x909C
+	BUFFER                                                                = 0x82E0
+	BUFFER_ACCESS_FLAGS                                                   = 0x911F
+	BUFFER_ACCESS_OES                                                     = 0x88BB
+	BUFFER_BINDING                                                        = 0x9302
+	BUFFER_DATA_SIZE                                                      = 0x9303
+	BUFFER_IMMUTABLE_STORAGE_EXT                                          = 0x821F
+	BUFFER_KHR                                                            = 0x82E0
+	BUFFER_MAPPED                                                         = 0x88BC
+	BUFFER_MAPPED_OES                                                     = 0x88BC
+	BUFFER_MAP_LENGTH                                                     = 0x9120
+	BUFFER_MAP_OFFSET                                                     = 0x9121
+	BUFFER_MAP_POINTER                                                    = 0x88BD
+	BUFFER_MAP_POINTER_OES                                                = 0x88BD
+	BUFFER_OBJECT_EXT                                                     = 0x9151
+	BUFFER_SIZE                                                           = 0x8764
+	BUFFER_STORAGE_FLAGS_EXT                                              = 0x8220
+	BUFFER_UPDATE_BARRIER_BIT                                             = 0x00000200
+	BUFFER_USAGE                                                          = 0x8765
+	BUFFER_VARIABLE                                                       = 0x92E5
+	BYTE                                                                  = 0x1400
+	CCW                                                                   = 0x0901
+	CIRCULAR_CCW_ARC_TO_NV                                                = 0xF8
+	CIRCULAR_CW_ARC_TO_NV                                                 = 0xFA
+	CIRCULAR_TANGENT_ARC_TO_NV                                            = 0xFC
+	CLAMP_TO_BORDER_EXT                                                   = 0x812D
+	CLAMP_TO_BORDER_NV                                                    = 0x812D
+	CLAMP_TO_BORDER_OES                                                   = 0x812D
+	CLAMP_TO_EDGE                                                         = 0x812F
+	CLIENT_MAPPED_BUFFER_BARRIER_BIT_EXT                                  = 0x00004000
+	CLIENT_STORAGE_BIT_EXT                                                = 0x0200
+	CLIP_DEPTH_MODE_EXT                                                   = 0x935D
+	CLIP_DISTANCE0_APPLE                                                  = 0x3000
+	CLIP_DISTANCE0_EXT                                                    = 0x3000
+	CLIP_DISTANCE1_APPLE                                                  = 0x3001
+	CLIP_DISTANCE1_EXT                                                    = 0x3001
+	CLIP_DISTANCE2_APPLE                                                  = 0x3002
+	CLIP_DISTANCE2_EXT                                                    = 0x3002
+	CLIP_DISTANCE3_APPLE                                                  = 0x3003
+	CLIP_DISTANCE3_EXT                                                    = 0x3003
+	CLIP_DISTANCE4_APPLE                                                  = 0x3004
+	CLIP_DISTANCE4_EXT                                                    = 0x3004
+	CLIP_DISTANCE5_APPLE                                                  = 0x3005
+	CLIP_DISTANCE5_EXT                                                    = 0x3005
+	CLIP_DISTANCE6_APPLE                                                  = 0x3006
+	CLIP_DISTANCE6_EXT                                                    = 0x3006
+	CLIP_DISTANCE7_APPLE                                                  = 0x3007
+	CLIP_DISTANCE7_EXT                                                    = 0x3007
+	CLIP_ORIGIN_EXT                                                       = 0x935C
+	CLOSE_PATH_NV                                                         = 0x00
+	COLOR                                                                 = 0x1800
+	COLORBURN_KHR                                                         = 0x929A
+	COLORBURN_NV                                                          = 0x929A
+	COLORDODGE_KHR                                                        = 0x9299
+	COLORDODGE_NV                                                         = 0x9299
+	COLOR_ATTACHMENT0                                                     = 0x8CE0
+	COLOR_ATTACHMENT0_EXT                                                 = 0x8CE0
+	COLOR_ATTACHMENT0_NV                                                  = 0x8CE0
+	COLOR_ATTACHMENT1                                                     = 0x8CE1
+	COLOR_ATTACHMENT10                                                    = 0x8CEA
+	COLOR_ATTACHMENT10_EXT                                                = 0x8CEA
+	COLOR_ATTACHMENT10_NV                                                 = 0x8CEA
+	COLOR_ATTACHMENT11                                                    = 0x8CEB
+	COLOR_ATTACHMENT11_EXT                                                = 0x8CEB
+	COLOR_ATTACHMENT11_NV                                                 = 0x8CEB
+	COLOR_ATTACHMENT12                                                    = 0x8CEC
+	COLOR_ATTACHMENT12_EXT                                                = 0x8CEC
+	COLOR_ATTACHMENT12_NV                                                 = 0x8CEC
+	COLOR_ATTACHMENT13                                                    = 0x8CED
+	COLOR_ATTACHMENT13_EXT                                                = 0x8CED
+	COLOR_ATTACHMENT13_NV                                                 = 0x8CED
+	COLOR_ATTACHMENT14                                                    = 0x8CEE
+	COLOR_ATTACHMENT14_EXT                                                = 0x8CEE
+	COLOR_ATTACHMENT14_NV                                                 = 0x8CEE
+	COLOR_ATTACHMENT15                                                    = 0x8CEF
+	COLOR_ATTACHMENT15_EXT                                                = 0x8CEF
+	COLOR_ATTACHMENT15_NV                                                 = 0x8CEF
+	COLOR_ATTACHMENT16                                                    = 0x8CF0
+	COLOR_ATTACHMENT17                                                    = 0x8CF1
+	COLOR_ATTACHMENT18                                                    = 0x8CF2
+	COLOR_ATTACHMENT19                                                    = 0x8CF3
+	COLOR_ATTACHMENT1_EXT                                                 = 0x8CE1
+	COLOR_ATTACHMENT1_NV                                                  = 0x8CE1
+	COLOR_ATTACHMENT2                                                     = 0x8CE2
+	COLOR_ATTACHMENT20                                                    = 0x8CF4
+	COLOR_ATTACHMENT21                                                    = 0x8CF5
+	COLOR_ATTACHMENT22                                                    = 0x8CF6
+	COLOR_ATTACHMENT23                                                    = 0x8CF7
+	COLOR_ATTACHMENT24                                                    = 0x8CF8
+	COLOR_ATTACHMENT25                                                    = 0x8CF9
+	COLOR_ATTACHMENT26                                                    = 0x8CFA
+	COLOR_ATTACHMENT27                                                    = 0x8CFB
+	COLOR_ATTACHMENT28                                                    = 0x8CFC
+	COLOR_ATTACHMENT29                                                    = 0x8CFD
+	COLOR_ATTACHMENT2_EXT                                                 = 0x8CE2
+	COLOR_ATTACHMENT2_NV                                                  = 0x8CE2
+	COLOR_ATTACHMENT3                                                     = 0x8CE3
+	COLOR_ATTACHMENT30                                                    = 0x8CFE
+	COLOR_ATTACHMENT31                                                    = 0x8CFF
+	COLOR_ATTACHMENT3_EXT                                                 = 0x8CE3
+	COLOR_ATTACHMENT3_NV                                                  = 0x8CE3
+	COLOR_ATTACHMENT4                                                     = 0x8CE4
+	COLOR_ATTACHMENT4_EXT                                                 = 0x8CE4
+	COLOR_ATTACHMENT4_NV                                                  = 0x8CE4
+	COLOR_ATTACHMENT5                                                     = 0x8CE5
+	COLOR_ATTACHMENT5_EXT                                                 = 0x8CE5
+	COLOR_ATTACHMENT5_NV                                                  = 0x8CE5
+	COLOR_ATTACHMENT6                                                     = 0x8CE6
+	COLOR_ATTACHMENT6_EXT                                                 = 0x8CE6
+	COLOR_ATTACHMENT6_NV                                                  = 0x8CE6
+	COLOR_ATTACHMENT7                                                     = 0x8CE7
+	COLOR_ATTACHMENT7_EXT                                                 = 0x8CE7
+	COLOR_ATTACHMENT7_NV                                                  = 0x8CE7
+	COLOR_ATTACHMENT8                                                     = 0x8CE8
+	COLOR_ATTACHMENT8_EXT                                                 = 0x8CE8
+	COLOR_ATTACHMENT8_NV                                                  = 0x8CE8
+	COLOR_ATTACHMENT9                                                     = 0x8CE9
+	COLOR_ATTACHMENT9_EXT                                                 = 0x8CE9
+	COLOR_ATTACHMENT9_NV                                                  = 0x8CE9
+	COLOR_ATTACHMENT_EXT                                                  = 0x90F0
+	COLOR_BUFFER_BIT                                                      = 0x00004000
+	COLOR_BUFFER_BIT0_QCOM                                                = 0x00000001
+	COLOR_BUFFER_BIT1_QCOM                                                = 0x00000002
+	COLOR_BUFFER_BIT2_QCOM                                                = 0x00000004
+	COLOR_BUFFER_BIT3_QCOM                                                = 0x00000008
+	COLOR_BUFFER_BIT4_QCOM                                                = 0x00000010
+	COLOR_BUFFER_BIT5_QCOM                                                = 0x00000020
+	COLOR_BUFFER_BIT6_QCOM                                                = 0x00000040
+	COLOR_BUFFER_BIT7_QCOM                                                = 0x00000080
+	COLOR_CLEAR_VALUE                                                     = 0x0C22
+	COLOR_EXT                                                             = 0x1800
+	COLOR_SAMPLES_NV                                                      = 0x8E20
+	COLOR_WRITEMASK                                                       = 0x0C23
+	COMMAND_BARRIER_BIT                                                   = 0x00000040
+	COMPARE_REF_TO_TEXTURE                                                = 0x884E
+	COMPARE_REF_TO_TEXTURE_EXT                                            = 0x884E
+	COMPILE_STATUS                                                        = 0x8B81
+	COMPLETION_STATUS_KHR                                                 = 0x91B1
+	COMPRESSED_R11_EAC                                                    = 0x9270
+	COMPRESSED_RED_GREEN_RGTC2_EXT                                        = 0x8DBD
+	COMPRESSED_RED_RGTC1_EXT                                              = 0x8DBB
+	COMPRESSED_RG11_EAC                                                   = 0x9272
+	COMPRESSED_RGB8_ETC2                                                  = 0x9274
+	COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2                              = 0x9276
+	COMPRESSED_RGBA8_ETC2_EAC                                             = 0x9278
+	COMPRESSED_RGBA_ASTC_10x10_KHR                                        = 0x93BB
+	COMPRESSED_RGBA_ASTC_10x5_KHR                                         = 0x93B8
+	COMPRESSED_RGBA_ASTC_10x6_KHR                                         = 0x93B9
+	COMPRESSED_RGBA_ASTC_10x8_KHR                                         = 0x93BA
+	COMPRESSED_RGBA_ASTC_12x10_KHR                                        = 0x93BC
+	COMPRESSED_RGBA_ASTC_12x12_KHR                                        = 0x93BD
+	COMPRESSED_RGBA_ASTC_3x3x3_OES                                        = 0x93C0
+	COMPRESSED_RGBA_ASTC_4x3x3_OES                                        = 0x93C1
+	COMPRESSED_RGBA_ASTC_4x4_KHR                                          = 0x93B0
+	COMPRESSED_RGBA_ASTC_4x4x3_OES                                        = 0x93C2
+	COMPRESSED_RGBA_ASTC_4x4x4_OES                                        = 0x93C3
+	COMPRESSED_RGBA_ASTC_5x4_KHR                                          = 0x93B1
+	COMPRESSED_RGBA_ASTC_5x4x4_OES                                        = 0x93C4
+	COMPRESSED_RGBA_ASTC_5x5_KHR                                          = 0x93B2
+	COMPRESSED_RGBA_ASTC_5x5x4_OES                                        = 0x93C5
+	COMPRESSED_RGBA_ASTC_5x5x5_OES                                        = 0x93C6
+	COMPRESSED_RGBA_ASTC_6x5_KHR                                          = 0x93B3
+	COMPRESSED_RGBA_ASTC_6x5x5_OES                                        = 0x93C7
+	COMPRESSED_RGBA_ASTC_6x6_KHR                                          = 0x93B4
+	COMPRESSED_RGBA_ASTC_6x6x5_OES                                        = 0x93C8
+	COMPRESSED_RGBA_ASTC_6x6x6_OES                                        = 0x93C9
+	COMPRESSED_RGBA_ASTC_8x5_KHR                                          = 0x93B5
+	COMPRESSED_RGBA_ASTC_8x6_KHR                                          = 0x93B6
+	COMPRESSED_RGBA_ASTC_8x8_KHR                                          = 0x93B7
+	COMPRESSED_RGBA_BPTC_UNORM_EXT                                        = 0x8E8C
+	COMPRESSED_RGBA_PVRTC_2BPPV1_IMG                                      = 0x8C03
+	COMPRESSED_RGBA_PVRTC_2BPPV2_IMG                                      = 0x9137
+	COMPRESSED_RGBA_PVRTC_4BPPV1_IMG                                      = 0x8C02
+	COMPRESSED_RGBA_PVRTC_4BPPV2_IMG                                      = 0x9138
+	COMPRESSED_RGBA_S3TC_DXT1_EXT                                         = 0x83F1
+	COMPRESSED_RGBA_S3TC_DXT3_ANGLE                                       = 0x83F2
+	COMPRESSED_RGBA_S3TC_DXT3_EXT                                         = 0x83F2
+	COMPRESSED_RGBA_S3TC_DXT5_ANGLE                                       = 0x83F3
+	COMPRESSED_RGBA_S3TC_DXT5_EXT                                         = 0x83F3
+	COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT                                  = 0x8E8E
+	COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT                                = 0x8E8F
+	COMPRESSED_RGB_PVRTC_2BPPV1_IMG                                       = 0x8C01
+	COMPRESSED_RGB_PVRTC_4BPPV1_IMG                                       = 0x8C00
+	COMPRESSED_RGB_S3TC_DXT1_EXT                                          = 0x83F0
+	COMPRESSED_SIGNED_R11_EAC                                             = 0x9271
+	COMPRESSED_SIGNED_RED_GREEN_RGTC2_EXT                                 = 0x8DBE
+	COMPRESSED_SIGNED_RED_RGTC1_EXT                                       = 0x8DBC
+	COMPRESSED_SIGNED_RG11_EAC                                            = 0x9273
+	COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR                                = 0x93DB
+	COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR                                 = 0x93D8
+	COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR                                 = 0x93D9
+	COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR                                 = 0x93DA
+	COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR                                = 0x93DC
+	COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR                                = 0x93DD
+	COMPRESSED_SRGB8_ALPHA8_ASTC_3x3x3_OES                                = 0x93E0
+	COMPRESSED_SRGB8_ALPHA8_ASTC_4x3x3_OES                                = 0x93E1
+	COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR                                  = 0x93D0
+	COMPRESSED_SRGB8_ALPHA8_ASTC_4x4x3_OES                                = 0x93E2
+	COMPRESSED_SRGB8_ALPHA8_ASTC_4x4x4_OES                                = 0x93E3
+	COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR                                  = 0x93D1
+	COMPRESSED_SRGB8_ALPHA8_ASTC_5x4x4_OES                                = 0x93E4
+	COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR                                  = 0x93D2
+	COMPRESSED_SRGB8_ALPHA8_ASTC_5x5x4_OES                                = 0x93E5
+	COMPRESSED_SRGB8_ALPHA8_ASTC_5x5x5_OES                                = 0x93E6
+	COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR                                  = 0x93D3
+	COMPRESSED_SRGB8_ALPHA8_ASTC_6x5x5_OES                                = 0x93E7
+	COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR                                  = 0x93D4
+	COMPRESSED_SRGB8_ALPHA8_ASTC_6x6x5_OES                                = 0x93E8
+	COMPRESSED_SRGB8_ALPHA8_ASTC_6x6x6_OES                                = 0x93E9
+	COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR                                  = 0x93D5
+	COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR                                  = 0x93D6
+	COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR                                  = 0x93D7
+	COMPRESSED_SRGB8_ALPHA8_ETC2_EAC                                      = 0x9279
+	COMPRESSED_SRGB8_ETC2                                                 = 0x9275
+	COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2                             = 0x9277
+	COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT                                  = 0x8E8D
+	COMPRESSED_SRGB_ALPHA_PVRTC_2BPPV1_EXT                                = 0x8A56
+	COMPRESSED_SRGB_ALPHA_PVRTC_2BPPV2_IMG                                = 0x93F0
+	COMPRESSED_SRGB_ALPHA_PVRTC_4BPPV1_EXT                                = 0x8A57
+	COMPRESSED_SRGB_ALPHA_PVRTC_4BPPV2_IMG                                = 0x93F1
+	COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT                                   = 0x8C4D
+	COMPRESSED_SRGB_ALPHA_S3TC_DXT1_NV                                    = 0x8C4D
+	COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT                                   = 0x8C4E
+	COMPRESSED_SRGB_ALPHA_S3TC_DXT3_NV                                    = 0x8C4E
+	COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT                                   = 0x8C4F
+	COMPRESSED_SRGB_ALPHA_S3TC_DXT5_NV                                    = 0x8C4F
+	COMPRESSED_SRGB_PVRTC_2BPPV1_EXT                                      = 0x8A54
+	COMPRESSED_SRGB_PVRTC_4BPPV1_EXT                                      = 0x8A55
+	COMPRESSED_SRGB_S3TC_DXT1_EXT                                         = 0x8C4C
+	COMPRESSED_SRGB_S3TC_DXT1_NV                                          = 0x8C4C
+	COMPRESSED_TEXTURE_FORMATS                                            = 0x86A3
+	COMPUTE_SHADER                                                        = 0x91B9
+	COMPUTE_SHADER_BIT                                                    = 0x00000020
+	COMPUTE_WORK_GROUP_SIZE                                               = 0x8267
+	CONDITION_SATISFIED                                                   = 0x911C
+	CONDITION_SATISFIED_APPLE                                             = 0x911C
+	CONFORMANT_NV                                                         = 0x9374
+	CONIC_CURVE_TO_NV                                                     = 0x1A
+	CONJOINT_NV                                                           = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                                      = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                                         = 0x9346
+	CONSERVATIVE_RASTER_MODE_NV                                           = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                                 = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                                  = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV                        = 0x954F
+	CONSTANT_ALPHA                                                        = 0x8003
+	CONSTANT_COLOR                                                        = 0x8001
+	CONTEXT_FLAG_DEBUG_BIT                                                = 0x00000002
+	CONTEXT_FLAG_DEBUG_BIT_KHR                                            = 0x00000002
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                                         = 0x00000008
+	CONTEXT_FLAG_PROTECTED_CONTENT_BIT_EXT                                = 0x00000010
+	CONTEXT_LOST                                                          = 0x0507
+	CONTEXT_LOST_KHR                                                      = 0x0507
+	CONTEXT_RELEASE_BEHAVIOR                                              = 0x82FB
+	CONTEXT_RELEASE_BEHAVIOR_FLUSH                                        = 0x82FC
+	CONTEXT_RELEASE_BEHAVIOR_FLUSH_KHR                                    = 0x82FC
+	CONTEXT_RELEASE_BEHAVIOR_KHR                                          = 0x82FB
+	CONTEXT_ROBUST_ACCESS                                                 = 0x90F3
+	CONTEXT_ROBUST_ACCESS_EXT                                             = 0x90F3
+	CONTEXT_ROBUST_ACCESS_KHR                                             = 0x90F3
+	CONTRAST_NV                                                           = 0x92A1
+	CONVEX_HULL_NV                                                        = 0x908B
+	COPY_READ_BUFFER                                                      = 0x8F36
+	COPY_READ_BUFFER_BINDING                                              = 0x8F36
+	COPY_READ_BUFFER_NV                                                   = 0x8F36
+	COPY_WRITE_BUFFER                                                     = 0x8F37
+	COPY_WRITE_BUFFER_BINDING                                             = 0x8F37
+	COPY_WRITE_BUFFER_NV                                                  = 0x8F37
+	COUNTER_RANGE_AMD                                                     = 0x8BC1
+	COUNTER_TYPE_AMD                                                      = 0x8BC0
+	COUNT_DOWN_NV                                                         = 0x9089
+	COUNT_UP_NV                                                           = 0x9088
+	COVERAGE_ALL_FRAGMENTS_NV                                             = 0x8ED5
+	COVERAGE_ATTACHMENT_NV                                                = 0x8ED2
+	COVERAGE_AUTOMATIC_NV                                                 = 0x8ED7
+	COVERAGE_BUFFERS_NV                                                   = 0x8ED3
+	COVERAGE_BUFFER_BIT_NV                                                = 0x00008000
+	COVERAGE_COMPONENT4_NV                                                = 0x8ED1
+	COVERAGE_COMPONENT_NV                                                 = 0x8ED0
+	COVERAGE_EDGE_FRAGMENTS_NV                                            = 0x8ED6
+	COVERAGE_MODULATION_NV                                                = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                                          = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                                     = 0x9333
+	COVERAGE_SAMPLES_NV                                                   = 0x8ED4
+	CPU_OPTIMIZED_QCOM                                                    = 0x8FB1
+	CUBIC_CURVE_TO_NV                                                     = 0x0C
+	CUBIC_IMG                                                             = 0x9139
+	CUBIC_MIPMAP_LINEAR_IMG                                               = 0x913B
+	CUBIC_MIPMAP_NEAREST_IMG                                              = 0x913A
+	CULL_FACE                                                             = 0x0B44
+	CULL_FACE_MODE                                                        = 0x0B45
+	CURRENT_PROGRAM                                                       = 0x8B8D
+	CURRENT_QUERY                                                         = 0x8865
+	CURRENT_QUERY_EXT                                                     = 0x8865
+	CURRENT_VERTEX_ATTRIB                                                 = 0x8626
+	CW                                                                    = 0x0900
+	D3D12_FENCE_VALUE_EXT                                                 = 0x9595
+	DARKEN_KHR                                                            = 0x9297
+	DARKEN_NV                                                             = 0x9297
+	DEBUG_CALLBACK_FUNCTION                                               = 0x8244
+	DEBUG_CALLBACK_FUNCTION_KHR                                           = 0x8244
+	DEBUG_CALLBACK_USER_PARAM                                             = 0x8245
+	DEBUG_CALLBACK_USER_PARAM_KHR                                         = 0x8245
+	DEBUG_GROUP_STACK_DEPTH                                               = 0x826D
+	DEBUG_GROUP_STACK_DEPTH_KHR                                           = 0x826D
+	DEBUG_LOGGED_MESSAGES                                                 = 0x9145
+	DEBUG_LOGGED_MESSAGES_KHR                                             = 0x9145
+	DEBUG_NEXT_LOGGED_MESSAGE_LENGTH                                      = 0x8243
+	DEBUG_NEXT_LOGGED_MESSAGE_LENGTH_KHR                                  = 0x8243
+	DEBUG_OUTPUT                                                          = 0x92E0
+	DEBUG_OUTPUT_KHR                                                      = 0x92E0
+	DEBUG_OUTPUT_SYNCHRONOUS                                              = 0x8242
+	DEBUG_OUTPUT_SYNCHRONOUS_KHR                                          = 0x8242
+	DEBUG_SEVERITY_HIGH                                                   = 0x9146
+	DEBUG_SEVERITY_HIGH_KHR                                               = 0x9146
+	DEBUG_SEVERITY_LOW                                                    = 0x9148
+	DEBUG_SEVERITY_LOW_KHR                                                = 0x9148
+	DEBUG_SEVERITY_MEDIUM                                                 = 0x9147
+	DEBUG_SEVERITY_MEDIUM_KHR                                             = 0x9147
+	DEBUG_SEVERITY_NOTIFICATION                                           = 0x826B
+	DEBUG_SEVERITY_NOTIFICATION_KHR                                       = 0x826B
+	DEBUG_SOURCE_API                                                      = 0x8246
+	DEBUG_SOURCE_API_KHR                                                  = 0x8246
+	DEBUG_SOURCE_APPLICATION                                              = 0x824A
+	DEBUG_SOURCE_APPLICATION_KHR                                          = 0x824A
+	DEBUG_SOURCE_OTHER                                                    = 0x824B
+	DEBUG_SOURCE_OTHER_KHR                                                = 0x824B
+	DEBUG_SOURCE_SHADER_COMPILER                                          = 0x8248
+	DEBUG_SOURCE_SHADER_COMPILER_KHR                                      = 0x8248
+	DEBUG_SOURCE_THIRD_PARTY                                              = 0x8249
+	DEBUG_SOURCE_THIRD_PARTY_KHR                                          = 0x8249
+	DEBUG_SOURCE_WINDOW_SYSTEM                                            = 0x8247
+	DEBUG_SOURCE_WINDOW_SYSTEM_KHR                                        = 0x8247
+	DEBUG_TYPE_DEPRECATED_BEHAVIOR                                        = 0x824D
+	DEBUG_TYPE_DEPRECATED_BEHAVIOR_KHR                                    = 0x824D
+	DEBUG_TYPE_ERROR                                                      = 0x824C
+	DEBUG_TYPE_ERROR_KHR                                                  = 0x824C
+	DEBUG_TYPE_MARKER                                                     = 0x8268
+	DEBUG_TYPE_MARKER_KHR                                                 = 0x8268
+	DEBUG_TYPE_OTHER                                                      = 0x8251
+	DEBUG_TYPE_OTHER_KHR                                                  = 0x8251
+	DEBUG_TYPE_PERFORMANCE                                                = 0x8250
+	DEBUG_TYPE_PERFORMANCE_KHR                                            = 0x8250
+	DEBUG_TYPE_POP_GROUP                                                  = 0x826A
+	DEBUG_TYPE_POP_GROUP_KHR                                              = 0x826A
+	DEBUG_TYPE_PORTABILITY                                                = 0x824F
+	DEBUG_TYPE_PORTABILITY_KHR                                            = 0x824F
+	DEBUG_TYPE_PUSH_GROUP                                                 = 0x8269
+	DEBUG_TYPE_PUSH_GROUP_KHR                                             = 0x8269
+	DEBUG_TYPE_UNDEFINED_BEHAVIOR                                         = 0x824E
+	DEBUG_TYPE_UNDEFINED_BEHAVIOR_KHR                                     = 0x824E
+	DECODE_EXT                                                            = 0x8A49
+	DECR                                                                  = 0x1E03
+	DECR_WRAP                                                             = 0x8508
+	DEDICATED_MEMORY_OBJECT_EXT                                           = 0x9581
+	DELETE_STATUS                                                         = 0x8B80
+	DEPTH                                                                 = 0x1801
+	DEPTH24_STENCIL8                                                      = 0x88F0
+	DEPTH24_STENCIL8_OES                                                  = 0x88F0
+	DEPTH32F_STENCIL8                                                     = 0x8CAD
+	DEPTH_ATTACHMENT                                                      = 0x8D00
+	DEPTH_BITS                                                            = 0x0D56
+	DEPTH_BUFFER_BIT                                                      = 0x00000100
+	DEPTH_BUFFER_BIT0_QCOM                                                = 0x00000100
+	DEPTH_BUFFER_BIT1_QCOM                                                = 0x00000200
+	DEPTH_BUFFER_BIT2_QCOM                                                = 0x00000400
+	DEPTH_BUFFER_BIT3_QCOM                                                = 0x00000800
+	DEPTH_BUFFER_BIT4_QCOM                                                = 0x00001000
+	DEPTH_BUFFER_BIT5_QCOM                                                = 0x00002000
+	DEPTH_BUFFER_BIT6_QCOM                                                = 0x00004000
+	DEPTH_BUFFER_BIT7_QCOM                                                = 0x00008000
+	DEPTH_CLEAR_VALUE                                                     = 0x0B73
+	DEPTH_COMPONENT                                                       = 0x1902
+	DEPTH_COMPONENT16                                                     = 0x81A5
+	DEPTH_COMPONENT16_NONLINEAR_NV                                        = 0x8E2C
+	DEPTH_COMPONENT16_OES                                                 = 0x81A5
+	DEPTH_COMPONENT24                                                     = 0x81A6
+	DEPTH_COMPONENT24_OES                                                 = 0x81A6
+	DEPTH_COMPONENT32F                                                    = 0x8CAC
+	DEPTH_COMPONENT32_OES                                                 = 0x81A7
+	DEPTH_EXT                                                             = 0x1801
+	DEPTH_FUNC                                                            = 0x0B74
+	DEPTH_RANGE                                                           = 0x0B70
+	DEPTH_SAMPLES_NV                                                      = 0x932D
+	DEPTH_STENCIL                                                         = 0x84F9
+	DEPTH_STENCIL_ATTACHMENT                                              = 0x821A
+	DEPTH_STENCIL_OES                                                     = 0x84F9
+	DEPTH_STENCIL_TEXTURE_MODE                                            = 0x90EA
+	DEPTH_TEST                                                            = 0x0B71
+	DEPTH_WRITEMASK                                                       = 0x0B72
+	DEVICE_LUID_EXT                                                       = 0x9599
+	DEVICE_NODE_MASK_EXT                                                  = 0x959A
+	DEVICE_UUID_EXT                                                       = 0x9597
+	DIFFERENCE_KHR                                                        = 0x929E
+	DIFFERENCE_NV                                                         = 0x929E
+	DISJOINT_NV                                                           = 0x9283
+	DISPATCH_INDIRECT_BUFFER                                              = 0x90EE
+	DISPATCH_INDIRECT_BUFFER_BINDING                                      = 0x90EF
+	DITHER                                                                = 0x0BD0
+	DMP_PROGRAM_BINARY_DMP                                                = 0x9253
+	DONT_CARE                                                             = 0x1100
+	DOWNSAMPLE_SCALES_IMG                                                 = 0x913E
+	DRAW_BUFFER0                                                          = 0x8825
+	DRAW_BUFFER0_EXT                                                      = 0x8825
+	DRAW_BUFFER0_NV                                                       = 0x8825
+	DRAW_BUFFER1                                                          = 0x8826
+	DRAW_BUFFER10                                                         = 0x882F
+	DRAW_BUFFER10_EXT                                                     = 0x882F
+	DRAW_BUFFER10_NV                                                      = 0x882F
+	DRAW_BUFFER11                                                         = 0x8830
+	DRAW_BUFFER11_EXT                                                     = 0x8830
+	DRAW_BUFFER11_NV                                                      = 0x8830
+	DRAW_BUFFER12                                                         = 0x8831
+	DRAW_BUFFER12_EXT                                                     = 0x8831
+	DRAW_BUFFER12_NV                                                      = 0x8831
+	DRAW_BUFFER13                                                         = 0x8832
+	DRAW_BUFFER13_EXT                                                     = 0x8832
+	DRAW_BUFFER13_NV                                                      = 0x8832
+	DRAW_BUFFER14                                                         = 0x8833
+	DRAW_BUFFER14_EXT                                                     = 0x8833
+	DRAW_BUFFER14_NV                                                      = 0x8833
+	DRAW_BUFFER15                                                         = 0x8834
+	DRAW_BUFFER15_EXT                                                     = 0x8834
+	DRAW_BUFFER15_NV                                                      = 0x8834
+	DRAW_BUFFER1_EXT                                                      = 0x8826
+	DRAW_BUFFER1_NV                                                       = 0x8826
+	DRAW_BUFFER2                                                          = 0x8827
+	DRAW_BUFFER2_EXT                                                      = 0x8827
+	DRAW_BUFFER2_NV                                                       = 0x8827
+	DRAW_BUFFER3                                                          = 0x8828
+	DRAW_BUFFER3_EXT                                                      = 0x8828
+	DRAW_BUFFER3_NV                                                       = 0x8828
+	DRAW_BUFFER4                                                          = 0x8829
+	DRAW_BUFFER4_EXT                                                      = 0x8829
+	DRAW_BUFFER4_NV                                                       = 0x8829
+	DRAW_BUFFER5                                                          = 0x882A
+	DRAW_BUFFER5_EXT                                                      = 0x882A
+	DRAW_BUFFER5_NV                                                       = 0x882A
+	DRAW_BUFFER6                                                          = 0x882B
+	DRAW_BUFFER6_EXT                                                      = 0x882B
+	DRAW_BUFFER6_NV                                                       = 0x882B
+	DRAW_BUFFER7                                                          = 0x882C
+	DRAW_BUFFER7_EXT                                                      = 0x882C
+	DRAW_BUFFER7_NV                                                       = 0x882C
+	DRAW_BUFFER8                                                          = 0x882D
+	DRAW_BUFFER8_EXT                                                      = 0x882D
+	DRAW_BUFFER8_NV                                                       = 0x882D
+	DRAW_BUFFER9                                                          = 0x882E
+	DRAW_BUFFER9_EXT                                                      = 0x882E
+	DRAW_BUFFER9_NV                                                       = 0x882E
+	DRAW_BUFFER_EXT                                                       = 0x0C01
+	DRAW_FRAMEBUFFER                                                      = 0x8CA9
+	DRAW_FRAMEBUFFER_ANGLE                                                = 0x8CA9
+	DRAW_FRAMEBUFFER_APPLE                                                = 0x8CA9
+	DRAW_FRAMEBUFFER_BINDING                                              = 0x8CA6
+	DRAW_FRAMEBUFFER_BINDING_ANGLE                                        = 0x8CA6
+	DRAW_FRAMEBUFFER_BINDING_APPLE                                        = 0x8CA6
+	DRAW_FRAMEBUFFER_BINDING_NV                                           = 0x8CA6
+	DRAW_FRAMEBUFFER_NV                                                   = 0x8CA9
+	DRAW_INDIRECT_BUFFER                                                  = 0x8F3F
+	DRAW_INDIRECT_BUFFER_BINDING                                          = 0x8F43
+	DRIVER_UUID_EXT                                                       = 0x9598
+	DST_ALPHA                                                             = 0x0304
+	DST_ATOP_NV                                                           = 0x928F
+	DST_COLOR                                                             = 0x0306
+	DST_IN_NV                                                             = 0x928B
+	DST_NV                                                                = 0x9287
+	DST_OUT_NV                                                            = 0x928D
+	DST_OVER_NV                                                           = 0x9289
+	DUP_FIRST_CUBIC_CURVE_TO_NV                                           = 0xF2
+	DUP_LAST_CUBIC_CURVE_TO_NV                                            = 0xF4
+	DYNAMIC_COPY                                                          = 0x88EA
+	DYNAMIC_DRAW                                                          = 0x88E8
+	DYNAMIC_READ                                                          = 0x88E9
+	DYNAMIC_STORAGE_BIT_EXT                                               = 0x0100
+	EFFECTIVE_RASTER_SAMPLES_EXT                                          = 0x932C
+	ELEMENT_ARRAY_BARRIER_BIT                                             = 0x00000002
+	ELEMENT_ARRAY_BUFFER                                                  = 0x8893
+	ELEMENT_ARRAY_BUFFER_BINDING                                          = 0x8895
+	EQUAL                                                                 = 0x0202
+	ETC1_RGB8_OES                                                         = 0x8D64
+	ETC1_SRGB8_NV                                                         = 0x88EE
+	EXCLUSION_KHR                                                         = 0x92A0
+	EXCLUSION_NV                                                          = 0x92A0
+	EXCLUSIVE_EXT                                                         = 0x8F11
+	EXTENSIONS                                                            = 0x1F03
+	FACTOR_MAX_AMD                                                        = 0x901D
+	FACTOR_MIN_AMD                                                        = 0x901C
+	FALSE                                                                 = 0
+	FASTEST                                                               = 0x1101
+	FENCE_CONDITION_NV                                                    = 0x84F4
+	FENCE_STATUS_NV                                                       = 0x84F3
+	FETCH_PER_SAMPLE_ARM                                                  = 0x8F65
+	FILE_NAME_NV                                                          = 0x9074
+	FILL_NV                                                               = 0x1B02
+	FILL_RECTANGLE_NV                                                     = 0x933C
+	FIRST_TO_REST_NV                                                      = 0x90AF
+	FIRST_VERTEX_CONVENTION_EXT                                           = 0x8E4D
+	FIRST_VERTEX_CONVENTION_OES                                           = 0x8E4D
+	FIXED                                                                 = 0x140C
+	FLOAT                                                                 = 0x1406
+	FLOAT16_NV                                                            = 0x8FF8
+	FLOAT16_VEC2_NV                                                       = 0x8FF9
+	FLOAT16_VEC3_NV                                                       = 0x8FFA
+	FLOAT16_VEC4_NV                                                       = 0x8FFB
+	FLOAT_32_UNSIGNED_INT_24_8_REV                                        = 0x8DAD
+	FLOAT_MAT2                                                            = 0x8B5A
+	FLOAT_MAT2x3                                                          = 0x8B65
+	FLOAT_MAT2x3_NV                                                       = 0x8B65
+	FLOAT_MAT2x4                                                          = 0x8B66
+	FLOAT_MAT2x4_NV                                                       = 0x8B66
+	FLOAT_MAT3                                                            = 0x8B5B
+	FLOAT_MAT3x2                                                          = 0x8B67
+	FLOAT_MAT3x2_NV                                                       = 0x8B67
+	FLOAT_MAT3x4                                                          = 0x8B68
+	FLOAT_MAT3x4_NV                                                       = 0x8B68
+	FLOAT_MAT4                                                            = 0x8B5C
+	FLOAT_MAT4x2                                                          = 0x8B69
+	FLOAT_MAT4x2_NV                                                       = 0x8B69
+	FLOAT_MAT4x3                                                          = 0x8B6A
+	FLOAT_MAT4x3_NV                                                       = 0x8B6A
+	FLOAT_VEC2                                                            = 0x8B50
+	FLOAT_VEC3                                                            = 0x8B51
+	FLOAT_VEC4                                                            = 0x8B52
+	FONT_ASCENDER_BIT_NV                                                  = 0x00200000
+	FONT_DESCENDER_BIT_NV                                                 = 0x00400000
+	FONT_GLYPHS_AVAILABLE_NV                                              = 0x9368
+	FONT_HAS_KERNING_BIT_NV                                               = 0x10000000
+	FONT_HEIGHT_BIT_NV                                                    = 0x00800000
+	FONT_MAX_ADVANCE_HEIGHT_BIT_NV                                        = 0x02000000
+	FONT_MAX_ADVANCE_WIDTH_BIT_NV                                         = 0x01000000
+	FONT_NUM_GLYPH_INDICES_BIT_NV                                         = 0x20000000
+	FONT_TARGET_UNAVAILABLE_NV                                            = 0x9369
+	FONT_UNAVAILABLE_NV                                                   = 0x936A
+	FONT_UNDERLINE_POSITION_BIT_NV                                        = 0x04000000
+	FONT_UNDERLINE_THICKNESS_BIT_NV                                       = 0x08000000
+	FONT_UNINTELLIGIBLE_NV                                                = 0x936B
+	FONT_UNITS_PER_EM_BIT_NV                                              = 0x00100000
+	FONT_X_MAX_BOUNDS_BIT_NV                                              = 0x00040000
+	FONT_X_MIN_BOUNDS_BIT_NV                                              = 0x00010000
+	FONT_Y_MAX_BOUNDS_BIT_NV                                              = 0x00080000
+	FONT_Y_MIN_BOUNDS_BIT_NV                                              = 0x00020000
+	FOVEATION_ENABLE_BIT_QCOM                                             = 0x00000001
+	FOVEATION_SCALED_BIN_METHOD_BIT_QCOM                                  = 0x00000002
+	FRACTIONAL_EVEN_EXT                                                   = 0x8E7C
+	FRACTIONAL_EVEN_OES                                                   = 0x8E7C
+	FRACTIONAL_ODD_EXT                                                    = 0x8E7B
+	FRACTIONAL_ODD_OES                                                    = 0x8E7B
+	FRAGMENT_COVERAGE_COLOR_NV                                            = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                                         = 0x92DD
+	FRAGMENT_INPUT_NV                                                     = 0x936D
+	FRAGMENT_INTERPOLATION_OFFSET_BITS_OES                                = 0x8E5D
+	FRAGMENT_SHADER                                                       = 0x8B30
+	FRAGMENT_SHADER_BIT                                                   = 0x00000002
+	FRAGMENT_SHADER_BIT_EXT                                               = 0x00000002
+	FRAGMENT_SHADER_DERIVATIVE_HINT                                       = 0x8B8B
+	FRAGMENT_SHADER_DERIVATIVE_HINT_OES                                   = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                                  = 0x8A52
+	FRAGMENT_SHADER_FRAMEBUFFER_FETCH_MRT_ARM                             = 0x8F66
+	FRAMEBUFFER                                                           = 0x8D40
+	FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE                                     = 0x8215
+	FRAMEBUFFER_ATTACHMENT_ANGLE                                          = 0x93A3
+	FRAMEBUFFER_ATTACHMENT_BLUE_SIZE                                      = 0x8214
+	FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING                                 = 0x8210
+	FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT                             = 0x8210
+	FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE                                 = 0x8211
+	FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT                             = 0x8211
+	FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE                                     = 0x8216
+	FRAMEBUFFER_ATTACHMENT_GREEN_SIZE                                     = 0x8213
+	FRAMEBUFFER_ATTACHMENT_LAYERED_EXT                                    = 0x8DA7
+	FRAMEBUFFER_ATTACHMENT_LAYERED_OES                                    = 0x8DA7
+	FRAMEBUFFER_ATTACHMENT_OBJECT_NAME                                    = 0x8CD1
+	FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE                                    = 0x8CD0
+	FRAMEBUFFER_ATTACHMENT_RED_SIZE                                       = 0x8212
+	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                                   = 0x8217
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_3D_ZOFFSET_OES                         = 0x8CD4
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR                    = 0x9632
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE                          = 0x8CD3
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                                  = 0x8CD4
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                                  = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR                          = 0x9630
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_SAMPLES_EXT                            = 0x8D6C
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_SCALE_IMG                              = 0x913F
+	FRAMEBUFFER_BARRIER_BIT                                               = 0x00000400
+	FRAMEBUFFER_BINDING                                                   = 0x8CA6
+	FRAMEBUFFER_COMPLETE                                                  = 0x8CD5
+	FRAMEBUFFER_DEFAULT                                                   = 0x8218
+	FRAMEBUFFER_DEFAULT_FIXED_SAMPLE_LOCATIONS                            = 0x9314
+	FRAMEBUFFER_DEFAULT_HEIGHT                                            = 0x9311
+	FRAMEBUFFER_DEFAULT_LAYERS_EXT                                        = 0x9312
+	FRAMEBUFFER_DEFAULT_LAYERS_OES                                        = 0x9312
+	FRAMEBUFFER_DEFAULT_SAMPLES                                           = 0x9313
+	FRAMEBUFFER_DEFAULT_WIDTH                                             = 0x9310
+	FRAMEBUFFER_FETCH_NONCOHERENT_QCOM                                    = 0x96A2
+	FRAMEBUFFER_INCOMPLETE_ATTACHMENT                                     = 0x8CD6
+	FRAMEBUFFER_INCOMPLETE_DIMENSIONS                                     = 0x8CD9
+	FRAMEBUFFER_INCOMPLETE_FOVEATION_QCOM                                 = 0x8BFF
+	FRAMEBUFFER_INCOMPLETE_INSUFFICIENT_SHADER_COMBINED_LOCAL_STORAGE_EXT = 0x9652
+	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS_EXT                              = 0x8DA8
+	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS_OES                              = 0x8DA8
+	FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT                             = 0x8CD7
+	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE                                    = 0x8D56
+	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_AND_DOWNSAMPLE_IMG                 = 0x913C
+	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_ANGLE                              = 0x8D56
+	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_APPLE                              = 0x8D56
+	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_EXT                                = 0x8D56
+	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_IMG                                = 0x9134
+	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_NV                                 = 0x8D56
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                               = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV                          = 0x9342
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                             = 0x9343
+	FRAMEBUFFER_SRGB_EXT                                                  = 0x8DB9
+	FRAMEBUFFER_UNDEFINED                                                 = 0x8219
+	FRAMEBUFFER_UNDEFINED_OES                                             = 0x8219
+	FRAMEBUFFER_UNSUPPORTED                                               = 0x8CDD
+	FRONT                                                                 = 0x0404
+	FRONT_AND_BACK                                                        = 0x0408
+	FRONT_FACE                                                            = 0x0B46
+	FUNC_ADD                                                              = 0x8006
+	FUNC_ADD_EXT                                                          = 0x8006
+	FUNC_REVERSE_SUBTRACT                                                 = 0x800B
+	FUNC_SUBTRACT                                                         = 0x800A
+	GCCSO_SHADER_BINARY_FJ                                                = 0x9260
+	GENERATE_MIPMAP_HINT                                                  = 0x8192
+	GEOMETRY_LINKED_INPUT_TYPE_EXT                                        = 0x8917
+	GEOMETRY_LINKED_INPUT_TYPE_OES                                        = 0x8917
+	GEOMETRY_LINKED_OUTPUT_TYPE_EXT                                       = 0x8918
+	GEOMETRY_LINKED_OUTPUT_TYPE_OES                                       = 0x8918
+	GEOMETRY_LINKED_VERTICES_OUT_EXT                                      = 0x8916
+	GEOMETRY_LINKED_VERTICES_OUT_OES                                      = 0x8916
+	GEOMETRY_SHADER_BIT_EXT                                               = 0x00000004
+	GEOMETRY_SHADER_BIT_OES                                               = 0x00000004
+	GEOMETRY_SHADER_EXT                                                   = 0x8DD9
+	GEOMETRY_SHADER_INVOCATIONS_EXT                                       = 0x887F
+	GEOMETRY_SHADER_INVOCATIONS_OES                                       = 0x887F
+	GEOMETRY_SHADER_OES                                                   = 0x8DD9
+	GEQUAL                                                                = 0x0206
+	GLYPH_HAS_KERNING_BIT_NV                                              = 0x100
+	GLYPH_HEIGHT_BIT_NV                                                   = 0x02
+	GLYPH_HORIZONTAL_BEARING_ADVANCE_BIT_NV                               = 0x10
+	GLYPH_HORIZONTAL_BEARING_X_BIT_NV                                     = 0x04
+	GLYPH_HORIZONTAL_BEARING_Y_BIT_NV                                     = 0x08
+	GLYPH_VERTICAL_BEARING_ADVANCE_BIT_NV                                 = 0x80
+	GLYPH_VERTICAL_BEARING_X_BIT_NV                                       = 0x20
+	GLYPH_VERTICAL_BEARING_Y_BIT_NV                                       = 0x40
+	GLYPH_WIDTH_BIT_NV                                                    = 0x01
+	GPU_DISJOINT_EXT                                                      = 0x8FBB
+	GPU_OPTIMIZED_QCOM                                                    = 0x8FB2
+	GREATER                                                               = 0x0204
+	GREEN                                                                 = 0x1904
+	GREEN_BITS                                                            = 0x0D53
+	GREEN_NV                                                              = 0x1904
+	GUILTY_CONTEXT_RESET                                                  = 0x8253
+	GUILTY_CONTEXT_RESET_EXT                                              = 0x8253
+	GUILTY_CONTEXT_RESET_KHR                                              = 0x8253
+	HALF_FLOAT                                                            = 0x140B
+	HALF_FLOAT_OES                                                        = 0x8D61
+	HANDLE_TYPE_D3D11_IMAGE_EXT                                           = 0x958B
+	HANDLE_TYPE_D3D11_IMAGE_KMT_EXT                                       = 0x958C
+	HANDLE_TYPE_D3D12_FENCE_EXT                                           = 0x9594
+	HANDLE_TYPE_D3D12_RESOURCE_EXT                                        = 0x958A
+	HANDLE_TYPE_D3D12_TILEPOOL_EXT                                        = 0x9589
+	HANDLE_TYPE_OPAQUE_FD_EXT                                             = 0x9586
+	HANDLE_TYPE_OPAQUE_WIN32_EXT                                          = 0x9587
+	HANDLE_TYPE_OPAQUE_WIN32_KMT_EXT                                      = 0x9588
+	HARDLIGHT_KHR                                                         = 0x929B
+	HARDLIGHT_NV                                                          = 0x929B
+	HARDMIX_NV                                                            = 0x92A9
+	HIGH_FLOAT                                                            = 0x8DF2
+	HIGH_INT                                                              = 0x8DF5
+	HORIZONTAL_LINE_TO_NV                                                 = 0x06
+	HSL_COLOR_KHR                                                         = 0x92AF
+	HSL_COLOR_NV                                                          = 0x92AF
+	HSL_HUE_KHR                                                           = 0x92AD
+	HSL_HUE_NV                                                            = 0x92AD
+	HSL_LUMINOSITY_KHR                                                    = 0x92B0
+	HSL_LUMINOSITY_NV                                                     = 0x92B0
+	HSL_SATURATION_KHR                                                    = 0x92AE
+	HSL_SATURATION_NV                                                     = 0x92AE
+	IMAGE_2D                                                              = 0x904D
+	IMAGE_2D_ARRAY                                                        = 0x9053
+	IMAGE_3D                                                              = 0x904E
+	IMAGE_BINDING_ACCESS                                                  = 0x8F3E
+	IMAGE_BINDING_FORMAT                                                  = 0x906E
+	IMAGE_BINDING_LAYER                                                   = 0x8F3D
+	IMAGE_BINDING_LAYERED                                                 = 0x8F3C
+	IMAGE_BINDING_LEVEL                                                   = 0x8F3B
+	IMAGE_BINDING_NAME                                                    = 0x8F3A
+	IMAGE_BUFFER_EXT                                                      = 0x9051
+	IMAGE_BUFFER_OES                                                      = 0x9051
+	IMAGE_CUBE                                                            = 0x9050
+	IMAGE_CUBE_MAP_ARRAY_EXT                                              = 0x9054
+	IMAGE_CUBE_MAP_ARRAY_OES                                              = 0x9054
+	IMAGE_FORMAT_COMPATIBILITY_BY_CLASS                                   = 0x90C9
+	IMAGE_FORMAT_COMPATIBILITY_BY_SIZE                                    = 0x90C8
+	IMAGE_FORMAT_COMPATIBILITY_TYPE                                       = 0x90C7
+	IMPLEMENTATION_COLOR_READ_FORMAT                                      = 0x8B9B
+	IMPLEMENTATION_COLOR_READ_TYPE                                        = 0x8B9A
+	INCLUSIVE_EXT                                                         = 0x8F10
+	INCR                                                                  = 0x1E02
+	INCR_WRAP                                                             = 0x8507
+	INFO_LOG_LENGTH                                                       = 0x8B84
+	INNOCENT_CONTEXT_RESET                                                = 0x8254
+	INNOCENT_CONTEXT_RESET_EXT                                            = 0x8254
+	INNOCENT_CONTEXT_RESET_KHR                                            = 0x8254
+	INT                                                                   = 0x1404
+	INT16_NV                                                              = 0x8FE4
+	INT16_VEC2_NV                                                         = 0x8FE5
+	INT16_VEC3_NV                                                         = 0x8FE6
+	INT16_VEC4_NV                                                         = 0x8FE7
+	INT64_NV                                                              = 0x140E
+	INT64_VEC2_NV                                                         = 0x8FE9
+	INT64_VEC3_NV                                                         = 0x8FEA
+	INT64_VEC4_NV                                                         = 0x8FEB
+	INT8_NV                                                               = 0x8FE0
+	INT8_VEC2_NV                                                          = 0x8FE1
+	INT8_VEC3_NV                                                          = 0x8FE2
+	INT8_VEC4_NV                                                          = 0x8FE3
+	INTERLEAVED_ATTRIBS                                                   = 0x8C8C
+	INT_10_10_10_2_OES                                                    = 0x8DF7
+	INT_2_10_10_10_REV                                                    = 0x8D9F
+	INT_IMAGE_2D                                                          = 0x9058
+	INT_IMAGE_2D_ARRAY                                                    = 0x905E
+	INT_IMAGE_3D                                                          = 0x9059
+	INT_IMAGE_BUFFER_EXT                                                  = 0x905C
+	INT_IMAGE_BUFFER_OES                                                  = 0x905C
+	INT_IMAGE_CUBE                                                        = 0x905B
+	INT_IMAGE_CUBE_MAP_ARRAY_EXT                                          = 0x905F
+	INT_IMAGE_CUBE_MAP_ARRAY_OES                                          = 0x905F
+	INT_SAMPLER_2D                                                        = 0x8DCA
+	INT_SAMPLER_2D_ARRAY                                                  = 0x8DCF
+	INT_SAMPLER_2D_MULTISAMPLE                                            = 0x9109
+	INT_SAMPLER_2D_MULTISAMPLE_ARRAY_OES                                  = 0x910C
+	INT_SAMPLER_3D                                                        = 0x8DCB
+	INT_SAMPLER_BUFFER_EXT                                                = 0x8DD0
+	INT_SAMPLER_BUFFER_OES                                                = 0x8DD0
+	INT_SAMPLER_CUBE                                                      = 0x8DCC
+	INT_SAMPLER_CUBE_MAP_ARRAY_EXT                                        = 0x900E
+	INT_SAMPLER_CUBE_MAP_ARRAY_OES                                        = 0x900E
+	INT_VEC2                                                              = 0x8B53
+	INT_VEC3                                                              = 0x8B54
+	INT_VEC4                                                              = 0x8B55
+	INVALID_ENUM                                                          = 0x0500
+	INVALID_FRAMEBUFFER_OPERATION                                         = 0x0506
+	INVALID_INDEX                                                         = 0xFFFFFFFF
+	INVALID_OPERATION                                                     = 0x0502
+	INVALID_VALUE                                                         = 0x0501
+	INVERT                                                                = 0x150A
+	INVERT_OVG_NV                                                         = 0x92B4
+	INVERT_RGB_NV                                                         = 0x92A3
+	ISOLINES_EXT                                                          = 0x8E7A
+	ISOLINES_OES                                                          = 0x8E7A
+	IS_PER_PATCH_EXT                                                      = 0x92E7
+	IS_PER_PATCH_OES                                                      = 0x92E7
+	IS_ROW_MAJOR                                                          = 0x9300
+	ITALIC_BIT_NV                                                         = 0x02
+	KEEP                                                                  = 0x1E00
+	LARGE_CCW_ARC_TO_NV                                                   = 0x16
+	LARGE_CW_ARC_TO_NV                                                    = 0x18
+	LAST_VERTEX_CONVENTION_EXT                                            = 0x8E4E
+	LAST_VERTEX_CONVENTION_OES                                            = 0x8E4E
+	LAYER_PROVOKING_VERTEX_EXT                                            = 0x825E
+	LAYER_PROVOKING_VERTEX_OES                                            = 0x825E
+	LAYOUT_COLOR_ATTACHMENT_EXT                                           = 0x958E
+	LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT                         = 0x9531
+	LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT                         = 0x9530
+	LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT                                   = 0x958F
+	LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT                                    = 0x9590
+	LAYOUT_GENERAL_EXT                                                    = 0x958D
+	LAYOUT_SHADER_READ_ONLY_EXT                                           = 0x9591
+	LAYOUT_TRANSFER_DST_EXT                                               = 0x9593
+	LAYOUT_TRANSFER_SRC_EXT                                               = 0x9592
+	LEQUAL                                                                = 0x0203
+	LESS                                                                  = 0x0201
+	LIGHTEN_KHR                                                           = 0x9298
+	LIGHTEN_NV                                                            = 0x9298
+	LINEAR                                                                = 0x2601
+	LINEARBURN_NV                                                         = 0x92A5
+	LINEARDODGE_NV                                                        = 0x92A4
+	LINEARLIGHT_NV                                                        = 0x92A7
+	LINEAR_MIPMAP_LINEAR                                                  = 0x2703
+	LINEAR_MIPMAP_NEAREST                                                 = 0x2701
+	LINEAR_TILING_EXT                                                     = 0x9585
+	LINES                                                                 = 0x0001
+	LINES_ADJACENCY_EXT                                                   = 0x000A
+	LINES_ADJACENCY_OES                                                   = 0x000A
+	LINE_LOOP                                                             = 0x0002
+	LINE_NV                                                               = 0x1B01
+	LINE_STRIP                                                            = 0x0003
+	LINE_STRIP_ADJACENCY_EXT                                              = 0x000B
+	LINE_STRIP_ADJACENCY_OES                                              = 0x000B
+	LINE_TO_NV                                                            = 0x04
+	LINE_WIDTH                                                            = 0x0B21
+	LINK_STATUS                                                           = 0x8B82
+	LOCATION                                                              = 0x930E
+	LOCATION_INDEX_EXT                                                    = 0x930F
+	LOSE_CONTEXT_ON_RESET                                                 = 0x8252
+	LOSE_CONTEXT_ON_RESET_EXT                                             = 0x8252
+	LOSE_CONTEXT_ON_RESET_KHR                                             = 0x8252
+	LOWER_LEFT_EXT                                                        = 0x8CA1
+	LOW_FLOAT                                                             = 0x8DF0
+	LOW_INT                                                               = 0x8DF3
+	LUID_SIZE_EXT                                                         = 8
+	LUMINANCE                                                             = 0x1909
+	LUMINANCE16F_EXT                                                      = 0x881E
+	LUMINANCE32F_EXT                                                      = 0x8818
+	LUMINANCE4_ALPHA4_OES                                                 = 0x8043
+	LUMINANCE8_ALPHA8_EXT                                                 = 0x8045
+	LUMINANCE8_ALPHA8_OES                                                 = 0x8045
+	LUMINANCE8_EXT                                                        = 0x8040
+	LUMINANCE8_OES                                                        = 0x8040
+	LUMINANCE_ALPHA                                                       = 0x190A
+	LUMINANCE_ALPHA16F_EXT                                                = 0x881F
+	LUMINANCE_ALPHA32F_EXT                                                = 0x8819
+	MAJOR_VERSION                                                         = 0x821B
+	MALI_PROGRAM_BINARY_ARM                                               = 0x8F61
+	MALI_SHADER_BINARY_ARM                                                = 0x8F60
+	MAP_COHERENT_BIT_EXT                                                  = 0x0080
+	MAP_FLUSH_EXPLICIT_BIT                                                = 0x0010
+	MAP_FLUSH_EXPLICIT_BIT_EXT                                            = 0x0010
+	MAP_INVALIDATE_BUFFER_BIT                                             = 0x0008
+	MAP_INVALIDATE_BUFFER_BIT_EXT                                         = 0x0008
+	MAP_INVALIDATE_RANGE_BIT                                              = 0x0004
+	MAP_INVALIDATE_RANGE_BIT_EXT                                          = 0x0004
+	MAP_PERSISTENT_BIT_EXT                                                = 0x0040
+	MAP_READ_BIT                                                          = 0x0001
+	MAP_READ_BIT_EXT                                                      = 0x0001
+	MAP_UNSYNCHRONIZED_BIT                                                = 0x0020
+	MAP_UNSYNCHRONIZED_BIT_EXT                                            = 0x0020
+	MAP_WRITE_BIT                                                         = 0x0002
+	MAP_WRITE_BIT_EXT                                                     = 0x0002
+	MATRIX_STRIDE                                                         = 0x92FF
+	MAX                                                                   = 0x8008
+	MAX_3D_TEXTURE_SIZE                                                   = 0x8073
+	MAX_3D_TEXTURE_SIZE_OES                                               = 0x8073
+	MAX_ARRAY_TEXTURE_LAYERS                                              = 0x88FF
+	MAX_ATOMIC_COUNTER_BUFFER_BINDINGS                                    = 0x92DC
+	MAX_ATOMIC_COUNTER_BUFFER_SIZE                                        = 0x92D8
+	MAX_CLIP_DISTANCES_APPLE                                              = 0x0D32
+	MAX_CLIP_DISTANCES_EXT                                                = 0x0D32
+	MAX_COLOR_ATTACHMENTS                                                 = 0x8CDF
+	MAX_COLOR_ATTACHMENTS_EXT                                             = 0x8CDF
+	MAX_COLOR_ATTACHMENTS_NV                                              = 0x8CDF
+	MAX_COLOR_TEXTURE_SAMPLES                                             = 0x910E
+	MAX_COMBINED_ATOMIC_COUNTERS                                          = 0x92D7
+	MAX_COMBINED_ATOMIC_COUNTER_BUFFERS                                   = 0x92D1
+	MAX_COMBINED_CLIP_AND_CULL_DISTANCES_EXT                              = 0x82FA
+	MAX_COMBINED_COMPUTE_UNIFORM_COMPONENTS                               = 0x8266
+	MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS                              = 0x8A33
+	MAX_COMBINED_GEOMETRY_UNIFORM_COMPONENTS_EXT                          = 0x8A32
+	MAX_COMBINED_GEOMETRY_UNIFORM_COMPONENTS_OES                          = 0x8A32
+	MAX_COMBINED_IMAGE_UNIFORMS                                           = 0x90CF
+	MAX_COMBINED_SHADER_OUTPUT_RESOURCES                                  = 0x8F39
+	MAX_COMBINED_SHADER_STORAGE_BLOCKS                                    = 0x90DC
+	MAX_COMBINED_TESS_CONTROL_UNIFORM_COMPONENTS_EXT                      = 0x8E1E
+	MAX_COMBINED_TESS_CONTROL_UNIFORM_COMPONENTS_OES                      = 0x8E1E
+	MAX_COMBINED_TESS_EVALUATION_UNIFORM_COMPONENTS_EXT                   = 0x8E1F
+	MAX_COMBINED_TESS_EVALUATION_UNIFORM_COMPONENTS_OES                   = 0x8E1F
+	MAX_COMBINED_TEXTURE_IMAGE_UNITS                                      = 0x8B4D
+	MAX_COMBINED_UNIFORM_BLOCKS                                           = 0x8A2E
+	MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS                                = 0x8A31
+	MAX_COMPUTE_ATOMIC_COUNTERS                                           = 0x8265
+	MAX_COMPUTE_ATOMIC_COUNTER_BUFFERS                                    = 0x8264
+	MAX_COMPUTE_IMAGE_UNIFORMS                                            = 0x91BD
+	MAX_COMPUTE_SHADER_STORAGE_BLOCKS                                     = 0x90DB
+	MAX_COMPUTE_SHARED_MEMORY_SIZE                                        = 0x8262
+	MAX_COMPUTE_TEXTURE_IMAGE_UNITS                                       = 0x91BC
+	MAX_COMPUTE_UNIFORM_BLOCKS                                            = 0x91BB
+	MAX_COMPUTE_UNIFORM_COMPONENTS                                        = 0x8263
+	MAX_COMPUTE_WORK_GROUP_COUNT                                          = 0x91BE
+	MAX_COMPUTE_WORK_GROUP_INVOCATIONS                                    = 0x90EB
+	MAX_COMPUTE_WORK_GROUP_SIZE                                           = 0x91BF
+	MAX_CUBE_MAP_TEXTURE_SIZE                                             = 0x851C
+	MAX_CULL_DISTANCES_EXT                                                = 0x82F9
+	MAX_DEBUG_GROUP_STACK_DEPTH                                           = 0x826C
+	MAX_DEBUG_GROUP_STACK_DEPTH_KHR                                       = 0x826C
+	MAX_DEBUG_LOGGED_MESSAGES                                             = 0x9144
+	MAX_DEBUG_LOGGED_MESSAGES_KHR                                         = 0x9144
+	MAX_DEBUG_MESSAGE_LENGTH                                              = 0x9143
+	MAX_DEBUG_MESSAGE_LENGTH_KHR                                          = 0x9143
+	MAX_DEPTH_TEXTURE_SAMPLES                                             = 0x910F
+	MAX_DRAW_BUFFERS                                                      = 0x8824
+	MAX_DRAW_BUFFERS_EXT                                                  = 0x8824
+	MAX_DRAW_BUFFERS_NV                                                   = 0x8824
+	MAX_DUAL_SOURCE_DRAW_BUFFERS_EXT                                      = 0x88FC
+	MAX_ELEMENTS_INDICES                                                  = 0x80E9
+	MAX_ELEMENTS_VERTICES                                                 = 0x80E8
+	MAX_ELEMENT_INDEX                                                     = 0x8D6B
+	MAX_EXT                                                               = 0x8008
+	MAX_FRAGMENT_ATOMIC_COUNTERS                                          = 0x92D6
+	MAX_FRAGMENT_ATOMIC_COUNTER_BUFFERS                                   = 0x92D0
+	MAX_FRAGMENT_IMAGE_UNIFORMS                                           = 0x90CE
+	MAX_FRAGMENT_INPUT_COMPONENTS                                         = 0x9125
+	MAX_FRAGMENT_INTERPOLATION_OFFSET_OES                                 = 0x8E5C
+	MAX_FRAGMENT_SHADER_STORAGE_BLOCKS                                    = 0x90DA
+	MAX_FRAGMENT_UNIFORM_BLOCKS                                           = 0x8A2D
+	MAX_FRAGMENT_UNIFORM_COMPONENTS                                       = 0x8B49
+	MAX_FRAGMENT_UNIFORM_VECTORS                                          = 0x8DFD
+	MAX_FRAMEBUFFER_HEIGHT                                                = 0x9316
+	MAX_FRAMEBUFFER_LAYERS_EXT                                            = 0x9317
+	MAX_FRAMEBUFFER_LAYERS_OES                                            = 0x9317
+	MAX_FRAMEBUFFER_SAMPLES                                               = 0x9318
+	MAX_FRAMEBUFFER_WIDTH                                                 = 0x9315
+	MAX_GEOMETRY_ATOMIC_COUNTERS_EXT                                      = 0x92D5
+	MAX_GEOMETRY_ATOMIC_COUNTERS_OES                                      = 0x92D5
+	MAX_GEOMETRY_ATOMIC_COUNTER_BUFFERS_EXT                               = 0x92CF
+	MAX_GEOMETRY_ATOMIC_COUNTER_BUFFERS_OES                               = 0x92CF
+	MAX_GEOMETRY_IMAGE_UNIFORMS_EXT                                       = 0x90CD
+	MAX_GEOMETRY_IMAGE_UNIFORMS_OES                                       = 0x90CD
+	MAX_GEOMETRY_INPUT_COMPONENTS_EXT                                     = 0x9123
+	MAX_GEOMETRY_INPUT_COMPONENTS_OES                                     = 0x9123
+	MAX_GEOMETRY_OUTPUT_COMPONENTS_EXT                                    = 0x9124
+	MAX_GEOMETRY_OUTPUT_COMPONENTS_OES                                    = 0x9124
+	MAX_GEOMETRY_OUTPUT_VERTICES_EXT                                      = 0x8DE0
+	MAX_GEOMETRY_OUTPUT_VERTICES_OES                                      = 0x8DE0
+	MAX_GEOMETRY_SHADER_INVOCATIONS_EXT                                   = 0x8E5A
+	MAX_GEOMETRY_SHADER_INVOCATIONS_OES                                   = 0x8E5A
+	MAX_GEOMETRY_SHADER_STORAGE_BLOCKS_EXT                                = 0x90D7
+	MAX_GEOMETRY_SHADER_STORAGE_BLOCKS_OES                                = 0x90D7
+	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS_EXT                                  = 0x8C29
+	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS_OES                                  = 0x8C29
+	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS_EXT                              = 0x8DE1
+	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS_OES                              = 0x8DE1
+	MAX_GEOMETRY_UNIFORM_BLOCKS_EXT                                       = 0x8A2C
+	MAX_GEOMETRY_UNIFORM_BLOCKS_OES                                       = 0x8A2C
+	MAX_GEOMETRY_UNIFORM_COMPONENTS_EXT                                   = 0x8DDF
+	MAX_GEOMETRY_UNIFORM_COMPONENTS_OES                                   = 0x8DDF
+	MAX_IMAGE_UNITS                                                       = 0x8F38
+	MAX_INTEGER_SAMPLES                                                   = 0x9110
+	MAX_LABEL_LENGTH                                                      = 0x82E8
+	MAX_LABEL_LENGTH_KHR                                                  = 0x82E8
+	MAX_MULTIVIEW_BUFFERS_EXT                                             = 0x90F2
+	MAX_NAME_LENGTH                                                       = 0x92F6
+	MAX_NUM_ACTIVE_VARIABLES                                              = 0x92F7
+	MAX_PATCH_VERTICES_EXT                                                = 0x8E7D
+	MAX_PATCH_VERTICES_OES                                                = 0x8E7D
+	MAX_PROGRAM_TEXEL_OFFSET                                              = 0x8905
+	MAX_PROGRAM_TEXTURE_GATHER_OFFSET                                     = 0x8E5F
+	MAX_RASTER_SAMPLES_EXT                                                = 0x9329
+	MAX_RENDERBUFFER_SIZE                                                 = 0x84E8
+	MAX_SAMPLES                                                           = 0x8D57
+	MAX_SAMPLES_ANGLE                                                     = 0x8D57
+	MAX_SAMPLES_APPLE                                                     = 0x8D57
+	MAX_SAMPLES_EXT                                                       = 0x8D57
+	MAX_SAMPLES_IMG                                                       = 0x9135
+	MAX_SAMPLES_NV                                                        = 0x8D57
+	MAX_SAMPLE_MASK_WORDS                                                 = 0x8E59
+	MAX_SERVER_WAIT_TIMEOUT                                               = 0x9111
+	MAX_SERVER_WAIT_TIMEOUT_APPLE                                         = 0x9111
+	MAX_SHADER_COMBINED_LOCAL_STORAGE_FAST_SIZE_EXT                       = 0x9650
+	MAX_SHADER_COMBINED_LOCAL_STORAGE_SIZE_EXT                            = 0x9651
+	MAX_SHADER_COMPILER_THREADS_KHR                                       = 0x91B0
+	MAX_SHADER_PIXEL_LOCAL_STORAGE_FAST_SIZE_EXT                          = 0x8F63
+	MAX_SHADER_PIXEL_LOCAL_STORAGE_SIZE_EXT                               = 0x8F67
+	MAX_SHADER_STORAGE_BLOCK_SIZE                                         = 0x90DE
+	MAX_SHADER_STORAGE_BUFFER_BINDINGS                                    = 0x90DD
+	MAX_SPARSE_3D_TEXTURE_SIZE_EXT                                        = 0x9199
+	MAX_SPARSE_ARRAY_TEXTURE_LAYERS_EXT                                   = 0x919A
+	MAX_SPARSE_TEXTURE_SIZE_EXT                                           = 0x9198
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                                   = 0x9349
+	MAX_TESS_CONTROL_ATOMIC_COUNTERS_EXT                                  = 0x92D3
+	MAX_TESS_CONTROL_ATOMIC_COUNTERS_OES                                  = 0x92D3
+	MAX_TESS_CONTROL_ATOMIC_COUNTER_BUFFERS_EXT                           = 0x92CD
+	MAX_TESS_CONTROL_ATOMIC_COUNTER_BUFFERS_OES                           = 0x92CD
+	MAX_TESS_CONTROL_IMAGE_UNIFORMS_EXT                                   = 0x90CB
+	MAX_TESS_CONTROL_IMAGE_UNIFORMS_OES                                   = 0x90CB
+	MAX_TESS_CONTROL_INPUT_COMPONENTS_EXT                                 = 0x886C
+	MAX_TESS_CONTROL_INPUT_COMPONENTS_OES                                 = 0x886C
+	MAX_TESS_CONTROL_OUTPUT_COMPONENTS_EXT                                = 0x8E83
+	MAX_TESS_CONTROL_OUTPUT_COMPONENTS_OES                                = 0x8E83
+	MAX_TESS_CONTROL_SHADER_STORAGE_BLOCKS_EXT                            = 0x90D8
+	MAX_TESS_CONTROL_SHADER_STORAGE_BLOCKS_OES                            = 0x90D8
+	MAX_TESS_CONTROL_TEXTURE_IMAGE_UNITS_EXT                              = 0x8E81
+	MAX_TESS_CONTROL_TEXTURE_IMAGE_UNITS_OES                              = 0x8E81
+	MAX_TESS_CONTROL_TOTAL_OUTPUT_COMPONENTS_EXT                          = 0x8E85
+	MAX_TESS_CONTROL_TOTAL_OUTPUT_COMPONENTS_OES                          = 0x8E85
+	MAX_TESS_CONTROL_UNIFORM_BLOCKS_EXT                                   = 0x8E89
+	MAX_TESS_CONTROL_UNIFORM_BLOCKS_OES                                   = 0x8E89
+	MAX_TESS_CONTROL_UNIFORM_COMPONENTS_EXT                               = 0x8E7F
+	MAX_TESS_CONTROL_UNIFORM_COMPONENTS_OES                               = 0x8E7F
+	MAX_TESS_EVALUATION_ATOMIC_COUNTERS_EXT                               = 0x92D4
+	MAX_TESS_EVALUATION_ATOMIC_COUNTERS_OES                               = 0x92D4
+	MAX_TESS_EVALUATION_ATOMIC_COUNTER_BUFFERS_EXT                        = 0x92CE
+	MAX_TESS_EVALUATION_ATOMIC_COUNTER_BUFFERS_OES                        = 0x92CE
+	MAX_TESS_EVALUATION_IMAGE_UNIFORMS_EXT                                = 0x90CC
+	MAX_TESS_EVALUATION_IMAGE_UNIFORMS_OES                                = 0x90CC
+	MAX_TESS_EVALUATION_INPUT_COMPONENTS_EXT                              = 0x886D
+	MAX_TESS_EVALUATION_INPUT_COMPONENTS_OES                              = 0x886D
+	MAX_TESS_EVALUATION_OUTPUT_COMPONENTS_EXT                             = 0x8E86
+	MAX_TESS_EVALUATION_OUTPUT_COMPONENTS_OES                             = 0x8E86
+	MAX_TESS_EVALUATION_SHADER_STORAGE_BLOCKS_EXT                         = 0x90D9
+	MAX_TESS_EVALUATION_SHADER_STORAGE_BLOCKS_OES                         = 0x90D9
+	MAX_TESS_EVALUATION_TEXTURE_IMAGE_UNITS_EXT                           = 0x8E82
+	MAX_TESS_EVALUATION_TEXTURE_IMAGE_UNITS_OES                           = 0x8E82
+	MAX_TESS_EVALUATION_UNIFORM_BLOCKS_EXT                                = 0x8E8A
+	MAX_TESS_EVALUATION_UNIFORM_BLOCKS_OES                                = 0x8E8A
+	MAX_TESS_EVALUATION_UNIFORM_COMPONENTS_EXT                            = 0x8E80
+	MAX_TESS_EVALUATION_UNIFORM_COMPONENTS_OES                            = 0x8E80
+	MAX_TESS_GEN_LEVEL_EXT                                                = 0x8E7E
+	MAX_TESS_GEN_LEVEL_OES                                                = 0x8E7E
+	MAX_TESS_PATCH_COMPONENTS_EXT                                         = 0x8E84
+	MAX_TESS_PATCH_COMPONENTS_OES                                         = 0x8E84
+	MAX_TEXTURE_BUFFER_SIZE_EXT                                           = 0x8C2B
+	MAX_TEXTURE_BUFFER_SIZE_OES                                           = 0x8C2B
+	MAX_TEXTURE_IMAGE_UNITS                                               = 0x8872
+	MAX_TEXTURE_LOD_BIAS                                                  = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY_EXT                                        = 0x84FF
+	MAX_TEXTURE_SIZE                                                      = 0x0D33
+	MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS                         = 0x8C8A
+	MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS                               = 0x8C8B
+	MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS                            = 0x8C80
+	MAX_UNIFORM_BLOCK_SIZE                                                = 0x8A30
+	MAX_UNIFORM_BUFFER_BINDINGS                                           = 0x8A2F
+	MAX_UNIFORM_LOCATIONS                                                 = 0x826E
+	MAX_VARYING_COMPONENTS                                                = 0x8B4B
+	MAX_VARYING_VECTORS                                                   = 0x8DFC
+	MAX_VERTEX_ATOMIC_COUNTERS                                            = 0x92D2
+	MAX_VERTEX_ATOMIC_COUNTER_BUFFERS                                     = 0x92CC
+	MAX_VERTEX_ATTRIBS                                                    = 0x8869
+	MAX_VERTEX_ATTRIB_BINDINGS                                            = 0x82DA
+	MAX_VERTEX_ATTRIB_RELATIVE_OFFSET                                     = 0x82D9
+	MAX_VERTEX_ATTRIB_STRIDE                                              = 0x82E5
+	MAX_VERTEX_IMAGE_UNIFORMS                                             = 0x90CA
+	MAX_VERTEX_OUTPUT_COMPONENTS                                          = 0x9122
+	MAX_VERTEX_SHADER_STORAGE_BLOCKS                                      = 0x90D6
+	MAX_VERTEX_TEXTURE_IMAGE_UNITS                                        = 0x8B4C
+	MAX_VERTEX_UNIFORM_BLOCKS                                             = 0x8A2B
+	MAX_VERTEX_UNIFORM_COMPONENTS                                         = 0x8B4A
+	MAX_VERTEX_UNIFORM_VECTORS                                            = 0x8DFB
+	MAX_VIEWPORTS_NV                                                      = 0x825B
+	MAX_VIEWPORTS_OES                                                     = 0x825B
+	MAX_VIEWPORT_DIMS                                                     = 0x0D3A
+	MAX_VIEWS_OVR                                                         = 0x9631
+	MAX_WINDOW_RECTANGLES_EXT                                             = 0x8F14
+	MEDIUM_FLOAT                                                          = 0x8DF1
+	MEDIUM_INT                                                            = 0x8DF4
+	MIN                                                                   = 0x8007
+	MINOR_VERSION                                                         = 0x821C
+	MINUS_CLAMPED_NV                                                      = 0x92B3
+	MINUS_NV                                                              = 0x929F
+	MIN_EXT                                                               = 0x8007
+	MIN_FRAGMENT_INTERPOLATION_OFFSET_OES                                 = 0x8E5B
+	MIN_PROGRAM_TEXEL_OFFSET                                              = 0x8904
+	MIN_PROGRAM_TEXTURE_GATHER_OFFSET                                     = 0x8E5E
+	MIN_SAMPLE_SHADING_VALUE_OES                                          = 0x8C37
+	MIRRORED_REPEAT                                                       = 0x8370
+	MIRROR_CLAMP_TO_EDGE_EXT                                              = 0x8743
+	MITER_REVERT_NV                                                       = 0x90A7
+	MITER_TRUNCATE_NV                                                     = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                                      = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                                    = 0x9330
+	MOVE_TO_CONTINUES_NV                                                  = 0x90B6
+	MOVE_TO_NV                                                            = 0x02
+	MOVE_TO_RESETS_NV                                                     = 0x90B5
+	MULTIPLY_KHR                                                          = 0x9294
+	MULTIPLY_NV                                                           = 0x9294
+	MULTISAMPLES_NV                                                       = 0x9371
+	MULTISAMPLE_BUFFER_BIT0_QCOM                                          = 0x01000000
+	MULTISAMPLE_BUFFER_BIT1_QCOM                                          = 0x02000000
+	MULTISAMPLE_BUFFER_BIT2_QCOM                                          = 0x04000000
+	MULTISAMPLE_BUFFER_BIT3_QCOM                                          = 0x08000000
+	MULTISAMPLE_BUFFER_BIT4_QCOM                                          = 0x10000000
+	MULTISAMPLE_BUFFER_BIT5_QCOM                                          = 0x20000000
+	MULTISAMPLE_BUFFER_BIT6_QCOM                                          = 0x40000000
+	MULTISAMPLE_BUFFER_BIT7_QCOM                                          = 0x80000000
+	MULTISAMPLE_EXT                                                       = 0x809D
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                                 = 0x932B
+	MULTIVIEW_EXT                                                         = 0x90F1
+	NAME_LENGTH                                                           = 0x92F9
+	NEAREST                                                               = 0x2600
+	NEAREST_MIPMAP_LINEAR                                                 = 0x2702
+	NEAREST_MIPMAP_NEAREST                                                = 0x2700
+	NEGATIVE_ONE_TO_ONE_EXT                                               = 0x935E
+	NEVER                                                                 = 0x0200
+	NICEST                                                                = 0x1102
+	NONE                                                                  = 0
+	NOTEQUAL                                                              = 0x0205
+	NO_ERROR                                                              = 0
+	NO_RESET_NOTIFICATION                                                 = 0x8261
+	NO_RESET_NOTIFICATION_EXT                                             = 0x8261
+	NO_RESET_NOTIFICATION_KHR                                             = 0x8261
+	NUM_ACTIVE_VARIABLES                                                  = 0x9304
+	NUM_COMPRESSED_TEXTURE_FORMATS                                        = 0x86A2
+	NUM_DEVICE_UUIDS_EXT                                                  = 0x9596
+	NUM_DOWNSAMPLE_SCALES_IMG                                             = 0x913D
+	NUM_EXTENSIONS                                                        = 0x821D
+	NUM_PROGRAM_BINARY_FORMATS                                            = 0x87FE
+	NUM_PROGRAM_BINARY_FORMATS_OES                                        = 0x87FE
+	NUM_SAMPLE_COUNTS                                                     = 0x9380
+	NUM_SHADER_BINARY_FORMATS                                             = 0x8DF9
+	NUM_SPARSE_LEVELS_EXT                                                 = 0x91AA
+	NUM_TILING_TYPES_EXT                                                  = 0x9582
+	NUM_VIRTUAL_PAGE_SIZES_EXT                                            = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                             = 0x8F15
+	OBJECT_TYPE                                                           = 0x9112
+	OBJECT_TYPE_APPLE                                                     = 0x9112
+	OFFSET                                                                = 0x92FC
+	ONE                                                                   = 1
+	ONE_MINUS_CONSTANT_ALPHA                                              = 0x8004
+	ONE_MINUS_CONSTANT_COLOR                                              = 0x8002
+	ONE_MINUS_DST_ALPHA                                                   = 0x0305
+	ONE_MINUS_DST_COLOR                                                   = 0x0307
+	ONE_MINUS_SRC1_ALPHA_EXT                                              = 0x88FB
+	ONE_MINUS_SRC1_COLOR_EXT                                              = 0x88FA
+	ONE_MINUS_SRC_ALPHA                                                   = 0x0303
+	ONE_MINUS_SRC_COLOR                                                   = 0x0301
+	OPTIMAL_TILING_EXT                                                    = 0x9584
+	OUT_OF_MEMORY                                                         = 0x0505
+	OVERLAY_KHR                                                           = 0x9296
+	OVERLAY_NV                                                            = 0x9296
+	PACK_ALIGNMENT                                                        = 0x0D05
+	PACK_REVERSE_ROW_ORDER_ANGLE                                          = 0x93A4
+	PACK_ROW_LENGTH                                                       = 0x0D02
+	PACK_SKIP_PIXELS                                                      = 0x0D04
+	PACK_SKIP_ROWS                                                        = 0x0D03
+	PALETTE4_R5_G6_B5_OES                                                 = 0x8B92
+	PALETTE4_RGB5_A1_OES                                                  = 0x8B94
+	PALETTE4_RGB8_OES                                                     = 0x8B90
+	PALETTE4_RGBA4_OES                                                    = 0x8B93
+	PALETTE4_RGBA8_OES                                                    = 0x8B91
+	PALETTE8_R5_G6_B5_OES                                                 = 0x8B97
+	PALETTE8_RGB5_A1_OES                                                  = 0x8B99
+	PALETTE8_RGB8_OES                                                     = 0x8B95
+	PALETTE8_RGBA4_OES                                                    = 0x8B98
+	PALETTE8_RGBA8_OES                                                    = 0x8B96
+	PATCHES                                                               = 0x000E
+	PATCHES_EXT                                                           = 0x000E
+	PATCHES_OES                                                           = 0x000E
+	PATCH_VERTICES_EXT                                                    = 0x8E72
+	PATCH_VERTICES_OES                                                    = 0x8E72
+	PATH_CLIENT_LENGTH_NV                                                 = 0x907F
+	PATH_COMMAND_COUNT_NV                                                 = 0x909D
+	PATH_COMPUTED_LENGTH_NV                                               = 0x90A0
+	PATH_COORD_COUNT_NV                                                   = 0x909E
+	PATH_COVER_DEPTH_FUNC_NV                                              = 0x90BF
+	PATH_DASH_ARRAY_COUNT_NV                                              = 0x909F
+	PATH_DASH_CAPS_NV                                                     = 0x907B
+	PATH_DASH_OFFSET_NV                                                   = 0x907E
+	PATH_DASH_OFFSET_RESET_NV                                             = 0x90B4
+	PATH_END_CAPS_NV                                                      = 0x9076
+	PATH_ERROR_POSITION_NV                                                = 0x90AB
+	PATH_FILL_BOUNDING_BOX_NV                                             = 0x90A1
+	PATH_FILL_COVER_MODE_NV                                               = 0x9082
+	PATH_FILL_MASK_NV                                                     = 0x9081
+	PATH_FILL_MODE_NV                                                     = 0x9080
+	PATH_FORMAT_PS_NV                                                     = 0x9071
+	PATH_FORMAT_SVG_NV                                                    = 0x9070
+	PATH_GEN_COEFF_NV                                                     = 0x90B1
+	PATH_GEN_COMPONENTS_NV                                                = 0x90B3
+	PATH_GEN_MODE_NV                                                      = 0x90B0
+	PATH_INITIAL_DASH_CAP_NV                                              = 0x907C
+	PATH_INITIAL_END_CAP_NV                                               = 0x9077
+	PATH_JOIN_STYLE_NV                                                    = 0x9079
+	PATH_MAX_MODELVIEW_STACK_DEPTH_NV                                     = 0x0D36
+	PATH_MAX_PROJECTION_STACK_DEPTH_NV                                    = 0x0D38
+	PATH_MITER_LIMIT_NV                                                   = 0x907A
+	PATH_MODELVIEW_MATRIX_NV                                              = 0x0BA6
+	PATH_MODELVIEW_NV                                                     = 0x1700
+	PATH_MODELVIEW_STACK_DEPTH_NV                                         = 0x0BA3
+	PATH_OBJECT_BOUNDING_BOX_NV                                           = 0x908A
+	PATH_PROJECTION_MATRIX_NV                                             = 0x0BA7
+	PATH_PROJECTION_NV                                                    = 0x1701
+	PATH_PROJECTION_STACK_DEPTH_NV                                        = 0x0BA4
+	PATH_STENCIL_DEPTH_OFFSET_FACTOR_NV                                   = 0x90BD
+	PATH_STENCIL_DEPTH_OFFSET_UNITS_NV                                    = 0x90BE
+	PATH_STENCIL_FUNC_NV                                                  = 0x90B7
+	PATH_STENCIL_REF_NV                                                   = 0x90B8
+	PATH_STENCIL_VALUE_MASK_NV                                            = 0x90B9
+	PATH_STROKE_BOUNDING_BOX_NV                                           = 0x90A2
+	PATH_STROKE_COVER_MODE_NV                                             = 0x9083
+	PATH_STROKE_MASK_NV                                                   = 0x9084
+	PATH_STROKE_WIDTH_NV                                                  = 0x9075
+	PATH_TERMINAL_DASH_CAP_NV                                             = 0x907D
+	PATH_TERMINAL_END_CAP_NV                                              = 0x9078
+	PATH_TRANSPOSE_MODELVIEW_MATRIX_NV                                    = 0x84E3
+	PATH_TRANSPOSE_PROJECTION_MATRIX_NV                                   = 0x84E4
+	PERCENTAGE_AMD                                                        = 0x8BC3
+	PERFMON_GLOBAL_MODE_QCOM                                              = 0x8FA0
+	PERFMON_RESULT_AMD                                                    = 0x8BC6
+	PERFMON_RESULT_AVAILABLE_AMD                                          = 0x8BC4
+	PERFMON_RESULT_SIZE_AMD                                               = 0x8BC5
+	PERFQUERY_COUNTER_DATA_BOOL32_INTEL                                   = 0x94FC
+	PERFQUERY_COUNTER_DATA_DOUBLE_INTEL                                   = 0x94FB
+	PERFQUERY_COUNTER_DATA_FLOAT_INTEL                                    = 0x94FA
+	PERFQUERY_COUNTER_DATA_UINT32_INTEL                                   = 0x94F8
+	PERFQUERY_COUNTER_DATA_UINT64_INTEL                                   = 0x94F9
+	PERFQUERY_COUNTER_DESC_LENGTH_MAX_INTEL                               = 0x94FF
+	PERFQUERY_COUNTER_DURATION_NORM_INTEL                                 = 0x94F1
+	PERFQUERY_COUNTER_DURATION_RAW_INTEL                                  = 0x94F2
+	PERFQUERY_COUNTER_EVENT_INTEL                                         = 0x94F0
+	PERFQUERY_COUNTER_NAME_LENGTH_MAX_INTEL                               = 0x94FE
+	PERFQUERY_COUNTER_RAW_INTEL                                           = 0x94F4
+	PERFQUERY_COUNTER_THROUGHPUT_INTEL                                    = 0x94F3
+	PERFQUERY_COUNTER_TIMESTAMP_INTEL                                     = 0x94F5
+	PERFQUERY_DONOT_FLUSH_INTEL                                           = 0x83F9
+	PERFQUERY_FLUSH_INTEL                                                 = 0x83FA
+	PERFQUERY_GLOBAL_CONTEXT_INTEL                                        = 0x00000001
+	PERFQUERY_GPA_EXTENDED_COUNTERS_INTEL                                 = 0x9500
+	PERFQUERY_QUERY_NAME_LENGTH_MAX_INTEL                                 = 0x94FD
+	PERFQUERY_SINGLE_CONTEXT_INTEL                                        = 0x00000000
+	PERFQUERY_WAIT_INTEL                                                  = 0x83FB
+	PINLIGHT_NV                                                           = 0x92A8
+	PIXEL_BUFFER_BARRIER_BIT                                              = 0x00000080
+	PIXEL_PACK_BUFFER                                                     = 0x88EB
+	PIXEL_PACK_BUFFER_BINDING                                             = 0x88ED
+	PIXEL_PACK_BUFFER_BINDING_NV                                          = 0x88ED
+	PIXEL_PACK_BUFFER_NV                                                  = 0x88EB
+	PIXEL_UNPACK_BUFFER                                                   = 0x88EC
+	PIXEL_UNPACK_BUFFER_BINDING                                           = 0x88EF
+	PIXEL_UNPACK_BUFFER_BINDING_NV                                        = 0x88EF
+	PIXEL_UNPACK_BUFFER_NV                                                = 0x88EC
+	PLUS_CLAMPED_ALPHA_NV                                                 = 0x92B2
+	PLUS_CLAMPED_NV                                                       = 0x92B1
+	PLUS_DARKER_NV                                                        = 0x9292
+	PLUS_NV                                                               = 0x9291
+	POINTS                                                                = 0x0000
+	POINT_NV                                                              = 0x1B00
+	POLYGON_MODE_NV                                                       = 0x0B40
+	POLYGON_OFFSET_CLAMP_EXT                                              = 0x8E1B
+	POLYGON_OFFSET_FACTOR                                                 = 0x8038
+	POLYGON_OFFSET_FILL                                                   = 0x8037
+	POLYGON_OFFSET_LINE_NV                                                = 0x2A02
+	POLYGON_OFFSET_POINT_NV                                               = 0x2A01
+	POLYGON_OFFSET_UNITS                                                  = 0x2A00
+	PRIMITIVES_GENERATED_EXT                                              = 0x8C87
+	PRIMITIVES_GENERATED_OES                                              = 0x8C87
+	PRIMITIVE_BOUNDING_BOX_EXT                                            = 0x92BE
+	PRIMITIVE_BOUNDING_BOX_OES                                            = 0x92BE
+	PRIMITIVE_RESTART_FIXED_INDEX                                         = 0x8D69
+	PRIMITIVE_RESTART_FOR_PATCHES_SUPPORTED                               = 0x8221
+	PRIMITIVE_RESTART_FOR_PATCHES_SUPPORTED_OES                           = 0x8221
+	PROGRAM                                                               = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                                       = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                            = 0x9340
+	PROGRAM_BINARY_ANGLE                                                  = 0x93A6
+	PROGRAM_BINARY_FORMATS                                                = 0x87FF
+	PROGRAM_BINARY_FORMATS_OES                                            = 0x87FF
+	PROGRAM_BINARY_FORMAT_MESA                                            = 0x875F
+	PROGRAM_BINARY_LENGTH                                                 = 0x8741
+	PROGRAM_BINARY_LENGTH_OES                                             = 0x8741
+	PROGRAM_BINARY_RETRIEVABLE_HINT                                       = 0x8257
+	PROGRAM_INPUT                                                         = 0x92E3
+	PROGRAM_KHR                                                           = 0x82E2
+	PROGRAM_OBJECT_EXT                                                    = 0x8B40
+	PROGRAM_OUTPUT                                                        = 0x92E4
+	PROGRAM_PIPELINE                                                      = 0x82E4
+	PROGRAM_PIPELINE_BINDING                                              = 0x825A
+	PROGRAM_PIPELINE_BINDING_EXT                                          = 0x825A
+	PROGRAM_PIPELINE_KHR                                                  = 0x82E4
+	PROGRAM_PIPELINE_OBJECT_EXT                                           = 0x8A4F
+	PROGRAM_SEPARABLE                                                     = 0x8258
+	PROGRAM_SEPARABLE_EXT                                                 = 0x8258
+	PROTECTED_MEMORY_OBJECT_EXT                                           = 0x959B
+	QUADRATIC_CURVE_TO_NV                                                 = 0x0A
+	QUADS_EXT                                                             = 0x0007
+	QUADS_OES                                                             = 0x0007
+	QUERY                                                                 = 0x82E3
+	QUERY_BY_REGION_NO_WAIT_NV                                            = 0x8E16
+	QUERY_BY_REGION_WAIT_NV                                               = 0x8E15
+	QUERY_COUNTER_BITS_EXT                                                = 0x8864
+	QUERY_KHR                                                             = 0x82E3
+	QUERY_NO_WAIT_NV                                                      = 0x8E14
+	QUERY_OBJECT_EXT                                                      = 0x9153
+	QUERY_RESULT                                                          = 0x8866
+	QUERY_RESULT_AVAILABLE                                                = 0x8867
+	QUERY_RESULT_AVAILABLE_EXT                                            = 0x8867
+	QUERY_RESULT_EXT                                                      = 0x8866
+	QUERY_WAIT_NV                                                         = 0x8E13
+	R11F_G11F_B10F                                                        = 0x8C3A
+	R11F_G11F_B10F_APPLE                                                  = 0x8C3A
+	R16F                                                                  = 0x822D
+	R16F_EXT                                                              = 0x822D
+	R16I                                                                  = 0x8233
+	R16UI                                                                 = 0x8234
+	R16_EXT                                                               = 0x822A
+	R16_SNORM_EXT                                                         = 0x8F98
+	R32F                                                                  = 0x822E
+	R32F_EXT                                                              = 0x822E
+	R32I                                                                  = 0x8235
+	R32UI                                                                 = 0x8236
+	R8                                                                    = 0x8229
+	R8I                                                                   = 0x8231
+	R8UI                                                                  = 0x8232
+	R8_EXT                                                                = 0x8229
+	R8_SNORM                                                              = 0x8F94
+	RASTERIZER_DISCARD                                                    = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                                     = 0x932A
+	RASTER_MULTISAMPLE_EXT                                                = 0x9327
+	RASTER_SAMPLES_EXT                                                    = 0x9328
+	READ_BUFFER                                                           = 0x0C02
+	READ_BUFFER_EXT                                                       = 0x0C02
+	READ_BUFFER_NV                                                        = 0x0C02
+	READ_FRAMEBUFFER                                                      = 0x8CA8
+	READ_FRAMEBUFFER_ANGLE                                                = 0x8CA8
+	READ_FRAMEBUFFER_APPLE                                                = 0x8CA8
+	READ_FRAMEBUFFER_BINDING                                              = 0x8CAA
+	READ_FRAMEBUFFER_BINDING_ANGLE                                        = 0x8CAA
+	READ_FRAMEBUFFER_BINDING_APPLE                                        = 0x8CAA
+	READ_FRAMEBUFFER_BINDING_NV                                           = 0x8CAA
+	READ_FRAMEBUFFER_NV                                                   = 0x8CA8
+	READ_ONLY                                                             = 0x88B8
+	READ_WRITE                                                            = 0x88BA
+	RECT_NV                                                               = 0xF6
+	RED                                                                   = 0x1903
+	RED_BITS                                                              = 0x0D52
+	RED_EXT                                                               = 0x1903
+	RED_INTEGER                                                           = 0x8D94
+	RED_NV                                                                = 0x1903
+	REFERENCED_BY_COMPUTE_SHADER                                          = 0x930B
+	REFERENCED_BY_FRAGMENT_SHADER                                         = 0x930A
+	REFERENCED_BY_GEOMETRY_SHADER_EXT                                     = 0x9309
+	REFERENCED_BY_GEOMETRY_SHADER_OES                                     = 0x9309
+	REFERENCED_BY_TESS_CONTROL_SHADER_EXT                                 = 0x9307
+	REFERENCED_BY_TESS_CONTROL_SHADER_OES                                 = 0x9307
+	REFERENCED_BY_TESS_EVALUATION_SHADER_EXT                              = 0x9308
+	REFERENCED_BY_TESS_EVALUATION_SHADER_OES                              = 0x9308
+	REFERENCED_BY_VERTEX_SHADER                                           = 0x9306
+	RELATIVE_ARC_TO_NV                                                    = 0xFF
+	RELATIVE_CONIC_CURVE_TO_NV                                            = 0x1B
+	RELATIVE_CUBIC_CURVE_TO_NV                                            = 0x0D
+	RELATIVE_HORIZONTAL_LINE_TO_NV                                        = 0x07
+	RELATIVE_LARGE_CCW_ARC_TO_NV                                          = 0x17
+	RELATIVE_LARGE_CW_ARC_TO_NV                                           = 0x19
+	RELATIVE_LINE_TO_NV                                                   = 0x05
+	RELATIVE_MOVE_TO_NV                                                   = 0x03
+	RELATIVE_QUADRATIC_CURVE_TO_NV                                        = 0x0B
+	RELATIVE_RECT_NV                                                      = 0xF7
+	RELATIVE_ROUNDED_RECT2_NV                                             = 0xEB
+	RELATIVE_ROUNDED_RECT4_NV                                             = 0xED
+	RELATIVE_ROUNDED_RECT8_NV                                             = 0xEF
+	RELATIVE_ROUNDED_RECT_NV                                              = 0xE9
+	RELATIVE_SMALL_CCW_ARC_TO_NV                                          = 0x13
+	RELATIVE_SMALL_CW_ARC_TO_NV                                           = 0x15
+	RELATIVE_SMOOTH_CUBIC_CURVE_TO_NV                                     = 0x11
+	RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV                                 = 0x0F
+	RELATIVE_VERTICAL_LINE_TO_NV                                          = 0x09
+	RENDERBUFFER                                                          = 0x8D41
+	RENDERBUFFER_ALPHA_SIZE                                               = 0x8D53
+	RENDERBUFFER_BINDING                                                  = 0x8CA7
+	RENDERBUFFER_BLUE_SIZE                                                = 0x8D52
+	RENDERBUFFER_DEPTH_SIZE                                               = 0x8D54
+	RENDERBUFFER_GREEN_SIZE                                               = 0x8D51
+	RENDERBUFFER_HEIGHT                                                   = 0x8D43
+	RENDERBUFFER_INTERNAL_FORMAT                                          = 0x8D44
+	RENDERBUFFER_RED_SIZE                                                 = 0x8D50
+	RENDERBUFFER_SAMPLES                                                  = 0x8CAB
+	RENDERBUFFER_SAMPLES_ANGLE                                            = 0x8CAB
+	RENDERBUFFER_SAMPLES_APPLE                                            = 0x8CAB
+	RENDERBUFFER_SAMPLES_EXT                                              = 0x8CAB
+	RENDERBUFFER_SAMPLES_IMG                                              = 0x9133
+	RENDERBUFFER_SAMPLES_NV                                               = 0x8CAB
+	RENDERBUFFER_STENCIL_SIZE                                             = 0x8D55
+	RENDERBUFFER_WIDTH                                                    = 0x8D42
+	RENDERER                                                              = 0x1F01
+	RENDER_DIRECT_TO_FRAMEBUFFER_QCOM                                     = 0x8FB3
+	REPEAT                                                                = 0x2901
+	REPLACE                                                               = 0x1E01
+	REQUIRED_TEXTURE_IMAGE_UNITS_OES                                      = 0x8D68
+	RESET_NOTIFICATION_STRATEGY                                           = 0x8256
+	RESET_NOTIFICATION_STRATEGY_EXT                                       = 0x8256
+	RESET_NOTIFICATION_STRATEGY_KHR                                       = 0x8256
+	RESTART_PATH_NV                                                       = 0xF0
+	RG                                                                    = 0x8227
+	RG16F                                                                 = 0x822F
+	RG16F_EXT                                                             = 0x822F
+	RG16I                                                                 = 0x8239
+	RG16UI                                                                = 0x823A
+	RG16_EXT                                                              = 0x822C
+	RG16_SNORM_EXT                                                        = 0x8F99
+	RG32F                                                                 = 0x8230
+	RG32F_EXT                                                             = 0x8230
+	RG32I                                                                 = 0x823B
+	RG32UI                                                                = 0x823C
+	RG8                                                                   = 0x822B
+	RG8I                                                                  = 0x8237
+	RG8UI                                                                 = 0x8238
+	RG8_EXT                                                               = 0x822B
+	RG8_SNORM                                                             = 0x8F95
+	RGB                                                                   = 0x1907
+	RGB10_A2                                                              = 0x8059
+	RGB10_A2UI                                                            = 0x906F
+	RGB10_A2_EXT                                                          = 0x8059
+	RGB10_EXT                                                             = 0x8052
+	RGB16F                                                                = 0x881B
+	RGB16F_EXT                                                            = 0x881B
+	RGB16I                                                                = 0x8D89
+	RGB16UI                                                               = 0x8D77
+	RGB16_EXT                                                             = 0x8054
+	RGB16_SNORM_EXT                                                       = 0x8F9A
+	RGB32F                                                                = 0x8815
+	RGB32F_EXT                                                            = 0x8815
+	RGB32I                                                                = 0x8D83
+	RGB32UI                                                               = 0x8D71
+	RGB565                                                                = 0x8D62
+	RGB565_OES                                                            = 0x8D62
+	RGB5_A1                                                               = 0x8057
+	RGB5_A1_OES                                                           = 0x8057
+	RGB8                                                                  = 0x8051
+	RGB8I                                                                 = 0x8D8F
+	RGB8UI                                                                = 0x8D7D
+	RGB8_OES                                                              = 0x8051
+	RGB8_SNORM                                                            = 0x8F96
+	RGB9_E5                                                               = 0x8C3D
+	RGB9_E5_APPLE                                                         = 0x8C3D
+	RGBA                                                                  = 0x1908
+	RGBA16F                                                               = 0x881A
+	RGBA16F_EXT                                                           = 0x881A
+	RGBA16I                                                               = 0x8D88
+	RGBA16UI                                                              = 0x8D76
+	RGBA16_EXT                                                            = 0x805B
+	RGBA16_SNORM_EXT                                                      = 0x8F9B
+	RGBA32F                                                               = 0x8814
+	RGBA32F_EXT                                                           = 0x8814
+	RGBA32I                                                               = 0x8D82
+	RGBA32UI                                                              = 0x8D70
+	RGBA4                                                                 = 0x8056
+	RGBA4_OES                                                             = 0x8056
+	RGBA8                                                                 = 0x8058
+	RGBA8I                                                                = 0x8D8E
+	RGBA8UI                                                               = 0x8D7C
+	RGBA8_OES                                                             = 0x8058
+	RGBA8_SNORM                                                           = 0x8F97
+	RGBA_INTEGER                                                          = 0x8D99
+	RGB_422_APPLE                                                         = 0x8A1F
+	RGB_INTEGER                                                           = 0x8D98
+	RGB_RAW_422_APPLE                                                     = 0x8A51
+	RG_EXT                                                                = 0x8227
+	RG_INTEGER                                                            = 0x8228
+	ROUNDED_RECT2_NV                                                      = 0xEA
+	ROUNDED_RECT4_NV                                                      = 0xEC
+	ROUNDED_RECT8_NV                                                      = 0xEE
+	ROUNDED_RECT_NV                                                       = 0xE8
+	ROUND_NV                                                              = 0x90A4
+	SAMPLER                                                               = 0x82E6
+	SAMPLER_2D                                                            = 0x8B5E
+	SAMPLER_2D_ARRAY                                                      = 0x8DC1
+	SAMPLER_2D_ARRAY_SHADOW                                               = 0x8DC4
+	SAMPLER_2D_ARRAY_SHADOW_NV                                            = 0x8DC4
+	SAMPLER_2D_MULTISAMPLE                                                = 0x9108
+	SAMPLER_2D_MULTISAMPLE_ARRAY_OES                                      = 0x910B
+	SAMPLER_2D_SHADOW                                                     = 0x8B62
+	SAMPLER_2D_SHADOW_EXT                                                 = 0x8B62
+	SAMPLER_3D                                                            = 0x8B5F
+	SAMPLER_3D_OES                                                        = 0x8B5F
+	SAMPLER_BINDING                                                       = 0x8919
+	SAMPLER_BUFFER_EXT                                                    = 0x8DC2
+	SAMPLER_BUFFER_OES                                                    = 0x8DC2
+	SAMPLER_CUBE                                                          = 0x8B60
+	SAMPLER_CUBE_MAP_ARRAY_EXT                                            = 0x900C
+	SAMPLER_CUBE_MAP_ARRAY_OES                                            = 0x900C
+	SAMPLER_CUBE_MAP_ARRAY_SHADOW_EXT                                     = 0x900D
+	SAMPLER_CUBE_MAP_ARRAY_SHADOW_OES                                     = 0x900D
+	SAMPLER_CUBE_SHADOW                                                   = 0x8DC5
+	SAMPLER_CUBE_SHADOW_NV                                                = 0x8DC5
+	SAMPLER_EXTERNAL_2D_Y2Y_EXT                                           = 0x8BE7
+	SAMPLER_EXTERNAL_OES                                                  = 0x8D66
+	SAMPLER_KHR                                                           = 0x82E6
+	SAMPLES                                                               = 0x80A9
+	SAMPLE_ALPHA_TO_COVERAGE                                              = 0x809E
+	SAMPLE_ALPHA_TO_ONE_EXT                                               = 0x809F
+	SAMPLE_BUFFERS                                                        = 0x80A8
+	SAMPLE_COVERAGE                                                       = 0x80A0
+	SAMPLE_COVERAGE_INVERT                                                = 0x80AB
+	SAMPLE_COVERAGE_VALUE                                                 = 0x80AA
+	SAMPLE_LOCATION_NV                                                    = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                                  = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                                   = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                                      = 0x933D
+	SAMPLE_MASK                                                           = 0x8E51
+	SAMPLE_MASK_VALUE                                                     = 0x8E52
+	SAMPLE_POSITION                                                       = 0x8E50
+	SAMPLE_SHADING_OES                                                    = 0x8C36
+	SCISSOR_BOX                                                           = 0x0C10
+	SCISSOR_TEST                                                          = 0x0C11
+	SCREEN_KHR                                                            = 0x9295
+	SCREEN_NV                                                             = 0x9295
+	SEPARATE_ATTRIBS                                                      = 0x8C8D
+	SGX_BINARY_IMG                                                        = 0x8C0A
+	SGX_PROGRAM_BINARY_IMG                                                = 0x9130
+	SHADER                                                                = 0x82E1
+	SHADER_BINARY_DMP                                                     = 0x9250
+	SHADER_BINARY_FORMATS                                                 = 0x8DF8
+	SHADER_BINARY_VIV                                                     = 0x8FC4
+	SHADER_COMPILER                                                       = 0x8DFA
+	SHADER_IMAGE_ACCESS_BARRIER_BIT                                       = 0x00000020
+	SHADER_KHR                                                            = 0x82E1
+	SHADER_OBJECT_EXT                                                     = 0x8B48
+	SHADER_PIXEL_LOCAL_STORAGE_EXT                                        = 0x8F64
+	SHADER_SOURCE_LENGTH                                                  = 0x8B88
+	SHADER_STORAGE_BARRIER_BIT                                            = 0x00002000
+	SHADER_STORAGE_BLOCK                                                  = 0x92E6
+	SHADER_STORAGE_BUFFER                                                 = 0x90D2
+	SHADER_STORAGE_BUFFER_BINDING                                         = 0x90D3
+	SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT                                = 0x90DF
+	SHADER_STORAGE_BUFFER_SIZE                                            = 0x90D5
+	SHADER_STORAGE_BUFFER_START                                           = 0x90D4
+	SHADER_TYPE                                                           = 0x8B4F
+	SHADING_LANGUAGE_VERSION                                              = 0x8B8C
+	SHARED_EDGE_NV                                                        = 0xC0
+	SHORT                                                                 = 0x1402
+	SIGNALED                                                              = 0x9119
+	SIGNALED_APPLE                                                        = 0x9119
+	SIGNED_NORMALIZED                                                     = 0x8F9C
+	SKIP_DECODE_EXT                                                       = 0x8A4A
+	SKIP_MISSING_GLYPH_NV                                                 = 0x90A9
+	SLUMINANCE8_ALPHA8_NV                                                 = 0x8C45
+	SLUMINANCE8_NV                                                        = 0x8C47
+	SLUMINANCE_ALPHA_NV                                                   = 0x8C44
+	SLUMINANCE_NV                                                         = 0x8C46
+	SMALL_CCW_ARC_TO_NV                                                   = 0x12
+	SMALL_CW_ARC_TO_NV                                                    = 0x14
+	SMAPHS30_PROGRAM_BINARY_DMP                                           = 0x9251
+	SMAPHS_PROGRAM_BINARY_DMP                                             = 0x9252
+	SMOOTH_CUBIC_CURVE_TO_NV                                              = 0x10
+	SMOOTH_QUADRATIC_CURVE_TO_NV                                          = 0x0E
+	SOFTLIGHT_KHR                                                         = 0x929C
+	SOFTLIGHT_NV                                                          = 0x929C
+	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_EXT                            = 0x91A9
+	SQUARE_NV                                                             = 0x90A3
+	SR8_EXT                                                               = 0x8FBD
+	SRC1_ALPHA_EXT                                                        = 0x8589
+	SRC1_COLOR_EXT                                                        = 0x88F9
+	SRC_ALPHA                                                             = 0x0302
+	SRC_ALPHA_SATURATE                                                    = 0x0308
+	SRC_ALPHA_SATURATE_EXT                                                = 0x0308
+	SRC_ATOP_NV                                                           = 0x928E
+	SRC_COLOR                                                             = 0x0300
+	SRC_IN_NV                                                             = 0x928A
+	SRC_NV                                                                = 0x9286
+	SRC_OUT_NV                                                            = 0x928C
+	SRC_OVER_NV                                                           = 0x9288
+	SRG8_EXT                                                              = 0x8FBE
+	SRGB                                                                  = 0x8C40
+	SRGB8                                                                 = 0x8C41
+	SRGB8_ALPHA8                                                          = 0x8C43
+	SRGB8_ALPHA8_EXT                                                      = 0x8C43
+	SRGB8_NV                                                              = 0x8C41
+	SRGB_ALPHA_EXT                                                        = 0x8C42
+	SRGB_EXT                                                              = 0x8C40
+	STACK_OVERFLOW                                                        = 0x0503
+	STACK_OVERFLOW_KHR                                                    = 0x0503
+	STACK_UNDERFLOW                                                       = 0x0504
+	STACK_UNDERFLOW_KHR                                                   = 0x0504
+	STANDARD_FONT_FORMAT_NV                                               = 0x936C
+	STANDARD_FONT_NAME_NV                                                 = 0x9072
+	STATE_RESTORE                                                         = 0x8BDC
+	STATIC_COPY                                                           = 0x88E6
+	STATIC_DRAW                                                           = 0x88E4
+	STATIC_READ                                                           = 0x88E5
+	STENCIL                                                               = 0x1802
+	STENCIL_ATTACHMENT                                                    = 0x8D20
+	STENCIL_BACK_FAIL                                                     = 0x8801
+	STENCIL_BACK_FUNC                                                     = 0x8800
+	STENCIL_BACK_PASS_DEPTH_FAIL                                          = 0x8802
+	STENCIL_BACK_PASS_DEPTH_PASS                                          = 0x8803
+	STENCIL_BACK_REF                                                      = 0x8CA3
+	STENCIL_BACK_VALUE_MASK                                               = 0x8CA4
+	STENCIL_BACK_WRITEMASK                                                = 0x8CA5
+	STENCIL_BITS                                                          = 0x0D57
+	STENCIL_BUFFER_BIT                                                    = 0x00000400
+	STENCIL_BUFFER_BIT0_QCOM                                              = 0x00010000
+	STENCIL_BUFFER_BIT1_QCOM                                              = 0x00020000
+	STENCIL_BUFFER_BIT2_QCOM                                              = 0x00040000
+	STENCIL_BUFFER_BIT3_QCOM                                              = 0x00080000
+	STENCIL_BUFFER_BIT4_QCOM                                              = 0x00100000
+	STENCIL_BUFFER_BIT5_QCOM                                              = 0x00200000
+	STENCIL_BUFFER_BIT6_QCOM                                              = 0x00400000
+	STENCIL_BUFFER_BIT7_QCOM                                              = 0x00800000
+	STENCIL_CLEAR_VALUE                                                   = 0x0B91
+	STENCIL_EXT                                                           = 0x1802
+	STENCIL_FAIL                                                          = 0x0B94
+	STENCIL_FUNC                                                          = 0x0B92
+	STENCIL_INDEX                                                         = 0x1901
+	STENCIL_INDEX1_OES                                                    = 0x8D46
+	STENCIL_INDEX4_OES                                                    = 0x8D47
+	STENCIL_INDEX8                                                        = 0x8D48
+	STENCIL_INDEX8_OES                                                    = 0x8D48
+	STENCIL_INDEX_OES                                                     = 0x1901
+	STENCIL_PASS_DEPTH_FAIL                                               = 0x0B95
+	STENCIL_PASS_DEPTH_PASS                                               = 0x0B96
+	STENCIL_REF                                                           = 0x0B97
+	STENCIL_SAMPLES_NV                                                    = 0x932E
+	STENCIL_TEST                                                          = 0x0B90
+	STENCIL_VALUE_MASK                                                    = 0x0B93
+	STENCIL_WRITEMASK                                                     = 0x0B98
+	STREAM_COPY                                                           = 0x88E2
+	STREAM_DRAW                                                           = 0x88E0
+	STREAM_READ                                                           = 0x88E1
+	SUBPIXEL_BITS                                                         = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                                     = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                                     = 0x9348
+	SUPERSAMPLE_SCALE_X_NV                                                = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                                = 0x9373
+	SYNC_CONDITION                                                        = 0x9113
+	SYNC_CONDITION_APPLE                                                  = 0x9113
+	SYNC_FENCE                                                            = 0x9116
+	SYNC_FENCE_APPLE                                                      = 0x9116
+	SYNC_FLAGS                                                            = 0x9115
+	SYNC_FLAGS_APPLE                                                      = 0x9115
+	SYNC_FLUSH_COMMANDS_BIT                                               = 0x00000001
+	SYNC_FLUSH_COMMANDS_BIT_APPLE                                         = 0x00000001
+	SYNC_GPU_COMMANDS_COMPLETE                                            = 0x9117
+	SYNC_GPU_COMMANDS_COMPLETE_APPLE                                      = 0x9117
+	SYNC_OBJECT_APPLE                                                     = 0x8A53
+	SYNC_STATUS                                                           = 0x9114
+	SYNC_STATUS_APPLE                                                     = 0x9114
+	SYSTEM_FONT_NAME_NV                                                   = 0x9073
+	TESS_CONTROL_OUTPUT_VERTICES_EXT                                      = 0x8E75
+	TESS_CONTROL_OUTPUT_VERTICES_OES                                      = 0x8E75
+	TESS_CONTROL_SHADER_BIT_EXT                                           = 0x00000008
+	TESS_CONTROL_SHADER_BIT_OES                                           = 0x00000008
+	TESS_CONTROL_SHADER_EXT                                               = 0x8E88
+	TESS_CONTROL_SHADER_OES                                               = 0x8E88
+	TESS_EVALUATION_SHADER_BIT_EXT                                        = 0x00000010
+	TESS_EVALUATION_SHADER_BIT_OES                                        = 0x00000010
+	TESS_EVALUATION_SHADER_EXT                                            = 0x8E87
+	TESS_EVALUATION_SHADER_OES                                            = 0x8E87
+	TESS_GEN_MODE_EXT                                                     = 0x8E76
+	TESS_GEN_MODE_OES                                                     = 0x8E76
+	TESS_GEN_POINT_MODE_EXT                                               = 0x8E79
+	TESS_GEN_POINT_MODE_OES                                               = 0x8E79
+	TESS_GEN_SPACING_EXT                                                  = 0x8E77
+	TESS_GEN_SPACING_OES                                                  = 0x8E77
+	TESS_GEN_VERTEX_ORDER_EXT                                             = 0x8E78
+	TESS_GEN_VERTEX_ORDER_OES                                             = 0x8E78
+	TEXTURE                                                               = 0x1702
+	TEXTURE0                                                              = 0x84C0
+	TEXTURE1                                                              = 0x84C1
+	TEXTURE10                                                             = 0x84CA
+	TEXTURE11                                                             = 0x84CB
+	TEXTURE12                                                             = 0x84CC
+	TEXTURE13                                                             = 0x84CD
+	TEXTURE14                                                             = 0x84CE
+	TEXTURE15                                                             = 0x84CF
+	TEXTURE16                                                             = 0x84D0
+	TEXTURE17                                                             = 0x84D1
+	TEXTURE18                                                             = 0x84D2
+	TEXTURE19                                                             = 0x84D3
+	TEXTURE2                                                              = 0x84C2
+	TEXTURE20                                                             = 0x84D4
+	TEXTURE21                                                             = 0x84D5
+	TEXTURE22                                                             = 0x84D6
+	TEXTURE23                                                             = 0x84D7
+	TEXTURE24                                                             = 0x84D8
+	TEXTURE25                                                             = 0x84D9
+	TEXTURE26                                                             = 0x84DA
+	TEXTURE27                                                             = 0x84DB
+	TEXTURE28                                                             = 0x84DC
+	TEXTURE29                                                             = 0x84DD
+	TEXTURE3                                                              = 0x84C3
+	TEXTURE30                                                             = 0x84DE
+	TEXTURE31                                                             = 0x84DF
+	TEXTURE4                                                              = 0x84C4
+	TEXTURE5                                                              = 0x84C5
+	TEXTURE6                                                              = 0x84C6
+	TEXTURE7                                                              = 0x84C7
+	TEXTURE8                                                              = 0x84C8
+	TEXTURE9                                                              = 0x84C9
+	TEXTURE_2D                                                            = 0x0DE1
+	TEXTURE_2D_ARRAY                                                      = 0x8C1A
+	TEXTURE_2D_MULTISAMPLE                                                = 0x9100
+	TEXTURE_2D_MULTISAMPLE_ARRAY                                          = 0x9102
+	TEXTURE_2D_MULTISAMPLE_ARRAY_OES                                      = 0x9102
+	TEXTURE_3D                                                            = 0x806F
+	TEXTURE_3D_OES                                                        = 0x806F
+	TEXTURE_ALPHA_SIZE                                                    = 0x805F
+	TEXTURE_ALPHA_TYPE                                                    = 0x8C13
+	TEXTURE_ASTC_DECODE_PRECISION_EXT                                     = 0x8F69
+	TEXTURE_BASE_LEVEL                                                    = 0x813C
+	TEXTURE_BINDING_2D                                                    = 0x8069
+	TEXTURE_BINDING_2D_ARRAY                                              = 0x8C1D
+	TEXTURE_BINDING_2D_MULTISAMPLE                                        = 0x9104
+	TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY_OES                              = 0x9105
+	TEXTURE_BINDING_3D                                                    = 0x806A
+	TEXTURE_BINDING_3D_OES                                                = 0x806A
+	TEXTURE_BINDING_BUFFER_EXT                                            = 0x8C2C
+	TEXTURE_BINDING_BUFFER_OES                                            = 0x8C2C
+	TEXTURE_BINDING_CUBE_MAP                                              = 0x8514
+	TEXTURE_BINDING_CUBE_MAP_ARRAY_EXT                                    = 0x900A
+	TEXTURE_BINDING_CUBE_MAP_ARRAY_OES                                    = 0x900A
+	TEXTURE_BINDING_EXTERNAL_OES                                          = 0x8D67
+	TEXTURE_BLUE_SIZE                                                     = 0x805E
+	TEXTURE_BLUE_TYPE                                                     = 0x8C12
+	TEXTURE_BORDER_COLOR_EXT                                              = 0x1004
+	TEXTURE_BORDER_COLOR_NV                                               = 0x1004
+	TEXTURE_BORDER_COLOR_OES                                              = 0x1004
+	TEXTURE_BUFFER_BINDING_EXT                                            = 0x8C2A
+	TEXTURE_BUFFER_BINDING_OES                                            = 0x8C2A
+	TEXTURE_BUFFER_DATA_STORE_BINDING_EXT                                 = 0x8C2D
+	TEXTURE_BUFFER_DATA_STORE_BINDING_OES                                 = 0x8C2D
+	TEXTURE_BUFFER_EXT                                                    = 0x8C2A
+	TEXTURE_BUFFER_OES                                                    = 0x8C2A
+	TEXTURE_BUFFER_OFFSET_ALIGNMENT_EXT                                   = 0x919F
+	TEXTURE_BUFFER_OFFSET_ALIGNMENT_OES                                   = 0x919F
+	TEXTURE_BUFFER_OFFSET_EXT                                             = 0x919D
+	TEXTURE_BUFFER_OFFSET_OES                                             = 0x919D
+	TEXTURE_BUFFER_SIZE_EXT                                               = 0x919E
+	TEXTURE_BUFFER_SIZE_OES                                               = 0x919E
+	TEXTURE_COMPARE_FUNC                                                  = 0x884D
+	TEXTURE_COMPARE_FUNC_EXT                                              = 0x884D
+	TEXTURE_COMPARE_MODE                                                  = 0x884C
+	TEXTURE_COMPARE_MODE_EXT                                              = 0x884C
+	TEXTURE_COMPRESSED                                                    = 0x86A1
+	TEXTURE_CUBE_MAP                                                      = 0x8513
+	TEXTURE_CUBE_MAP_ARRAY_EXT                                            = 0x9009
+	TEXTURE_CUBE_MAP_ARRAY_OES                                            = 0x9009
+	TEXTURE_CUBE_MAP_NEGATIVE_X                                           = 0x8516
+	TEXTURE_CUBE_MAP_NEGATIVE_Y                                           = 0x8518
+	TEXTURE_CUBE_MAP_NEGATIVE_Z                                           = 0x851A
+	TEXTURE_CUBE_MAP_POSITIVE_X                                           = 0x8515
+	TEXTURE_CUBE_MAP_POSITIVE_Y                                           = 0x8517
+	TEXTURE_CUBE_MAP_POSITIVE_Z                                           = 0x8519
+	TEXTURE_DEPTH                                                         = 0x8071
+	TEXTURE_DEPTH_QCOM                                                    = 0x8BD4
+	TEXTURE_DEPTH_SIZE                                                    = 0x884A
+	TEXTURE_DEPTH_TYPE                                                    = 0x8C16
+	TEXTURE_EXTERNAL_OES                                                  = 0x8D65
+	TEXTURE_FETCH_BARRIER_BIT                                             = 0x00000008
+	TEXTURE_FIXED_SAMPLE_LOCATIONS                                        = 0x9107
+	TEXTURE_FORMAT_QCOM                                                   = 0x8BD6
+	TEXTURE_FORMAT_SRGB_OVERRIDE_EXT                                      = 0x8FBF
+	TEXTURE_FOVEATED_FEATURE_BITS_QCOM                                    = 0x8BFB
+	TEXTURE_FOVEATED_FEATURE_QUERY_QCOM                                   = 0x8BFD
+	TEXTURE_FOVEATED_MIN_PIXEL_DENSITY_QCOM                               = 0x8BFC
+	TEXTURE_FOVEATED_NUM_FOCAL_POINTS_QUERY_QCOM                          = 0x8BFE
+	TEXTURE_GREEN_SIZE                                                    = 0x805D
+	TEXTURE_GREEN_TYPE                                                    = 0x8C11
+	TEXTURE_HEIGHT                                                        = 0x1001
+	TEXTURE_HEIGHT_QCOM                                                   = 0x8BD3
+	TEXTURE_IMAGE_VALID_QCOM                                              = 0x8BD8
+	TEXTURE_IMMUTABLE_FORMAT                                              = 0x912F
+	TEXTURE_IMMUTABLE_FORMAT_EXT                                          = 0x912F
+	TEXTURE_IMMUTABLE_LEVELS                                              = 0x82DF
+	TEXTURE_INTERNAL_FORMAT                                               = 0x1003
+	TEXTURE_INTERNAL_FORMAT_QCOM                                          = 0x8BD5
+	TEXTURE_MAG_FILTER                                                    = 0x2800
+	TEXTURE_MAX_ANISOTROPY_EXT                                            = 0x84FE
+	TEXTURE_MAX_LEVEL                                                     = 0x813D
+	TEXTURE_MAX_LEVEL_APPLE                                               = 0x813D
+	TEXTURE_MAX_LOD                                                       = 0x813B
+	TEXTURE_MIN_FILTER                                                    = 0x2801
+	TEXTURE_MIN_LOD                                                       = 0x813A
+	TEXTURE_NUM_LEVELS_QCOM                                               = 0x8BD9
+	TEXTURE_OBJECT_VALID_QCOM                                             = 0x8BDB
+	TEXTURE_PROTECTED_EXT                                                 = 0x8BFA
+	TEXTURE_REDUCTION_MODE_EXT                                            = 0x9366
+	TEXTURE_RED_SIZE                                                      = 0x805C
+	TEXTURE_RED_TYPE                                                      = 0x8C10
+	TEXTURE_SAMPLES                                                       = 0x9106
+	TEXTURE_SAMPLES_IMG                                                   = 0x9136
+	TEXTURE_SHARED_SIZE                                                   = 0x8C3F
+	TEXTURE_SPARSE_EXT                                                    = 0x91A6
+	TEXTURE_SRGB_DECODE_EXT                                               = 0x8A48
+	TEXTURE_STENCIL_SIZE                                                  = 0x88F1
+	TEXTURE_SWIZZLE_A                                                     = 0x8E45
+	TEXTURE_SWIZZLE_B                                                     = 0x8E44
+	TEXTURE_SWIZZLE_G                                                     = 0x8E43
+	TEXTURE_SWIZZLE_R                                                     = 0x8E42
+	TEXTURE_TARGET_QCOM                                                   = 0x8BDA
+	TEXTURE_TILING_EXT                                                    = 0x9580
+	TEXTURE_TYPE_QCOM                                                     = 0x8BD7
+	TEXTURE_UPDATE_BARRIER_BIT                                            = 0x00000100
+	TEXTURE_USAGE_ANGLE                                                   = 0x93A2
+	TEXTURE_VIEW_MIN_LAYER_EXT                                            = 0x82DD
+	TEXTURE_VIEW_MIN_LAYER_OES                                            = 0x82DD
+	TEXTURE_VIEW_MIN_LEVEL_EXT                                            = 0x82DB
+	TEXTURE_VIEW_MIN_LEVEL_OES                                            = 0x82DB
+	TEXTURE_VIEW_NUM_LAYERS_EXT                                           = 0x82DE
+	TEXTURE_VIEW_NUM_LAYERS_OES                                           = 0x82DE
+	TEXTURE_VIEW_NUM_LEVELS_EXT                                           = 0x82DC
+	TEXTURE_VIEW_NUM_LEVELS_OES                                           = 0x82DC
+	TEXTURE_WIDTH                                                         = 0x1000
+	TEXTURE_WIDTH_QCOM                                                    = 0x8BD2
+	TEXTURE_WRAP_R                                                        = 0x8072
+	TEXTURE_WRAP_R_OES                                                    = 0x8072
+	TEXTURE_WRAP_S                                                        = 0x2802
+	TEXTURE_WRAP_T                                                        = 0x2803
+	TILING_TYPES_EXT                                                      = 0x9583
+	TIMEOUT_EXPIRED                                                       = 0x911B
+	TIMEOUT_EXPIRED_APPLE                                                 = 0x911B
+	TIMEOUT_IGNORED                                                       = 0xFFFFFFFFFFFFFFFF
+	TIMEOUT_IGNORED_APPLE                                                 = 0xFFFFFFFFFFFFFFFF
+	TIMESTAMP_EXT                                                         = 0x8E28
+	TIME_ELAPSED_EXT                                                      = 0x88BF
+	TOP_LEVEL_ARRAY_SIZE                                                  = 0x930C
+	TOP_LEVEL_ARRAY_STRIDE                                                = 0x930D
+	TRANSFORM_FEEDBACK                                                    = 0x8E22
+	TRANSFORM_FEEDBACK_ACTIVE                                             = 0x8E24
+	TRANSFORM_FEEDBACK_BARRIER_BIT                                        = 0x00000800
+	TRANSFORM_FEEDBACK_BINDING                                            = 0x8E25
+	TRANSFORM_FEEDBACK_BUFFER                                             = 0x8C8E
+	TRANSFORM_FEEDBACK_BUFFER_BINDING                                     = 0x8C8F
+	TRANSFORM_FEEDBACK_BUFFER_MODE                                        = 0x8C7F
+	TRANSFORM_FEEDBACK_BUFFER_SIZE                                        = 0x8C85
+	TRANSFORM_FEEDBACK_BUFFER_START                                       = 0x8C84
+	TRANSFORM_FEEDBACK_PAUSED                                             = 0x8E23
+	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN                                 = 0x8C88
+	TRANSFORM_FEEDBACK_VARYING                                            = 0x92F4
+	TRANSFORM_FEEDBACK_VARYINGS                                           = 0x8C83
+	TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH                                 = 0x8C76
+	TRANSLATED_SHADER_SOURCE_LENGTH_ANGLE                                 = 0x93A0
+	TRANSLATE_2D_NV                                                       = 0x9090
+	TRANSLATE_3D_NV                                                       = 0x9091
+	TRANSLATE_X_NV                                                        = 0x908E
+	TRANSLATE_Y_NV                                                        = 0x908F
+	TRANSPOSE_AFFINE_2D_NV                                                = 0x9096
+	TRANSPOSE_AFFINE_3D_NV                                                = 0x9098
+	TRIANGLES                                                             = 0x0004
+	TRIANGLES_ADJACENCY_EXT                                               = 0x000C
+	TRIANGLES_ADJACENCY_OES                                               = 0x000C
+	TRIANGLE_FAN                                                          = 0x0006
+	TRIANGLE_STRIP                                                        = 0x0005
+	TRIANGLE_STRIP_ADJACENCY_EXT                                          = 0x000D
+	TRIANGLE_STRIP_ADJACENCY_OES                                          = 0x000D
+	TRIANGULAR_NV                                                         = 0x90A5
+	TRUE                                                                  = 1
+	TYPE                                                                  = 0x92FA
+	UNCORRELATED_NV                                                       = 0x9282
+	UNDEFINED_VERTEX_EXT                                                  = 0x8260
+	UNDEFINED_VERTEX_OES                                                  = 0x8260
+	UNIFORM                                                               = 0x92E1
+	UNIFORM_ARRAY_STRIDE                                                  = 0x8A3C
+	UNIFORM_BARRIER_BIT                                                   = 0x00000004
+	UNIFORM_BLOCK                                                         = 0x92E2
+	UNIFORM_BLOCK_ACTIVE_UNIFORMS                                         = 0x8A42
+	UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES                                  = 0x8A43
+	UNIFORM_BLOCK_BINDING                                                 = 0x8A3F
+	UNIFORM_BLOCK_DATA_SIZE                                               = 0x8A40
+	UNIFORM_BLOCK_INDEX                                                   = 0x8A3A
+	UNIFORM_BLOCK_NAME_LENGTH                                             = 0x8A41
+	UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER                           = 0x8A46
+	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                             = 0x8A44
+	UNIFORM_BUFFER                                                        = 0x8A11
+	UNIFORM_BUFFER_BINDING                                                = 0x8A28
+	UNIFORM_BUFFER_OFFSET_ALIGNMENT                                       = 0x8A34
+	UNIFORM_BUFFER_SIZE                                                   = 0x8A2A
+	UNIFORM_BUFFER_START                                                  = 0x8A29
+	UNIFORM_IS_ROW_MAJOR                                                  = 0x8A3E
+	UNIFORM_MATRIX_STRIDE                                                 = 0x8A3D
+	UNIFORM_NAME_LENGTH                                                   = 0x8A39
+	UNIFORM_OFFSET                                                        = 0x8A3B
+	UNIFORM_SIZE                                                          = 0x8A38
+	UNIFORM_TYPE                                                          = 0x8A37
+	UNKNOWN_CONTEXT_RESET                                                 = 0x8255
+	UNKNOWN_CONTEXT_RESET_EXT                                             = 0x8255
+	UNKNOWN_CONTEXT_RESET_KHR                                             = 0x8255
+	UNPACK_ALIGNMENT                                                      = 0x0CF5
+	UNPACK_IMAGE_HEIGHT                                                   = 0x806E
+	UNPACK_ROW_LENGTH                                                     = 0x0CF2
+	UNPACK_ROW_LENGTH_EXT                                                 = 0x0CF2
+	UNPACK_SKIP_IMAGES                                                    = 0x806D
+	UNPACK_SKIP_PIXELS                                                    = 0x0CF4
+	UNPACK_SKIP_PIXELS_EXT                                                = 0x0CF4
+	UNPACK_SKIP_ROWS                                                      = 0x0CF3
+	UNPACK_SKIP_ROWS_EXT                                                  = 0x0CF3
+	UNSIGNALED                                                            = 0x9118
+	UNSIGNALED_APPLE                                                      = 0x9118
+	UNSIGNED_BYTE                                                         = 0x1401
+	UNSIGNED_INT                                                          = 0x1405
+	UNSIGNED_INT16_NV                                                     = 0x8FF0
+	UNSIGNED_INT16_VEC2_NV                                                = 0x8FF1
+	UNSIGNED_INT16_VEC3_NV                                                = 0x8FF2
+	UNSIGNED_INT16_VEC4_NV                                                = 0x8FF3
+	UNSIGNED_INT64_AMD                                                    = 0x8BC2
+	UNSIGNED_INT64_NV                                                     = 0x140F
+	UNSIGNED_INT64_VEC2_NV                                                = 0x8FF5
+	UNSIGNED_INT64_VEC3_NV                                                = 0x8FF6
+	UNSIGNED_INT64_VEC4_NV                                                = 0x8FF7
+	UNSIGNED_INT8_NV                                                      = 0x8FEC
+	UNSIGNED_INT8_VEC2_NV                                                 = 0x8FED
+	UNSIGNED_INT8_VEC3_NV                                                 = 0x8FEE
+	UNSIGNED_INT8_VEC4_NV                                                 = 0x8FEF
+	UNSIGNED_INT_10F_11F_11F_REV                                          = 0x8C3B
+	UNSIGNED_INT_10F_11F_11F_REV_APPLE                                    = 0x8C3B
+	UNSIGNED_INT_10_10_10_2_OES                                           = 0x8DF6
+	UNSIGNED_INT_24_8                                                     = 0x84FA
+	UNSIGNED_INT_24_8_OES                                                 = 0x84FA
+	UNSIGNED_INT_2_10_10_10_REV                                           = 0x8368
+	UNSIGNED_INT_2_10_10_10_REV_EXT                                       = 0x8368
+	UNSIGNED_INT_5_9_9_9_REV                                              = 0x8C3E
+	UNSIGNED_INT_5_9_9_9_REV_APPLE                                        = 0x8C3E
+	UNSIGNED_INT_ATOMIC_COUNTER                                           = 0x92DB
+	UNSIGNED_INT_IMAGE_2D                                                 = 0x9063
+	UNSIGNED_INT_IMAGE_2D_ARRAY                                           = 0x9069
+	UNSIGNED_INT_IMAGE_3D                                                 = 0x9064
+	UNSIGNED_INT_IMAGE_BUFFER_EXT                                         = 0x9067
+	UNSIGNED_INT_IMAGE_BUFFER_OES                                         = 0x9067
+	UNSIGNED_INT_IMAGE_CUBE                                               = 0x9066
+	UNSIGNED_INT_IMAGE_CUBE_MAP_ARRAY_EXT                                 = 0x906A
+	UNSIGNED_INT_IMAGE_CUBE_MAP_ARRAY_OES                                 = 0x906A
+	UNSIGNED_INT_SAMPLER_2D                                               = 0x8DD2
+	UNSIGNED_INT_SAMPLER_2D_ARRAY                                         = 0x8DD7
+	UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE                                   = 0x910A
+	UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE_ARRAY_OES                         = 0x910D
+	UNSIGNED_INT_SAMPLER_3D                                               = 0x8DD3
+	UNSIGNED_INT_SAMPLER_BUFFER_EXT                                       = 0x8DD8
+	UNSIGNED_INT_SAMPLER_BUFFER_OES                                       = 0x8DD8
+	UNSIGNED_INT_SAMPLER_CUBE                                             = 0x8DD4
+	UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY_EXT                               = 0x900F
+	UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY_OES                               = 0x900F
+	UNSIGNED_INT_VEC2                                                     = 0x8DC6
+	UNSIGNED_INT_VEC3                                                     = 0x8DC7
+	UNSIGNED_INT_VEC4                                                     = 0x8DC8
+	UNSIGNED_NORMALIZED                                                   = 0x8C17
+	UNSIGNED_NORMALIZED_EXT                                               = 0x8C17
+	UNSIGNED_SHORT                                                        = 0x1403
+	UNSIGNED_SHORT_1_5_5_5_REV_EXT                                        = 0x8366
+	UNSIGNED_SHORT_4_4_4_4                                                = 0x8033
+	UNSIGNED_SHORT_4_4_4_4_REV_EXT                                        = 0x8365
+	UNSIGNED_SHORT_4_4_4_4_REV_IMG                                        = 0x8365
+	UNSIGNED_SHORT_5_5_5_1                                                = 0x8034
+	UNSIGNED_SHORT_5_6_5                                                  = 0x8363
+	UNSIGNED_SHORT_8_8_APPLE                                              = 0x85BA
+	UNSIGNED_SHORT_8_8_REV_APPLE                                          = 0x85BB
+	UPPER_LEFT_EXT                                                        = 0x8CA2
+	USE_MISSING_GLYPH_NV                                                  = 0x90AA
+	UTF16_NV                                                              = 0x909B
+	UTF8_NV                                                               = 0x909A
+	UUID_SIZE_EXT                                                         = 16
+	VALIDATE_STATUS                                                       = 0x8B83
+	VENDOR                                                                = 0x1F00
+	VERSION                                                               = 0x1F02
+	VERTEX_ARRAY                                                          = 0x8074
+	VERTEX_ARRAY_BINDING                                                  = 0x85B5
+	VERTEX_ARRAY_BINDING_OES                                              = 0x85B5
+	VERTEX_ARRAY_KHR                                                      = 0x8074
+	VERTEX_ARRAY_OBJECT_EXT                                               = 0x9154
+	VERTEX_ATTRIB_ARRAY_BARRIER_BIT                                       = 0x00000001
+	VERTEX_ATTRIB_ARRAY_BUFFER_BINDING                                    = 0x889F
+	VERTEX_ATTRIB_ARRAY_DIVISOR                                           = 0x88FE
+	VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE                                     = 0x88FE
+	VERTEX_ATTRIB_ARRAY_DIVISOR_EXT                                       = 0x88FE
+	VERTEX_ATTRIB_ARRAY_DIVISOR_NV                                        = 0x88FE
+	VERTEX_ATTRIB_ARRAY_ENABLED                                           = 0x8622
+	VERTEX_ATTRIB_ARRAY_INTEGER                                           = 0x88FD
+	VERTEX_ATTRIB_ARRAY_NORMALIZED                                        = 0x886A
+	VERTEX_ATTRIB_ARRAY_POINTER                                           = 0x8645
+	VERTEX_ATTRIB_ARRAY_SIZE                                              = 0x8623
+	VERTEX_ATTRIB_ARRAY_STRIDE                                            = 0x8624
+	VERTEX_ATTRIB_ARRAY_TYPE                                              = 0x8625
+	VERTEX_ATTRIB_BINDING                                                 = 0x82D4
+	VERTEX_ATTRIB_RELATIVE_OFFSET                                         = 0x82D5
+	VERTEX_BINDING_BUFFER                                                 = 0x8F4F
+	VERTEX_BINDING_DIVISOR                                                = 0x82D6
+	VERTEX_BINDING_OFFSET                                                 = 0x82D7
+	VERTEX_BINDING_STRIDE                                                 = 0x82D8
+	VERTEX_SHADER                                                         = 0x8B31
+	VERTEX_SHADER_BIT                                                     = 0x00000001
+	VERTEX_SHADER_BIT_EXT                                                 = 0x00000001
+	VERTICAL_LINE_TO_NV                                                   = 0x08
+	VIEWPORT                                                              = 0x0BA2
+	VIEWPORT_BOUNDS_RANGE_NV                                              = 0x825D
+	VIEWPORT_BOUNDS_RANGE_OES                                             = 0x825D
+	VIEWPORT_INDEX_PROVOKING_VERTEX_NV                                    = 0x825F
+	VIEWPORT_INDEX_PROVOKING_VERTEX_OES                                   = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                                          = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                                  = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                                  = 0x937E
+	VIEWPORT_SUBPIXEL_BITS_NV                                             = 0x825C
+	VIEWPORT_SUBPIXEL_BITS_OES                                            = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                                        = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                                        = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                                        = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                                        = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                                        = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                                        = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                                        = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                                        = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                                 = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                                 = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                                 = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                                 = 0x935A
+	VIRTUAL_PAGE_SIZE_INDEX_EXT                                           = 0x91A7
+	VIRTUAL_PAGE_SIZE_X_EXT                                               = 0x9195
+	VIRTUAL_PAGE_SIZE_Y_EXT                                               = 0x9196
+	VIRTUAL_PAGE_SIZE_Z_EXT                                               = 0x9197
+	VIVIDLIGHT_NV                                                         = 0x92A6
+	WAIT_FAILED                                                           = 0x911D
+	WAIT_FAILED_APPLE                                                     = 0x911D
+	WEIGHTED_AVERAGE_EXT                                                  = 0x9367
+	WINDOW_RECTANGLE_EXT                                                  = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                             = 0x8F13
+	WRITEONLY_RENDERING_QCOM                                              = 0x8823
+	WRITE_ONLY                                                            = 0x88B9
+	WRITE_ONLY_OES                                                        = 0x88B9
+	XOR_NV                                                                = 0x1506
+	Z400_BINARY_AMD                                                       = 0x8740
+	ZERO                                                                  = 0
+	ZERO_TO_ONE_EXT                                                       = 0x935F
 )
 
 var (
-	gpActiveProgramEXT                     C.GPACTIVEPROGRAMEXT
-	gpActiveShaderProgram                  C.GPACTIVESHADERPROGRAM
-	gpActiveShaderProgramEXT               C.GPACTIVESHADERPROGRAMEXT
-	gpActiveTexture                        C.GPACTIVETEXTURE
-	gpAlphaFuncQCOM                        C.GPALPHAFUNCQCOM
-	gpAttachShader                         C.GPATTACHSHADER
-	gpBeginPerfMonitorAMD                  C.GPBEGINPERFMONITORAMD
-	gpBeginPerfQueryINTEL                  C.GPBEGINPERFQUERYINTEL
-	gpBeginQuery                           C.GPBEGINQUERY
-	gpBeginQueryEXT                        C.GPBEGINQUERYEXT
-	gpBeginTransformFeedback               C.GPBEGINTRANSFORMFEEDBACK
-	gpBindAttribLocation                   C.GPBINDATTRIBLOCATION
-	gpBindBuffer                           C.GPBINDBUFFER
-	gpBindBufferBase                       C.GPBINDBUFFERBASE
-	gpBindBufferRange                      C.GPBINDBUFFERRANGE
-	gpBindFramebuffer                      C.GPBINDFRAMEBUFFER
-	gpBindImageTexture                     C.GPBINDIMAGETEXTURE
-	gpBindProgramPipeline                  C.GPBINDPROGRAMPIPELINE
-	gpBindProgramPipelineEXT               C.GPBINDPROGRAMPIPELINEEXT
-	gpBindRenderbuffer                     C.GPBINDRENDERBUFFER
-	gpBindSampler                          C.GPBINDSAMPLER
-	gpBindTexture                          C.GPBINDTEXTURE
-	gpBindTransformFeedback                C.GPBINDTRANSFORMFEEDBACK
-	gpBindVertexArray                      C.GPBINDVERTEXARRAY
-	gpBindVertexArrayOES                   C.GPBINDVERTEXARRAYOES
-	gpBindVertexBuffer                     C.GPBINDVERTEXBUFFER
-	gpBlendBarrierKHR                      C.GPBLENDBARRIERKHR
-	gpBlendBarrierNV                       C.GPBLENDBARRIERNV
-	gpBlendColor                           C.GPBLENDCOLOR
-	gpBlendEquation                        C.GPBLENDEQUATION
-	gpBlendEquationEXT                     C.GPBLENDEQUATIONEXT
-	gpBlendEquationSeparate                C.GPBLENDEQUATIONSEPARATE
-	gpBlendEquationSeparateiEXT            C.GPBLENDEQUATIONSEPARATEIEXT
-	gpBlendEquationiEXT                    C.GPBLENDEQUATIONIEXT
-	gpBlendFunc                            C.GPBLENDFUNC
-	gpBlendFuncSeparate                    C.GPBLENDFUNCSEPARATE
-	gpBlendFuncSeparateiEXT                C.GPBLENDFUNCSEPARATEIEXT
-	gpBlendFunciEXT                        C.GPBLENDFUNCIEXT
-	gpBlendParameteriNV                    C.GPBLENDPARAMETERINV
-	gpBlitFramebuffer                      C.GPBLITFRAMEBUFFER
-	gpBlitFramebufferANGLE                 C.GPBLITFRAMEBUFFERANGLE
-	gpBlitFramebufferNV                    C.GPBLITFRAMEBUFFERNV
-	gpBufferData                           C.GPBUFFERDATA
-	gpBufferSubData                        C.GPBUFFERSUBDATA
-	gpCheckFramebufferStatus               C.GPCHECKFRAMEBUFFERSTATUS
-	gpClear                                C.GPCLEAR
-	gpClearBufferfi                        C.GPCLEARBUFFERFI
-	gpClearBufferfv                        C.GPCLEARBUFFERFV
-	gpClearBufferiv                        C.GPCLEARBUFFERIV
-	gpClearBufferuiv                       C.GPCLEARBUFFERUIV
-	gpClearColor                           C.GPCLEARCOLOR
-	gpClearDepthf                          C.GPCLEARDEPTHF
-	gpClearStencil                         C.GPCLEARSTENCIL
-	gpClientWaitSync                       C.GPCLIENTWAITSYNC
-	gpClientWaitSyncAPPLE                  C.GPCLIENTWAITSYNCAPPLE
-	gpColorMask                            C.GPCOLORMASK
-	gpColorMaskiEXT                        C.GPCOLORMASKIEXT
-	gpCompileShader                        C.GPCOMPILESHADER
-	gpCompressedTexImage2D                 C.GPCOMPRESSEDTEXIMAGE2D
-	gpCompressedTexImage3D                 C.GPCOMPRESSEDTEXIMAGE3D
-	gpCompressedTexImage3DOES              C.GPCOMPRESSEDTEXIMAGE3DOES
-	gpCompressedTexSubImage2D              C.GPCOMPRESSEDTEXSUBIMAGE2D
-	gpCompressedTexSubImage3D              C.GPCOMPRESSEDTEXSUBIMAGE3D
-	gpCompressedTexSubImage3DOES           C.GPCOMPRESSEDTEXSUBIMAGE3DOES
-	gpCopyBufferSubData                    C.GPCOPYBUFFERSUBDATA
-	gpCopyBufferSubDataNV                  C.GPCOPYBUFFERSUBDATANV
-	gpCopyImageSubDataEXT                  C.GPCOPYIMAGESUBDATAEXT
-	gpCopyTexImage2D                       C.GPCOPYTEXIMAGE2D
-	gpCopyTexSubImage2D                    C.GPCOPYTEXSUBIMAGE2D
-	gpCopyTexSubImage3D                    C.GPCOPYTEXSUBIMAGE3D
-	gpCopyTexSubImage3DOES                 C.GPCOPYTEXSUBIMAGE3DOES
-	gpCopyTextureLevelsAPPLE               C.GPCOPYTEXTURELEVELSAPPLE
-	gpCoverageMaskNV                       C.GPCOVERAGEMASKNV
-	gpCoverageOperationNV                  C.GPCOVERAGEOPERATIONNV
-	gpCreatePerfQueryINTEL                 C.GPCREATEPERFQUERYINTEL
-	gpCreateProgram                        C.GPCREATEPROGRAM
-	gpCreateShader                         C.GPCREATESHADER
-	gpCreateShaderProgramEXT               C.GPCREATESHADERPROGRAMEXT
-	gpCreateShaderProgramv                 C.GPCREATESHADERPROGRAMV
-	gpCreateShaderProgramvEXT              C.GPCREATESHADERPROGRAMVEXT
-	gpCullFace                             C.GPCULLFACE
-	gpDebugMessageCallback                 C.GPDEBUGMESSAGECALLBACK
-	gpDebugMessageCallbackKHR              C.GPDEBUGMESSAGECALLBACKKHR
-	gpDebugMessageControl                  C.GPDEBUGMESSAGECONTROL
-	gpDebugMessageControlKHR               C.GPDEBUGMESSAGECONTROLKHR
-	gpDebugMessageInsert                   C.GPDEBUGMESSAGEINSERT
-	gpDebugMessageInsertKHR                C.GPDEBUGMESSAGEINSERTKHR
-	gpDeleteBuffers                        C.GPDELETEBUFFERS
-	gpDeleteFencesNV                       C.GPDELETEFENCESNV
-	gpDeleteFramebuffers                   C.GPDELETEFRAMEBUFFERS
-	gpDeletePerfMonitorsAMD                C.GPDELETEPERFMONITORSAMD
-	gpDeletePerfQueryINTEL                 C.GPDELETEPERFQUERYINTEL
-	gpDeleteProgram                        C.GPDELETEPROGRAM
-	gpDeleteProgramPipelines               C.GPDELETEPROGRAMPIPELINES
-	gpDeleteProgramPipelinesEXT            C.GPDELETEPROGRAMPIPELINESEXT
-	gpDeleteQueries                        C.GPDELETEQUERIES
-	gpDeleteQueriesEXT                     C.GPDELETEQUERIESEXT
-	gpDeleteRenderbuffers                  C.GPDELETERENDERBUFFERS
-	gpDeleteSamplers                       C.GPDELETESAMPLERS
-	gpDeleteShader                         C.GPDELETESHADER
-	gpDeleteSync                           C.GPDELETESYNC
-	gpDeleteSyncAPPLE                      C.GPDELETESYNCAPPLE
-	gpDeleteTextures                       C.GPDELETETEXTURES
-	gpDeleteTransformFeedbacks             C.GPDELETETRANSFORMFEEDBACKS
-	gpDeleteVertexArrays                   C.GPDELETEVERTEXARRAYS
-	gpDeleteVertexArraysOES                C.GPDELETEVERTEXARRAYSOES
-	gpDepthFunc                            C.GPDEPTHFUNC
-	gpDepthMask                            C.GPDEPTHMASK
-	gpDepthRangef                          C.GPDEPTHRANGEF
-	gpDetachShader                         C.GPDETACHSHADER
-	gpDisable                              C.GPDISABLE
-	gpDisableDriverControlQCOM             C.GPDISABLEDRIVERCONTROLQCOM
-	gpDisableVertexAttribArray             C.GPDISABLEVERTEXATTRIBARRAY
-	gpDisableiEXT                          C.GPDISABLEIEXT
-	gpDiscardFramebufferEXT                C.GPDISCARDFRAMEBUFFEREXT
-	gpDispatchCompute                      C.GPDISPATCHCOMPUTE
-	gpDispatchComputeIndirect              C.GPDISPATCHCOMPUTEINDIRECT
-	gpDrawArrays                           C.GPDRAWARRAYS
-	gpDrawArraysIndirect                   C.GPDRAWARRAYSINDIRECT
-	gpDrawArraysInstanced                  C.GPDRAWARRAYSINSTANCED
-	gpDrawArraysInstancedANGLE             C.GPDRAWARRAYSINSTANCEDANGLE
-	gpDrawArraysInstancedEXT               C.GPDRAWARRAYSINSTANCEDEXT
-	gpDrawArraysInstancedNV                C.GPDRAWARRAYSINSTANCEDNV
-	gpDrawBuffers                          C.GPDRAWBUFFERS
-	gpDrawBuffersEXT                       C.GPDRAWBUFFERSEXT
-	gpDrawBuffersIndexedEXT                C.GPDRAWBUFFERSINDEXEDEXT
-	gpDrawBuffersNV                        C.GPDRAWBUFFERSNV
-	gpDrawElements                         C.GPDRAWELEMENTS
-	gpDrawElementsIndirect                 C.GPDRAWELEMENTSINDIRECT
-	gpDrawElementsInstanced                C.GPDRAWELEMENTSINSTANCED
-	gpDrawElementsInstancedANGLE           C.GPDRAWELEMENTSINSTANCEDANGLE
-	gpDrawElementsInstancedEXT             C.GPDRAWELEMENTSINSTANCEDEXT
-	gpDrawElementsInstancedNV              C.GPDRAWELEMENTSINSTANCEDNV
-	gpDrawRangeElements                    C.GPDRAWRANGEELEMENTS
-	gpEGLImageTargetRenderbufferStorageOES C.GPEGLIMAGETARGETRENDERBUFFERSTORAGEOES
-	gpEGLImageTargetTexture2DOES           C.GPEGLIMAGETARGETTEXTURE2DOES
-	gpEnable                               C.GPENABLE
-	gpEnableDriverControlQCOM              C.GPENABLEDRIVERCONTROLQCOM
-	gpEnableVertexAttribArray              C.GPENABLEVERTEXATTRIBARRAY
-	gpEnableiEXT                           C.GPENABLEIEXT
-	gpEndPerfMonitorAMD                    C.GPENDPERFMONITORAMD
-	gpEndPerfQueryINTEL                    C.GPENDPERFQUERYINTEL
-	gpEndQuery                             C.GPENDQUERY
-	gpEndQueryEXT                          C.GPENDQUERYEXT
-	gpEndTilingQCOM                        C.GPENDTILINGQCOM
-	gpEndTransformFeedback                 C.GPENDTRANSFORMFEEDBACK
-	gpExtGetBufferPointervQCOM             C.GPEXTGETBUFFERPOINTERVQCOM
-	gpExtGetBuffersQCOM                    C.GPEXTGETBUFFERSQCOM
-	gpExtGetFramebuffersQCOM               C.GPEXTGETFRAMEBUFFERSQCOM
-	gpExtGetProgramBinarySourceQCOM        C.GPEXTGETPROGRAMBINARYSOURCEQCOM
-	gpExtGetProgramsQCOM                   C.GPEXTGETPROGRAMSQCOM
-	gpExtGetRenderbuffersQCOM              C.GPEXTGETRENDERBUFFERSQCOM
-	gpExtGetShadersQCOM                    C.GPEXTGETSHADERSQCOM
-	gpExtGetTexLevelParameterivQCOM        C.GPEXTGETTEXLEVELPARAMETERIVQCOM
-	gpExtGetTexSubImageQCOM                C.GPEXTGETTEXSUBIMAGEQCOM
-	gpExtGetTexturesQCOM                   C.GPEXTGETTEXTURESQCOM
-	gpExtIsProgramBinaryQCOM               C.GPEXTISPROGRAMBINARYQCOM
-	gpExtTexObjectStateOverrideiQCOM       C.GPEXTTEXOBJECTSTATEOVERRIDEIQCOM
-	gpFenceSync                            C.GPFENCESYNC
-	gpFenceSyncAPPLE                       C.GPFENCESYNCAPPLE
-	gpFinish                               C.GPFINISH
-	gpFinishFenceNV                        C.GPFINISHFENCENV
-	gpFlush                                C.GPFLUSH
-	gpFlushMappedBufferRange               C.GPFLUSHMAPPEDBUFFERRANGE
-	gpFlushMappedBufferRangeEXT            C.GPFLUSHMAPPEDBUFFERRANGEEXT
-	gpFramebufferParameteri                C.GPFRAMEBUFFERPARAMETERI
-	gpFramebufferRenderbuffer              C.GPFRAMEBUFFERRENDERBUFFER
-	gpFramebufferTexture2D                 C.GPFRAMEBUFFERTEXTURE2D
-	gpFramebufferTexture2DMultisampleEXT   C.GPFRAMEBUFFERTEXTURE2DMULTISAMPLEEXT
-	gpFramebufferTexture2DMultisampleIMG   C.GPFRAMEBUFFERTEXTURE2DMULTISAMPLEIMG
-	gpFramebufferTexture3DOES              C.GPFRAMEBUFFERTEXTURE3DOES
-	gpFramebufferTextureEXT                C.GPFRAMEBUFFERTEXTUREEXT
-	gpFramebufferTextureLayer              C.GPFRAMEBUFFERTEXTURELAYER
-	gpFrontFace                            C.GPFRONTFACE
-	gpGenBuffers                           C.GPGENBUFFERS
-	gpGenFencesNV                          C.GPGENFENCESNV
-	gpGenFramebuffers                      C.GPGENFRAMEBUFFERS
-	gpGenPerfMonitorsAMD                   C.GPGENPERFMONITORSAMD
-	gpGenProgramPipelines                  C.GPGENPROGRAMPIPELINES
-	gpGenProgramPipelinesEXT               C.GPGENPROGRAMPIPELINESEXT
-	gpGenQueries                           C.GPGENQUERIES
-	gpGenQueriesEXT                        C.GPGENQUERIESEXT
-	gpGenRenderbuffers                     C.GPGENRENDERBUFFERS
-	gpGenSamplers                          C.GPGENSAMPLERS
-	gpGenTextures                          C.GPGENTEXTURES
-	gpGenTransformFeedbacks                C.GPGENTRANSFORMFEEDBACKS
-	gpGenVertexArrays                      C.GPGENVERTEXARRAYS
-	gpGenVertexArraysOES                   C.GPGENVERTEXARRAYSOES
-	gpGenerateMipmap                       C.GPGENERATEMIPMAP
-	gpGetActiveAttrib                      C.GPGETACTIVEATTRIB
-	gpGetActiveUniform                     C.GPGETACTIVEUNIFORM
-	gpGetActiveUniformBlockName            C.GPGETACTIVEUNIFORMBLOCKNAME
-	gpGetActiveUniformBlockiv              C.GPGETACTIVEUNIFORMBLOCKIV
-	gpGetActiveUniformsiv                  C.GPGETACTIVEUNIFORMSIV
-	gpGetAttachedShaders                   C.GPGETATTACHEDSHADERS
-	gpGetAttribLocation                    C.GPGETATTRIBLOCATION
-	gpGetBooleani_v                        C.GPGETBOOLEANI_V
-	gpGetBooleanv                          C.GPGETBOOLEANV
-	gpGetBufferParameteri64v               C.GPGETBUFFERPARAMETERI64V
-	gpGetBufferParameteriv                 C.GPGETBUFFERPARAMETERIV
-	gpGetBufferPointerv                    C.GPGETBUFFERPOINTERV
-	gpGetBufferPointervOES                 C.GPGETBUFFERPOINTERVOES
-	gpGetDebugMessageLog                   C.GPGETDEBUGMESSAGELOG
-	gpGetDebugMessageLogKHR                C.GPGETDEBUGMESSAGELOGKHR
-	gpGetDriverControlStringQCOM           C.GPGETDRIVERCONTROLSTRINGQCOM
-	gpGetDriverControlsQCOM                C.GPGETDRIVERCONTROLSQCOM
-	gpGetError                             C.GPGETERROR
-	gpGetFenceivNV                         C.GPGETFENCEIVNV
-	gpGetFirstPerfQueryIdINTEL             C.GPGETFIRSTPERFQUERYIDINTEL
-	gpGetFloatv                            C.GPGETFLOATV
-	gpGetFragDataLocation                  C.GPGETFRAGDATALOCATION
-	gpGetFramebufferAttachmentParameteriv  C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetFramebufferParameteriv            C.GPGETFRAMEBUFFERPARAMETERIV
-	gpGetGraphicsResetStatus               C.GPGETGRAPHICSRESETSTATUS
-	gpGetGraphicsResetStatusEXT            C.GPGETGRAPHICSRESETSTATUSEXT
-	gpGetGraphicsResetStatusKHR            C.GPGETGRAPHICSRESETSTATUSKHR
-	gpGetInteger64i_v                      C.GPGETINTEGER64I_V
-	gpGetInteger64v                        C.GPGETINTEGER64V
-	gpGetInteger64vAPPLE                   C.GPGETINTEGER64VAPPLE
-	gpGetIntegeri_v                        C.GPGETINTEGERI_V
-	gpGetIntegeri_vEXT                     C.GPGETINTEGERI_VEXT
-	gpGetIntegerv                          C.GPGETINTEGERV
-	gpGetInternalformativ                  C.GPGETINTERNALFORMATIV
-	gpGetMultisamplefv                     C.GPGETMULTISAMPLEFV
-	gpGetNextPerfQueryIdINTEL              C.GPGETNEXTPERFQUERYIDINTEL
-	gpGetObjectLabel                       C.GPGETOBJECTLABEL
-	gpGetObjectLabelEXT                    C.GPGETOBJECTLABELEXT
-	gpGetObjectLabelKHR                    C.GPGETOBJECTLABELKHR
-	gpGetObjectPtrLabel                    C.GPGETOBJECTPTRLABEL
-	gpGetObjectPtrLabelKHR                 C.GPGETOBJECTPTRLABELKHR
-	gpGetPerfCounterInfoINTEL              C.GPGETPERFCOUNTERINFOINTEL
-	gpGetPerfMonitorCounterDataAMD         C.GPGETPERFMONITORCOUNTERDATAAMD
-	gpGetPerfMonitorCounterInfoAMD         C.GPGETPERFMONITORCOUNTERINFOAMD
-	gpGetPerfMonitorCounterStringAMD       C.GPGETPERFMONITORCOUNTERSTRINGAMD
-	gpGetPerfMonitorCountersAMD            C.GPGETPERFMONITORCOUNTERSAMD
-	gpGetPerfMonitorGroupStringAMD         C.GPGETPERFMONITORGROUPSTRINGAMD
-	gpGetPerfMonitorGroupsAMD              C.GPGETPERFMONITORGROUPSAMD
-	gpGetPerfQueryDataINTEL                C.GPGETPERFQUERYDATAINTEL
-	gpGetPerfQueryIdByNameINTEL            C.GPGETPERFQUERYIDBYNAMEINTEL
-	gpGetPerfQueryInfoINTEL                C.GPGETPERFQUERYINFOINTEL
-	gpGetPointerv                          C.GPGETPOINTERV
-	gpGetPointervKHR                       C.GPGETPOINTERVKHR
-	gpGetProgramBinary                     C.GPGETPROGRAMBINARY
-	gpGetProgramBinaryOES                  C.GPGETPROGRAMBINARYOES
-	gpGetProgramInfoLog                    C.GPGETPROGRAMINFOLOG
-	gpGetProgramInterfaceiv                C.GPGETPROGRAMINTERFACEIV
-	gpGetProgramPipelineInfoLog            C.GPGETPROGRAMPIPELINEINFOLOG
-	gpGetProgramPipelineInfoLogEXT         C.GPGETPROGRAMPIPELINEINFOLOGEXT
-	gpGetProgramPipelineiv                 C.GPGETPROGRAMPIPELINEIV
-	gpGetProgramPipelineivEXT              C.GPGETPROGRAMPIPELINEIVEXT
-	gpGetProgramResourceIndex              C.GPGETPROGRAMRESOURCEINDEX
-	gpGetProgramResourceLocation           C.GPGETPROGRAMRESOURCELOCATION
-	gpGetProgramResourceName               C.GPGETPROGRAMRESOURCENAME
-	gpGetProgramResourceiv                 C.GPGETPROGRAMRESOURCEIV
-	gpGetProgramiv                         C.GPGETPROGRAMIV
-	gpGetQueryObjecti64vEXT                C.GPGETQUERYOBJECTI64VEXT
-	gpGetQueryObjectivEXT                  C.GPGETQUERYOBJECTIVEXT
-	gpGetQueryObjectui64vEXT               C.GPGETQUERYOBJECTUI64VEXT
-	gpGetQueryObjectuiv                    C.GPGETQUERYOBJECTUIV
-	gpGetQueryObjectuivEXT                 C.GPGETQUERYOBJECTUIVEXT
-	gpGetQueryiv                           C.GPGETQUERYIV
-	gpGetQueryivEXT                        C.GPGETQUERYIVEXT
-	gpGetRenderbufferParameteriv           C.GPGETRENDERBUFFERPARAMETERIV
-	gpGetSamplerParameterIivEXT            C.GPGETSAMPLERPARAMETERIIVEXT
-	gpGetSamplerParameterIuivEXT           C.GPGETSAMPLERPARAMETERIUIVEXT
-	gpGetSamplerParameterfv                C.GPGETSAMPLERPARAMETERFV
-	gpGetSamplerParameteriv                C.GPGETSAMPLERPARAMETERIV
-	gpGetShaderInfoLog                     C.GPGETSHADERINFOLOG
-	gpGetShaderPrecisionFormat             C.GPGETSHADERPRECISIONFORMAT
-	gpGetShaderSource                      C.GPGETSHADERSOURCE
-	gpGetShaderiv                          C.GPGETSHADERIV
-	gpGetString                            C.GPGETSTRING
-	gpGetStringi                           C.GPGETSTRINGI
-	gpGetSynciv                            C.GPGETSYNCIV
-	gpGetSyncivAPPLE                       C.GPGETSYNCIVAPPLE
-	gpGetTexLevelParameterfv               C.GPGETTEXLEVELPARAMETERFV
-	gpGetTexLevelParameteriv               C.GPGETTEXLEVELPARAMETERIV
-	gpGetTexParameterIivEXT                C.GPGETTEXPARAMETERIIVEXT
-	gpGetTexParameterIuivEXT               C.GPGETTEXPARAMETERIUIVEXT
-	gpGetTexParameterfv                    C.GPGETTEXPARAMETERFV
-	gpGetTexParameteriv                    C.GPGETTEXPARAMETERIV
-	gpGetTransformFeedbackVarying          C.GPGETTRANSFORMFEEDBACKVARYING
-	gpGetTranslatedShaderSourceANGLE       C.GPGETTRANSLATEDSHADERSOURCEANGLE
-	gpGetUniformBlockIndex                 C.GPGETUNIFORMBLOCKINDEX
-	gpGetUniformIndices                    C.GPGETUNIFORMINDICES
-	gpGetUniformLocation                   C.GPGETUNIFORMLOCATION
-	gpGetUniformfv                         C.GPGETUNIFORMFV
-	gpGetUniformiv                         C.GPGETUNIFORMIV
-	gpGetUniformuiv                        C.GPGETUNIFORMUIV
-	gpGetVertexAttribIiv                   C.GPGETVERTEXATTRIBIIV
-	gpGetVertexAttribIuiv                  C.GPGETVERTEXATTRIBIUIV
-	gpGetVertexAttribPointerv              C.GPGETVERTEXATTRIBPOINTERV
-	gpGetVertexAttribfv                    C.GPGETVERTEXATTRIBFV
-	gpGetVertexAttribiv                    C.GPGETVERTEXATTRIBIV
-	gpGetnUniformfv                        C.GPGETNUNIFORMFV
-	gpGetnUniformfvEXT                     C.GPGETNUNIFORMFVEXT
-	gpGetnUniformfvKHR                     C.GPGETNUNIFORMFVKHR
-	gpGetnUniformiv                        C.GPGETNUNIFORMIV
-	gpGetnUniformivEXT                     C.GPGETNUNIFORMIVEXT
-	gpGetnUniformivKHR                     C.GPGETNUNIFORMIVKHR
-	gpGetnUniformuiv                       C.GPGETNUNIFORMUIV
-	gpGetnUniformuivKHR                    C.GPGETNUNIFORMUIVKHR
-	gpHint                                 C.GPHINT
-	gpInsertEventMarkerEXT                 C.GPINSERTEVENTMARKEREXT
-	gpInvalidateFramebuffer                C.GPINVALIDATEFRAMEBUFFER
-	gpInvalidateSubFramebuffer             C.GPINVALIDATESUBFRAMEBUFFER
-	gpIsBuffer                             C.GPISBUFFER
-	gpIsEnabled                            C.GPISENABLED
-	gpIsEnablediEXT                        C.GPISENABLEDIEXT
-	gpIsFenceNV                            C.GPISFENCENV
-	gpIsFramebuffer                        C.GPISFRAMEBUFFER
-	gpIsProgram                            C.GPISPROGRAM
-	gpIsProgramPipeline                    C.GPISPROGRAMPIPELINE
-	gpIsProgramPipelineEXT                 C.GPISPROGRAMPIPELINEEXT
-	gpIsQuery                              C.GPISQUERY
-	gpIsQueryEXT                           C.GPISQUERYEXT
-	gpIsRenderbuffer                       C.GPISRENDERBUFFER
-	gpIsSampler                            C.GPISSAMPLER
-	gpIsShader                             C.GPISSHADER
-	gpIsSync                               C.GPISSYNC
-	gpIsSyncAPPLE                          C.GPISSYNCAPPLE
-	gpIsTexture                            C.GPISTEXTURE
-	gpIsTransformFeedback                  C.GPISTRANSFORMFEEDBACK
-	gpIsVertexArray                        C.GPISVERTEXARRAY
-	gpIsVertexArrayOES                     C.GPISVERTEXARRAYOES
-	gpLabelObjectEXT                       C.GPLABELOBJECTEXT
-	gpLineWidth                            C.GPLINEWIDTH
-	gpLinkProgram                          C.GPLINKPROGRAM
-	gpMapBufferOES                         C.GPMAPBUFFEROES
-	gpMapBufferRange                       C.GPMAPBUFFERRANGE
-	gpMapBufferRangeEXT                    C.GPMAPBUFFERRANGEEXT
-	gpMemoryBarrier                        C.GPMEMORYBARRIER
-	gpMemoryBarrierByRegion                C.GPMEMORYBARRIERBYREGION
-	gpMinSampleShadingOES                  C.GPMINSAMPLESHADINGOES
-	gpMultiDrawArraysEXT                   C.GPMULTIDRAWARRAYSEXT
-	gpMultiDrawElementsEXT                 C.GPMULTIDRAWELEMENTSEXT
-	gpObjectLabel                          C.GPOBJECTLABEL
-	gpObjectLabelKHR                       C.GPOBJECTLABELKHR
-	gpObjectPtrLabel                       C.GPOBJECTPTRLABEL
-	gpObjectPtrLabelKHR                    C.GPOBJECTPTRLABELKHR
-	gpPatchParameteriEXT                   C.GPPATCHPARAMETERIEXT
-	gpPauseTransformFeedback               C.GPPAUSETRANSFORMFEEDBACK
-	gpPixelStorei                          C.GPPIXELSTOREI
-	gpPolygonOffset                        C.GPPOLYGONOFFSET
-	gpPopDebugGroup                        C.GPPOPDEBUGGROUP
-	gpPopDebugGroupKHR                     C.GPPOPDEBUGGROUPKHR
-	gpPopGroupMarkerEXT                    C.GPPOPGROUPMARKEREXT
-	gpPrimitiveBoundingBoxEXT              C.GPPRIMITIVEBOUNDINGBOXEXT
-	gpProgramBinary                        C.GPPROGRAMBINARY
-	gpProgramBinaryOES                     C.GPPROGRAMBINARYOES
-	gpProgramParameteri                    C.GPPROGRAMPARAMETERI
-	gpProgramParameteriEXT                 C.GPPROGRAMPARAMETERIEXT
-	gpProgramUniform1f                     C.GPPROGRAMUNIFORM1F
-	gpProgramUniform1fEXT                  C.GPPROGRAMUNIFORM1FEXT
-	gpProgramUniform1fv                    C.GPPROGRAMUNIFORM1FV
-	gpProgramUniform1fvEXT                 C.GPPROGRAMUNIFORM1FVEXT
-	gpProgramUniform1i                     C.GPPROGRAMUNIFORM1I
-	gpProgramUniform1iEXT                  C.GPPROGRAMUNIFORM1IEXT
-	gpProgramUniform1iv                    C.GPPROGRAMUNIFORM1IV
-	gpProgramUniform1ivEXT                 C.GPPROGRAMUNIFORM1IVEXT
-	gpProgramUniform1ui                    C.GPPROGRAMUNIFORM1UI
-	gpProgramUniform1uiEXT                 C.GPPROGRAMUNIFORM1UIEXT
-	gpProgramUniform1uiv                   C.GPPROGRAMUNIFORM1UIV
-	gpProgramUniform1uivEXT                C.GPPROGRAMUNIFORM1UIVEXT
-	gpProgramUniform2f                     C.GPPROGRAMUNIFORM2F
-	gpProgramUniform2fEXT                  C.GPPROGRAMUNIFORM2FEXT
-	gpProgramUniform2fv                    C.GPPROGRAMUNIFORM2FV
-	gpProgramUniform2fvEXT                 C.GPPROGRAMUNIFORM2FVEXT
-	gpProgramUniform2i                     C.GPPROGRAMUNIFORM2I
-	gpProgramUniform2iEXT                  C.GPPROGRAMUNIFORM2IEXT
-	gpProgramUniform2iv                    C.GPPROGRAMUNIFORM2IV
-	gpProgramUniform2ivEXT                 C.GPPROGRAMUNIFORM2IVEXT
-	gpProgramUniform2ui                    C.GPPROGRAMUNIFORM2UI
-	gpProgramUniform2uiEXT                 C.GPPROGRAMUNIFORM2UIEXT
-	gpProgramUniform2uiv                   C.GPPROGRAMUNIFORM2UIV
-	gpProgramUniform2uivEXT                C.GPPROGRAMUNIFORM2UIVEXT
-	gpProgramUniform3f                     C.GPPROGRAMUNIFORM3F
-	gpProgramUniform3fEXT                  C.GPPROGRAMUNIFORM3FEXT
-	gpProgramUniform3fv                    C.GPPROGRAMUNIFORM3FV
-	gpProgramUniform3fvEXT                 C.GPPROGRAMUNIFORM3FVEXT
-	gpProgramUniform3i                     C.GPPROGRAMUNIFORM3I
-	gpProgramUniform3iEXT                  C.GPPROGRAMUNIFORM3IEXT
-	gpProgramUniform3iv                    C.GPPROGRAMUNIFORM3IV
-	gpProgramUniform3ivEXT                 C.GPPROGRAMUNIFORM3IVEXT
-	gpProgramUniform3ui                    C.GPPROGRAMUNIFORM3UI
-	gpProgramUniform3uiEXT                 C.GPPROGRAMUNIFORM3UIEXT
-	gpProgramUniform3uiv                   C.GPPROGRAMUNIFORM3UIV
-	gpProgramUniform3uivEXT                C.GPPROGRAMUNIFORM3UIVEXT
-	gpProgramUniform4f                     C.GPPROGRAMUNIFORM4F
-	gpProgramUniform4fEXT                  C.GPPROGRAMUNIFORM4FEXT
-	gpProgramUniform4fv                    C.GPPROGRAMUNIFORM4FV
-	gpProgramUniform4fvEXT                 C.GPPROGRAMUNIFORM4FVEXT
-	gpProgramUniform4i                     C.GPPROGRAMUNIFORM4I
-	gpProgramUniform4iEXT                  C.GPPROGRAMUNIFORM4IEXT
-	gpProgramUniform4iv                    C.GPPROGRAMUNIFORM4IV
-	gpProgramUniform4ivEXT                 C.GPPROGRAMUNIFORM4IVEXT
-	gpProgramUniform4ui                    C.GPPROGRAMUNIFORM4UI
-	gpProgramUniform4uiEXT                 C.GPPROGRAMUNIFORM4UIEXT
-	gpProgramUniform4uiv                   C.GPPROGRAMUNIFORM4UIV
-	gpProgramUniform4uivEXT                C.GPPROGRAMUNIFORM4UIVEXT
-	gpProgramUniformMatrix2fv              C.GPPROGRAMUNIFORMMATRIX2FV
-	gpProgramUniformMatrix2fvEXT           C.GPPROGRAMUNIFORMMATRIX2FVEXT
-	gpProgramUniformMatrix2x3fv            C.GPPROGRAMUNIFORMMATRIX2X3FV
-	gpProgramUniformMatrix2x3fvEXT         C.GPPROGRAMUNIFORMMATRIX2X3FVEXT
-	gpProgramUniformMatrix2x4fv            C.GPPROGRAMUNIFORMMATRIX2X4FV
-	gpProgramUniformMatrix2x4fvEXT         C.GPPROGRAMUNIFORMMATRIX2X4FVEXT
-	gpProgramUniformMatrix3fv              C.GPPROGRAMUNIFORMMATRIX3FV
-	gpProgramUniformMatrix3fvEXT           C.GPPROGRAMUNIFORMMATRIX3FVEXT
-	gpProgramUniformMatrix3x2fv            C.GPPROGRAMUNIFORMMATRIX3X2FV
-	gpProgramUniformMatrix3x2fvEXT         C.GPPROGRAMUNIFORMMATRIX3X2FVEXT
-	gpProgramUniformMatrix3x4fv            C.GPPROGRAMUNIFORMMATRIX3X4FV
-	gpProgramUniformMatrix3x4fvEXT         C.GPPROGRAMUNIFORMMATRIX3X4FVEXT
-	gpProgramUniformMatrix4fv              C.GPPROGRAMUNIFORMMATRIX4FV
-	gpProgramUniformMatrix4fvEXT           C.GPPROGRAMUNIFORMMATRIX4FVEXT
-	gpProgramUniformMatrix4x2fv            C.GPPROGRAMUNIFORMMATRIX4X2FV
-	gpProgramUniformMatrix4x2fvEXT         C.GPPROGRAMUNIFORMMATRIX4X2FVEXT
-	gpProgramUniformMatrix4x3fv            C.GPPROGRAMUNIFORMMATRIX4X3FV
-	gpProgramUniformMatrix4x3fvEXT         C.GPPROGRAMUNIFORMMATRIX4X3FVEXT
-	gpPushDebugGroup                       C.GPPUSHDEBUGGROUP
-	gpPushDebugGroupKHR                    C.GPPUSHDEBUGGROUPKHR
-	gpPushGroupMarkerEXT                   C.GPPUSHGROUPMARKEREXT
-	gpQueryCounterEXT                      C.GPQUERYCOUNTEREXT
-	gpReadBuffer                           C.GPREADBUFFER
-	gpReadBufferIndexedEXT                 C.GPREADBUFFERINDEXEDEXT
-	gpReadBufferNV                         C.GPREADBUFFERNV
-	gpReadPixels                           C.GPREADPIXELS
-	gpReadnPixels                          C.GPREADNPIXELS
-	gpReadnPixelsEXT                       C.GPREADNPIXELSEXT
-	gpReadnPixelsKHR                       C.GPREADNPIXELSKHR
-	gpReleaseShaderCompiler                C.GPRELEASESHADERCOMPILER
-	gpRenderbufferStorage                  C.GPRENDERBUFFERSTORAGE
-	gpRenderbufferStorageMultisample       C.GPRENDERBUFFERSTORAGEMULTISAMPLE
-	gpRenderbufferStorageMultisampleANGLE  C.GPRENDERBUFFERSTORAGEMULTISAMPLEANGLE
-	gpRenderbufferStorageMultisampleAPPLE  C.GPRENDERBUFFERSTORAGEMULTISAMPLEAPPLE
-	gpRenderbufferStorageMultisampleEXT    C.GPRENDERBUFFERSTORAGEMULTISAMPLEEXT
-	gpRenderbufferStorageMultisampleIMG    C.GPRENDERBUFFERSTORAGEMULTISAMPLEIMG
-	gpRenderbufferStorageMultisampleNV     C.GPRENDERBUFFERSTORAGEMULTISAMPLENV
-	gpResolveMultisampleFramebufferAPPLE   C.GPRESOLVEMULTISAMPLEFRAMEBUFFERAPPLE
-	gpResumeTransformFeedback              C.GPRESUMETRANSFORMFEEDBACK
-	gpSampleCoverage                       C.GPSAMPLECOVERAGE
-	gpSampleMaski                          C.GPSAMPLEMASKI
-	gpSamplerParameterIivEXT               C.GPSAMPLERPARAMETERIIVEXT
-	gpSamplerParameterIuivEXT              C.GPSAMPLERPARAMETERIUIVEXT
-	gpSamplerParameterf                    C.GPSAMPLERPARAMETERF
-	gpSamplerParameterfv                   C.GPSAMPLERPARAMETERFV
-	gpSamplerParameteri                    C.GPSAMPLERPARAMETERI
-	gpSamplerParameteriv                   C.GPSAMPLERPARAMETERIV
-	gpScissor                              C.GPSCISSOR
-	gpSelectPerfMonitorCountersAMD         C.GPSELECTPERFMONITORCOUNTERSAMD
-	gpSetFenceNV                           C.GPSETFENCENV
-	gpShaderBinary                         C.GPSHADERBINARY
-	gpShaderSource                         C.GPSHADERSOURCE
-	gpStartTilingQCOM                      C.GPSTARTTILINGQCOM
-	gpStencilFunc                          C.GPSTENCILFUNC
-	gpStencilFuncSeparate                  C.GPSTENCILFUNCSEPARATE
-	gpStencilMask                          C.GPSTENCILMASK
-	gpStencilMaskSeparate                  C.GPSTENCILMASKSEPARATE
-	gpStencilOp                            C.GPSTENCILOP
-	gpStencilOpSeparate                    C.GPSTENCILOPSEPARATE
-	gpTestFenceNV                          C.GPTESTFENCENV
-	gpTexBufferEXT                         C.GPTEXBUFFEREXT
-	gpTexBufferRangeEXT                    C.GPTEXBUFFERRANGEEXT
-	gpTexImage2D                           C.GPTEXIMAGE2D
-	gpTexImage3D                           C.GPTEXIMAGE3D
-	gpTexImage3DOES                        C.GPTEXIMAGE3DOES
-	gpTexParameterIivEXT                   C.GPTEXPARAMETERIIVEXT
-	gpTexParameterIuivEXT                  C.GPTEXPARAMETERIUIVEXT
-	gpTexParameterf                        C.GPTEXPARAMETERF
-	gpTexParameterfv                       C.GPTEXPARAMETERFV
-	gpTexParameteri                        C.GPTEXPARAMETERI
-	gpTexParameteriv                       C.GPTEXPARAMETERIV
-	gpTexStorage1DEXT                      C.GPTEXSTORAGE1DEXT
-	gpTexStorage2D                         C.GPTEXSTORAGE2D
-	gpTexStorage2DEXT                      C.GPTEXSTORAGE2DEXT
-	gpTexStorage2DMultisample              C.GPTEXSTORAGE2DMULTISAMPLE
-	gpTexStorage3D                         C.GPTEXSTORAGE3D
-	gpTexStorage3DEXT                      C.GPTEXSTORAGE3DEXT
-	gpTexStorage3DMultisampleOES           C.GPTEXSTORAGE3DMULTISAMPLEOES
-	gpTexSubImage2D                        C.GPTEXSUBIMAGE2D
-	gpTexSubImage3D                        C.GPTEXSUBIMAGE3D
-	gpTexSubImage3DOES                     C.GPTEXSUBIMAGE3DOES
-	gpTextureStorage1DEXT                  C.GPTEXTURESTORAGE1DEXT
-	gpTextureStorage2DEXT                  C.GPTEXTURESTORAGE2DEXT
-	gpTextureStorage3DEXT                  C.GPTEXTURESTORAGE3DEXT
-	gpTextureViewEXT                       C.GPTEXTUREVIEWEXT
-	gpTransformFeedbackVaryings            C.GPTRANSFORMFEEDBACKVARYINGS
-	gpUniform1f                            C.GPUNIFORM1F
-	gpUniform1fv                           C.GPUNIFORM1FV
-	gpUniform1i                            C.GPUNIFORM1I
-	gpUniform1iv                           C.GPUNIFORM1IV
-	gpUniform1ui                           C.GPUNIFORM1UI
-	gpUniform1uiv                          C.GPUNIFORM1UIV
-	gpUniform2f                            C.GPUNIFORM2F
-	gpUniform2fv                           C.GPUNIFORM2FV
-	gpUniform2i                            C.GPUNIFORM2I
-	gpUniform2iv                           C.GPUNIFORM2IV
-	gpUniform2ui                           C.GPUNIFORM2UI
-	gpUniform2uiv                          C.GPUNIFORM2UIV
-	gpUniform3f                            C.GPUNIFORM3F
-	gpUniform3fv                           C.GPUNIFORM3FV
-	gpUniform3i                            C.GPUNIFORM3I
-	gpUniform3iv                           C.GPUNIFORM3IV
-	gpUniform3ui                           C.GPUNIFORM3UI
-	gpUniform3uiv                          C.GPUNIFORM3UIV
-	gpUniform4f                            C.GPUNIFORM4F
-	gpUniform4fv                           C.GPUNIFORM4FV
-	gpUniform4i                            C.GPUNIFORM4I
-	gpUniform4iv                           C.GPUNIFORM4IV
-	gpUniform4ui                           C.GPUNIFORM4UI
-	gpUniform4uiv                          C.GPUNIFORM4UIV
-	gpUniformBlockBinding                  C.GPUNIFORMBLOCKBINDING
-	gpUniformMatrix2fv                     C.GPUNIFORMMATRIX2FV
-	gpUniformMatrix2x3fv                   C.GPUNIFORMMATRIX2X3FV
-	gpUniformMatrix2x3fvNV                 C.GPUNIFORMMATRIX2X3FVNV
-	gpUniformMatrix2x4fv                   C.GPUNIFORMMATRIX2X4FV
-	gpUniformMatrix2x4fvNV                 C.GPUNIFORMMATRIX2X4FVNV
-	gpUniformMatrix3fv                     C.GPUNIFORMMATRIX3FV
-	gpUniformMatrix3x2fv                   C.GPUNIFORMMATRIX3X2FV
-	gpUniformMatrix3x2fvNV                 C.GPUNIFORMMATRIX3X2FVNV
-	gpUniformMatrix3x4fv                   C.GPUNIFORMMATRIX3X4FV
-	gpUniformMatrix3x4fvNV                 C.GPUNIFORMMATRIX3X4FVNV
-	gpUniformMatrix4fv                     C.GPUNIFORMMATRIX4FV
-	gpUniformMatrix4x2fv                   C.GPUNIFORMMATRIX4X2FV
-	gpUniformMatrix4x2fvNV                 C.GPUNIFORMMATRIX4X2FVNV
-	gpUniformMatrix4x3fv                   C.GPUNIFORMMATRIX4X3FV
-	gpUniformMatrix4x3fvNV                 C.GPUNIFORMMATRIX4X3FVNV
-	gpUnmapBuffer                          C.GPUNMAPBUFFER
-	gpUnmapBufferOES                       C.GPUNMAPBUFFEROES
-	gpUseProgram                           C.GPUSEPROGRAM
-	gpUseProgramStages                     C.GPUSEPROGRAMSTAGES
-	gpUseProgramStagesEXT                  C.GPUSEPROGRAMSTAGESEXT
-	gpUseShaderProgramEXT                  C.GPUSESHADERPROGRAMEXT
-	gpValidateProgram                      C.GPVALIDATEPROGRAM
-	gpValidateProgramPipeline              C.GPVALIDATEPROGRAMPIPELINE
-	gpValidateProgramPipelineEXT           C.GPVALIDATEPROGRAMPIPELINEEXT
-	gpVertexAttrib1f                       C.GPVERTEXATTRIB1F
-	gpVertexAttrib1fv                      C.GPVERTEXATTRIB1FV
-	gpVertexAttrib2f                       C.GPVERTEXATTRIB2F
-	gpVertexAttrib2fv                      C.GPVERTEXATTRIB2FV
-	gpVertexAttrib3f                       C.GPVERTEXATTRIB3F
-	gpVertexAttrib3fv                      C.GPVERTEXATTRIB3FV
-	gpVertexAttrib4f                       C.GPVERTEXATTRIB4F
-	gpVertexAttrib4fv                      C.GPVERTEXATTRIB4FV
-	gpVertexAttribBinding                  C.GPVERTEXATTRIBBINDING
-	gpVertexAttribDivisor                  C.GPVERTEXATTRIBDIVISOR
-	gpVertexAttribDivisorANGLE             C.GPVERTEXATTRIBDIVISORANGLE
-	gpVertexAttribDivisorEXT               C.GPVERTEXATTRIBDIVISOREXT
-	gpVertexAttribDivisorNV                C.GPVERTEXATTRIBDIVISORNV
-	gpVertexAttribFormat                   C.GPVERTEXATTRIBFORMAT
-	gpVertexAttribI4i                      C.GPVERTEXATTRIBI4I
-	gpVertexAttribI4iv                     C.GPVERTEXATTRIBI4IV
-	gpVertexAttribI4ui                     C.GPVERTEXATTRIBI4UI
-	gpVertexAttribI4uiv                    C.GPVERTEXATTRIBI4UIV
-	gpVertexAttribIFormat                  C.GPVERTEXATTRIBIFORMAT
-	gpVertexAttribIPointer                 C.GPVERTEXATTRIBIPOINTER
-	gpVertexAttribPointer                  C.GPVERTEXATTRIBPOINTER
-	gpVertexBindingDivisor                 C.GPVERTEXBINDINGDIVISOR
-	gpViewport                             C.GPVIEWPORT
-	gpWaitSync                             C.GPWAITSYNC
-	gpWaitSyncAPPLE                        C.GPWAITSYNCAPPLE
+	gpAcquireKeyedMutexWin32EXT                      C.GPACQUIREKEYEDMUTEXWIN32EXT
+	gpActiveProgramEXT                               C.GPACTIVEPROGRAMEXT
+	gpActiveShaderProgram                            C.GPACTIVESHADERPROGRAM
+	gpActiveShaderProgramEXT                         C.GPACTIVESHADERPROGRAMEXT
+	gpActiveTexture                                  C.GPACTIVETEXTURE
+	gpAlphaFuncQCOM                                  C.GPALPHAFUNCQCOM
+	gpApplyFramebufferAttachmentCMAAINTEL            C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
+	gpAttachShader                                   C.GPATTACHSHADER
+	gpBeginConditionalRenderNV                       C.GPBEGINCONDITIONALRENDERNV
+	gpBeginPerfMonitorAMD                            C.GPBEGINPERFMONITORAMD
+	gpBeginPerfQueryINTEL                            C.GPBEGINPERFQUERYINTEL
+	gpBeginQuery                                     C.GPBEGINQUERY
+	gpBeginQueryEXT                                  C.GPBEGINQUERYEXT
+	gpBeginTransformFeedback                         C.GPBEGINTRANSFORMFEEDBACK
+	gpBindAttribLocation                             C.GPBINDATTRIBLOCATION
+	gpBindBuffer                                     C.GPBINDBUFFER
+	gpBindBufferBase                                 C.GPBINDBUFFERBASE
+	gpBindBufferRange                                C.GPBINDBUFFERRANGE
+	gpBindFragDataLocationEXT                        C.GPBINDFRAGDATALOCATIONEXT
+	gpBindFragDataLocationIndexedEXT                 C.GPBINDFRAGDATALOCATIONINDEXEDEXT
+	gpBindFramebuffer                                C.GPBINDFRAMEBUFFER
+	gpBindImageTexture                               C.GPBINDIMAGETEXTURE
+	gpBindProgramPipeline                            C.GPBINDPROGRAMPIPELINE
+	gpBindProgramPipelineEXT                         C.GPBINDPROGRAMPIPELINEEXT
+	gpBindRenderbuffer                               C.GPBINDRENDERBUFFER
+	gpBindSampler                                    C.GPBINDSAMPLER
+	gpBindTexture                                    C.GPBINDTEXTURE
+	gpBindTransformFeedback                          C.GPBINDTRANSFORMFEEDBACK
+	gpBindVertexArray                                C.GPBINDVERTEXARRAY
+	gpBindVertexArrayOES                             C.GPBINDVERTEXARRAYOES
+	gpBindVertexBuffer                               C.GPBINDVERTEXBUFFER
+	gpBlendBarrierKHR                                C.GPBLENDBARRIERKHR
+	gpBlendBarrierNV                                 C.GPBLENDBARRIERNV
+	gpBlendColor                                     C.GPBLENDCOLOR
+	gpBlendEquation                                  C.GPBLENDEQUATION
+	gpBlendEquationEXT                               C.GPBLENDEQUATIONEXT
+	gpBlendEquationSeparate                          C.GPBLENDEQUATIONSEPARATE
+	gpBlendEquationSeparateiEXT                      C.GPBLENDEQUATIONSEPARATEIEXT
+	gpBlendEquationSeparateiOES                      C.GPBLENDEQUATIONSEPARATEIOES
+	gpBlendEquationiEXT                              C.GPBLENDEQUATIONIEXT
+	gpBlendEquationiOES                              C.GPBLENDEQUATIONIOES
+	gpBlendFunc                                      C.GPBLENDFUNC
+	gpBlendFuncSeparate                              C.GPBLENDFUNCSEPARATE
+	gpBlendFuncSeparateiEXT                          C.GPBLENDFUNCSEPARATEIEXT
+	gpBlendFuncSeparateiOES                          C.GPBLENDFUNCSEPARATEIOES
+	gpBlendFunciEXT                                  C.GPBLENDFUNCIEXT
+	gpBlendFunciOES                                  C.GPBLENDFUNCIOES
+	gpBlendParameteriNV                              C.GPBLENDPARAMETERINV
+	gpBlitFramebuffer                                C.GPBLITFRAMEBUFFER
+	gpBlitFramebufferANGLE                           C.GPBLITFRAMEBUFFERANGLE
+	gpBlitFramebufferNV                              C.GPBLITFRAMEBUFFERNV
+	gpBufferData                                     C.GPBUFFERDATA
+	gpBufferStorageEXT                               C.GPBUFFERSTORAGEEXT
+	gpBufferStorageExternalEXT                       C.GPBUFFERSTORAGEEXTERNALEXT
+	gpBufferStorageMemEXT                            C.GPBUFFERSTORAGEMEMEXT
+	gpBufferSubData                                  C.GPBUFFERSUBDATA
+	gpCheckFramebufferStatus                         C.GPCHECKFRAMEBUFFERSTATUS
+	gpClear                                          C.GPCLEAR
+	gpClearBufferfi                                  C.GPCLEARBUFFERFI
+	gpClearBufferfv                                  C.GPCLEARBUFFERFV
+	gpClearBufferiv                                  C.GPCLEARBUFFERIV
+	gpClearBufferuiv                                 C.GPCLEARBUFFERUIV
+	gpClearColor                                     C.GPCLEARCOLOR
+	gpClearDepthf                                    C.GPCLEARDEPTHF
+	gpClearPixelLocalStorageuiEXT                    C.GPCLEARPIXELLOCALSTORAGEUIEXT
+	gpClearStencil                                   C.GPCLEARSTENCIL
+	gpClearTexImageEXT                               C.GPCLEARTEXIMAGEEXT
+	gpClearTexSubImageEXT                            C.GPCLEARTEXSUBIMAGEEXT
+	gpClientWaitSync                                 C.GPCLIENTWAITSYNC
+	gpClientWaitSyncAPPLE                            C.GPCLIENTWAITSYNCAPPLE
+	gpClipControlEXT                                 C.GPCLIPCONTROLEXT
+	gpColorMask                                      C.GPCOLORMASK
+	gpColorMaskiEXT                                  C.GPCOLORMASKIEXT
+	gpColorMaskiOES                                  C.GPCOLORMASKIOES
+	gpCompileShader                                  C.GPCOMPILESHADER
+	gpCompressedTexImage2D                           C.GPCOMPRESSEDTEXIMAGE2D
+	gpCompressedTexImage3D                           C.GPCOMPRESSEDTEXIMAGE3D
+	gpCompressedTexImage3DOES                        C.GPCOMPRESSEDTEXIMAGE3DOES
+	gpCompressedTexSubImage2D                        C.GPCOMPRESSEDTEXSUBIMAGE2D
+	gpCompressedTexSubImage3D                        C.GPCOMPRESSEDTEXSUBIMAGE3D
+	gpCompressedTexSubImage3DOES                     C.GPCOMPRESSEDTEXSUBIMAGE3DOES
+	gpConservativeRasterParameteriNV                 C.GPCONSERVATIVERASTERPARAMETERINV
+	gpCopyBufferSubData                              C.GPCOPYBUFFERSUBDATA
+	gpCopyBufferSubDataNV                            C.GPCOPYBUFFERSUBDATANV
+	gpCopyImageSubDataEXT                            C.GPCOPYIMAGESUBDATAEXT
+	gpCopyImageSubDataOES                            C.GPCOPYIMAGESUBDATAOES
+	gpCopyPathNV                                     C.GPCOPYPATHNV
+	gpCopyTexImage2D                                 C.GPCOPYTEXIMAGE2D
+	gpCopyTexSubImage2D                              C.GPCOPYTEXSUBIMAGE2D
+	gpCopyTexSubImage3D                              C.GPCOPYTEXSUBIMAGE3D
+	gpCopyTexSubImage3DOES                           C.GPCOPYTEXSUBIMAGE3DOES
+	gpCopyTextureLevelsAPPLE                         C.GPCOPYTEXTURELEVELSAPPLE
+	gpCoverFillPathInstancedNV                       C.GPCOVERFILLPATHINSTANCEDNV
+	gpCoverFillPathNV                                C.GPCOVERFILLPATHNV
+	gpCoverStrokePathInstancedNV                     C.GPCOVERSTROKEPATHINSTANCEDNV
+	gpCoverStrokePathNV                              C.GPCOVERSTROKEPATHNV
+	gpCoverageMaskNV                                 C.GPCOVERAGEMASKNV
+	gpCoverageModulationNV                           C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                      C.GPCOVERAGEMODULATIONTABLENV
+	gpCoverageOperationNV                            C.GPCOVERAGEOPERATIONNV
+	gpCreateMemoryObjectsEXT                         C.GPCREATEMEMORYOBJECTSEXT
+	gpCreatePerfQueryINTEL                           C.GPCREATEPERFQUERYINTEL
+	gpCreateProgram                                  C.GPCREATEPROGRAM
+	gpCreateShader                                   C.GPCREATESHADER
+	gpCreateShaderProgramEXT                         C.GPCREATESHADERPROGRAMEXT
+	gpCreateShaderProgramv                           C.GPCREATESHADERPROGRAMV
+	gpCreateShaderProgramvEXT                        C.GPCREATESHADERPROGRAMVEXT
+	gpCullFace                                       C.GPCULLFACE
+	gpDebugMessageCallback                           C.GPDEBUGMESSAGECALLBACK
+	gpDebugMessageCallbackKHR                        C.GPDEBUGMESSAGECALLBACKKHR
+	gpDebugMessageControl                            C.GPDEBUGMESSAGECONTROL
+	gpDebugMessageControlKHR                         C.GPDEBUGMESSAGECONTROLKHR
+	gpDebugMessageInsert                             C.GPDEBUGMESSAGEINSERT
+	gpDebugMessageInsertKHR                          C.GPDEBUGMESSAGEINSERTKHR
+	gpDeleteBuffers                                  C.GPDELETEBUFFERS
+	gpDeleteFencesNV                                 C.GPDELETEFENCESNV
+	gpDeleteFramebuffers                             C.GPDELETEFRAMEBUFFERS
+	gpDeleteMemoryObjectsEXT                         C.GPDELETEMEMORYOBJECTSEXT
+	gpDeletePathsNV                                  C.GPDELETEPATHSNV
+	gpDeletePerfMonitorsAMD                          C.GPDELETEPERFMONITORSAMD
+	gpDeletePerfQueryINTEL                           C.GPDELETEPERFQUERYINTEL
+	gpDeleteProgram                                  C.GPDELETEPROGRAM
+	gpDeleteProgramPipelines                         C.GPDELETEPROGRAMPIPELINES
+	gpDeleteProgramPipelinesEXT                      C.GPDELETEPROGRAMPIPELINESEXT
+	gpDeleteQueries                                  C.GPDELETEQUERIES
+	gpDeleteQueriesEXT                               C.GPDELETEQUERIESEXT
+	gpDeleteRenderbuffers                            C.GPDELETERENDERBUFFERS
+	gpDeleteSamplers                                 C.GPDELETESAMPLERS
+	gpDeleteSemaphoresEXT                            C.GPDELETESEMAPHORESEXT
+	gpDeleteShader                                   C.GPDELETESHADER
+	gpDeleteSync                                     C.GPDELETESYNC
+	gpDeleteSyncAPPLE                                C.GPDELETESYNCAPPLE
+	gpDeleteTextures                                 C.GPDELETETEXTURES
+	gpDeleteTransformFeedbacks                       C.GPDELETETRANSFORMFEEDBACKS
+	gpDeleteVertexArrays                             C.GPDELETEVERTEXARRAYS
+	gpDeleteVertexArraysOES                          C.GPDELETEVERTEXARRAYSOES
+	gpDepthFunc                                      C.GPDEPTHFUNC
+	gpDepthMask                                      C.GPDEPTHMASK
+	gpDepthRangeArrayfvNV                            C.GPDEPTHRANGEARRAYFVNV
+	gpDepthRangeArrayfvOES                           C.GPDEPTHRANGEARRAYFVOES
+	gpDepthRangeIndexedfNV                           C.GPDEPTHRANGEINDEXEDFNV
+	gpDepthRangeIndexedfOES                          C.GPDEPTHRANGEINDEXEDFOES
+	gpDepthRangef                                    C.GPDEPTHRANGEF
+	gpDetachShader                                   C.GPDETACHSHADER
+	gpDisable                                        C.GPDISABLE
+	gpDisableDriverControlQCOM                       C.GPDISABLEDRIVERCONTROLQCOM
+	gpDisableVertexAttribArray                       C.GPDISABLEVERTEXATTRIBARRAY
+	gpDisableiEXT                                    C.GPDISABLEIEXT
+	gpDisableiNV                                     C.GPDISABLEINV
+	gpDisableiOES                                    C.GPDISABLEIOES
+	gpDiscardFramebufferEXT                          C.GPDISCARDFRAMEBUFFEREXT
+	gpDispatchCompute                                C.GPDISPATCHCOMPUTE
+	gpDispatchComputeIndirect                        C.GPDISPATCHCOMPUTEINDIRECT
+	gpDrawArrays                                     C.GPDRAWARRAYS
+	gpDrawArraysIndirect                             C.GPDRAWARRAYSINDIRECT
+	gpDrawArraysInstanced                            C.GPDRAWARRAYSINSTANCED
+	gpDrawArraysInstancedANGLE                       C.GPDRAWARRAYSINSTANCEDANGLE
+	gpDrawArraysInstancedBaseInstanceEXT             C.GPDRAWARRAYSINSTANCEDBASEINSTANCEEXT
+	gpDrawArraysInstancedEXT                         C.GPDRAWARRAYSINSTANCEDEXT
+	gpDrawArraysInstancedNV                          C.GPDRAWARRAYSINSTANCEDNV
+	gpDrawBuffers                                    C.GPDRAWBUFFERS
+	gpDrawBuffersEXT                                 C.GPDRAWBUFFERSEXT
+	gpDrawBuffersIndexedEXT                          C.GPDRAWBUFFERSINDEXEDEXT
+	gpDrawBuffersNV                                  C.GPDRAWBUFFERSNV
+	gpDrawElements                                   C.GPDRAWELEMENTS
+	gpDrawElementsBaseVertexEXT                      C.GPDRAWELEMENTSBASEVERTEXEXT
+	gpDrawElementsBaseVertexOES                      C.GPDRAWELEMENTSBASEVERTEXOES
+	gpDrawElementsIndirect                           C.GPDRAWELEMENTSINDIRECT
+	gpDrawElementsInstanced                          C.GPDRAWELEMENTSINSTANCED
+	gpDrawElementsInstancedANGLE                     C.GPDRAWELEMENTSINSTANCEDANGLE
+	gpDrawElementsInstancedBaseInstanceEXT           C.GPDRAWELEMENTSINSTANCEDBASEINSTANCEEXT
+	gpDrawElementsInstancedBaseVertexBaseInstanceEXT C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCEEXT
+	gpDrawElementsInstancedBaseVertexEXT             C.GPDRAWELEMENTSINSTANCEDBASEVERTEXEXT
+	gpDrawElementsInstancedBaseVertexOES             C.GPDRAWELEMENTSINSTANCEDBASEVERTEXOES
+	gpDrawElementsInstancedEXT                       C.GPDRAWELEMENTSINSTANCEDEXT
+	gpDrawElementsInstancedNV                        C.GPDRAWELEMENTSINSTANCEDNV
+	gpDrawRangeElements                              C.GPDRAWRANGEELEMENTS
+	gpDrawRangeElementsBaseVertexEXT                 C.GPDRAWRANGEELEMENTSBASEVERTEXEXT
+	gpDrawRangeElementsBaseVertexOES                 C.GPDRAWRANGEELEMENTSBASEVERTEXOES
+	gpDrawTransformFeedbackEXT                       C.GPDRAWTRANSFORMFEEDBACKEXT
+	gpDrawTransformFeedbackInstancedEXT              C.GPDRAWTRANSFORMFEEDBACKINSTANCEDEXT
+	gpDrawVkImageNV                                  C.GPDRAWVKIMAGENV
+	gpEGLImageTargetRenderbufferStorageOES           C.GPEGLIMAGETARGETRENDERBUFFERSTORAGEOES
+	gpEGLImageTargetTexture2DOES                     C.GPEGLIMAGETARGETTEXTURE2DOES
+	gpEnable                                         C.GPENABLE
+	gpEnableDriverControlQCOM                        C.GPENABLEDRIVERCONTROLQCOM
+	gpEnableVertexAttribArray                        C.GPENABLEVERTEXATTRIBARRAY
+	gpEnableiEXT                                     C.GPENABLEIEXT
+	gpEnableiNV                                      C.GPENABLEINV
+	gpEnableiOES                                     C.GPENABLEIOES
+	gpEndConditionalRenderNV                         C.GPENDCONDITIONALRENDERNV
+	gpEndPerfMonitorAMD                              C.GPENDPERFMONITORAMD
+	gpEndPerfQueryINTEL                              C.GPENDPERFQUERYINTEL
+	gpEndQuery                                       C.GPENDQUERY
+	gpEndQueryEXT                                    C.GPENDQUERYEXT
+	gpEndTilingQCOM                                  C.GPENDTILINGQCOM
+	gpEndTransformFeedback                           C.GPENDTRANSFORMFEEDBACK
+	gpExtGetBufferPointervQCOM                       C.GPEXTGETBUFFERPOINTERVQCOM
+	gpExtGetBuffersQCOM                              C.GPEXTGETBUFFERSQCOM
+	gpExtGetFramebuffersQCOM                         C.GPEXTGETFRAMEBUFFERSQCOM
+	gpExtGetProgramBinarySourceQCOM                  C.GPEXTGETPROGRAMBINARYSOURCEQCOM
+	gpExtGetProgramsQCOM                             C.GPEXTGETPROGRAMSQCOM
+	gpExtGetRenderbuffersQCOM                        C.GPEXTGETRENDERBUFFERSQCOM
+	gpExtGetShadersQCOM                              C.GPEXTGETSHADERSQCOM
+	gpExtGetTexLevelParameterivQCOM                  C.GPEXTGETTEXLEVELPARAMETERIVQCOM
+	gpExtGetTexSubImageQCOM                          C.GPEXTGETTEXSUBIMAGEQCOM
+	gpExtGetTexturesQCOM                             C.GPEXTGETTEXTURESQCOM
+	gpExtIsProgramBinaryQCOM                         C.GPEXTISPROGRAMBINARYQCOM
+	gpExtTexObjectStateOverrideiQCOM                 C.GPEXTTEXOBJECTSTATEOVERRIDEIQCOM
+	gpFenceSync                                      C.GPFENCESYNC
+	gpFenceSyncAPPLE                                 C.GPFENCESYNCAPPLE
+	gpFinish                                         C.GPFINISH
+	gpFinishFenceNV                                  C.GPFINISHFENCENV
+	gpFlush                                          C.GPFLUSH
+	gpFlushMappedBufferRange                         C.GPFLUSHMAPPEDBUFFERRANGE
+	gpFlushMappedBufferRangeEXT                      C.GPFLUSHMAPPEDBUFFERRANGEEXT
+	gpFragmentCoverageColorNV                        C.GPFRAGMENTCOVERAGECOLORNV
+	gpFramebufferFetchBarrierEXT                     C.GPFRAMEBUFFERFETCHBARRIEREXT
+	gpFramebufferFetchBarrierQCOM                    C.GPFRAMEBUFFERFETCHBARRIERQCOM
+	gpFramebufferFoveationConfigQCOM                 C.GPFRAMEBUFFERFOVEATIONCONFIGQCOM
+	gpFramebufferFoveationParametersQCOM             C.GPFRAMEBUFFERFOVEATIONPARAMETERSQCOM
+	gpFramebufferParameteri                          C.GPFRAMEBUFFERPARAMETERI
+	gpFramebufferPixelLocalStorageSizeEXT            C.GPFRAMEBUFFERPIXELLOCALSTORAGESIZEEXT
+	gpFramebufferRenderbuffer                        C.GPFRAMEBUFFERRENDERBUFFER
+	gpFramebufferSampleLocationsfvNV                 C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferTexture2D                           C.GPFRAMEBUFFERTEXTURE2D
+	gpFramebufferTexture2DDownsampleIMG              C.GPFRAMEBUFFERTEXTURE2DDOWNSAMPLEIMG
+	gpFramebufferTexture2DMultisampleEXT             C.GPFRAMEBUFFERTEXTURE2DMULTISAMPLEEXT
+	gpFramebufferTexture2DMultisampleIMG             C.GPFRAMEBUFFERTEXTURE2DMULTISAMPLEIMG
+	gpFramebufferTexture3DOES                        C.GPFRAMEBUFFERTEXTURE3DOES
+	gpFramebufferTextureEXT                          C.GPFRAMEBUFFERTEXTUREEXT
+	gpFramebufferTextureLayer                        C.GPFRAMEBUFFERTEXTURELAYER
+	gpFramebufferTextureLayerDownsampleIMG           C.GPFRAMEBUFFERTEXTURELAYERDOWNSAMPLEIMG
+	gpFramebufferTextureMultisampleMultiviewOVR      C.GPFRAMEBUFFERTEXTUREMULTISAMPLEMULTIVIEWOVR
+	gpFramebufferTextureMultiviewOVR                 C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
+	gpFramebufferTextureOES                          C.GPFRAMEBUFFERTEXTUREOES
+	gpFrontFace                                      C.GPFRONTFACE
+	gpGenBuffers                                     C.GPGENBUFFERS
+	gpGenFencesNV                                    C.GPGENFENCESNV
+	gpGenFramebuffers                                C.GPGENFRAMEBUFFERS
+	gpGenPathsNV                                     C.GPGENPATHSNV
+	gpGenPerfMonitorsAMD                             C.GPGENPERFMONITORSAMD
+	gpGenProgramPipelines                            C.GPGENPROGRAMPIPELINES
+	gpGenProgramPipelinesEXT                         C.GPGENPROGRAMPIPELINESEXT
+	gpGenQueries                                     C.GPGENQUERIES
+	gpGenQueriesEXT                                  C.GPGENQUERIESEXT
+	gpGenRenderbuffers                               C.GPGENRENDERBUFFERS
+	gpGenSamplers                                    C.GPGENSAMPLERS
+	gpGenSemaphoresEXT                               C.GPGENSEMAPHORESEXT
+	gpGenTextures                                    C.GPGENTEXTURES
+	gpGenTransformFeedbacks                          C.GPGENTRANSFORMFEEDBACKS
+	gpGenVertexArrays                                C.GPGENVERTEXARRAYS
+	gpGenVertexArraysOES                             C.GPGENVERTEXARRAYSOES
+	gpGenerateMipmap                                 C.GPGENERATEMIPMAP
+	gpGetActiveAttrib                                C.GPGETACTIVEATTRIB
+	gpGetActiveUniform                               C.GPGETACTIVEUNIFORM
+	gpGetActiveUniformBlockName                      C.GPGETACTIVEUNIFORMBLOCKNAME
+	gpGetActiveUniformBlockiv                        C.GPGETACTIVEUNIFORMBLOCKIV
+	gpGetActiveUniformsiv                            C.GPGETACTIVEUNIFORMSIV
+	gpGetAttachedShaders                             C.GPGETATTACHEDSHADERS
+	gpGetAttribLocation                              C.GPGETATTRIBLOCATION
+	gpGetBooleani_v                                  C.GPGETBOOLEANI_V
+	gpGetBooleanv                                    C.GPGETBOOLEANV
+	gpGetBufferParameteri64v                         C.GPGETBUFFERPARAMETERI64V
+	gpGetBufferParameteriv                           C.GPGETBUFFERPARAMETERIV
+	gpGetBufferPointerv                              C.GPGETBUFFERPOINTERV
+	gpGetBufferPointervOES                           C.GPGETBUFFERPOINTERVOES
+	gpGetCoverageModulationTableNV                   C.GPGETCOVERAGEMODULATIONTABLENV
+	gpGetDebugMessageLog                             C.GPGETDEBUGMESSAGELOG
+	gpGetDebugMessageLogKHR                          C.GPGETDEBUGMESSAGELOGKHR
+	gpGetDriverControlStringQCOM                     C.GPGETDRIVERCONTROLSTRINGQCOM
+	gpGetDriverControlsQCOM                          C.GPGETDRIVERCONTROLSQCOM
+	gpGetError                                       C.GPGETERROR
+	gpGetFenceivNV                                   C.GPGETFENCEIVNV
+	gpGetFirstPerfQueryIdINTEL                       C.GPGETFIRSTPERFQUERYIDINTEL
+	gpGetFloati_vNV                                  C.GPGETFLOATI_VNV
+	gpGetFloati_vOES                                 C.GPGETFLOATI_VOES
+	gpGetFloatv                                      C.GPGETFLOATV
+	gpGetFragDataIndexEXT                            C.GPGETFRAGDATAINDEXEXT
+	gpGetFragDataLocation                            C.GPGETFRAGDATALOCATION
+	gpGetFramebufferAttachmentParameteriv            C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetFramebufferParameteriv                      C.GPGETFRAMEBUFFERPARAMETERIV
+	gpGetFramebufferPixelLocalStorageSizeEXT         C.GPGETFRAMEBUFFERPIXELLOCALSTORAGESIZEEXT
+	gpGetGraphicsResetStatus                         C.GPGETGRAPHICSRESETSTATUS
+	gpGetGraphicsResetStatusEXT                      C.GPGETGRAPHICSRESETSTATUSEXT
+	gpGetGraphicsResetStatusKHR                      C.GPGETGRAPHICSRESETSTATUSKHR
+	gpGetImageHandleNV                               C.GPGETIMAGEHANDLENV
+	gpGetInteger64i_v                                C.GPGETINTEGER64I_V
+	gpGetInteger64v                                  C.GPGETINTEGER64V
+	gpGetInteger64vAPPLE                             C.GPGETINTEGER64VAPPLE
+	gpGetIntegeri_v                                  C.GPGETINTEGERI_V
+	gpGetIntegeri_vEXT                               C.GPGETINTEGERI_VEXT
+	gpGetIntegerv                                    C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                    C.GPGETINTERNALFORMATSAMPLEIVNV
+	gpGetInternalformativ                            C.GPGETINTERNALFORMATIV
+	gpGetMemoryObjectParameterivEXT                  C.GPGETMEMORYOBJECTPARAMETERIVEXT
+	gpGetMultisamplefv                               C.GPGETMULTISAMPLEFV
+	gpGetNextPerfQueryIdINTEL                        C.GPGETNEXTPERFQUERYIDINTEL
+	gpGetObjectLabel                                 C.GPGETOBJECTLABEL
+	gpGetObjectLabelEXT                              C.GPGETOBJECTLABELEXT
+	gpGetObjectLabelKHR                              C.GPGETOBJECTLABELKHR
+	gpGetObjectPtrLabel                              C.GPGETOBJECTPTRLABEL
+	gpGetObjectPtrLabelKHR                           C.GPGETOBJECTPTRLABELKHR
+	gpGetPathCommandsNV                              C.GPGETPATHCOMMANDSNV
+	gpGetPathCoordsNV                                C.GPGETPATHCOORDSNV
+	gpGetPathDashArrayNV                             C.GPGETPATHDASHARRAYNV
+	gpGetPathLengthNV                                C.GPGETPATHLENGTHNV
+	gpGetPathMetricRangeNV                           C.GPGETPATHMETRICRANGENV
+	gpGetPathMetricsNV                               C.GPGETPATHMETRICSNV
+	gpGetPathParameterfvNV                           C.GPGETPATHPARAMETERFVNV
+	gpGetPathParameterivNV                           C.GPGETPATHPARAMETERIVNV
+	gpGetPathSpacingNV                               C.GPGETPATHSPACINGNV
+	gpGetPerfCounterInfoINTEL                        C.GPGETPERFCOUNTERINFOINTEL
+	gpGetPerfMonitorCounterDataAMD                   C.GPGETPERFMONITORCOUNTERDATAAMD
+	gpGetPerfMonitorCounterInfoAMD                   C.GPGETPERFMONITORCOUNTERINFOAMD
+	gpGetPerfMonitorCounterStringAMD                 C.GPGETPERFMONITORCOUNTERSTRINGAMD
+	gpGetPerfMonitorCountersAMD                      C.GPGETPERFMONITORCOUNTERSAMD
+	gpGetPerfMonitorGroupStringAMD                   C.GPGETPERFMONITORGROUPSTRINGAMD
+	gpGetPerfMonitorGroupsAMD                        C.GPGETPERFMONITORGROUPSAMD
+	gpGetPerfQueryDataINTEL                          C.GPGETPERFQUERYDATAINTEL
+	gpGetPerfQueryIdByNameINTEL                      C.GPGETPERFQUERYIDBYNAMEINTEL
+	gpGetPerfQueryInfoINTEL                          C.GPGETPERFQUERYINFOINTEL
+	gpGetPointerv                                    C.GPGETPOINTERV
+	gpGetPointervKHR                                 C.GPGETPOINTERVKHR
+	gpGetProgramBinary                               C.GPGETPROGRAMBINARY
+	gpGetProgramBinaryOES                            C.GPGETPROGRAMBINARYOES
+	gpGetProgramInfoLog                              C.GPGETPROGRAMINFOLOG
+	gpGetProgramInterfaceiv                          C.GPGETPROGRAMINTERFACEIV
+	gpGetProgramPipelineInfoLog                      C.GPGETPROGRAMPIPELINEINFOLOG
+	gpGetProgramPipelineInfoLogEXT                   C.GPGETPROGRAMPIPELINEINFOLOGEXT
+	gpGetProgramPipelineiv                           C.GPGETPROGRAMPIPELINEIV
+	gpGetProgramPipelineivEXT                        C.GPGETPROGRAMPIPELINEIVEXT
+	gpGetProgramResourceIndex                        C.GPGETPROGRAMRESOURCEINDEX
+	gpGetProgramResourceLocation                     C.GPGETPROGRAMRESOURCELOCATION
+	gpGetProgramResourceLocationIndexEXT             C.GPGETPROGRAMRESOURCELOCATIONINDEXEXT
+	gpGetProgramResourceName                         C.GPGETPROGRAMRESOURCENAME
+	gpGetProgramResourcefvNV                         C.GPGETPROGRAMRESOURCEFVNV
+	gpGetProgramResourceiv                           C.GPGETPROGRAMRESOURCEIV
+	gpGetProgramiv                                   C.GPGETPROGRAMIV
+	gpGetQueryObjecti64vEXT                          C.GPGETQUERYOBJECTI64VEXT
+	gpGetQueryObjectivEXT                            C.GPGETQUERYOBJECTIVEXT
+	gpGetQueryObjectui64vEXT                         C.GPGETQUERYOBJECTUI64VEXT
+	gpGetQueryObjectuiv                              C.GPGETQUERYOBJECTUIV
+	gpGetQueryObjectuivEXT                           C.GPGETQUERYOBJECTUIVEXT
+	gpGetQueryiv                                     C.GPGETQUERYIV
+	gpGetQueryivEXT                                  C.GPGETQUERYIVEXT
+	gpGetRenderbufferParameteriv                     C.GPGETRENDERBUFFERPARAMETERIV
+	gpGetSamplerParameterIivEXT                      C.GPGETSAMPLERPARAMETERIIVEXT
+	gpGetSamplerParameterIivOES                      C.GPGETSAMPLERPARAMETERIIVOES
+	gpGetSamplerParameterIuivEXT                     C.GPGETSAMPLERPARAMETERIUIVEXT
+	gpGetSamplerParameterIuivOES                     C.GPGETSAMPLERPARAMETERIUIVOES
+	gpGetSamplerParameterfv                          C.GPGETSAMPLERPARAMETERFV
+	gpGetSamplerParameteriv                          C.GPGETSAMPLERPARAMETERIV
+	gpGetSemaphoreParameterui64vEXT                  C.GPGETSEMAPHOREPARAMETERUI64VEXT
+	gpGetShaderInfoLog                               C.GPGETSHADERINFOLOG
+	gpGetShaderPrecisionFormat                       C.GPGETSHADERPRECISIONFORMAT
+	gpGetShaderSource                                C.GPGETSHADERSOURCE
+	gpGetShaderiv                                    C.GPGETSHADERIV
+	gpGetString                                      C.GPGETSTRING
+	gpGetStringi                                     C.GPGETSTRINGI
+	gpGetSynciv                                      C.GPGETSYNCIV
+	gpGetSyncivAPPLE                                 C.GPGETSYNCIVAPPLE
+	gpGetTexLevelParameterfv                         C.GPGETTEXLEVELPARAMETERFV
+	gpGetTexLevelParameteriv                         C.GPGETTEXLEVELPARAMETERIV
+	gpGetTexParameterIivEXT                          C.GPGETTEXPARAMETERIIVEXT
+	gpGetTexParameterIivOES                          C.GPGETTEXPARAMETERIIVOES
+	gpGetTexParameterIuivEXT                         C.GPGETTEXPARAMETERIUIVEXT
+	gpGetTexParameterIuivOES                         C.GPGETTEXPARAMETERIUIVOES
+	gpGetTexParameterfv                              C.GPGETTEXPARAMETERFV
+	gpGetTexParameteriv                              C.GPGETTEXPARAMETERIV
+	gpGetTextureHandleIMG                            C.GPGETTEXTUREHANDLEIMG
+	gpGetTextureHandleNV                             C.GPGETTEXTUREHANDLENV
+	gpGetTextureSamplerHandleIMG                     C.GPGETTEXTURESAMPLERHANDLEIMG
+	gpGetTextureSamplerHandleNV                      C.GPGETTEXTURESAMPLERHANDLENV
+	gpGetTransformFeedbackVarying                    C.GPGETTRANSFORMFEEDBACKVARYING
+	gpGetTranslatedShaderSourceANGLE                 C.GPGETTRANSLATEDSHADERSOURCEANGLE
+	gpGetUniformBlockIndex                           C.GPGETUNIFORMBLOCKINDEX
+	gpGetUniformIndices                              C.GPGETUNIFORMINDICES
+	gpGetUniformLocation                             C.GPGETUNIFORMLOCATION
+	gpGetUniformfv                                   C.GPGETUNIFORMFV
+	gpGetUniformi64vNV                               C.GPGETUNIFORMI64VNV
+	gpGetUniformiv                                   C.GPGETUNIFORMIV
+	gpGetUniformuiv                                  C.GPGETUNIFORMUIV
+	gpGetUnsignedBytei_vEXT                          C.GPGETUNSIGNEDBYTEI_VEXT
+	gpGetUnsignedBytevEXT                            C.GPGETUNSIGNEDBYTEVEXT
+	gpGetVertexAttribIiv                             C.GPGETVERTEXATTRIBIIV
+	gpGetVertexAttribIuiv                            C.GPGETVERTEXATTRIBIUIV
+	gpGetVertexAttribPointerv                        C.GPGETVERTEXATTRIBPOINTERV
+	gpGetVertexAttribfv                              C.GPGETVERTEXATTRIBFV
+	gpGetVertexAttribiv                              C.GPGETVERTEXATTRIBIV
+	gpGetVkProcAddrNV                                C.GPGETVKPROCADDRNV
+	gpGetnUniformfv                                  C.GPGETNUNIFORMFV
+	gpGetnUniformfvEXT                               C.GPGETNUNIFORMFVEXT
+	gpGetnUniformfvKHR                               C.GPGETNUNIFORMFVKHR
+	gpGetnUniformiv                                  C.GPGETNUNIFORMIV
+	gpGetnUniformivEXT                               C.GPGETNUNIFORMIVEXT
+	gpGetnUniformivKHR                               C.GPGETNUNIFORMIVKHR
+	gpGetnUniformuiv                                 C.GPGETNUNIFORMUIV
+	gpGetnUniformuivKHR                              C.GPGETNUNIFORMUIVKHR
+	gpHint                                           C.GPHINT
+	gpImportMemoryFdEXT                              C.GPIMPORTMEMORYFDEXT
+	gpImportMemoryWin32HandleEXT                     C.GPIMPORTMEMORYWIN32HANDLEEXT
+	gpImportMemoryWin32NameEXT                       C.GPIMPORTMEMORYWIN32NAMEEXT
+	gpImportSemaphoreFdEXT                           C.GPIMPORTSEMAPHOREFDEXT
+	gpImportSemaphoreWin32HandleEXT                  C.GPIMPORTSEMAPHOREWIN32HANDLEEXT
+	gpImportSemaphoreWin32NameEXT                    C.GPIMPORTSEMAPHOREWIN32NAMEEXT
+	gpInsertEventMarkerEXT                           C.GPINSERTEVENTMARKEREXT
+	gpInterpolatePathsNV                             C.GPINTERPOLATEPATHSNV
+	gpInvalidateFramebuffer                          C.GPINVALIDATEFRAMEBUFFER
+	gpInvalidateSubFramebuffer                       C.GPINVALIDATESUBFRAMEBUFFER
+	gpIsBuffer                                       C.GPISBUFFER
+	gpIsEnabled                                      C.GPISENABLED
+	gpIsEnablediEXT                                  C.GPISENABLEDIEXT
+	gpIsEnablediNV                                   C.GPISENABLEDINV
+	gpIsEnablediOES                                  C.GPISENABLEDIOES
+	gpIsFenceNV                                      C.GPISFENCENV
+	gpIsFramebuffer                                  C.GPISFRAMEBUFFER
+	gpIsImageHandleResidentNV                        C.GPISIMAGEHANDLERESIDENTNV
+	gpIsMemoryObjectEXT                              C.GPISMEMORYOBJECTEXT
+	gpIsPathNV                                       C.GPISPATHNV
+	gpIsPointInFillPathNV                            C.GPISPOINTINFILLPATHNV
+	gpIsPointInStrokePathNV                          C.GPISPOINTINSTROKEPATHNV
+	gpIsProgram                                      C.GPISPROGRAM
+	gpIsProgramPipeline                              C.GPISPROGRAMPIPELINE
+	gpIsProgramPipelineEXT                           C.GPISPROGRAMPIPELINEEXT
+	gpIsQuery                                        C.GPISQUERY
+	gpIsQueryEXT                                     C.GPISQUERYEXT
+	gpIsRenderbuffer                                 C.GPISRENDERBUFFER
+	gpIsSampler                                      C.GPISSAMPLER
+	gpIsSemaphoreEXT                                 C.GPISSEMAPHOREEXT
+	gpIsShader                                       C.GPISSHADER
+	gpIsSync                                         C.GPISSYNC
+	gpIsSyncAPPLE                                    C.GPISSYNCAPPLE
+	gpIsTexture                                      C.GPISTEXTURE
+	gpIsTextureHandleResidentNV                      C.GPISTEXTUREHANDLERESIDENTNV
+	gpIsTransformFeedback                            C.GPISTRANSFORMFEEDBACK
+	gpIsVertexArray                                  C.GPISVERTEXARRAY
+	gpIsVertexArrayOES                               C.GPISVERTEXARRAYOES
+	gpLabelObjectEXT                                 C.GPLABELOBJECTEXT
+	gpLineWidth                                      C.GPLINEWIDTH
+	gpLinkProgram                                    C.GPLINKPROGRAM
+	gpMakeImageHandleNonResidentNV                   C.GPMAKEIMAGEHANDLENONRESIDENTNV
+	gpMakeImageHandleResidentNV                      C.GPMAKEIMAGEHANDLERESIDENTNV
+	gpMakeTextureHandleNonResidentNV                 C.GPMAKETEXTUREHANDLENONRESIDENTNV
+	gpMakeTextureHandleResidentNV                    C.GPMAKETEXTUREHANDLERESIDENTNV
+	gpMapBufferOES                                   C.GPMAPBUFFEROES
+	gpMapBufferRange                                 C.GPMAPBUFFERRANGE
+	gpMapBufferRangeEXT                              C.GPMAPBUFFERRANGEEXT
+	gpMatrixFrustumEXT                               C.GPMATRIXFRUSTUMEXT
+	gpMatrixLoad3x2fNV                               C.GPMATRIXLOAD3X2FNV
+	gpMatrixLoad3x3fNV                               C.GPMATRIXLOAD3X3FNV
+	gpMatrixLoadIdentityEXT                          C.GPMATRIXLOADIDENTITYEXT
+	gpMatrixLoadTranspose3x3fNV                      C.GPMATRIXLOADTRANSPOSE3X3FNV
+	gpMatrixLoadTransposedEXT                        C.GPMATRIXLOADTRANSPOSEDEXT
+	gpMatrixLoadTransposefEXT                        C.GPMATRIXLOADTRANSPOSEFEXT
+	gpMatrixLoaddEXT                                 C.GPMATRIXLOADDEXT
+	gpMatrixLoadfEXT                                 C.GPMATRIXLOADFEXT
+	gpMatrixMult3x2fNV                               C.GPMATRIXMULT3X2FNV
+	gpMatrixMult3x3fNV                               C.GPMATRIXMULT3X3FNV
+	gpMatrixMultTranspose3x3fNV                      C.GPMATRIXMULTTRANSPOSE3X3FNV
+	gpMatrixMultTransposedEXT                        C.GPMATRIXMULTTRANSPOSEDEXT
+	gpMatrixMultTransposefEXT                        C.GPMATRIXMULTTRANSPOSEFEXT
+	gpMatrixMultdEXT                                 C.GPMATRIXMULTDEXT
+	gpMatrixMultfEXT                                 C.GPMATRIXMULTFEXT
+	gpMatrixOrthoEXT                                 C.GPMATRIXORTHOEXT
+	gpMatrixPopEXT                                   C.GPMATRIXPOPEXT
+	gpMatrixPushEXT                                  C.GPMATRIXPUSHEXT
+	gpMatrixRotatedEXT                               C.GPMATRIXROTATEDEXT
+	gpMatrixRotatefEXT                               C.GPMATRIXROTATEFEXT
+	gpMatrixScaledEXT                                C.GPMATRIXSCALEDEXT
+	gpMatrixScalefEXT                                C.GPMATRIXSCALEFEXT
+	gpMatrixTranslatedEXT                            C.GPMATRIXTRANSLATEDEXT
+	gpMatrixTranslatefEXT                            C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsKHR                    C.GPMAXSHADERCOMPILERTHREADSKHR
+	gpMemoryBarrier                                  C.GPMEMORYBARRIER
+	gpMemoryBarrierByRegion                          C.GPMEMORYBARRIERBYREGION
+	gpMemoryObjectParameterivEXT                     C.GPMEMORYOBJECTPARAMETERIVEXT
+	gpMinSampleShadingOES                            C.GPMINSAMPLESHADINGOES
+	gpMultiDrawArraysEXT                             C.GPMULTIDRAWARRAYSEXT
+	gpMultiDrawArraysIndirectEXT                     C.GPMULTIDRAWARRAYSINDIRECTEXT
+	gpMultiDrawElementsBaseVertexEXT                 C.GPMULTIDRAWELEMENTSBASEVERTEXEXT
+	gpMultiDrawElementsEXT                           C.GPMULTIDRAWELEMENTSEXT
+	gpMultiDrawElementsIndirectEXT                   C.GPMULTIDRAWELEMENTSINDIRECTEXT
+	gpNamedBufferStorageExternalEXT                  C.GPNAMEDBUFFERSTORAGEEXTERNALEXT
+	gpNamedBufferStorageMemEXT                       C.GPNAMEDBUFFERSTORAGEMEMEXT
+	gpNamedFramebufferSampleLocationsfvNV            C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpObjectLabel                                    C.GPOBJECTLABEL
+	gpObjectLabelKHR                                 C.GPOBJECTLABELKHR
+	gpObjectPtrLabel                                 C.GPOBJECTPTRLABEL
+	gpObjectPtrLabelKHR                              C.GPOBJECTPTRLABELKHR
+	gpPatchParameteriEXT                             C.GPPATCHPARAMETERIEXT
+	gpPatchParameteriOES                             C.GPPATCHPARAMETERIOES
+	gpPathCommandsNV                                 C.GPPATHCOMMANDSNV
+	gpPathCoordsNV                                   C.GPPATHCOORDSNV
+	gpPathCoverDepthFuncNV                           C.GPPATHCOVERDEPTHFUNCNV
+	gpPathDashArrayNV                                C.GPPATHDASHARRAYNV
+	gpPathGlyphIndexArrayNV                          C.GPPATHGLYPHINDEXARRAYNV
+	gpPathGlyphIndexRangeNV                          C.GPPATHGLYPHINDEXRANGENV
+	gpPathGlyphRangeNV                               C.GPPATHGLYPHRANGENV
+	gpPathGlyphsNV                                   C.GPPATHGLYPHSNV
+	gpPathMemoryGlyphIndexArrayNV                    C.GPPATHMEMORYGLYPHINDEXARRAYNV
+	gpPathParameterfNV                               C.GPPATHPARAMETERFNV
+	gpPathParameterfvNV                              C.GPPATHPARAMETERFVNV
+	gpPathParameteriNV                               C.GPPATHPARAMETERINV
+	gpPathParameterivNV                              C.GPPATHPARAMETERIVNV
+	gpPathStencilDepthOffsetNV                       C.GPPATHSTENCILDEPTHOFFSETNV
+	gpPathStencilFuncNV                              C.GPPATHSTENCILFUNCNV
+	gpPathStringNV                                   C.GPPATHSTRINGNV
+	gpPathSubCommandsNV                              C.GPPATHSUBCOMMANDSNV
+	gpPathSubCoordsNV                                C.GPPATHSUBCOORDSNV
+	gpPauseTransformFeedback                         C.GPPAUSETRANSFORMFEEDBACK
+	gpPixelStorei                                    C.GPPIXELSTOREI
+	gpPointAlongPathNV                               C.GPPOINTALONGPATHNV
+	gpPolygonModeNV                                  C.GPPOLYGONMODENV
+	gpPolygonOffset                                  C.GPPOLYGONOFFSET
+	gpPolygonOffsetClampEXT                          C.GPPOLYGONOFFSETCLAMPEXT
+	gpPopDebugGroup                                  C.GPPOPDEBUGGROUP
+	gpPopDebugGroupKHR                               C.GPPOPDEBUGGROUPKHR
+	gpPopGroupMarkerEXT                              C.GPPOPGROUPMARKEREXT
+	gpPrimitiveBoundingBoxEXT                        C.GPPRIMITIVEBOUNDINGBOXEXT
+	gpPrimitiveBoundingBoxOES                        C.GPPRIMITIVEBOUNDINGBOXOES
+	gpProgramBinary                                  C.GPPROGRAMBINARY
+	gpProgramBinaryOES                               C.GPPROGRAMBINARYOES
+	gpProgramParameteri                              C.GPPROGRAMPARAMETERI
+	gpProgramParameteriEXT                           C.GPPROGRAMPARAMETERIEXT
+	gpProgramPathFragmentInputGenNV                  C.GPPROGRAMPATHFRAGMENTINPUTGENNV
+	gpProgramUniform1f                               C.GPPROGRAMUNIFORM1F
+	gpProgramUniform1fEXT                            C.GPPROGRAMUNIFORM1FEXT
+	gpProgramUniform1fv                              C.GPPROGRAMUNIFORM1FV
+	gpProgramUniform1fvEXT                           C.GPPROGRAMUNIFORM1FVEXT
+	gpProgramUniform1i                               C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64NV                           C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vNV                          C.GPPROGRAMUNIFORM1I64VNV
+	gpProgramUniform1iEXT                            C.GPPROGRAMUNIFORM1IEXT
+	gpProgramUniform1iv                              C.GPPROGRAMUNIFORM1IV
+	gpProgramUniform1ivEXT                           C.GPPROGRAMUNIFORM1IVEXT
+	gpProgramUniform1ui                              C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64NV                          C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vNV                         C.GPPROGRAMUNIFORM1UI64VNV
+	gpProgramUniform1uiEXT                           C.GPPROGRAMUNIFORM1UIEXT
+	gpProgramUniform1uiv                             C.GPPROGRAMUNIFORM1UIV
+	gpProgramUniform1uivEXT                          C.GPPROGRAMUNIFORM1UIVEXT
+	gpProgramUniform2f                               C.GPPROGRAMUNIFORM2F
+	gpProgramUniform2fEXT                            C.GPPROGRAMUNIFORM2FEXT
+	gpProgramUniform2fv                              C.GPPROGRAMUNIFORM2FV
+	gpProgramUniform2fvEXT                           C.GPPROGRAMUNIFORM2FVEXT
+	gpProgramUniform2i                               C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64NV                           C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vNV                          C.GPPROGRAMUNIFORM2I64VNV
+	gpProgramUniform2iEXT                            C.GPPROGRAMUNIFORM2IEXT
+	gpProgramUniform2iv                              C.GPPROGRAMUNIFORM2IV
+	gpProgramUniform2ivEXT                           C.GPPROGRAMUNIFORM2IVEXT
+	gpProgramUniform2ui                              C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64NV                          C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vNV                         C.GPPROGRAMUNIFORM2UI64VNV
+	gpProgramUniform2uiEXT                           C.GPPROGRAMUNIFORM2UIEXT
+	gpProgramUniform2uiv                             C.GPPROGRAMUNIFORM2UIV
+	gpProgramUniform2uivEXT                          C.GPPROGRAMUNIFORM2UIVEXT
+	gpProgramUniform3f                               C.GPPROGRAMUNIFORM3F
+	gpProgramUniform3fEXT                            C.GPPROGRAMUNIFORM3FEXT
+	gpProgramUniform3fv                              C.GPPROGRAMUNIFORM3FV
+	gpProgramUniform3fvEXT                           C.GPPROGRAMUNIFORM3FVEXT
+	gpProgramUniform3i                               C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64NV                           C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vNV                          C.GPPROGRAMUNIFORM3I64VNV
+	gpProgramUniform3iEXT                            C.GPPROGRAMUNIFORM3IEXT
+	gpProgramUniform3iv                              C.GPPROGRAMUNIFORM3IV
+	gpProgramUniform3ivEXT                           C.GPPROGRAMUNIFORM3IVEXT
+	gpProgramUniform3ui                              C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64NV                          C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vNV                         C.GPPROGRAMUNIFORM3UI64VNV
+	gpProgramUniform3uiEXT                           C.GPPROGRAMUNIFORM3UIEXT
+	gpProgramUniform3uiv                             C.GPPROGRAMUNIFORM3UIV
+	gpProgramUniform3uivEXT                          C.GPPROGRAMUNIFORM3UIVEXT
+	gpProgramUniform4f                               C.GPPROGRAMUNIFORM4F
+	gpProgramUniform4fEXT                            C.GPPROGRAMUNIFORM4FEXT
+	gpProgramUniform4fv                              C.GPPROGRAMUNIFORM4FV
+	gpProgramUniform4fvEXT                           C.GPPROGRAMUNIFORM4FVEXT
+	gpProgramUniform4i                               C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64NV                           C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vNV                          C.GPPROGRAMUNIFORM4I64VNV
+	gpProgramUniform4iEXT                            C.GPPROGRAMUNIFORM4IEXT
+	gpProgramUniform4iv                              C.GPPROGRAMUNIFORM4IV
+	gpProgramUniform4ivEXT                           C.GPPROGRAMUNIFORM4IVEXT
+	gpProgramUniform4ui                              C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64NV                          C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vNV                         C.GPPROGRAMUNIFORM4UI64VNV
+	gpProgramUniform4uiEXT                           C.GPPROGRAMUNIFORM4UIEXT
+	gpProgramUniform4uiv                             C.GPPROGRAMUNIFORM4UIV
+	gpProgramUniform4uivEXT                          C.GPPROGRAMUNIFORM4UIVEXT
+	gpProgramUniformHandleui64IMG                    C.GPPROGRAMUNIFORMHANDLEUI64IMG
+	gpProgramUniformHandleui64NV                     C.GPPROGRAMUNIFORMHANDLEUI64NV
+	gpProgramUniformHandleui64vIMG                   C.GPPROGRAMUNIFORMHANDLEUI64VIMG
+	gpProgramUniformHandleui64vNV                    C.GPPROGRAMUNIFORMHANDLEUI64VNV
+	gpProgramUniformMatrix2fv                        C.GPPROGRAMUNIFORMMATRIX2FV
+	gpProgramUniformMatrix2fvEXT                     C.GPPROGRAMUNIFORMMATRIX2FVEXT
+	gpProgramUniformMatrix2x3fv                      C.GPPROGRAMUNIFORMMATRIX2X3FV
+	gpProgramUniformMatrix2x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3FVEXT
+	gpProgramUniformMatrix2x4fv                      C.GPPROGRAMUNIFORMMATRIX2X4FV
+	gpProgramUniformMatrix2x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4FVEXT
+	gpProgramUniformMatrix3fv                        C.GPPROGRAMUNIFORMMATRIX3FV
+	gpProgramUniformMatrix3fvEXT                     C.GPPROGRAMUNIFORMMATRIX3FVEXT
+	gpProgramUniformMatrix3x2fv                      C.GPPROGRAMUNIFORMMATRIX3X2FV
+	gpProgramUniformMatrix3x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2FVEXT
+	gpProgramUniformMatrix3x4fv                      C.GPPROGRAMUNIFORMMATRIX3X4FV
+	gpProgramUniformMatrix3x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4FVEXT
+	gpProgramUniformMatrix4fv                        C.GPPROGRAMUNIFORMMATRIX4FV
+	gpProgramUniformMatrix4fvEXT                     C.GPPROGRAMUNIFORMMATRIX4FVEXT
+	gpProgramUniformMatrix4x2fv                      C.GPPROGRAMUNIFORMMATRIX4X2FV
+	gpProgramUniformMatrix4x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2FVEXT
+	gpProgramUniformMatrix4x3fv                      C.GPPROGRAMUNIFORMMATRIX4X3FV
+	gpProgramUniformMatrix4x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3FVEXT
+	gpPushDebugGroup                                 C.GPPUSHDEBUGGROUP
+	gpPushDebugGroupKHR                              C.GPPUSHDEBUGGROUPKHR
+	gpPushGroupMarkerEXT                             C.GPPUSHGROUPMARKEREXT
+	gpQueryCounterEXT                                C.GPQUERYCOUNTEREXT
+	gpRasterSamplesEXT                               C.GPRASTERSAMPLESEXT
+	gpReadBuffer                                     C.GPREADBUFFER
+	gpReadBufferIndexedEXT                           C.GPREADBUFFERINDEXEDEXT
+	gpReadBufferNV                                   C.GPREADBUFFERNV
+	gpReadPixels                                     C.GPREADPIXELS
+	gpReadnPixels                                    C.GPREADNPIXELS
+	gpReadnPixelsEXT                                 C.GPREADNPIXELSEXT
+	gpReadnPixelsKHR                                 C.GPREADNPIXELSKHR
+	gpReleaseKeyedMutexWin32EXT                      C.GPRELEASEKEYEDMUTEXWIN32EXT
+	gpReleaseShaderCompiler                          C.GPRELEASESHADERCOMPILER
+	gpRenderbufferStorage                            C.GPRENDERBUFFERSTORAGE
+	gpRenderbufferStorageMultisample                 C.GPRENDERBUFFERSTORAGEMULTISAMPLE
+	gpRenderbufferStorageMultisampleANGLE            C.GPRENDERBUFFERSTORAGEMULTISAMPLEANGLE
+	gpRenderbufferStorageMultisampleAPPLE            C.GPRENDERBUFFERSTORAGEMULTISAMPLEAPPLE
+	gpRenderbufferStorageMultisampleEXT              C.GPRENDERBUFFERSTORAGEMULTISAMPLEEXT
+	gpRenderbufferStorageMultisampleIMG              C.GPRENDERBUFFERSTORAGEMULTISAMPLEIMG
+	gpRenderbufferStorageMultisampleNV               C.GPRENDERBUFFERSTORAGEMULTISAMPLENV
+	gpResolveDepthValuesNV                           C.GPRESOLVEDEPTHVALUESNV
+	gpResolveMultisampleFramebufferAPPLE             C.GPRESOLVEMULTISAMPLEFRAMEBUFFERAPPLE
+	gpResumeTransformFeedback                        C.GPRESUMETRANSFORMFEEDBACK
+	gpSampleCoverage                                 C.GPSAMPLECOVERAGE
+	gpSampleMaski                                    C.GPSAMPLEMASKI
+	gpSamplerParameterIivEXT                         C.GPSAMPLERPARAMETERIIVEXT
+	gpSamplerParameterIivOES                         C.GPSAMPLERPARAMETERIIVOES
+	gpSamplerParameterIuivEXT                        C.GPSAMPLERPARAMETERIUIVEXT
+	gpSamplerParameterIuivOES                        C.GPSAMPLERPARAMETERIUIVOES
+	gpSamplerParameterf                              C.GPSAMPLERPARAMETERF
+	gpSamplerParameterfv                             C.GPSAMPLERPARAMETERFV
+	gpSamplerParameteri                              C.GPSAMPLERPARAMETERI
+	gpSamplerParameteriv                             C.GPSAMPLERPARAMETERIV
+	gpScissor                                        C.GPSCISSOR
+	gpScissorArrayvNV                                C.GPSCISSORARRAYVNV
+	gpScissorArrayvOES                               C.GPSCISSORARRAYVOES
+	gpScissorIndexedNV                               C.GPSCISSORINDEXEDNV
+	gpScissorIndexedOES                              C.GPSCISSORINDEXEDOES
+	gpScissorIndexedvNV                              C.GPSCISSORINDEXEDVNV
+	gpScissorIndexedvOES                             C.GPSCISSORINDEXEDVOES
+	gpSelectPerfMonitorCountersAMD                   C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpSemaphoreParameterui64vEXT                     C.GPSEMAPHOREPARAMETERUI64VEXT
+	gpSetFenceNV                                     C.GPSETFENCENV
+	gpShaderBinary                                   C.GPSHADERBINARY
+	gpShaderSource                                   C.GPSHADERSOURCE
+	gpSignalSemaphoreEXT                             C.GPSIGNALSEMAPHOREEXT
+	gpSignalVkFenceNV                                C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                            C.GPSIGNALVKSEMAPHORENV
+	gpStartTilingQCOM                                C.GPSTARTTILINGQCOM
+	gpStencilFillPathInstancedNV                     C.GPSTENCILFILLPATHINSTANCEDNV
+	gpStencilFillPathNV                              C.GPSTENCILFILLPATHNV
+	gpStencilFunc                                    C.GPSTENCILFUNC
+	gpStencilFuncSeparate                            C.GPSTENCILFUNCSEPARATE
+	gpStencilMask                                    C.GPSTENCILMASK
+	gpStencilMaskSeparate                            C.GPSTENCILMASKSEPARATE
+	gpStencilOp                                      C.GPSTENCILOP
+	gpStencilOpSeparate                              C.GPSTENCILOPSEPARATE
+	gpStencilStrokePathInstancedNV                   C.GPSTENCILSTROKEPATHINSTANCEDNV
+	gpStencilStrokePathNV                            C.GPSTENCILSTROKEPATHNV
+	gpStencilThenCoverFillPathInstancedNV            C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV
+	gpStencilThenCoverFillPathNV                     C.GPSTENCILTHENCOVERFILLPATHNV
+	gpStencilThenCoverStrokePathInstancedNV          C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV
+	gpStencilThenCoverStrokePathNV                   C.GPSTENCILTHENCOVERSTROKEPATHNV
+	gpSubpixelPrecisionBiasNV                        C.GPSUBPIXELPRECISIONBIASNV
+	gpTestFenceNV                                    C.GPTESTFENCENV
+	gpTexBufferEXT                                   C.GPTEXBUFFEREXT
+	gpTexBufferOES                                   C.GPTEXBUFFEROES
+	gpTexBufferRangeEXT                              C.GPTEXBUFFERRANGEEXT
+	gpTexBufferRangeOES                              C.GPTEXBUFFERRANGEOES
+	gpTexImage2D                                     C.GPTEXIMAGE2D
+	gpTexImage3D                                     C.GPTEXIMAGE3D
+	gpTexImage3DOES                                  C.GPTEXIMAGE3DOES
+	gpTexPageCommitmentEXT                           C.GPTEXPAGECOMMITMENTEXT
+	gpTexParameterIivEXT                             C.GPTEXPARAMETERIIVEXT
+	gpTexParameterIivOES                             C.GPTEXPARAMETERIIVOES
+	gpTexParameterIuivEXT                            C.GPTEXPARAMETERIUIVEXT
+	gpTexParameterIuivOES                            C.GPTEXPARAMETERIUIVOES
+	gpTexParameterf                                  C.GPTEXPARAMETERF
+	gpTexParameterfv                                 C.GPTEXPARAMETERFV
+	gpTexParameteri                                  C.GPTEXPARAMETERI
+	gpTexParameteriv                                 C.GPTEXPARAMETERIV
+	gpTexStorage1DEXT                                C.GPTEXSTORAGE1DEXT
+	gpTexStorage2D                                   C.GPTEXSTORAGE2D
+	gpTexStorage2DEXT                                C.GPTEXSTORAGE2DEXT
+	gpTexStorage2DMultisample                        C.GPTEXSTORAGE2DMULTISAMPLE
+	gpTexStorage3D                                   C.GPTEXSTORAGE3D
+	gpTexStorage3DEXT                                C.GPTEXSTORAGE3DEXT
+	gpTexStorage3DMultisampleOES                     C.GPTEXSTORAGE3DMULTISAMPLEOES
+	gpTexStorageMem1DEXT                             C.GPTEXSTORAGEMEM1DEXT
+	gpTexStorageMem2DEXT                             C.GPTEXSTORAGEMEM2DEXT
+	gpTexStorageMem2DMultisampleEXT                  C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT
+	gpTexStorageMem3DEXT                             C.GPTEXSTORAGEMEM3DEXT
+	gpTexStorageMem3DMultisampleEXT                  C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT
+	gpTexSubImage2D                                  C.GPTEXSUBIMAGE2D
+	gpTexSubImage3D                                  C.GPTEXSUBIMAGE3D
+	gpTexSubImage3DOES                               C.GPTEXSUBIMAGE3DOES
+	gpTextureFoveationParametersQCOM                 C.GPTEXTUREFOVEATIONPARAMETERSQCOM
+	gpTextureStorage1DEXT                            C.GPTEXTURESTORAGE1DEXT
+	gpTextureStorage2DEXT                            C.GPTEXTURESTORAGE2DEXT
+	gpTextureStorage3DEXT                            C.GPTEXTURESTORAGE3DEXT
+	gpTextureStorageMem1DEXT                         C.GPTEXTURESTORAGEMEM1DEXT
+	gpTextureStorageMem2DEXT                         C.GPTEXTURESTORAGEMEM2DEXT
+	gpTextureStorageMem2DMultisampleEXT              C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT
+	gpTextureStorageMem3DEXT                         C.GPTEXTURESTORAGEMEM3DEXT
+	gpTextureStorageMem3DMultisampleEXT              C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT
+	gpTextureViewEXT                                 C.GPTEXTUREVIEWEXT
+	gpTextureViewOES                                 C.GPTEXTUREVIEWOES
+	gpTransformFeedbackVaryings                      C.GPTRANSFORMFEEDBACKVARYINGS
+	gpTransformPathNV                                C.GPTRANSFORMPATHNV
+	gpUniform1f                                      C.GPUNIFORM1F
+	gpUniform1fv                                     C.GPUNIFORM1FV
+	gpUniform1i                                      C.GPUNIFORM1I
+	gpUniform1i64NV                                  C.GPUNIFORM1I64NV
+	gpUniform1i64vNV                                 C.GPUNIFORM1I64VNV
+	gpUniform1iv                                     C.GPUNIFORM1IV
+	gpUniform1ui                                     C.GPUNIFORM1UI
+	gpUniform1ui64NV                                 C.GPUNIFORM1UI64NV
+	gpUniform1ui64vNV                                C.GPUNIFORM1UI64VNV
+	gpUniform1uiv                                    C.GPUNIFORM1UIV
+	gpUniform2f                                      C.GPUNIFORM2F
+	gpUniform2fv                                     C.GPUNIFORM2FV
+	gpUniform2i                                      C.GPUNIFORM2I
+	gpUniform2i64NV                                  C.GPUNIFORM2I64NV
+	gpUniform2i64vNV                                 C.GPUNIFORM2I64VNV
+	gpUniform2iv                                     C.GPUNIFORM2IV
+	gpUniform2ui                                     C.GPUNIFORM2UI
+	gpUniform2ui64NV                                 C.GPUNIFORM2UI64NV
+	gpUniform2ui64vNV                                C.GPUNIFORM2UI64VNV
+	gpUniform2uiv                                    C.GPUNIFORM2UIV
+	gpUniform3f                                      C.GPUNIFORM3F
+	gpUniform3fv                                     C.GPUNIFORM3FV
+	gpUniform3i                                      C.GPUNIFORM3I
+	gpUniform3i64NV                                  C.GPUNIFORM3I64NV
+	gpUniform3i64vNV                                 C.GPUNIFORM3I64VNV
+	gpUniform3iv                                     C.GPUNIFORM3IV
+	gpUniform3ui                                     C.GPUNIFORM3UI
+	gpUniform3ui64NV                                 C.GPUNIFORM3UI64NV
+	gpUniform3ui64vNV                                C.GPUNIFORM3UI64VNV
+	gpUniform3uiv                                    C.GPUNIFORM3UIV
+	gpUniform4f                                      C.GPUNIFORM4F
+	gpUniform4fv                                     C.GPUNIFORM4FV
+	gpUniform4i                                      C.GPUNIFORM4I
+	gpUniform4i64NV                                  C.GPUNIFORM4I64NV
+	gpUniform4i64vNV                                 C.GPUNIFORM4I64VNV
+	gpUniform4iv                                     C.GPUNIFORM4IV
+	gpUniform4ui                                     C.GPUNIFORM4UI
+	gpUniform4ui64NV                                 C.GPUNIFORM4UI64NV
+	gpUniform4ui64vNV                                C.GPUNIFORM4UI64VNV
+	gpUniform4uiv                                    C.GPUNIFORM4UIV
+	gpUniformBlockBinding                            C.GPUNIFORMBLOCKBINDING
+	gpUniformHandleui64IMG                           C.GPUNIFORMHANDLEUI64IMG
+	gpUniformHandleui64NV                            C.GPUNIFORMHANDLEUI64NV
+	gpUniformHandleui64vIMG                          C.GPUNIFORMHANDLEUI64VIMG
+	gpUniformHandleui64vNV                           C.GPUNIFORMHANDLEUI64VNV
+	gpUniformMatrix2fv                               C.GPUNIFORMMATRIX2FV
+	gpUniformMatrix2x3fv                             C.GPUNIFORMMATRIX2X3FV
+	gpUniformMatrix2x3fvNV                           C.GPUNIFORMMATRIX2X3FVNV
+	gpUniformMatrix2x4fv                             C.GPUNIFORMMATRIX2X4FV
+	gpUniformMatrix2x4fvNV                           C.GPUNIFORMMATRIX2X4FVNV
+	gpUniformMatrix3fv                               C.GPUNIFORMMATRIX3FV
+	gpUniformMatrix3x2fv                             C.GPUNIFORMMATRIX3X2FV
+	gpUniformMatrix3x2fvNV                           C.GPUNIFORMMATRIX3X2FVNV
+	gpUniformMatrix3x4fv                             C.GPUNIFORMMATRIX3X4FV
+	gpUniformMatrix3x4fvNV                           C.GPUNIFORMMATRIX3X4FVNV
+	gpUniformMatrix4fv                               C.GPUNIFORMMATRIX4FV
+	gpUniformMatrix4x2fv                             C.GPUNIFORMMATRIX4X2FV
+	gpUniformMatrix4x2fvNV                           C.GPUNIFORMMATRIX4X2FVNV
+	gpUniformMatrix4x3fv                             C.GPUNIFORMMATRIX4X3FV
+	gpUniformMatrix4x3fvNV                           C.GPUNIFORMMATRIX4X3FVNV
+	gpUnmapBuffer                                    C.GPUNMAPBUFFER
+	gpUnmapBufferOES                                 C.GPUNMAPBUFFEROES
+	gpUseProgram                                     C.GPUSEPROGRAM
+	gpUseProgramStages                               C.GPUSEPROGRAMSTAGES
+	gpUseProgramStagesEXT                            C.GPUSEPROGRAMSTAGESEXT
+	gpUseShaderProgramEXT                            C.GPUSESHADERPROGRAMEXT
+	gpValidateProgram                                C.GPVALIDATEPROGRAM
+	gpValidateProgramPipeline                        C.GPVALIDATEPROGRAMPIPELINE
+	gpValidateProgramPipelineEXT                     C.GPVALIDATEPROGRAMPIPELINEEXT
+	gpVertexAttrib1f                                 C.GPVERTEXATTRIB1F
+	gpVertexAttrib1fv                                C.GPVERTEXATTRIB1FV
+	gpVertexAttrib2f                                 C.GPVERTEXATTRIB2F
+	gpVertexAttrib2fv                                C.GPVERTEXATTRIB2FV
+	gpVertexAttrib3f                                 C.GPVERTEXATTRIB3F
+	gpVertexAttrib3fv                                C.GPVERTEXATTRIB3FV
+	gpVertexAttrib4f                                 C.GPVERTEXATTRIB4F
+	gpVertexAttrib4fv                                C.GPVERTEXATTRIB4FV
+	gpVertexAttribBinding                            C.GPVERTEXATTRIBBINDING
+	gpVertexAttribDivisor                            C.GPVERTEXATTRIBDIVISOR
+	gpVertexAttribDivisorANGLE                       C.GPVERTEXATTRIBDIVISORANGLE
+	gpVertexAttribDivisorEXT                         C.GPVERTEXATTRIBDIVISOREXT
+	gpVertexAttribDivisorNV                          C.GPVERTEXATTRIBDIVISORNV
+	gpVertexAttribFormat                             C.GPVERTEXATTRIBFORMAT
+	gpVertexAttribI4i                                C.GPVERTEXATTRIBI4I
+	gpVertexAttribI4iv                               C.GPVERTEXATTRIBI4IV
+	gpVertexAttribI4ui                               C.GPVERTEXATTRIBI4UI
+	gpVertexAttribI4uiv                              C.GPVERTEXATTRIBI4UIV
+	gpVertexAttribIFormat                            C.GPVERTEXATTRIBIFORMAT
+	gpVertexAttribIPointer                           C.GPVERTEXATTRIBIPOINTER
+	gpVertexAttribPointer                            C.GPVERTEXATTRIBPOINTER
+	gpVertexBindingDivisor                           C.GPVERTEXBINDINGDIVISOR
+	gpViewport                                       C.GPVIEWPORT
+	gpViewportArrayvNV                               C.GPVIEWPORTARRAYVNV
+	gpViewportArrayvOES                              C.GPVIEWPORTARRAYVOES
+	gpViewportIndexedfNV                             C.GPVIEWPORTINDEXEDFNV
+	gpViewportIndexedfOES                            C.GPVIEWPORTINDEXEDFOES
+	gpViewportIndexedfvNV                            C.GPVIEWPORTINDEXEDFVNV
+	gpViewportIndexedfvOES                           C.GPVIEWPORTINDEXEDFVOES
+	gpViewportPositionWScaleNV                       C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                              C.GPVIEWPORTSWIZZLENV
+	gpWaitSemaphoreEXT                               C.GPWAITSEMAPHOREEXT
+	gpWaitSync                                       C.GPWAITSYNC
+	gpWaitSyncAPPLE                                  C.GPWAITSYNCAPPLE
+	gpWaitVkSemaphoreNV                              C.GPWAITVKSEMAPHORENV
+	gpWeightPathsNV                                  C.GPWEIGHTPATHSNV
+	gpWindowRectanglesEXT                            C.GPWINDOWRECTANGLESEXT
 )
 
 // Helper functions
@@ -4411,6 +6292,10 @@ func boolToInt(b bool) int {
 		return 1
 	}
 	return 0
+}
+func AcquireKeyedMutexWin32EXT(memory uint32, key uint64, timeout uint32) bool {
+	ret := C.glowAcquireKeyedMutexWin32EXT(gpAcquireKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key), (C.GLuint)(timeout))
+	return ret == TRUE
 }
 func ActiveProgramEXT(program uint32) {
 	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
@@ -4431,10 +6316,16 @@ func ActiveTexture(texture uint32) {
 func AlphaFuncQCOM(xfunc uint32, ref float32) {
 	C.glowAlphaFuncQCOM(gpAlphaFuncQCOM, (C.GLenum)(xfunc), (C.GLclampf)(ref))
 }
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
+}
 
 // Attaches a shader object to a program object
 func AttachShader(program uint32, shader uint32) {
 	C.glowAttachShader(gpAttachShader, (C.GLuint)(program), (C.GLuint)(shader))
+}
+func BeginConditionalRenderNV(id uint32, mode uint32) {
+	C.glowBeginConditionalRenderNV(gpBeginConditionalRenderNV, (C.GLuint)(id), (C.GLenum)(mode))
 }
 func BeginPerfMonitorAMD(monitor uint32) {
 	C.glowBeginPerfMonitorAMD(gpBeginPerfMonitorAMD, (C.GLuint)(monitor))
@@ -4474,6 +6365,12 @@ func BindBufferBase(target uint32, index uint32, buffer uint32) {
 // bind a range within a buffer object to an indexed buffer target
 func BindBufferRange(target uint32, index uint32, buffer uint32, offset int, size int) {
 	C.glowBindBufferRange(gpBindBufferRange, (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func BindFragDataLocationEXT(program uint32, color uint32, name *uint8) {
+	C.glowBindFragDataLocationEXT(gpBindFragDataLocationEXT, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
+}
+func BindFragDataLocationIndexedEXT(program uint32, colorNumber uint32, index uint32, name *uint8) {
+	C.glowBindFragDataLocationIndexedEXT(gpBindFragDataLocationIndexedEXT, (C.GLuint)(program), (C.GLuint)(colorNumber), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // bind a framebuffer to a framebuffer target
@@ -4553,8 +6450,14 @@ func BlendEquationSeparate(modeRGB uint32, modeAlpha uint32) {
 func BlendEquationSeparateiEXT(buf uint32, modeRGB uint32, modeAlpha uint32) {
 	C.glowBlendEquationSeparateiEXT(gpBlendEquationSeparateiEXT, (C.GLuint)(buf), (C.GLenum)(modeRGB), (C.GLenum)(modeAlpha))
 }
+func BlendEquationSeparateiOES(buf uint32, modeRGB uint32, modeAlpha uint32) {
+	C.glowBlendEquationSeparateiOES(gpBlendEquationSeparateiOES, (C.GLuint)(buf), (C.GLenum)(modeRGB), (C.GLenum)(modeAlpha))
+}
 func BlendEquationiEXT(buf uint32, mode uint32) {
 	C.glowBlendEquationiEXT(gpBlendEquationiEXT, (C.GLuint)(buf), (C.GLenum)(mode))
+}
+func BlendEquationiOES(buf uint32, mode uint32) {
+	C.glowBlendEquationiOES(gpBlendEquationiOES, (C.GLuint)(buf), (C.GLenum)(mode))
 }
 
 // specify pixel arithmetic
@@ -4569,8 +6472,14 @@ func BlendFuncSeparate(sfactorRGB uint32, dfactorRGB uint32, sfactorAlpha uint32
 func BlendFuncSeparateiEXT(buf uint32, srcRGB uint32, dstRGB uint32, srcAlpha uint32, dstAlpha uint32) {
 	C.glowBlendFuncSeparateiEXT(gpBlendFuncSeparateiEXT, (C.GLuint)(buf), (C.GLenum)(srcRGB), (C.GLenum)(dstRGB), (C.GLenum)(srcAlpha), (C.GLenum)(dstAlpha))
 }
+func BlendFuncSeparateiOES(buf uint32, srcRGB uint32, dstRGB uint32, srcAlpha uint32, dstAlpha uint32) {
+	C.glowBlendFuncSeparateiOES(gpBlendFuncSeparateiOES, (C.GLuint)(buf), (C.GLenum)(srcRGB), (C.GLenum)(dstRGB), (C.GLenum)(srcAlpha), (C.GLenum)(dstAlpha))
+}
 func BlendFunciEXT(buf uint32, src uint32, dst uint32) {
 	C.glowBlendFunciEXT(gpBlendFunciEXT, (C.GLuint)(buf), (C.GLenum)(src), (C.GLenum)(dst))
+}
+func BlendFunciOES(buf uint32, src uint32, dst uint32) {
+	C.glowBlendFunciOES(gpBlendFunciOES, (C.GLuint)(buf), (C.GLenum)(src), (C.GLenum)(dst))
 }
 func BlendParameteriNV(pname uint32, value int32) {
 	C.glowBlendParameteriNV(gpBlendParameteriNV, (C.GLenum)(pname), (C.GLint)(value))
@@ -4590,6 +6499,15 @@ func BlitFramebufferNV(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0
 // creates and initializes a buffer object's data     store
 func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferData(gpBufferData, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
+}
+func BufferStorageEXT(target uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowBufferStorageEXT(gpBufferStorageEXT, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
+}
+func BufferStorageExternalEXT(target uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowBufferStorageExternalEXT(gpBufferStorageExternalEXT, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func BufferStorageMemEXT(target uint32, size int, memory uint32, offset uint64) {
+	C.glowBufferStorageMemEXT(gpBufferStorageMemEXT, (C.GLenum)(target), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
 }
 
 // updates a subset of a buffer object's data store
@@ -4624,29 +6542,46 @@ func ClearBufferuiv(buffer uint32, drawbuffer int32, value *uint32) {
 func ClearColor(red float32, green float32, blue float32, alpha float32) {
 	C.glowClearColor(gpClearColor, (C.GLfloat)(red), (C.GLfloat)(green), (C.GLfloat)(blue), (C.GLfloat)(alpha))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
+}
+func ClearPixelLocalStorageuiEXT(offset int32, n int32, values *uint32) {
+	C.glowClearPixelLocalStorageuiEXT(gpClearPixelLocalStorageuiEXT, (C.GLsizei)(offset), (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(values)))
 }
 
 // specify the clear value for the stencil buffer
 func ClearStencil(s int32) {
 	C.glowClearStencil(gpClearStencil, (C.GLint)(s))
 }
+func ClearTexImageEXT(texture uint32, level int32, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearTexImageEXT(gpClearTexImageEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
+func ClearTexSubImageEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearTexSubImageEXT(gpClearTexSubImageEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
-func ClientWaitSyncAPPLE(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSyncAPPLE(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSyncAPPLE(gpClientWaitSyncAPPLE, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
+}
+func ClipControlEXT(origin uint32, depth uint32) {
+	C.glowClipControlEXT(gpClipControlEXT, (C.GLenum)(origin), (C.GLenum)(depth))
 }
 func ColorMask(red bool, green bool, blue bool, alpha bool) {
 	C.glowColorMask(gpColorMask, (C.GLboolean)(boolToInt(red)), (C.GLboolean)(boolToInt(green)), (C.GLboolean)(boolToInt(blue)), (C.GLboolean)(boolToInt(alpha)))
 }
 func ColorMaskiEXT(index uint32, r bool, g bool, b bool, a bool) {
 	C.glowColorMaskiEXT(gpColorMaskiEXT, (C.GLuint)(index), (C.GLboolean)(boolToInt(r)), (C.GLboolean)(boolToInt(g)), (C.GLboolean)(boolToInt(b)), (C.GLboolean)(boolToInt(a)))
+}
+func ColorMaskiOES(index uint32, r bool, g bool, b bool, a bool) {
+	C.glowColorMaskiOES(gpColorMaskiOES, (C.GLuint)(index), (C.GLboolean)(boolToInt(r)), (C.GLboolean)(boolToInt(g)), (C.GLboolean)(boolToInt(b)), (C.GLboolean)(boolToInt(a)))
 }
 
 // Compiles a shader object
@@ -4679,6 +6614,9 @@ func CompressedTexSubImage3D(target uint32, level int32, xoffset int32, yoffset 
 func CompressedTexSubImage3DOES(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTexSubImage3DOES(gpCompressedTexSubImage3DOES, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
 func CopyBufferSubData(readTarget uint32, writeTarget uint32, readOffset int, writeOffset int, size int) {
@@ -4689,6 +6627,12 @@ func CopyBufferSubDataNV(readTarget uint32, writeTarget uint32, readOffset int, 
 }
 func CopyImageSubDataEXT(srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
 	C.glowCopyImageSubDataEXT(gpCopyImageSubDataEXT, (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
+}
+func CopyImageSubDataOES(srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
+	C.glowCopyImageSubDataOES(gpCopyImageSubDataOES, (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
+}
+func CopyPathNV(resultPath uint32, srcPath uint32) {
+	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
 }
 
 // copy pixels into a 2D texture image
@@ -4711,11 +6655,32 @@ func CopyTexSubImage3DOES(target uint32, level int32, xoffset int32, yoffset int
 func CopyTextureLevelsAPPLE(destinationTexture uint32, sourceTexture uint32, sourceBaseLevel int32, sourceLevelCount int32) {
 	C.glowCopyTextureLevelsAPPLE(gpCopyTextureLevelsAPPLE, (C.GLuint)(destinationTexture), (C.GLuint)(sourceTexture), (C.GLint)(sourceBaseLevel), (C.GLsizei)(sourceLevelCount))
 }
+func CoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverFillPathInstancedNV(gpCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverFillPathNV(path uint32, coverMode uint32) {
+	C.glowCoverFillPathNV(gpCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverStrokePathInstancedNV(gpCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverStrokePathNV(path uint32, coverMode uint32) {
+	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
 func CoverageMaskNV(mask bool) {
 	C.glowCoverageMaskNV(gpCoverageMaskNV, (C.GLboolean)(boolToInt(mask)))
 }
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 func CoverageOperationNV(operation uint32) {
 	C.glowCoverageOperationNV(gpCoverageOperationNV, (C.GLenum)(operation))
+}
+func CreateMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowCreateMemoryObjectsEXT(gpCreateMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
 	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
@@ -4790,6 +6755,12 @@ func DeleteFencesNV(n int32, fences *uint32) {
 func DeleteFramebuffers(n int32, framebuffers *uint32) {
 	C.glowDeleteFramebuffers(gpDeleteFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
 }
+func DeleteMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowDeleteMemoryObjectsEXT(gpDeleteMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
+}
+func DeletePathsNV(path uint32, xrange int32) {
+	C.glowDeletePathsNV(gpDeletePathsNV, (C.GLuint)(path), (C.GLsizei)(xrange))
+}
 func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
 	C.glowDeletePerfMonitorsAMD(gpDeletePerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
 }
@@ -4827,6 +6798,9 @@ func DeleteRenderbuffers(n int32, renderbuffers *uint32) {
 func DeleteSamplers(count int32, samplers *uint32) {
 	C.glowDeleteSamplers(gpDeleteSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
 }
+func DeleteSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowDeleteSemaphoresEXT(gpDeleteSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
+}
 
 // Deletes a shader object
 func DeleteShader(shader uint32) {
@@ -4834,10 +6808,10 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
-func DeleteSyncAPPLE(sync unsafe.Pointer) {
+func DeleteSyncAPPLE(sync uintptr) {
 	C.glowDeleteSyncAPPLE(gpDeleteSyncAPPLE, (C.GLsync)(sync))
 }
 
@@ -4868,6 +6842,20 @@ func DepthFunc(xfunc uint32) {
 func DepthMask(flag bool) {
 	C.glowDepthMask(gpDepthMask, (C.GLboolean)(boolToInt(flag)))
 }
+func DepthRangeArrayfvNV(first uint32, count int32, v *float32) {
+	C.glowDepthRangeArrayfvNV(gpDepthRangeArrayfvNV, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func DepthRangeArrayfvOES(first uint32, count int32, v *float32) {
+	C.glowDepthRangeArrayfvOES(gpDepthRangeArrayfvOES, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func DepthRangeIndexedfNV(index uint32, n float32, f float32) {
+	C.glowDepthRangeIndexedfNV(gpDepthRangeIndexedfNV, (C.GLuint)(index), (C.GLfloat)(n), (C.GLfloat)(f))
+}
+func DepthRangeIndexedfOES(index uint32, n float32, f float32) {
+	C.glowDepthRangeIndexedfOES(gpDepthRangeIndexedfOES, (C.GLuint)(index), (C.GLfloat)(n), (C.GLfloat)(f))
+}
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -4889,6 +6877,12 @@ func DisableVertexAttribArray(index uint32) {
 }
 func DisableiEXT(target uint32, index uint32) {
 	C.glowDisableiEXT(gpDisableiEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
+func DisableiNV(target uint32, index uint32) {
+	C.glowDisableiNV(gpDisableiNV, (C.GLenum)(target), (C.GLuint)(index))
+}
+func DisableiOES(target uint32, index uint32) {
+	C.glowDisableiOES(gpDisableiOES, (C.GLenum)(target), (C.GLuint)(index))
 }
 func DiscardFramebufferEXT(target uint32, numAttachments int32, attachments *uint32) {
 	C.glowDiscardFramebufferEXT(gpDiscardFramebufferEXT, (C.GLenum)(target), (C.GLsizei)(numAttachments), (*C.GLenum)(unsafe.Pointer(attachments)))
@@ -4921,6 +6915,9 @@ func DrawArraysInstanced(mode uint32, first int32, count int32, instancecount in
 func DrawArraysInstancedANGLE(mode uint32, first int32, count int32, primcount int32) {
 	C.glowDrawArraysInstancedANGLE(gpDrawArraysInstancedANGLE, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(primcount))
 }
+func DrawArraysInstancedBaseInstanceEXT(mode uint32, first int32, count int32, instancecount int32, baseinstance uint32) {
+	C.glowDrawArraysInstancedBaseInstanceEXT(gpDrawArraysInstancedBaseInstanceEXT, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount), (C.GLuint)(baseinstance))
+}
 func DrawArraysInstancedEXT(mode uint32, start int32, count int32, primcount int32) {
 	C.glowDrawArraysInstancedEXT(gpDrawArraysInstancedEXT, (C.GLenum)(mode), (C.GLint)(start), (C.GLsizei)(count), (C.GLsizei)(primcount))
 }
@@ -4946,6 +6943,12 @@ func DrawBuffersNV(n int32, bufs *uint32) {
 func DrawElements(mode uint32, count int32, xtype uint32, indices unsafe.Pointer) {
 	C.glowDrawElements(gpDrawElements, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices)
 }
+func DrawElementsBaseVertexEXT(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, basevertex int32) {
+	C.glowDrawElementsBaseVertexEXT(gpDrawElementsBaseVertexEXT, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLint)(basevertex))
+}
+func DrawElementsBaseVertexOES(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, basevertex int32) {
+	C.glowDrawElementsBaseVertexOES(gpDrawElementsBaseVertexOES, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLint)(basevertex))
+}
 
 // render indexed primitives from array data, taking parameters from memory
 func DrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer) {
@@ -4959,6 +6962,18 @@ func DrawElementsInstanced(mode uint32, count int32, xtype uint32, indices unsaf
 func DrawElementsInstancedANGLE(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
 	C.glowDrawElementsInstancedANGLE(gpDrawElementsInstancedANGLE, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
 }
+func DrawElementsInstancedBaseInstanceEXT(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, baseinstance uint32) {
+	C.glowDrawElementsInstancedBaseInstanceEXT(gpDrawElementsInstancedBaseInstanceEXT, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount), (C.GLuint)(baseinstance))
+}
+func DrawElementsInstancedBaseVertexBaseInstanceEXT(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, basevertex int32, baseinstance uint32) {
+	C.glowDrawElementsInstancedBaseVertexBaseInstanceEXT(gpDrawElementsInstancedBaseVertexBaseInstanceEXT, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount), (C.GLint)(basevertex), (C.GLuint)(baseinstance))
+}
+func DrawElementsInstancedBaseVertexEXT(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, basevertex int32) {
+	C.glowDrawElementsInstancedBaseVertexEXT(gpDrawElementsInstancedBaseVertexEXT, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount), (C.GLint)(basevertex))
+}
+func DrawElementsInstancedBaseVertexOES(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, basevertex int32) {
+	C.glowDrawElementsInstancedBaseVertexOES(gpDrawElementsInstancedBaseVertexOES, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount), (C.GLint)(basevertex))
+}
 func DrawElementsInstancedEXT(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
 	C.glowDrawElementsInstancedEXT(gpDrawElementsInstancedEXT, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
 }
@@ -4969,6 +6984,21 @@ func DrawElementsInstancedNV(mode uint32, count int32, xtype uint32, indices uns
 // render primitives from array data
 func DrawRangeElements(mode uint32, start uint32, end uint32, count int32, xtype uint32, indices unsafe.Pointer) {
 	C.glowDrawRangeElements(gpDrawRangeElements, (C.GLenum)(mode), (C.GLuint)(start), (C.GLuint)(end), (C.GLsizei)(count), (C.GLenum)(xtype), indices)
+}
+func DrawRangeElementsBaseVertexEXT(mode uint32, start uint32, end uint32, count int32, xtype uint32, indices unsafe.Pointer, basevertex int32) {
+	C.glowDrawRangeElementsBaseVertexEXT(gpDrawRangeElementsBaseVertexEXT, (C.GLenum)(mode), (C.GLuint)(start), (C.GLuint)(end), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLint)(basevertex))
+}
+func DrawRangeElementsBaseVertexOES(mode uint32, start uint32, end uint32, count int32, xtype uint32, indices unsafe.Pointer, basevertex int32) {
+	C.glowDrawRangeElementsBaseVertexOES(gpDrawRangeElementsBaseVertexOES, (C.GLenum)(mode), (C.GLuint)(start), (C.GLuint)(end), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLint)(basevertex))
+}
+func DrawTransformFeedbackEXT(mode uint32, id uint32) {
+	C.glowDrawTransformFeedbackEXT(gpDrawTransformFeedbackEXT, (C.GLenum)(mode), (C.GLuint)(id))
+}
+func DrawTransformFeedbackInstancedEXT(mode uint32, id uint32, instancecount int32) {
+	C.glowDrawTransformFeedbackInstancedEXT(gpDrawTransformFeedbackInstancedEXT, (C.GLenum)(mode), (C.GLuint)(id), (C.GLsizei)(instancecount))
+}
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
 }
 func EGLImageTargetRenderbufferStorageOES(target uint32, image C.GLeglImageOES) {
 	C.glowEGLImageTargetRenderbufferStorageOES(gpEGLImageTargetRenderbufferStorageOES, (C.GLenum)(target), (C.GLeglImageOES)(image))
@@ -4991,6 +7021,15 @@ func EnableVertexAttribArray(index uint32) {
 }
 func EnableiEXT(target uint32, index uint32) {
 	C.glowEnableiEXT(gpEnableiEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
+func EnableiNV(target uint32, index uint32) {
+	C.glowEnableiNV(gpEnableiNV, (C.GLenum)(target), (C.GLuint)(index))
+}
+func EnableiOES(target uint32, index uint32) {
+	C.glowEnableiOES(gpEnableiOES, (C.GLenum)(target), (C.GLuint)(index))
+}
+func EndConditionalRenderNV() {
+	C.glowEndConditionalRenderNV(gpEndConditionalRenderNV)
 }
 func EndPerfMonitorAMD(monitor uint32) {
 	C.glowEndPerfMonitorAMD(gpEndPerfMonitorAMD, (C.GLuint)(monitor))
@@ -5049,13 +7088,13 @@ func ExtTexObjectStateOverrideiQCOM(target uint32, pname uint32, param int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
-func FenceSyncAPPLE(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSyncAPPLE(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSyncAPPLE(gpFenceSyncAPPLE, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -5078,18 +7117,44 @@ func FlushMappedBufferRange(target uint32, offset int, length int) {
 func FlushMappedBufferRangeEXT(target uint32, offset int, length int) {
 	C.glowFlushMappedBufferRangeEXT(gpFlushMappedBufferRangeEXT, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
 }
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
+}
+func FramebufferFetchBarrierQCOM() {
+	C.glowFramebufferFetchBarrierQCOM(gpFramebufferFetchBarrierQCOM)
+}
+func FramebufferFoveationConfigQCOM(framebuffer uint32, numLayers uint32, focalPointsPerLayer uint32, requestedFeatures uint32, providedFeatures *uint32) {
+	C.glowFramebufferFoveationConfigQCOM(gpFramebufferFoveationConfigQCOM, (C.GLuint)(framebuffer), (C.GLuint)(numLayers), (C.GLuint)(focalPointsPerLayer), (C.GLuint)(requestedFeatures), (*C.GLuint)(unsafe.Pointer(providedFeatures)))
+}
+func FramebufferFoveationParametersQCOM(framebuffer uint32, layer uint32, focalPoint uint32, focalX float32, focalY float32, gainX float32, gainY float32, foveaArea float32) {
+	C.glowFramebufferFoveationParametersQCOM(gpFramebufferFoveationParametersQCOM, (C.GLuint)(framebuffer), (C.GLuint)(layer), (C.GLuint)(focalPoint), (C.GLfloat)(focalX), (C.GLfloat)(focalY), (C.GLfloat)(gainX), (C.GLfloat)(gainY), (C.GLfloat)(foveaArea))
+}
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
 	C.glowFramebufferParameteri(gpFramebufferParameteri, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func FramebufferPixelLocalStorageSizeEXT(target uint32, size int32) {
+	C.glowFramebufferPixelLocalStorageSizeEXT(gpFramebufferPixelLocalStorageSizeEXT, (C.GLuint)(target), (C.GLsizei)(size))
 }
 
 // attach a renderbuffer as a logical buffer of a framebuffer object
 func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbuffer(gpFramebufferRenderbuffer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func FramebufferTexture2DDownsampleIMG(target uint32, attachment uint32, textarget uint32, texture uint32, level int32, xscale int32, yscale int32) {
+	C.glowFramebufferTexture2DDownsampleIMG(gpFramebufferTexture2DDownsampleIMG, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xscale), (C.GLint)(yscale))
 }
 func FramebufferTexture2DMultisampleEXT(target uint32, attachment uint32, textarget uint32, texture uint32, level int32, samples int32) {
 	C.glowFramebufferTexture2DMultisampleEXT(gpFramebufferTexture2DMultisampleEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLsizei)(samples))
@@ -5108,6 +7173,18 @@ func FramebufferTextureEXT(target uint32, attachment uint32, texture uint32, lev
 func FramebufferTextureLayer(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayer(gpFramebufferTextureLayer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
 }
+func FramebufferTextureLayerDownsampleIMG(target uint32, attachment uint32, texture uint32, level int32, layer int32, xscale int32, yscale int32) {
+	C.glowFramebufferTextureLayerDownsampleIMG(gpFramebufferTextureLayerDownsampleIMG, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer), (C.GLint)(xscale), (C.GLint)(yscale))
+}
+func FramebufferTextureMultisampleMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, samples int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultisampleMultiviewOVR(gpFramebufferTextureMultisampleMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLsizei)(samples), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
+}
+func FramebufferTextureOES(target uint32, attachment uint32, texture uint32, level int32) {
+	C.glowFramebufferTextureOES(gpFramebufferTextureOES, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
 
 // define front- and back-facing polygons
 func FrontFace(mode uint32) {
@@ -5125,6 +7202,10 @@ func GenFencesNV(n int32, fences *uint32) {
 // generate framebuffer object names
 func GenFramebuffers(n int32, framebuffers *uint32) {
 	C.glowGenFramebuffers(gpGenFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func GenPathsNV(xrange int32) uint32 {
+	ret := C.glowGenPathsNV(gpGenPathsNV, (C.GLsizei)(xrange))
+	return (uint32)(ret)
 }
 func GenPerfMonitorsAMD(n int32, monitors *uint32) {
 	C.glowGenPerfMonitorsAMD(gpGenPerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
@@ -5154,6 +7235,9 @@ func GenRenderbuffers(n int32, renderbuffers *uint32) {
 // generate sampler object names
 func GenSamplers(count int32, samplers *uint32) {
 	C.glowGenSamplers(gpGenSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
+}
+func GenSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowGenSemaphoresEXT(gpGenSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
 }
 
 // generate texture names
@@ -5193,6 +7277,8 @@ func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -5236,6 +7322,9 @@ func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
 func GetBufferPointervOES(target uint32, pname uint32, params *unsafe.Pointer) {
 	C.glowGetBufferPointervOES(gpGetBufferPointervOES, (C.GLenum)(target), (C.GLenum)(pname), params)
 }
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 
 // retrieve messages from the debug message log
 func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
@@ -5264,8 +7353,18 @@ func GetFenceivNV(fence uint32, pname uint32, params *int32) {
 func GetFirstPerfQueryIdINTEL(queryId *uint32) {
 	C.glowGetFirstPerfQueryIdINTEL(gpGetFirstPerfQueryIdINTEL, (*C.GLuint)(unsafe.Pointer(queryId)))
 }
+func GetFloati_vNV(target uint32, index uint32, data *float32) {
+	C.glowGetFloati_vNV(gpGetFloati_vNV, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
+func GetFloati_vOES(target uint32, index uint32, data *float32) {
+	C.glowGetFloati_vOES(gpGetFloati_vOES, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
 func GetFloatv(pname uint32, data *float32) {
 	C.glowGetFloatv(gpGetFloatv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(data)))
+}
+func GetFragDataIndexEXT(program uint32, name *uint8) int32 {
+	ret := C.glowGetFragDataIndexEXT(gpGetFragDataIndexEXT, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
+	return (int32)(ret)
 }
 
 // query the bindings of color numbers to user-defined varying out variables
@@ -5274,14 +7373,18 @@ func GetFragDataLocation(program uint32, name *uint8) int32 {
 	return (int32)(ret)
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetFramebufferPixelLocalStorageSizeEXT(target uint32) int32 {
+	ret := C.glowGetFramebufferPixelLocalStorageSizeEXT(gpGetFramebufferPixelLocalStorageSizeEXT, (C.GLuint)(target))
+	return (int32)(ret)
 }
 
 // check if the rendering context has not been lost due to software or hardware issues
@@ -5296,6 +7399,10 @@ func GetGraphicsResetStatusEXT() uint32 {
 func GetGraphicsResetStatusKHR() uint32 {
 	ret := C.glowGetGraphicsResetStatusKHR(gpGetGraphicsResetStatusKHR)
 	return (uint32)(ret)
+}
+func GetImageHandleNV(texture uint32, level int32, layered bool, layer int32, format uint32) uint64 {
+	ret := C.glowGetImageHandleNV(gpGetImageHandleNV, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
+	return (uint64)(ret)
 }
 func GetInteger64i_v(target uint32, index uint32, data *int64) {
 	C.glowGetInteger64i_v(gpGetInteger64i_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint64)(unsafe.Pointer(data)))
@@ -5315,8 +7422,16 @@ func GetIntegeri_vEXT(target uint32, index uint32, data *int32) {
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowGetMemoryObjectParameterivEXT(gpGetMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // retrieve the location of a sample
@@ -5344,6 +7459,34 @@ func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *
 }
 func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetPathCommandsNV(path uint32, commands *uint8) {
+	C.glowGetPathCommandsNV(gpGetPathCommandsNV, (C.GLuint)(path), (*C.GLubyte)(unsafe.Pointer(commands)))
+}
+func GetPathCoordsNV(path uint32, coords *float32) {
+	C.glowGetPathCoordsNV(gpGetPathCoordsNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(coords)))
+}
+func GetPathDashArrayNV(path uint32, dashArray *float32) {
+	C.glowGetPathDashArrayNV(gpGetPathDashArrayNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func GetPathLengthNV(path uint32, startSegment int32, numSegments int32) float32 {
+	ret := C.glowGetPathLengthNV(gpGetPathLengthNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments))
+	return (float32)(ret)
+}
+func GetPathMetricRangeNV(metricQueryMask uint32, firstPathName uint32, numPaths int32, stride int32, metrics *float32) {
+	C.glowGetPathMetricRangeNV(gpGetPathMetricRangeNV, (C.GLbitfield)(metricQueryMask), (C.GLuint)(firstPathName), (C.GLsizei)(numPaths), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathMetricsNV(metricQueryMask uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, stride int32, metrics *float32) {
+	C.glowGetPathMetricsNV(gpGetPathMetricsNV, (C.GLbitfield)(metricQueryMask), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowGetPathParameterfvNV(gpGetPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func GetPathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowGetPathParameterivNV(gpGetPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func GetPathSpacingNV(pathListMode uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, advanceScale float32, kerningScale float32, transformType uint32, returnedSpacing *float32) {
+	C.glowGetPathSpacingNV(gpGetPathSpacingNV, (C.GLenum)(pathListMode), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLfloat)(advanceScale), (C.GLfloat)(kerningScale), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(returnedSpacing)))
 }
 func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
 	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
@@ -5425,10 +7568,17 @@ func GetProgramResourceLocation(program uint32, programInterface uint32, name *u
 	ret := C.glowGetProgramResourceLocation(gpGetProgramResourceLocation, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
+func GetProgramResourceLocationIndexEXT(program uint32, programInterface uint32, name *uint8) int32 {
+	ret := C.glowGetProgramResourceLocationIndexEXT(gpGetProgramResourceLocationIndexEXT, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
+	return (int32)(ret)
+}
 
 // query the name of an indexed resource within a program
 func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
+}
+func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
+	C.glowGetProgramResourcefvNV(gpGetProgramResourcefvNV, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
 	C.glowGetProgramResourceiv(gpGetProgramResourceiv, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(params)))
@@ -5447,6 +7597,8 @@ func GetQueryObjectivEXT(id uint32, pname uint32, params *int32) {
 func GetQueryObjectui64vEXT(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64vEXT(gpGetQueryObjectui64vEXT, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -5462,21 +7614,30 @@ func GetQueryivEXT(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryivEXT(gpGetQueryivEXT, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetSamplerParameterIivEXT(sampler uint32, pname uint32, params *int32) {
 	C.glowGetSamplerParameterIivEXT(gpGetSamplerParameterIivEXT, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetSamplerParameterIivOES(sampler uint32, pname uint32, params *int32) {
+	C.glowGetSamplerParameterIivOES(gpGetSamplerParameterIivOES, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetSamplerParameterIuivEXT(sampler uint32, pname uint32, params *uint32) {
 	C.glowGetSamplerParameterIuivEXT(gpGetSamplerParameterIuivEXT, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetSamplerParameterIuivOES(sampler uint32, pname uint32, params *uint32) {
+	C.glowGetSamplerParameterIuivOES(gpGetSamplerParameterIuivOES, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
 func GetSamplerParameterfv(sampler uint32, pname uint32, params *float32) {
 	C.glowGetSamplerParameterfv(gpGetSamplerParameterfv, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 	C.glowGetSamplerParameteriv(gpGetSamplerParameteriv, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetSemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowGetSemaphoreParameterui64vEXT(gpGetSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 
 // Returns the information log for a shader object
@@ -5510,10 +7671,10 @@ func GetStringi(name uint32, index uint32) *uint8 {
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
-func GetSyncivAPPLE(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSyncivAPPLE(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSyncivAPPLE(gpGetSyncivAPPLE, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexLevelParameterfv(target uint32, level int32, pname uint32, params *float32) {
@@ -5525,14 +7686,36 @@ func GetTexLevelParameteriv(target uint32, level int32, pname uint32, params *in
 func GetTexParameterIivEXT(target uint32, pname uint32, params *int32) {
 	C.glowGetTexParameterIivEXT(gpGetTexParameterIivEXT, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTexParameterIivOES(target uint32, pname uint32, params *int32) {
+	C.glowGetTexParameterIivOES(gpGetTexParameterIivOES, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTexParameterIuivEXT(target uint32, pname uint32, params *uint32) {
 	C.glowGetTexParameterIuivEXT(gpGetTexParameterIuivEXT, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetTexParameterIuivOES(target uint32, pname uint32, params *uint32) {
+	C.glowGetTexParameterIuivOES(gpGetTexParameterIuivOES, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
 func GetTexParameterfv(target uint32, pname uint32, params *float32) {
 	C.glowGetTexParameterfv(gpGetTexParameterfv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTexParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetTexParameteriv(gpGetTexParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetTextureHandleIMG(texture uint32) uint64 {
+	ret := C.glowGetTextureHandleIMG(gpGetTextureHandleIMG, (C.GLuint)(texture))
+	return (uint64)(ret)
+}
+func GetTextureHandleNV(texture uint32) uint64 {
+	ret := C.glowGetTextureHandleNV(gpGetTextureHandleNV, (C.GLuint)(texture))
+	return (uint64)(ret)
+}
+func GetTextureSamplerHandleIMG(texture uint32, sampler uint32) uint64 {
+	ret := C.glowGetTextureSamplerHandleIMG(gpGetTextureSamplerHandleIMG, (C.GLuint)(texture), (C.GLuint)(sampler))
+	return (uint64)(ret)
+}
+func GetTextureSamplerHandleNV(texture uint32, sampler uint32) uint64 {
+	ret := C.glowGetTextureSamplerHandleNV(gpGetTextureSamplerHandleNV, (C.GLuint)(texture), (C.GLuint)(sampler))
+	return (uint64)(ret)
 }
 
 // retrieve information about varying variables selected for transform feedback
@@ -5564,6 +7747,9 @@ func GetUniformLocation(program uint32, name *uint8) int32 {
 func GetUniformfv(program uint32, location int32, params *float32) {
 	C.glowGetUniformfv(gpGetUniformfv, (C.GLuint)(program), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vNV(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 
 // Returns the value of a uniform variable
 func GetUniformiv(program uint32, location int32, params *int32) {
@@ -5571,6 +7757,12 @@ func GetUniformiv(program uint32, location int32, params *int32) {
 }
 func GetUniformuiv(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuiv(gpGetUniformuiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetUnsignedBytei_vEXT(target uint32, index uint32, data *uint8) {
+	C.glowGetUnsignedBytei_vEXT(gpGetUnsignedBytei_vEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLubyte)(unsafe.Pointer(data)))
+}
+func GetUnsignedBytevEXT(pname uint32, data *uint8) {
+	C.glowGetUnsignedBytevEXT(gpGetUnsignedBytevEXT, (C.GLenum)(pname), (*C.GLubyte)(unsafe.Pointer(data)))
 }
 
 // Return a generic vertex attribute parameter
@@ -5596,6 +7788,10 @@ func GetVertexAttribfv(index uint32, pname uint32, params *float32) {
 // Return a generic vertex attribute parameter
 func GetVertexAttribiv(index uint32, pname uint32, params *int32) {
 	C.glowGetVertexAttribiv(gpGetVertexAttribiv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
 }
 func GetnUniformfv(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfv(gpGetnUniformfv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
@@ -5626,8 +7822,29 @@ func GetnUniformuivKHR(program uint32, location int32, bufSize int32, params *ui
 func Hint(target uint32, mode uint32) {
 	C.glowHint(gpHint, (C.GLenum)(target), (C.GLenum)(mode))
 }
+func ImportMemoryFdEXT(memory uint32, size uint64, handleType uint32, fd int32) {
+	C.glowImportMemoryFdEXT(gpImportMemoryFdEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportMemoryWin32HandleEXT(memory uint32, size uint64, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportMemoryWin32HandleEXT(gpImportMemoryWin32HandleEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), handle)
+}
+func ImportMemoryWin32NameEXT(memory uint32, size uint64, handleType uint32, name unsafe.Pointer) {
+	C.glowImportMemoryWin32NameEXT(gpImportMemoryWin32NameEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), name)
+}
+func ImportSemaphoreFdEXT(semaphore uint32, handleType uint32, fd int32) {
+	C.glowImportSemaphoreFdEXT(gpImportSemaphoreFdEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportSemaphoreWin32HandleEXT(semaphore uint32, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportSemaphoreWin32HandleEXT(gpImportSemaphoreWin32HandleEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), handle)
+}
+func ImportSemaphoreWin32NameEXT(semaphore uint32, handleType uint32, name unsafe.Pointer) {
+	C.glowImportSemaphoreWin32NameEXT(gpImportSemaphoreWin32NameEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), name)
+}
 func InsertEventMarkerEXT(length int32, marker *uint8) {
 	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
+func InterpolatePathsNV(resultPath uint32, pathA uint32, pathB uint32, weight float32) {
+	C.glowInterpolatePathsNV(gpInterpolatePathsNV, (C.GLuint)(resultPath), (C.GLuint)(pathA), (C.GLuint)(pathB), (C.GLfloat)(weight))
 }
 
 // invalidate the content of some or all of a framebuffer's attachments
@@ -5653,6 +7870,14 @@ func IsEnablediEXT(target uint32, index uint32) bool {
 	ret := C.glowIsEnablediEXT(gpIsEnablediEXT, (C.GLenum)(target), (C.GLuint)(index))
 	return ret == TRUE
 }
+func IsEnablediNV(target uint32, index uint32) bool {
+	ret := C.glowIsEnablediNV(gpIsEnablediNV, (C.GLenum)(target), (C.GLuint)(index))
+	return ret == TRUE
+}
+func IsEnablediOES(target uint32, index uint32) bool {
+	ret := C.glowIsEnablediOES(gpIsEnablediOES, (C.GLenum)(target), (C.GLuint)(index))
+	return ret == TRUE
+}
 func IsFenceNV(fence uint32) bool {
 	ret := C.glowIsFenceNV(gpIsFenceNV, (C.GLuint)(fence))
 	return ret == TRUE
@@ -5661,6 +7886,26 @@ func IsFenceNV(fence uint32) bool {
 // determine if a name corresponds to a framebuffer object
 func IsFramebuffer(framebuffer uint32) bool {
 	ret := C.glowIsFramebuffer(gpIsFramebuffer, (C.GLuint)(framebuffer))
+	return ret == TRUE
+}
+func IsImageHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsImageHandleResidentNV(gpIsImageHandleResidentNV, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsMemoryObjectEXT(memoryObject uint32) bool {
+	ret := C.glowIsMemoryObjectEXT(gpIsMemoryObjectEXT, (C.GLuint)(memoryObject))
+	return ret == TRUE
+}
+func IsPathNV(path uint32) bool {
+	ret := C.glowIsPathNV(gpIsPathNV, (C.GLuint)(path))
+	return ret == TRUE
+}
+func IsPointInFillPathNV(path uint32, mask uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInFillPathNV(gpIsPointInFillPathNV, (C.GLuint)(path), (C.GLuint)(mask), (C.GLfloat)(x), (C.GLfloat)(y))
+	return ret == TRUE
+}
+func IsPointInStrokePathNV(path uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInStrokePathNV(gpIsPointInStrokePathNV, (C.GLuint)(path), (C.GLfloat)(x), (C.GLfloat)(y))
 	return ret == TRUE
 }
 
@@ -5701,6 +7946,10 @@ func IsSampler(sampler uint32) bool {
 	ret := C.glowIsSampler(gpIsSampler, (C.GLuint)(sampler))
 	return ret == TRUE
 }
+func IsSemaphoreEXT(semaphore uint32) bool {
+	ret := C.glowIsSemaphoreEXT(gpIsSemaphoreEXT, (C.GLuint)(semaphore))
+	return ret == TRUE
+}
 
 // Determines if a name corresponds to a shader object
 func IsShader(shader uint32) bool {
@@ -5709,11 +7958,11 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
-func IsSyncAPPLE(sync unsafe.Pointer) bool {
+func IsSyncAPPLE(sync uintptr) bool {
 	ret := C.glowIsSyncAPPLE(gpIsSyncAPPLE, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -5721,6 +7970,10 @@ func IsSyncAPPLE(sync unsafe.Pointer) bool {
 // determine if a name corresponds to a texture
 func IsTexture(texture uint32) bool {
 	ret := C.glowIsTexture(gpIsTexture, (C.GLuint)(texture))
+	return ret == TRUE
+}
+func IsTextureHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsTextureHandleResidentNV(gpIsTextureHandleResidentNV, (C.GLuint64)(handle))
 	return ret == TRUE
 }
 
@@ -5752,6 +8005,18 @@ func LineWidth(width float32) {
 func LinkProgram(program uint32) {
 	C.glowLinkProgram(gpLinkProgram, (C.GLuint)(program))
 }
+func MakeImageHandleNonResidentNV(handle uint64) {
+	C.glowMakeImageHandleNonResidentNV(gpMakeImageHandleNonResidentNV, (C.GLuint64)(handle))
+}
+func MakeImageHandleResidentNV(handle uint64, access uint32) {
+	C.glowMakeImageHandleResidentNV(gpMakeImageHandleResidentNV, (C.GLuint64)(handle), (C.GLenum)(access))
+}
+func MakeTextureHandleNonResidentNV(handle uint64) {
+	C.glowMakeTextureHandleNonResidentNV(gpMakeTextureHandleNonResidentNV, (C.GLuint64)(handle))
+}
+func MakeTextureHandleResidentNV(handle uint64) {
+	C.glowMakeTextureHandleResidentNV(gpMakeTextureHandleResidentNV, (C.GLuint64)(handle))
+}
 func MapBufferOES(target uint32, access uint32) unsafe.Pointer {
 	ret := C.glowMapBufferOES(gpMapBufferOES, (C.GLenum)(target), (C.GLenum)(access))
 	return (unsafe.Pointer)(ret)
@@ -5766,6 +8031,84 @@ func MapBufferRangeEXT(target uint32, offset int, length int, access uint32) uns
 	ret := C.glowMapBufferRangeEXT(gpMapBufferRangeEXT, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
 }
+func MatrixFrustumEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixFrustumEXT(gpMatrixFrustumEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixLoad3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x2fNV(gpMatrixLoad3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoad3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x3fNV(gpMatrixLoad3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadIdentityEXT(mode uint32) {
+	C.glowMatrixLoadIdentityEXT(gpMatrixLoadIdentityEXT, (C.GLenum)(mode))
+}
+func MatrixLoadTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoadTranspose3x3fNV(gpMatrixLoadTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixLoadTransposedEXT(gpMatrixLoadTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadTransposefEXT(gpMatrixLoadTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoaddEXT(mode uint32, m *float64) {
+	C.glowMatrixLoaddEXT(gpMatrixLoaddEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadfEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadfEXT(gpMatrixLoadfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x2fNV(gpMatrixMult3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x3fNV(gpMatrixMult3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMultTranspose3x3fNV(gpMatrixMultTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixMultTransposedEXT(gpMatrixMultTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixMultTransposefEXT(gpMatrixMultTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultdEXT(mode uint32, m *float64) {
+	C.glowMatrixMultdEXT(gpMatrixMultdEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultfEXT(mode uint32, m *float32) {
+	C.glowMatrixMultfEXT(gpMatrixMultfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixOrthoEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixOrthoEXT(gpMatrixOrthoEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixPopEXT(mode uint32) {
+	C.glowMatrixPopEXT(gpMatrixPopEXT, (C.GLenum)(mode))
+}
+func MatrixPushEXT(mode uint32) {
+	C.glowMatrixPushEXT(gpMatrixPushEXT, (C.GLenum)(mode))
+}
+func MatrixRotatedEXT(mode uint32, angle float64, x float64, y float64, z float64) {
+	C.glowMatrixRotatedEXT(gpMatrixRotatedEXT, (C.GLenum)(mode), (C.GLdouble)(angle), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixRotatefEXT(mode uint32, angle float32, x float32, y float32, z float32) {
+	C.glowMatrixRotatefEXT(gpMatrixRotatefEXT, (C.GLenum)(mode), (C.GLfloat)(angle), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixScaledEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixScaledEXT(gpMatrixScaledEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixScalefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixScalefEXT(gpMatrixScalefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixTranslatedEXT(gpMatrixTranslatedEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
+}
 
 // defines a barrier ordering memory transactions
 func MemoryBarrier(barriers uint32) {
@@ -5774,14 +8117,35 @@ func MemoryBarrier(barriers uint32) {
 func MemoryBarrierByRegion(barriers uint32) {
 	C.glowMemoryBarrierByRegion(gpMemoryBarrierByRegion, (C.GLbitfield)(barriers))
 }
+func MemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowMemoryObjectParameterivEXT(gpMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func MinSampleShadingOES(value float32) {
 	C.glowMinSampleShadingOES(gpMinSampleShadingOES, (C.GLfloat)(value))
 }
 func MultiDrawArraysEXT(mode uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawArraysEXT(gpMultiDrawArraysEXT, (C.GLenum)(mode), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
 }
+func MultiDrawArraysIndirectEXT(mode uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectEXT(gpMultiDrawArraysIndirectEXT, (C.GLenum)(mode), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
+}
+func MultiDrawElementsBaseVertexEXT(mode uint32, count *int32, xtype uint32, indices *unsafe.Pointer, primcount int32, basevertex *int32) {
+	C.glowMultiDrawElementsBaseVertexEXT(gpMultiDrawElementsBaseVertexEXT, (C.GLenum)(mode), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount), (*C.GLint)(unsafe.Pointer(basevertex)))
+}
 func MultiDrawElementsEXT(mode uint32, count *int32, xtype uint32, indices *unsafe.Pointer, primcount int32) {
 	C.glowMultiDrawElementsEXT(gpMultiDrawElementsEXT, (C.GLenum)(mode), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
+}
+func MultiDrawElementsIndirectEXT(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectEXT(gpMultiDrawElementsIndirectEXT, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
+}
+func NamedBufferStorageExternalEXT(buffer uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowNamedBufferStorageExternalEXT(gpNamedBufferStorageExternalEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func NamedBufferStorageMemEXT(buffer uint32, size int, memory uint32, offset uint64) {
+	C.glowNamedBufferStorageMemEXT(gpNamedBufferStorageMemEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // label a named object identified within a namespace
@@ -5802,18 +8166,90 @@ func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 func PatchParameteriEXT(pname uint32, value int32) {
 	C.glowPatchParameteriEXT(gpPatchParameteriEXT, (C.GLenum)(pname), (C.GLint)(value))
 }
+func PatchParameteriOES(pname uint32, value int32) {
+	C.glowPatchParameteriOES(gpPatchParameteriOES, (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathCommandsNV(path uint32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCommandsNV(gpPathCommandsNV, (C.GLuint)(path), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoordsNV(path uint32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCoordsNV(gpPathCoordsNV, (C.GLuint)(path), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoverDepthFuncNV(xfunc uint32) {
+	C.glowPathCoverDepthFuncNV(gpPathCoverDepthFuncNV, (C.GLenum)(xfunc))
+}
+func PathDashArrayNV(path uint32, dashCount int32, dashArray *float32) {
+	C.glowPathDashArrayNV(gpPathDashArrayNV, (C.GLuint)(path), (C.GLsizei)(dashCount), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func PathGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathGlyphIndexArrayNV(gpPathGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathGlyphIndexRangeNV(fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, pathParameterTemplate uint32, emScale float32, baseAndCount *uint32) uint32 {
+	ret := C.glowPathGlyphIndexRangeNV(gpPathGlyphIndexRangeNV, (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale), (*C.GLuint)(unsafe.Pointer(baseAndCount)))
+	return (uint32)(ret)
+}
+func PathGlyphRangeNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyph uint32, numGlyphs int32, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphRangeNV(gpPathGlyphRangeNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyph), (C.GLsizei)(numGlyphs), (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathGlyphsNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, numGlyphs int32, xtype uint32, charcodes unsafe.Pointer, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphsNV(gpPathGlyphsNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLsizei)(numGlyphs), (C.GLenum)(xtype), charcodes, (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathMemoryGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontSize int, fontData unsafe.Pointer, faceIndex int32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathMemoryGlyphIndexArrayNV(gpPathMemoryGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), (C.GLsizeiptr)(fontSize), fontData, (C.GLsizei)(faceIndex), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathParameterfNV(path uint32, pname uint32, value float32) {
+	C.glowPathParameterfNV(gpPathParameterfNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func PathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowPathParameterfvNV(gpPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func PathParameteriNV(path uint32, pname uint32, value int32) {
+	C.glowPathParameteriNV(gpPathParameteriNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowPathParameterivNV(gpPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func PathStencilDepthOffsetNV(factor float32, units float32) {
+	C.glowPathStencilDepthOffsetNV(gpPathStencilDepthOffsetNV, (C.GLfloat)(factor), (C.GLfloat)(units))
+}
+func PathStencilFuncNV(xfunc uint32, ref int32, mask uint32) {
+	C.glowPathStencilFuncNV(gpPathStencilFuncNV, (C.GLenum)(xfunc), (C.GLint)(ref), (C.GLuint)(mask))
+}
+func PathStringNV(path uint32, format uint32, length int32, pathString unsafe.Pointer) {
+	C.glowPathStringNV(gpPathStringNV, (C.GLuint)(path), (C.GLenum)(format), (C.GLsizei)(length), pathString)
+}
+func PathSubCommandsNV(path uint32, commandStart int32, commandsToDelete int32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCommandsNV(gpPathSubCommandsNV, (C.GLuint)(path), (C.GLsizei)(commandStart), (C.GLsizei)(commandsToDelete), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathSubCoordsNV(path uint32, coordStart int32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCoordsNV(gpPathSubCoordsNV, (C.GLuint)(path), (C.GLsizei)(coordStart), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
 
 // pause transform feedback operations
 func PauseTransformFeedback() {
 	C.glowPauseTransformFeedback(gpPauseTransformFeedback)
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
+}
+func PointAlongPathNV(path uint32, startSegment int32, numSegments int32, distance float32, x *float32, y *float32, tangentX *float32, tangentY *float32) bool {
+	ret := C.glowPointAlongPathNV(gpPointAlongPathNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments), (C.GLfloat)(distance), (*C.GLfloat)(unsafe.Pointer(x)), (*C.GLfloat)(unsafe.Pointer(y)), (*C.GLfloat)(unsafe.Pointer(tangentX)), (*C.GLfloat)(unsafe.Pointer(tangentY)))
+	return ret == TRUE
+}
+func PolygonModeNV(face uint32, mode uint32) {
+	C.glowPolygonModeNV(gpPolygonModeNV, (C.GLenum)(face), (C.GLenum)(mode))
 }
 
 // set the scale and units used to calculate depth values
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
 }
 
 // pop the active debug group
@@ -5829,6 +8265,9 @@ func PopGroupMarkerEXT() {
 func PrimitiveBoundingBoxEXT(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
 	C.glowPrimitiveBoundingBoxEXT(gpPrimitiveBoundingBoxEXT, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
+func PrimitiveBoundingBoxOES(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxOES(gpPrimitiveBoundingBoxOES, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
+}
 
 // load a program object with a program binary
 func ProgramBinary(program uint32, binaryFormat uint32, binary unsafe.Pointer, length int32) {
@@ -5837,11 +8276,16 @@ func ProgramBinary(program uint32, binaryFormat uint32, binary unsafe.Pointer, l
 func ProgramBinaryOES(program uint32, binaryFormat uint32, binary unsafe.Pointer, length int32) {
 	C.glowProgramBinaryOES(gpProgramBinaryOES, (C.GLuint)(program), (C.GLenum)(binaryFormat), binary, (C.GLint)(length))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
 }
 func ProgramParameteriEXT(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteriEXT(gpProgramParameteriEXT, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramPathFragmentInputGenNV(program uint32, location int32, genMode uint32, components int32, coeffs *float32) {
+	C.glowProgramPathFragmentInputGenNV(gpProgramPathFragmentInputGenNV, (C.GLuint)(program), (C.GLint)(location), (C.GLenum)(genMode), (C.GLint)(components), (*C.GLfloat)(unsafe.Pointer(coeffs)))
 }
 
 // Specify the value of a uniform variable for a specified program object
@@ -5864,6 +8308,12 @@ func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64NV(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 func ProgramUniform1iEXT(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1iEXT(gpProgramUniform1iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
@@ -5879,6 +8329,12 @@ func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *in
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
+}
+func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 func ProgramUniform1uiEXT(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1uiEXT(gpProgramUniform1uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
@@ -5912,6 +8368,12 @@ func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 func ProgramUniform2iEXT(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2iEXT(gpProgramUniform2iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
@@ -5927,6 +8389,12 @@ func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *in
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
+func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 func ProgramUniform2uiEXT(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2uiEXT(gpProgramUniform2uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
@@ -5960,6 +8428,12 @@ func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 func ProgramUniform3iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3iEXT(gpProgramUniform3iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
@@ -5975,6 +8449,12 @@ func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *in
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
+func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 func ProgramUniform3uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3uiEXT(gpProgramUniform3uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
@@ -6008,6 +8488,12 @@ func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 func ProgramUniform4iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4iEXT(gpProgramUniform4iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
@@ -6024,6 +8510,12 @@ func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 func ProgramUniform4uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4uiEXT(gpProgramUniform4uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
@@ -6034,6 +8526,18 @@ func ProgramUniform4uiv(program uint32, location int32, count int32, value *uint
 }
 func ProgramUniform4uivEXT(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform4uivEXT(gpProgramUniform4uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
+func ProgramUniformHandleui64IMG(program uint32, location int32, value uint64) {
+	C.glowProgramUniformHandleui64IMG(gpProgramUniformHandleui64IMG, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
+}
+func ProgramUniformHandleui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformHandleui64NV(gpProgramUniformHandleui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
+}
+func ProgramUniformHandleui64vIMG(program uint32, location int32, count int32, values *uint64) {
+	C.glowProgramUniformHandleui64vIMG(gpProgramUniformHandleui64vIMG, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
+}
+func ProgramUniformHandleui64vNV(program uint32, location int32, count int32, values *uint64) {
+	C.glowProgramUniformHandleui64vNV(gpProgramUniformHandleui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
 }
 
 // Specify the value of a uniform variable for a specified program object
@@ -6121,6 +8625,9 @@ func PushGroupMarkerEXT(length int32, marker *uint8) {
 func QueryCounterEXT(id uint32, target uint32) {
 	C.glowQueryCounterEXT(gpQueryCounterEXT, (C.GLuint)(id), (C.GLenum)(target))
 }
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // select a color buffer source for pixels
 func ReadBuffer(src uint32) {
@@ -6147,6 +8654,10 @@ func ReadnPixelsEXT(x int32, y int32, width int32, height int32, format uint32, 
 }
 func ReadnPixelsKHR(x int32, y int32, width int32, height int32, format uint32, xtype uint32, bufSize int32, data unsafe.Pointer) {
 	C.glowReadnPixelsKHR(gpReadnPixelsKHR, (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), data)
+}
+func ReleaseKeyedMutexWin32EXT(memory uint32, key uint64) bool {
+	ret := C.glowReleaseKeyedMutexWin32EXT(gpReleaseKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key))
+	return ret == TRUE
 }
 
 // release resources consumed by the implementation's shader compiler
@@ -6178,6 +8689,9 @@ func RenderbufferStorageMultisampleIMG(target uint32, samples int32, internalfor
 func RenderbufferStorageMultisampleNV(target uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowRenderbufferStorageMultisampleNV(gpRenderbufferStorageMultisampleNV, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
+}
 func ResolveMultisampleFramebufferAPPLE() {
 	C.glowResolveMultisampleFramebufferAPPLE(gpResolveMultisampleFramebufferAPPLE)
 }
@@ -6199,8 +8713,14 @@ func SampleMaski(maskNumber uint32, mask uint32) {
 func SamplerParameterIivEXT(sampler uint32, pname uint32, param *int32) {
 	C.glowSamplerParameterIivEXT(gpSamplerParameterIivEXT, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
 }
+func SamplerParameterIivOES(sampler uint32, pname uint32, param *int32) {
+	C.glowSamplerParameterIivOES(gpSamplerParameterIivOES, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
 func SamplerParameterIuivEXT(sampler uint32, pname uint32, param *uint32) {
 	C.glowSamplerParameterIuivEXT(gpSamplerParameterIuivEXT, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(param)))
+}
+func SamplerParameterIuivOES(sampler uint32, pname uint32, param *uint32) {
+	C.glowSamplerParameterIuivOES(gpSamplerParameterIuivOES, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(param)))
 }
 func SamplerParameterf(sampler uint32, pname uint32, param float32) {
 	C.glowSamplerParameterf(gpSamplerParameterf, (C.GLuint)(sampler), (C.GLenum)(pname), (C.GLfloat)(param))
@@ -6219,8 +8739,29 @@ func SamplerParameteriv(sampler uint32, pname uint32, param *int32) {
 func Scissor(x int32, y int32, width int32, height int32) {
 	C.glowScissor(gpScissor, (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func ScissorArrayvNV(first uint32, count int32, v *int32) {
+	C.glowScissorArrayvNV(gpScissorArrayvNV, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(v)))
+}
+func ScissorArrayvOES(first uint32, count int32, v *int32) {
+	C.glowScissorArrayvOES(gpScissorArrayvOES, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(v)))
+}
+func ScissorIndexedNV(index uint32, left int32, bottom int32, width int32, height int32) {
+	C.glowScissorIndexedNV(gpScissorIndexedNV, (C.GLuint)(index), (C.GLint)(left), (C.GLint)(bottom), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func ScissorIndexedOES(index uint32, left int32, bottom int32, width int32, height int32) {
+	C.glowScissorIndexedOES(gpScissorIndexedOES, (C.GLuint)(index), (C.GLint)(left), (C.GLint)(bottom), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func ScissorIndexedvNV(index uint32, v *int32) {
+	C.glowScissorIndexedvNV(gpScissorIndexedvNV, (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(v)))
+}
+func ScissorIndexedvOES(index uint32, v *int32) {
+	C.glowScissorIndexedvOES(gpScissorIndexedvOES, (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(v)))
+}
 func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
 	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
+}
+func SemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowSemaphoreParameterui64vEXT(gpSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func SetFenceNV(fence uint32, condition uint32) {
 	C.glowSetFenceNV(gpSetFenceNV, (C.GLuint)(fence), (C.GLenum)(condition))
@@ -6235,8 +8776,23 @@ func ShaderBinary(count int32, shaders *uint32, binaryformat uint32, binary unsa
 func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSource(gpShaderSource, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
+func SignalSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, dstLayouts *uint32) {
+	C.glowSignalSemaphoreEXT(gpSignalSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(dstLayouts)))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
 func StartTilingQCOM(x uint32, y uint32, width uint32, height uint32, preserveMask uint32) {
 	C.glowStartTilingQCOM(gpStartTilingQCOM, (C.GLuint)(x), (C.GLuint)(y), (C.GLuint)(width), (C.GLuint)(height), (C.GLbitfield)(preserveMask))
+}
+func StencilFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilFillPathInstancedNV(gpStencilFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilFillPathNV(path uint32, fillMode uint32, mask uint32) {
+	C.glowStencilFillPathNV(gpStencilFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask))
 }
 
 // set front and back function and reference value for stencil testing
@@ -6268,6 +8824,27 @@ func StencilOp(fail uint32, zfail uint32, zpass uint32) {
 func StencilOpSeparate(face uint32, sfail uint32, dpfail uint32, dppass uint32) {
 	C.glowStencilOpSeparate(gpStencilOpSeparate, (C.GLenum)(face), (C.GLenum)(sfail), (C.GLenum)(dpfail), (C.GLenum)(dppass))
 }
+func StencilStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilStrokePathInstancedNV(gpStencilStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilStrokePathNV(path uint32, reference int32, mask uint32) {
+	C.glowStencilStrokePathNV(gpStencilStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask))
+}
+func StencilThenCoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverFillPathInstancedNV(gpStencilThenCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverFillPathNV(path uint32, fillMode uint32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverFillPathNV(gpStencilThenCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func StencilThenCoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverStrokePathInstancedNV(gpStencilThenCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverStrokePathNV(path uint32, reference int32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverStrokePathNV(gpStencilThenCoverStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
+}
 func TestFenceNV(fence uint32) bool {
 	ret := C.glowTestFenceNV(gpTestFenceNV, (C.GLuint)(fence))
 	return ret == TRUE
@@ -6275,8 +8852,14 @@ func TestFenceNV(fence uint32) bool {
 func TexBufferEXT(target uint32, internalformat uint32, buffer uint32) {
 	C.glowTexBufferEXT(gpTexBufferEXT, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TexBufferOES(target uint32, internalformat uint32, buffer uint32) {
+	C.glowTexBufferOES(gpTexBufferOES, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 func TexBufferRangeEXT(target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTexBufferRangeEXT(gpTexBufferRangeEXT, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TexBufferRangeOES(target uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTexBufferRangeOES(gpTexBufferRangeOES, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 
 // specify a two-dimensional texture image
@@ -6291,11 +8874,20 @@ func TexImage3D(target uint32, level int32, internalformat int32, width int32, h
 func TexImage3DOES(target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTexImage3DOES(gpTexImage3DOES, (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func TexPageCommitmentEXT(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentEXT(gpTexPageCommitmentEXT, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
+}
 func TexParameterIivEXT(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIivEXT(gpTexParameterIivEXT, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func TexParameterIivOES(target uint32, pname uint32, params *int32) {
+	C.glowTexParameterIivOES(gpTexParameterIivOES, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func TexParameterIuivEXT(target uint32, pname uint32, params *uint32) {
 	C.glowTexParameterIuivEXT(gpTexParameterIuivEXT, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func TexParameterIuivOES(target uint32, pname uint32, params *uint32) {
+	C.glowTexParameterIuivOES(gpTexParameterIuivOES, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
 func TexParameterf(target uint32, pname uint32, param float32) {
 	C.glowTexParameterf(gpTexParameterf, (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
@@ -6336,6 +8928,21 @@ func TexStorage3DEXT(target uint32, levels int32, internalformat uint32, width i
 func TexStorage3DMultisampleOES(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexStorage3DMultisampleOES(gpTexStorage3DMultisampleOES, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TexStorageMem1DEXT(target uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem1DEXT(gpTexStorageMem1DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DEXT(gpTexStorageMem2DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DMultisampleEXT(gpTexStorageMem2DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DEXT(gpTexStorageMem3DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DMultisampleEXT(gpTexStorageMem3DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // specify a two-dimensional texture subimage
 func TexSubImage2D(target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
@@ -6349,6 +8956,9 @@ func TexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zof
 func TexSubImage3DOES(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTexSubImage3DOES(gpTexSubImage3DOES, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func TextureFoveationParametersQCOM(texture uint32, layer uint32, focalPoint uint32, focalX float32, focalY float32, gainX float32, gainY float32, foveaArea float32) {
+	C.glowTextureFoveationParametersQCOM(gpTextureFoveationParametersQCOM, (C.GLuint)(texture), (C.GLuint)(layer), (C.GLuint)(focalPoint), (C.GLfloat)(focalX), (C.GLfloat)(focalY), (C.GLfloat)(gainX), (C.GLfloat)(gainY), (C.GLfloat)(foveaArea))
+}
 func TextureStorage1DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32) {
 	C.glowTextureStorage1DEXT(gpTextureStorage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
 }
@@ -6358,13 +8968,34 @@ func TextureStorage2DEXT(texture uint32, target uint32, levels int32, internalfo
 func TextureStorage3DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
 	C.glowTextureStorage3DEXT(gpTextureStorage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
 }
+func TextureStorageMem1DEXT(texture uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem1DEXT(gpTextureStorageMem1DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DEXT(gpTextureStorageMem2DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DMultisampleEXT(gpTextureStorageMem2DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DEXT(gpTextureStorageMem3DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DMultisampleEXT(gpTextureStorageMem3DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TextureViewEXT(texture uint32, target uint32, origtexture uint32, internalformat uint32, minlevel uint32, numlevels uint32, minlayer uint32, numlayers uint32) {
 	C.glowTextureViewEXT(gpTextureViewEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLuint)(origtexture), (C.GLenum)(internalformat), (C.GLuint)(minlevel), (C.GLuint)(numlevels), (C.GLuint)(minlayer), (C.GLuint)(numlayers))
+}
+func TextureViewOES(texture uint32, target uint32, origtexture uint32, internalformat uint32, minlevel uint32, numlevels uint32, minlayer uint32, numlayers uint32) {
+	C.glowTextureViewOES(gpTextureViewOES, (C.GLuint)(texture), (C.GLenum)(target), (C.GLuint)(origtexture), (C.GLenum)(internalformat), (C.GLuint)(minlevel), (C.GLuint)(numlevels), (C.GLuint)(minlayer), (C.GLuint)(numlayers))
 }
 
 // specify values to record in transform feedback buffers
 func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
+}
+func TransformPathNV(resultPath uint32, srcPath uint32, transformType uint32, transformValues *float32) {
+	C.glowTransformPathNV(gpTransformPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -6381,6 +9012,12 @@ func Uniform1fv(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64NV(location int32, x int64) {
+	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform1iv(location int32, count int32, value *int32) {
@@ -6390,6 +9027,12 @@ func Uniform1iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
+}
+func Uniform1ui64NV(location int32, x uint64) {
+	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -6411,6 +9054,12 @@ func Uniform2fv(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64NV(location int32, x int64, y int64) {
+	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform2iv(location int32, count int32, value *int32) {
@@ -6420,6 +9069,12 @@ func Uniform2iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
+func Uniform2ui64NV(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -6441,6 +9096,12 @@ func Uniform3fv(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64NV(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform3iv(location int32, count int32, value *int32) {
@@ -6450,6 +9111,12 @@ func Uniform3iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
+func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -6471,6 +9138,12 @@ func Uniform4fv(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform4iv(location int32, count int32, value *int32) {
@@ -6481,6 +9154,12 @@ func Uniform4iv(location int32, count int32, value *int32) {
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform4uiv(location int32, count int32, value *uint32) {
@@ -6490,6 +9169,18 @@ func Uniform4uiv(location int32, count int32, value *uint32) {
 // assign a binding point to an active uniform block
 func UniformBlockBinding(program uint32, uniformBlockIndex uint32, uniformBlockBinding uint32) {
 	C.glowUniformBlockBinding(gpUniformBlockBinding, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLuint)(uniformBlockBinding))
+}
+func UniformHandleui64IMG(location int32, value uint64) {
+	C.glowUniformHandleui64IMG(gpUniformHandleui64IMG, (C.GLint)(location), (C.GLuint64)(value))
+}
+func UniformHandleui64NV(location int32, value uint64) {
+	C.glowUniformHandleui64NV(gpUniformHandleui64NV, (C.GLint)(location), (C.GLuint64)(value))
+}
+func UniformHandleui64vIMG(location int32, count int32, value *uint64) {
+	C.glowUniformHandleui64vIMG(gpUniformHandleui64vIMG, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func UniformHandleui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformHandleui64vNV(gpUniformHandleui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -6674,13 +9365,49 @@ func VertexBindingDivisor(bindingindex uint32, divisor uint32) {
 func Viewport(x int32, y int32, width int32, height int32) {
 	C.glowViewport(gpViewport, (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func ViewportArrayvNV(first uint32, count int32, v *float32) {
+	C.glowViewportArrayvNV(gpViewportArrayvNV, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func ViewportArrayvOES(first uint32, count int32, v *float32) {
+	C.glowViewportArrayvOES(gpViewportArrayvOES, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func ViewportIndexedfNV(index uint32, x float32, y float32, w float32, h float32) {
+	C.glowViewportIndexedfNV(gpViewportIndexedfNV, (C.GLuint)(index), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(w), (C.GLfloat)(h))
+}
+func ViewportIndexedfOES(index uint32, x float32, y float32, w float32, h float32) {
+	C.glowViewportIndexedfOES(gpViewportIndexedfOES, (C.GLuint)(index), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(w), (C.GLfloat)(h))
+}
+func ViewportIndexedfvNV(index uint32, v *float32) {
+	C.glowViewportIndexedfvNV(gpViewportIndexedfvNV, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func ViewportIndexedfvOES(index uint32, v *float32) {
+	C.glowViewportIndexedfvOES(gpViewportIndexedfvOES, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
+func WaitSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, srcLayouts *uint32) {
+	C.glowWaitSemaphoreEXT(gpWaitSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(srcLayouts)))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
-func WaitSyncAPPLE(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSyncAPPLE(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSyncAPPLE(gpWaitSyncAPPLE, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
+	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
+}
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
 }
 
 // Init initializes the OpenGL bindings by loading the function pointers (for
@@ -6710,6 +9437,7 @@ func Init() error {
 // function pointer loading function. For more cases Init should be used
 // instead.
 func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
+	gpAcquireKeyedMutexWin32EXT = (C.GPACQUIREKEYEDMUTEXWIN32EXT)(getProcAddr("glAcquireKeyedMutexWin32EXT"))
 	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
 	if gpActiveShaderProgram == nil {
@@ -6721,10 +9449,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glActiveTexture")
 	}
 	gpAlphaFuncQCOM = (C.GPALPHAFUNCQCOM)(getProcAddr("glAlphaFuncQCOM"))
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpAttachShader = (C.GPATTACHSHADER)(getProcAddr("glAttachShader"))
 	if gpAttachShader == nil {
 		return errors.New("glAttachShader")
 	}
+	gpBeginConditionalRenderNV = (C.GPBEGINCONDITIONALRENDERNV)(getProcAddr("glBeginConditionalRenderNV"))
 	gpBeginPerfMonitorAMD = (C.GPBEGINPERFMONITORAMD)(getProcAddr("glBeginPerfMonitorAMD"))
 	gpBeginPerfQueryINTEL = (C.GPBEGINPERFQUERYINTEL)(getProcAddr("glBeginPerfQueryINTEL"))
 	gpBeginQuery = (C.GPBEGINQUERY)(getProcAddr("glBeginQuery"))
@@ -6752,6 +9482,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBindBufferRange == nil {
 		return errors.New("glBindBufferRange")
 	}
+	gpBindFragDataLocationEXT = (C.GPBINDFRAGDATALOCATIONEXT)(getProcAddr("glBindFragDataLocationEXT"))
+	gpBindFragDataLocationIndexedEXT = (C.GPBINDFRAGDATALOCATIONINDEXEDEXT)(getProcAddr("glBindFragDataLocationIndexedEXT"))
 	gpBindFramebuffer = (C.GPBINDFRAMEBUFFER)(getProcAddr("glBindFramebuffer"))
 	if gpBindFramebuffer == nil {
 		return errors.New("glBindFramebuffer")
@@ -6806,7 +9538,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glBlendEquationSeparate")
 	}
 	gpBlendEquationSeparateiEXT = (C.GPBLENDEQUATIONSEPARATEIEXT)(getProcAddr("glBlendEquationSeparateiEXT"))
+	gpBlendEquationSeparateiOES = (C.GPBLENDEQUATIONSEPARATEIOES)(getProcAddr("glBlendEquationSeparateiOES"))
 	gpBlendEquationiEXT = (C.GPBLENDEQUATIONIEXT)(getProcAddr("glBlendEquationiEXT"))
+	gpBlendEquationiOES = (C.GPBLENDEQUATIONIOES)(getProcAddr("glBlendEquationiOES"))
 	gpBlendFunc = (C.GPBLENDFUNC)(getProcAddr("glBlendFunc"))
 	if gpBlendFunc == nil {
 		return errors.New("glBlendFunc")
@@ -6816,7 +9550,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glBlendFuncSeparate")
 	}
 	gpBlendFuncSeparateiEXT = (C.GPBLENDFUNCSEPARATEIEXT)(getProcAddr("glBlendFuncSeparateiEXT"))
+	gpBlendFuncSeparateiOES = (C.GPBLENDFUNCSEPARATEIOES)(getProcAddr("glBlendFuncSeparateiOES"))
 	gpBlendFunciEXT = (C.GPBLENDFUNCIEXT)(getProcAddr("glBlendFunciEXT"))
+	gpBlendFunciOES = (C.GPBLENDFUNCIOES)(getProcAddr("glBlendFunciOES"))
 	gpBlendParameteriNV = (C.GPBLENDPARAMETERINV)(getProcAddr("glBlendParameteriNV"))
 	gpBlitFramebuffer = (C.GPBLITFRAMEBUFFER)(getProcAddr("glBlitFramebuffer"))
 	if gpBlitFramebuffer == nil {
@@ -6828,6 +9564,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBufferData == nil {
 		return errors.New("glBufferData")
 	}
+	gpBufferStorageEXT = (C.GPBUFFERSTORAGEEXT)(getProcAddr("glBufferStorageEXT"))
+	gpBufferStorageExternalEXT = (C.GPBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glBufferStorageExternalEXT"))
+	gpBufferStorageMemEXT = (C.GPBUFFERSTORAGEMEMEXT)(getProcAddr("glBufferStorageMemEXT"))
 	gpBufferSubData = (C.GPBUFFERSUBDATA)(getProcAddr("glBufferSubData"))
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
@@ -6864,20 +9603,25 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpClearDepthf == nil {
 		return errors.New("glClearDepthf")
 	}
+	gpClearPixelLocalStorageuiEXT = (C.GPCLEARPIXELLOCALSTORAGEUIEXT)(getProcAddr("glClearPixelLocalStorageuiEXT"))
 	gpClearStencil = (C.GPCLEARSTENCIL)(getProcAddr("glClearStencil"))
 	if gpClearStencil == nil {
 		return errors.New("glClearStencil")
 	}
+	gpClearTexImageEXT = (C.GPCLEARTEXIMAGEEXT)(getProcAddr("glClearTexImageEXT"))
+	gpClearTexSubImageEXT = (C.GPCLEARTEXSUBIMAGEEXT)(getProcAddr("glClearTexSubImageEXT"))
 	gpClientWaitSync = (C.GPCLIENTWAITSYNC)(getProcAddr("glClientWaitSync"))
 	if gpClientWaitSync == nil {
 		return errors.New("glClientWaitSync")
 	}
 	gpClientWaitSyncAPPLE = (C.GPCLIENTWAITSYNCAPPLE)(getProcAddr("glClientWaitSyncAPPLE"))
+	gpClipControlEXT = (C.GPCLIPCONTROLEXT)(getProcAddr("glClipControlEXT"))
 	gpColorMask = (C.GPCOLORMASK)(getProcAddr("glColorMask"))
 	if gpColorMask == nil {
 		return errors.New("glColorMask")
 	}
 	gpColorMaskiEXT = (C.GPCOLORMASKIEXT)(getProcAddr("glColorMaskiEXT"))
+	gpColorMaskiOES = (C.GPCOLORMASKIOES)(getProcAddr("glColorMaskiOES"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
@@ -6900,12 +9644,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glCompressedTexSubImage3D")
 	}
 	gpCompressedTexSubImage3DOES = (C.GPCOMPRESSEDTEXSUBIMAGE3DOES)(getProcAddr("glCompressedTexSubImage3DOES"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpCopyBufferSubData = (C.GPCOPYBUFFERSUBDATA)(getProcAddr("glCopyBufferSubData"))
 	if gpCopyBufferSubData == nil {
 		return errors.New("glCopyBufferSubData")
 	}
 	gpCopyBufferSubDataNV = (C.GPCOPYBUFFERSUBDATANV)(getProcAddr("glCopyBufferSubDataNV"))
 	gpCopyImageSubDataEXT = (C.GPCOPYIMAGESUBDATAEXT)(getProcAddr("glCopyImageSubDataEXT"))
+	gpCopyImageSubDataOES = (C.GPCOPYIMAGESUBDATAOES)(getProcAddr("glCopyImageSubDataOES"))
+	gpCopyPathNV = (C.GPCOPYPATHNV)(getProcAddr("glCopyPathNV"))
 	gpCopyTexImage2D = (C.GPCOPYTEXIMAGE2D)(getProcAddr("glCopyTexImage2D"))
 	if gpCopyTexImage2D == nil {
 		return errors.New("glCopyTexImage2D")
@@ -6920,8 +9667,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpCopyTexSubImage3DOES = (C.GPCOPYTEXSUBIMAGE3DOES)(getProcAddr("glCopyTexSubImage3DOES"))
 	gpCopyTextureLevelsAPPLE = (C.GPCOPYTEXTURELEVELSAPPLE)(getProcAddr("glCopyTextureLevelsAPPLE"))
+	gpCoverFillPathInstancedNV = (C.GPCOVERFILLPATHINSTANCEDNV)(getProcAddr("glCoverFillPathInstancedNV"))
+	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
+	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
+	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
 	gpCoverageMaskNV = (C.GPCOVERAGEMASKNV)(getProcAddr("glCoverageMaskNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCoverageOperationNV = (C.GPCOVERAGEOPERATIONNV)(getProcAddr("glCoverageOperationNV"))
+	gpCreateMemoryObjectsEXT = (C.GPCREATEMEMORYOBJECTSEXT)(getProcAddr("glCreateMemoryObjectsEXT"))
 	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
@@ -6956,6 +9710,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteFramebuffers == nil {
 		return errors.New("glDeleteFramebuffers")
 	}
+	gpDeleteMemoryObjectsEXT = (C.GPDELETEMEMORYOBJECTSEXT)(getProcAddr("glDeleteMemoryObjectsEXT"))
+	gpDeletePathsNV = (C.GPDELETEPATHSNV)(getProcAddr("glDeletePathsNV"))
 	gpDeletePerfMonitorsAMD = (C.GPDELETEPERFMONITORSAMD)(getProcAddr("glDeletePerfMonitorsAMD"))
 	gpDeletePerfQueryINTEL = (C.GPDELETEPERFQUERYINTEL)(getProcAddr("glDeletePerfQueryINTEL"))
 	gpDeleteProgram = (C.GPDELETEPROGRAM)(getProcAddr("glDeleteProgram"))
@@ -6980,6 +9736,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteSamplers == nil {
 		return errors.New("glDeleteSamplers")
 	}
+	gpDeleteSemaphoresEXT = (C.GPDELETESEMAPHORESEXT)(getProcAddr("glDeleteSemaphoresEXT"))
 	gpDeleteShader = (C.GPDELETESHADER)(getProcAddr("glDeleteShader"))
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
@@ -7010,6 +9767,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDepthMask == nil {
 		return errors.New("glDepthMask")
 	}
+	gpDepthRangeArrayfvNV = (C.GPDEPTHRANGEARRAYFVNV)(getProcAddr("glDepthRangeArrayfvNV"))
+	gpDepthRangeArrayfvOES = (C.GPDEPTHRANGEARRAYFVOES)(getProcAddr("glDepthRangeArrayfvOES"))
+	gpDepthRangeIndexedfNV = (C.GPDEPTHRANGEINDEXEDFNV)(getProcAddr("glDepthRangeIndexedfNV"))
+	gpDepthRangeIndexedfOES = (C.GPDEPTHRANGEINDEXEDFOES)(getProcAddr("glDepthRangeIndexedfOES"))
 	gpDepthRangef = (C.GPDEPTHRANGEF)(getProcAddr("glDepthRangef"))
 	if gpDepthRangef == nil {
 		return errors.New("glDepthRangef")
@@ -7028,6 +9789,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDisableVertexAttribArray")
 	}
 	gpDisableiEXT = (C.GPDISABLEIEXT)(getProcAddr("glDisableiEXT"))
+	gpDisableiNV = (C.GPDISABLEINV)(getProcAddr("glDisableiNV"))
+	gpDisableiOES = (C.GPDISABLEIOES)(getProcAddr("glDisableiOES"))
 	gpDiscardFramebufferEXT = (C.GPDISCARDFRAMEBUFFEREXT)(getProcAddr("glDiscardFramebufferEXT"))
 	gpDispatchCompute = (C.GPDISPATCHCOMPUTE)(getProcAddr("glDispatchCompute"))
 	if gpDispatchCompute == nil {
@@ -7050,6 +9813,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDrawArraysInstanced")
 	}
 	gpDrawArraysInstancedANGLE = (C.GPDRAWARRAYSINSTANCEDANGLE)(getProcAddr("glDrawArraysInstancedANGLE"))
+	gpDrawArraysInstancedBaseInstanceEXT = (C.GPDRAWARRAYSINSTANCEDBASEINSTANCEEXT)(getProcAddr("glDrawArraysInstancedBaseInstanceEXT"))
 	gpDrawArraysInstancedEXT = (C.GPDRAWARRAYSINSTANCEDEXT)(getProcAddr("glDrawArraysInstancedEXT"))
 	gpDrawArraysInstancedNV = (C.GPDRAWARRAYSINSTANCEDNV)(getProcAddr("glDrawArraysInstancedNV"))
 	gpDrawBuffers = (C.GPDRAWBUFFERS)(getProcAddr("glDrawBuffers"))
@@ -7063,6 +9827,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawElements == nil {
 		return errors.New("glDrawElements")
 	}
+	gpDrawElementsBaseVertexEXT = (C.GPDRAWELEMENTSBASEVERTEXEXT)(getProcAddr("glDrawElementsBaseVertexEXT"))
+	gpDrawElementsBaseVertexOES = (C.GPDRAWELEMENTSBASEVERTEXOES)(getProcAddr("glDrawElementsBaseVertexOES"))
 	gpDrawElementsIndirect = (C.GPDRAWELEMENTSINDIRECT)(getProcAddr("glDrawElementsIndirect"))
 	if gpDrawElementsIndirect == nil {
 		return errors.New("glDrawElementsIndirect")
@@ -7072,12 +9838,21 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDrawElementsInstanced")
 	}
 	gpDrawElementsInstancedANGLE = (C.GPDRAWELEMENTSINSTANCEDANGLE)(getProcAddr("glDrawElementsInstancedANGLE"))
+	gpDrawElementsInstancedBaseInstanceEXT = (C.GPDRAWELEMENTSINSTANCEDBASEINSTANCEEXT)(getProcAddr("glDrawElementsInstancedBaseInstanceEXT"))
+	gpDrawElementsInstancedBaseVertexBaseInstanceEXT = (C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCEEXT)(getProcAddr("glDrawElementsInstancedBaseVertexBaseInstanceEXT"))
+	gpDrawElementsInstancedBaseVertexEXT = (C.GPDRAWELEMENTSINSTANCEDBASEVERTEXEXT)(getProcAddr("glDrawElementsInstancedBaseVertexEXT"))
+	gpDrawElementsInstancedBaseVertexOES = (C.GPDRAWELEMENTSINSTANCEDBASEVERTEXOES)(getProcAddr("glDrawElementsInstancedBaseVertexOES"))
 	gpDrawElementsInstancedEXT = (C.GPDRAWELEMENTSINSTANCEDEXT)(getProcAddr("glDrawElementsInstancedEXT"))
 	gpDrawElementsInstancedNV = (C.GPDRAWELEMENTSINSTANCEDNV)(getProcAddr("glDrawElementsInstancedNV"))
 	gpDrawRangeElements = (C.GPDRAWRANGEELEMENTS)(getProcAddr("glDrawRangeElements"))
 	if gpDrawRangeElements == nil {
 		return errors.New("glDrawRangeElements")
 	}
+	gpDrawRangeElementsBaseVertexEXT = (C.GPDRAWRANGEELEMENTSBASEVERTEXEXT)(getProcAddr("glDrawRangeElementsBaseVertexEXT"))
+	gpDrawRangeElementsBaseVertexOES = (C.GPDRAWRANGEELEMENTSBASEVERTEXOES)(getProcAddr("glDrawRangeElementsBaseVertexOES"))
+	gpDrawTransformFeedbackEXT = (C.GPDRAWTRANSFORMFEEDBACKEXT)(getProcAddr("glDrawTransformFeedbackEXT"))
+	gpDrawTransformFeedbackInstancedEXT = (C.GPDRAWTRANSFORMFEEDBACKINSTANCEDEXT)(getProcAddr("glDrawTransformFeedbackInstancedEXT"))
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
 	gpEGLImageTargetRenderbufferStorageOES = (C.GPEGLIMAGETARGETRENDERBUFFERSTORAGEOES)(getProcAddr("glEGLImageTargetRenderbufferStorageOES"))
 	gpEGLImageTargetTexture2DOES = (C.GPEGLIMAGETARGETTEXTURE2DOES)(getProcAddr("glEGLImageTargetTexture2DOES"))
 	gpEnable = (C.GPENABLE)(getProcAddr("glEnable"))
@@ -7090,6 +9865,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glEnableVertexAttribArray")
 	}
 	gpEnableiEXT = (C.GPENABLEIEXT)(getProcAddr("glEnableiEXT"))
+	gpEnableiNV = (C.GPENABLEINV)(getProcAddr("glEnableiNV"))
+	gpEnableiOES = (C.GPENABLEIOES)(getProcAddr("glEnableiOES"))
+	gpEndConditionalRenderNV = (C.GPENDCONDITIONALRENDERNV)(getProcAddr("glEndConditionalRenderNV"))
 	gpEndPerfMonitorAMD = (C.GPENDPERFMONITORAMD)(getProcAddr("glEndPerfMonitorAMD"))
 	gpEndPerfQueryINTEL = (C.GPENDPERFQUERYINTEL)(getProcAddr("glEndPerfQueryINTEL"))
 	gpEndQuery = (C.GPENDQUERY)(getProcAddr("glEndQuery"))
@@ -7133,18 +9911,26 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glFlushMappedBufferRange")
 	}
 	gpFlushMappedBufferRangeEXT = (C.GPFLUSHMAPPEDBUFFERRANGEEXT)(getProcAddr("glFlushMappedBufferRangeEXT"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
+	gpFramebufferFetchBarrierQCOM = (C.GPFRAMEBUFFERFETCHBARRIERQCOM)(getProcAddr("glFramebufferFetchBarrierQCOM"))
+	gpFramebufferFoveationConfigQCOM = (C.GPFRAMEBUFFERFOVEATIONCONFIGQCOM)(getProcAddr("glFramebufferFoveationConfigQCOM"))
+	gpFramebufferFoveationParametersQCOM = (C.GPFRAMEBUFFERFOVEATIONPARAMETERSQCOM)(getProcAddr("glFramebufferFoveationParametersQCOM"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
 	if gpFramebufferParameteri == nil {
 		return errors.New("glFramebufferParameteri")
 	}
+	gpFramebufferPixelLocalStorageSizeEXT = (C.GPFRAMEBUFFERPIXELLOCALSTORAGESIZEEXT)(getProcAddr("glFramebufferPixelLocalStorageSizeEXT"))
 	gpFramebufferRenderbuffer = (C.GPFRAMEBUFFERRENDERBUFFER)(getProcAddr("glFramebufferRenderbuffer"))
 	if gpFramebufferRenderbuffer == nil {
 		return errors.New("glFramebufferRenderbuffer")
 	}
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
 	gpFramebufferTexture2D = (C.GPFRAMEBUFFERTEXTURE2D)(getProcAddr("glFramebufferTexture2D"))
 	if gpFramebufferTexture2D == nil {
 		return errors.New("glFramebufferTexture2D")
 	}
+	gpFramebufferTexture2DDownsampleIMG = (C.GPFRAMEBUFFERTEXTURE2DDOWNSAMPLEIMG)(getProcAddr("glFramebufferTexture2DDownsampleIMG"))
 	gpFramebufferTexture2DMultisampleEXT = (C.GPFRAMEBUFFERTEXTURE2DMULTISAMPLEEXT)(getProcAddr("glFramebufferTexture2DMultisampleEXT"))
 	gpFramebufferTexture2DMultisampleIMG = (C.GPFRAMEBUFFERTEXTURE2DMULTISAMPLEIMG)(getProcAddr("glFramebufferTexture2DMultisampleIMG"))
 	gpFramebufferTexture3DOES = (C.GPFRAMEBUFFERTEXTURE3DOES)(getProcAddr("glFramebufferTexture3DOES"))
@@ -7153,6 +9939,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpFramebufferTextureLayer == nil {
 		return errors.New("glFramebufferTextureLayer")
 	}
+	gpFramebufferTextureLayerDownsampleIMG = (C.GPFRAMEBUFFERTEXTURELAYERDOWNSAMPLEIMG)(getProcAddr("glFramebufferTextureLayerDownsampleIMG"))
+	gpFramebufferTextureMultisampleMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTISAMPLEMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultisampleMultiviewOVR"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
+	gpFramebufferTextureOES = (C.GPFRAMEBUFFERTEXTUREOES)(getProcAddr("glFramebufferTextureOES"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
 		return errors.New("glFrontFace")
@@ -7166,6 +9956,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenFramebuffers == nil {
 		return errors.New("glGenFramebuffers")
 	}
+	gpGenPathsNV = (C.GPGENPATHSNV)(getProcAddr("glGenPathsNV"))
 	gpGenPerfMonitorsAMD = (C.GPGENPERFMONITORSAMD)(getProcAddr("glGenPerfMonitorsAMD"))
 	gpGenProgramPipelines = (C.GPGENPROGRAMPIPELINES)(getProcAddr("glGenProgramPipelines"))
 	if gpGenProgramPipelines == nil {
@@ -7185,6 +9976,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenSamplers == nil {
 		return errors.New("glGenSamplers")
 	}
+	gpGenSemaphoresEXT = (C.GPGENSEMAPHORESEXT)(getProcAddr("glGenSemaphoresEXT"))
 	gpGenTextures = (C.GPGENTEXTURES)(getProcAddr("glGenTextures"))
 	if gpGenTextures == nil {
 		return errors.New("glGenTextures")
@@ -7251,6 +10043,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetBufferPointerv")
 	}
 	gpGetBufferPointervOES = (C.GPGETBUFFERPOINTERVOES)(getProcAddr("glGetBufferPointervOES"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	gpGetDebugMessageLogKHR = (C.GPGETDEBUGMESSAGELOGKHR)(getProcAddr("glGetDebugMessageLogKHR"))
 	gpGetDriverControlStringQCOM = (C.GPGETDRIVERCONTROLSTRINGQCOM)(getProcAddr("glGetDriverControlStringQCOM"))
@@ -7261,10 +10054,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetFenceivNV = (C.GPGETFENCEIVNV)(getProcAddr("glGetFenceivNV"))
 	gpGetFirstPerfQueryIdINTEL = (C.GPGETFIRSTPERFQUERYIDINTEL)(getProcAddr("glGetFirstPerfQueryIdINTEL"))
+	gpGetFloati_vNV = (C.GPGETFLOATI_VNV)(getProcAddr("glGetFloati_vNV"))
+	gpGetFloati_vOES = (C.GPGETFLOATI_VOES)(getProcAddr("glGetFloati_vOES"))
 	gpGetFloatv = (C.GPGETFLOATV)(getProcAddr("glGetFloatv"))
 	if gpGetFloatv == nil {
 		return errors.New("glGetFloatv")
 	}
+	gpGetFragDataIndexEXT = (C.GPGETFRAGDATAINDEXEXT)(getProcAddr("glGetFragDataIndexEXT"))
 	gpGetFragDataLocation = (C.GPGETFRAGDATALOCATION)(getProcAddr("glGetFragDataLocation"))
 	if gpGetFragDataLocation == nil {
 		return errors.New("glGetFragDataLocation")
@@ -7277,9 +10073,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetFramebufferParameteriv == nil {
 		return errors.New("glGetFramebufferParameteriv")
 	}
+	gpGetFramebufferPixelLocalStorageSizeEXT = (C.GPGETFRAMEBUFFERPIXELLOCALSTORAGESIZEEXT)(getProcAddr("glGetFramebufferPixelLocalStorageSizeEXT"))
 	gpGetGraphicsResetStatus = (C.GPGETGRAPHICSRESETSTATUS)(getProcAddr("glGetGraphicsResetStatus"))
 	gpGetGraphicsResetStatusEXT = (C.GPGETGRAPHICSRESETSTATUSEXT)(getProcAddr("glGetGraphicsResetStatusEXT"))
 	gpGetGraphicsResetStatusKHR = (C.GPGETGRAPHICSRESETSTATUSKHR)(getProcAddr("glGetGraphicsResetStatusKHR"))
+	gpGetImageHandleNV = (C.GPGETIMAGEHANDLENV)(getProcAddr("glGetImageHandleNV"))
 	gpGetInteger64i_v = (C.GPGETINTEGER64I_V)(getProcAddr("glGetInteger64i_v"))
 	if gpGetInteger64i_v == nil {
 		return errors.New("glGetInteger64i_v")
@@ -7298,10 +10096,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformativ = (C.GPGETINTERNALFORMATIV)(getProcAddr("glGetInternalformativ"))
 	if gpGetInternalformativ == nil {
 		return errors.New("glGetInternalformativ")
 	}
+	gpGetMemoryObjectParameterivEXT = (C.GPGETMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glGetMemoryObjectParameterivEXT"))
 	gpGetMultisamplefv = (C.GPGETMULTISAMPLEFV)(getProcAddr("glGetMultisamplefv"))
 	if gpGetMultisamplefv == nil {
 		return errors.New("glGetMultisamplefv")
@@ -7312,6 +10112,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetObjectLabelKHR = (C.GPGETOBJECTLABELKHR)(getProcAddr("glGetObjectLabelKHR"))
 	gpGetObjectPtrLabel = (C.GPGETOBJECTPTRLABEL)(getProcAddr("glGetObjectPtrLabel"))
 	gpGetObjectPtrLabelKHR = (C.GPGETOBJECTPTRLABELKHR)(getProcAddr("glGetObjectPtrLabelKHR"))
+	gpGetPathCommandsNV = (C.GPGETPATHCOMMANDSNV)(getProcAddr("glGetPathCommandsNV"))
+	gpGetPathCoordsNV = (C.GPGETPATHCOORDSNV)(getProcAddr("glGetPathCoordsNV"))
+	gpGetPathDashArrayNV = (C.GPGETPATHDASHARRAYNV)(getProcAddr("glGetPathDashArrayNV"))
+	gpGetPathLengthNV = (C.GPGETPATHLENGTHNV)(getProcAddr("glGetPathLengthNV"))
+	gpGetPathMetricRangeNV = (C.GPGETPATHMETRICRANGENV)(getProcAddr("glGetPathMetricRangeNV"))
+	gpGetPathMetricsNV = (C.GPGETPATHMETRICSNV)(getProcAddr("glGetPathMetricsNV"))
+	gpGetPathParameterfvNV = (C.GPGETPATHPARAMETERFVNV)(getProcAddr("glGetPathParameterfvNV"))
+	gpGetPathParameterivNV = (C.GPGETPATHPARAMETERIVNV)(getProcAddr("glGetPathParameterivNV"))
+	gpGetPathSpacingNV = (C.GPGETPATHSPACINGNV)(getProcAddr("glGetPathSpacingNV"))
 	gpGetPerfCounterInfoINTEL = (C.GPGETPERFCOUNTERINFOINTEL)(getProcAddr("glGetPerfCounterInfoINTEL"))
 	gpGetPerfMonitorCounterDataAMD = (C.GPGETPERFMONITORCOUNTERDATAAMD)(getProcAddr("glGetPerfMonitorCounterDataAMD"))
 	gpGetPerfMonitorCounterInfoAMD = (C.GPGETPERFMONITORCOUNTERINFOAMD)(getProcAddr("glGetPerfMonitorCounterInfoAMD"))
@@ -7355,10 +10164,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetProgramResourceLocation == nil {
 		return errors.New("glGetProgramResourceLocation")
 	}
+	gpGetProgramResourceLocationIndexEXT = (C.GPGETPROGRAMRESOURCELOCATIONINDEXEXT)(getProcAddr("glGetProgramResourceLocationIndexEXT"))
 	gpGetProgramResourceName = (C.GPGETPROGRAMRESOURCENAME)(getProcAddr("glGetProgramResourceName"))
 	if gpGetProgramResourceName == nil {
 		return errors.New("glGetProgramResourceName")
 	}
+	gpGetProgramResourcefvNV = (C.GPGETPROGRAMRESOURCEFVNV)(getProcAddr("glGetProgramResourcefvNV"))
 	gpGetProgramResourceiv = (C.GPGETPROGRAMRESOURCEIV)(getProcAddr("glGetProgramResourceiv"))
 	if gpGetProgramResourceiv == nil {
 		return errors.New("glGetProgramResourceiv")
@@ -7385,7 +10196,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetRenderbufferParameteriv")
 	}
 	gpGetSamplerParameterIivEXT = (C.GPGETSAMPLERPARAMETERIIVEXT)(getProcAddr("glGetSamplerParameterIivEXT"))
+	gpGetSamplerParameterIivOES = (C.GPGETSAMPLERPARAMETERIIVOES)(getProcAddr("glGetSamplerParameterIivOES"))
 	gpGetSamplerParameterIuivEXT = (C.GPGETSAMPLERPARAMETERIUIVEXT)(getProcAddr("glGetSamplerParameterIuivEXT"))
+	gpGetSamplerParameterIuivOES = (C.GPGETSAMPLERPARAMETERIUIVOES)(getProcAddr("glGetSamplerParameterIuivOES"))
 	gpGetSamplerParameterfv = (C.GPGETSAMPLERPARAMETERFV)(getProcAddr("glGetSamplerParameterfv"))
 	if gpGetSamplerParameterfv == nil {
 		return errors.New("glGetSamplerParameterfv")
@@ -7394,6 +10207,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetSamplerParameteriv == nil {
 		return errors.New("glGetSamplerParameteriv")
 	}
+	gpGetSemaphoreParameterui64vEXT = (C.GPGETSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glGetSemaphoreParameterui64vEXT"))
 	gpGetShaderInfoLog = (C.GPGETSHADERINFOLOG)(getProcAddr("glGetShaderInfoLog"))
 	if gpGetShaderInfoLog == nil {
 		return errors.New("glGetShaderInfoLog")
@@ -7432,7 +10246,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetTexLevelParameteriv")
 	}
 	gpGetTexParameterIivEXT = (C.GPGETTEXPARAMETERIIVEXT)(getProcAddr("glGetTexParameterIivEXT"))
+	gpGetTexParameterIivOES = (C.GPGETTEXPARAMETERIIVOES)(getProcAddr("glGetTexParameterIivOES"))
 	gpGetTexParameterIuivEXT = (C.GPGETTEXPARAMETERIUIVEXT)(getProcAddr("glGetTexParameterIuivEXT"))
+	gpGetTexParameterIuivOES = (C.GPGETTEXPARAMETERIUIVOES)(getProcAddr("glGetTexParameterIuivOES"))
 	gpGetTexParameterfv = (C.GPGETTEXPARAMETERFV)(getProcAddr("glGetTexParameterfv"))
 	if gpGetTexParameterfv == nil {
 		return errors.New("glGetTexParameterfv")
@@ -7441,6 +10257,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetTexParameteriv == nil {
 		return errors.New("glGetTexParameteriv")
 	}
+	gpGetTextureHandleIMG = (C.GPGETTEXTUREHANDLEIMG)(getProcAddr("glGetTextureHandleIMG"))
+	gpGetTextureHandleNV = (C.GPGETTEXTUREHANDLENV)(getProcAddr("glGetTextureHandleNV"))
+	gpGetTextureSamplerHandleIMG = (C.GPGETTEXTURESAMPLERHANDLEIMG)(getProcAddr("glGetTextureSamplerHandleIMG"))
+	gpGetTextureSamplerHandleNV = (C.GPGETTEXTURESAMPLERHANDLENV)(getProcAddr("glGetTextureSamplerHandleNV"))
 	gpGetTransformFeedbackVarying = (C.GPGETTRANSFORMFEEDBACKVARYING)(getProcAddr("glGetTransformFeedbackVarying"))
 	if gpGetTransformFeedbackVarying == nil {
 		return errors.New("glGetTransformFeedbackVarying")
@@ -7462,6 +10282,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetUniformfv == nil {
 		return errors.New("glGetUniformfv")
 	}
+	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
@@ -7470,6 +10291,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
 	}
+	gpGetUnsignedBytei_vEXT = (C.GPGETUNSIGNEDBYTEI_VEXT)(getProcAddr("glGetUnsignedBytei_vEXT"))
+	gpGetUnsignedBytevEXT = (C.GPGETUNSIGNEDBYTEVEXT)(getProcAddr("glGetUnsignedBytevEXT"))
 	gpGetVertexAttribIiv = (C.GPGETVERTEXATTRIBIIV)(getProcAddr("glGetVertexAttribIiv"))
 	if gpGetVertexAttribIiv == nil {
 		return errors.New("glGetVertexAttribIiv")
@@ -7490,6 +10313,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetVertexAttribiv == nil {
 		return errors.New("glGetVertexAttribiv")
 	}
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvEXT = (C.GPGETNUNIFORMFVEXT)(getProcAddr("glGetnUniformfvEXT"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
@@ -7502,7 +10326,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpHint == nil {
 		return errors.New("glHint")
 	}
+	gpImportMemoryFdEXT = (C.GPIMPORTMEMORYFDEXT)(getProcAddr("glImportMemoryFdEXT"))
+	gpImportMemoryWin32HandleEXT = (C.GPIMPORTMEMORYWIN32HANDLEEXT)(getProcAddr("glImportMemoryWin32HandleEXT"))
+	gpImportMemoryWin32NameEXT = (C.GPIMPORTMEMORYWIN32NAMEEXT)(getProcAddr("glImportMemoryWin32NameEXT"))
+	gpImportSemaphoreFdEXT = (C.GPIMPORTSEMAPHOREFDEXT)(getProcAddr("glImportSemaphoreFdEXT"))
+	gpImportSemaphoreWin32HandleEXT = (C.GPIMPORTSEMAPHOREWIN32HANDLEEXT)(getProcAddr("glImportSemaphoreWin32HandleEXT"))
+	gpImportSemaphoreWin32NameEXT = (C.GPIMPORTSEMAPHOREWIN32NAMEEXT)(getProcAddr("glImportSemaphoreWin32NameEXT"))
 	gpInsertEventMarkerEXT = (C.GPINSERTEVENTMARKEREXT)(getProcAddr("glInsertEventMarkerEXT"))
+	gpInterpolatePathsNV = (C.GPINTERPOLATEPATHSNV)(getProcAddr("glInterpolatePathsNV"))
 	gpInvalidateFramebuffer = (C.GPINVALIDATEFRAMEBUFFER)(getProcAddr("glInvalidateFramebuffer"))
 	if gpInvalidateFramebuffer == nil {
 		return errors.New("glInvalidateFramebuffer")
@@ -7520,11 +10351,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsEnabled")
 	}
 	gpIsEnablediEXT = (C.GPISENABLEDIEXT)(getProcAddr("glIsEnablediEXT"))
+	gpIsEnablediNV = (C.GPISENABLEDINV)(getProcAddr("glIsEnablediNV"))
+	gpIsEnablediOES = (C.GPISENABLEDIOES)(getProcAddr("glIsEnablediOES"))
 	gpIsFenceNV = (C.GPISFENCENV)(getProcAddr("glIsFenceNV"))
 	gpIsFramebuffer = (C.GPISFRAMEBUFFER)(getProcAddr("glIsFramebuffer"))
 	if gpIsFramebuffer == nil {
 		return errors.New("glIsFramebuffer")
 	}
+	gpIsImageHandleResidentNV = (C.GPISIMAGEHANDLERESIDENTNV)(getProcAddr("glIsImageHandleResidentNV"))
+	gpIsMemoryObjectEXT = (C.GPISMEMORYOBJECTEXT)(getProcAddr("glIsMemoryObjectEXT"))
+	gpIsPathNV = (C.GPISPATHNV)(getProcAddr("glIsPathNV"))
+	gpIsPointInFillPathNV = (C.GPISPOINTINFILLPATHNV)(getProcAddr("glIsPointInFillPathNV"))
+	gpIsPointInStrokePathNV = (C.GPISPOINTINSTROKEPATHNV)(getProcAddr("glIsPointInStrokePathNV"))
 	gpIsProgram = (C.GPISPROGRAM)(getProcAddr("glIsProgram"))
 	if gpIsProgram == nil {
 		return errors.New("glIsProgram")
@@ -7547,6 +10385,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsSampler == nil {
 		return errors.New("glIsSampler")
 	}
+	gpIsSemaphoreEXT = (C.GPISSEMAPHOREEXT)(getProcAddr("glIsSemaphoreEXT"))
 	gpIsShader = (C.GPISSHADER)(getProcAddr("glIsShader"))
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
@@ -7560,6 +10399,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsTexture == nil {
 		return errors.New("glIsTexture")
 	}
+	gpIsTextureHandleResidentNV = (C.GPISTEXTUREHANDLERESIDENTNV)(getProcAddr("glIsTextureHandleResidentNV"))
 	gpIsTransformFeedback = (C.GPISTRANSFORMFEEDBACK)(getProcAddr("glIsTransformFeedback"))
 	if gpIsTransformFeedback == nil {
 		return errors.New("glIsTransformFeedback")
@@ -7578,12 +10418,42 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpLinkProgram == nil {
 		return errors.New("glLinkProgram")
 	}
+	gpMakeImageHandleNonResidentNV = (C.GPMAKEIMAGEHANDLENONRESIDENTNV)(getProcAddr("glMakeImageHandleNonResidentNV"))
+	gpMakeImageHandleResidentNV = (C.GPMAKEIMAGEHANDLERESIDENTNV)(getProcAddr("glMakeImageHandleResidentNV"))
+	gpMakeTextureHandleNonResidentNV = (C.GPMAKETEXTUREHANDLENONRESIDENTNV)(getProcAddr("glMakeTextureHandleNonResidentNV"))
+	gpMakeTextureHandleResidentNV = (C.GPMAKETEXTUREHANDLERESIDENTNV)(getProcAddr("glMakeTextureHandleResidentNV"))
 	gpMapBufferOES = (C.GPMAPBUFFEROES)(getProcAddr("glMapBufferOES"))
 	gpMapBufferRange = (C.GPMAPBUFFERRANGE)(getProcAddr("glMapBufferRange"))
 	if gpMapBufferRange == nil {
 		return errors.New("glMapBufferRange")
 	}
 	gpMapBufferRangeEXT = (C.GPMAPBUFFERRANGEEXT)(getProcAddr("glMapBufferRangeEXT"))
+	gpMatrixFrustumEXT = (C.GPMATRIXFRUSTUMEXT)(getProcAddr("glMatrixFrustumEXT"))
+	gpMatrixLoad3x2fNV = (C.GPMATRIXLOAD3X2FNV)(getProcAddr("glMatrixLoad3x2fNV"))
+	gpMatrixLoad3x3fNV = (C.GPMATRIXLOAD3X3FNV)(getProcAddr("glMatrixLoad3x3fNV"))
+	gpMatrixLoadIdentityEXT = (C.GPMATRIXLOADIDENTITYEXT)(getProcAddr("glMatrixLoadIdentityEXT"))
+	gpMatrixLoadTranspose3x3fNV = (C.GPMATRIXLOADTRANSPOSE3X3FNV)(getProcAddr("glMatrixLoadTranspose3x3fNV"))
+	gpMatrixLoadTransposedEXT = (C.GPMATRIXLOADTRANSPOSEDEXT)(getProcAddr("glMatrixLoadTransposedEXT"))
+	gpMatrixLoadTransposefEXT = (C.GPMATRIXLOADTRANSPOSEFEXT)(getProcAddr("glMatrixLoadTransposefEXT"))
+	gpMatrixLoaddEXT = (C.GPMATRIXLOADDEXT)(getProcAddr("glMatrixLoaddEXT"))
+	gpMatrixLoadfEXT = (C.GPMATRIXLOADFEXT)(getProcAddr("glMatrixLoadfEXT"))
+	gpMatrixMult3x2fNV = (C.GPMATRIXMULT3X2FNV)(getProcAddr("glMatrixMult3x2fNV"))
+	gpMatrixMult3x3fNV = (C.GPMATRIXMULT3X3FNV)(getProcAddr("glMatrixMult3x3fNV"))
+	gpMatrixMultTranspose3x3fNV = (C.GPMATRIXMULTTRANSPOSE3X3FNV)(getProcAddr("glMatrixMultTranspose3x3fNV"))
+	gpMatrixMultTransposedEXT = (C.GPMATRIXMULTTRANSPOSEDEXT)(getProcAddr("glMatrixMultTransposedEXT"))
+	gpMatrixMultTransposefEXT = (C.GPMATRIXMULTTRANSPOSEFEXT)(getProcAddr("glMatrixMultTransposefEXT"))
+	gpMatrixMultdEXT = (C.GPMATRIXMULTDEXT)(getProcAddr("glMatrixMultdEXT"))
+	gpMatrixMultfEXT = (C.GPMATRIXMULTFEXT)(getProcAddr("glMatrixMultfEXT"))
+	gpMatrixOrthoEXT = (C.GPMATRIXORTHOEXT)(getProcAddr("glMatrixOrthoEXT"))
+	gpMatrixPopEXT = (C.GPMATRIXPOPEXT)(getProcAddr("glMatrixPopEXT"))
+	gpMatrixPushEXT = (C.GPMATRIXPUSHEXT)(getProcAddr("glMatrixPushEXT"))
+	gpMatrixRotatedEXT = (C.GPMATRIXROTATEDEXT)(getProcAddr("glMatrixRotatedEXT"))
+	gpMatrixRotatefEXT = (C.GPMATRIXROTATEFEXT)(getProcAddr("glMatrixRotatefEXT"))
+	gpMatrixScaledEXT = (C.GPMATRIXSCALEDEXT)(getProcAddr("glMatrixScaledEXT"))
+	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
+	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
+	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	if gpMemoryBarrier == nil {
 		return errors.New("glMemoryBarrier")
@@ -7592,14 +10462,40 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpMemoryBarrierByRegion == nil {
 		return errors.New("glMemoryBarrierByRegion")
 	}
+	gpMemoryObjectParameterivEXT = (C.GPMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glMemoryObjectParameterivEXT"))
 	gpMinSampleShadingOES = (C.GPMINSAMPLESHADINGOES)(getProcAddr("glMinSampleShadingOES"))
 	gpMultiDrawArraysEXT = (C.GPMULTIDRAWARRAYSEXT)(getProcAddr("glMultiDrawArraysEXT"))
+	gpMultiDrawArraysIndirectEXT = (C.GPMULTIDRAWARRAYSINDIRECTEXT)(getProcAddr("glMultiDrawArraysIndirectEXT"))
+	gpMultiDrawElementsBaseVertexEXT = (C.GPMULTIDRAWELEMENTSBASEVERTEXEXT)(getProcAddr("glMultiDrawElementsBaseVertexEXT"))
 	gpMultiDrawElementsEXT = (C.GPMULTIDRAWELEMENTSEXT)(getProcAddr("glMultiDrawElementsEXT"))
+	gpMultiDrawElementsIndirectEXT = (C.GPMULTIDRAWELEMENTSINDIRECTEXT)(getProcAddr("glMultiDrawElementsIndirectEXT"))
+	gpNamedBufferStorageExternalEXT = (C.GPNAMEDBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glNamedBufferStorageExternalEXT"))
+	gpNamedBufferStorageMemEXT = (C.GPNAMEDBUFFERSTORAGEMEMEXT)(getProcAddr("glNamedBufferStorageMemEXT"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
 	gpObjectLabel = (C.GPOBJECTLABEL)(getProcAddr("glObjectLabel"))
 	gpObjectLabelKHR = (C.GPOBJECTLABELKHR)(getProcAddr("glObjectLabelKHR"))
 	gpObjectPtrLabel = (C.GPOBJECTPTRLABEL)(getProcAddr("glObjectPtrLabel"))
 	gpObjectPtrLabelKHR = (C.GPOBJECTPTRLABELKHR)(getProcAddr("glObjectPtrLabelKHR"))
 	gpPatchParameteriEXT = (C.GPPATCHPARAMETERIEXT)(getProcAddr("glPatchParameteriEXT"))
+	gpPatchParameteriOES = (C.GPPATCHPARAMETERIOES)(getProcAddr("glPatchParameteriOES"))
+	gpPathCommandsNV = (C.GPPATHCOMMANDSNV)(getProcAddr("glPathCommandsNV"))
+	gpPathCoordsNV = (C.GPPATHCOORDSNV)(getProcAddr("glPathCoordsNV"))
+	gpPathCoverDepthFuncNV = (C.GPPATHCOVERDEPTHFUNCNV)(getProcAddr("glPathCoverDepthFuncNV"))
+	gpPathDashArrayNV = (C.GPPATHDASHARRAYNV)(getProcAddr("glPathDashArrayNV"))
+	gpPathGlyphIndexArrayNV = (C.GPPATHGLYPHINDEXARRAYNV)(getProcAddr("glPathGlyphIndexArrayNV"))
+	gpPathGlyphIndexRangeNV = (C.GPPATHGLYPHINDEXRANGENV)(getProcAddr("glPathGlyphIndexRangeNV"))
+	gpPathGlyphRangeNV = (C.GPPATHGLYPHRANGENV)(getProcAddr("glPathGlyphRangeNV"))
+	gpPathGlyphsNV = (C.GPPATHGLYPHSNV)(getProcAddr("glPathGlyphsNV"))
+	gpPathMemoryGlyphIndexArrayNV = (C.GPPATHMEMORYGLYPHINDEXARRAYNV)(getProcAddr("glPathMemoryGlyphIndexArrayNV"))
+	gpPathParameterfNV = (C.GPPATHPARAMETERFNV)(getProcAddr("glPathParameterfNV"))
+	gpPathParameterfvNV = (C.GPPATHPARAMETERFVNV)(getProcAddr("glPathParameterfvNV"))
+	gpPathParameteriNV = (C.GPPATHPARAMETERINV)(getProcAddr("glPathParameteriNV"))
+	gpPathParameterivNV = (C.GPPATHPARAMETERIVNV)(getProcAddr("glPathParameterivNV"))
+	gpPathStencilDepthOffsetNV = (C.GPPATHSTENCILDEPTHOFFSETNV)(getProcAddr("glPathStencilDepthOffsetNV"))
+	gpPathStencilFuncNV = (C.GPPATHSTENCILFUNCNV)(getProcAddr("glPathStencilFuncNV"))
+	gpPathStringNV = (C.GPPATHSTRINGNV)(getProcAddr("glPathStringNV"))
+	gpPathSubCommandsNV = (C.GPPATHSUBCOMMANDSNV)(getProcAddr("glPathSubCommandsNV"))
+	gpPathSubCoordsNV = (C.GPPATHSUBCOORDSNV)(getProcAddr("glPathSubCoordsNV"))
 	gpPauseTransformFeedback = (C.GPPAUSETRANSFORMFEEDBACK)(getProcAddr("glPauseTransformFeedback"))
 	if gpPauseTransformFeedback == nil {
 		return errors.New("glPauseTransformFeedback")
@@ -7608,14 +10504,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPixelStorei == nil {
 		return errors.New("glPixelStorei")
 	}
+	gpPointAlongPathNV = (C.GPPOINTALONGPATHNV)(getProcAddr("glPointAlongPathNV"))
+	gpPolygonModeNV = (C.GPPOLYGONMODENV)(getProcAddr("glPolygonModeNV"))
 	gpPolygonOffset = (C.GPPOLYGONOFFSET)(getProcAddr("glPolygonOffset"))
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPopDebugGroup = (C.GPPOPDEBUGGROUP)(getProcAddr("glPopDebugGroup"))
 	gpPopDebugGroupKHR = (C.GPPOPDEBUGGROUPKHR)(getProcAddr("glPopDebugGroupKHR"))
 	gpPopGroupMarkerEXT = (C.GPPOPGROUPMARKEREXT)(getProcAddr("glPopGroupMarkerEXT"))
 	gpPrimitiveBoundingBoxEXT = (C.GPPRIMITIVEBOUNDINGBOXEXT)(getProcAddr("glPrimitiveBoundingBoxEXT"))
+	gpPrimitiveBoundingBoxOES = (C.GPPRIMITIVEBOUNDINGBOXOES)(getProcAddr("glPrimitiveBoundingBoxOES"))
 	gpProgramBinary = (C.GPPROGRAMBINARY)(getProcAddr("glProgramBinary"))
 	if gpProgramBinary == nil {
 		return errors.New("glProgramBinary")
@@ -7626,6 +10526,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glProgramParameteri")
 	}
 	gpProgramParameteriEXT = (C.GPPROGRAMPARAMETERIEXT)(getProcAddr("glProgramParameteriEXT"))
+	gpProgramPathFragmentInputGenNV = (C.GPPROGRAMPATHFRAGMENTINPUTGENNV)(getProcAddr("glProgramPathFragmentInputGenNV"))
 	gpProgramUniform1f = (C.GPPROGRAMUNIFORM1F)(getProcAddr("glProgramUniform1f"))
 	if gpProgramUniform1f == nil {
 		return errors.New("glProgramUniform1f")
@@ -7640,6 +10541,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform1i == nil {
 		return errors.New("glProgramUniform1i")
 	}
+	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
 	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
 	if gpProgramUniform1iv == nil {
@@ -7650,6 +10553,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform1ui == nil {
 		return errors.New("glProgramUniform1ui")
 	}
+	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
 	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
 	if gpProgramUniform1uiv == nil {
@@ -7670,6 +10575,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform2i == nil {
 		return errors.New("glProgramUniform2i")
 	}
+	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
 	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
 	if gpProgramUniform2iv == nil {
@@ -7680,6 +10587,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform2ui == nil {
 		return errors.New("glProgramUniform2ui")
 	}
+	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
 	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
 	if gpProgramUniform2uiv == nil {
@@ -7700,6 +10609,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform3i == nil {
 		return errors.New("glProgramUniform3i")
 	}
+	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
 	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
 	if gpProgramUniform3iv == nil {
@@ -7710,6 +10621,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform3ui == nil {
 		return errors.New("glProgramUniform3ui")
 	}
+	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
 	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
 	if gpProgramUniform3uiv == nil {
@@ -7730,6 +10643,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform4i == nil {
 		return errors.New("glProgramUniform4i")
 	}
+	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
 	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
 	if gpProgramUniform4iv == nil {
@@ -7740,12 +10655,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform4ui == nil {
 		return errors.New("glProgramUniform4ui")
 	}
+	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
 	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
 	if gpProgramUniform4uiv == nil {
 		return errors.New("glProgramUniform4uiv")
 	}
 	gpProgramUniform4uivEXT = (C.GPPROGRAMUNIFORM4UIVEXT)(getProcAddr("glProgramUniform4uivEXT"))
+	gpProgramUniformHandleui64IMG = (C.GPPROGRAMUNIFORMHANDLEUI64IMG)(getProcAddr("glProgramUniformHandleui64IMG"))
+	gpProgramUniformHandleui64NV = (C.GPPROGRAMUNIFORMHANDLEUI64NV)(getProcAddr("glProgramUniformHandleui64NV"))
+	gpProgramUniformHandleui64vIMG = (C.GPPROGRAMUNIFORMHANDLEUI64VIMG)(getProcAddr("glProgramUniformHandleui64vIMG"))
+	gpProgramUniformHandleui64vNV = (C.GPPROGRAMUNIFORMHANDLEUI64VNV)(getProcAddr("glProgramUniformHandleui64vNV"))
 	gpProgramUniformMatrix2fv = (C.GPPROGRAMUNIFORMMATRIX2FV)(getProcAddr("glProgramUniformMatrix2fv"))
 	if gpProgramUniformMatrix2fv == nil {
 		return errors.New("glProgramUniformMatrix2fv")
@@ -7795,6 +10716,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpPushDebugGroupKHR = (C.GPPUSHDEBUGGROUPKHR)(getProcAddr("glPushDebugGroupKHR"))
 	gpPushGroupMarkerEXT = (C.GPPUSHGROUPMARKEREXT)(getProcAddr("glPushGroupMarkerEXT"))
 	gpQueryCounterEXT = (C.GPQUERYCOUNTEREXT)(getProcAddr("glQueryCounterEXT"))
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -7808,6 +10730,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpReadnPixels = (C.GPREADNPIXELS)(getProcAddr("glReadnPixels"))
 	gpReadnPixelsEXT = (C.GPREADNPIXELSEXT)(getProcAddr("glReadnPixelsEXT"))
 	gpReadnPixelsKHR = (C.GPREADNPIXELSKHR)(getProcAddr("glReadnPixelsKHR"))
+	gpReleaseKeyedMutexWin32EXT = (C.GPRELEASEKEYEDMUTEXWIN32EXT)(getProcAddr("glReleaseKeyedMutexWin32EXT"))
 	gpReleaseShaderCompiler = (C.GPRELEASESHADERCOMPILER)(getProcAddr("glReleaseShaderCompiler"))
 	if gpReleaseShaderCompiler == nil {
 		return errors.New("glReleaseShaderCompiler")
@@ -7825,6 +10748,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpRenderbufferStorageMultisampleEXT = (C.GPRENDERBUFFERSTORAGEMULTISAMPLEEXT)(getProcAddr("glRenderbufferStorageMultisampleEXT"))
 	gpRenderbufferStorageMultisampleIMG = (C.GPRENDERBUFFERSTORAGEMULTISAMPLEIMG)(getProcAddr("glRenderbufferStorageMultisampleIMG"))
 	gpRenderbufferStorageMultisampleNV = (C.GPRENDERBUFFERSTORAGEMULTISAMPLENV)(getProcAddr("glRenderbufferStorageMultisampleNV"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResolveMultisampleFramebufferAPPLE = (C.GPRESOLVEMULTISAMPLEFRAMEBUFFERAPPLE)(getProcAddr("glResolveMultisampleFramebufferAPPLE"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	if gpResumeTransformFeedback == nil {
@@ -7839,7 +10763,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSampleMaski")
 	}
 	gpSamplerParameterIivEXT = (C.GPSAMPLERPARAMETERIIVEXT)(getProcAddr("glSamplerParameterIivEXT"))
+	gpSamplerParameterIivOES = (C.GPSAMPLERPARAMETERIIVOES)(getProcAddr("glSamplerParameterIivOES"))
 	gpSamplerParameterIuivEXT = (C.GPSAMPLERPARAMETERIUIVEXT)(getProcAddr("glSamplerParameterIuivEXT"))
+	gpSamplerParameterIuivOES = (C.GPSAMPLERPARAMETERIUIVOES)(getProcAddr("glSamplerParameterIuivOES"))
 	gpSamplerParameterf = (C.GPSAMPLERPARAMETERF)(getProcAddr("glSamplerParameterf"))
 	if gpSamplerParameterf == nil {
 		return errors.New("glSamplerParameterf")
@@ -7860,7 +10786,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpScissor == nil {
 		return errors.New("glScissor")
 	}
+	gpScissorArrayvNV = (C.GPSCISSORARRAYVNV)(getProcAddr("glScissorArrayvNV"))
+	gpScissorArrayvOES = (C.GPSCISSORARRAYVOES)(getProcAddr("glScissorArrayvOES"))
+	gpScissorIndexedNV = (C.GPSCISSORINDEXEDNV)(getProcAddr("glScissorIndexedNV"))
+	gpScissorIndexedOES = (C.GPSCISSORINDEXEDOES)(getProcAddr("glScissorIndexedOES"))
+	gpScissorIndexedvNV = (C.GPSCISSORINDEXEDVNV)(getProcAddr("glScissorIndexedvNV"))
+	gpScissorIndexedvOES = (C.GPSCISSORINDEXEDVOES)(getProcAddr("glScissorIndexedvOES"))
 	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
+	gpSemaphoreParameterui64vEXT = (C.GPSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glSemaphoreParameterui64vEXT"))
 	gpSetFenceNV = (C.GPSETFENCENV)(getProcAddr("glSetFenceNV"))
 	gpShaderBinary = (C.GPSHADERBINARY)(getProcAddr("glShaderBinary"))
 	if gpShaderBinary == nil {
@@ -7870,7 +10803,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpShaderSource == nil {
 		return errors.New("glShaderSource")
 	}
+	gpSignalSemaphoreEXT = (C.GPSIGNALSEMAPHOREEXT)(getProcAddr("glSignalSemaphoreEXT"))
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
 	gpStartTilingQCOM = (C.GPSTARTTILINGQCOM)(getProcAddr("glStartTilingQCOM"))
+	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
+	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
 	gpStencilFunc = (C.GPSTENCILFUNC)(getProcAddr("glStencilFunc"))
 	if gpStencilFunc == nil {
 		return errors.New("glStencilFunc")
@@ -7895,9 +10833,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpStencilOpSeparate == nil {
 		return errors.New("glStencilOpSeparate")
 	}
+	gpStencilStrokePathInstancedNV = (C.GPSTENCILSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilStrokePathInstancedNV"))
+	gpStencilStrokePathNV = (C.GPSTENCILSTROKEPATHNV)(getProcAddr("glStencilStrokePathNV"))
+	gpStencilThenCoverFillPathInstancedNV = (C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverFillPathInstancedNV"))
+	gpStencilThenCoverFillPathNV = (C.GPSTENCILTHENCOVERFILLPATHNV)(getProcAddr("glStencilThenCoverFillPathNV"))
+	gpStencilThenCoverStrokePathInstancedNV = (C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverStrokePathInstancedNV"))
+	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpTestFenceNV = (C.GPTESTFENCENV)(getProcAddr("glTestFenceNV"))
 	gpTexBufferEXT = (C.GPTEXBUFFEREXT)(getProcAddr("glTexBufferEXT"))
+	gpTexBufferOES = (C.GPTEXBUFFEROES)(getProcAddr("glTexBufferOES"))
 	gpTexBufferRangeEXT = (C.GPTEXBUFFERRANGEEXT)(getProcAddr("glTexBufferRangeEXT"))
+	gpTexBufferRangeOES = (C.GPTEXBUFFERRANGEOES)(getProcAddr("glTexBufferRangeOES"))
 	gpTexImage2D = (C.GPTEXIMAGE2D)(getProcAddr("glTexImage2D"))
 	if gpTexImage2D == nil {
 		return errors.New("glTexImage2D")
@@ -7907,8 +10854,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glTexImage3D")
 	}
 	gpTexImage3DOES = (C.GPTEXIMAGE3DOES)(getProcAddr("glTexImage3DOES"))
+	gpTexPageCommitmentEXT = (C.GPTEXPAGECOMMITMENTEXT)(getProcAddr("glTexPageCommitmentEXT"))
 	gpTexParameterIivEXT = (C.GPTEXPARAMETERIIVEXT)(getProcAddr("glTexParameterIivEXT"))
+	gpTexParameterIivOES = (C.GPTEXPARAMETERIIVOES)(getProcAddr("glTexParameterIivOES"))
 	gpTexParameterIuivEXT = (C.GPTEXPARAMETERIUIVEXT)(getProcAddr("glTexParameterIuivEXT"))
+	gpTexParameterIuivOES = (C.GPTEXPARAMETERIUIVOES)(getProcAddr("glTexParameterIuivOES"))
 	gpTexParameterf = (C.GPTEXPARAMETERF)(getProcAddr("glTexParameterf"))
 	if gpTexParameterf == nil {
 		return errors.New("glTexParameterf")
@@ -7941,6 +10891,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpTexStorage3DEXT = (C.GPTEXSTORAGE3DEXT)(getProcAddr("glTexStorage3DEXT"))
 	gpTexStorage3DMultisampleOES = (C.GPTEXSTORAGE3DMULTISAMPLEOES)(getProcAddr("glTexStorage3DMultisampleOES"))
+	gpTexStorageMem1DEXT = (C.GPTEXSTORAGEMEM1DEXT)(getProcAddr("glTexStorageMem1DEXT"))
+	gpTexStorageMem2DEXT = (C.GPTEXSTORAGEMEM2DEXT)(getProcAddr("glTexStorageMem2DEXT"))
+	gpTexStorageMem2DMultisampleEXT = (C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem2DMultisampleEXT"))
+	gpTexStorageMem3DEXT = (C.GPTEXSTORAGEMEM3DEXT)(getProcAddr("glTexStorageMem3DEXT"))
+	gpTexStorageMem3DMultisampleEXT = (C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem3DMultisampleEXT"))
 	gpTexSubImage2D = (C.GPTEXSUBIMAGE2D)(getProcAddr("glTexSubImage2D"))
 	if gpTexSubImage2D == nil {
 		return errors.New("glTexSubImage2D")
@@ -7950,14 +10905,22 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glTexSubImage3D")
 	}
 	gpTexSubImage3DOES = (C.GPTEXSUBIMAGE3DOES)(getProcAddr("glTexSubImage3DOES"))
+	gpTextureFoveationParametersQCOM = (C.GPTEXTUREFOVEATIONPARAMETERSQCOM)(getProcAddr("glTextureFoveationParametersQCOM"))
 	gpTextureStorage1DEXT = (C.GPTEXTURESTORAGE1DEXT)(getProcAddr("glTextureStorage1DEXT"))
 	gpTextureStorage2DEXT = (C.GPTEXTURESTORAGE2DEXT)(getProcAddr("glTextureStorage2DEXT"))
 	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
+	gpTextureStorageMem1DEXT = (C.GPTEXTURESTORAGEMEM1DEXT)(getProcAddr("glTextureStorageMem1DEXT"))
+	gpTextureStorageMem2DEXT = (C.GPTEXTURESTORAGEMEM2DEXT)(getProcAddr("glTextureStorageMem2DEXT"))
+	gpTextureStorageMem2DMultisampleEXT = (C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem2DMultisampleEXT"))
+	gpTextureStorageMem3DEXT = (C.GPTEXTURESTORAGEMEM3DEXT)(getProcAddr("glTextureStorageMem3DEXT"))
+	gpTextureStorageMem3DMultisampleEXT = (C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem3DMultisampleEXT"))
 	gpTextureViewEXT = (C.GPTEXTUREVIEWEXT)(getProcAddr("glTextureViewEXT"))
+	gpTextureViewOES = (C.GPTEXTUREVIEWOES)(getProcAddr("glTextureViewOES"))
 	gpTransformFeedbackVaryings = (C.GPTRANSFORMFEEDBACKVARYINGS)(getProcAddr("glTransformFeedbackVaryings"))
 	if gpTransformFeedbackVaryings == nil {
 		return errors.New("glTransformFeedbackVaryings")
 	}
+	gpTransformPathNV = (C.GPTRANSFORMPATHNV)(getProcAddr("glTransformPathNV"))
 	gpUniform1f = (C.GPUNIFORM1F)(getProcAddr("glUniform1f"))
 	if gpUniform1f == nil {
 		return errors.New("glUniform1f")
@@ -7970,6 +10933,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
 	if gpUniform1iv == nil {
 		return errors.New("glUniform1iv")
@@ -7978,6 +10943,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
 	if gpUniform1uiv == nil {
 		return errors.New("glUniform1uiv")
@@ -7994,6 +10961,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
 	if gpUniform2iv == nil {
 		return errors.New("glUniform2iv")
@@ -8002,6 +10971,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
 	if gpUniform2uiv == nil {
 		return errors.New("glUniform2uiv")
@@ -8018,6 +10989,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
 	if gpUniform3iv == nil {
 		return errors.New("glUniform3iv")
@@ -8026,6 +10999,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
 	if gpUniform3uiv == nil {
 		return errors.New("glUniform3uiv")
@@ -8042,6 +11017,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
 	if gpUniform4iv == nil {
 		return errors.New("glUniform4iv")
@@ -8050,6 +11027,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
 	if gpUniform4uiv == nil {
 		return errors.New("glUniform4uiv")
@@ -8058,6 +11037,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniformBlockBinding == nil {
 		return errors.New("glUniformBlockBinding")
 	}
+	gpUniformHandleui64IMG = (C.GPUNIFORMHANDLEUI64IMG)(getProcAddr("glUniformHandleui64IMG"))
+	gpUniformHandleui64NV = (C.GPUNIFORMHANDLEUI64NV)(getProcAddr("glUniformHandleui64NV"))
+	gpUniformHandleui64vIMG = (C.GPUNIFORMHANDLEUI64VIMG)(getProcAddr("glUniformHandleui64vIMG"))
+	gpUniformHandleui64vNV = (C.GPUNIFORMHANDLEUI64VNV)(getProcAddr("glUniformHandleui64vNV"))
 	gpUniformMatrix2fv = (C.GPUNIFORMMATRIX2FV)(getProcAddr("glUniformMatrix2fv"))
 	if gpUniformMatrix2fv == nil {
 		return errors.New("glUniformMatrix2fv")
@@ -8207,10 +11190,22 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpViewport == nil {
 		return errors.New("glViewport")
 	}
+	gpViewportArrayvNV = (C.GPVIEWPORTARRAYVNV)(getProcAddr("glViewportArrayvNV"))
+	gpViewportArrayvOES = (C.GPVIEWPORTARRAYVOES)(getProcAddr("glViewportArrayvOES"))
+	gpViewportIndexedfNV = (C.GPVIEWPORTINDEXEDFNV)(getProcAddr("glViewportIndexedfNV"))
+	gpViewportIndexedfOES = (C.GPVIEWPORTINDEXEDFOES)(getProcAddr("glViewportIndexedfOES"))
+	gpViewportIndexedfvNV = (C.GPVIEWPORTINDEXEDFVNV)(getProcAddr("glViewportIndexedfvNV"))
+	gpViewportIndexedfvOES = (C.GPVIEWPORTINDEXEDFVOES)(getProcAddr("glViewportIndexedfvOES"))
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
+	gpWaitSemaphoreEXT = (C.GPWAITSEMAPHOREEXT)(getProcAddr("glWaitSemaphoreEXT"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
 	gpWaitSyncAPPLE = (C.GPWAITSYNCAPPLE)(getProcAddr("glWaitSyncAPPLE"))
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
+	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	return nil
 }

--- a/v3.1/gles2/procaddr.go
+++ b/v3.1/gles2/procaddr.go
@@ -51,7 +51,7 @@ package gles2
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_gles231(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v3.2-compatibility/gl/package.go
+++ b/v3.2-compatibility/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -75,7 +73,6 @@ package gl
 // typedef unsigned int GLenum;
 // typedef unsigned char GLboolean;
 // typedef unsigned int GLbitfield;
-// typedef void GLvoid;
 // typedef signed char GLbyte;
 // typedef short GLshort;
 // typedef int GLint;
@@ -88,6 +85,7 @@ package gl
 // typedef float GLclampf;
 // typedef double GLdouble;
 // typedef double GLclampd;
+// typedef void *GLeglClientBufferEXT;
 // typedef char GLchar;
 // typedef char GLcharARB;
 // #ifdef __APPLE__
@@ -104,7 +102,7 @@ package gl
 // typedef ptrdiff_t GLsizeiptrARB;
 // typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
@@ -113,12 +111,14 @@ package gl
 // typedef void (APIENTRY *GLDEBUGPROCAMD)(GLuint id,GLenum category,GLenum severity,GLsizei length,const GLchar *message,void *userParam);
 // typedef unsigned short GLhalfNV;
 // typedef GLintptr GLvdpauSurfaceNV;
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcompatibility32(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcompatibility32(source, type, id, severity, length, message, userParam);
 // }
 // typedef void  (APIENTRYP GPACCUM)(GLenum  op, GLfloat  value);
 // typedef void  (APIENTRYP GPACCUMXOES)(GLenum  op, GLfixed  value);
+// typedef GLboolean  (APIENTRYP GPACQUIREKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key, GLuint  timeout);
 // typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
@@ -131,6 +131,8 @@ package gl
 // typedef void  (APIENTRYP GPALPHAFRAGMENTOP3ATI)(GLenum  op, GLuint  dst, GLuint  dstMod, GLuint  arg1, GLuint  arg1Rep, GLuint  arg1Mod, GLuint  arg2, GLuint  arg2Rep, GLuint  arg2Mod, GLuint  arg3, GLuint  arg3Rep, GLuint  arg3Mod);
 // typedef void  (APIENTRYP GPALPHAFUNC)(GLenum  func, GLfloat  ref);
 // typedef void  (APIENTRYP GPALPHAFUNCXOES)(GLenum  func, GLfixed  ref);
+// typedef void  (APIENTRYP GPALPHATOCOVERAGEDITHERCONTROLNV)(GLenum  mode);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPAPPLYTEXTUREEXT)(GLenum  mode);
 // typedef GLboolean  (APIENTRYP GPAREPROGRAMSRESIDENTNV)(GLsizei  n, const GLuint * programs, GLboolean * residences);
 // typedef GLboolean  (APIENTRYP GPARETEXTURESRESIDENT)(GLsizei  n, const GLuint * textures, GLboolean * residences);
@@ -248,11 +250,14 @@ package gl
 // typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPBUFFERDATAARB)(GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERPARAMETERIAPPLE)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEEXTERNALEXT)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEMEMEXT)(GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPBUFFERSUBDATAARB)(GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLIST)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLISTS)(GLsizei  n, GLenum  type, const void * lists);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
@@ -282,9 +287,9 @@ package gl
 // typedef void  (APIENTRYP GPCLEARINDEX)(GLfloat  c);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
@@ -380,6 +385,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERIVNV)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERARB)(GLhandleARB  shaderObj);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
@@ -410,6 +417,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER2D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * image);
@@ -440,7 +449,7 @@ package gl
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  type);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
@@ -465,8 +474,12 @@ package gl
 // typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEMEMORYOBJECTSEXT)(GLsizei  n, GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef GLhandleARB  (APIENTRYP GPCREATEPROGRAMOBJECTARB)();
@@ -479,6 +492,7 @@ package gl
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -505,12 +519,14 @@ package gl
 // typedef void  (APIENTRYP GPDELETEASYNCMARKERSSGIX)(GLuint  marker, GLsizei  range);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
 // typedef void  (APIENTRYP GPDELETEBUFFERSARB)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFENCESAPPLE)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFENCESNV)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFRAGMENTSHADERATI)(GLuint  id);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERSEXT)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETELISTS)(GLuint  list, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEMEMORYOBJECTSEXT)(GLsizei  n, const GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
 // typedef void  (APIENTRYP GPDELETENAMESAMD)(GLenum  identifier, GLuint  num, const GLuint * names);
 // typedef void  (APIENTRYP GPDELETEOBJECTARB)(GLhandleARB  obj);
@@ -525,10 +541,13 @@ package gl
 // typedef void  (APIENTRYP GPDELETEPROGRAMSNV)(GLsizei  n, const GLuint * programs);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETEQUERIESARB)(GLsizei  n, const GLuint * ids);
+// typedef void  (APIENTRYP GPDELETEQUERYRESOURCETAGNV)(GLsizei  n, const GLint * tagIds);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERSEXT)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
+// typedef void  (APIENTRYP GPDELETESEMAPHORESEXT)(GLsizei  n, const GLuint * semaphores);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETEXTURESEXT)(GLsizei  n, const GLuint * textures);
@@ -578,6 +597,10 @@ package gl
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSARB)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSATI)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYAPPLE)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYATI)(GLenum  mode, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
@@ -602,6 +625,7 @@ package gl
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKNV)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
 // typedef void  (APIENTRYP GPEDGEFLAG)(GLboolean  flag);
 // typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPEDGEFLAGPOINTER)(GLsizei  stride, const void * pointer);
@@ -657,6 +681,7 @@ package gl
 // typedef void  (APIENTRYP GPEVALMESH2)(GLenum  mode, GLint  i1, GLint  i2, GLint  j1, GLint  j2);
 // typedef void  (APIENTRYP GPEVALPOINT1)(GLint  i);
 // typedef void  (APIENTRYP GPEVALPOINT2)(GLint  i, GLint  j);
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef void  (APIENTRYP GPEXECUTEPROGRAMNV)(GLenum  target, GLuint  id, const GLfloat * params);
 // typedef void  (APIENTRYP GPEXTRACTCOMPONENTEXT)(GLuint  res, GLuint  src, GLuint  num);
 // typedef void  (APIENTRYP GPFEEDBACKBUFFER)(GLsizei  size, GLenum  type, GLfloat * buffer);
@@ -672,7 +697,7 @@ package gl
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGEAPPLE)(GLenum  target, GLintptr  offset, GLsizeiptr  size);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHPIXELDATARANGENV)(GLenum  target);
 // typedef void  (APIENTRYP GPFLUSHRASTERSGIX)();
@@ -701,6 +726,7 @@ package gl
 // typedef void  (APIENTRYP GPFOGXOES)(GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPFOGXVOES)(GLenum  pname, const GLfixed * param);
 // typedef void  (APIENTRYP GPFRAGMENTCOLORMATERIALSGIX)(GLenum  face, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELISGIX)(GLenum  pname, GLint  param);
@@ -717,10 +743,14 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEZOOMSGIX)(GLint  factor);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFEREXT)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1DEXT)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -735,6 +765,7 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYEREXT)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFREEOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPFRUSTUM)(GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
@@ -759,9 +790,11 @@ package gl
 // typedef void  (APIENTRYP GPGENPROGRAMSNV)(GLsizei  n, GLuint * programs);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENQUERIESARB)(GLsizei  n, GLuint * ids);
+// typedef void  (APIENTRYP GPGENQUERYRESOURCETAGNV)(GLsizei  n, GLint * tagIds);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERSEXT)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
+// typedef void  (APIENTRYP GPGENSEMAPHORESEXT)(GLsizei  n, GLuint * semaphores);
 // typedef GLuint  (APIENTRYP GPGENSYMBOLSEXT)(GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components);
 // typedef void  (APIENTRYP GPGENTEXTURES)(GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPGENTEXTURESEXT)(GLsizei  n, GLuint * textures);
@@ -822,6 +855,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERFVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERIVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, GLfloat * params);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  level, void * img);
@@ -835,6 +869,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIVEXT)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERXVOES)(GLenum  target, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGAMD)(GLuint  count, GLsizei  bufsize, GLenum * categories, GLuint * severities, GLuint * ids, GLsizei * lengths, GLchar * message);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
@@ -864,6 +899,7 @@ package gl
 // typedef void  (APIENTRYP GPGETFRAGMENTMATERIALIVSGIX)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERFVAMD)(GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
@@ -890,6 +926,7 @@ package gl
 // typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -917,6 +954,7 @@ package gl
 // typedef void  (APIENTRYP GPGETMATERIALIV)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMATERIALXOES)(GLenum  face, GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPGETMATERIALXVOES)(GLenum  face, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMINMAX)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXEXT)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
@@ -943,10 +981,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
@@ -992,7 +1031,7 @@ package gl
 // typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
-// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
 // typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
 // typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
 // typedef void  (APIENTRYP GPGETPIXELMAPFV)(GLenum  map, GLfloat * values);
@@ -1041,6 +1080,10 @@ package gl
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVARB)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVNV)(GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64VEXT)(GLuint  id, GLenum  pname, GLint64 * params);
@@ -1058,6 +1101,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIUIV)(GLuint  sampler, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERFV)(GLuint  sampler, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIV)(GLuint  sampler, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTER)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTEREXT)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSHADERINFOLOG)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
@@ -1066,6 +1110,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERSOURCEARB)(GLhandleARB  obj, GLsizei  maxLength, GLsizei * length, GLcharARB * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETSHARPENTEXFUNCSGIS)(GLenum  target, GLfloat * points);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -1129,12 +1174,16 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFVARB)(GLhandleARB  programObj, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIVARB)(GLhandleARB  programObj, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIVEXT)(GLuint  program, GLint  location, GLuint * params);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEI_VEXT)(GLenum  target, GLuint  index, GLubyte * data);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEVEXT)(GLenum  pname, GLubyte * data);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTFVATI)(GLuint  id, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTIVATI)(GLuint  id, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -1180,6 +1229,7 @@ package gl
 // typedef void  (APIENTRYP GPGETVIDEOIVNV)(GLuint  video_slot, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVIDEOUI64VNV)(GLuint  video_slot, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVIDEOUIVNV)(GLuint  video_slot, GLenum  pname, GLuint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOLORTABLEARB)(GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNCONVOLUTIONFILTERARB)(GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * image);
@@ -1198,9 +1248,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
@@ -1221,6 +1273,12 @@ package gl
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERFVHP)(GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIHP)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIVHP)(GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPIMPORTMEMORYFDEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32HANDLEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32NAMEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, const void * name);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREFDEXT)(GLuint  semaphore, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32HANDLEEXT)(GLuint  semaphore, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32NAMEEXT)(GLuint  semaphore, GLenum  handleType, const void * name);
 // typedef GLsync  (APIENTRYP GPIMPORTSYNCEXT)(GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags);
 // typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPINDEXFUNCEXT)(GLenum  func, GLclampf  ref);
@@ -1259,6 +1317,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERARB)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
 // typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
@@ -1269,6 +1328,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISLIST)(GLuint  list);
+// typedef GLboolean  (APIENTRYP GPISMEMORYOBJECTEXT)(GLuint  memoryObject);
 // typedef GLboolean  (APIENTRYP GPISNAMEAMD)(GLenum  identifier, GLuint  name);
 // typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
@@ -1287,7 +1347,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFEREXT)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
+// typedef GLboolean  (APIENTRYP GPISSEMAPHOREEXT)(GLuint  semaphore);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREEXT)(GLuint  texture);
@@ -1299,6 +1361,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAYAPPLE)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXATTRIBENABLEDAPPLE)(GLuint  index, GLenum  pname);
+// typedef void  (APIENTRYP GPLGPUCOPYIMAGESUBDATANVX)(GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPLGPUINTERLOCKNVX)();
+// typedef void  (APIENTRYP GPLGPUNAMEDBUFFERSUBDATANVX)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLIGHTENVISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPLIGHTMODELF)(GLenum  pname, GLfloat  param);
@@ -1319,6 +1384,7 @@ package gl
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPLINKPROGRAMARB)(GLhandleARB  programObj);
 // typedef void  (APIENTRYP GPLISTBASE)(GLuint  base);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLISTPARAMETERFSGIX)(GLuint  list, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPLISTPARAMETERFVSGIX)(GLuint  list, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPLISTPARAMETERISGIX)(GLuint  list, GLenum  pname, GLint  param);
@@ -1367,7 +1433,7 @@ package gl
 // typedef void  (APIENTRYP GPMAPGRID2XOES)(GLint  n, GLfixed  u1, GLfixed  u2, GLfixed  v1, GLfixed  v2);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPMAPPARAMETERFVNV)(GLenum  target, GLenum  pname, const GLfloat * params);
@@ -1413,9 +1479,12 @@ package gl
 // typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIEREXT)(GLbitfield  barriers);
+// typedef void  (APIENTRYP GPMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINMAX)(GLenum  target, GLenum  internalformat, GLboolean  sink);
 // typedef void  (APIENTRYP GPMINMAXEXT)(GLenum  target, GLenum  internalformat, GLboolean  sink);
@@ -1433,7 +1502,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTAMD)(GLenum  mode, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTARRAYAPPLE)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
@@ -1442,7 +1511,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTAMD)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWRANGEELEMENTARRAYAPPLE)(GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWARRAYSIBM)(const GLenum * mode, const GLint * first, const GLsizei * count, GLsizei  primcount, GLint  modestride);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWELEMENTSIBM)(const GLenum * mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  primcount, GLint  modestride);
@@ -1567,13 +1636,26 @@ package gl
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPMULTICASTBARRIERNV)();
+// typedef void  (APIENTRYP GPMULTICASTBLITFRAMEBUFFERNV)(GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPMULTICASTBUFFERSUBDATANV)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPMULTICASTCOPYBUFFERSUBDATANV)(GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPMULTICASTCOPYIMAGESUBDATANV)(GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
+// typedef void  (APIENTRYP GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPMULTICASTWAITSYNCNV)(GLuint  signalGpu, GLbitfield  waitGpuMask);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXTERNALEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEMEMEXT)(GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
@@ -1583,6 +1665,9 @@ package gl
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -1726,6 +1811,8 @@ package gl
 // typedef GLint  (APIENTRYP GPPOLLINSTRUMENTSSGIX)(GLint * marker_p);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETEXT)(GLfloat  factor, GLfloat  bias);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETXOES)(GLfixed  factor, GLfixed  units);
 // typedef void  (APIENTRYP GPPOLYGONSTIPPLE)(const GLubyte * mask);
@@ -1738,6 +1825,7 @@ package gl
 // typedef void  (APIENTRYP GPPOPNAME)();
 // typedef void  (APIENTRYP GPPRESENTFRAMEDUALFILLNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLenum  target1, GLuint  fill1, GLenum  target2, GLuint  fill2, GLenum  target3, GLuint  fill3);
 // typedef void  (APIENTRYP GPPRESENTFRAMEKEYEDNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1);
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEXNV)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTNV)();
@@ -1795,13 +1883,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1815,13 +1907,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1835,13 +1931,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1855,13 +1955,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1922,6 +2026,8 @@ package gl
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
 // typedef GLbitfield  (APIENTRYP GPQUERYMATRIXXOES)(GLfixed * mantissa, GLint * exponent);
 // typedef void  (APIENTRYP GPQUERYOBJECTPARAMETERUIAMD)(GLenum  target, GLuint  id, GLenum  pname, GLuint  param);
+// typedef GLint  (APIENTRYP GPQUERYRESOURCENV)(GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer);
+// typedef void  (APIENTRYP GPQUERYRESOURCETAGNV)(GLint  tagId, const GLchar * tagString);
 // typedef void  (APIENTRYP GPRASTERPOS2D)(GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPRASTERPOS2DV)(const GLdouble * v);
 // typedef void  (APIENTRYP GPRASTERPOS2F)(GLfloat  x, GLfloat  y);
@@ -1952,6 +2058,7 @@ package gl
 // typedef void  (APIENTRYP GPRASTERPOS4SV)(const GLshort * v);
 // typedef void  (APIENTRYP GPRASTERPOS4XOES)(GLfixed  x, GLfixed  y, GLfixed  z, GLfixed  w);
 // typedef void  (APIENTRYP GPRASTERPOS4XVOES)(const GLfixed * coords);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
@@ -1969,7 +2076,9 @@ package gl
 // typedef void  (APIENTRYP GPRECTXOES)(GLfixed  x1, GLfixed  y1, GLfixed  x2, GLfixed  y2);
 // typedef void  (APIENTRYP GPRECTXVOES)(const GLfixed * v1, const GLfixed * v2);
 // typedef void  (APIENTRYP GPREFERENCEPLANESGIX)(const GLdouble * equation);
+// typedef GLboolean  (APIENTRYP GPRELEASEKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key);
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
+// typedef void  (APIENTRYP GPRENDERGPUMASKNV)(GLbitfield  mask);
 // typedef GLint  (APIENTRYP GPRENDERMODE)(GLenum  mode);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
@@ -2005,6 +2114,7 @@ package gl
 // typedef void  (APIENTRYP GPRESETMINMAX)(GLenum  target);
 // typedef void  (APIENTRYP GPRESETMINMAXEXT)(GLenum  target);
 // typedef void  (APIENTRYP GPRESIZEBUFFERSMESA)();
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACKNV)();
 // typedef void  (APIENTRYP GPROTATED)(GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
@@ -2012,7 +2122,6 @@ package gl
 // typedef void  (APIENTRYP GPROTATEXOES)(GLfixed  angle, GLfixed  x, GLfixed  y, GLfixed  z);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEARB)(GLfloat  value, GLboolean  invert);
-// typedef void  (APIENTRYP GPSAMPLECOVERAGEOES)(GLfixed  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEXOES)(GLclampx  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMAPATI)(GLuint  dst, GLuint  interp, GLenum  swizzle);
 // typedef void  (APIENTRYP GPSAMPLEMASKEXT)(GLclampf  value, GLboolean  invert);
@@ -2076,6 +2185,7 @@ package gl
 // typedef void  (APIENTRYP GPSECONDARYCOLORPOINTERLISTIBM)(GLint  size, GLenum  type, GLint  stride, const void ** pointer, GLint  ptrstride);
 // typedef void  (APIENTRYP GPSELECTBUFFER)(GLsizei  size, GLuint * buffer);
 // typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
+// typedef void  (APIENTRYP GPSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, const GLuint64 * params);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSETFENCEAPPLE)(GLuint  fence);
@@ -2093,11 +2203,16 @@ package gl
 // typedef void  (APIENTRYP GPSHADERSOURCEARB)(GLhandleARB  shaderObj, GLsizei  count, const GLcharARB ** string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
 // typedef void  (APIENTRYP GPSHARPENTEXFUNCSGIS)(GLenum  target, GLsizei  n, const GLfloat * points);
+// typedef void  (APIENTRYP GPSIGNALSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERIVSGIX)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPSTARTINSTRUMENTSSGIX)();
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
 // typedef void  (APIENTRYP GPSTENCILCLEARTAGEXT)(GLsizei  stencilTagBits, GLuint  stencilClearTag);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
@@ -2118,6 +2233,7 @@ package gl
 // typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
 // typedef void  (APIENTRYP GPSTOPINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPSTRINGMARKERGREMEDY)(GLsizei  len, const void * string);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPSWIZZLEEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // typedef void  (APIENTRYP GPSYNCTEXTUREINTEL)(GLuint  texture);
 // typedef void  (APIENTRYP GPTAGSAMPLEBUFFERSGIX)();
@@ -2251,7 +2367,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLint  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations);
 // typedef void  (APIENTRYP GPTEXIMAGE4DSGIS)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIVEXT)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
@@ -2268,6 +2384,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXSTORAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXSTORAGE3D)(GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXSTORAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM1DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXSTORAGESPARSEAMD)(GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1DEXT)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2280,7 +2401,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTURECOLORMASKSGIS)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
@@ -2293,7 +2414,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURELIGHTEXT)(GLenum  pname);
 // typedef void  (APIENTRYP GPTEXTUREMATERIALEXT)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPTEXTURENORMALEXT)(GLenum  mode);
-// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
@@ -2318,6 +2439,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM1DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXTURESTORAGESPARSEAMD)(GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2329,7 +2455,7 @@ package gl
 // typedef void  (APIENTRYP GPTRACKMATRIXNV)(GLenum  target, GLuint  address, GLenum  matrix, GLenum  transform);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKATTRIBSNV)(GLsizei  count, const GLint * attribs, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKSTREAMATTRIBSNV)(GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGSEXT)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
@@ -2345,13 +2471,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IARB)(GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIEXT)(GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2363,13 +2493,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IARB)(GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIEXT)(GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2381,13 +2515,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2399,13 +2537,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2831,7 +2973,11 @@ package gl
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
+// typedef void  (APIENTRYP GPWAITSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
 // typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
 // typedef void  (APIENTRYP GPWEIGHTPOINTERARB)(GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPWEIGHTBVARB)(GLint  size, const GLbyte * weights);
@@ -2898,12 +3044,16 @@ package gl
 // typedef void  (APIENTRYP GPWINDOWPOS4IVMESA)(const GLint * v);
 // typedef void  (APIENTRYP GPWINDOWPOS4SMESA)(GLshort  x, GLshort  y, GLshort  z, GLshort  w);
 // typedef void  (APIENTRYP GPWINDOWPOS4SVMESA)(const GLshort * v);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
 // typedef void  (APIENTRYP GPWRITEMASKEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // static void  glowAccum(GPACCUM fnptr, GLenum  op, GLfloat  value) {
 //   (*fnptr)(op, value);
 // }
 // static void  glowAccumxOES(GPACCUMXOES fnptr, GLenum  op, GLfixed  value) {
 //   (*fnptr)(op, value);
+// }
+// static GLboolean  glowAcquireKeyedMutexWin32EXT(GPACQUIREKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key, GLuint  timeout) {
+//   return (*fnptr)(memory, key, timeout);
 // }
 // static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
 //   (*fnptr)(program);
@@ -2940,6 +3090,12 @@ package gl
 // }
 // static void  glowAlphaFuncxOES(GPALPHAFUNCXOES fnptr, GLenum  func, GLfixed  ref) {
 //   (*fnptr)(func, ref);
+// }
+// static void  glowAlphaToCoverageDitherControlNV(GPALPHATOCOVERAGEDITHERCONTROLNV fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowApplyTextureEXT(GPAPPLYTEXTUREEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -3292,7 +3448,7 @@ package gl
 // static void  glowBufferDataARB(GPBUFFERDATAARB fnptr, GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferParameteriAPPLE(GPBUFFERPARAMETERIAPPLE fnptr, GLenum  target, GLenum  pname, GLint  param) {
@@ -3301,11 +3457,20 @@ package gl
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(target, size, data, flags);
 // }
+// static void  glowBufferStorageExternalEXT(GPBUFFERSTORAGEEXTERNALEXT fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(target, offset, size, clientBuffer, flags);
+// }
+// static void  glowBufferStorageMemEXT(GPBUFFERSTORAGEMEMEXT fnptr, GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, size, memory, offset);
+// }
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
 // static void  glowBufferSubDataARB(GPBUFFERSUBDATAARB fnptr, GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
 // }
 // static void  glowCallList(GPCALLLIST fnptr, GLuint  list) {
 //   (*fnptr)(list);
@@ -3394,14 +3559,14 @@ package gl
 // static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
 // static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -3688,6 +3853,12 @@ package gl
 // static void  glowCombinerStageParameterfvNV(GPCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, const GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
@@ -3777,6 +3948,12 @@ package gl
 // }
 // static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
 //   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowConvolutionFilter1D(GPCONVOLUTIONFILTER1D fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image) {
 //   (*fnptr)(target, internalformat, width, format, type, image);
@@ -3868,7 +4045,7 @@ package gl
 // static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
@@ -3943,11 +4120,23 @@ package gl
 // static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
 //   (*fnptr)(path, coverMode);
 // }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
+// }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreateMemoryObjectsEXT(GPCREATEMEMORYOBJECTSEXT fnptr, GLsizei  n, GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
 //   (*fnptr)(queryId, queryHandle);
@@ -3984,6 +4173,9 @@ package gl
 // }
 // static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -4063,6 +4255,9 @@ package gl
 // static void  glowDeleteBuffersARB(GPDELETEBUFFERSARB fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFencesAPPLE(GPDELETEFENCESAPPLE fnptr, GLsizei  n, const GLuint * fences) {
 //   (*fnptr)(n, fences);
 // }
@@ -4080,6 +4275,9 @@ package gl
 // }
 // static void  glowDeleteLists(GPDELETELISTS fnptr, GLuint  list, GLsizei  range) {
 //   (*fnptr)(list, range);
+// }
+// static void  glowDeleteMemoryObjectsEXT(GPDELETEMEMORYOBJECTSEXT fnptr, GLsizei  n, const GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
@@ -4123,6 +4321,9 @@ package gl
 // static void  glowDeleteQueriesARB(GPDELETEQUERIESARB fnptr, GLsizei  n, const GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowDeleteQueryResourceTagNV(GPDELETEQUERYRESOURCETAGNV fnptr, GLsizei  n, const GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowDeleteRenderbuffers(GPDELETERENDERBUFFERS fnptr, GLsizei  n, const GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4132,8 +4333,14 @@ package gl
 // static void  glowDeleteSamplers(GPDELETESAMPLERS fnptr, GLsizei  count, const GLuint * samplers) {
 //   (*fnptr)(count, samplers);
 // }
+// static void  glowDeleteSemaphoresEXT(GPDELETESEMAPHORESEXT fnptr, GLsizei  n, const GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
+// }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -4282,6 +4489,18 @@ package gl
 // static void  glowDrawBuffersATI(GPDRAWBUFFERSATI fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
 // }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
+// }
 // static void  glowDrawElementArrayAPPLE(GPDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, GLint  first, GLsizei  count) {
 //   (*fnptr)(mode, first, count);
 // }
@@ -4353,6 +4572,9 @@ package gl
 // }
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
+// }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
 // }
 // static void  glowEdgeFlag(GPEDGEFLAG fnptr, GLboolean  flag) {
 //   (*fnptr)(flag);
@@ -4519,6 +4741,9 @@ package gl
 // static void  glowEvalPoint2(GPEVALPOINT2 fnptr, GLint  i, GLint  j) {
 //   (*fnptr)(i, j);
 // }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowExecuteProgramNV(GPEXECUTEPROGRAMNV fnptr, GLenum  target, GLuint  id, const GLfloat * params) {
 //   (*fnptr)(target, id, params);
 // }
@@ -4564,7 +4789,7 @@ package gl
 // static void  glowFlushMappedBufferRangeAPPLE(GPFLUSHMAPPEDBUFFERRANGEAPPLE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, offset, size);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
 // }
 // static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
@@ -4651,6 +4876,9 @@ package gl
 // static void  glowFragmentColorMaterialSGIX(GPFRAGMENTCOLORMATERIALSGIX fnptr, GLenum  face, GLenum  mode) {
 //   (*fnptr)(face, mode);
 // }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
 // static void  glowFragmentLightModelfSGIX(GPFRAGMENTLIGHTMODELFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -4699,6 +4927,9 @@ package gl
 // static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(framebuffer, n, bufs);
 // }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
@@ -4710,6 +4941,15 @@ package gl
 // }
 // static void  glowFramebufferRenderbufferEXT(GPFRAMEBUFFERRENDERBUFFEREXT fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSamplePositionsfvAMD(GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(target, numsamples, pixelindex, values);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -4752,6 +4992,9 @@ package gl
 // }
 // static void  glowFramebufferTextureLayerEXT(GPFRAMEBUFFERTEXTURELAYEREXT fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFreeObjectBufferATI(GPFREEOBJECTBUFFERATI fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -4825,6 +5068,9 @@ package gl
 // static void  glowGenQueriesARB(GPGENQUERIESARB fnptr, GLsizei  n, GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowGenQueryResourceTagNV(GPGENQUERYRESOURCETAGNV fnptr, GLsizei  n, GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowGenRenderbuffers(GPGENRENDERBUFFERS fnptr, GLsizei  n, GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4833,6 +5079,9 @@ package gl
 // }
 // static void  glowGenSamplers(GPGENSAMPLERS fnptr, GLsizei  count, GLuint * samplers) {
 //   (*fnptr)(count, samplers);
+// }
+// static void  glowGenSemaphoresEXT(GPGENSEMAPHORESEXT fnptr, GLsizei  n, GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
 // }
 // static GLuint  glowGenSymbolsEXT(GPGENSYMBOLSEXT fnptr, GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components) {
 //   return (*fnptr)(datatype, storagetype, range, components);
@@ -5014,6 +5263,9 @@ package gl
 // static void  glowGetCombinerStageParameterfvNV(GPGETCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
 // static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
 //   (*fnptr)(texunit, target, lod, img);
 // }
@@ -5052,6 +5304,9 @@ package gl
 // }
 // static void  glowGetConvolutionParameterxvOES(GPGETCONVOLUTIONPARAMETERXVOES fnptr, GLenum  target, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -5140,6 +5395,9 @@ package gl
 // static void  glowGetFramebufferAttachmentParameterivEXT(GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLenum  target, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, attachment, pname, params);
 // }
+// static void  glowGetFramebufferParameterfvAMD(GPGETFRAMEBUFFERPARAMETERFVAMD fnptr, GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(target, pname, numsamples, pixelindex, size, values);
+// }
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
@@ -5217,6 +5475,9 @@ package gl
 // }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
@@ -5299,6 +5560,9 @@ package gl
 // static void  glowGetMaterialxvOES(GPGETMATERIALXVOES fnptr, GLenum  face, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(face, pname, params);
 // }
+// static void  glowGetMemoryObjectParameterivEXT(GPGETMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
+// }
 // static void  glowGetMinmax(GPGETMINMAX fnptr, GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values) {
 //   (*fnptr)(target, reset, format, type, values);
 // }
@@ -5377,7 +5641,7 @@ package gl
 // static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
@@ -5388,6 +5652,9 @@ package gl
 // }
 // static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
+// }
+// static void  glowGetNamedFramebufferParameterfvAMD(GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD fnptr, GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(framebuffer, pname, numsamples, pixelindex, size, values);
 // }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
@@ -5524,7 +5791,7 @@ package gl
 // static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
 //   (*fnptr)(numGroups, groupsSize, groups);
 // }
-// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten) {
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
 //   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
 // }
 // static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
@@ -5671,6 +5938,18 @@ package gl
 // static void  glowGetProgramivNV(GPGETPROGRAMIVNV fnptr, GLuint  id, GLenum  pname, GLint * params) {
 //   (*fnptr)(id, pname, params);
 // }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
 // }
@@ -5722,6 +6001,9 @@ package gl
 // static void  glowGetSamplerParameteriv(GPGETSAMPLERPARAMETERIV fnptr, GLuint  sampler, GLenum  pname, GLint * params) {
 //   (*fnptr)(sampler, pname, params);
 // }
+// static void  glowGetSemaphoreParameterui64vEXT(GPGETSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowGetSeparableFilter(GPGETSEPARABLEFILTER fnptr, GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span) {
 //   (*fnptr)(target, format, type, row, column, span);
 // }
@@ -5745,6 +6027,9 @@ package gl
 // }
 // static void  glowGetSharpenTexFuncSGIS(GPGETSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLfloat * points) {
 //   (*fnptr)(target, points);
+// }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
 // }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
@@ -5935,6 +6220,9 @@ package gl
 // static void  glowGetUniformfvARB(GPGETUNIFORMFVARB fnptr, GLhandleARB  programObj, GLint  location, GLfloat * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5944,6 +6232,9 @@ package gl
 // static void  glowGetUniformivARB(GPGETUNIFORMIVARB fnptr, GLhandleARB  programObj, GLint  location, GLint * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5952,6 +6243,12 @@ package gl
 // }
 // static void  glowGetUniformuivEXT(GPGETUNIFORMUIVEXT fnptr, GLuint  program, GLint  location, GLuint * params) {
 //   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUnsignedBytei_vEXT(GPGETUNSIGNEDBYTEI_VEXT fnptr, GLenum  target, GLuint  index, GLubyte * data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetUnsignedBytevEXT(GPGETUNSIGNEDBYTEVEXT fnptr, GLenum  pname, GLubyte * data) {
+//   (*fnptr)(pname, data);
 // }
 // static void  glowGetVariantArrayObjectfvATI(GPGETVARIANTARRAYOBJECTFVATI fnptr, GLuint  id, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(id, pname, params);
@@ -6088,6 +6385,9 @@ package gl
 // static void  glowGetVideouivNV(GPGETVIDEOUIVNV fnptr, GLuint  video_slot, GLenum  pname, GLuint * params) {
 //   (*fnptr)(video_slot, pname, params);
 // }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
+// }
 // static void  glowGetnColorTableARB(GPGETNCOLORTABLEARB fnptr, GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table) {
 //   (*fnptr)(target, format, type, bufSize, table);
 // }
@@ -6142,6 +6442,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -6149,6 +6452,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -6210,6 +6516,24 @@ package gl
 // }
 // static void  glowImageTransformParameterivHP(GPIMAGETRANSFORMPARAMETERIVHP fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowImportMemoryFdEXT(GPIMPORTMEMORYFDEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(memory, size, handleType, fd);
+// }
+// static void  glowImportMemoryWin32HandleEXT(GPIMPORTMEMORYWIN32HANDLEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, void * handle) {
+//   (*fnptr)(memory, size, handleType, handle);
+// }
+// static void  glowImportMemoryWin32NameEXT(GPIMPORTMEMORYWIN32NAMEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, const void * name) {
+//   (*fnptr)(memory, size, handleType, name);
+// }
+// static void  glowImportSemaphoreFdEXT(GPIMPORTSEMAPHOREFDEXT fnptr, GLuint  semaphore, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(semaphore, handleType, fd);
+// }
+// static void  glowImportSemaphoreWin32HandleEXT(GPIMPORTSEMAPHOREWIN32HANDLEEXT fnptr, GLuint  semaphore, GLenum  handleType, void * handle) {
+//   (*fnptr)(semaphore, handleType, handle);
+// }
+// static void  glowImportSemaphoreWin32NameEXT(GPIMPORTSEMAPHOREWIN32NAMEEXT fnptr, GLuint  semaphore, GLenum  handleType, const void * name) {
+//   (*fnptr)(semaphore, handleType, name);
 // }
 // static GLsync  glowImportSyncEXT(GPIMPORTSYNCEXT fnptr, GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags) {
 //   return (*fnptr)(external_sync_type, external_sync, flags);
@@ -6325,6 +6649,9 @@ package gl
 // static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
 // }
@@ -6354,6 +6681,9 @@ package gl
 // }
 // static GLboolean  glowIsList(GPISLIST fnptr, GLuint  list) {
 //   return (*fnptr)(list);
+// }
+// static GLboolean  glowIsMemoryObjectEXT(GPISMEMORYOBJECTEXT fnptr, GLuint  memoryObject) {
+//   return (*fnptr)(memoryObject);
 // }
 // static GLboolean  glowIsNameAMD(GPISNAMEAMD fnptr, GLenum  identifier, GLuint  name) {
 //   return (*fnptr)(identifier, name);
@@ -6409,8 +6739,14 @@ package gl
 // static GLboolean  glowIsSampler(GPISSAMPLER fnptr, GLuint  sampler) {
 //   return (*fnptr)(sampler);
 // }
+// static GLboolean  glowIsSemaphoreEXT(GPISSEMAPHOREEXT fnptr, GLuint  semaphore) {
+//   return (*fnptr)(semaphore);
+// }
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
+// }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
 // }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
@@ -6444,6 +6780,15 @@ package gl
 // }
 // static GLboolean  glowIsVertexAttribEnabledAPPLE(GPISVERTEXATTRIBENABLEDAPPLE fnptr, GLuint  index, GLenum  pname) {
 //   return (*fnptr)(index, pname);
+// }
+// static void  glowLGPUCopyImageSubDataNVX(GPLGPUCOPYIMAGESUBDATANVX fnptr, GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(sourceGpu, destinationGpuMask, srcName, srcTarget, srcLevel, srcX, srxY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, width, height, depth);
+// }
+// static void  glowLGPUInterlockNVX(GPLGPUINTERLOCKNVX fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowLGPUNamedBufferSubDataNVX(GPLGPUNAMEDBUFFERSUBDATANVX fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
 // }
 // static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(type, object, length, label);
@@ -6504,6 +6849,9 @@ package gl
 // }
 // static void  glowListBase(GPLISTBASE fnptr, GLuint  base) {
 //   (*fnptr)(base);
+// }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
 // }
 // static void  glowListParameterfSGIX(GPLISTPARAMETERFSGIX fnptr, GLuint  list, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(list, pname, param);
@@ -6649,7 +6997,7 @@ package gl
 // static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
 // }
 // static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
@@ -6787,6 +7135,12 @@ package gl
 // static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
 //   (*fnptr)(mode, x, y, z);
 // }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
 // }
@@ -6795,6 +7149,9 @@ package gl
 // }
 // static void  glowMemoryBarrierEXT(GPMEMORYBARRIEREXT fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
+// }
+// static void  glowMemoryObjectParameterivEXT(GPMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, const GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
 // }
 // static void  glowMinSampleShadingARB(GPMINSAMPLESHADINGARB fnptr, GLfloat  value) {
 //   (*fnptr)(value);
@@ -6847,7 +7204,7 @@ package gl
 // static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElementArrayAPPLE(GPMULTIDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -6874,7 +7231,7 @@ package gl
 // static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawRangeElementArrayAPPLE(GPMULTIDRAWRANGEELEMENTARRAYAPPLE fnptr, GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -7249,25 +7606,64 @@ package gl
 // static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMulticastBarrierNV(GPMULTICASTBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowMulticastBlitFramebufferNV(GPMULTICASTBLITFRAMEBUFFERNV fnptr, GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
+//   (*fnptr)(srcGpu, dstGpu, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+// }
+// static void  glowMulticastBufferSubDataNV(GPMULTICASTBUFFERSUBDATANV fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
+// }
+// static void  glowMulticastCopyBufferSubDataNV(GPMULTICASTCOPYBUFFERSUBDATANV fnptr, GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readGpu, writeGpuMask, readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowMulticastCopyImageSubDataNV(GPMULTICASTCOPYIMAGESUBDATANV fnptr, GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
+//   (*fnptr)(srcGpu, dstGpuMask, srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
+// }
+// static void  glowMulticastFramebufferSampleLocationsfvNV(GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(gpu, framebuffer, start, count, v);
+// }
+// static void  glowMulticastGetQueryObjecti64vNV(GPMULTICASTGETQUERYOBJECTI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectivNV(GPMULTICASTGETQUERYOBJECTIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectui64vNV(GPMULTICASTGETQUERYOBJECTUI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectuivNV(GPMULTICASTGETQUERYOBJECTUIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastWaitSyncNV(GPMULTICASTWAITSYNCNV fnptr, GLuint  signalGpu, GLbitfield  waitGpuMask) {
+//   (*fnptr)(signalGpu, waitGpuMask);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
 // static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
 // static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageExternalEXT(GPNAMEDBUFFERSTORAGEEXTERNALEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(buffer, offset, size, clientBuffer, flags);
+// }
+// static void  glowNamedBufferStorageMemEXT(GPNAMEDBUFFERSTORAGEMEMEXT fnptr, GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(buffer, size, memory, offset);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
@@ -7296,6 +7692,15 @@ package gl
 // }
 // static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSamplePositionsfvAMD(GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(framebuffer, numsamples, pixelindex, values);
 // }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
@@ -7726,6 +8131,12 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPolygonOffsetEXT(GPPOLYGONOFFSETEXT fnptr, GLfloat  factor, GLfloat  bias) {
 //   (*fnptr)(factor, bias);
 // }
@@ -7761,6 +8172,9 @@ package gl
 // }
 // static void  glowPresentFrameKeyedNV(GPPRESENTFRAMEKEYEDNV fnptr, GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1) {
 //   (*fnptr)(video_slot, minPresentTime, beginPresentTimeId, presentDurationId, type, target0, fill0, key0, target1, fill1, key1);
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -7933,8 +8347,14 @@ package gl
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7951,8 +8371,14 @@ package gl
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7993,8 +8419,14 @@ package gl
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8011,8 +8443,14 @@ package gl
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8053,8 +8491,14 @@ package gl
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8071,8 +8515,14 @@ package gl
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8113,8 +8563,14 @@ package gl
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8131,8 +8587,14 @@ package gl
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8314,6 +8776,12 @@ package gl
 // static void  glowQueryObjectParameteruiAMD(GPQUERYOBJECTPARAMETERUIAMD fnptr, GLenum  target, GLuint  id, GLenum  pname, GLuint  param) {
 //   (*fnptr)(target, id, pname, param);
 // }
+// static GLint  glowQueryResourceNV(GPQUERYRESOURCENV fnptr, GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer) {
+//   return (*fnptr)(queryType, tagId, bufSize, buffer);
+// }
+// static void  glowQueryResourceTagNV(GPQUERYRESOURCETAGNV fnptr, GLint  tagId, const GLchar * tagString) {
+//   (*fnptr)(tagId, tagString);
+// }
 // static void  glowRasterPos2d(GPRASTERPOS2D fnptr, GLdouble  x, GLdouble  y) {
 //   (*fnptr)(x, y);
 // }
@@ -8404,6 +8872,9 @@ package gl
 // static void  glowRasterPos4xvOES(GPRASTERPOS4XVOES fnptr, const GLfixed * coords) {
 //   (*fnptr)(coords);
 // }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
+// }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
 // }
@@ -8455,8 +8926,14 @@ package gl
 // static void  glowReferencePlaneSGIX(GPREFERENCEPLANESGIX fnptr, const GLdouble * equation) {
 //   (*fnptr)(equation);
 // }
+// static GLboolean  glowReleaseKeyedMutexWin32EXT(GPRELEASEKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key) {
+//   return (*fnptr)(memory, key);
+// }
 // static void  glowReleaseShaderCompiler(GPRELEASESHADERCOMPILER fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowRenderGpuMaskNV(GPRENDERGPUMASKNV fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static GLint  glowRenderMode(GPRENDERMODE fnptr, GLenum  mode) {
 //   return (*fnptr)(mode);
@@ -8563,6 +9040,9 @@ package gl
 // static void  glowResizeBuffersMESA(GPRESIZEBUFFERSMESA fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -8582,9 +9062,6 @@ package gl
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoverageARB(GPSAMPLECOVERAGEARB fnptr, GLfloat  value, GLboolean  invert) {
-//   (*fnptr)(value, invert);
-// }
-// static void  glowSampleCoverageOES(GPSAMPLECOVERAGEOES fnptr, GLfixed  value, GLboolean  invert) {
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoveragexOES(GPSAMPLECOVERAGEXOES fnptr, GLclampx  value, GLboolean  invert) {
@@ -8776,6 +9253,9 @@ package gl
 // static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
 //   (*fnptr)(monitor, enable, group, numCounters, counterList);
 // }
+// static void  glowSemaphoreParameterui64vEXT(GPSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, const GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowSeparableFilter2D(GPSEPARABLEFILTER2D fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column) {
 //   (*fnptr)(target, internalformat, width, height, format, type, row, column);
 // }
@@ -8827,6 +9307,18 @@ package gl
 // static void  glowSharpenTexFuncSGIS(GPSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLsizei  n, const GLfloat * points) {
 //   (*fnptr)(target, n, points);
 // }
+// static void  glowSignalSemaphoreEXT(GPSIGNALSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, dstLayouts);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
 // static void  glowSpriteParameterfSGIX(GPSPRITEPARAMETERFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -8841,6 +9333,9 @@ package gl
 // }
 // static void  glowStartInstrumentsSGIX(GPSTARTINSTRUMENTSSGIX fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
 // }
 // static void  glowStencilClearTagEXT(GPSTENCILCLEARTAGEXT fnptr, GLsizei  stencilTagBits, GLuint  stencilClearTag) {
 //   (*fnptr)(stencilTagBits, stencilClearTag);
@@ -8901,6 +9396,9 @@ package gl
 // }
 // static void  glowStringMarkerGREMEDY(GPSTRINGMARKERGREMEDY fnptr, GLsizei  len, const void * string) {
 //   (*fnptr)(len, string);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
 // }
 // static void  glowSwizzleEXT(GPSWIZZLEEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
@@ -9301,8 +9799,8 @@ package gl
 // static void  glowTexImage4DSGIS(GPTEXIMAGE4DSGIS fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, height, depth, size4d, border, format, type, pixels);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -9352,6 +9850,21 @@ package gl
 // static void  glowTexStorage3DMultisample(GPTEXSTORAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTexStorageMem1DEXT(GPTEXSTORAGEMEM1DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTexStorageMem2DEXT(GPTEXSTORAGEMEM2DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTexStorageMem2DMultisampleEXT(GPTEXSTORAGEMEM2DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTexStorageMem3DEXT(GPTEXSTORAGEMEM3DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTexStorageMem3DMultisampleEXT(GPTEXSTORAGEMEM3DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTexStorageSparseAMD(GPTEXSTORAGESPARSEAMD fnptr, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9388,7 +9901,7 @@ package gl
 // static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, target, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
 // }
 // static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
@@ -9427,8 +9940,8 @@ package gl
 // static void  glowTextureNormalEXT(GPTEXTURENORMALEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
 // }
-// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
@@ -9502,6 +10015,21 @@ package gl
 // static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorageMem1DEXT(GPTEXTURESTORAGEMEM1DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTextureStorageMem2DEXT(GPTEXTURESTORAGEMEM2DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTextureStorageMem2DMultisampleEXT(GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTextureStorageMem3DEXT(GPTEXTURESTORAGEMEM3DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTextureStorageMem3DMultisampleEXT(GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTextureStorageSparseAMD(GPTEXTURESTORAGESPARSEAMD fnptr, GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(texture, target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9535,7 +10063,7 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackStreamAttribsNV(GPTRANSFORMFEEDBACKSTREAMATTRIBSNV fnptr, GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode) {
@@ -9583,8 +10111,14 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9601,8 +10135,14 @@ package gl
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9637,8 +10177,14 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9655,8 +10201,14 @@ package gl
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9691,8 +10243,14 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9709,8 +10267,14 @@ package gl
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9745,8 +10309,14 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9763,8 +10333,14 @@ package gl
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -11041,8 +11617,20 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
+// static void  glowWaitSemaphoreEXT(GPWAITSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, srcLayouts);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
 // }
 // static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
 //   (*fnptr)(resultPath, numPaths, paths, weights);
@@ -11242,6 +11830,9 @@ package gl
 // static void  glowWindowPos4svMESA(GPWINDOWPOS4SVMESA fnptr, const GLshort * v) {
 //   (*fnptr)(v);
 // }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
+// }
 // static void  glowWriteMaskEXT(GPWRITEMASKEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
 // }
@@ -11333,6 +11924,7 @@ const (
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_BARRIER_BITS_EXT                                       = 0xFFFFFFFF
 	ALL_COMPLETED_NV                                           = 0x84F2
+	ALL_PIXELS_AMD                                             = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
 	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALL_STATIC_DATA_IBM                                        = 103060
@@ -11367,11 +11959,16 @@ const (
 	ALPHA_MAX_SGIX                                             = 0x8321
 	ALPHA_MIN_CLAMP_INGR                                       = 0x8563
 	ALPHA_MIN_SGIX                                             = 0x8320
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALPHA_SCALE                                                = 0x0D1C
 	ALPHA_SNORM                                                = 0x9010
 	ALPHA_TEST                                                 = 0x0BC0
 	ALPHA_TEST_FUNC                                            = 0x0BC1
 	ALPHA_TEST_REF                                             = 0x0BC2
+	ALPHA_TO_COVERAGE_DITHER_DEFAULT_NV                        = 0x934D
+	ALPHA_TO_COVERAGE_DITHER_DISABLE_NV                        = 0x934F
+	ALPHA_TO_COVERAGE_DITHER_ENABLE_NV                         = 0x934E
+	ALPHA_TO_COVERAGE_DITHER_MODE_NV                           = 0x92BF
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	ALWAYS_FAST_HINT_PGI                                       = 0x1A20C
@@ -11417,6 +12014,7 @@ const (
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
 	ATTENUATION_EXT                                            = 0x834D
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	ATTRIB_ARRAY_POINTER_NV                                    = 0x8645
 	ATTRIB_ARRAY_SIZE_NV                                       = 0x8623
 	ATTRIB_ARRAY_STRIDE_NV                                     = 0x8624
@@ -11459,6 +12057,7 @@ const (
 	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
 	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_COLOR_EXT                                            = 0x8005
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
@@ -11636,10 +12235,26 @@ const (
 	COLOR_ATTACHMENT14_EXT                                     = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
 	COLOR_ATTACHMENT15_EXT                                     = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT1_EXT                                      = 0x8CE1
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT2_EXT                                      = 0x8CE2
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT3_EXT                                      = 0x8CE3
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT4_EXT                                      = 0x8CE4
@@ -11743,6 +12358,8 @@ const (
 	COMPILE                                                    = 0x1300
 	COMPILE_AND_EXECUTE                                        = 0x1301
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_ALPHA                                           = 0x84E9
 	COMPRESSED_ALPHA_ARB                                       = 0x84E9
 	COMPRESSED_INTENSITY                                       = 0x84EC
@@ -11842,8 +12459,18 @@ const (
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	COMP_BIT_ATI                                               = 0x00000002
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
 	CONIC_CURVE_TO_NV                                          = 0x1A
 	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSERVE_MEMORY_HINT_PGI                                   = 0x1A1FD
 	CONSTANT                                                   = 0x8576
 	CONSTANT_ALPHA                                             = 0x8003
@@ -11865,6 +12492,7 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
 	CONTEXT_LOST_KHR                                           = 0x0507
@@ -11936,13 +12564,14 @@ const (
 	COPY_INVERTED                                              = 0x150C
 	COPY_PIXEL_TOKEN                                           = 0x0706
 	COPY_READ_BUFFER                                           = 0x8F36
-	COPY_READ_BUFFER_BINDING                                   = 0x8F36
 	COPY_WRITE_BUFFER                                          = 0x8F37
-	COPY_WRITE_BUFFER_BINDING                                  = 0x8F37
 	COUNTER_RANGE_AMD                                          = 0x8BC1
 	COUNTER_TYPE_AMD                                           = 0x8BC0
 	COUNT_DOWN_NV                                              = 0x9089
 	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
 	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CUBIC_EXT                                                  = 0x8334
 	CUBIC_HP                                                   = 0x815F
@@ -11992,6 +12621,7 @@ const (
 	CURRENT_VERTEX_WEIGHT_EXT                                  = 0x850B
 	CURRENT_WEIGHT_ARB                                         = 0x86A8
 	CW                                                         = 0x0900
+	D3D12_FENCE_VALUE_EXT                                      = 0x9595
 	DARKEN_KHR                                                 = 0x9297
 	DARKEN_NV                                                  = 0x9297
 	DATA_BUFFER_AMD                                            = 0x9151
@@ -12084,6 +12714,7 @@ const (
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DECR_WRAP_EXT                                              = 0x8508
+	DEDICATED_MEMORY_OBJECT_EXT                                = 0x9581
 	DEFORMATIONS_MASK_SGIX                                     = 0x8196
 	DELETE_STATUS                                              = 0x8B80
 	DEPENDENT_AR_TEXTURE_2D_NV                                 = 0x86E9
@@ -12125,6 +12756,7 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_SCALE                                                = 0x0D1E
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
@@ -12142,6 +12774,9 @@ const (
 	DETAIL_TEXTURE_FUNC_POINTS_SGIS                            = 0x809C
 	DETAIL_TEXTURE_LEVEL_SGIS                                  = 0x809A
 	DETAIL_TEXTURE_MODE_SGIS                                   = 0x809B
+	DEVICE_LUID_EXT                                            = 0x9599
+	DEVICE_NODE_MASK_EXT                                       = 0x959A
+	DEVICE_UUID_EXT                                            = 0x9597
 	DIFFERENCE_KHR                                             = 0x929E
 	DIFFERENCE_NV                                              = 0x929E
 	DIFFUSE                                                    = 0x1201
@@ -12204,6 +12839,9 @@ const (
 	DOUBLE_VEC3_EXT                                            = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
 	DOUBLE_VEC4_EXT                                            = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER0_ARB                                           = 0x8825
@@ -12253,6 +12891,9 @@ const (
 	DRAW_BUFFER9                                               = 0x882E
 	DRAW_BUFFER9_ARB                                           = 0x882E
 	DRAW_BUFFER9_ATI                                           = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
 	DRAW_FRAMEBUFFER_BINDING_EXT                               = 0x8CA6
@@ -12264,6 +12905,7 @@ const (
 	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DRAW_PIXELS_APPLE                                          = 0x8A0A
 	DRAW_PIXEL_TOKEN                                           = 0x0705
+	DRIVER_UUID_EXT                                            = 0x9598
 	DSDT8_MAG8_INTENSITY8_NV                                   = 0x870B
 	DSDT8_MAG8_NV                                              = 0x870A
 	DSDT8_NV                                                   = 0x8709
@@ -12324,7 +12966,9 @@ const (
 	EDGE_FLAG_ARRAY_POINTER_EXT                                = 0x8093
 	EDGE_FLAG_ARRAY_STRIDE                                     = 0x808C
 	EDGE_FLAG_ARRAY_STRIDE_EXT                                 = 0x808C
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
 	EIGHTH_BIT_ATI                                             = 0x00000020
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
 	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_APPLE                                        = 0x8A0C
 	ELEMENT_ARRAY_ATI                                          = 0x8768
@@ -12369,6 +13013,7 @@ const (
 	EVAL_VERTEX_ATTRIB9_NV                                     = 0x86CF
 	EXCLUSION_KHR                                              = 0x92A0
 	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXP                                                        = 0x0800
 	EXP2                                                       = 0x0801
 	EXPAND_NEGATE_NV                                           = 0x8539
@@ -12402,6 +13047,7 @@ const (
 	FIELD_UPPER_NV                                             = 0x9022
 	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
 	FILTER4_SGIS                                               = 0x8146
 	FIRST_TO_REST_NV                                           = 0x90AF
@@ -12413,6 +13059,15 @@ const (
 	FIXED_ONLY_ARB                                             = 0x891D
 	FLAT                                                       = 0x1D00
 	FLOAT                                                      = 0x1406
+	FLOAT16_MAT2_AMD                                           = 0x91C5
+	FLOAT16_MAT2x3_AMD                                         = 0x91C8
+	FLOAT16_MAT2x4_AMD                                         = 0x91C9
+	FLOAT16_MAT3_AMD                                           = 0x91C6
+	FLOAT16_MAT3x2_AMD                                         = 0x91CA
+	FLOAT16_MAT3x4_AMD                                         = 0x91CB
+	FLOAT16_MAT4_AMD                                           = 0x91C7
+	FLOAT16_MAT4x2_AMD                                         = 0x91CC
+	FLOAT16_MAT4x3_AMD                                         = 0x91CD
 	FLOAT16_NV                                                 = 0x8FF8
 	FLOAT16_VEC2_NV                                            = 0x8FF9
 	FLOAT16_VEC3_NV                                            = 0x8FFA
@@ -12518,6 +13173,8 @@ const (
 	FRAGMENT_COLOR_MATERIAL_FACE_SGIX                          = 0x8402
 	FRAGMENT_COLOR_MATERIAL_PARAMETER_SGIX                     = 0x8403
 	FRAGMENT_COLOR_MATERIAL_SGIX                               = 0x8401
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
 	FRAGMENT_DEPTH                                             = 0x8452
 	FRAGMENT_DEPTH_EXT                                         = 0x8452
 	FRAGMENT_INPUT_NV                                          = 0x936D
@@ -12549,6 +13206,7 @@ const (
 	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
 	FRAGMENT_SHADER_DERIVATIVE_HINT_ARB                        = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -12570,12 +13228,14 @@ const (
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_3D_ZOFFSET_EXT              = 0x8CD4
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE_EXT           = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER_EXT                   = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL_EXT                   = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BARRIER_BIT_EXT                                = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
@@ -12607,8 +13267,13 @@ const (
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_EXT                     = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER_EXT                     = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_SRGB_CAPABLE_EXT                               = 0x8DBA
 	FRAMEBUFFER_SRGB_EXT                                       = 0x8DB9
@@ -12621,6 +13286,7 @@ const (
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_RANGE_EXT                                             = 0x87E1
@@ -12700,6 +13366,14 @@ const (
 	HALF_FLOAT                                                 = 0x140B
 	HALF_FLOAT_ARB                                             = 0x140B
 	HALF_FLOAT_NV                                              = 0x140B
+	HANDLE_TYPE_D3D11_IMAGE_EXT                                = 0x958B
+	HANDLE_TYPE_D3D11_IMAGE_KMT_EXT                            = 0x958C
+	HANDLE_TYPE_D3D12_FENCE_EXT                                = 0x9594
+	HANDLE_TYPE_D3D12_RESOURCE_EXT                             = 0x958A
+	HANDLE_TYPE_D3D12_TILEPOOL_EXT                             = 0x9589
+	HANDLE_TYPE_OPAQUE_FD_EXT                                  = 0x9586
+	HANDLE_TYPE_OPAQUE_WIN32_EXT                               = 0x9587
+	HANDLE_TYPE_OPAQUE_WIN32_KMT_EXT                           = 0x9588
 	HARDLIGHT_KHR                                              = 0x929B
 	HARDLIGHT_NV                                               = 0x929B
 	HARDMIX_NV                                                 = 0x92A9
@@ -12807,6 +13481,7 @@ const (
 	IMPLEMENTATION_COLOR_READ_FORMAT_OES                       = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
 	IMPLEMENTATION_COLOR_READ_TYPE_OES                         = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
 	INCR_WRAP_EXT                                              = 0x8507
@@ -12851,9 +13526,13 @@ const (
 	INT16_VEC2_NV                                              = 0x8FE5
 	INT16_VEC3_NV                                              = 0x8FE6
 	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
 	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
 	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
 	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
 	INT64_VEC4_NV                                              = 0x8FEB
 	INT8_NV                                                    = 0x8FE0
 	INT8_VEC2_NV                                               = 0x8FE1
@@ -12991,13 +13670,23 @@ const (
 	LAST_VIDEO_CAPTURE_STATUS_NV                               = 0x9027
 	LAYER_NV                                                   = 0x8DAA
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
+	LAYOUT_COLOR_ATTACHMENT_EXT                                = 0x958E
 	LAYOUT_DEFAULT_INTEL                                       = 0
+	LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT              = 0x9531
+	LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT              = 0x9530
+	LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT                        = 0x958F
+	LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT                         = 0x9590
+	LAYOUT_GENERAL_EXT                                         = 0x958D
 	LAYOUT_LINEAR_CPU_CACHED_INTEL                             = 2
 	LAYOUT_LINEAR_INTEL                                        = 1
+	LAYOUT_SHADER_READ_ONLY_EXT                                = 0x9591
+	LAYOUT_TRANSFER_DST_EXT                                    = 0x9593
+	LAYOUT_TRANSFER_SRC_EXT                                    = 0x9592
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LERP_ATI                                                   = 0x8969
 	LESS                                                       = 0x0201
+	LGPU_SEPARATE_STORAGE_BIT_NVX                              = 0x0800
 	LIGHT0                                                     = 0x4000
 	LIGHT1                                                     = 0x4001
 	LIGHT2                                                     = 0x4002
@@ -13033,6 +13722,7 @@ const (
 	LINEAR_SHARPEN_ALPHA_SGIS                                  = 0x80AE
 	LINEAR_SHARPEN_COLOR_SGIS                                  = 0x80AF
 	LINEAR_SHARPEN_SGIS                                        = 0x80AD
+	LINEAR_TILING_EXT                                          = 0x9585
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
 	LINES_ADJACENCY_ARB                                        = 0x000A
@@ -13052,6 +13742,7 @@ const (
 	LINE_TOKEN                                                 = 0x0702
 	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -13078,6 +13769,7 @@ const (
 	LOW_INT                                                    = 0x8DF3
 	LO_BIAS_NV                                                 = 0x8715
 	LO_SCALE_NV                                                = 0x870F
+	LUID_SIZE_EXT                                              = 8
 	LUMINANCE                                                  = 0x1909
 	LUMINANCE12                                                = 0x8041
 	LUMINANCE12_ALPHA12                                        = 0x8047
@@ -13411,6 +14103,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_LGPU_GPUS_NVX                                          = 0x92BA
 	MAX_LIGHTS                                                 = 0x0D31
 	MAX_LIST_NESTING                                           = 0x0B31
 	MAX_MAP_TESSELLATION_NV                                    = 0x86D6
@@ -13474,6 +14167,7 @@ const (
 	MAX_PROGRAM_TEX_INSTRUCTIONS_ARB                           = 0x880C
 	MAX_PROGRAM_TOTAL_OUTPUT_COMPONENTS_NV                     = 0x8C28
 	MAX_PROJECTION_STACK_DEPTH                                 = 0x0D38
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RATIONAL_EVAL_ORDER_NV                                 = 0x86D7
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RECTANGLE_TEXTURE_SIZE_ARB                             = 0x84F8
@@ -13486,6 +14180,8 @@ const (
 	MAX_SAMPLE_MASK_WORDS_NV                                   = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
 	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SHININESS_NV                                           = 0x8504
@@ -13496,6 +14192,7 @@ const (
 	MAX_SPARSE_TEXTURE_SIZE_AMD                                = 0x9198
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
 	MAX_SPOT_EXPONENT_NV                                       = 0x8505
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -13530,6 +14227,7 @@ const (
 	MAX_TEXTURE_IMAGE_UNITS_NV                                 = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
 	MAX_TEXTURE_LOD_BIAS_EXT                                   = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_MAX_ANISOTROPY_EXT                             = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TEXTURE_STACK_DEPTH                                    = 0x0D39
@@ -13585,7 +14283,9 @@ const (
 	MAX_VERTEX_VARYING_COMPONENTS_EXT                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
@@ -13610,7 +14310,6 @@ const (
 	MIN_PROGRAM_TEXTURE_GATHER_OFFSET_NV                       = 0x8E5E
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
 	MIN_SPARSE_LEVEL_AMD                                       = 0x919B
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
 	MIRRORED_REPEAT_ARB                                        = 0x8370
@@ -13623,6 +14322,8 @@ const (
 	MIRROR_CLAMP_TO_EDGE_EXT                                   = 0x8743
 	MITER_REVERT_NV                                            = 0x90A7
 	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
 	MODELVIEW                                                  = 0x1700
 	MODELVIEW0_ARB                                             = 0x1700
 	MODELVIEW0_EXT                                             = 0x1700
@@ -13674,9 +14375,12 @@ const (
 	MOVE_TO_RESETS_NV                                          = 0x90B5
 	MOV_ATI                                                    = 0x8961
 	MULT                                                       = 0x0103
+	MULTICAST_GPUS_NV                                          = 0x92BA
+	MULTICAST_PROGRAMMABLE_SAMPLE_LOCATION_NV                  = 0x9549
 	MULTIPLY_KHR                                               = 0x9294
 	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
 	MULTISAMPLE_3DFX                                           = 0x86B2
 	MULTISAMPLE_ARB                                            = 0x809D
 	MULTISAMPLE_BIT                                            = 0x20000000
@@ -13686,6 +14390,9 @@ const (
 	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
 	MULTISAMPLE_EXT                                            = 0x809D
 	MULTISAMPLE_FILTER_HINT_NV                                 = 0x8534
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	MULTISAMPLE_SGIS                                           = 0x809D
 	MUL_ATI                                                    = 0x8964
 	MVP_MATRIX_EXT                                             = 0x87E3
@@ -13716,6 +14423,7 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
 	NORMALIZE                                                  = 0x0BA1
 	NORMALIZED_RANGE_EXT                                       = 0x87E0
@@ -13749,6 +14457,7 @@ const (
 	NUM_COMPATIBLE_SUBROUTINES                                 = 0x8E4A
 	NUM_COMPRESSED_TEXTURE_FORMATS                             = 0x86A2
 	NUM_COMPRESSED_TEXTURE_FORMATS_ARB                         = 0x86A2
+	NUM_DEVICE_UUIDS_EXT                                       = 0x9596
 	NUM_EXTENSIONS                                             = 0x821D
 	NUM_FILL_STREAMS_NV                                        = 0x8E29
 	NUM_FRAGMENT_CONSTANTS_ATI                                 = 0x896F
@@ -13762,8 +14471,12 @@ const (
 	NUM_PROGRAM_BINARY_FORMATS                                 = 0x87FE
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
+	NUM_TILING_TYPES_EXT                                       = 0x9582
 	NUM_VIDEO_CAPTURE_STREAMS_NV                               = 0x9024
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_ACTIVE_ATTRIBUTES_ARB                               = 0x8B89
 	OBJECT_ACTIVE_ATTRIBUTE_MAX_LENGTH_ARB                     = 0x8B8A
 	OBJECT_ACTIVE_UNIFORMS_ARB                                 = 0x8B86
@@ -13840,6 +14553,7 @@ const (
 	OPERAND2_RGB_EXT                                           = 0x8592
 	OPERAND3_ALPHA_NV                                          = 0x859B
 	OPERAND3_RGB_NV                                            = 0x8593
+	OPTIMAL_TILING_EXT                                         = 0x9584
 	OP_ADD_EXT                                                 = 0x8787
 	OP_CLAMP_EXT                                               = 0x878E
 	OP_CROSS_PRODUCT_EXT                                       = 0x8797
@@ -13919,7 +14633,7 @@ const (
 	PACK_INVERT_MESA                                           = 0x8758
 	PACK_LSB_FIRST                                             = 0x0D01
 	PACK_RESAMPLE_OML                                          = 0x8984
-	PACK_RESAMPLE_SGIX                                         = 0x842C
+	PACK_RESAMPLE_SGIX                                         = 0x842E
 	PACK_ROW_BYTES_APPLE                                       = 0x8A15
 	PACK_ROW_LENGTH                                            = 0x0D02
 	PACK_SKIP_IMAGES                                           = 0x806B
@@ -14024,10 +14738,14 @@ const (
 	PERFQUERY_WAIT_INTEL                                       = 0x83FB
 	PERSPECTIVE_CORRECTION_HINT                                = 0x0C50
 	PERTURB_EXT                                                = 0x85AE
+	PER_GPU_STORAGE_BIT_NV                                     = 0x0800
+	PER_GPU_STORAGE_NV                                         = 0x9548
 	PER_STAGE_CONSTANTS_NV                                     = 0x8535
 	PHONG_HINT_WIN                                             = 0x80EB
 	PHONG_WIN                                                  = 0x80EA
 	PINLIGHT_NV                                                = 0x92A8
+	PIXELS_PER_SAMPLE_PATTERN_X_AMD                            = 0x91AE
+	PIXELS_PER_SAMPLE_PATTERN_Y_AMD                            = 0x91AF
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_BUFFER_BARRIER_BIT_EXT                               = 0x00000080
 	PIXEL_COUNTER_BITS_NV                                      = 0x8864
@@ -14133,6 +14851,9 @@ const (
 	POLYGON_BIT                                                = 0x00000008
 	POLYGON_MODE                                               = 0x0B40
 	POLYGON_OFFSET_BIAS_EXT                                    = 0x8039
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_EXT                                         = 0x8037
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FACTOR_EXT                                  = 0x8038
@@ -14203,6 +14924,7 @@ const (
 	PRIMITIVES_GENERATED_EXT                                   = 0x8C87
 	PRIMITIVES_GENERATED_NV                                    = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_ID_NV                                            = 0x8C7C
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
@@ -14210,11 +14932,16 @@ const (
 	PRIMITIVE_RESTART_INDEX_NV                                 = 0x8559
 	PRIMITIVE_RESTART_NV                                       = 0x8558
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_ADDRESS_REGISTERS_ARB                              = 0x88B0
 	PROGRAM_ALU_INSTRUCTIONS_ARB                               = 0x8805
 	PROGRAM_ATTRIBS_ARB                                        = 0x88AC
 	PROGRAM_ATTRIB_COMPONENTS_NV                               = 0x8906
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
+	PROGRAM_BINARY_FORMAT_MESA                                 = 0x875F
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_BINDING_ARB                                        = 0x8677
@@ -14247,6 +14974,7 @@ const (
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
 	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
 	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
 	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
@@ -14265,6 +14993,7 @@ const (
 	PROJECTION                                                 = 0x1701
 	PROJECTION_MATRIX                                          = 0x0BA7
 	PROJECTION_STACK_DEPTH                                     = 0x0BA4
+	PROTECTED_MEMORY_OBJECT_EXT                                = 0x959B
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROVOKING_VERTEX_EXT                                       = 0x8E4F
 	PROXY_COLOR_TABLE                                          = 0x80D3
@@ -14300,6 +15029,7 @@ const (
 	PROXY_TEXTURE_RECTANGLE_ARB                                = 0x84F7
 	PROXY_TEXTURE_RECTANGLE_NV                                 = 0x84F7
 	PURGEABLE_APPLE                                            = 0x8A1D
+	PURGED_CONTEXT_RESET_NV                                    = 0x92BB
 	Q                                                          = 0x2003
 	QUADRATIC_ATTENUATION                                      = 0x1209
 	QUADRATIC_CURVE_TO_NV                                      = 0x0A
@@ -14340,6 +15070,12 @@ const (
 	QUERY_NO_WAIT_NV                                           = 0x8E14
 	QUERY_OBJECT_AMD                                           = 0x9153
 	QUERY_OBJECT_EXT                                           = 0x9153
+	QUERY_RESOURCE_BUFFEROBJECT_NV                             = 0x9547
+	QUERY_RESOURCE_MEMTYPE_VIDMEM_NV                           = 0x9542
+	QUERY_RESOURCE_RENDERBUFFER_NV                             = 0x9546
+	QUERY_RESOURCE_SYS_RESERVED_NV                             = 0x9544
+	QUERY_RESOURCE_TEXTURE_NV                                  = 0x9545
+	QUERY_RESOURCE_TYPE_VIDMEM_ALLOC_NV                        = 0x9540
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_ARB                                           = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
@@ -14378,7 +15114,10 @@ const (
 	RASTERIZER_DISCARD                                         = 0x8C89
 	RASTERIZER_DISCARD_EXT                                     = 0x8C89
 	RASTERIZER_DISCARD_NV                                      = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
 	RASTER_POSITION_UNCLIPPED_IBM                              = 0x19262
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -14503,6 +15242,7 @@ const (
 	RENDERBUFFER_WIDTH                                         = 0x8D42
 	RENDERBUFFER_WIDTH_EXT                                     = 0x8D42
 	RENDERER                                                   = 0x1F01
+	RENDER_GPU_MASK_NV                                         = 0x9558
 	RENDER_MODE                                                = 0x0C40
 	REPEAT                                                     = 0x2901
 	REPLACE                                                    = 0x1E01
@@ -14521,9 +15261,9 @@ const (
 	RESAMPLE_DECIMATE_OML                                      = 0x8989
 	RESAMPLE_DECIMATE_SGIX                                     = 0x8430
 	RESAMPLE_REPLICATE_OML                                     = 0x8986
-	RESAMPLE_REPLICATE_SGIX                                    = 0x842E
+	RESAMPLE_REPLICATE_SGIX                                    = 0x8433
 	RESAMPLE_ZERO_FILL_OML                                     = 0x8987
-	RESAMPLE_ZERO_FILL_SGIX                                    = 0x842F
+	RESAMPLE_ZERO_FILL_SGIX                                    = 0x8434
 	RESCALE_NORMAL                                             = 0x803A
 	RESCALE_NORMAL_EXT                                         = 0x803A
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
@@ -14719,6 +15459,14 @@ const (
 	SAMPLE_COVERAGE_INVERT_ARB                                 = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
 	SAMPLE_COVERAGE_VALUE_ARB                                  = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_EXT                                            = 0x80A0
 	SAMPLE_MASK_INVERT_EXT                                     = 0x80AB
@@ -14744,6 +15492,7 @@ const (
 	SCALE_BY_TWO_NV                                            = 0x853E
 	SCISSOR_BIT                                                = 0x00080000
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
 	SCREEN_COORDINATES_REND                                    = 0x8490
 	SCREEN_KHR                                                 = 0x9295
@@ -14780,6 +15529,7 @@ const (
 	SET_AMD                                                    = 0x874A
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
 	SHADER_CONSISTENT_NV                                       = 0x86DD
 	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
@@ -14807,6 +15557,7 @@ const (
 	SHADING_LANGUAGE_VERSION_ARB                               = 0x8B8C
 	SHADOW_AMBIENT_SGIX                                        = 0x80BF
 	SHADOW_ATTENUATION_EXT                                     = 0x834E
+	SHARED_EDGE_NV                                             = 0xC0
 	SHARED_TEXTURE_PALETTE_EXT                                 = 0x81FB
 	SHARPEN_TEXTURE_FUNC_POINTS_SGIS                           = 0x80B0
 	SHININESS                                                  = 0x1601
@@ -14893,6 +15644,8 @@ const (
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
 	SPECULAR                                                   = 0x1202
 	SPHERE_MAP                                                 = 0x2402
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
 	SPOT_CUTOFF                                                = 0x1206
 	SPOT_DIRECTION                                             = 0x1204
 	SPOT_EXPONENT                                              = 0x1205
@@ -14979,7 +15732,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TAG_BITS_EXT                                       = 0x88F2
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_TEST_TWO_SIDE_EXT                                  = 0x8910
@@ -15001,11 +15756,15 @@ const (
 	STRICT_LIGHTING_HINT_PGI                                   = 0x1A217
 	STRICT_SCISSOR_HINT_PGI                                    = 0x1A218
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
 	SUBSAMPLE_DISTANCE_AMD                                     = 0x883F
 	SUBTRACT                                                   = 0x84E7
 	SUBTRACT_ARB                                               = 0x84E7
 	SUB_ATI                                                    = 0x8965
 	SUCCESS_NV                                                 = 0x902F
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SURFACE_MAPPED_NV                                          = 0x8700
 	SURFACE_REGISTERED_NV                                      = 0x86FD
 	SURFACE_STATE_NV                                           = 0x86EB
@@ -15043,6 +15802,7 @@ const (
 	TANGENT_ARRAY_POINTER_EXT                                  = 0x8442
 	TANGENT_ARRAY_STRIDE_EXT                                   = 0x843F
 	TANGENT_ARRAY_TYPE_EXT                                     = 0x843E
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESSELLATION_FACTOR_AMD                                    = 0x9005
 	TESSELLATION_MODE_AMD                                      = 0x9004
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
@@ -15162,7 +15922,6 @@ const (
 	TEXTURE_APPLICATION_MODE_EXT                               = 0x834F
 	TEXTURE_BASE_LEVEL                                         = 0x813C
 	TEXTURE_BASE_LEVEL_SGIS                                    = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_1D_ARRAY_EXT                               = 0x8C1C
@@ -15338,6 +16097,7 @@ const (
 	TEXTURE_MATERIAL_FACE_EXT                                  = 0x8351
 	TEXTURE_MATERIAL_PARAMETER_EXT                             = 0x8352
 	TEXTURE_MATRIX                                             = 0x0BA8
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_ANISOTROPY_EXT                                 = 0x84FE
 	TEXTURE_MAX_CLAMP_R_SGIX                                   = 0x836B
 	TEXTURE_MAX_CLAMP_S_SGIX                                   = 0x8369
@@ -15361,6 +16121,8 @@ const (
 	TEXTURE_RECTANGLE                                          = 0x84F5
 	TEXTURE_RECTANGLE_ARB                                      = 0x84F5
 	TEXTURE_RECTANGLE_NV                                       = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_SIZE_EXT                                       = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
@@ -15392,6 +16154,7 @@ const (
 	TEXTURE_SWIZZLE_RGBA_EXT                                   = 0x8E46
 	TEXTURE_SWIZZLE_R_EXT                                      = 0x8E42
 	TEXTURE_TARGET                                             = 0x1006
+	TEXTURE_TILING_EXT                                         = 0x9580
 	TEXTURE_TOO_LARGE_EXT                                      = 0x8065
 	TEXTURE_UNSIGNED_REMAP_MODE_NV                             = 0x888F
 	TEXTURE_UPDATE_BARRIER_BIT                                 = 0x00000100
@@ -15408,6 +16171,10 @@ const (
 	TEXTURE_WRAP_S                                             = 0x2802
 	TEXTURE_WRAP_T                                             = 0x2803
 	TEXT_FRAGMENT_SHADER_ATI                                   = 0x8200
+	TILE_RASTER_ORDER_FIXED_MESA                               = 0x8BB8
+	TILE_RASTER_ORDER_INCREASING_X_MESA                        = 0x8BB9
+	TILE_RASTER_ORDER_INCREASING_Y_MESA                        = 0x8BBA
+	TILING_TYPES_EXT                                           = 0x9583
 	TIMEOUT_EXPIRED                                            = 0x911B
 	TIMEOUT_IGNORED                                            = 0xFFFFFFFFFFFFFFFF
 	TIMESTAMP                                                  = 0x8E28
@@ -15419,7 +16186,6 @@ const (
 	TRACK_MATRIX_TRANSFORM_NV                                  = 0x8649
 	TRANSFORM_BIT                                              = 0x00001000
 	TRANSFORM_FEEDBACK                                         = 0x8E22
-	TRANSFORM_FEEDBACK_ACTIVE                                  = 0x8E24
 	TRANSFORM_FEEDBACK_ATTRIBS_NV                              = 0x8C7E
 	TRANSFORM_FEEDBACK_BARRIER_BIT                             = 0x00000800
 	TRANSFORM_FEEDBACK_BARRIER_BIT_EXT                         = 0x00000800
@@ -15448,7 +16214,6 @@ const (
 	TRANSFORM_FEEDBACK_BUFFER_STRIDE                           = 0x934C
 	TRANSFORM_FEEDBACK_NV                                      = 0x8E22
 	TRANSFORM_FEEDBACK_OVERFLOW_ARB                            = 0x82EC
-	TRANSFORM_FEEDBACK_PAUSED                                  = 0x8E23
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN                      = 0x8C88
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN_EXT                  = 0x8C88
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN_NV                   = 0x8C88
@@ -15496,6 +16261,7 @@ const (
 	UNDEFINED_APPLE                                            = 0x8A1C
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -15514,12 +16280,15 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
 	UNIFORM_BUFFER_BINDING_EXT                                 = 0x8DEF
 	UNIFORM_BUFFER_EXT                                         = 0x8DEE
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -15542,7 +16311,7 @@ const (
 	UNPACK_IMAGE_HEIGHT_EXT                                    = 0x806E
 	UNPACK_LSB_FIRST                                           = 0x0CF1
 	UNPACK_RESAMPLE_OML                                        = 0x8985
-	UNPACK_RESAMPLE_SGIX                                       = 0x842D
+	UNPACK_RESAMPLE_SGIX                                       = 0x842F
 	UNPACK_ROW_BYTES_APPLE                                     = 0x8A16
 	UNPACK_ROW_LENGTH                                          = 0x0CF2
 	UNPACK_SKIP_IMAGES                                         = 0x806D
@@ -15566,8 +16335,11 @@ const (
 	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
 	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
 	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
 	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
 	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
 	UNSIGNED_INT8_NV                                           = 0x8FEC
 	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
@@ -15658,6 +16430,7 @@ const (
 	USE_MISSING_GLYPH_NV                                       = 0x90AA
 	UTF16_NV                                                   = 0x909B
 	UTF8_NV                                                    = 0x909A
+	UUID_SIZE_EXT                                              = 16
 	V2F                                                        = 0x2A20
 	V3F                                                        = 0x2A21
 	VALIDATE_STATUS                                            = 0x8B83
@@ -15838,8 +16611,24 @@ const (
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BIT                                               = 0x00000800
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -15869,6 +16658,8 @@ const (
 	WAIT_FAILED                                                = 0x911D
 	WARPS_PER_SM_NV                                            = 0x933A
 	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
 	WEIGHT_ARRAY_ARB                                           = 0x86AD
 	WEIGHT_ARRAY_BUFFER_BINDING                                = 0x889E
 	WEIGHT_ARRAY_BUFFER_BINDING_ARB                            = 0x889E
@@ -15878,6 +16669,8 @@ const (
 	WEIGHT_ARRAY_TYPE_ARB                                      = 0x86A9
 	WEIGHT_SUM_UNITY_ARB                                       = 0x86A6
 	WIDE_LINE_HINT_PGI                                         = 0x1A222
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRAP_BORDER_SUN                                            = 0x81D4
 	WRITE_DISCARD_NV                                           = 0x88BE
 	WRITE_ONLY                                                 = 0x88B9
@@ -15914,6 +16707,7 @@ const (
 var (
 	gpAccum                                                  C.GPACCUM
 	gpAccumxOES                                              C.GPACCUMXOES
+	gpAcquireKeyedMutexWin32EXT                              C.GPACQUIREKEYEDMUTEXWIN32EXT
 	gpActiveProgramEXT                                       C.GPACTIVEPROGRAMEXT
 	gpActiveShaderProgram                                    C.GPACTIVESHADERPROGRAM
 	gpActiveShaderProgramEXT                                 C.GPACTIVESHADERPROGRAMEXT
@@ -15926,6 +16720,8 @@ var (
 	gpAlphaFragmentOp3ATI                                    C.GPALPHAFRAGMENTOP3ATI
 	gpAlphaFunc                                              C.GPALPHAFUNC
 	gpAlphaFuncxOES                                          C.GPALPHAFUNCXOES
+	gpAlphaToCoverageDitherControlNV                         C.GPALPHATOCOVERAGEDITHERCONTROLNV
+	gpApplyFramebufferAttachmentCMAAINTEL                    C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
 	gpApplyTextureEXT                                        C.GPAPPLYTEXTUREEXT
 	gpAreProgramsResidentNV                                  C.GPAREPROGRAMSRESIDENTNV
 	gpAreTexturesResident                                    C.GPARETEXTURESRESIDENT
@@ -16046,8 +16842,11 @@ var (
 	gpBufferPageCommitmentARB                                C.GPBUFFERPAGECOMMITMENTARB
 	gpBufferParameteriAPPLE                                  C.GPBUFFERPARAMETERIAPPLE
 	gpBufferStorage                                          C.GPBUFFERSTORAGE
+	gpBufferStorageExternalEXT                               C.GPBUFFERSTORAGEEXTERNALEXT
+	gpBufferStorageMemEXT                                    C.GPBUFFERSTORAGEMEMEXT
 	gpBufferSubData                                          C.GPBUFFERSUBDATA
 	gpBufferSubDataARB                                       C.GPBUFFERSUBDATAARB
+	gpCallCommandListNV                                      C.GPCALLCOMMANDLISTNV
 	gpCallList                                               C.GPCALLLIST
 	gpCallLists                                              C.GPCALLLISTS
 	gpCheckFramebufferStatus                                 C.GPCHECKFRAMEBUFFERSTATUS
@@ -16175,6 +16974,8 @@ var (
 	gpCombinerParameteriNV                                   C.GPCOMBINERPARAMETERINV
 	gpCombinerParameterivNV                                  C.GPCOMBINERPARAMETERIVNV
 	gpCombinerStageParameterfvNV                             C.GPCOMBINERSTAGEPARAMETERFVNV
+	gpCommandListSegmentsNV                                  C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                                   C.GPCOMPILECOMMANDLISTNV
 	gpCompileShader                                          C.GPCOMPILESHADER
 	gpCompileShaderARB                                       C.GPCOMPILESHADERARB
 	gpCompileShaderIncludeARB                                C.GPCOMPILESHADERINCLUDEARB
@@ -16205,6 +17006,8 @@ var (
 	gpCompressedTextureSubImage2DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
 	gpCompressedTextureSubImage3D                            C.GPCOMPRESSEDTEXTURESUBIMAGE3D
 	gpCompressedTextureSubImage3DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                         C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                         C.GPCONSERVATIVERASTERPARAMETERINV
 	gpConvolutionFilter1D                                    C.GPCONVOLUTIONFILTER1D
 	gpConvolutionFilter1DEXT                                 C.GPCONVOLUTIONFILTER1DEXT
 	gpConvolutionFilter2D                                    C.GPCONVOLUTIONFILTER2D
@@ -16260,8 +17063,12 @@ var (
 	gpCoverFillPathNV                                        C.GPCOVERFILLPATHNV
 	gpCoverStrokePathInstancedNV                             C.GPCOVERSTROKEPATHINSTANCEDNV
 	gpCoverStrokePathNV                                      C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                                   C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                              C.GPCOVERAGEMODULATIONTABLENV
 	gpCreateBuffers                                          C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                                   C.GPCREATECOMMANDLISTSNV
 	gpCreateFramebuffers                                     C.GPCREATEFRAMEBUFFERS
+	gpCreateMemoryObjectsEXT                                 C.GPCREATEMEMORYOBJECTSEXT
 	gpCreatePerfQueryINTEL                                   C.GPCREATEPERFQUERYINTEL
 	gpCreateProgram                                          C.GPCREATEPROGRAM
 	gpCreateProgramObjectARB                                 C.GPCREATEPROGRAMOBJECTARB
@@ -16274,6 +17081,7 @@ var (
 	gpCreateShaderProgramEXT                                 C.GPCREATESHADERPROGRAMEXT
 	gpCreateShaderProgramv                                   C.GPCREATESHADERPROGRAMV
 	gpCreateShaderProgramvEXT                                C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                         C.GPCREATESTATESNV
 	gpCreateSyncFromCLeventARB                               C.GPCREATESYNCFROMCLEVENTARB
 	gpCreateTextures                                         C.GPCREATETEXTURES
 	gpCreateTransformFeedbacks                               C.GPCREATETRANSFORMFEEDBACKS
@@ -16300,12 +17108,14 @@ var (
 	gpDeleteAsyncMarkersSGIX                                 C.GPDELETEASYNCMARKERSSGIX
 	gpDeleteBuffers                                          C.GPDELETEBUFFERS
 	gpDeleteBuffersARB                                       C.GPDELETEBUFFERSARB
+	gpDeleteCommandListsNV                                   C.GPDELETECOMMANDLISTSNV
 	gpDeleteFencesAPPLE                                      C.GPDELETEFENCESAPPLE
 	gpDeleteFencesNV                                         C.GPDELETEFENCESNV
 	gpDeleteFragmentShaderATI                                C.GPDELETEFRAGMENTSHADERATI
 	gpDeleteFramebuffers                                     C.GPDELETEFRAMEBUFFERS
 	gpDeleteFramebuffersEXT                                  C.GPDELETEFRAMEBUFFERSEXT
 	gpDeleteLists                                            C.GPDELETELISTS
+	gpDeleteMemoryObjectsEXT                                 C.GPDELETEMEMORYOBJECTSEXT
 	gpDeleteNamedStringARB                                   C.GPDELETENAMEDSTRINGARB
 	gpDeleteNamesAMD                                         C.GPDELETENAMESAMD
 	gpDeleteObjectARB                                        C.GPDELETEOBJECTARB
@@ -16320,10 +17130,13 @@ var (
 	gpDeleteProgramsNV                                       C.GPDELETEPROGRAMSNV
 	gpDeleteQueries                                          C.GPDELETEQUERIES
 	gpDeleteQueriesARB                                       C.GPDELETEQUERIESARB
+	gpDeleteQueryResourceTagNV                               C.GPDELETEQUERYRESOURCETAGNV
 	gpDeleteRenderbuffers                                    C.GPDELETERENDERBUFFERS
 	gpDeleteRenderbuffersEXT                                 C.GPDELETERENDERBUFFERSEXT
 	gpDeleteSamplers                                         C.GPDELETESAMPLERS
+	gpDeleteSemaphoresEXT                                    C.GPDELETESEMAPHORESEXT
 	gpDeleteShader                                           C.GPDELETESHADER
+	gpDeleteStatesNV                                         C.GPDELETESTATESNV
 	gpDeleteSync                                             C.GPDELETESYNC
 	gpDeleteTextures                                         C.GPDELETETEXTURES
 	gpDeleteTexturesEXT                                      C.GPDELETETEXTURESEXT
@@ -16373,6 +17186,10 @@ var (
 	gpDrawBuffers                                            C.GPDRAWBUFFERS
 	gpDrawBuffersARB                                         C.GPDRAWBUFFERSARB
 	gpDrawBuffersATI                                         C.GPDRAWBUFFERSATI
+	gpDrawCommandsAddressNV                                  C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                         C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                            C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                                   C.GPDRAWCOMMANDSSTATESNV
 	gpDrawElementArrayAPPLE                                  C.GPDRAWELEMENTARRAYAPPLE
 	gpDrawElementArrayATI                                    C.GPDRAWELEMENTARRAYATI
 	gpDrawElements                                           C.GPDRAWELEMENTS
@@ -16397,6 +17214,7 @@ var (
 	gpDrawTransformFeedbackNV                                C.GPDRAWTRANSFORMFEEDBACKNV
 	gpDrawTransformFeedbackStream                            C.GPDRAWTRANSFORMFEEDBACKSTREAM
 	gpDrawTransformFeedbackStreamInstanced                   C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                          C.GPDRAWVKIMAGENV
 	gpEdgeFlag                                               C.GPEDGEFLAG
 	gpEdgeFlagFormatNV                                       C.GPEDGEFLAGFORMATNV
 	gpEdgeFlagPointer                                        C.GPEDGEFLAGPOINTER
@@ -16452,6 +17270,7 @@ var (
 	gpEvalMesh2                                              C.GPEVALMESH2
 	gpEvalPoint1                                             C.GPEVALPOINT1
 	gpEvalPoint2                                             C.GPEVALPOINT2
+	gpEvaluateDepthValuesARB                                 C.GPEVALUATEDEPTHVALUESARB
 	gpExecuteProgramNV                                       C.GPEXECUTEPROGRAMNV
 	gpExtractComponentEXT                                    C.GPEXTRACTCOMPONENTEXT
 	gpFeedbackBuffer                                         C.GPFEEDBACKBUFFER
@@ -16496,6 +17315,7 @@ var (
 	gpFogxOES                                                C.GPFOGXOES
 	gpFogxvOES                                               C.GPFOGXVOES
 	gpFragmentColorMaterialSGIX                              C.GPFRAGMENTCOLORMATERIALSGIX
+	gpFragmentCoverageColorNV                                C.GPFRAGMENTCOVERAGECOLORNV
 	gpFragmentLightModelfSGIX                                C.GPFRAGMENTLIGHTMODELFSGIX
 	gpFragmentLightModelfvSGIX                               C.GPFRAGMENTLIGHTMODELFVSGIX
 	gpFragmentLightModeliSGIX                                C.GPFRAGMENTLIGHTMODELISGIX
@@ -16512,10 +17332,14 @@ var (
 	gpFrameZoomSGIX                                          C.GPFRAMEZOOMSGIX
 	gpFramebufferDrawBufferEXT                               C.GPFRAMEBUFFERDRAWBUFFEREXT
 	gpFramebufferDrawBuffersEXT                              C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                             C.GPFRAMEBUFFERFETCHBARRIEREXT
 	gpFramebufferParameteri                                  C.GPFRAMEBUFFERPARAMETERI
 	gpFramebufferReadBufferEXT                               C.GPFRAMEBUFFERREADBUFFEREXT
 	gpFramebufferRenderbuffer                                C.GPFRAMEBUFFERRENDERBUFFER
 	gpFramebufferRenderbufferEXT                             C.GPFRAMEBUFFERRENDERBUFFEREXT
+	gpFramebufferSampleLocationsfvARB                        C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                         C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferSamplePositionsfvAMD                        C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpFramebufferTexture                                     C.GPFRAMEBUFFERTEXTURE
 	gpFramebufferTexture1D                                   C.GPFRAMEBUFFERTEXTURE1D
 	gpFramebufferTexture1DEXT                                C.GPFRAMEBUFFERTEXTURE1DEXT
@@ -16530,6 +17354,7 @@ var (
 	gpFramebufferTextureLayer                                C.GPFRAMEBUFFERTEXTURELAYER
 	gpFramebufferTextureLayerARB                             C.GPFRAMEBUFFERTEXTURELAYERARB
 	gpFramebufferTextureLayerEXT                             C.GPFRAMEBUFFERTEXTURELAYEREXT
+	gpFramebufferTextureMultiviewOVR                         C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
 	gpFreeObjectBufferATI                                    C.GPFREEOBJECTBUFFERATI
 	gpFrontFace                                              C.GPFRONTFACE
 	gpFrustum                                                C.GPFRUSTUM
@@ -16554,9 +17379,11 @@ var (
 	gpGenProgramsNV                                          C.GPGENPROGRAMSNV
 	gpGenQueries                                             C.GPGENQUERIES
 	gpGenQueriesARB                                          C.GPGENQUERIESARB
+	gpGenQueryResourceTagNV                                  C.GPGENQUERYRESOURCETAGNV
 	gpGenRenderbuffers                                       C.GPGENRENDERBUFFERS
 	gpGenRenderbuffersEXT                                    C.GPGENRENDERBUFFERSEXT
 	gpGenSamplers                                            C.GPGENSAMPLERS
+	gpGenSemaphoresEXT                                       C.GPGENSEMAPHORESEXT
 	gpGenSymbolsEXT                                          C.GPGENSYMBOLSEXT
 	gpGenTextures                                            C.GPGENTEXTURES
 	gpGenTexturesEXT                                         C.GPGENTEXTURESEXT
@@ -16617,6 +17444,7 @@ var (
 	gpGetCombinerOutputParameterfvNV                         C.GPGETCOMBINEROUTPUTPARAMETERFVNV
 	gpGetCombinerOutputParameterivNV                         C.GPGETCOMBINEROUTPUTPARAMETERIVNV
 	gpGetCombinerStageParameterfvNV                          C.GPGETCOMBINERSTAGEPARAMETERFVNV
+	gpGetCommandHeaderNV                                     C.GPGETCOMMANDHEADERNV
 	gpGetCompressedMultiTexImageEXT                          C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
 	gpGetCompressedTexImage                                  C.GPGETCOMPRESSEDTEXIMAGE
 	gpGetCompressedTexImageARB                               C.GPGETCOMPRESSEDTEXIMAGEARB
@@ -16630,6 +17458,7 @@ var (
 	gpGetConvolutionParameteriv                              C.GPGETCONVOLUTIONPARAMETERIV
 	gpGetConvolutionParameterivEXT                           C.GPGETCONVOLUTIONPARAMETERIVEXT
 	gpGetConvolutionParameterxvOES                           C.GPGETCONVOLUTIONPARAMETERXVOES
+	gpGetCoverageModulationTableNV                           C.GPGETCOVERAGEMODULATIONTABLENV
 	gpGetDebugMessageLog                                     C.GPGETDEBUGMESSAGELOG
 	gpGetDebugMessageLogAMD                                  C.GPGETDEBUGMESSAGELOGAMD
 	gpGetDebugMessageLogARB                                  C.GPGETDEBUGMESSAGELOGARB
@@ -16659,6 +17488,7 @@ var (
 	gpGetFragmentMaterialivSGIX                              C.GPGETFRAGMENTMATERIALIVSGIX
 	gpGetFramebufferAttachmentParameteriv                    C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetFramebufferAttachmentParameterivEXT                 C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetFramebufferParameterfvAMD                           C.GPGETFRAMEBUFFERPARAMETERFVAMD
 	gpGetFramebufferParameteriv                              C.GPGETFRAMEBUFFERPARAMETERIV
 	gpGetFramebufferParameterivEXT                           C.GPGETFRAMEBUFFERPARAMETERIVEXT
 	gpGetGraphicsResetStatus                                 C.GPGETGRAPHICSRESETSTATUS
@@ -16685,6 +17515,7 @@ var (
 	gpGetIntegerui64i_vNV                                    C.GPGETINTEGERUI64I_VNV
 	gpGetIntegerui64vNV                                      C.GPGETINTEGERUI64VNV
 	gpGetIntegerv                                            C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                            C.GPGETINTERNALFORMATSAMPLEIVNV
 	gpGetInternalformati64v                                  C.GPGETINTERNALFORMATI64V
 	gpGetInternalformativ                                    C.GPGETINTERNALFORMATIV
 	gpGetInvariantBooleanvEXT                                C.GPGETINVARIANTBOOLEANVEXT
@@ -16712,6 +17543,7 @@ var (
 	gpGetMaterialiv                                          C.GPGETMATERIALIV
 	gpGetMaterialxOES                                        C.GPGETMATERIALXOES
 	gpGetMaterialxvOES                                       C.GPGETMATERIALXVOES
+	gpGetMemoryObjectParameterivEXT                          C.GPGETMEMORYOBJECTPARAMETERIVEXT
 	gpGetMinmax                                              C.GPGETMINMAX
 	gpGetMinmaxEXT                                           C.GPGETMINMAXEXT
 	gpGetMinmaxParameterfv                                   C.GPGETMINMAXPARAMETERFV
@@ -16742,6 +17574,7 @@ var (
 	gpGetNamedBufferSubDataEXT                               C.GPGETNAMEDBUFFERSUBDATAEXT
 	gpGetNamedFramebufferAttachmentParameteriv               C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetNamedFramebufferAttachmentParameterivEXT            C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameterfvAMD                      C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD
 	gpGetNamedFramebufferParameteriv                         C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
 	gpGetNamedFramebufferParameterivEXT                      C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
 	gpGetNamedProgramLocalParameterIivEXT                    C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
@@ -16836,6 +17669,10 @@ var (
 	gpGetProgramiv                                           C.GPGETPROGRAMIV
 	gpGetProgramivARB                                        C.GPGETPROGRAMIVARB
 	gpGetProgramivNV                                         C.GPGETPROGRAMIVNV
+	gpGetQueryBufferObjecti64v                               C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                                 C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                              C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                                C.GPGETQUERYBUFFEROBJECTUIV
 	gpGetQueryIndexediv                                      C.GPGETQUERYINDEXEDIV
 	gpGetQueryObjecti64v                                     C.GPGETQUERYOBJECTI64V
 	gpGetQueryObjecti64vEXT                                  C.GPGETQUERYOBJECTI64VEXT
@@ -16853,6 +17690,7 @@ var (
 	gpGetSamplerParameterIuiv                                C.GPGETSAMPLERPARAMETERIUIV
 	gpGetSamplerParameterfv                                  C.GPGETSAMPLERPARAMETERFV
 	gpGetSamplerParameteriv                                  C.GPGETSAMPLERPARAMETERIV
+	gpGetSemaphoreParameterui64vEXT                          C.GPGETSEMAPHOREPARAMETERUI64VEXT
 	gpGetSeparableFilter                                     C.GPGETSEPARABLEFILTER
 	gpGetSeparableFilterEXT                                  C.GPGETSEPARABLEFILTEREXT
 	gpGetShaderInfoLog                                       C.GPGETSHADERINFOLOG
@@ -16861,6 +17699,7 @@ var (
 	gpGetShaderSourceARB                                     C.GPGETSHADERSOURCEARB
 	gpGetShaderiv                                            C.GPGETSHADERIV
 	gpGetSharpenTexFuncSGIS                                  C.GPGETSHARPENTEXFUNCSGIS
+	gpGetStageIndexNV                                        C.GPGETSTAGEINDEXNV
 	gpGetString                                              C.GPGETSTRING
 	gpGetStringi                                             C.GPGETSTRINGI
 	gpGetSubroutineIndex                                     C.GPGETSUBROUTINEINDEX
@@ -16924,12 +17763,16 @@ var (
 	gpGetUniformdv                                           C.GPGETUNIFORMDV
 	gpGetUniformfv                                           C.GPGETUNIFORMFV
 	gpGetUniformfvARB                                        C.GPGETUNIFORMFVARB
+	gpGetUniformi64vARB                                      C.GPGETUNIFORMI64VARB
 	gpGetUniformi64vNV                                       C.GPGETUNIFORMI64VNV
 	gpGetUniformiv                                           C.GPGETUNIFORMIV
 	gpGetUniformivARB                                        C.GPGETUNIFORMIVARB
+	gpGetUniformui64vARB                                     C.GPGETUNIFORMUI64VARB
 	gpGetUniformui64vNV                                      C.GPGETUNIFORMUI64VNV
 	gpGetUniformuiv                                          C.GPGETUNIFORMUIV
 	gpGetUniformuivEXT                                       C.GPGETUNIFORMUIVEXT
+	gpGetUnsignedBytei_vEXT                                  C.GPGETUNSIGNEDBYTEI_VEXT
+	gpGetUnsignedBytevEXT                                    C.GPGETUNSIGNEDBYTEVEXT
 	gpGetVariantArrayObjectfvATI                             C.GPGETVARIANTARRAYOBJECTFVATI
 	gpGetVariantArrayObjectivATI                             C.GPGETVARIANTARRAYOBJECTIVATI
 	gpGetVariantBooleanvEXT                                  C.GPGETVARIANTBOOLEANVEXT
@@ -16975,6 +17818,7 @@ var (
 	gpGetVideoivNV                                           C.GPGETVIDEOIVNV
 	gpGetVideoui64vNV                                        C.GPGETVIDEOUI64VNV
 	gpGetVideouivNV                                          C.GPGETVIDEOUIVNV
+	gpGetVkProcAddrNV                                        C.GPGETVKPROCADDRNV
 	gpGetnColorTableARB                                      C.GPGETNCOLORTABLEARB
 	gpGetnCompressedTexImageARB                              C.GPGETNCOMPRESSEDTEXIMAGEARB
 	gpGetnConvolutionFilterARB                               C.GPGETNCONVOLUTIONFILTERARB
@@ -16993,9 +17837,11 @@ var (
 	gpGetnUniformfv                                          C.GPGETNUNIFORMFV
 	gpGetnUniformfvARB                                       C.GPGETNUNIFORMFVARB
 	gpGetnUniformfvKHR                                       C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                                     C.GPGETNUNIFORMI64VARB
 	gpGetnUniformiv                                          C.GPGETNUNIFORMIV
 	gpGetnUniformivARB                                       C.GPGETNUNIFORMIVARB
 	gpGetnUniformivKHR                                       C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                                    C.GPGETNUNIFORMUI64VARB
 	gpGetnUniformuiv                                         C.GPGETNUNIFORMUIV
 	gpGetnUniformuivARB                                      C.GPGETNUNIFORMUIVARB
 	gpGetnUniformuivKHR                                      C.GPGETNUNIFORMUIVKHR
@@ -17016,6 +17862,12 @@ var (
 	gpImageTransformParameterfvHP                            C.GPIMAGETRANSFORMPARAMETERFVHP
 	gpImageTransformParameteriHP                             C.GPIMAGETRANSFORMPARAMETERIHP
 	gpImageTransformParameterivHP                            C.GPIMAGETRANSFORMPARAMETERIVHP
+	gpImportMemoryFdEXT                                      C.GPIMPORTMEMORYFDEXT
+	gpImportMemoryWin32HandleEXT                             C.GPIMPORTMEMORYWIN32HANDLEEXT
+	gpImportMemoryWin32NameEXT                               C.GPIMPORTMEMORYWIN32NAMEEXT
+	gpImportSemaphoreFdEXT                                   C.GPIMPORTSEMAPHOREFDEXT
+	gpImportSemaphoreWin32HandleEXT                          C.GPIMPORTSEMAPHOREWIN32HANDLEEXT
+	gpImportSemaphoreWin32NameEXT                            C.GPIMPORTSEMAPHOREWIN32NAMEEXT
 	gpImportSyncEXT                                          C.GPIMPORTSYNCEXT
 	gpIndexFormatNV                                          C.GPINDEXFORMATNV
 	gpIndexFuncEXT                                           C.GPINDEXFUNCEXT
@@ -17054,6 +17906,7 @@ var (
 	gpIsBuffer                                               C.GPISBUFFER
 	gpIsBufferARB                                            C.GPISBUFFERARB
 	gpIsBufferResidentNV                                     C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                        C.GPISCOMMANDLISTNV
 	gpIsEnabled                                              C.GPISENABLED
 	gpIsEnabledIndexedEXT                                    C.GPISENABLEDINDEXEDEXT
 	gpIsEnabledi                                             C.GPISENABLEDI
@@ -17064,6 +17917,7 @@ var (
 	gpIsImageHandleResidentARB                               C.GPISIMAGEHANDLERESIDENTARB
 	gpIsImageHandleResidentNV                                C.GPISIMAGEHANDLERESIDENTNV
 	gpIsList                                                 C.GPISLIST
+	gpIsMemoryObjectEXT                                      C.GPISMEMORYOBJECTEXT
 	gpIsNameAMD                                              C.GPISNAMEAMD
 	gpIsNamedBufferResidentNV                                C.GPISNAMEDBUFFERRESIDENTNV
 	gpIsNamedStringARB                                       C.GPISNAMEDSTRINGARB
@@ -17082,7 +17936,9 @@ var (
 	gpIsRenderbuffer                                         C.GPISRENDERBUFFER
 	gpIsRenderbufferEXT                                      C.GPISRENDERBUFFEREXT
 	gpIsSampler                                              C.GPISSAMPLER
+	gpIsSemaphoreEXT                                         C.GPISSEMAPHOREEXT
 	gpIsShader                                               C.GPISSHADER
+	gpIsStateNV                                              C.GPISSTATENV
 	gpIsSync                                                 C.GPISSYNC
 	gpIsTexture                                              C.GPISTEXTURE
 	gpIsTextureEXT                                           C.GPISTEXTUREEXT
@@ -17094,6 +17950,9 @@ var (
 	gpIsVertexArray                                          C.GPISVERTEXARRAY
 	gpIsVertexArrayAPPLE                                     C.GPISVERTEXARRAYAPPLE
 	gpIsVertexAttribEnabledAPPLE                             C.GPISVERTEXATTRIBENABLEDAPPLE
+	gpLGPUCopyImageSubDataNVX                                C.GPLGPUCOPYIMAGESUBDATANVX
+	gpLGPUInterlockNVX                                       C.GPLGPUINTERLOCKNVX
+	gpLGPUNamedBufferSubDataNVX                              C.GPLGPUNAMEDBUFFERSUBDATANVX
 	gpLabelObjectEXT                                         C.GPLABELOBJECTEXT
 	gpLightEnviSGIX                                          C.GPLIGHTENVISGIX
 	gpLightModelf                                            C.GPLIGHTMODELF
@@ -17114,6 +17973,7 @@ var (
 	gpLinkProgram                                            C.GPLINKPROGRAM
 	gpLinkProgramARB                                         C.GPLINKPROGRAMARB
 	gpListBase                                               C.GPLISTBASE
+	gpListDrawCommandsStatesClientNV                         C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
 	gpListParameterfSGIX                                     C.GPLISTPARAMETERFSGIX
 	gpListParameterfvSGIX                                    C.GPLISTPARAMETERFVSGIX
 	gpListParameteriSGIX                                     C.GPLISTPARAMETERISGIX
@@ -17208,9 +18068,12 @@ var (
 	gpMatrixScalefEXT                                        C.GPMATRIXSCALEFEXT
 	gpMatrixTranslatedEXT                                    C.GPMATRIXTRANSLATEDEXT
 	gpMatrixTranslatefEXT                                    C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                            C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                            C.GPMAXSHADERCOMPILERTHREADSKHR
 	gpMemoryBarrier                                          C.GPMEMORYBARRIER
 	gpMemoryBarrierByRegion                                  C.GPMEMORYBARRIERBYREGION
 	gpMemoryBarrierEXT                                       C.GPMEMORYBARRIEREXT
+	gpMemoryObjectParameterivEXT                             C.GPMEMORYOBJECTPARAMETERIVEXT
 	gpMinSampleShadingARB                                    C.GPMINSAMPLESHADINGARB
 	gpMinmax                                                 C.GPMINMAX
 	gpMinmaxEXT                                              C.GPMINMAXEXT
@@ -17362,12 +18225,25 @@ var (
 	gpMultiTexSubImage1DEXT                                  C.GPMULTITEXSUBIMAGE1DEXT
 	gpMultiTexSubImage2DEXT                                  C.GPMULTITEXSUBIMAGE2DEXT
 	gpMultiTexSubImage3DEXT                                  C.GPMULTITEXSUBIMAGE3DEXT
+	gpMulticastBarrierNV                                     C.GPMULTICASTBARRIERNV
+	gpMulticastBlitFramebufferNV                             C.GPMULTICASTBLITFRAMEBUFFERNV
+	gpMulticastBufferSubDataNV                               C.GPMULTICASTBUFFERSUBDATANV
+	gpMulticastCopyBufferSubDataNV                           C.GPMULTICASTCOPYBUFFERSUBDATANV
+	gpMulticastCopyImageSubDataNV                            C.GPMULTICASTCOPYIMAGESUBDATANV
+	gpMulticastFramebufferSampleLocationsfvNV                C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpMulticastGetQueryObjecti64vNV                          C.GPMULTICASTGETQUERYOBJECTI64VNV
+	gpMulticastGetQueryObjectivNV                            C.GPMULTICASTGETQUERYOBJECTIVNV
+	gpMulticastGetQueryObjectui64vNV                         C.GPMULTICASTGETQUERYOBJECTUI64VNV
+	gpMulticastGetQueryObjectuivNV                           C.GPMULTICASTGETQUERYOBJECTUIVNV
+	gpMulticastWaitSyncNV                                    C.GPMULTICASTWAITSYNCNV
 	gpNamedBufferData                                        C.GPNAMEDBUFFERDATA
 	gpNamedBufferDataEXT                                     C.GPNAMEDBUFFERDATAEXT
 	gpNamedBufferPageCommitmentARB                           C.GPNAMEDBUFFERPAGECOMMITMENTARB
 	gpNamedBufferPageCommitmentEXT                           C.GPNAMEDBUFFERPAGECOMMITMENTEXT
 	gpNamedBufferStorage                                     C.GPNAMEDBUFFERSTORAGE
 	gpNamedBufferStorageEXT                                  C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferStorageExternalEXT                          C.GPNAMEDBUFFERSTORAGEEXTERNALEXT
+	gpNamedBufferStorageMemEXT                               C.GPNAMEDBUFFERSTORAGEMEMEXT
 	gpNamedBufferSubData                                     C.GPNAMEDBUFFERSUBDATA
 	gpNamedBufferSubDataEXT                                  C.GPNAMEDBUFFERSUBDATAEXT
 	gpNamedCopyBufferSubDataEXT                              C.GPNAMEDCOPYBUFFERSUBDATAEXT
@@ -17378,6 +18254,9 @@ var (
 	gpNamedFramebufferReadBuffer                             C.GPNAMEDFRAMEBUFFERREADBUFFER
 	gpNamedFramebufferRenderbuffer                           C.GPNAMEDFRAMEBUFFERRENDERBUFFER
 	gpNamedFramebufferRenderbufferEXT                        C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB                   C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV                    C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferSamplePositionsfvAMD                   C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpNamedFramebufferTexture                                C.GPNAMEDFRAMEBUFFERTEXTURE
 	gpNamedFramebufferTexture1DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
 	gpNamedFramebufferTexture2DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
@@ -17521,6 +18400,8 @@ var (
 	gpPollInstrumentsSGIX                                    C.GPPOLLINSTRUMENTSSGIX
 	gpPolygonMode                                            C.GPPOLYGONMODE
 	gpPolygonOffset                                          C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                                     C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                                  C.GPPOLYGONOFFSETCLAMPEXT
 	gpPolygonOffsetEXT                                       C.GPPOLYGONOFFSETEXT
 	gpPolygonOffsetxOES                                      C.GPPOLYGONOFFSETXOES
 	gpPolygonStipple                                         C.GPPOLYGONSTIPPLE
@@ -17533,6 +18414,7 @@ var (
 	gpPopName                                                C.GPPOPNAME
 	gpPresentFrameDualFillNV                                 C.GPPRESENTFRAMEDUALFILLNV
 	gpPresentFrameKeyedNV                                    C.GPPRESENTFRAMEKEYEDNV
+	gpPrimitiveBoundingBoxARB                                C.GPPRIMITIVEBOUNDINGBOXARB
 	gpPrimitiveRestartIndex                                  C.GPPRIMITIVERESTARTINDEX
 	gpPrimitiveRestartIndexNV                                C.GPPRIMITIVERESTARTINDEXNV
 	gpPrimitiveRestartNV                                     C.GPPRIMITIVERESTARTNV
@@ -17590,13 +18472,17 @@ var (
 	gpProgramUniform1fv                                      C.GPPROGRAMUNIFORM1FV
 	gpProgramUniform1fvEXT                                   C.GPPROGRAMUNIFORM1FVEXT
 	gpProgramUniform1i                                       C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                                  C.GPPROGRAMUNIFORM1I64ARB
 	gpProgramUniform1i64NV                                   C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                                 C.GPPROGRAMUNIFORM1I64VARB
 	gpProgramUniform1i64vNV                                  C.GPPROGRAMUNIFORM1I64VNV
 	gpProgramUniform1iEXT                                    C.GPPROGRAMUNIFORM1IEXT
 	gpProgramUniform1iv                                      C.GPPROGRAMUNIFORM1IV
 	gpProgramUniform1ivEXT                                   C.GPPROGRAMUNIFORM1IVEXT
 	gpProgramUniform1ui                                      C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                                 C.GPPROGRAMUNIFORM1UI64ARB
 	gpProgramUniform1ui64NV                                  C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                                C.GPPROGRAMUNIFORM1UI64VARB
 	gpProgramUniform1ui64vNV                                 C.GPPROGRAMUNIFORM1UI64VNV
 	gpProgramUniform1uiEXT                                   C.GPPROGRAMUNIFORM1UIEXT
 	gpProgramUniform1uiv                                     C.GPPROGRAMUNIFORM1UIV
@@ -17610,13 +18496,17 @@ var (
 	gpProgramUniform2fv                                      C.GPPROGRAMUNIFORM2FV
 	gpProgramUniform2fvEXT                                   C.GPPROGRAMUNIFORM2FVEXT
 	gpProgramUniform2i                                       C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                                  C.GPPROGRAMUNIFORM2I64ARB
 	gpProgramUniform2i64NV                                   C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                                 C.GPPROGRAMUNIFORM2I64VARB
 	gpProgramUniform2i64vNV                                  C.GPPROGRAMUNIFORM2I64VNV
 	gpProgramUniform2iEXT                                    C.GPPROGRAMUNIFORM2IEXT
 	gpProgramUniform2iv                                      C.GPPROGRAMUNIFORM2IV
 	gpProgramUniform2ivEXT                                   C.GPPROGRAMUNIFORM2IVEXT
 	gpProgramUniform2ui                                      C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                                 C.GPPROGRAMUNIFORM2UI64ARB
 	gpProgramUniform2ui64NV                                  C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                                C.GPPROGRAMUNIFORM2UI64VARB
 	gpProgramUniform2ui64vNV                                 C.GPPROGRAMUNIFORM2UI64VNV
 	gpProgramUniform2uiEXT                                   C.GPPROGRAMUNIFORM2UIEXT
 	gpProgramUniform2uiv                                     C.GPPROGRAMUNIFORM2UIV
@@ -17630,13 +18520,17 @@ var (
 	gpProgramUniform3fv                                      C.GPPROGRAMUNIFORM3FV
 	gpProgramUniform3fvEXT                                   C.GPPROGRAMUNIFORM3FVEXT
 	gpProgramUniform3i                                       C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                                  C.GPPROGRAMUNIFORM3I64ARB
 	gpProgramUniform3i64NV                                   C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                                 C.GPPROGRAMUNIFORM3I64VARB
 	gpProgramUniform3i64vNV                                  C.GPPROGRAMUNIFORM3I64VNV
 	gpProgramUniform3iEXT                                    C.GPPROGRAMUNIFORM3IEXT
 	gpProgramUniform3iv                                      C.GPPROGRAMUNIFORM3IV
 	gpProgramUniform3ivEXT                                   C.GPPROGRAMUNIFORM3IVEXT
 	gpProgramUniform3ui                                      C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                                 C.GPPROGRAMUNIFORM3UI64ARB
 	gpProgramUniform3ui64NV                                  C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                                C.GPPROGRAMUNIFORM3UI64VARB
 	gpProgramUniform3ui64vNV                                 C.GPPROGRAMUNIFORM3UI64VNV
 	gpProgramUniform3uiEXT                                   C.GPPROGRAMUNIFORM3UIEXT
 	gpProgramUniform3uiv                                     C.GPPROGRAMUNIFORM3UIV
@@ -17650,13 +18544,17 @@ var (
 	gpProgramUniform4fv                                      C.GPPROGRAMUNIFORM4FV
 	gpProgramUniform4fvEXT                                   C.GPPROGRAMUNIFORM4FVEXT
 	gpProgramUniform4i                                       C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                                  C.GPPROGRAMUNIFORM4I64ARB
 	gpProgramUniform4i64NV                                   C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                                 C.GPPROGRAMUNIFORM4I64VARB
 	gpProgramUniform4i64vNV                                  C.GPPROGRAMUNIFORM4I64VNV
 	gpProgramUniform4iEXT                                    C.GPPROGRAMUNIFORM4IEXT
 	gpProgramUniform4iv                                      C.GPPROGRAMUNIFORM4IV
 	gpProgramUniform4ivEXT                                   C.GPPROGRAMUNIFORM4IVEXT
 	gpProgramUniform4ui                                      C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                                 C.GPPROGRAMUNIFORM4UI64ARB
 	gpProgramUniform4ui64NV                                  C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                                C.GPPROGRAMUNIFORM4UI64VARB
 	gpProgramUniform4ui64vNV                                 C.GPPROGRAMUNIFORM4UI64VNV
 	gpProgramUniform4uiEXT                                   C.GPPROGRAMUNIFORM4UIEXT
 	gpProgramUniform4uiv                                     C.GPPROGRAMUNIFORM4UIV
@@ -17717,6 +18615,8 @@ var (
 	gpQueryCounter                                           C.GPQUERYCOUNTER
 	gpQueryMatrixxOES                                        C.GPQUERYMATRIXXOES
 	gpQueryObjectParameteruiAMD                              C.GPQUERYOBJECTPARAMETERUIAMD
+	gpQueryResourceNV                                        C.GPQUERYRESOURCENV
+	gpQueryResourceTagNV                                     C.GPQUERYRESOURCETAGNV
 	gpRasterPos2d                                            C.GPRASTERPOS2D
 	gpRasterPos2dv                                           C.GPRASTERPOS2DV
 	gpRasterPos2f                                            C.GPRASTERPOS2F
@@ -17747,6 +18647,7 @@ var (
 	gpRasterPos4sv                                           C.GPRASTERPOS4SV
 	gpRasterPos4xOES                                         C.GPRASTERPOS4XOES
 	gpRasterPos4xvOES                                        C.GPRASTERPOS4XVOES
+	gpRasterSamplesEXT                                       C.GPRASTERSAMPLESEXT
 	gpReadBuffer                                             C.GPREADBUFFER
 	gpReadInstrumentsSGIX                                    C.GPREADINSTRUMENTSSGIX
 	gpReadPixels                                             C.GPREADPIXELS
@@ -17764,7 +18665,9 @@ var (
 	gpRectxOES                                               C.GPRECTXOES
 	gpRectxvOES                                              C.GPRECTXVOES
 	gpReferencePlaneSGIX                                     C.GPREFERENCEPLANESGIX
+	gpReleaseKeyedMutexWin32EXT                              C.GPRELEASEKEYEDMUTEXWIN32EXT
 	gpReleaseShaderCompiler                                  C.GPRELEASESHADERCOMPILER
+	gpRenderGpuMaskNV                                        C.GPRENDERGPUMASKNV
 	gpRenderMode                                             C.GPRENDERMODE
 	gpRenderbufferStorage                                    C.GPRENDERBUFFERSTORAGE
 	gpRenderbufferStorageEXT                                 C.GPRENDERBUFFERSTORAGEEXT
@@ -17800,6 +18703,7 @@ var (
 	gpResetMinmax                                            C.GPRESETMINMAX
 	gpResetMinmaxEXT                                         C.GPRESETMINMAXEXT
 	gpResizeBuffersMESA                                      C.GPRESIZEBUFFERSMESA
+	gpResolveDepthValuesNV                                   C.GPRESOLVEDEPTHVALUESNV
 	gpResumeTransformFeedback                                C.GPRESUMETRANSFORMFEEDBACK
 	gpResumeTransformFeedbackNV                              C.GPRESUMETRANSFORMFEEDBACKNV
 	gpRotated                                                C.GPROTATED
@@ -17807,7 +18711,6 @@ var (
 	gpRotatexOES                                             C.GPROTATEXOES
 	gpSampleCoverage                                         C.GPSAMPLECOVERAGE
 	gpSampleCoverageARB                                      C.GPSAMPLECOVERAGEARB
-	gpSampleCoverageOES                                      C.GPSAMPLECOVERAGEOES
 	gpSampleCoveragexOES                                     C.GPSAMPLECOVERAGEXOES
 	gpSampleMapATI                                           C.GPSAMPLEMAPATI
 	gpSampleMaskEXT                                          C.GPSAMPLEMASKEXT
@@ -17871,6 +18774,7 @@ var (
 	gpSecondaryColorPointerListIBM                           C.GPSECONDARYCOLORPOINTERLISTIBM
 	gpSelectBuffer                                           C.GPSELECTBUFFER
 	gpSelectPerfMonitorCountersAMD                           C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpSemaphoreParameterui64vEXT                             C.GPSEMAPHOREPARAMETERUI64VEXT
 	gpSeparableFilter2D                                      C.GPSEPARABLEFILTER2D
 	gpSeparableFilter2DEXT                                   C.GPSEPARABLEFILTER2DEXT
 	gpSetFenceAPPLE                                          C.GPSETFENCEAPPLE
@@ -17888,11 +18792,16 @@ var (
 	gpShaderSourceARB                                        C.GPSHADERSOURCEARB
 	gpShaderStorageBlockBinding                              C.GPSHADERSTORAGEBLOCKBINDING
 	gpSharpenTexFuncSGIS                                     C.GPSHARPENTEXFUNCSGIS
+	gpSignalSemaphoreEXT                                     C.GPSIGNALSEMAPHOREEXT
+	gpSignalVkFenceNV                                        C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                                    C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                                    C.GPSPECIALIZESHADERARB
 	gpSpriteParameterfSGIX                                   C.GPSPRITEPARAMETERFSGIX
 	gpSpriteParameterfvSGIX                                  C.GPSPRITEPARAMETERFVSGIX
 	gpSpriteParameteriSGIX                                   C.GPSPRITEPARAMETERISGIX
 	gpSpriteParameterivSGIX                                  C.GPSPRITEPARAMETERIVSGIX
 	gpStartInstrumentsSGIX                                   C.GPSTARTINSTRUMENTSSGIX
+	gpStateCaptureNV                                         C.GPSTATECAPTURENV
 	gpStencilClearTagEXT                                     C.GPSTENCILCLEARTAGEXT
 	gpStencilFillPathInstancedNV                             C.GPSTENCILFILLPATHINSTANCEDNV
 	gpStencilFillPathNV                                      C.GPSTENCILFILLPATHNV
@@ -17913,6 +18822,7 @@ var (
 	gpStencilThenCoverStrokePathNV                           C.GPSTENCILTHENCOVERSTROKEPATHNV
 	gpStopInstrumentsSGIX                                    C.GPSTOPINSTRUMENTSSGIX
 	gpStringMarkerGREMEDY                                    C.GPSTRINGMARKERGREMEDY
+	gpSubpixelPrecisionBiasNV                                C.GPSUBPIXELPRECISIONBIASNV
 	gpSwizzleEXT                                             C.GPSWIZZLEEXT
 	gpSyncTextureINTEL                                       C.GPSYNCTEXTUREINTEL
 	gpTagSampleBufferSGIX                                    C.GPTAGSAMPLEBUFFERSGIX
@@ -18063,6 +18973,11 @@ var (
 	gpTexStorage2DMultisample                                C.GPTEXSTORAGE2DMULTISAMPLE
 	gpTexStorage3D                                           C.GPTEXSTORAGE3D
 	gpTexStorage3DMultisample                                C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexStorageMem1DEXT                                     C.GPTEXSTORAGEMEM1DEXT
+	gpTexStorageMem2DEXT                                     C.GPTEXSTORAGEMEM2DEXT
+	gpTexStorageMem2DMultisampleEXT                          C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT
+	gpTexStorageMem3DEXT                                     C.GPTEXSTORAGEMEM3DEXT
+	gpTexStorageMem3DMultisampleEXT                          C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT
 	gpTexStorageSparseAMD                                    C.GPTEXSTORAGESPARSEAMD
 	gpTexSubImage1D                                          C.GPTEXSUBIMAGE1D
 	gpTexSubImage1DEXT                                       C.GPTEXSUBIMAGE1DEXT
@@ -18113,6 +19028,11 @@ var (
 	gpTextureStorage3DEXT                                    C.GPTEXTURESTORAGE3DEXT
 	gpTextureStorage3DMultisample                            C.GPTEXTURESTORAGE3DMULTISAMPLE
 	gpTextureStorage3DMultisampleEXT                         C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureStorageMem1DEXT                                 C.GPTEXTURESTORAGEMEM1DEXT
+	gpTextureStorageMem2DEXT                                 C.GPTEXTURESTORAGEMEM2DEXT
+	gpTextureStorageMem2DMultisampleEXT                      C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT
+	gpTextureStorageMem3DEXT                                 C.GPTEXTURESTORAGEMEM3DEXT
+	gpTextureStorageMem3DMultisampleEXT                      C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT
 	gpTextureStorageSparseAMD                                C.GPTEXTURESTORAGESPARSEAMD
 	gpTextureSubImage1D                                      C.GPTEXTURESUBIMAGE1D
 	gpTextureSubImage1DEXT                                   C.GPTEXTURESUBIMAGE1DEXT
@@ -18140,13 +19060,17 @@ var (
 	gpUniform1fv                                             C.GPUNIFORM1FV
 	gpUniform1fvARB                                          C.GPUNIFORM1FVARB
 	gpUniform1i                                              C.GPUNIFORM1I
+	gpUniform1i64ARB                                         C.GPUNIFORM1I64ARB
 	gpUniform1i64NV                                          C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                        C.GPUNIFORM1I64VARB
 	gpUniform1i64vNV                                         C.GPUNIFORM1I64VNV
 	gpUniform1iARB                                           C.GPUNIFORM1IARB
 	gpUniform1iv                                             C.GPUNIFORM1IV
 	gpUniform1ivARB                                          C.GPUNIFORM1IVARB
 	gpUniform1ui                                             C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                        C.GPUNIFORM1UI64ARB
 	gpUniform1ui64NV                                         C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                                       C.GPUNIFORM1UI64VARB
 	gpUniform1ui64vNV                                        C.GPUNIFORM1UI64VNV
 	gpUniform1uiEXT                                          C.GPUNIFORM1UIEXT
 	gpUniform1uiv                                            C.GPUNIFORM1UIV
@@ -18158,13 +19082,17 @@ var (
 	gpUniform2fv                                             C.GPUNIFORM2FV
 	gpUniform2fvARB                                          C.GPUNIFORM2FVARB
 	gpUniform2i                                              C.GPUNIFORM2I
+	gpUniform2i64ARB                                         C.GPUNIFORM2I64ARB
 	gpUniform2i64NV                                          C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                        C.GPUNIFORM2I64VARB
 	gpUniform2i64vNV                                         C.GPUNIFORM2I64VNV
 	gpUniform2iARB                                           C.GPUNIFORM2IARB
 	gpUniform2iv                                             C.GPUNIFORM2IV
 	gpUniform2ivARB                                          C.GPUNIFORM2IVARB
 	gpUniform2ui                                             C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                        C.GPUNIFORM2UI64ARB
 	gpUniform2ui64NV                                         C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                                       C.GPUNIFORM2UI64VARB
 	gpUniform2ui64vNV                                        C.GPUNIFORM2UI64VNV
 	gpUniform2uiEXT                                          C.GPUNIFORM2UIEXT
 	gpUniform2uiv                                            C.GPUNIFORM2UIV
@@ -18176,13 +19104,17 @@ var (
 	gpUniform3fv                                             C.GPUNIFORM3FV
 	gpUniform3fvARB                                          C.GPUNIFORM3FVARB
 	gpUniform3i                                              C.GPUNIFORM3I
+	gpUniform3i64ARB                                         C.GPUNIFORM3I64ARB
 	gpUniform3i64NV                                          C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                        C.GPUNIFORM3I64VARB
 	gpUniform3i64vNV                                         C.GPUNIFORM3I64VNV
 	gpUniform3iARB                                           C.GPUNIFORM3IARB
 	gpUniform3iv                                             C.GPUNIFORM3IV
 	gpUniform3ivARB                                          C.GPUNIFORM3IVARB
 	gpUniform3ui                                             C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                        C.GPUNIFORM3UI64ARB
 	gpUniform3ui64NV                                         C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                                       C.GPUNIFORM3UI64VARB
 	gpUniform3ui64vNV                                        C.GPUNIFORM3UI64VNV
 	gpUniform3uiEXT                                          C.GPUNIFORM3UIEXT
 	gpUniform3uiv                                            C.GPUNIFORM3UIV
@@ -18194,13 +19126,17 @@ var (
 	gpUniform4fv                                             C.GPUNIFORM4FV
 	gpUniform4fvARB                                          C.GPUNIFORM4FVARB
 	gpUniform4i                                              C.GPUNIFORM4I
+	gpUniform4i64ARB                                         C.GPUNIFORM4I64ARB
 	gpUniform4i64NV                                          C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                        C.GPUNIFORM4I64VARB
 	gpUniform4i64vNV                                         C.GPUNIFORM4I64VNV
 	gpUniform4iARB                                           C.GPUNIFORM4IARB
 	gpUniform4iv                                             C.GPUNIFORM4IV
 	gpUniform4ivARB                                          C.GPUNIFORM4IVARB
 	gpUniform4ui                                             C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                        C.GPUNIFORM4UI64ARB
 	gpUniform4ui64NV                                         C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                                       C.GPUNIFORM4UI64VARB
 	gpUniform4ui64vNV                                        C.GPUNIFORM4UI64VNV
 	gpUniform4uiEXT                                          C.GPUNIFORM4UIEXT
 	gpUniform4uiv                                            C.GPUNIFORM4UIV
@@ -18626,7 +19562,11 @@ var (
 	gpViewportArrayv                                         C.GPVIEWPORTARRAYV
 	gpViewportIndexedf                                       C.GPVIEWPORTINDEXEDF
 	gpViewportIndexedfv                                      C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                               C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                                      C.GPVIEWPORTSWIZZLENV
+	gpWaitSemaphoreEXT                                       C.GPWAITSEMAPHOREEXT
 	gpWaitSync                                               C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                                      C.GPWAITVKSEMAPHORENV
 	gpWeightPathsNV                                          C.GPWEIGHTPATHSNV
 	gpWeightPointerARB                                       C.GPWEIGHTPOINTERARB
 	gpWeightbvARB                                            C.GPWEIGHTBVARB
@@ -18693,6 +19633,7 @@ var (
 	gpWindowPos4ivMESA                                       C.GPWINDOWPOS4IVMESA
 	gpWindowPos4sMESA                                        C.GPWINDOWPOS4SMESA
 	gpWindowPos4svMESA                                       C.GPWINDOWPOS4SVMESA
+	gpWindowRectanglesEXT                                    C.GPWINDOWRECTANGLESEXT
 	gpWriteMaskEXT                                           C.GPWRITEMASKEXT
 )
 
@@ -18710,6 +19651,10 @@ func Accum(op uint32, value float32) {
 }
 func AccumxOES(op uint32, value int32) {
 	C.glowAccumxOES(gpAccumxOES, (C.GLenum)(op), (C.GLfixed)(value))
+}
+func AcquireKeyedMutexWin32EXT(memory uint32, key uint64, timeout uint32) bool {
+	ret := C.glowAcquireKeyedMutexWin32EXT(gpAcquireKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key), (C.GLuint)(timeout))
+	return ret == TRUE
 }
 func ActiveProgramEXT(program uint32) {
 	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
@@ -18752,6 +19697,12 @@ func AlphaFunc(xfunc uint32, ref float32) {
 }
 func AlphaFuncxOES(xfunc uint32, ref int32) {
 	C.glowAlphaFuncxOES(gpAlphaFuncxOES, (C.GLenum)(xfunc), (C.GLfixed)(ref))
+}
+func AlphaToCoverageDitherControlNV(mode uint32) {
+	C.glowAlphaToCoverageDitherControlNV(gpAlphaToCoverageDitherControlNV, (C.GLenum)(mode))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 func ApplyTextureEXT(mode uint32) {
 	C.glowApplyTextureEXT(gpApplyTextureEXT, (C.GLenum)(mode))
@@ -19188,8 +20139,8 @@ func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 func BufferDataARB(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferDataARB(gpBufferDataARB, (C.GLenum)(target), (C.GLsizeiptrARB)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 	C.glowBufferParameteriAPPLE(gpBufferParameteriAPPLE, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
@@ -19199,6 +20150,12 @@ func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowBufferStorage(gpBufferStorage, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func BufferStorageExternalEXT(target uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowBufferStorageExternalEXT(gpBufferStorageExternalEXT, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func BufferStorageMemEXT(target uint32, size int, memory uint32, offset uint64) {
+	C.glowBufferStorageMemEXT(gpBufferStorageMemEXT, (C.GLenum)(target), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
@@ -19206,6 +20163,9 @@ func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 }
 func BufferSubDataARB(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubDataARB(gpBufferSubDataARB, (C.GLenum)(target), (C.GLintptrARB)(offset), (C.GLsizeiptrARB)(size), data)
+}
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
 }
 
 // execute a display list
@@ -19302,6 +20262,8 @@ func ClearDepth(depth float64) {
 func ClearDepthdNV(depth float64) {
 	C.glowClearDepthdNV(gpClearDepthdNV, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -19326,14 +20288,14 @@ func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32
 }
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
 func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -19375,7 +20337,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -19643,6 +20605,12 @@ func CombinerParameterivNV(pname uint32, params *int32) {
 func CombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowCombinerStageParameterfvNV(gpCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
+}
 
 // Compiles a shader object
 func CompileShader(shader uint32) {
@@ -19753,6 +20721,12 @@ func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yof
 func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // define a one-dimensional convolution filter
 func ConvolutionFilter1D(target uint32, internalformat uint32, width int32, format uint32, xtype uint32, image unsafe.Pointer) {
@@ -19861,8 +20835,8 @@ func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffs
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 func CopyPathNV(resultPath uint32, srcPath uint32) {
 	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
@@ -19954,15 +20928,27 @@ func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsaf
 func CoverStrokePathNV(path uint32, coverMode uint32) {
 	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
 }
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreateMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowCreateMemoryObjectsEXT(gpCreateMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
 	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
@@ -20021,9 +21007,12 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -20119,6 +21108,9 @@ func DeleteBuffers(n int32, buffers *uint32) {
 func DeleteBuffersARB(n int32, buffers *uint32) {
 	C.glowDeleteBuffersARB(gpDeleteBuffersARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 func DeleteFencesAPPLE(n int32, fences *uint32) {
 	C.glowDeleteFencesAPPLE(gpDeleteFencesAPPLE, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(fences)))
 }
@@ -20140,6 +21132,9 @@ func DeleteFramebuffersEXT(n int32, framebuffers *uint32) {
 // delete a contiguous group of display lists
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
+}
+func DeleteMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowDeleteMemoryObjectsEXT(gpDeleteMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
@@ -20189,6 +21184,9 @@ func DeleteQueries(n int32, ids *uint32) {
 func DeleteQueriesARB(n int32, ids *uint32) {
 	C.glowDeleteQueriesARB(gpDeleteQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func DeleteQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowDeleteQueryResourceTagNV(gpDeleteQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // delete renderbuffer objects
 func DeleteRenderbuffers(n int32, renderbuffers *uint32) {
@@ -20202,14 +21200,20 @@ func DeleteRenderbuffersEXT(n int32, renderbuffers *uint32) {
 func DeleteSamplers(count int32, samplers *uint32) {
 	C.glowDeleteSamplers(gpDeleteSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
 }
+func DeleteSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowDeleteSemaphoresEXT(gpDeleteSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
+}
 
 // Deletes a shader object
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -20271,6 +21275,8 @@ func DepthRangeIndexed(index uint32, n float64, f float64) {
 func DepthRangedNV(zNear float64, zFar float64) {
 	C.glowDepthRangedNV(gpDepthRangedNV, (C.GLdouble)(zNear), (C.GLdouble)(zFar))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -20392,6 +21398,18 @@ func DrawBuffersARB(n int32, bufs *uint32) {
 func DrawBuffersATI(n int32, bufs *uint32) {
 	C.glowDrawBuffersATI(gpDrawBuffersATI, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 func DrawElementArrayAPPLE(mode uint32, first int32, count int32) {
 	C.glowDrawElementArrayAPPLE(gpDrawElementArrayAPPLE, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count))
 }
@@ -20491,6 +21509,9 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 // render multiple instances of primitives using a count derived from a specifed stream of a transform feedback object
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
+}
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
 }
 
 // flag edges as either boundary or nonboundary
@@ -20669,6 +21690,9 @@ func EvalPoint1(i int32) {
 func EvalPoint2(i int32, j int32) {
 	C.glowEvalPoint2(gpEvalPoint2, (C.GLint)(i), (C.GLint)(j))
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 func ExecuteProgramNV(target uint32, id uint32, params *float32) {
 	C.glowExecuteProgramNV(gpExecuteProgramNV, (C.GLenum)(target), (C.GLuint)(id), (*C.GLfloat)(unsafe.Pointer(params)))
 }
@@ -20685,9 +21709,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -20728,8 +21752,8 @@ func FlushMappedBufferRangeAPPLE(target uint32, offset int, size int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
 }
 func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
 	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
@@ -20817,6 +21841,9 @@ func FogxvOES(pname uint32, param *int32) {
 func FragmentColorMaterialSGIX(face uint32, mode uint32) {
 	C.glowFragmentColorMaterialSGIX(gpFragmentColorMaterialSGIX, (C.GLenum)(face), (C.GLenum)(mode))
 }
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
 func FragmentLightModelfSGIX(pname uint32, param float32) {
 	C.glowFragmentLightModelfSGIX(gpFragmentLightModelfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -20865,6 +21892,9 @@ func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
 func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
 	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
+}
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
@@ -20881,6 +21911,15 @@ func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarge
 func FramebufferRenderbufferEXT(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbufferEXT(gpFramebufferRenderbufferEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSamplePositionsfvAMD(target uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowFramebufferSamplePositionsfvAMD(gpFramebufferSamplePositionsfvAMD, (C.GLenum)(target), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
 func FramebufferTexture(target uint32, attachment uint32, texture uint32, level int32) {
@@ -20892,6 +21931,8 @@ func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, te
 func FramebufferTexture1DEXT(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1DEXT(gpFramebufferTexture1DEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
@@ -20926,6 +21967,9 @@ func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32
 }
 func FramebufferTextureLayerEXT(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayerEXT(gpFramebufferTextureLayerEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 func FreeObjectBufferATI(buffer uint32) {
 	C.glowFreeObjectBufferATI(gpFreeObjectBufferATI, (C.GLuint)(buffer))
@@ -21017,6 +22061,9 @@ func GenQueries(n int32, ids *uint32) {
 func GenQueriesARB(n int32, ids *uint32) {
 	C.glowGenQueriesARB(gpGenQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func GenQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowGenQueryResourceTagNV(gpGenQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // generate renderbuffer object names
 func GenRenderbuffers(n int32, renderbuffers *uint32) {
@@ -21029,6 +22076,9 @@ func GenRenderbuffersEXT(n int32, renderbuffers *uint32) {
 // generate sampler object names
 func GenSamplers(count int32, samplers *uint32) {
 	C.glowGenSamplers(gpGenSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
+}
+func GenSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowGenSemaphoresEXT(gpGenSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
 }
 func GenSymbolsEXT(datatype uint32, storagetype uint32, xrange uint32, components uint32) uint32 {
 	ret := C.glowGenSymbolsEXT(gpGenSymbolsEXT, (C.GLenum)(datatype), (C.GLenum)(storagetype), (C.GLenum)(xrange), (C.GLuint)(components))
@@ -21120,6 +22170,8 @@ func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, leng
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21256,6 +22308,10 @@ func GetCombinerOutputParameterivNV(stage uint32, portion uint32, pname uint32, 
 func GetCombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowGetCombinerStageParameterfvNV(gpGetCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
 func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
 	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
@@ -21302,6 +22358,9 @@ func GetConvolutionParameterivEXT(target uint32, pname uint32, params *int32) {
 }
 func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 	C.glowGetConvolutionParameterxvOES(gpGetConvolutionParameterxvOES, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -21401,15 +22460,18 @@ func GetFragmentMaterialivSGIX(face uint32, pname uint32, params *int32) {
 	C.glowGetFragmentMaterialivSGIX(gpGetFragmentMaterialivSGIX, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetFramebufferAttachmentParameterivEXT(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameterivEXT(gpGetFramebufferAttachmentParameterivEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetFramebufferParameterfvAMD(target uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetFramebufferParameterfvAMD(gpGetFramebufferParameterfvAMD, (C.GLenum)(target), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21499,9 +22561,14 @@ func GetIntegerui64vNV(value uint32, result *uint64) {
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21579,6 +22646,9 @@ func GetMaterialxOES(face uint32, pname uint32, param int32) {
 }
 func GetMaterialxvOES(face uint32, pname uint32, params *int32) {
 	C.glowGetMaterialxvOES(gpGetMaterialxvOES, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetMemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowGetMemoryObjectParameterivEXT(gpGetMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // get minimum and maximum pixel values
@@ -21670,8 +22740,8 @@ func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Point
 }
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -21683,6 +22753,9 @@ func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uin
 }
 func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedFramebufferParameterfvAMD(framebuffer uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetNamedFramebufferParameterfvAMD(gpGetNamedFramebufferParameterfvAMD, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 
 // query a named parameter of a framebuffer object
@@ -21998,6 +23071,18 @@ func GetProgramivARB(target uint32, pname uint32, params *int32) {
 func GetProgramivNV(id uint32, pname uint32, params *int32) {
 	C.glowGetProgramivNV(gpGetProgramivNV, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
 
 // return parameters of an indexed query object target
 func GetQueryIndexediv(target uint32, index uint32, pname uint32, params *int32) {
@@ -22021,6 +23106,8 @@ func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 func GetQueryObjectui64vEXT(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64vEXT(gpGetQueryObjectui64vEXT, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -22036,7 +23123,7 @@ func GetQueryivARB(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryivARB(gpGetQueryivARB, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -22054,6 +23141,9 @@ func GetSamplerParameterfv(sampler uint32, pname uint32, params *float32) {
 }
 func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 	C.glowGetSamplerParameteriv(gpGetSamplerParameteriv, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetSemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowGetSemaphoreParameterui64vEXT(gpGetSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 
 // get separable convolution filter kernel images
@@ -22089,6 +23179,10 @@ func GetShaderiv(shader uint32, pname uint32, params *int32) {
 func GetSharpenTexFuncSGIS(target uint32, points *float32) {
 	C.glowGetSharpenTexFuncSGIS(gpGetSharpenTexFuncSGIS, (C.GLenum)(target), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -22113,7 +23207,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -22317,6 +23411,9 @@ func GetUniformfv(program uint32, location int32, params *float32) {
 func GetUniformfvARB(programObj uintptr, location int32, params *float32) {
 	C.glowGetUniformfvARB(gpGetUniformfvARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetUniformi64vNV(program uint32, location int32, params *int64) {
 	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
 }
@@ -22328,6 +23425,9 @@ func GetUniformiv(program uint32, location int32, params *int32) {
 func GetUniformivARB(programObj uintptr, location int32, params *int32) {
 	C.glowGetUniformivARB(gpGetUniformivARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 func GetUniformui64vNV(program uint32, location int32, params *uint64) {
 	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
@@ -22336,6 +23436,12 @@ func GetUniformuiv(program uint32, location int32, params *uint32) {
 }
 func GetUniformuivEXT(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuivEXT(gpGetUniformuivEXT, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetUnsignedBytei_vEXT(target uint32, index uint32, data *uint8) {
+	C.glowGetUnsignedBytei_vEXT(gpGetUnsignedBytei_vEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLubyte)(unsafe.Pointer(data)))
+}
+func GetUnsignedBytevEXT(pname uint32, data *uint8) {
+	C.glowGetUnsignedBytevEXT(gpGetUnsignedBytevEXT, (C.GLenum)(pname), (*C.GLubyte)(unsafe.Pointer(data)))
 }
 func GetVariantArrayObjectfvATI(id uint32, pname uint32, params *float32) {
 	C.glowGetVariantArrayObjectfvATI(gpGetVariantArrayObjectfvATI, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
@@ -22489,6 +23595,10 @@ func GetVideoui64vNV(video_slot uint32, pname uint32, params *uint64) {
 func GetVideouivNV(video_slot uint32, pname uint32, params *uint32) {
 	C.glowGetVideouivNV(gpGetVideouivNV, (C.GLuint)(video_slot), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
+}
 func GetnColorTableARB(target uint32, format uint32, xtype uint32, bufSize int32, table unsafe.Pointer) {
 	C.glowGetnColorTableARB(gpGetnColorTableARB, (C.GLenum)(target), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), table)
 }
@@ -22543,6 +23653,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -22551,6 +23664,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -22616,9 +23732,27 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportMemoryFdEXT(memory uint32, size uint64, handleType uint32, fd int32) {
+	C.glowImportMemoryFdEXT(gpImportMemoryFdEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportMemoryWin32HandleEXT(memory uint32, size uint64, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportMemoryWin32HandleEXT(gpImportMemoryWin32HandleEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), handle)
+}
+func ImportMemoryWin32NameEXT(memory uint32, size uint64, handleType uint32, name unsafe.Pointer) {
+	C.glowImportMemoryWin32NameEXT(gpImportMemoryWin32NameEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), name)
+}
+func ImportSemaphoreFdEXT(semaphore uint32, handleType uint32, fd int32) {
+	C.glowImportSemaphoreFdEXT(gpImportSemaphoreFdEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportSemaphoreWin32HandleEXT(semaphore uint32, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportSemaphoreWin32HandleEXT(gpImportSemaphoreWin32HandleEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), handle)
+}
+func ImportSemaphoreWin32NameEXT(semaphore uint32, handleType uint32, name unsafe.Pointer) {
+	C.glowImportSemaphoreWin32NameEXT(gpImportSemaphoreWin32NameEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), name)
+}
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -22761,6 +23895,10 @@ func IsBufferResidentNV(target uint32) bool {
 	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
 	return ret == TRUE
 }
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
 	return ret == TRUE
@@ -22803,6 +23941,10 @@ func IsImageHandleResidentNV(handle uint64) bool {
 // determine if a name corresponds to a display list
 func IsList(list uint32) bool {
 	ret := C.glowIsList(gpIsList, (C.GLuint)(list))
+	return ret == TRUE
+}
+func IsMemoryObjectEXT(memoryObject uint32) bool {
+	ret := C.glowIsMemoryObjectEXT(gpIsMemoryObjectEXT, (C.GLuint)(memoryObject))
 	return ret == TRUE
 }
 func IsNameAMD(identifier uint32, name uint32) bool {
@@ -22887,15 +24029,23 @@ func IsSampler(sampler uint32) bool {
 	ret := C.glowIsSampler(gpIsSampler, (C.GLuint)(sampler))
 	return ret == TRUE
 }
+func IsSemaphoreEXT(semaphore uint32) bool {
+	ret := C.glowIsSemaphoreEXT(gpIsSemaphoreEXT, (C.GLuint)(semaphore))
+	return ret == TRUE
+}
 
 // Determines if a name corresponds to a shader object
 func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -22944,6 +24094,15 @@ func IsVertexArrayAPPLE(array uint32) bool {
 func IsVertexAttribEnabledAPPLE(index uint32, pname uint32) bool {
 	ret := C.glowIsVertexAttribEnabledAPPLE(gpIsVertexAttribEnabledAPPLE, (C.GLuint)(index), (C.GLenum)(pname))
 	return ret == TRUE
+}
+func LGPUCopyImageSubDataNVX(sourceGpu uint32, destinationGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srxY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, width int32, height int32, depth int32) {
+	C.glowLGPUCopyImageSubDataNVX(gpLGPUCopyImageSubDataNVX, (C.GLuint)(sourceGpu), (C.GLbitfield)(destinationGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srxY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func LGPUInterlockNVX() {
+	C.glowLGPUInterlockNVX(gpLGPUInterlockNVX)
+}
+func LGPUNamedBufferSubDataNVX(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowLGPUNamedBufferSubDataNVX(gpLGPUNamedBufferSubDataNVX, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
@@ -23012,6 +24171,9 @@ func LinkProgramARB(programObj uintptr) {
 // set the display-list base for
 func ListBase(base uint32) {
 	C.glowListBase(gpListBase, (C.GLuint)(base))
+}
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 func ListParameterfSGIX(list uint32, pname uint32, param float32) {
 	C.glowListParameterfSGIX(gpListParameterfSGIX, (C.GLuint)(list), (C.GLenum)(pname), (C.GLfloat)(param))
@@ -23176,8 +24338,8 @@ func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
 }
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
 }
 func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
@@ -23320,6 +24482,12 @@ func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
 func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
 	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
 }
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
+}
 
 // defines a barrier ordering memory transactions
 func MemoryBarrier(barriers uint32) {
@@ -23330,6 +24498,9 @@ func MemoryBarrierByRegion(barriers uint32) {
 }
 func MemoryBarrierEXT(barriers uint32) {
 	C.glowMemoryBarrierEXT(gpMemoryBarrierEXT, (C.GLbitfield)(barriers))
+}
+func MemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowMemoryObjectParameterivEXT(gpMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func MinSampleShadingARB(value float32) {
 	C.glowMinSampleShadingARB(gpMinSampleShadingARB, (C.GLfloat)(value))
@@ -23388,8 +24559,8 @@ func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer
 func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawElementArrayAPPLE(mode uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawElementArrayAPPLE(gpMultiDrawElementArrayAPPLE, (C.GLenum)(mode), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -23421,8 +24592,8 @@ func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirec
 func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawRangeElementArrayAPPLE(mode uint32, start uint32, end uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawRangeElementArrayAPPLE(gpMultiDrawRangeElementArrayAPPLE, (C.GLenum)(mode), (C.GLuint)(start), (C.GLuint)(end), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -23796,32 +24967,71 @@ func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset i
 func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func MulticastBarrierNV() {
+	C.glowMulticastBarrierNV(gpMulticastBarrierNV)
+}
+func MulticastBlitFramebufferNV(srcGpu uint32, dstGpu uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
+	C.glowMulticastBlitFramebufferNV(gpMulticastBlitFramebufferNV, (C.GLuint)(srcGpu), (C.GLuint)(dstGpu), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
+}
+func MulticastBufferSubDataNV(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowMulticastBufferSubDataNV(gpMulticastBufferSubDataNV, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func MulticastCopyBufferSubDataNV(readGpu uint32, writeGpuMask uint32, readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowMulticastCopyBufferSubDataNV(gpMulticastCopyBufferSubDataNV, (C.GLuint)(readGpu), (C.GLbitfield)(writeGpuMask), (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func MulticastCopyImageSubDataNV(srcGpu uint32, dstGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
+	C.glowMulticastCopyImageSubDataNV(gpMulticastCopyImageSubDataNV, (C.GLuint)(srcGpu), (C.GLbitfield)(dstGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
+}
+func MulticastFramebufferSampleLocationsfvNV(gpu uint32, framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowMulticastFramebufferSampleLocationsfvNV(gpMulticastFramebufferSampleLocationsfvNV, (C.GLuint)(gpu), (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func MulticastGetQueryObjecti64vNV(gpu uint32, id uint32, pname uint32, params *int64) {
+	C.glowMulticastGetQueryObjecti64vNV(gpMulticastGetQueryObjecti64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectivNV(gpu uint32, id uint32, pname uint32, params *int32) {
+	C.glowMulticastGetQueryObjectivNV(gpMulticastGetQueryObjectivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectui64vNV(gpu uint32, id uint32, pname uint32, params *uint64) {
+	C.glowMulticastGetQueryObjectui64vNV(gpMulticastGetQueryObjectui64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectuivNV(gpu uint32, id uint32, pname uint32, params *uint32) {
+	C.glowMulticastGetQueryObjectuivNV(gpMulticastGetQueryObjectuivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MulticastWaitSyncNV(signalGpu uint32, waitGpuMask uint32) {
+	C.glowMulticastWaitSyncNV(gpMulticastWaitSyncNV, (C.GLuint)(signalGpu), (C.GLbitfield)(waitGpuMask))
+}
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
 func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func NamedBufferStorageExternalEXT(buffer uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowNamedBufferStorageExternalEXT(gpNamedBufferStorageExternalEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func NamedBufferStorageMemEXT(buffer uint32, size int, memory uint32, offset uint64) {
+	C.glowNamedBufferStorageMemEXT(gpNamedBufferStorageMemEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -23859,6 +25069,15 @@ func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderb
 }
 func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSamplePositionsfvAMD(framebuffer uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowNamedFramebufferSamplePositionsfvAMD(gpNamedFramebufferSamplePositionsfvAMD, (C.GLuint)(framebuffer), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
@@ -24109,6 +25328,8 @@ func PassThroughxOES(token int32) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -24204,6 +25425,8 @@ func PixelMapx(xmap uint32, size int32, values *int32) {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
 }
@@ -24326,6 +25549,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 func PolygonOffsetEXT(factor float32, bias float32) {
 	C.glowPolygonOffsetEXT(gpPolygonOffsetEXT, (C.GLfloat)(factor), (C.GLfloat)(bias))
 }
@@ -24365,6 +25594,9 @@ func PresentFrameDualFillNV(video_slot uint32, minPresentTime uint64, beginPrese
 }
 func PresentFrameKeyedNV(video_slot uint32, minPresentTime uint64, beginPresentTimeId uint32, presentDurationId uint32, xtype uint32, target0 uint32, fill0 uint32, key0 uint32, target1 uint32, fill1 uint32, key1 uint32) {
 	C.glowPresentFrameKeyedNV(gpPresentFrameKeyedNV, (C.GLuint)(video_slot), (C.GLuint64EXT)(minPresentTime), (C.GLuint)(beginPresentTimeId), (C.GLuint)(presentDurationId), (C.GLenum)(xtype), (C.GLenum)(target0), (C.GLuint)(fill0), (C.GLuint)(key0), (C.GLenum)(target1), (C.GLuint)(fill1), (C.GLuint)(key1))
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -24492,6 +25724,8 @@ func ProgramParameter4fNV(target uint32, index uint32, x float32, y float32, z f
 func ProgramParameter4fvNV(target uint32, index uint32, v *float32) {
 	C.glowProgramParameter4fvNV(gpProgramParameter4fvNV, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -24549,8 +25783,14 @@ func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
 func ProgramUniform1i64NV(program uint32, location int32, x int64) {
 	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24571,8 +25811,14 @@ func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
 func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
 	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24621,8 +25867,14 @@ func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
 	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24643,8 +25895,14 @@ func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
 	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24693,8 +25951,14 @@ func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
 	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24715,8 +25979,14 @@ func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
 	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24765,8 +26035,14 @@ func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
 	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24787,8 +26063,14 @@ func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24998,12 +26280,21 @@ func PushName(name uint32) {
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
 }
+
+// return the values of the current matrix
 func QueryMatrixxOES(mantissa *int32, exponent *int32) uint32 {
 	ret := C.glowQueryMatrixxOES(gpQueryMatrixxOES, (*C.GLfixed)(unsafe.Pointer(mantissa)), (*C.GLint)(unsafe.Pointer(exponent)))
 	return (uint32)(ret)
 }
 func QueryObjectParameteruiAMD(target uint32, id uint32, pname uint32, param uint32) {
 	C.glowQueryObjectParameteruiAMD(gpQueryObjectParameteruiAMD, (C.GLenum)(target), (C.GLuint)(id), (C.GLenum)(pname), (C.GLuint)(param))
+}
+func QueryResourceNV(queryType uint32, tagId int32, bufSize uint32, buffer *int32) int32 {
+	ret := C.glowQueryResourceNV(gpQueryResourceNV, (C.GLenum)(queryType), (C.GLint)(tagId), (C.GLuint)(bufSize), (*C.GLint)(unsafe.Pointer(buffer)))
+	return (int32)(ret)
+}
+func QueryResourceTagNV(tagId int32, tagString *uint8) {
+	C.glowQueryResourceTagNV(gpQueryResourceTagNV, (C.GLint)(tagId), (*C.GLchar)(unsafe.Pointer(tagString)))
 }
 func RasterPos2d(x float64, y float64) {
 	C.glowRasterPos2d(gpRasterPos2d, (C.GLdouble)(x), (C.GLdouble)(y))
@@ -25095,6 +26386,9 @@ func RasterPos4xOES(x int32, y int32, z int32, w int32) {
 func RasterPos4xvOES(coords *int32) {
 	C.glowRasterPos4xvOES(gpRasterPos4xvOES, (*C.GLfixed)(unsafe.Pointer(coords)))
 }
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // select a color buffer source for pixels
 func ReadBuffer(src uint32) {
@@ -25152,10 +26446,17 @@ func RectxvOES(v1 *int32, v2 *int32) {
 func ReferencePlaneSGIX(equation *float64) {
 	C.glowReferencePlaneSGIX(gpReferencePlaneSGIX, (*C.GLdouble)(unsafe.Pointer(equation)))
 }
+func ReleaseKeyedMutexWin32EXT(memory uint32, key uint64) bool {
+	ret := C.glowReleaseKeyedMutexWin32EXT(gpReleaseKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key))
+	return ret == TRUE
+}
 
 // release resources consumed by the implementation's shader compiler
 func ReleaseShaderCompiler() {
 	C.glowReleaseShaderCompiler(gpReleaseShaderCompiler)
+}
+func RenderGpuMaskNV(mask uint32) {
+	C.glowRenderGpuMaskNV(gpRenderGpuMaskNV, (C.GLbitfield)(mask))
 }
 
 // set rasterization mode
@@ -25273,6 +26574,9 @@ func ResetMinmaxEXT(target uint32) {
 func ResizeBuffersMESA() {
 	C.glowResizeBuffersMESA(gpResizeBuffersMESA)
 }
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
+}
 
 // resume transform feedback operations
 func ResumeTransformFeedback() {
@@ -25297,9 +26601,6 @@ func SampleCoverage(value float32, invert bool) {
 }
 func SampleCoverageARB(value float32, invert bool) {
 	C.glowSampleCoverageARB(gpSampleCoverageARB, (C.GLfloat)(value), (C.GLboolean)(boolToInt(invert)))
-}
-func SampleCoverageOES(value int32, invert bool) {
-	C.glowSampleCoverageOES(gpSampleCoverageOES, (C.GLfixed)(value), (C.GLboolean)(boolToInt(invert)))
 }
 func SampleCoveragexOES(value int32, invert bool) {
 	C.glowSampleCoveragexOES(gpSampleCoveragexOES, (C.GLclampx)(value), (C.GLboolean)(boolToInt(invert)))
@@ -25500,6 +26801,9 @@ func SelectBuffer(size int32, buffer *uint32) {
 func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
 	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
 }
+func SemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowSemaphoreParameterui64vEXT(gpSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 
 // define a separable two-dimensional convolution filter
 func SeparableFilter2D(target uint32, internalformat uint32, width int32, height int32, format uint32, xtype uint32, row unsafe.Pointer, column unsafe.Pointer) {
@@ -25561,6 +26865,18 @@ func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storage
 func SharpenTexFuncSGIS(target uint32, n int32, points *float32) {
 	C.glowSharpenTexFuncSGIS(gpSharpenTexFuncSGIS, (C.GLenum)(target), (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func SignalSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, dstLayouts *uint32) {
+	C.glowSignalSemaphoreEXT(gpSignalSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(dstLayouts)))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
 func SpriteParameterfSGIX(pname uint32, param float32) {
 	C.glowSpriteParameterfSGIX(gpSpriteParameterfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -25575,6 +26891,9 @@ func SpriteParameterivSGIX(pname uint32, params *int32) {
 }
 func StartInstrumentsSGIX() {
 	C.glowStartInstrumentsSGIX(gpStartInstrumentsSGIX)
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
 }
 func StencilClearTagEXT(stencilTagBits int32, stencilClearTag uint32) {
 	C.glowStencilClearTagEXT(gpStencilClearTagEXT, (C.GLsizei)(stencilTagBits), (C.GLuint)(stencilClearTag))
@@ -25647,6 +26966,9 @@ func StopInstrumentsSGIX(marker int32) {
 }
 func StringMarkerGREMEDY(len int32, xstring unsafe.Pointer) {
 	C.glowStringMarkerGREMEDY(gpStringMarkerGREMEDY, (C.GLsizei)(len), xstring)
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
 }
 func SwizzleEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowSwizzleEXT(gpSwizzleEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
@@ -26066,8 +27388,8 @@ func TexImage3DMultisampleCoverageNV(target uint32, coverageSamples int32, color
 func TexImage4DSGIS(target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, size4d int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTexImage4DSGIS(gpTexImage4DSGIS, (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(size4d), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -26127,6 +27449,21 @@ func TexStorage3D(target uint32, levels int32, internalformat uint32, width int3
 func TexStorage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexStorage3DMultisample(gpTexStorage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TexStorageMem1DEXT(target uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem1DEXT(gpTexStorageMem1DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DEXT(gpTexStorageMem2DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DMultisampleEXT(gpTexStorageMem2DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DEXT(gpTexStorageMem3DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DMultisampleEXT(gpTexStorageMem3DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TexStorageSparseAMD(target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTexStorageSparseAMD(gpTexStorageSparseAMD, (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -26175,8 +27512,8 @@ func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buff
 }
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
@@ -26214,8 +27551,8 @@ func TextureMaterialEXT(face uint32, mode uint32) {
 func TextureNormalEXT(mode uint32) {
 	C.glowTextureNormalEXT(gpTextureNormalEXT, (C.GLenum)(mode))
 }
-func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -26299,6 +27636,21 @@ func TextureStorage3DMultisample(texture uint32, samples int32, internalformat u
 func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorageMem1DEXT(texture uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem1DEXT(gpTextureStorageMem1DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DEXT(gpTextureStorageMem2DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DMultisampleEXT(gpTextureStorageMem2DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DEXT(gpTextureStorageMem3DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DMultisampleEXT(gpTextureStorageMem3DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TextureStorageSparseAMD(texture uint32, target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTextureStorageSparseAMD(gpTextureStorageSparseAMD, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -26344,8 +27696,8 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TransformFeedbackStreamAttribsNV(count int32, attribs *int32, nbuffers int32, bufstreams *int32, bufferMode uint32) {
 	C.glowTransformFeedbackStreamAttribsNV(gpTransformFeedbackStreamAttribsNV, (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(attribs)), (C.GLsizei)(nbuffers), (*C.GLint)(unsafe.Pointer(bufstreams)), (C.GLenum)(bufferMode))
@@ -26400,8 +27752,14 @@ func Uniform1fvARB(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
 func Uniform1i64NV(location int32, x int64) {
 	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform1i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26422,8 +27780,14 @@ func Uniform1ivARB(location int32, count int32, value *int32) {
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
 }
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
 func Uniform1ui64NV(location int32, x uint64) {
 	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform1ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26466,8 +27830,14 @@ func Uniform2fvARB(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func Uniform2i64NV(location int32, x int64, y int64) {
 	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform2i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26488,8 +27858,14 @@ func Uniform2ivARB(location int32, count int32, value *int32) {
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func Uniform2ui64NV(location int32, x uint64, y uint64) {
 	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform2ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26532,8 +27908,14 @@ func Uniform3fvARB(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func Uniform3i64NV(location int32, x int64, y int64, z int64) {
 	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform3i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26554,8 +27936,14 @@ func Uniform3ivARB(location int32, count int32, value *int32) {
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
 	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform3ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26598,8 +27986,14 @@ func Uniform4fvARB(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
 	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform4i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26620,8 +28014,14 @@ func Uniform4ivARB(location int32, count int32, value *int32) {
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform4ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -27962,10 +29362,22 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
+func WaitSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, srcLayouts *uint32) {
+	C.glowWaitSemaphoreEXT(gpWaitSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(srcLayouts)))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
 	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
@@ -28165,6 +29577,9 @@ func WindowPos4sMESA(x int16, y int16, z int16, w int16) {
 func WindowPos4svMESA(v *int16) {
 	C.glowWindowPos4svMESA(gpWindowPos4svMESA, (*C.GLshort)(unsafe.Pointer(v)))
 }
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
+}
 func WriteMaskEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowWriteMaskEXT(gpWriteMaskEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
 }
@@ -28201,6 +29616,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAccum")
 	}
 	gpAccumxOES = (C.GPACCUMXOES)(getProcAddr("glAccumxOES"))
+	gpAcquireKeyedMutexWin32EXT = (C.GPACQUIREKEYEDMUTEXWIN32EXT)(getProcAddr("glAcquireKeyedMutexWin32EXT"))
 	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
 	gpActiveShaderProgramEXT = (C.GPACTIVESHADERPROGRAMEXT)(getProcAddr("glActiveShaderProgramEXT"))
@@ -28219,6 +29635,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAlphaFunc")
 	}
 	gpAlphaFuncxOES = (C.GPALPHAFUNCXOES)(getProcAddr("glAlphaFuncxOES"))
+	gpAlphaToCoverageDitherControlNV = (C.GPALPHATOCOVERAGEDITHERCONTROLNV)(getProcAddr("glAlphaToCoverageDitherControlNV"))
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpApplyTextureEXT = (C.GPAPPLYTEXTUREEXT)(getProcAddr("glApplyTextureEXT"))
 	gpAreProgramsResidentNV = (C.GPAREPROGRAMSRESIDENTNV)(getProcAddr("glAreProgramsResidentNV"))
 	gpAreTexturesResident = (C.GPARETEXTURESRESIDENT)(getProcAddr("glAreTexturesResident"))
@@ -28411,11 +29829,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpBufferPageCommitmentARB = (C.GPBUFFERPAGECOMMITMENTARB)(getProcAddr("glBufferPageCommitmentARB"))
 	gpBufferParameteriAPPLE = (C.GPBUFFERPARAMETERIAPPLE)(getProcAddr("glBufferParameteriAPPLE"))
 	gpBufferStorage = (C.GPBUFFERSTORAGE)(getProcAddr("glBufferStorage"))
+	gpBufferStorageExternalEXT = (C.GPBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glBufferStorageExternalEXT"))
+	gpBufferStorageMemEXT = (C.GPBUFFERSTORAGEMEMEXT)(getProcAddr("glBufferStorageMemEXT"))
 	gpBufferSubData = (C.GPBUFFERSUBDATA)(getProcAddr("glBufferSubData"))
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
 	gpBufferSubDataARB = (C.GPBUFFERSUBDATAARB)(getProcAddr("glBufferSubDataARB"))
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCallList = (C.GPCALLLIST)(getProcAddr("glCallList"))
 	if gpCallList == nil {
 		return errors.New("glCallList")
@@ -28702,6 +30123,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCombinerParameteriNV = (C.GPCOMBINERPARAMETERINV)(getProcAddr("glCombinerParameteriNV"))
 	gpCombinerParameterivNV = (C.GPCOMBINERPARAMETERIVNV)(getProcAddr("glCombinerParameterivNV"))
 	gpCombinerStageParameterfvNV = (C.GPCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glCombinerStageParameterfvNV"))
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
@@ -28753,6 +30176,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
 	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpConvolutionFilter1D = (C.GPCONVOLUTIONFILTER1D)(getProcAddr("glConvolutionFilter1D"))
 	gpConvolutionFilter1DEXT = (C.GPCONVOLUTIONFILTER1DEXT)(getProcAddr("glConvolutionFilter1DEXT"))
 	gpConvolutionFilter2D = (C.GPCONVOLUTIONFILTER2D)(getProcAddr("glConvolutionFilter2D"))
@@ -28829,8 +30254,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
 	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
 	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
+	gpCreateMemoryObjectsEXT = (C.GPCREATEMEMORYOBJECTSEXT)(getProcAddr("glCreateMemoryObjectsEXT"))
 	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
@@ -28849,6 +30278,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCreateShaderProgramEXT = (C.GPCREATESHADERPROGRAMEXT)(getProcAddr("glCreateShaderProgramEXT"))
 	gpCreateShaderProgramv = (C.GPCREATESHADERPROGRAMV)(getProcAddr("glCreateShaderProgramv"))
 	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	gpCreateTransformFeedbacks = (C.GPCREATETRANSFORMFEEDBACKS)(getProcAddr("glCreateTransformFeedbacks"))
@@ -28881,6 +30311,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteBuffers")
 	}
 	gpDeleteBuffersARB = (C.GPDELETEBUFFERSARB)(getProcAddr("glDeleteBuffersARB"))
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFencesAPPLE = (C.GPDELETEFENCESAPPLE)(getProcAddr("glDeleteFencesAPPLE"))
 	gpDeleteFencesNV = (C.GPDELETEFENCESNV)(getProcAddr("glDeleteFencesNV"))
 	gpDeleteFragmentShaderATI = (C.GPDELETEFRAGMENTSHADERATI)(getProcAddr("glDeleteFragmentShaderATI"))
@@ -28893,6 +30324,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteLists == nil {
 		return errors.New("glDeleteLists")
 	}
+	gpDeleteMemoryObjectsEXT = (C.GPDELETEMEMORYOBJECTSEXT)(getProcAddr("glDeleteMemoryObjectsEXT"))
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
 	gpDeleteNamesAMD = (C.GPDELETENAMESAMD)(getProcAddr("glDeleteNamesAMD"))
 	gpDeleteObjectARB = (C.GPDELETEOBJECTARB)(getProcAddr("glDeleteObjectARB"))
@@ -28913,16 +30345,19 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteQueries")
 	}
 	gpDeleteQueriesARB = (C.GPDELETEQUERIESARB)(getProcAddr("glDeleteQueriesARB"))
+	gpDeleteQueryResourceTagNV = (C.GPDELETEQUERYRESOURCETAGNV)(getProcAddr("glDeleteQueryResourceTagNV"))
 	gpDeleteRenderbuffers = (C.GPDELETERENDERBUFFERS)(getProcAddr("glDeleteRenderbuffers"))
 	if gpDeleteRenderbuffers == nil {
 		return errors.New("glDeleteRenderbuffers")
 	}
 	gpDeleteRenderbuffersEXT = (C.GPDELETERENDERBUFFERSEXT)(getProcAddr("glDeleteRenderbuffersEXT"))
 	gpDeleteSamplers = (C.GPDELETESAMPLERS)(getProcAddr("glDeleteSamplers"))
+	gpDeleteSemaphoresEXT = (C.GPDELETESEMAPHORESEXT)(getProcAddr("glDeleteSemaphoresEXT"))
 	gpDeleteShader = (C.GPDELETESHADER)(getProcAddr("glDeleteShader"))
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	if gpDeleteSync == nil {
 		return errors.New("glDeleteSync")
@@ -29017,6 +30452,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpDrawBuffersARB = (C.GPDRAWBUFFERSARB)(getProcAddr("glDrawBuffersARB"))
 	gpDrawBuffersATI = (C.GPDRAWBUFFERSATI)(getProcAddr("glDrawBuffersATI"))
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElementArrayAPPLE = (C.GPDRAWELEMENTARRAYAPPLE)(getProcAddr("glDrawElementArrayAPPLE"))
 	gpDrawElementArrayATI = (C.GPDRAWELEMENTARRAYATI)(getProcAddr("glDrawElementArrayATI"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
@@ -29062,6 +30501,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpDrawTransformFeedbackNV = (C.GPDRAWTRANSFORMFEEDBACKNV)(getProcAddr("glDrawTransformFeedbackNV"))
 	gpDrawTransformFeedbackStream = (C.GPDRAWTRANSFORMFEEDBACKSTREAM)(getProcAddr("glDrawTransformFeedbackStream"))
 	gpDrawTransformFeedbackStreamInstanced = (C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(getProcAddr("glDrawTransformFeedbackStreamInstanced"))
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
 	gpEdgeFlag = (C.GPEDGEFLAG)(getProcAddr("glEdgeFlag"))
 	if gpEdgeFlag == nil {
 		return errors.New("glEdgeFlag")
@@ -29189,6 +30629,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEvalPoint2 == nil {
 		return errors.New("glEvalPoint2")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpExecuteProgramNV = (C.GPEXECUTEPROGRAMNV)(getProcAddr("glExecuteProgramNV"))
 	gpExtractComponentEXT = (C.GPEXTRACTCOMPONENTEXT)(getProcAddr("glExtractComponentEXT"))
 	gpFeedbackBuffer = (C.GPFEEDBACKBUFFER)(getProcAddr("glFeedbackBuffer"))
@@ -29275,6 +30716,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFogxOES = (C.GPFOGXOES)(getProcAddr("glFogxOES"))
 	gpFogxvOES = (C.GPFOGXVOES)(getProcAddr("glFogxvOES"))
 	gpFragmentColorMaterialSGIX = (C.GPFRAGMENTCOLORMATERIALSGIX)(getProcAddr("glFragmentColorMaterialSGIX"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
 	gpFragmentLightModelfSGIX = (C.GPFRAGMENTLIGHTMODELFSGIX)(getProcAddr("glFragmentLightModelfSGIX"))
 	gpFragmentLightModelfvSGIX = (C.GPFRAGMENTLIGHTMODELFVSGIX)(getProcAddr("glFragmentLightModelfvSGIX"))
 	gpFragmentLightModeliSGIX = (C.GPFRAGMENTLIGHTMODELISGIX)(getProcAddr("glFragmentLightModeliSGIX"))
@@ -29291,6 +30733,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFrameZoomSGIX = (C.GPFRAMEZOOMSGIX)(getProcAddr("glFrameZoomSGIX"))
 	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
 	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
 	gpFramebufferReadBufferEXT = (C.GPFRAMEBUFFERREADBUFFEREXT)(getProcAddr("glFramebufferReadBufferEXT"))
 	gpFramebufferRenderbuffer = (C.GPFRAMEBUFFERRENDERBUFFER)(getProcAddr("glFramebufferRenderbuffer"))
@@ -29298,6 +30741,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glFramebufferRenderbuffer")
 	}
 	gpFramebufferRenderbufferEXT = (C.GPFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glFramebufferRenderbufferEXT"))
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
+	gpFramebufferSamplePositionsfvAMD = (C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glFramebufferSamplePositionsfvAMD"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	if gpFramebufferTexture == nil {
 		return errors.New("glFramebufferTexture")
@@ -29327,6 +30773,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
 	gpFramebufferTextureLayerEXT = (C.GPFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glFramebufferTextureLayerEXT"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFreeObjectBufferATI = (C.GPFREEOBJECTBUFFERATI)(getProcAddr("glFreeObjectBufferATI"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
@@ -29369,12 +30816,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGenQueries")
 	}
 	gpGenQueriesARB = (C.GPGENQUERIESARB)(getProcAddr("glGenQueriesARB"))
+	gpGenQueryResourceTagNV = (C.GPGENQUERYRESOURCETAGNV)(getProcAddr("glGenQueryResourceTagNV"))
 	gpGenRenderbuffers = (C.GPGENRENDERBUFFERS)(getProcAddr("glGenRenderbuffers"))
 	if gpGenRenderbuffers == nil {
 		return errors.New("glGenRenderbuffers")
 	}
 	gpGenRenderbuffersEXT = (C.GPGENRENDERBUFFERSEXT)(getProcAddr("glGenRenderbuffersEXT"))
 	gpGenSamplers = (C.GPGENSAMPLERS)(getProcAddr("glGenSamplers"))
+	gpGenSemaphoresEXT = (C.GPGENSEMAPHORESEXT)(getProcAddr("glGenSemaphoresEXT"))
 	gpGenSymbolsEXT = (C.GPGENSYMBOLSEXT)(getProcAddr("glGenSymbolsEXT"))
 	gpGenTextures = (C.GPGENTEXTURES)(getProcAddr("glGenTextures"))
 	if gpGenTextures == nil {
@@ -29489,6 +30938,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetCombinerOutputParameterfvNV = (C.GPGETCOMBINEROUTPUTPARAMETERFVNV)(getProcAddr("glGetCombinerOutputParameterfvNV"))
 	gpGetCombinerOutputParameterivNV = (C.GPGETCOMBINEROUTPUTPARAMETERIVNV)(getProcAddr("glGetCombinerOutputParameterivNV"))
 	gpGetCombinerStageParameterfvNV = (C.GPGETCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glGetCombinerStageParameterfvNV"))
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
 	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
@@ -29505,6 +30955,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetConvolutionParameteriv = (C.GPGETCONVOLUTIONPARAMETERIV)(getProcAddr("glGetConvolutionParameteriv"))
 	gpGetConvolutionParameterivEXT = (C.GPGETCONVOLUTIONPARAMETERIVEXT)(getProcAddr("glGetConvolutionParameterivEXT"))
 	gpGetConvolutionParameterxvOES = (C.GPGETCONVOLUTIONPARAMETERXVOES)(getProcAddr("glGetConvolutionParameterxvOES"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	gpGetDebugMessageLogAMD = (C.GPGETDEBUGMESSAGELOGAMD)(getProcAddr("glGetDebugMessageLogAMD"))
 	gpGetDebugMessageLogARB = (C.GPGETDEBUGMESSAGELOGARB)(getProcAddr("glGetDebugMessageLogARB"))
@@ -29549,6 +31000,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetFramebufferAttachmentParameteriv")
 	}
 	gpGetFramebufferAttachmentParameterivEXT = (C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetFramebufferAttachmentParameterivEXT"))
+	gpGetFramebufferParameterfvAMD = (C.GPGETFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetFramebufferParameterfvAMD"))
 	gpGetFramebufferParameteriv = (C.GPGETFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetFramebufferParameteriv"))
 	gpGetFramebufferParameterivEXT = (C.GPGETFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetFramebufferParameterivEXT"))
 	gpGetGraphicsResetStatus = (C.GPGETGRAPHICSRESETSTATUS)(getProcAddr("glGetGraphicsResetStatus"))
@@ -29587,6 +31039,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	gpGetInternalformativ = (C.GPGETINTERNALFORMATIV)(getProcAddr("glGetInternalformativ"))
 	gpGetInvariantBooleanvEXT = (C.GPGETINVARIANTBOOLEANVEXT)(getProcAddr("glGetInvariantBooleanvEXT"))
@@ -29635,6 +31088,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetMaterialxOES = (C.GPGETMATERIALXOES)(getProcAddr("glGetMaterialxOES"))
 	gpGetMaterialxvOES = (C.GPGETMATERIALXVOES)(getProcAddr("glGetMaterialxvOES"))
+	gpGetMemoryObjectParameterivEXT = (C.GPGETMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glGetMemoryObjectParameterivEXT"))
 	gpGetMinmax = (C.GPGETMINMAX)(getProcAddr("glGetMinmax"))
 	gpGetMinmaxEXT = (C.GPGETMINMAXEXT)(getProcAddr("glGetMinmaxEXT"))
 	gpGetMinmaxParameterfv = (C.GPGETMINMAXPARAMETERFV)(getProcAddr("glGetMinmaxParameterfv"))
@@ -29668,6 +31122,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
 	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
+	gpGetNamedFramebufferParameterfvAMD = (C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetNamedFramebufferParameterfvAMD"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
 	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
 	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
@@ -29783,6 +31238,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetProgramivARB = (C.GPGETPROGRAMIVARB)(getProcAddr("glGetProgramivARB"))
 	gpGetProgramivNV = (C.GPGETPROGRAMIVNV)(getProcAddr("glGetProgramivNV"))
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	gpGetQueryObjecti64v = (C.GPGETQUERYOBJECTI64V)(getProcAddr("glGetQueryObjecti64v"))
 	gpGetQueryObjecti64vEXT = (C.GPGETQUERYOBJECTI64VEXT)(getProcAddr("glGetQueryObjecti64vEXT"))
@@ -29812,6 +31271,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetSamplerParameterIuiv = (C.GPGETSAMPLERPARAMETERIUIV)(getProcAddr("glGetSamplerParameterIuiv"))
 	gpGetSamplerParameterfv = (C.GPGETSAMPLERPARAMETERFV)(getProcAddr("glGetSamplerParameterfv"))
 	gpGetSamplerParameteriv = (C.GPGETSAMPLERPARAMETERIV)(getProcAddr("glGetSamplerParameteriv"))
+	gpGetSemaphoreParameterui64vEXT = (C.GPGETSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glGetSemaphoreParameterui64vEXT"))
 	gpGetSeparableFilter = (C.GPGETSEPARABLEFILTER)(getProcAddr("glGetSeparableFilter"))
 	gpGetSeparableFilterEXT = (C.GPGETSEPARABLEFILTEREXT)(getProcAddr("glGetSeparableFilterEXT"))
 	gpGetShaderInfoLog = (C.GPGETSHADERINFOLOG)(getProcAddr("glGetShaderInfoLog"))
@@ -29829,6 +31289,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetShaderiv")
 	}
 	gpGetSharpenTexFuncSGIS = (C.GPGETSHARPENTEXFUNCSGIS)(getProcAddr("glGetSharpenTexFuncSGIS"))
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -29952,18 +31413,22 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetUniformfv")
 	}
 	gpGetUniformfvARB = (C.GPGETUNIFORMFVARB)(getProcAddr("glGetUniformfvARB"))
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
 	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
 	gpGetUniformivARB = (C.GPGETUNIFORMIVARB)(getProcAddr("glGetUniformivARB"))
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
 	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
 	}
 	gpGetUniformuivEXT = (C.GPGETUNIFORMUIVEXT)(getProcAddr("glGetUniformuivEXT"))
+	gpGetUnsignedBytei_vEXT = (C.GPGETUNSIGNEDBYTEI_VEXT)(getProcAddr("glGetUnsignedBytei_vEXT"))
+	gpGetUnsignedBytevEXT = (C.GPGETUNSIGNEDBYTEVEXT)(getProcAddr("glGetUnsignedBytevEXT"))
 	gpGetVariantArrayObjectfvATI = (C.GPGETVARIANTARRAYOBJECTFVATI)(getProcAddr("glGetVariantArrayObjectfvATI"))
 	gpGetVariantArrayObjectivATI = (C.GPGETVARIANTARRAYOBJECTIVATI)(getProcAddr("glGetVariantArrayObjectivATI"))
 	gpGetVariantBooleanvEXT = (C.GPGETVARIANTBOOLEANVEXT)(getProcAddr("glGetVariantBooleanvEXT"))
@@ -30027,6 +31492,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetVideoivNV = (C.GPGETVIDEOIVNV)(getProcAddr("glGetVideoivNV"))
 	gpGetVideoui64vNV = (C.GPGETVIDEOUI64VNV)(getProcAddr("glGetVideoui64vNV"))
 	gpGetVideouivNV = (C.GPGETVIDEOUIVNV)(getProcAddr("glGetVideouivNV"))
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnColorTableARB = (C.GPGETNCOLORTABLEARB)(getProcAddr("glGetnColorTableARB"))
 	gpGetnCompressedTexImageARB = (C.GPGETNCOMPRESSEDTEXIMAGEARB)(getProcAddr("glGetnCompressedTexImageARB"))
 	gpGetnConvolutionFilterARB = (C.GPGETNCONVOLUTIONFILTERARB)(getProcAddr("glGetnConvolutionFilterARB"))
@@ -30045,9 +31511,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	gpGetnUniformuivARB = (C.GPGETNUNIFORMUIVARB)(getProcAddr("glGetnUniformuivARB"))
 	gpGetnUniformuivKHR = (C.GPGETNUNIFORMUIVKHR)(getProcAddr("glGetnUniformuivKHR"))
@@ -30071,6 +31539,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpImageTransformParameterfvHP = (C.GPIMAGETRANSFORMPARAMETERFVHP)(getProcAddr("glImageTransformParameterfvHP"))
 	gpImageTransformParameteriHP = (C.GPIMAGETRANSFORMPARAMETERIHP)(getProcAddr("glImageTransformParameteriHP"))
 	gpImageTransformParameterivHP = (C.GPIMAGETRANSFORMPARAMETERIVHP)(getProcAddr("glImageTransformParameterivHP"))
+	gpImportMemoryFdEXT = (C.GPIMPORTMEMORYFDEXT)(getProcAddr("glImportMemoryFdEXT"))
+	gpImportMemoryWin32HandleEXT = (C.GPIMPORTMEMORYWIN32HANDLEEXT)(getProcAddr("glImportMemoryWin32HandleEXT"))
+	gpImportMemoryWin32NameEXT = (C.GPIMPORTMEMORYWIN32NAMEEXT)(getProcAddr("glImportMemoryWin32NameEXT"))
+	gpImportSemaphoreFdEXT = (C.GPIMPORTSEMAPHOREFDEXT)(getProcAddr("glImportSemaphoreFdEXT"))
+	gpImportSemaphoreWin32HandleEXT = (C.GPIMPORTSEMAPHOREWIN32HANDLEEXT)(getProcAddr("glImportSemaphoreWin32HandleEXT"))
+	gpImportSemaphoreWin32NameEXT = (C.GPIMPORTSEMAPHOREWIN32NAMEEXT)(getProcAddr("glImportSemaphoreWin32NameEXT"))
 	gpImportSyncEXT = (C.GPIMPORTSYNCEXT)(getProcAddr("glImportSyncEXT"))
 	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
 	gpIndexFuncEXT = (C.GPINDEXFUNCEXT)(getProcAddr("glIndexFuncEXT"))
@@ -30154,6 +31628,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsBufferARB = (C.GPISBUFFERARB)(getProcAddr("glIsBufferARB"))
 	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
@@ -30176,6 +31651,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsList == nil {
 		return errors.New("glIsList")
 	}
+	gpIsMemoryObjectEXT = (C.GPISMEMORYOBJECTEXT)(getProcAddr("glIsMemoryObjectEXT"))
 	gpIsNameAMD = (C.GPISNAMEAMD)(getProcAddr("glIsNameAMD"))
 	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
@@ -30203,10 +31679,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsRenderbufferEXT = (C.GPISRENDERBUFFEREXT)(getProcAddr("glIsRenderbufferEXT"))
 	gpIsSampler = (C.GPISSAMPLER)(getProcAddr("glIsSampler"))
+	gpIsSemaphoreEXT = (C.GPISSEMAPHOREEXT)(getProcAddr("glIsSemaphoreEXT"))
 	gpIsShader = (C.GPISSHADER)(getProcAddr("glIsShader"))
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	if gpIsSync == nil {
 		return errors.New("glIsSync")
@@ -30227,6 +31705,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsVertexArrayAPPLE = (C.GPISVERTEXARRAYAPPLE)(getProcAddr("glIsVertexArrayAPPLE"))
 	gpIsVertexAttribEnabledAPPLE = (C.GPISVERTEXATTRIBENABLEDAPPLE)(getProcAddr("glIsVertexAttribEnabledAPPLE"))
+	gpLGPUCopyImageSubDataNVX = (C.GPLGPUCOPYIMAGESUBDATANVX)(getProcAddr("glLGPUCopyImageSubDataNVX"))
+	gpLGPUInterlockNVX = (C.GPLGPUINTERLOCKNVX)(getProcAddr("glLGPUInterlockNVX"))
+	gpLGPUNamedBufferSubDataNVX = (C.GPLGPUNAMEDBUFFERSUBDATANVX)(getProcAddr("glLGPUNamedBufferSubDataNVX"))
 	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLightEnviSGIX = (C.GPLIGHTENVISGIX)(getProcAddr("glLightEnviSGIX"))
 	gpLightModelf = (C.GPLIGHTMODELF)(getProcAddr("glLightModelf"))
@@ -30283,6 +31764,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpListBase == nil {
 		return errors.New("glListBase")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpListParameterfSGIX = (C.GPLISTPARAMETERFSGIX)(getProcAddr("glListParameterfSGIX"))
 	gpListParameterfvSGIX = (C.GPLISTPARAMETERFVSGIX)(getProcAddr("glListParameterfvSGIX"))
 	gpListParameteriSGIX = (C.GPLISTPARAMETERISGIX)(getProcAddr("glListParameteriSGIX"))
@@ -30443,9 +31925,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
 	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
 	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	gpMemoryBarrierByRegion = (C.GPMEMORYBARRIERBYREGION)(getProcAddr("glMemoryBarrierByRegion"))
 	gpMemoryBarrierEXT = (C.GPMEMORYBARRIEREXT)(getProcAddr("glMemoryBarrierEXT"))
+	gpMemoryObjectParameterivEXT = (C.GPMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glMemoryObjectParameterivEXT"))
 	gpMinSampleShadingARB = (C.GPMINSAMPLESHADINGARB)(getProcAddr("glMinSampleShadingARB"))
 	gpMinmax = (C.GPMINMAX)(getProcAddr("glMinmax"))
 	gpMinmaxEXT = (C.GPMINMAXEXT)(getProcAddr("glMinmaxEXT"))
@@ -30714,12 +32199,25 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
 	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
 	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
+	gpMulticastBarrierNV = (C.GPMULTICASTBARRIERNV)(getProcAddr("glMulticastBarrierNV"))
+	gpMulticastBlitFramebufferNV = (C.GPMULTICASTBLITFRAMEBUFFERNV)(getProcAddr("glMulticastBlitFramebufferNV"))
+	gpMulticastBufferSubDataNV = (C.GPMULTICASTBUFFERSUBDATANV)(getProcAddr("glMulticastBufferSubDataNV"))
+	gpMulticastCopyBufferSubDataNV = (C.GPMULTICASTCOPYBUFFERSUBDATANV)(getProcAddr("glMulticastCopyBufferSubDataNV"))
+	gpMulticastCopyImageSubDataNV = (C.GPMULTICASTCOPYIMAGESUBDATANV)(getProcAddr("glMulticastCopyImageSubDataNV"))
+	gpMulticastFramebufferSampleLocationsfvNV = (C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glMulticastFramebufferSampleLocationsfvNV"))
+	gpMulticastGetQueryObjecti64vNV = (C.GPMULTICASTGETQUERYOBJECTI64VNV)(getProcAddr("glMulticastGetQueryObjecti64vNV"))
+	gpMulticastGetQueryObjectivNV = (C.GPMULTICASTGETQUERYOBJECTIVNV)(getProcAddr("glMulticastGetQueryObjectivNV"))
+	gpMulticastGetQueryObjectui64vNV = (C.GPMULTICASTGETQUERYOBJECTUI64VNV)(getProcAddr("glMulticastGetQueryObjectui64vNV"))
+	gpMulticastGetQueryObjectuivNV = (C.GPMULTICASTGETQUERYOBJECTUIVNV)(getProcAddr("glMulticastGetQueryObjectuivNV"))
+	gpMulticastWaitSyncNV = (C.GPMULTICASTWAITSYNCNV)(getProcAddr("glMulticastWaitSyncNV"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
 	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
 	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
+	gpNamedBufferStorageExternalEXT = (C.GPNAMEDBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glNamedBufferStorageExternalEXT"))
+	gpNamedBufferStorageMemEXT = (C.GPNAMEDBUFFERSTORAGEMEMEXT)(getProcAddr("glNamedBufferStorageMemEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
 	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
 	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
@@ -30730,6 +32228,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	gpNamedFramebufferRenderbuffer = (C.GPNAMEDFRAMEBUFFERRENDERBUFFER)(getProcAddr("glNamedFramebufferRenderbuffer"))
 	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
+	gpNamedFramebufferSamplePositionsfvAMD = (C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glNamedFramebufferSamplePositionsfvAMD"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
 	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
 	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
@@ -30960,6 +32461,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPolygonOffsetEXT = (C.GPPOLYGONOFFSETEXT)(getProcAddr("glPolygonOffsetEXT"))
 	gpPolygonOffsetxOES = (C.GPPOLYGONOFFSETXOES)(getProcAddr("glPolygonOffsetxOES"))
 	gpPolygonStipple = (C.GPPOLYGONSTIPPLE)(getProcAddr("glPolygonStipple"))
@@ -30987,6 +32490,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpPresentFrameDualFillNV = (C.GPPRESENTFRAMEDUALFILLNV)(getProcAddr("glPresentFrameDualFillNV"))
 	gpPresentFrameKeyedNV = (C.GPPRESENTFRAMEKEYEDNV)(getProcAddr("glPresentFrameKeyedNV"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	if gpPrimitiveRestartIndex == nil {
 		return errors.New("glPrimitiveRestartIndex")
@@ -31050,13 +32554,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpProgramUniform1fv = (C.GPPROGRAMUNIFORM1FV)(getProcAddr("glProgramUniform1fv"))
 	gpProgramUniform1fvEXT = (C.GPPROGRAMUNIFORM1FVEXT)(getProcAddr("glProgramUniform1fvEXT"))
 	gpProgramUniform1i = (C.GPPROGRAMUNIFORM1I)(getProcAddr("glProgramUniform1i"))
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
 	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
 	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
 	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
 	gpProgramUniform1ivEXT = (C.GPPROGRAMUNIFORM1IVEXT)(getProcAddr("glProgramUniform1ivEXT"))
 	gpProgramUniform1ui = (C.GPPROGRAMUNIFORM1UI)(getProcAddr("glProgramUniform1ui"))
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
 	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
 	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
 	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
@@ -31070,13 +32578,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpProgramUniform2fv = (C.GPPROGRAMUNIFORM2FV)(getProcAddr("glProgramUniform2fv"))
 	gpProgramUniform2fvEXT = (C.GPPROGRAMUNIFORM2FVEXT)(getProcAddr("glProgramUniform2fvEXT"))
 	gpProgramUniform2i = (C.GPPROGRAMUNIFORM2I)(getProcAddr("glProgramUniform2i"))
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
 	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
 	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
 	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
 	gpProgramUniform2ivEXT = (C.GPPROGRAMUNIFORM2IVEXT)(getProcAddr("glProgramUniform2ivEXT"))
 	gpProgramUniform2ui = (C.GPPROGRAMUNIFORM2UI)(getProcAddr("glProgramUniform2ui"))
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
 	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
 	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
 	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
@@ -31090,13 +32602,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpProgramUniform3fv = (C.GPPROGRAMUNIFORM3FV)(getProcAddr("glProgramUniform3fv"))
 	gpProgramUniform3fvEXT = (C.GPPROGRAMUNIFORM3FVEXT)(getProcAddr("glProgramUniform3fvEXT"))
 	gpProgramUniform3i = (C.GPPROGRAMUNIFORM3I)(getProcAddr("glProgramUniform3i"))
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
 	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
 	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
 	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
 	gpProgramUniform3ivEXT = (C.GPPROGRAMUNIFORM3IVEXT)(getProcAddr("glProgramUniform3ivEXT"))
 	gpProgramUniform3ui = (C.GPPROGRAMUNIFORM3UI)(getProcAddr("glProgramUniform3ui"))
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
 	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
 	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
 	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
@@ -31110,13 +32626,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpProgramUniform4fv = (C.GPPROGRAMUNIFORM4FV)(getProcAddr("glProgramUniform4fv"))
 	gpProgramUniform4fvEXT = (C.GPPROGRAMUNIFORM4FVEXT)(getProcAddr("glProgramUniform4fvEXT"))
 	gpProgramUniform4i = (C.GPPROGRAMUNIFORM4I)(getProcAddr("glProgramUniform4i"))
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
 	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
 	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
 	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
 	gpProgramUniform4ivEXT = (C.GPPROGRAMUNIFORM4IVEXT)(getProcAddr("glProgramUniform4ivEXT"))
 	gpProgramUniform4ui = (C.GPPROGRAMUNIFORM4UI)(getProcAddr("glProgramUniform4ui"))
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
 	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
 	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
 	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
@@ -31192,6 +32712,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpQueryCounter = (C.GPQUERYCOUNTER)(getProcAddr("glQueryCounter"))
 	gpQueryMatrixxOES = (C.GPQUERYMATRIXXOES)(getProcAddr("glQueryMatrixxOES"))
 	gpQueryObjectParameteruiAMD = (C.GPQUERYOBJECTPARAMETERUIAMD)(getProcAddr("glQueryObjectParameteruiAMD"))
+	gpQueryResourceNV = (C.GPQUERYRESOURCENV)(getProcAddr("glQueryResourceNV"))
+	gpQueryResourceTagNV = (C.GPQUERYRESOURCETAGNV)(getProcAddr("glQueryResourceTagNV"))
 	gpRasterPos2d = (C.GPRASTERPOS2D)(getProcAddr("glRasterPos2d"))
 	if gpRasterPos2d == nil {
 		return errors.New("glRasterPos2d")
@@ -31294,6 +32816,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpRasterPos4xOES = (C.GPRASTERPOS4XOES)(getProcAddr("glRasterPos4xOES"))
 	gpRasterPos4xvOES = (C.GPRASTERPOS4XVOES)(getProcAddr("glRasterPos4xvOES"))
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -31341,7 +32864,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpRectxOES = (C.GPRECTXOES)(getProcAddr("glRectxOES"))
 	gpRectxvOES = (C.GPRECTXVOES)(getProcAddr("glRectxvOES"))
 	gpReferencePlaneSGIX = (C.GPREFERENCEPLANESGIX)(getProcAddr("glReferencePlaneSGIX"))
+	gpReleaseKeyedMutexWin32EXT = (C.GPRELEASEKEYEDMUTEXWIN32EXT)(getProcAddr("glReleaseKeyedMutexWin32EXT"))
 	gpReleaseShaderCompiler = (C.GPRELEASESHADERCOMPILER)(getProcAddr("glReleaseShaderCompiler"))
+	gpRenderGpuMaskNV = (C.GPRENDERGPUMASKNV)(getProcAddr("glRenderGpuMaskNV"))
 	gpRenderMode = (C.GPRENDERMODE)(getProcAddr("glRenderMode"))
 	if gpRenderMode == nil {
 		return errors.New("glRenderMode")
@@ -31386,6 +32911,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpResetMinmax = (C.GPRESETMINMAX)(getProcAddr("glResetMinmax"))
 	gpResetMinmaxEXT = (C.GPRESETMINMAXEXT)(getProcAddr("glResetMinmaxEXT"))
 	gpResizeBuffersMESA = (C.GPRESIZEBUFFERSMESA)(getProcAddr("glResizeBuffersMESA"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	gpResumeTransformFeedbackNV = (C.GPRESUMETRANSFORMFEEDBACKNV)(getProcAddr("glResumeTransformFeedbackNV"))
 	gpRotated = (C.GPROTATED)(getProcAddr("glRotated"))
@@ -31402,7 +32928,6 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSampleCoverage")
 	}
 	gpSampleCoverageARB = (C.GPSAMPLECOVERAGEARB)(getProcAddr("glSampleCoverageARB"))
-	gpSampleCoverageOES = (C.GPSAMPLECOVERAGEOES)(getProcAddr("glSampleCoverageOES"))
 	gpSampleCoveragexOES = (C.GPSAMPLECOVERAGEXOES)(getProcAddr("glSampleCoveragexOES"))
 	gpSampleMapATI = (C.GPSAMPLEMAPATI)(getProcAddr("glSampleMapATI"))
 	gpSampleMaskEXT = (C.GPSAMPLEMASKEXT)(getProcAddr("glSampleMaskEXT"))
@@ -31532,6 +33057,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSelectBuffer")
 	}
 	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
+	gpSemaphoreParameterui64vEXT = (C.GPSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glSemaphoreParameterui64vEXT"))
 	gpSeparableFilter2D = (C.GPSEPARABLEFILTER2D)(getProcAddr("glSeparableFilter2D"))
 	gpSeparableFilter2DEXT = (C.GPSEPARABLEFILTER2DEXT)(getProcAddr("glSeparableFilter2DEXT"))
 	gpSetFenceAPPLE = (C.GPSETFENCEAPPLE)(getProcAddr("glSetFenceAPPLE"))
@@ -31555,11 +33081,16 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpShaderSourceARB = (C.GPSHADERSOURCEARB)(getProcAddr("glShaderSourceARB"))
 	gpShaderStorageBlockBinding = (C.GPSHADERSTORAGEBLOCKBINDING)(getProcAddr("glShaderStorageBlockBinding"))
 	gpSharpenTexFuncSGIS = (C.GPSHARPENTEXFUNCSGIS)(getProcAddr("glSharpenTexFuncSGIS"))
+	gpSignalSemaphoreEXT = (C.GPSIGNALSEMAPHOREEXT)(getProcAddr("glSignalSemaphoreEXT"))
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
 	gpSpriteParameterfSGIX = (C.GPSPRITEPARAMETERFSGIX)(getProcAddr("glSpriteParameterfSGIX"))
 	gpSpriteParameterfvSGIX = (C.GPSPRITEPARAMETERFVSGIX)(getProcAddr("glSpriteParameterfvSGIX"))
 	gpSpriteParameteriSGIX = (C.GPSPRITEPARAMETERISGIX)(getProcAddr("glSpriteParameteriSGIX"))
 	gpSpriteParameterivSGIX = (C.GPSPRITEPARAMETERIVSGIX)(getProcAddr("glSpriteParameterivSGIX"))
 	gpStartInstrumentsSGIX = (C.GPSTARTINSTRUMENTSSGIX)(getProcAddr("glStartInstrumentsSGIX"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
 	gpStencilClearTagEXT = (C.GPSTENCILCLEARTAGEXT)(getProcAddr("glStencilClearTagEXT"))
 	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
 	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
@@ -31598,6 +33129,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
 	gpStopInstrumentsSGIX = (C.GPSTOPINSTRUMENTSSGIX)(getProcAddr("glStopInstrumentsSGIX"))
 	gpStringMarkerGREMEDY = (C.GPSTRINGMARKERGREMEDY)(getProcAddr("glStringMarkerGREMEDY"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpSwizzleEXT = (C.GPSWIZZLEEXT)(getProcAddr("glSwizzleEXT"))
 	gpSyncTextureINTEL = (C.GPSYNCTEXTUREINTEL)(getProcAddr("glSyncTextureINTEL"))
 	gpTagSampleBufferSGIX = (C.GPTAGSAMPLEBUFFERSGIX)(getProcAddr("glTagSampleBufferSGIX"))
@@ -31913,6 +33445,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpTexStorage2DMultisample = (C.GPTEXSTORAGE2DMULTISAMPLE)(getProcAddr("glTexStorage2DMultisample"))
 	gpTexStorage3D = (C.GPTEXSTORAGE3D)(getProcAddr("glTexStorage3D"))
 	gpTexStorage3DMultisample = (C.GPTEXSTORAGE3DMULTISAMPLE)(getProcAddr("glTexStorage3DMultisample"))
+	gpTexStorageMem1DEXT = (C.GPTEXSTORAGEMEM1DEXT)(getProcAddr("glTexStorageMem1DEXT"))
+	gpTexStorageMem2DEXT = (C.GPTEXSTORAGEMEM2DEXT)(getProcAddr("glTexStorageMem2DEXT"))
+	gpTexStorageMem2DMultisampleEXT = (C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem2DMultisampleEXT"))
+	gpTexStorageMem3DEXT = (C.GPTEXSTORAGEMEM3DEXT)(getProcAddr("glTexStorageMem3DEXT"))
+	gpTexStorageMem3DMultisampleEXT = (C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem3DMultisampleEXT"))
 	gpTexStorageSparseAMD = (C.GPTEXSTORAGESPARSEAMD)(getProcAddr("glTexStorageSparseAMD"))
 	gpTexSubImage1D = (C.GPTEXSUBIMAGE1D)(getProcAddr("glTexSubImage1D"))
 	if gpTexSubImage1D == nil {
@@ -31972,6 +33509,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
 	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
+	gpTextureStorageMem1DEXT = (C.GPTEXTURESTORAGEMEM1DEXT)(getProcAddr("glTextureStorageMem1DEXT"))
+	gpTextureStorageMem2DEXT = (C.GPTEXTURESTORAGEMEM2DEXT)(getProcAddr("glTextureStorageMem2DEXT"))
+	gpTextureStorageMem2DMultisampleEXT = (C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem2DMultisampleEXT"))
+	gpTextureStorageMem3DEXT = (C.GPTEXTURESTORAGEMEM3DEXT)(getProcAddr("glTextureStorageMem3DEXT"))
+	gpTextureStorageMem3DMultisampleEXT = (C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem3DMultisampleEXT"))
 	gpTextureStorageSparseAMD = (C.GPTEXTURESTORAGESPARSEAMD)(getProcAddr("glTextureStorageSparseAMD"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
 	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
@@ -32017,7 +33559,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
 	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
 	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iARB = (C.GPUNIFORM1IARB)(getProcAddr("glUniform1iARB"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
@@ -32029,7 +33573,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
 	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
 	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiEXT = (C.GPUNIFORM1UIEXT)(getProcAddr("glUniform1uiEXT"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
@@ -32053,7 +33599,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
 	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
 	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iARB = (C.GPUNIFORM2IARB)(getProcAddr("glUniform2iARB"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
@@ -32065,7 +33613,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
 	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
 	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiEXT = (C.GPUNIFORM2UIEXT)(getProcAddr("glUniform2uiEXT"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
@@ -32089,7 +33639,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
 	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
 	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iARB = (C.GPUNIFORM3IARB)(getProcAddr("glUniform3iARB"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
@@ -32101,7 +33653,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
 	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
 	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiEXT = (C.GPUNIFORM3UIEXT)(getProcAddr("glUniform3uiEXT"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
@@ -32125,7 +33679,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
 	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
 	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iARB = (C.GPUNIFORM4IARB)(getProcAddr("glUniform4iARB"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
@@ -32137,7 +33693,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
 	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
 	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiEXT = (C.GPUNIFORM4UIEXT)(getProcAddr("glUniform4uiEXT"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
@@ -32857,10 +34415,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpViewportArrayv = (C.GPVIEWPORTARRAYV)(getProcAddr("glViewportArrayv"))
 	gpViewportIndexedf = (C.GPVIEWPORTINDEXEDF)(getProcAddr("glViewportIndexedf"))
 	gpViewportIndexedfv = (C.GPVIEWPORTINDEXEDFV)(getProcAddr("glViewportIndexedfv"))
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
+	gpWaitSemaphoreEXT = (C.GPWAITSEMAPHOREEXT)(getProcAddr("glWaitSemaphoreEXT"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
 	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
 	gpWeightPointerARB = (C.GPWEIGHTPOINTERARB)(getProcAddr("glWeightPointerARB"))
 	gpWeightbvARB = (C.GPWEIGHTBVARB)(getProcAddr("glWeightbvARB"))
@@ -32975,6 +34537,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpWindowPos4ivMESA = (C.GPWINDOWPOS4IVMESA)(getProcAddr("glWindowPos4ivMESA"))
 	gpWindowPos4sMESA = (C.GPWINDOWPOS4SMESA)(getProcAddr("glWindowPos4sMESA"))
 	gpWindowPos4svMESA = (C.GPWINDOWPOS4SVMESA)(getProcAddr("glWindowPos4svMESA"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	gpWriteMaskEXT = (C.GPWRITEMASKEXT)(getProcAddr("glWriteMaskEXT"))
 	return nil
 }

--- a/v3.2-compatibility/gl/procaddr.go
+++ b/v3.2-compatibility/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcompatibility32(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v3.2-core/gl/package.go
+++ b/v3.2-core/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -89,21 +87,29 @@ package gl
 // typedef ptrdiff_t GLsizeiptr;
 // typedef int64_t GLint64;
 // typedef uint64_t GLuint64;
+// typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCARB)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCKHR)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcore32(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcore32(source, type, id, severity, length, message, userParam);
 // }
+// typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
+// typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVETEXTURE)(GLenum  texture);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPATTACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPBEGINCONDITIONALRENDER)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINCONDITIONALRENDERNV)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPBEGINPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPBEGINQUERY)(GLenum  target, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINQUERYINDEXED)(GLenum  target, GLuint  index, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINTRANSFORMFEEDBACK)(GLenum  primitiveMode);
@@ -118,7 +124,9 @@ package gl
 // typedef void  (APIENTRYP GPBINDFRAMEBUFFER)(GLenum  target, GLuint  framebuffer);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURE)(GLuint  unit, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  access, GLenum  format);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURES)(GLuint  first, GLsizei  count, const GLuint * textures);
+// typedef void  (APIENTRYP GPBINDMULTITEXTUREEXT)(GLenum  texunit, GLenum  target, GLuint  texture);
 // typedef void  (APIENTRYP GPBINDPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPBINDPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPBINDRENDERBUFFER)(GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPBINDSAMPLER)(GLuint  unit, GLuint  sampler);
 // typedef void  (APIENTRYP GPBINDSAMPLERS)(GLuint  first, GLsizei  count, const GLuint * samplers);
@@ -129,6 +137,8 @@ package gl
 // typedef void  (APIENTRYP GPBINDVERTEXARRAY)(GLuint  array);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFER)(GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFERS)(GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPBLENDBARRIERKHR)();
+// typedef void  (APIENTRYP GPBLENDBARRIERNV)();
 // typedef void  (APIENTRYP GPBLENDCOLOR)(GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha);
 // typedef void  (APIENTRYP GPBLENDEQUATION)(GLenum  mode);
 // typedef void  (APIENTRYP GPBLENDEQUATIONSEPARATE)(GLenum  modeRGB, GLenum  modeAlpha);
@@ -138,14 +148,18 @@ package gl
 // typedef void  (APIENTRYP GPBLENDFUNCSEPARATE)(GLenum  sfactorRGB, GLenum  dfactorRGB, GLenum  sfactorAlpha, GLenum  dfactorAlpha);
 // typedef void  (APIENTRYP GPBLENDFUNCSEPARATEIARB)(GLuint  buf, GLenum  srcRGB, GLenum  dstRGB, GLenum  srcAlpha, GLenum  dstAlpha);
 // typedef void  (APIENTRYP GPBLENDFUNCIARB)(GLuint  buf, GLenum  src, GLenum  dst);
+// typedef void  (APIENTRYP GPBLENDPARAMETERINV)(GLenum  pname, GLint  value);
 // typedef void  (APIENTRYP GPBLITFRAMEBUFFER)(GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
 // typedef void  (APIENTRYP GPBLITNAMEDFRAMEBUFFER)(GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
 // typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUS)(GLuint  framebuffer, GLenum  target);
+// typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(GLuint  framebuffer, GLenum  target);
 // typedef void  (APIENTRYP GPCLAMPCOLOR)(GLenum  target, GLenum  clamp);
 // typedef void  (APIENTRYP GPCLEAR)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPCLEARBUFFERDATA)(GLenum  target, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
@@ -158,49 +172,91 @@ package gl
 // typedef void  (APIENTRYP GPCLEARDEPTH)(GLdouble  depth);
 // typedef void  (APIENTRYP GPCLEARDEPTHF)(GLfloat  d);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
 // typedef void  (APIENTRYP GPCLEARSTENCIL)(GLint  s);
 // typedef void  (APIENTRYP GPCLEARTEXIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARTEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef GLenum  (APIENTRYP GPCLIENTWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
 // typedef void  (APIENTRYP GPCLIPCONTROL)(GLenum  origin, GLenum  depth);
+// typedef void  (APIENTRYP GPCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPCOLORMASK)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPCOLORMASKI)(GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE3D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOPYBUFFERSUBDATA)(GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYIMAGESUBDATA)(GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef void  (APIENTRYP GPCREATEPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPCREATEQUERIES)(GLenum  target, GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPCREATERENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPCREATESAMPLERS)(GLsizei  n, GLuint * samplers);
 // typedef GLuint  (APIENTRYP GPCREATESHADER)(GLenum  type);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -216,14 +272,20 @@ package gl
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTARB)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTKHR)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef void  (APIENTRYP GPDELETEPATHSNV)(GLuint  path, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
+// typedef void  (APIENTRYP GPDELETEPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPDELETEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINES)(GLsizei  n, const GLuint * pipelines);
+// typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINESEXT)(GLsizei  n, const GLuint * pipelines);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETRANSFORMFEEDBACKS)(GLsizei  n, const GLuint * ids);
@@ -236,7 +298,12 @@ package gl
 // typedef void  (APIENTRYP GPDEPTHRANGEF)(GLfloat  n, GLfloat  f);
 // typedef void  (APIENTRYP GPDETACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPDISABLE)(GLenum  cap);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPDISABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISPATCHCOMPUTE)(GLuint  num_groups_x, GLuint  num_groups_y, GLuint  num_groups_z);
@@ -245,46 +312,81 @@ package gl
 // typedef void  (APIENTRYP GPDRAWARRAYS)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCED)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDARB)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDBASEINSTANCE)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDEXT)(GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWBUFFER)(GLenum  buf);
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWELEMENTSBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCED)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDARB)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDEXT)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTS)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTSBASEVERTEX)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACK)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKINSTANCED)(GLenum  mode, GLuint  id, GLsizei  instancecount);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
+// typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPENABLE)(GLenum  cap);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPENABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPENABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDCONDITIONALRENDER)();
+// typedef void  (APIENTRYP GPENDCONDITIONALRENDERNV)();
+// typedef void  (APIENTRYP GPENDPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPENDPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPENDQUERY)(GLenum  target);
 // typedef void  (APIENTRYP GPENDQUERYINDEXED)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDTRANSFORMFEEDBACK)();
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef GLsync  (APIENTRYP GPFENCESYNC)(GLenum  condition, GLbitfield  flags);
 // typedef void  (APIENTRYP GPFINISH)();
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFOGCOORDFORMATNV)(GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE2D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE3D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREFACEARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPGENBUFFERS)(GLsizei  n, GLuint * buffers);
 // typedef void  (APIENTRYP GPGENFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef GLuint  (APIENTRYP GPGENPATHSNV)(GLsizei  range);
+// typedef void  (APIENTRYP GPGENPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
 // typedef void  (APIENTRYP GPGENPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
+// typedef void  (APIENTRYP GPGENPROGRAMPIPELINESEXT)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
@@ -292,7 +394,9 @@ package gl
 // typedef void  (APIENTRYP GPGENTRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENVERTEXARRAYS)(GLsizei  n, GLuint * arrays);
 // typedef void  (APIENTRYP GPGENERATEMIPMAP)(GLenum  target);
+// typedef void  (APIENTRYP GPGENERATEMULTITEXMIPMAPEXT)(GLenum  texunit, GLenum  target);
 // typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAP)(GLuint  texture);
+// typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAPEXT)(GLuint  texture, GLenum  target);
 // typedef void  (APIENTRYP GPGETACTIVEATOMICCOUNTERBUFFERIV)(GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETACTIVEATTRIB)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLint * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETACTIVESUBROUTINENAME)(GLuint  program, GLenum  shadertype, GLuint  index, GLsizei  bufsize, GLsizei * length, GLchar * name);
@@ -305,65 +409,137 @@ package gl
 // typedef void  (APIENTRYP GPGETACTIVEUNIFORMSIV)(GLuint  program, GLsizei  uniformCount, const GLuint * uniformIndices, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETATTACHEDSHADERS)(GLuint  program, GLsizei  maxCount, GLsizei * count, GLuint * shaders);
 // typedef GLint  (APIENTRYP GPGETATTRIBLOCATION)(GLuint  program, const GLchar * name);
+// typedef void  (APIENTRYP GPGETBOOLEANINDEXEDVEXT)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANI_V)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANV)(GLenum  pname, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERI64V)(GLenum  target, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETBUFFERPARAMETERUI64VNV)(GLenum  target, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETBUFFERPOINTERV)(GLenum  target, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGE)(GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGKHR)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
+// typedef void  (APIENTRYP GPGETDOUBLEINDEXEDVEXT)(GLenum  target, GLuint  index, GLdouble * data);
 // typedef void  (APIENTRYP GPGETDOUBLEI_V)(GLenum  target, GLuint  index, GLdouble * data);
+// typedef void  (APIENTRYP GPGETDOUBLEI_VEXT)(GLenum  pname, GLuint  index, GLdouble * params);
 // typedef void  (APIENTRYP GPGETDOUBLEV)(GLenum  pname, GLdouble * data);
 // typedef GLenum  (APIENTRYP GPGETERROR)();
+// typedef void  (APIENTRYP GPGETFIRSTPERFQUERYIDINTEL)(GLuint * queryId);
+// typedef void  (APIENTRYP GPGETFLOATINDEXEDVEXT)(GLenum  target, GLuint  index, GLfloat * data);
 // typedef void  (APIENTRYP GPGETFLOATI_V)(GLenum  target, GLuint  index, GLfloat * data);
+// typedef void  (APIENTRYP GPGETFLOATI_VEXT)(GLenum  pname, GLuint  index, GLfloat * params);
 // typedef void  (APIENTRYP GPGETFLOATV)(GLenum  pname, GLfloat * data);
 // typedef GLint  (APIENTRYP GPGETFRAGDATAINDEX)(GLuint  program, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETFRAGDATALOCATION)(GLuint  program, const GLchar * name);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSARB)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSKHR)();
 // typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLEARB)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
+// typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLENV)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
 // typedef void  (APIENTRYP GPGETINTEGER64I_V)(GLenum  target, GLuint  index, GLint64 * data);
 // typedef void  (APIENTRYP GPGETINTEGER64V)(GLenum  pname, GLint64 * data);
+// typedef void  (APIENTRYP GPGETINTEGERINDEXEDVEXT)(GLenum  target, GLuint  index, GLint * data);
 // typedef void  (APIENTRYP GPGETINTEGERI_V)(GLenum  target, GLuint  index, GLint * data);
+// typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
+// typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMULTISAMPLEFV)(GLenum  pname, GLuint  index, GLfloat * val);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERI64V)(GLuint  buffer, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIV)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIVEXT)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  pname, void * string);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMIVEXT)(GLuint  program, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIV)(GLuint  renderbuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(GLuint  renderbuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGARB)(GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGIVARB)(GLint  namelen, const GLchar * name, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNEXTPERFQUERYIDINTEL)(GLuint  queryId, GLuint * nextQueryId);
 // typedef void  (APIENTRYP GPGETOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETOBJECTLABELEXT)(GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABEL)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABELKHR)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETPATHCOMMANDSNV)(GLuint  path, GLubyte * commands);
+// typedef void  (APIENTRYP GPGETPATHCOORDSNV)(GLuint  path, GLfloat * coords);
+// typedef void  (APIENTRYP GPGETPATHDASHARRAYNV)(GLuint  path, GLfloat * dashArray);
+// typedef GLfloat  (APIENTRYP GPGETPATHLENGTHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments);
+// typedef void  (APIENTRYP GPGETPATHMETRICRANGENV)(GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHMETRICSNV)(GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, GLfloat * value);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, GLint * value);
+// typedef void  (APIENTRYP GPGETPATHSPACINGNV)(GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing);
+// typedef void  (APIENTRYP GPGETPERFCOUNTERINFOINTEL)(GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERDATAAMD)(GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERINFOAMD)(GLuint  group, GLuint  counter, GLenum  pname, void * data);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSTRINGAMD)(GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
+// typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
+// typedef void  (APIENTRYP GPGETPOINTERINDEXEDVEXT)(GLenum  target, GLuint  index, void ** data);
+// typedef void  (APIENTRYP GPGETPOINTERI_VEXT)(GLenum  pname, GLuint  index, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERV)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERVKHR)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPROGRAMBINARY)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLenum * binaryFormat, void * binary);
 // typedef void  (APIENTRYP GPGETPROGRAMINFOLOG)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMINTERFACEIV)(GLuint  program, GLenum  programInterface, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOG)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOGEXT)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIV)(GLuint  pipeline, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIVEXT)(GLuint  pipeline, GLenum  pname, GLint * params);
 // typedef GLuint  (APIENTRYP GPGETPROGRAMRESOURCEINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATION)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATIONINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCENAME)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name);
+// typedef void  (APIENTRYP GPGETPROGRAMRESOURCEFVNV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCEIV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMSTAGEIV)(GLuint  program, GLenum  shadertype, GLenum  pname, GLint * values);
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTIV)(GLuint  id, GLenum  pname, GLint * params);
@@ -379,6 +555,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERPRECISIONFORMAT)(GLenum  shadertype, GLenum  precisiontype, GLint * range, GLint * precision);
 // typedef void  (APIENTRYP GPGETSHADERSOURCE)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -392,14 +569,23 @@ package gl
 // typedef void  (APIENTRYP GPGETTEXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLEARB)(GLuint  texture);
+// typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLENV)(GLuint  texture);
 // typedef void  (APIENTRYP GPGETTEXTUREIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFV)(GLuint  texture, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIV)(GLuint  texture, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLEARB)(GLuint  texture, GLuint  sampler);
+// typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLENV)(GLuint  texture, GLuint  sampler);
 // typedef void  (APIENTRYP GPGETTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKVARYING)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLsizei * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKI64_V)(GLuint  xfb, GLenum  pname, GLuint  index, GLint64 * param);
@@ -411,32 +597,48 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMSUBROUTINEUIV)(GLenum  shadertype, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXED64IV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint64 * param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXEDIV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERVEXT)(GLuint  vaobj, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, void ** param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERVEXT)(GLuint  vaobj, GLenum  pname, void ** param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYIV)(GLuint  vaobj, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIIV)(GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIUIV)(GLuint  index, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLDV)(GLuint  index, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLI64VNV)(GLuint  index, GLenum  pname, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VARB)(GLuint  index, GLenum  pname, GLuint64EXT * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VNV)(GLuint  index, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBPOINTERV)(GLuint  index, GLenum  pname, void ** pointer);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBDV)(GLuint  index, GLenum  pname, GLdouble * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBFV)(GLuint  index, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIV)(GLuint  index, GLenum  pname, GLint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNTEXIMAGEARB)(GLenum  target, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNUNIFORMDVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLdouble * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPHINT)(GLenum  target, GLenum  mode);
+// typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPINSERTEVENTMARKEREXT)(GLsizei  length, const GLchar * marker);
+// typedef void  (APIENTRYP GPINTERPOLATEPATHSNV)(GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERDATA)(GLuint  buffer);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPINVALIDATEFRAMEBUFFER)(GLenum  target, GLsizei  numAttachments, const GLenum * attachments);
@@ -446,67 +648,195 @@ package gl
 // typedef void  (APIENTRYP GPINVALIDATETEXIMAGE)(GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPINVALIDATETEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
+// typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISFRAMEBUFFER)(GLuint  framebuffer);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef GLboolean  (APIENTRYP GPISPATHNV)(GLuint  path);
+// typedef GLboolean  (APIENTRYP GPISPOINTINFILLPATHNV)(GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y);
+// typedef GLboolean  (APIENTRYP GPISPOINTINSTROKEPATHNV)(GLuint  path, GLfloat  x, GLfloat  y);
 // typedef GLboolean  (APIENTRYP GPISPROGRAM)(GLuint  program);
 // typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef GLboolean  (APIENTRYP GPISQUERY)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISTRANSFORMFEEDBACK)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
+// typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLINEWIDTH)(GLfloat  width);
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLOGICOP)(GLenum  opcode);
+// typedef void  (APIENTRYP GPMAKEBUFFERNONRESIDENTNV)(GLenum  target);
+// typedef void  (APIENTRYP GPMAKEBUFFERRESIDENTNV)(GLenum  target, GLenum  access);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTARB)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTNV)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERNONRESIDENTNV)(GLuint  buffer);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERRESIDENTNV)(GLuint  buffer, GLenum  access);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef void * (APIENTRYP GPMAPBUFFER)(GLenum  target, GLenum  access);
 // typedef void * (APIENTRYP GPMAPBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void  (APIENTRYP GPMATRIXFRUSTUMEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADIDENTITYEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXORTHOEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXPOPEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXPUSHEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXROTATEDEXT)(GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXROTATEFEXT)(GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYS)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTITEXBUFFEREXT)(GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPMULTITEXCOORDPOINTEREXT)(GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
+// typedef void  (APIENTRYP GPMULTITEXENVFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXENVIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXGENDEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param);
+// typedef void  (APIENTRYP GPMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params);
+// typedef void  (APIENTRYP GPMULTITEXGENFEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXGENIEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXRENDERBUFFEREXT)(GLenum  texunit, GLenum  target, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFERS)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERI)(GLuint  framebuffer, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERIEXT)(GLuint  framebuffer, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYER)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLdouble * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGE)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEEXT)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDSTRINGARB)(GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string);
+// typedef void  (APIENTRYP GPNORMALFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABEL)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABELKHR)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPPATCHPARAMETERFV)(GLenum  pname, const GLfloat * values);
 // typedef void  (APIENTRYP GPPATCHPARAMETERI)(GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHCOMMANDSNV)(GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOORDSNV)(GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOVERDEPTHFUNCNV)(GLenum  func);
+// typedef void  (APIENTRYP GPPATHDASHARRAYNV)(GLuint  path, GLsizei  dashCount, const GLfloat * dashArray);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXRANGENV)(GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount);
+// typedef void  (APIENTRYP GPPATHGLYPHRANGENV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHGLYPHSNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHMEMORYGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHPARAMETERFNV)(GLuint  path, GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, const GLfloat * value);
+// typedef void  (APIENTRYP GPPATHPARAMETERINV)(GLuint  path, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, const GLint * value);
+// typedef void  (APIENTRYP GPPATHSTENCILDEPTHOFFSETNV)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPATHSTENCILFUNCNV)(GLenum  func, GLint  ref, GLuint  mask);
+// typedef void  (APIENTRYP GPPATHSTRINGNV)(GLuint  path, GLenum  format, GLsizei  length, const void * pathString);
+// typedef void  (APIENTRYP GPPATHSUBCOMMANDSNV)(GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHSUBCOORDSNV)(GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords);
 // typedef void  (APIENTRYP GPPAUSETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPPIXELSTOREF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPIXELSTOREI)(GLenum  pname, GLint  param);
+// typedef GLboolean  (APIENTRYP GPPOINTALONGPATHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY);
 // typedef void  (APIENTRYP GPPOINTPARAMETERF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPOINTPARAMETERFV)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPPOINTPARAMETERI)(GLenum  pname, GLint  param);
@@ -514,67 +844,163 @@ package gl
 // typedef void  (APIENTRYP GPPOINTSIZE)(GLfloat  size);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOPDEBUGGROUP)();
 // typedef void  (APIENTRYP GPPOPDEBUGGROUPKHR)();
+// typedef void  (APIENTRYP GPPOPGROUPMARKEREXT)();
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPROGRAMBINARY)(GLuint  program, GLenum  binaryFormat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPPROGRAMPARAMETERI)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIARB)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIEXT)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPATHFRAGMENTINPUTGENNV)(GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1D)(GLuint  program, GLint  location, GLdouble  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DEXT)(GLuint  program, GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1F)(GLuint  program, GLint  location, GLfloat  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FEXT)(GLuint  program, GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64ARB)(GLuint  program, GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64NV)(GLuint  program, GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64NV)(GLuint  program, GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROVOKINGVERTEX)(GLenum  mode);
+// typedef void  (APIENTRYP GPPUSHCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUP)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUPKHR)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
+// typedef void  (APIENTRYP GPPUSHGROUPMARKEREXT)(GLsizei  length, const GLchar * marker);
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPREADNPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, GLsizei  bufSize, void * data);
@@ -583,6 +1009,8 @@ package gl
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMASKI)(GLuint  maskNumber, GLbitfield  mask);
@@ -596,23 +1024,40 @@ package gl
 // typedef void  (APIENTRYP GPSCISSORARRAYV)(GLuint  first, GLsizei  count, const GLint * v);
 // typedef void  (APIENTRYP GPSCISSORINDEXED)(GLuint  index, GLint  left, GLint  bottom, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPSCISSORINDEXEDV)(GLuint  index, const GLint * v);
+// typedef void  (APIENTRYP GPSECONDARYCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
 // typedef void  (APIENTRYP GPSHADERBINARY)(GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPSHADERSOURCE)(GLuint  shader, GLsizei  count, const GLchar *const* string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNC)(GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNCSEPARATE)(GLenum  face, GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASK)(GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASKSEPARATE)(GLenum  face, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILOP)(GLenum  fail, GLenum  zfail, GLenum  zpass);
 // typedef void  (APIENTRYP GPSTENCILOPSEPARATE)(GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPTEXBUFFER)(GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXBUFFERARB)(GLenum  target, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXBUFFERRANGE)(GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXCOORDFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPTEXIMAGE1D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE2D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERF)(GLenum  target, GLenum  pname, GLfloat  param);
@@ -628,61 +1073,118 @@ package gl
 // typedef void  (APIENTRYP GPTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREBARRIER)();
+// typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERF)(GLuint  texture, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, const GLfloat * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERI)(GLuint  texture, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, const GLint * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTURERENDERBUFFEREXT)(GLuint  texture, GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE1D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE1DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREVIEW)(GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
+// typedef void  (APIENTRYP GPTRANSFORMPATHNV)(GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPUNIFORM1D)(GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPUNIFORM1DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM1F)(GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM2D)(GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPUNIFORM2DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM2F)(GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM3D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPUNIFORM3DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM3F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM4D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPUNIFORM4DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM4F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORMBLOCKBINDING)(GLuint  program, GLuint  uniformBlockIndex, GLuint  uniformBlockBinding);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64ARB)(GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64NV)(GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VNV)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
@@ -702,20 +1204,45 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMSUBROUTINESUIV)(GLenum  shadertype, GLsizei  count, const GLuint * indices);
+// typedef void  (APIENTRYP GPUNIFORMUI64NV)(GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPUNIFORMUI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef GLboolean  (APIENTRYP GPUNMAPBUFFER)(GLenum  target);
 // typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFEREXT)(GLuint  buffer);
 // typedef void  (APIENTRYP GPUSEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPUSEPROGRAMSTAGES)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSEPROGRAMSTAGESEXT)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSESHADERPROGRAMEXT)(GLenum  type, GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBBINDING)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBIFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBLFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYBINDVERTEXBUFFEREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYBINDINGDIVISOR)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYEDGEFLAGOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXARRAYELEMENTBUFFER)(GLuint  vaobj, GLuint  buffer);
+// typedef void  (APIENTRYP GPVERTEXARRAYFOGCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYINDEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYNORMALOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYTEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(GLuint  vaobj, GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFER)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFERS)(GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1DV)(GLuint  index, const GLdouble * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1F)(GLuint  index, GLfloat  x);
@@ -753,7 +1280,9 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIB4UIV)(GLuint  index, const GLuint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIB4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBBINDING)(GLuint  attribindex, GLuint  bindingindex);
+// typedef void  (APIENTRYP GPVERTEXATTRIBDIVISORARB)(GLuint  index, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXATTRIBFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1I)(GLuint  index, GLint  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1IV)(GLuint  index, const GLint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1UI)(GLuint  index, GLuint  x);
@@ -775,18 +1304,36 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4UIV)(GLuint  index, const GLuint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBIFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64NV)(GLuint  index, GLint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64VNV)(GLuint  index, const GLint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64ARB)(GLuint  index, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64NV)(GLuint  index, GLuint64EXT  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VARB)(GLuint  index, const GLuint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2D)(GLuint  index, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBLFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UI)(GLuint  index, GLenum  type, GLboolean  normalized, GLuint  value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
@@ -798,22 +1345,46 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBP4UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBPOINTER)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXBINDINGDIVISOR)(GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVIEWPORT)(GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
+// static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
+//   (*fnptr)(program);
+// }
 // static void  glowActiveShaderProgram(GPACTIVESHADERPROGRAM fnptr, GLuint  pipeline, GLuint  program) {
+//   (*fnptr)(pipeline, program);
+// }
+// static void  glowActiveShaderProgramEXT(GPACTIVESHADERPROGRAMEXT fnptr, GLuint  pipeline, GLuint  program) {
 //   (*fnptr)(pipeline, program);
 // }
 // static void  glowActiveTexture(GPACTIVETEXTURE fnptr, GLenum  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowAttachShader(GPATTACHSHADER fnptr, GLuint  program, GLuint  shader) {
 //   (*fnptr)(program, shader);
 // }
 // static void  glowBeginConditionalRender(GPBEGINCONDITIONALRENDER fnptr, GLuint  id, GLenum  mode) {
 //   (*fnptr)(id, mode);
+// }
+// static void  glowBeginConditionalRenderNV(GPBEGINCONDITIONALRENDERNV fnptr, GLuint  id, GLenum  mode) {
+//   (*fnptr)(id, mode);
+// }
+// static void  glowBeginPerfMonitorAMD(GPBEGINPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowBeginPerfQueryINTEL(GPBEGINPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
 // }
 // static void  glowBeginQuery(GPBEGINQUERY fnptr, GLenum  target, GLuint  id) {
 //   (*fnptr)(target, id);
@@ -857,7 +1428,13 @@ package gl
 // static void  glowBindImageTextures(GPBINDIMAGETEXTURES fnptr, GLuint  first, GLsizei  count, const GLuint * textures) {
 //   (*fnptr)(first, count, textures);
 // }
+// static void  glowBindMultiTextureEXT(GPBINDMULTITEXTUREEXT fnptr, GLenum  texunit, GLenum  target, GLuint  texture) {
+//   (*fnptr)(texunit, target, texture);
+// }
 // static void  glowBindProgramPipeline(GPBINDPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowBindProgramPipelineEXT(GPBINDPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowBindRenderbuffer(GPBINDRENDERBUFFER fnptr, GLenum  target, GLuint  renderbuffer) {
@@ -890,6 +1467,12 @@ package gl
 // static void  glowBindVertexBuffers(GPBINDVERTEXBUFFERS fnptr, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(first, count, buffers, offsets, strides);
 // }
+// static void  glowBlendBarrierKHR(GPBLENDBARRIERKHR fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowBlendBarrierNV(GPBLENDBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowBlendColor(GPBLENDCOLOR fnptr, GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
 // }
@@ -917,16 +1500,22 @@ package gl
 // static void  glowBlendFunciARB(GPBLENDFUNCIARB fnptr, GLuint  buf, GLenum  src, GLenum  dst) {
 //   (*fnptr)(buf, src, dst);
 // }
+// static void  glowBlendParameteriNV(GPBLENDPARAMETERINV fnptr, GLenum  pname, GLint  value) {
+//   (*fnptr)(pname, value);
+// }
 // static void  glowBlitFramebuffer(GPBLITFRAMEBUFFER fnptr, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
 // static void  glowBlitNamedFramebuffer(GPBLITNAMEDFRAMEBUFFER fnptr, GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
+// static void  glowBufferAddressRangeNV(GPBUFFERADDRESSRANGENV fnptr, GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length) {
+//   (*fnptr)(pname, index, address, length);
+// }
 // static void  glowBufferData(GPBUFFERDATA fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
@@ -935,10 +1524,16 @@ package gl
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static GLenum  glowCheckFramebufferStatus(GPCHECKFRAMEBUFFERSTATUS fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLenum  glowCheckNamedFramebufferStatus(GPCHECKNAMEDFRAMEBUFFERSTATUS fnptr, GLuint  framebuffer, GLenum  target) {
+//   return (*fnptr)(framebuffer, target);
+// }
+// static GLenum  glowCheckNamedFramebufferStatusEXT(GPCHECKNAMEDFRAMEBUFFERSTATUSEXT fnptr, GLuint  framebuffer, GLenum  target) {
 //   return (*fnptr)(framebuffer, target);
 // }
 // static void  glowClampColor(GPCLAMPCOLOR fnptr, GLenum  target, GLenum  clamp) {
@@ -977,11 +1572,17 @@ package gl
 // static void  glowClearNamedBufferData(GPCLEARNAMEDBUFFERDATA fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, format, type, data);
+// }
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
+// }
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -1001,11 +1602,17 @@ package gl
 // static void  glowClearTexSubImage(GPCLEARTEXSUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data);
 // }
+// static void  glowClientAttribDefaultEXT(GPCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
+// }
 // static GLenum  glowClientWaitSync(GPCLIENTWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   return (*fnptr)(sync, flags, timeout);
 // }
 // static void  glowClipControl(GPCLIPCONTROL fnptr, GLenum  origin, GLenum  depth) {
 //   (*fnptr)(origin, depth);
+// }
+// static void  glowColorFormatNV(GPCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
 // }
 // static void  glowColorMask(GPCOLORMASK fnptr, GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
@@ -1013,11 +1620,35 @@ package gl
 // static void  glowColorMaski(GPCOLORMASKI fnptr, GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a) {
 //   (*fnptr)(index, r, g, b, a);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
 // static void  glowCompileShaderIncludeARB(GPCOMPILESHADERINCLUDEARB fnptr, GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length) {
 //   (*fnptr)(shader, count, path, length);
+// }
+// static void  glowCompressedMultiTexImage1DEXT(GPCOMPRESSEDMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage2DEXT(GPCOMPRESSEDMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage3DEXT(GPCOMPRESSEDMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage1DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage2DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage3DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
 // }
 // static void  glowCompressedTexImage1D(GPCOMPRESSEDTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, internalformat, width, border, imageSize, data);
@@ -1037,14 +1668,38 @@ package gl
 // static void  glowCompressedTexSubImage3D(GPCOMPRESSEDTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
 // }
+// static void  glowCompressedTextureImage1DEXT(GPCOMPRESSEDTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage2DEXT(GPCOMPRESSEDTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage3DEXT(GPCOMPRESSEDTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage1D(GPCOMPRESSEDTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, width, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage1DEXT(GPCOMPRESSEDTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, imageSize, bits);
 // }
 // static void  glowCompressedTextureSubImage2D(GPCOMPRESSEDTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, imageSize, data);
 // }
+// static void  glowCompressedTextureSubImage2DEXT(GPCOMPRESSEDTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage3D(GPCOMPRESSEDTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowCopyBufferSubData(GPCOPYBUFFERSUBDATA fnptr, GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readTarget, writeTarget, readOffset, writeOffset, size);
@@ -1052,8 +1707,26 @@ package gl
 // static void  glowCopyImageSubData(GPCOPYIMAGESUBDATA fnptr, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
 //   (*fnptr)(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyMultiTexImage1DEXT(GPCOPYMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyMultiTexImage2DEXT(GPCOPYMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, height, border);
+// }
+// static void  glowCopyMultiTexSubImage1DEXT(GPCOPYMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texunit, target, level, xoffset, x, y, width);
+// }
+// static void  glowCopyMultiTexSubImage2DEXT(GPCOPYMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, x, y, width, height);
+// }
+// static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
+//   (*fnptr)(resultPath, srcPath);
 // }
 // static void  glowCopyTexImage1D(GPCOPYTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
 //   (*fnptr)(target, level, internalformat, x, y, width, border);
@@ -1070,20 +1743,59 @@ package gl
 // static void  glowCopyTexSubImage3D(GPCOPYTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureImage1DEXT(GPCOPYTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyTextureImage2DEXT(GPCOPYTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, height, border);
+// }
 // static void  glowCopyTextureSubImage1D(GPCOPYTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
 //   (*fnptr)(texture, level, xoffset, x, y, width);
+// }
+// static void  glowCopyTextureSubImage1DEXT(GPCOPYTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texture, target, level, xoffset, x, y, width);
 // }
 // static void  glowCopyTextureSubImage2D(GPCOPYTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureSubImage2DEXT(GPCOPYTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, x, y, width, height);
+// }
 // static void  glowCopyTextureSubImage3D(GPCOPYTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyTextureSubImage3DEXT(GPCOPYTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCoverFillPathInstancedNV(GPCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverFillPathNV(GPCOVERFILLPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverStrokePathInstancedNV(GPCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
 // }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
+//   (*fnptr)(queryId, queryHandle);
 // }
 // static GLuint  glowCreateProgram(GPCREATEPROGRAM fnptr) {
 //   return (*fnptr)();
@@ -1103,8 +1815,17 @@ package gl
 // static GLuint  glowCreateShader(GPCREATESHADER fnptr, GLenum  type) {
 //   return (*fnptr)(type);
 // }
+// static GLuint  glowCreateShaderProgramEXT(GPCREATESHADERPROGRAMEXT fnptr, GLenum  type, const GLchar * string) {
+//   return (*fnptr)(type, string);
+// }
 // static GLuint  glowCreateShaderProgramv(GPCREATESHADERPROGRAMV fnptr, GLenum  type, GLsizei  count, const GLchar *const* strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
+//   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -1151,16 +1872,31 @@ package gl
 // static void  glowDeleteBuffers(GPDELETEBUFFERS fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFramebuffers(GPDELETEFRAMEBUFFERS fnptr, GLsizei  n, const GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
 // }
+// static void  glowDeletePathsNV(GPDELETEPATHSNV fnptr, GLuint  path, GLsizei  range) {
+//   (*fnptr)(path, range);
+// }
+// static void  glowDeletePerfMonitorsAMD(GPDELETEPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
+// static void  glowDeletePerfQueryINTEL(GPDELETEPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowDeleteProgram(GPDELETEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowDeleteProgramPipelines(GPDELETEPROGRAMPIPELINES fnptr, GLsizei  n, const GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowDeleteProgramPipelinesEXT(GPDELETEPROGRAMPIPELINESEXT fnptr, GLsizei  n, const GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowDeleteQueries(GPDELETEQUERIES fnptr, GLsizei  n, const GLuint * ids) {
@@ -1174,6 +1910,9 @@ package gl
 // }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -1211,8 +1950,23 @@ package gl
 // static void  glowDisable(GPDISABLE fnptr, GLenum  cap) {
 //   (*fnptr)(cap);
 // }
+// static void  glowDisableClientStateIndexedEXT(GPDISABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableClientStateiEXT(GPDISABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableIndexedEXT(GPDISABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowDisableVertexArrayAttrib(GPDISABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayAttribEXT(GPDISABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayEXT(GPDISABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowDisableVertexAttribArray(GPDISABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1238,14 +1992,32 @@ package gl
 // static void  glowDrawArraysInstanced(GPDRAWARRAYSINSTANCED fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount) {
 //   (*fnptr)(mode, first, count, instancecount);
 // }
+// static void  glowDrawArraysInstancedARB(GPDRAWARRAYSINSTANCEDARB fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, first, count, primcount);
+// }
 // static void  glowDrawArraysInstancedBaseInstance(GPDRAWARRAYSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, first, count, instancecount, baseinstance);
+// }
+// static void  glowDrawArraysInstancedEXT(GPDRAWARRAYSINSTANCEDEXT fnptr, GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, start, count, primcount);
 // }
 // static void  glowDrawBuffer(GPDRAWBUFFER fnptr, GLenum  buf) {
 //   (*fnptr)(buf);
 // }
 // static void  glowDrawBuffers(GPDRAWBUFFERS fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
+// }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
 // }
 // static void  glowDrawElements(GPDRAWELEMENTS fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, count, type, indices);
@@ -1259,6 +2031,9 @@ package gl
 // static void  glowDrawElementsInstanced(GPDRAWELEMENTSINSTANCED fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount) {
 //   (*fnptr)(mode, count, type, indices, instancecount);
 // }
+// static void  glowDrawElementsInstancedARB(GPDRAWELEMENTSINSTANCEDARB fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
+// }
 // static void  glowDrawElementsInstancedBaseInstance(GPDRAWELEMENTSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, baseinstance);
 // }
@@ -1267,6 +2042,9 @@ package gl
 // }
 // static void  glowDrawElementsInstancedBaseVertexBaseInstance(GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, basevertex, baseinstance);
+// }
+// static void  glowDrawElementsInstancedEXT(GPDRAWELEMENTSINSTANCEDEXT fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
 // }
 // static void  glowDrawRangeElements(GPDRAWRANGEELEMENTS fnptr, GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, start, end, count, type, indices);
@@ -1286,11 +2064,32 @@ package gl
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
 // }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
+// }
+// static void  glowEdgeFlagFormatNV(GPEDGEFLAGFORMATNV fnptr, GLsizei  stride) {
+//   (*fnptr)(stride);
+// }
 // static void  glowEnable(GPENABLE fnptr, GLenum  cap) {
 //   (*fnptr)(cap);
 // }
+// static void  glowEnableClientStateIndexedEXT(GPENABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableClientStateiEXT(GPENABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableIndexedEXT(GPENABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowEnableVertexArrayAttrib(GPENABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayAttribEXT(GPENABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayEXT(GPENABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowEnableVertexAttribArray(GPENABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1301,6 +2100,15 @@ package gl
 // static void  glowEndConditionalRender(GPENDCONDITIONALRENDER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowEndConditionalRenderNV(GPENDCONDITIONALRENDERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowEndPerfMonitorAMD(GPENDPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowEndPerfQueryINTEL(GPENDPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowEndQuery(GPENDQUERY fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
@@ -1308,6 +2116,9 @@ package gl
 //   (*fnptr)(target, index);
 // }
 // static void  glowEndTransformFeedback(GPENDTRANSFORMFEEDBACK fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
 //   (*fnptr)();
 // }
 // static GLsync  glowFenceSync(GPFENCESYNC fnptr, GLenum  condition, GLbitfield  flags) {
@@ -1322,14 +2133,41 @@ package gl
 // static void  glowFlushMappedBufferRange(GPFLUSHMAPPEDBUFFERRANGE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(target, offset, length);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
+//   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFogCoordFormatNV(GPFOGCOORDFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
+// static void  glowFramebufferDrawBufferEXT(GPFRAMEBUFFERDRAWBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
+// static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
+//   (*fnptr)(framebuffer, n, bufs);
+// }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
+// static void  glowFramebufferReadBufferEXT(GPFRAMEBUFFERREADBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
 // static void  glowFramebufferRenderbuffer(GPFRAMEBUFFERRENDERBUFFER fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -1343,8 +2181,20 @@ package gl
 // static void  glowFramebufferTexture3D(GPFRAMEBUFFERTEXTURE3D fnptr, GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
 //   (*fnptr)(target, attachment, textarget, texture, level, zoffset);
 // }
+// static void  glowFramebufferTextureARB(GPFRAMEBUFFERTEXTUREARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(target, attachment, texture, level);
+// }
+// static void  glowFramebufferTextureFaceARB(GPFRAMEBUFFERTEXTUREFACEARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(target, attachment, texture, level, face);
+// }
 // static void  glowFramebufferTextureLayer(GPFRAMEBUFFERTEXTURELAYER fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureLayerARB(GPFRAMEBUFFERTEXTURELAYERARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFrontFace(GPFRONTFACE fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -1355,7 +2205,16 @@ package gl
 // static void  glowGenFramebuffers(GPGENFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
+// static GLuint  glowGenPathsNV(GPGENPATHSNV fnptr, GLsizei  range) {
+//   return (*fnptr)(range);
+// }
+// static void  glowGenPerfMonitorsAMD(GPGENPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
 // static void  glowGenProgramPipelines(GPGENPROGRAMPIPELINES fnptr, GLsizei  n, GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowGenProgramPipelinesEXT(GPGENPROGRAMPIPELINESEXT fnptr, GLsizei  n, GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowGenQueries(GPGENQUERIES fnptr, GLsizei  n, GLuint * ids) {
@@ -1379,8 +2238,14 @@ package gl
 // static void  glowGenerateMipmap(GPGENERATEMIPMAP fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
+// static void  glowGenerateMultiTexMipmapEXT(GPGENERATEMULTITEXMIPMAPEXT fnptr, GLenum  texunit, GLenum  target) {
+//   (*fnptr)(texunit, target);
+// }
 // static void  glowGenerateTextureMipmap(GPGENERATETEXTUREMIPMAP fnptr, GLuint  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowGenerateTextureMipmapEXT(GPGENERATETEXTUREMIPMAPEXT fnptr, GLuint  texture, GLenum  target) {
+//   (*fnptr)(texture, target);
 // }
 // static void  glowGetActiveAtomicCounterBufferiv(GPGETACTIVEATOMICCOUNTERBUFFERIV fnptr, GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, bufferIndex, pname, params);
@@ -1418,6 +2283,9 @@ package gl
 // static GLint  glowGetAttribLocation(GPGETATTRIBLOCATION fnptr, GLuint  program, const GLchar * name) {
 //   return (*fnptr)(program, name);
 // }
+// static void  glowGetBooleanIndexedvEXT(GPGETBOOLEANINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLboolean * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetBooleani_v(GPGETBOOLEANI_V fnptr, GLenum  target, GLuint  index, GLboolean * data) {
 //   (*fnptr)(target, index, data);
 // }
@@ -1430,11 +2298,20 @@ package gl
 // static void  glowGetBufferParameteriv(GPGETBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetBufferParameterui64vNV(GPGETBUFFERPARAMETERUI64VNV fnptr, GLenum  target, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(target, pname, params);
+// }
 // static void  glowGetBufferPointerv(GPGETBUFFERPOINTERV fnptr, GLenum  target, GLenum  pname, void ** params) {
 //   (*fnptr)(target, pname, params);
 // }
 // static void  glowGetBufferSubData(GPGETBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
+// static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texunit, target, lod, img);
 // }
 // static void  glowGetCompressedTexImage(GPGETCOMPRESSEDTEXIMAGE fnptr, GLenum  target, GLint  level, void * img) {
 //   (*fnptr)(target, level, img);
@@ -1442,8 +2319,14 @@ package gl
 // static void  glowGetCompressedTextureImage(GPGETCOMPRESSEDTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, bufSize, pixels);
 // }
+// static void  glowGetCompressedTextureImageEXT(GPGETCOMPRESSEDTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texture, target, lod, img);
+// }
 // static void  glowGetCompressedTextureSubImage(GPGETCOMPRESSEDTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -1454,8 +2337,14 @@ package gl
 // static GLuint  glowGetDebugMessageLogKHR(GPGETDEBUGMESSAGELOGKHR fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
 // }
+// static void  glowGetDoubleIndexedvEXT(GPGETDOUBLEINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLdouble * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetDoublei_v(GPGETDOUBLEI_V fnptr, GLenum  target, GLuint  index, GLdouble * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetDoublei_vEXT(GPGETDOUBLEI_VEXT fnptr, GLenum  pname, GLuint  index, GLdouble * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetDoublev(GPGETDOUBLEV fnptr, GLenum  pname, GLdouble * data) {
 //   (*fnptr)(pname, data);
@@ -1463,8 +2352,17 @@ package gl
 // static GLenum  glowGetError(GPGETERROR fnptr) {
 //   return (*fnptr)();
 // }
+// static void  glowGetFirstPerfQueryIdINTEL(GPGETFIRSTPERFQUERYIDINTEL fnptr, GLuint * queryId) {
+//   (*fnptr)(queryId);
+// }
+// static void  glowGetFloatIndexedvEXT(GPGETFLOATINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLfloat * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetFloati_v(GPGETFLOATI_V fnptr, GLenum  target, GLuint  index, GLfloat * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetFloati_vEXT(GPGETFLOATI_VEXT fnptr, GLenum  pname, GLuint  index, GLfloat * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetFloatv(GPGETFLOATV fnptr, GLenum  pname, GLfloat * data) {
 //   (*fnptr)(pname, data);
@@ -1481,6 +2379,9 @@ package gl
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetFramebufferParameterivEXT(GPGETFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
 // static GLenum  glowGetGraphicsResetStatus(GPGETGRAPHICSRESETSTATUS fnptr) {
 //   return (*fnptr)();
 // }
@@ -1493,23 +2394,74 @@ package gl
 // static GLuint64  glowGetImageHandleARB(GPGETIMAGEHANDLEARB fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
 //   return (*fnptr)(texture, level, layered, layer, format);
 // }
+// static GLuint64  glowGetImageHandleNV(GPGETIMAGEHANDLENV fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
+//   return (*fnptr)(texture, level, layered, layer, format);
+// }
 // static void  glowGetInteger64i_v(GPGETINTEGER64I_V fnptr, GLenum  target, GLuint  index, GLint64 * data) {
 //   (*fnptr)(target, index, data);
 // }
 // static void  glowGetInteger64v(GPGETINTEGER64V fnptr, GLenum  pname, GLint64 * data) {
 //   (*fnptr)(pname, data);
 // }
+// static void  glowGetIntegerIndexedvEXT(GPGETINTEGERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLint * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetIntegeri_v(GPGETINTEGERI_V fnptr, GLenum  target, GLuint  index, GLint * data) {
 //   (*fnptr)(target, index, data);
 // }
+// static void  glowGetIntegerui64i_vNV(GPGETINTEGERUI64I_VNV fnptr, GLenum  value, GLuint  index, GLuint64EXT * result) {
+//   (*fnptr)(value, index, result);
+// }
+// static void  glowGetIntegerui64vNV(GPGETINTEGERUI64VNV fnptr, GLenum  value, GLuint64EXT * result) {
+//   (*fnptr)(value, result);
+// }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
 // }
 // static void  glowGetInternalformativ(GPGETINTERNALFORMATIV fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
+// }
+// static void  glowGetMultiTexEnvfvEXT(GPGETMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexEnvivEXT(GPGETMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexGendvEXT(GPGETMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenfvEXT(GPGETMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenivEXT(GPGETMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexImageEXT(GPGETMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texunit, target, level, format, type, pixels);
+// }
+// static void  glowGetMultiTexLevelParameterfvEXT(GPGETMULTITEXLEVELPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexLevelParameterivEXT(GPGETMULTITEXLEVELPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexParameterIivEXT(GPGETMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterIuivEXT(GPGETMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterfvEXT(GPGETMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterivEXT(GPGETMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
 // }
 // static void  glowGetMultisamplefv(GPGETMULTISAMPLEFV fnptr, GLenum  pname, GLuint  index, GLfloat * val) {
 //   (*fnptr)(pname, index, val);
@@ -1520,19 +2472,58 @@ package gl
 // static void  glowGetNamedBufferParameteriv(GPGETNAMEDBUFFERPARAMETERIV fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(buffer, pname, params);
 // }
+// static void  glowGetNamedBufferParameterivEXT(GPGETNAMEDBUFFERPARAMETERIVEXT fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferParameterui64vNV(GPGETNAMEDBUFFERPARAMETERUI64VNV fnptr, GLuint  buffer, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
 // static void  glowGetNamedBufferPointerv(GPGETNAMEDBUFFERPOINTERV fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedFramebufferAttachmentParameteriv(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
 // }
+// static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, attachment, pname, params);
+// }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowGetNamedFramebufferParameterivEXT(GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIuivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterdvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterfvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramStringEXT(GPGETNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, void * string) {
+//   (*fnptr)(program, target, pname, string);
+// }
+// static void  glowGetNamedProgramivEXT(GPGETNAMEDPROGRAMIVEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(program, target, pname, params);
+// }
 // static void  glowGetNamedRenderbufferParameteriv(GPGETNAMEDRENDERBUFFERPARAMETERIV fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(renderbuffer, pname, params);
+// }
+// static void  glowGetNamedRenderbufferParameterivEXT(GPGETNAMEDRENDERBUFFERPARAMETERIVEXT fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(renderbuffer, pname, params);
 // }
 // static void  glowGetNamedStringARB(GPGETNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string) {
@@ -1541,8 +2532,14 @@ package gl
 // static void  glowGetNamedStringivARB(GPGETNAMEDSTRINGIVARB fnptr, GLint  namelen, const GLchar * name, GLenum  pname, GLint * params) {
 //   (*fnptr)(namelen, name, pname, params);
 // }
+// static void  glowGetNextPerfQueryIdINTEL(GPGETNEXTPERFQUERYIDINTEL fnptr, GLuint  queryId, GLuint * nextQueryId) {
+//   (*fnptr)(queryId, nextQueryId);
+// }
 // static void  glowGetObjectLabel(GPGETOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
+// }
+// static void  glowGetObjectLabelEXT(GPGETOBJECTLABELEXT fnptr, GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label) {
+//   (*fnptr)(type, object, bufSize, length, label);
 // }
 // static void  glowGetObjectLabelKHR(GPGETOBJECTLABELKHR fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
@@ -1552,6 +2549,69 @@ package gl
 // }
 // static void  glowGetObjectPtrLabelKHR(GPGETOBJECTPTRLABELKHR fnptr, const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(ptr, bufSize, length, label);
+// }
+// static void  glowGetPathCommandsNV(GPGETPATHCOMMANDSNV fnptr, GLuint  path, GLubyte * commands) {
+//   (*fnptr)(path, commands);
+// }
+// static void  glowGetPathCoordsNV(GPGETPATHCOORDSNV fnptr, GLuint  path, GLfloat * coords) {
+//   (*fnptr)(path, coords);
+// }
+// static void  glowGetPathDashArrayNV(GPGETPATHDASHARRAYNV fnptr, GLuint  path, GLfloat * dashArray) {
+//   (*fnptr)(path, dashArray);
+// }
+// static GLfloat  glowGetPathLengthNV(GPGETPATHLENGTHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments) {
+//   return (*fnptr)(path, startSegment, numSegments);
+// }
+// static void  glowGetPathMetricRangeNV(GPGETPATHMETRICRANGENV fnptr, GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, firstPathName, numPaths, stride, metrics);
+// }
+// static void  glowGetPathMetricsNV(GPGETPATHMETRICSNV fnptr, GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, numPaths, pathNameType, paths, pathBase, stride, metrics);
+// }
+// static void  glowGetPathParameterfvNV(GPGETPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathParameterivNV(GPGETPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathSpacingNV(GPGETPATHSPACINGNV fnptr, GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing) {
+//   (*fnptr)(pathListMode, numPaths, pathNameType, paths, pathBase, advanceScale, kerningScale, transformType, returnedSpacing);
+// }
+// static void  glowGetPerfCounterInfoINTEL(GPGETPERFCOUNTERINFOINTEL fnptr, GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue) {
+//   (*fnptr)(queryId, counterId, counterNameLength, counterName, counterDescLength, counterDesc, counterOffset, counterDataSize, counterTypeEnum, counterDataTypeEnum, rawCounterMaxValue);
+// }
+// static void  glowGetPerfMonitorCounterDataAMD(GPGETPERFMONITORCOUNTERDATAAMD fnptr, GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten) {
+//   (*fnptr)(monitor, pname, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfMonitorCounterInfoAMD(GPGETPERFMONITORCOUNTERINFOAMD fnptr, GLuint  group, GLuint  counter, GLenum  pname, void * data) {
+//   (*fnptr)(group, counter, pname, data);
+// }
+// static void  glowGetPerfMonitorCounterStringAMD(GPGETPERFMONITORCOUNTERSTRINGAMD fnptr, GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString) {
+//   (*fnptr)(group, counter, bufSize, length, counterString);
+// }
+// static void  glowGetPerfMonitorCountersAMD(GPGETPERFMONITORCOUNTERSAMD fnptr, GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters) {
+//   (*fnptr)(group, numCounters, maxActiveCounters, counterSize, counters);
+// }
+// static void  glowGetPerfMonitorGroupStringAMD(GPGETPERFMONITORGROUPSTRINGAMD fnptr, GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString) {
+//   (*fnptr)(group, bufSize, length, groupString);
+// }
+// static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
+//   (*fnptr)(numGroups, groupsSize, groups);
+// }
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
+//   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
+//   (*fnptr)(queryName, queryId);
+// }
+// static void  glowGetPerfQueryInfoINTEL(GPGETPERFQUERYINFOINTEL fnptr, GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask) {
+//   (*fnptr)(queryId, queryNameLength, queryName, dataSize, noCounters, noInstances, capsMask);
+// }
+// static void  glowGetPointerIndexedvEXT(GPGETPOINTERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, void ** data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetPointeri_vEXT(GPGETPOINTERI_VEXT fnptr, GLenum  pname, GLuint  index, void ** params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetPointerv(GPGETPOINTERV fnptr, GLenum  pname, void ** params) {
 //   (*fnptr)(pname, params);
@@ -1571,7 +2631,13 @@ package gl
 // static void  glowGetProgramPipelineInfoLog(GPGETPROGRAMPIPELINEINFOLOG fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
 //   (*fnptr)(pipeline, bufSize, length, infoLog);
 // }
+// static void  glowGetProgramPipelineInfoLogEXT(GPGETPROGRAMPIPELINEINFOLOGEXT fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
+//   (*fnptr)(pipeline, bufSize, length, infoLog);
+// }
 // static void  glowGetProgramPipelineiv(GPGETPROGRAMPIPELINEIV fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
+//   (*fnptr)(pipeline, pname, params);
+// }
+// static void  glowGetProgramPipelineivEXT(GPGETPROGRAMPIPELINEIVEXT fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
 //   (*fnptr)(pipeline, pname, params);
 // }
 // static GLuint  glowGetProgramResourceIndex(GPGETPROGRAMRESOURCEINDEX fnptr, GLuint  program, GLenum  programInterface, const GLchar * name) {
@@ -1586,6 +2652,9 @@ package gl
 // static void  glowGetProgramResourceName(GPGETPROGRAMRESOURCENAME fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name) {
 //   (*fnptr)(program, programInterface, index, bufSize, length, name);
 // }
+// static void  glowGetProgramResourcefvNV(GPGETPROGRAMRESOURCEFVNV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params) {
+//   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
+// }
 // static void  glowGetProgramResourceiv(GPGETPROGRAMRESOURCEIV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params) {
 //   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
 // }
@@ -1594,6 +2663,18 @@ package gl
 // }
 // static void  glowGetProgramiv(GPGETPROGRAMIV fnptr, GLuint  program, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, pname, params);
+// }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
 // }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
@@ -1640,6 +2721,9 @@ package gl
 // static void  glowGetShaderiv(GPGETSHADERIV fnptr, GLuint  shader, GLenum  pname, GLint * params) {
 //   (*fnptr)(shader, pname, params);
 // }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
+// }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
 // }
@@ -1679,28 +2763,55 @@ package gl
 // static GLuint64  glowGetTextureHandleARB(GPGETTEXTUREHANDLEARB fnptr, GLuint  texture) {
 //   return (*fnptr)(texture);
 // }
+// static GLuint64  glowGetTextureHandleNV(GPGETTEXTUREHANDLENV fnptr, GLuint  texture) {
+//   return (*fnptr)(texture);
+// }
 // static void  glowGetTextureImage(GPGETTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, format, type, bufSize, pixels);
+// }
+// static void  glowGetTextureImageEXT(GPGETTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texture, target, level, format, type, pixels);
 // }
 // static void  glowGetTextureLevelParameterfv(GPGETTEXTURELEVELPARAMETERFV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, level, pname, params);
 // }
+// static void  glowGetTextureLevelParameterfvEXT(GPGETTEXTURELEVELPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, level, pname, params);
+// }
 // static void  glowGetTextureLevelParameteriv(GPGETTEXTURELEVELPARAMETERIV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, level, pname, params);
+// }
+// static void  glowGetTextureLevelParameterivEXT(GPGETTEXTURELEVELPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, level, pname, params);
 // }
 // static void  glowGetTextureParameterIiv(GPGETTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterIivEXT(GPGETTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameterIuiv(GPGETTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowGetTextureParameterIuivEXT(GPGETTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowGetTextureParameterfv(GPGETTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterfvEXT(GPGETTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameteriv(GPGETTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterivEXT(GPGETTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static GLuint64  glowGetTextureSamplerHandleARB(GPGETTEXTURESAMPLERHANDLEARB fnptr, GLuint  texture, GLuint  sampler) {
+//   return (*fnptr)(texture, sampler);
+// }
+// static GLuint64  glowGetTextureSamplerHandleNV(GPGETTEXTURESAMPLERHANDLENV fnptr, GLuint  texture, GLuint  sampler) {
 //   return (*fnptr)(texture, sampler);
 // }
 // static void  glowGetTextureSubImage(GPGETTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
@@ -1736,7 +2847,19 @@ package gl
 // static void  glowGetUniformfv(GPGETUNIFORMFV fnptr, GLuint  program, GLint  location, GLfloat * params) {
 //   (*fnptr)(program, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformiv(GPGETUNIFORMIV fnptr, GLuint  program, GLint  location, GLint * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
 // static void  glowGetUniformuiv(GPGETUNIFORMUIV fnptr, GLuint  program, GLint  location, GLuint * params) {
@@ -1747,6 +2870,18 @@ package gl
 // }
 // static void  glowGetVertexArrayIndexediv(GPGETVERTEXARRAYINDEXEDIV fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegeri_vEXT(GPGETVERTEXARRAYINTEGERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegervEXT(GPGETVERTEXARRAYINTEGERVEXT fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, pname, param);
+// }
+// static void  glowGetVertexArrayPointeri_vEXT(GPGETVERTEXARRAYPOINTERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayPointervEXT(GPGETVERTEXARRAYPOINTERVEXT fnptr, GLuint  vaobj, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, pname, param);
 // }
 // static void  glowGetVertexArrayiv(GPGETVERTEXARRAYIV fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, pname, param);
@@ -1760,7 +2895,13 @@ package gl
 // static void  glowGetVertexAttribLdv(GPGETVERTEXATTRIBLDV fnptr, GLuint  index, GLenum  pname, GLdouble * params) {
 //   (*fnptr)(index, pname, params);
 // }
+// static void  glowGetVertexAttribLi64vNV(GPGETVERTEXATTRIBLI64VNV fnptr, GLuint  index, GLenum  pname, GLint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
 // static void  glowGetVertexAttribLui64vARB(GPGETVERTEXATTRIBLUI64VARB fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
+// static void  glowGetVertexAttribLui64vNV(GPGETVERTEXATTRIBLUI64VNV fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
 //   (*fnptr)(index, pname, params);
 // }
 // static void  glowGetVertexAttribPointerv(GPGETVERTEXATTRIBPOINTERV fnptr, GLuint  index, GLenum  pname, void ** pointer) {
@@ -1774,6 +2915,9 @@ package gl
 // }
 // static void  glowGetVertexAttribiv(GPGETVERTEXATTRIBIV fnptr, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(index, pname, params);
+// }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
 // }
 // static void  glowGetnCompressedTexImageARB(GPGETNCOMPRESSEDTEXIMAGEARB fnptr, GLenum  target, GLint  lod, GLsizei  bufSize, void * img) {
 //   (*fnptr)(target, lod, bufSize, img);
@@ -1793,6 +2937,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -1800,6 +2947,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -1813,6 +2963,15 @@ package gl
 // }
 // static void  glowHint(GPHINT fnptr, GLenum  target, GLenum  mode) {
 //   (*fnptr)(target, mode);
+// }
+// static void  glowIndexFormatNV(GPINDEXFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
+// static void  glowInsertEventMarkerEXT(GPINSERTEVENTMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
+// static void  glowInterpolatePathsNV(GPINTERPOLATEPATHSNV fnptr, GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight) {
+//   (*fnptr)(resultPath, pathA, pathB, weight);
 // }
 // static void  glowInvalidateBufferData(GPINVALIDATEBUFFERDATA fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -1841,8 +3000,17 @@ package gl
 // static GLboolean  glowIsBuffer(GPISBUFFER fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
+// static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
+//   return (*fnptr)(target);
+// }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
+// }
+// static GLboolean  glowIsEnabledIndexedEXT(GPISENABLEDINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   return (*fnptr)(target, index);
 // }
 // static GLboolean  glowIsEnabledi(GPISENABLEDI fnptr, GLenum  target, GLuint  index) {
 //   return (*fnptr)(target, index);
@@ -1853,13 +3021,31 @@ package gl
 // static GLboolean  glowIsImageHandleResidentARB(GPISIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsImageHandleResidentNV(GPISIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
+// static GLboolean  glowIsNamedBufferResidentNV(GPISNAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
 // static GLboolean  glowIsNamedStringARB(GPISNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   return (*fnptr)(namelen, name);
+// }
+// static GLboolean  glowIsPathNV(GPISPATHNV fnptr, GLuint  path) {
+//   return (*fnptr)(path);
+// }
+// static GLboolean  glowIsPointInFillPathNV(GPISPOINTINFILLPATHNV fnptr, GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, mask, x, y);
+// }
+// static GLboolean  glowIsPointInStrokePathNV(GPISPOINTINSTROKEPATHNV fnptr, GLuint  path, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, x, y);
 // }
 // static GLboolean  glowIsProgram(GPISPROGRAM fnptr, GLuint  program) {
 //   return (*fnptr)(program);
 // }
 // static GLboolean  glowIsProgramPipeline(GPISPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   return (*fnptr)(pipeline);
+// }
+// static GLboolean  glowIsProgramPipelineEXT(GPISPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   return (*fnptr)(pipeline);
 // }
 // static GLboolean  glowIsQuery(GPISQUERY fnptr, GLuint  id) {
@@ -1874,6 +3060,9 @@ package gl
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
 // }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
+// }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
 // }
@@ -1883,11 +3072,17 @@ package gl
 // static GLboolean  glowIsTextureHandleResidentARB(GPISTEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsTextureHandleResidentNV(GPISTEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
 // static GLboolean  glowIsTransformFeedback(GPISTRANSFORMFEEDBACK fnptr, GLuint  id) {
 //   return (*fnptr)(id);
 // }
 // static GLboolean  glowIsVertexArray(GPISVERTEXARRAY fnptr, GLuint  array) {
 //   return (*fnptr)(array);
+// }
+// static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
+//   (*fnptr)(type, object, length, label);
 // }
 // static void  glowLineWidth(GPLINEWIDTH fnptr, GLfloat  width) {
 //   (*fnptr)(width);
@@ -1895,19 +3090,46 @@ package gl
 // static void  glowLinkProgram(GPLINKPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
+// }
 // static void  glowLogicOp(GPLOGICOP fnptr, GLenum  opcode) {
 //   (*fnptr)(opcode);
 // }
+// static void  glowMakeBufferNonResidentNV(GPMAKEBUFFERNONRESIDENTNV fnptr, GLenum  target) {
+//   (*fnptr)(target);
+// }
+// static void  glowMakeBufferResidentNV(GPMAKEBUFFERRESIDENTNV fnptr, GLenum  target, GLenum  access) {
+//   (*fnptr)(target, access);
+// }
 // static void  glowMakeImageHandleNonResidentARB(GPMAKEIMAGEHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeImageHandleNonResidentNV(GPMAKEIMAGEHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void  glowMakeImageHandleResidentARB(GPMAKEIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle, GLenum  access) {
 //   (*fnptr)(handle, access);
 // }
+// static void  glowMakeImageHandleResidentNV(GPMAKEIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle, GLenum  access) {
+//   (*fnptr)(handle, access);
+// }
+// static void  glowMakeNamedBufferNonResidentNV(GPMAKENAMEDBUFFERNONRESIDENTNV fnptr, GLuint  buffer) {
+//   (*fnptr)(buffer);
+// }
+// static void  glowMakeNamedBufferResidentNV(GPMAKENAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer, GLenum  access) {
+//   (*fnptr)(buffer, access);
+// }
 // static void  glowMakeTextureHandleNonResidentARB(GPMAKETEXTUREHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
+// static void  glowMakeTextureHandleNonResidentNV(GPMAKETEXTUREHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
 // static void  glowMakeTextureHandleResidentARB(GPMAKETEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeTextureHandleResidentNV(GPMAKETEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void * glowMapBuffer(GPMAPBUFFER fnptr, GLenum  target, GLenum  access) {
@@ -1919,8 +3141,95 @@ package gl
 // static void * glowMapNamedBuffer(GPMAPNAMEDBUFFER fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
+//   return (*fnptr)(buffer, access);
+// }
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
+//   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void  glowMatrixFrustumEXT(GPMATRIXFRUSTUMEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixLoad3x2fNV(GPMATRIXLOAD3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoad3x3fNV(GPMATRIXLOAD3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadIdentityEXT(GPMATRIXLOADIDENTITYEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixLoadTranspose3x3fNV(GPMATRIXLOADTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadTransposedEXT(GPMATRIXLOADTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadTransposefEXT(GPMATRIXLOADTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoaddEXT(GPMATRIXLOADDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadfEXT(GPMATRIXLOADFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMult3x2fNV(GPMATRIXMULT3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMult3x3fNV(GPMATRIXMULT3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTranspose3x3fNV(GPMATRIXMULTTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTransposedEXT(GPMATRIXMULTTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultTransposefEXT(GPMATRIXMULTTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultdEXT(GPMATRIXMULTDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultfEXT(GPMATRIXMULTFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixOrthoEXT(GPMATRIXORTHOEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixPopEXT(GPMATRIXPOPEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixPushEXT(GPMATRIXPUSHEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixRotatedEXT(GPMATRIXROTATEDEXT fnptr, GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixRotatefEXT(GPMATRIXROTATEFEXT fnptr, GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixScaledEXT(GPMATRIXSCALEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixScalefEXT(GPMATRIXSCALEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatedEXT(GPMATRIXTRANSLATEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
 // }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
@@ -1937,7 +3246,13 @@ package gl
 // static void  glowMultiDrawArraysIndirect(GPMULTIDRAWARRAYSINDIRECT fnptr, GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectBindlessCountNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElements(GPMULTIDRAWELEMENTS fnptr, GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount) {
@@ -1949,23 +3264,116 @@ package gl
 // static void  glowMultiDrawElementsIndirect(GPMULTIDRAWELEMENTSINDIRECT fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectBindlessCountNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMultiTexBufferEXT(GPMULTITEXBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texunit, target, internalformat, buffer);
+// }
+// static void  glowMultiTexCoordPointerEXT(GPMULTITEXCOORDPOINTEREXT fnptr, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
+//   (*fnptr)(texunit, size, type, stride, pointer);
+// }
+// static void  glowMultiTexEnvfEXT(GPMULTITEXENVFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvfvEXT(GPMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexEnviEXT(GPMULTITEXENVIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvivEXT(GPMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexGendEXT(GPMULTITEXGENDEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGendvEXT(GPMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGenfEXT(GPMULTITEXGENFEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenfvEXT(GPMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGeniEXT(GPMULTITEXGENIEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenivEXT(GPMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexImage1DEXT(GPMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage2DEXT(GPMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage3DEXT(GPMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowMultiTexParameterIivEXT(GPMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterIuivEXT(GPMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterfEXT(GPMULTITEXPARAMETERFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterfvEXT(GPMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameteriEXT(GPMULTITEXPARAMETERIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterivEXT(GPMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexRenderbufferEXT(GPMULTITEXRENDERBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texunit, target, renderbuffer);
+// }
+// static void  glowMultiTexSubImage1DEXT(GPMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage2DEXT(GPMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
+//   (*fnptr)(buffer, size, data, usage);
+// }
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
+//   (*fnptr)(buffer, size, data, flags);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedCopyBufferSubDataEXT(GPNAMEDCOPYBUFFERSUBDATAEXT fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowNamedFramebufferDrawBuffer(GPNAMEDFRAMEBUFFERDRAWBUFFER fnptr, GLuint  framebuffer, GLenum  buf) {
 //   (*fnptr)(framebuffer, buf);
@@ -1976,26 +3384,104 @@ package gl
 // static void  glowNamedFramebufferParameteri(GPNAMEDFRAMEBUFFERPARAMETERI fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowNamedFramebufferParameteriEXT(GPNAMEDFRAMEBUFFERPARAMETERIEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
+//   (*fnptr)(framebuffer, pname, param);
+// }
 // static void  glowNamedFramebufferReadBuffer(GPNAMEDFRAMEBUFFERREADBUFFER fnptr, GLuint  framebuffer, GLenum  src) {
 //   (*fnptr)(framebuffer, src);
 // }
 // static void  glowNamedFramebufferRenderbuffer(GPNAMEDFRAMEBUFFERRENDERBUFFER fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
 // }
+// static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
+//   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTexture1DEXT(GPNAMEDFRAMEBUFFERTEXTURE1DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture2DEXT(GPNAMEDFRAMEBUFFERTEXTURE2DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture3DEXT(GPNAMEDFRAMEBUFFERTEXTURE3DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level, zoffset);
+// }
+// static void  glowNamedFramebufferTextureEXT(GPNAMEDFRAMEBUFFERTEXTUREEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTextureFaceEXT(GPNAMEDFRAMEBUFFERTEXTUREFACEEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(framebuffer, attachment, texture, level, face);
 // }
 // static void  glowNamedFramebufferTextureLayer(GPNAMEDFRAMEBUFFERTEXTURELAYER fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(framebuffer, attachment, texture, level, layer);
 // }
+// static void  glowNamedFramebufferTextureLayerEXT(GPNAMEDFRAMEBUFFERTEXTURELAYEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(framebuffer, attachment, texture, level, layer);
+// }
+// static void  glowNamedProgramLocalParameter4dEXT(GPNAMEDPROGRAMLOCALPARAMETER4DEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4dvEXT(GPNAMEDPROGRAMLOCALPARAMETER4DVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameter4fEXT(GPNAMEDPROGRAMLOCALPARAMETER4FEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4fvEXT(GPNAMEDPROGRAMLOCALPARAMETER4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4iEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4uiEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameters4fvEXT(GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramStringEXT(GPNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string) {
+//   (*fnptr)(program, target, format, len, string);
+// }
 // static void  glowNamedRenderbufferStorage(GPNAMEDRENDERBUFFERSTORAGE fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageEXT(GPNAMEDRENDERBUFFERSTORAGEEXT fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, internalformat, width, height);
 // }
 // static void  glowNamedRenderbufferStorageMultisample(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, samples, internalformat, width, height);
 // }
+// static void  glowNamedRenderbufferStorageMultisampleCoverageEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT fnptr, GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageMultisampleEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, samples, internalformat, width, height);
+// }
 // static void  glowNamedStringARB(GPNAMEDSTRINGARB fnptr, GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string) {
 //   (*fnptr)(type, namelen, name, stringlen, string);
+// }
+// static void  glowNormalFormatNV(GPNORMALFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
 // }
 // static void  glowObjectLabel(GPOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(identifier, name, length, label);
@@ -2015,6 +3501,60 @@ package gl
 // static void  glowPatchParameteri(GPPATCHPARAMETERI fnptr, GLenum  pname, GLint  value) {
 //   (*fnptr)(pname, value);
 // }
+// static void  glowPathCommandsNV(GPPATHCOMMANDSNV fnptr, GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathCoordsNV(GPPATHCOORDSNV fnptr, GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCoords, coordType, coords);
+// }
+// static void  glowPathCoverDepthFuncNV(GPPATHCOVERDEPTHFUNCNV fnptr, GLenum  func) {
+//   (*fnptr)(func);
+// }
+// static void  glowPathDashArrayNV(GPPATHDASHARRAYNV fnptr, GLuint  path, GLsizei  dashCount, const GLfloat * dashArray) {
+//   (*fnptr)(path, dashCount, dashArray);
+// }
+// static GLenum  glowPathGlyphIndexArrayNV(GPPATHGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathGlyphIndexRangeNV(GPPATHGLYPHINDEXRANGENV fnptr, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount) {
+//   return (*fnptr)(fontTarget, fontName, fontStyle, pathParameterTemplate, emScale, baseAndCount);
+// }
+// static void  glowPathGlyphRangeNV(GPPATHGLYPHRANGENV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyph, numGlyphs, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathGlyphsNV(GPPATHGLYPHSNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, numGlyphs, type, charcodes, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathMemoryGlyphIndexArrayNV(GPPATHMEMORYGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontSize, fontData, faceIndex, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathParameterfNV(GPPATHPARAMETERFNV fnptr, GLuint  path, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterfvNV(GPPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, const GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameteriNV(GPPATHPARAMETERINV fnptr, GLuint  path, GLenum  pname, GLint  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterivNV(GPPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, const GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathStencilDepthOffsetNV(GPPATHSTENCILDEPTHOFFSETNV fnptr, GLfloat  factor, GLfloat  units) {
+//   (*fnptr)(factor, units);
+// }
+// static void  glowPathStencilFuncNV(GPPATHSTENCILFUNCNV fnptr, GLenum  func, GLint  ref, GLuint  mask) {
+//   (*fnptr)(func, ref, mask);
+// }
+// static void  glowPathStringNV(GPPATHSTRINGNV fnptr, GLuint  path, GLenum  format, GLsizei  length, const void * pathString) {
+//   (*fnptr)(path, format, length, pathString);
+// }
+// static void  glowPathSubCommandsNV(GPPATHSUBCOMMANDSNV fnptr, GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, commandStart, commandsToDelete, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathSubCoordsNV(GPPATHSUBCOORDSNV fnptr, GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, coordStart, numCoords, coordType, coords);
+// }
 // static void  glowPauseTransformFeedback(GPPAUSETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -2023,6 +3563,9 @@ package gl
 // }
 // static void  glowPixelStorei(GPPIXELSTOREI fnptr, GLenum  pname, GLint  param) {
 //   (*fnptr)(pname, param);
+// }
+// static GLboolean  glowPointAlongPathNV(GPPOINTALONGPATHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY) {
+//   return (*fnptr)(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
 // }
 // static void  glowPointParameterf(GPPOINTPARAMETERF fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
@@ -2045,11 +3588,23 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPopDebugGroup(GPPOPDEBUGGROUP fnptr) {
 //   (*fnptr)();
 // }
 // static void  glowPopDebugGroupKHR(GPPOPDEBUGGROUPKHR fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowPopGroupMarkerEXT(GPPOPGROUPMARKEREXT fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -2060,164 +3615,434 @@ package gl
 // static void  glowProgramParameteri(GPPROGRAMPARAMETERI fnptr, GLuint  program, GLenum  pname, GLint  value) {
 //   (*fnptr)(program, pname, value);
 // }
+// static void  glowProgramParameteriARB(GPPROGRAMPARAMETERIARB fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramParameteriEXT(GPPROGRAMPARAMETERIEXT fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramPathFragmentInputGenNV(GPPROGRAMPATHFRAGMENTINPUTGENNV fnptr, GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs) {
+//   (*fnptr)(program, location, genMode, components, coeffs);
+// }
 // static void  glowProgramUniform1d(GPPROGRAMUNIFORM1D fnptr, GLuint  program, GLint  location, GLdouble  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1dEXT(GPPROGRAMUNIFORM1DEXT fnptr, GLuint  program, GLint  location, GLdouble  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1dv(GPPROGRAMUNIFORM1DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1dvEXT(GPPROGRAMUNIFORM1DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1f(GPPROGRAMUNIFORM1F fnptr, GLuint  program, GLint  location, GLfloat  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1fEXT(GPPROGRAMUNIFORM1FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1fv(GPPROGRAMUNIFORM1FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1fvEXT(GPPROGRAMUNIFORM1FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1iEXT(GPPROGRAMUNIFORM1IEXT fnptr, GLuint  program, GLint  location, GLint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1iv(GPPROGRAMUNIFORM1IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ivEXT(GPPROGRAMUNIFORM1IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uiEXT(GPPROGRAMUNIFORM1UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1uiv(GPPROGRAMUNIFORM1UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uivEXT(GPPROGRAMUNIFORM1UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2d(GPPROGRAMUNIFORM2D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2dEXT(GPPROGRAMUNIFORM2DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2dv(GPPROGRAMUNIFORM2DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2dvEXT(GPPROGRAMUNIFORM2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2f(GPPROGRAMUNIFORM2F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2fEXT(GPPROGRAMUNIFORM2FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2fv(GPPROGRAMUNIFORM2FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2fvEXT(GPPROGRAMUNIFORM2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2iEXT(GPPROGRAMUNIFORM2IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2iv(GPPROGRAMUNIFORM2IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ivEXT(GPPROGRAMUNIFORM2IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uiEXT(GPPROGRAMUNIFORM2UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2uiv(GPPROGRAMUNIFORM2UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uivEXT(GPPROGRAMUNIFORM2UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3d(GPPROGRAMUNIFORM3D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3dEXT(GPPROGRAMUNIFORM3DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3dv(GPPROGRAMUNIFORM3DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3dvEXT(GPPROGRAMUNIFORM3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3f(GPPROGRAMUNIFORM3F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3fEXT(GPPROGRAMUNIFORM3FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3fv(GPPROGRAMUNIFORM3FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3fvEXT(GPPROGRAMUNIFORM3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3iEXT(GPPROGRAMUNIFORM3IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3iv(GPPROGRAMUNIFORM3IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ivEXT(GPPROGRAMUNIFORM3IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uiEXT(GPPROGRAMUNIFORM3UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3uiv(GPPROGRAMUNIFORM3UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uivEXT(GPPROGRAMUNIFORM3UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4d(GPPROGRAMUNIFORM4D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4dEXT(GPPROGRAMUNIFORM4DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4dv(GPPROGRAMUNIFORM4DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4dvEXT(GPPROGRAMUNIFORM4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4f(GPPROGRAMUNIFORM4F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4fEXT(GPPROGRAMUNIFORM4FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4fv(GPPROGRAMUNIFORM4FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4fvEXT(GPPROGRAMUNIFORM4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4iEXT(GPPROGRAMUNIFORM4IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4iv(GPPROGRAMUNIFORM4IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ivEXT(GPPROGRAMUNIFORM4IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uiEXT(GPPROGRAMUNIFORM4UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4uiv(GPPROGRAMUNIFORM4UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uivEXT(GPPROGRAMUNIFORM4UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniformHandleui64ARB(GPPROGRAMUNIFORMHANDLEUI64ARB fnptr, GLuint  program, GLint  location, GLuint64  value) {
 //   (*fnptr)(program, location, value);
 // }
+// static void  glowProgramUniformHandleui64NV(GPPROGRAMUNIFORMHANDLEUI64NV fnptr, GLuint  program, GLint  location, GLuint64  value) {
+//   (*fnptr)(program, location, value);
+// }
 // static void  glowProgramUniformHandleui64vARB(GPPROGRAMUNIFORMHANDLEUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
+//   (*fnptr)(program, location, count, values);
+// }
+// static void  glowProgramUniformHandleui64vNV(GPPROGRAMUNIFORMHANDLEUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
 //   (*fnptr)(program, location, count, values);
 // }
 // static void  glowProgramUniformMatrix2dv(GPPROGRAMUNIFORMMATRIX2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2dvEXT(GPPROGRAMUNIFORMMATRIX2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2fv(GPPROGRAMUNIFORMMATRIX2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2fvEXT(GPPROGRAMUNIFORMMATRIX2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x3dv(GPPROGRAMUNIFORMMATRIX2X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x3dvEXT(GPPROGRAMUNIFORMMATRIX2X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x3fv(GPPROGRAMUNIFORMMATRIX2X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x3fvEXT(GPPROGRAMUNIFORMMATRIX2X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x4dv(GPPROGRAMUNIFORMMATRIX2X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x4dvEXT(GPPROGRAMUNIFORMMATRIX2X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x4fv(GPPROGRAMUNIFORMMATRIX2X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x4fvEXT(GPPROGRAMUNIFORMMATRIX2X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3dv(GPPROGRAMUNIFORMMATRIX3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3dvEXT(GPPROGRAMUNIFORMMATRIX3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3fv(GPPROGRAMUNIFORMMATRIX3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3fvEXT(GPPROGRAMUNIFORMMATRIX3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x2dv(GPPROGRAMUNIFORMMATRIX3X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x2dvEXT(GPPROGRAMUNIFORMMATRIX3X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x2fv(GPPROGRAMUNIFORMMATRIX3X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x2fvEXT(GPPROGRAMUNIFORMMATRIX3X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x4dv(GPPROGRAMUNIFORMMATRIX3X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x4dvEXT(GPPROGRAMUNIFORMMATRIX3X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x4fv(GPPROGRAMUNIFORMMATRIX3X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x4fvEXT(GPPROGRAMUNIFORMMATRIX3X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4dv(GPPROGRAMUNIFORMMATRIX4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4dvEXT(GPPROGRAMUNIFORMMATRIX4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4fv(GPPROGRAMUNIFORMMATRIX4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4fvEXT(GPPROGRAMUNIFORMMATRIX4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x2dv(GPPROGRAMUNIFORMMATRIX4X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x2dvEXT(GPPROGRAMUNIFORMMATRIX4X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x2fv(GPPROGRAMUNIFORMMATRIX4X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4x2fvEXT(GPPROGRAMUNIFORMMATRIX4X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x3dv(GPPROGRAMUNIFORMMATRIX4X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3dvEXT(GPPROGRAMUNIFORMMATRIX4X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x3fv(GPPROGRAMUNIFORMMATRIX4X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3fvEXT(GPPROGRAMUNIFORMMATRIX4X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformui64NV(GPPROGRAMUNIFORMUI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(program, location, value);
+// }
+// static void  glowProgramUniformui64vNV(GPPROGRAMUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
 // static void  glowProvokingVertex(GPPROVOKINGVERTEX fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
+// }
+// static void  glowPushClientAttribDefaultEXT(GPPUSHCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static void  glowPushDebugGroup(GPPUSHDEBUGGROUP fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
@@ -2225,8 +4050,14 @@ package gl
 // static void  glowPushDebugGroupKHR(GPPUSHDEBUGGROUPKHR fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
 // }
+// static void  glowPushGroupMarkerEXT(GPPUSHGROUPMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
 // static void  glowQueryCounter(GPQUERYCOUNTER fnptr, GLuint  id, GLenum  target) {
 //   (*fnptr)(id, target);
+// }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
 // }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
@@ -2251,6 +4082,12 @@ package gl
 // }
 // static void  glowRenderbufferStorageMultisample(GPRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, samples, internalformat, width, height);
+// }
+// static void  glowRenderbufferStorageMultisampleCoverageNV(GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV fnptr, GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(target, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
@@ -2291,6 +4128,12 @@ package gl
 // static void  glowScissorIndexedv(GPSCISSORINDEXEDV fnptr, GLuint  index, const GLint * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowSecondaryColorFormatNV(GPSECONDARYCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
+// static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
+//   (*fnptr)(monitor, enable, group, numCounters, counterList);
+// }
 // static void  glowShaderBinary(GPSHADERBINARY fnptr, GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length) {
 //   (*fnptr)(count, shaders, binaryformat, binary, length);
 // }
@@ -2299,6 +4142,24 @@ package gl
 // }
 // static void  glowShaderStorageBlockBinding(GPSHADERSTORAGEBLOCKBINDING fnptr, GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding) {
 //   (*fnptr)(program, storageBlockIndex, storageBlockBinding);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
+// }
+// static void  glowStencilFillPathInstancedNV(GPSTENCILFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, transformType, transformValues);
+// }
+// static void  glowStencilFillPathNV(GPSTENCILFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask) {
+//   (*fnptr)(path, fillMode, mask);
 // }
 // static void  glowStencilFunc(GPSTENCILFUNC fnptr, GLenum  func, GLint  ref, GLuint  mask) {
 //   (*fnptr)(func, ref, mask);
@@ -2318,11 +4179,38 @@ package gl
 // static void  glowStencilOpSeparate(GPSTENCILOPSEPARATE fnptr, GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass) {
 //   (*fnptr)(face, sfail, dpfail, dppass);
 // }
+// static void  glowStencilStrokePathInstancedNV(GPSTENCILSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, transformType, transformValues);
+// }
+// static void  glowStencilStrokePathNV(GPSTENCILSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask) {
+//   (*fnptr)(path, reference, mask);
+// }
+// static void  glowStencilThenCoverFillPathInstancedNV(GPSTENCILTHENCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverFillPathNV(GPSTENCILTHENCOVERFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, fillMode, mask, coverMode);
+// }
+// static void  glowStencilThenCoverStrokePathInstancedNV(GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverStrokePathNV(GPSTENCILTHENCOVERSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, reference, mask, coverMode);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
+// }
 // static void  glowTexBuffer(GPTEXBUFFER fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(target, internalformat, buffer);
+// }
+// static void  glowTexBufferARB(GPTEXBUFFERARB fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(target, internalformat, buffer);
 // }
 // static void  glowTexBufferRange(GPTEXBUFFERRANGE fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, internalformat, buffer, offset, size);
+// }
+// static void  glowTexCoordFormatNV(GPTEXCOORDFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
 // }
 // static void  glowTexImage1D(GPTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, border, format, type, pixels);
@@ -2339,8 +4227,8 @@ package gl
 // static void  glowTexImage3DMultisample(GPTEXIMAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -2387,53 +4275,119 @@ package gl
 // static void  glowTextureBarrier(GPTEXTUREBARRIER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowTextureBarrierNV(GPTEXTUREBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowTextureBuffer(GPTEXTUREBUFFER fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texture, target, internalformat, buffer);
+// }
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
+//   (*fnptr)(texture, target, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureImage1DEXT(GPTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowTextureImage2DEXT(GPTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowTextureImage3DEXT(GPTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowTextureParameterIivEXT(GPTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowTextureParameterIuiv(GPTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, const GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowTextureParameterIuivEXT(GPTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameterf(GPTEXTUREPARAMETERF fnptr, GLuint  texture, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameterfEXT(GPTEXTUREPARAMETERFEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameterfv(GPTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, const GLfloat * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterfvEXT(GPTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameteri(GPTEXTUREPARAMETERI fnptr, GLuint  texture, GLenum  pname, GLint  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameteriEXT(GPTEXTUREPARAMETERIEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameteriv(GPTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, const GLint * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterivEXT(GPTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
+// static void  glowTextureRenderbufferEXT(GPTEXTURERENDERBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texture, target, renderbuffer);
 // }
 // static void  glowTextureStorage1D(GPTEXTURESTORAGE1D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
 //   (*fnptr)(texture, levels, internalformat, width);
 // }
+// static void  glowTextureStorage1DEXT(GPTEXTURESTORAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
+//   (*fnptr)(texture, target, levels, internalformat, width);
+// }
 // static void  glowTextureStorage2D(GPTEXTURESTORAGE2D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, levels, internalformat, width, height);
+// }
+// static void  glowTextureStorage2DEXT(GPTEXTURESTORAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height);
 // }
 // static void  glowTextureStorage2DMultisample(GPTEXTURESTORAGE2DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, fixedsamplelocations);
 // }
+// static void  glowTextureStorage2DMultisampleEXT(GPTEXTURESTORAGE2DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, fixedsamplelocations);
+// }
 // static void  glowTextureStorage3D(GPTEXTURESTORAGE3D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
 //   (*fnptr)(texture, levels, internalformat, width, height, depth);
+// }
+// static void  glowTextureStorage3DEXT(GPTEXTURESTORAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height, depth);
 // }
 // static void  glowTextureStorage3DMultisample(GPTEXTURESTORAGE3DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
+// }
 // static void  glowTextureSubImage1D(GPTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowTextureSubImage1DEXT(GPTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, type, pixels);
 // }
 // static void  glowTextureSubImage2D(GPTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, type, pixels);
 // }
+// static void  glowTextureSubImage2DEXT(GPTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
 // static void  glowTextureSubImage3D(GPTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowTextureSubImage3DEXT(GPTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
 // static void  glowTextureView(GPTEXTUREVIEW fnptr, GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers) {
 //   (*fnptr)(texture, target, origtexture, internalformat, minlevel, numlevels, minlayer, numlayers);
@@ -2441,11 +4395,14 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackVaryings(GPTRANSFORMFEEDBACKVARYINGS fnptr, GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode) {
 //   (*fnptr)(program, count, varyings, bufferMode);
+// }
+// static void  glowTransformPathNV(GPTRANSFORMPATHNV fnptr, GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(resultPath, srcPath, transformType, transformValues);
 // }
 // static void  glowUniform1d(GPUNIFORM1D fnptr, GLint  location, GLdouble  x) {
 //   (*fnptr)(location, x);
@@ -2462,11 +4419,35 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform1iv(GPUNIFORM1IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
+// }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1uiv(GPUNIFORM1UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2486,11 +4467,35 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform2iv(GPUNIFORM2IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
+// }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2uiv(GPUNIFORM2UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2510,11 +4515,35 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform3iv(GPUNIFORM3IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
+// }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3uiv(GPUNIFORM3UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2534,11 +4563,35 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform4iv(GPUNIFORM4IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
+// }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4uiv(GPUNIFORM4UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2549,7 +4602,13 @@ package gl
 // static void  glowUniformHandleui64ARB(GPUNIFORMHANDLEUI64ARB fnptr, GLint  location, GLuint64  value) {
 //   (*fnptr)(location, value);
 // }
+// static void  glowUniformHandleui64NV(GPUNIFORMHANDLEUI64NV fnptr, GLint  location, GLuint64  value) {
+//   (*fnptr)(location, value);
+// }
 // static void  glowUniformHandleui64vARB(GPUNIFORMHANDLEUI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniformHandleui64vNV(GPUNIFORMHANDLEUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniformMatrix2dv(GPUNIFORMMATRIX2DV fnptr, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
@@ -2609,10 +4668,19 @@ package gl
 // static void  glowUniformSubroutinesuiv(GPUNIFORMSUBROUTINESUIV fnptr, GLenum  shadertype, GLsizei  count, const GLuint * indices) {
 //   (*fnptr)(shadertype, count, indices);
 // }
+// static void  glowUniformui64NV(GPUNIFORMUI64NV fnptr, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(location, value);
+// }
+// static void  glowUniformui64vNV(GPUNIFORMUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static GLboolean  glowUnmapBuffer(GPUNMAPBUFFER fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLboolean  glowUnmapNamedBuffer(GPUNMAPNAMEDBUFFER fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
+// static GLboolean  glowUnmapNamedBufferEXT(GPUNMAPNAMEDBUFFEREXT fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
 // static void  glowUseProgram(GPUSEPROGRAM fnptr, GLuint  program) {
@@ -2621,10 +4689,19 @@ package gl
 // static void  glowUseProgramStages(GPUSEPROGRAMSTAGES fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
 //   (*fnptr)(pipeline, stages, program);
 // }
+// static void  glowUseProgramStagesEXT(GPUSEPROGRAMSTAGESEXT fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
+//   (*fnptr)(pipeline, stages, program);
+// }
+// static void  glowUseShaderProgramEXT(GPUSESHADERPROGRAMEXT fnptr, GLenum  type, GLuint  program) {
+//   (*fnptr)(type, program);
+// }
 // static void  glowValidateProgram(GPVALIDATEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowValidateProgramPipeline(GPVALIDATEPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowValidateProgramPipelineEXT(GPVALIDATEPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowVertexArrayAttribBinding(GPVERTEXARRAYATTRIBBINDING fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
@@ -2639,17 +4716,74 @@ package gl
 // static void  glowVertexArrayAttribLFormat(GPVERTEXARRAYATTRIBLFORMAT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexArrayBindVertexBufferEXT(GPVERTEXARRAYBINDVERTEXBUFFEREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
+//   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
+// }
 // static void  glowVertexArrayBindingDivisor(GPVERTEXARRAYBINDINGDIVISOR fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(vaobj, bindingindex, divisor);
 // }
+// static void  glowVertexArrayColorOffsetEXT(GPVERTEXARRAYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayEdgeFlagOffsetEXT(GPVERTEXARRAYEDGEFLAGOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, stride, offset);
+// }
 // static void  glowVertexArrayElementBuffer(GPVERTEXARRAYELEMENTBUFFER fnptr, GLuint  vaobj, GLuint  buffer) {
 //   (*fnptr)(vaobj, buffer);
+// }
+// static void  glowVertexArrayFogCoordOffsetEXT(GPVERTEXARRAYFOGCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayIndexOffsetEXT(GPVERTEXARRAYINDEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayMultiTexCoordOffsetEXT(GPVERTEXARRAYMULTITEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, texunit, size, type, stride, offset);
+// }
+// static void  glowVertexArrayNormalOffsetEXT(GPVERTEXARRAYNORMALOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArraySecondaryColorOffsetEXT(GPVERTEXARRAYSECONDARYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayTexCoordOffsetEXT(GPVERTEXARRAYTEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribBindingEXT(GPVERTEXARRAYVERTEXATTRIBBINDINGEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
+//   (*fnptr)(vaobj, attribindex, bindingindex);
+// }
+// static void  glowVertexArrayVertexAttribDivisorEXT(GPVERTEXARRAYVERTEXATTRIBDIVISOREXT fnptr, GLuint  vaobj, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(vaobj, index, divisor);
+// }
+// static void  glowVertexArrayVertexAttribFormatEXT(GPVERTEXARRAYVERTEXATTRIBFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIFormatEXT(GPVERTEXARRAYVERTEXATTRIBIFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIOffsetEXT(GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribLFormatEXT(GPVERTEXARRAYVERTEXATTRIBLFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribLOffsetEXT(GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribOffsetEXT(GPVERTEXARRAYVERTEXATTRIBOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, normalized, stride, offset);
+// }
+// static void  glowVertexArrayVertexBindingDivisorEXT(GPVERTEXARRAYVERTEXBINDINGDIVISOREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
+//   (*fnptr)(vaobj, bindingindex, divisor);
 // }
 // static void  glowVertexArrayVertexBuffer(GPVERTEXARRAYVERTEXBUFFER fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
 //   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
 // }
 // static void  glowVertexArrayVertexBuffers(GPVERTEXARRAYVERTEXBUFFERS fnptr, GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(vaobj, first, count, buffers, offsets, strides);
+// }
+// static void  glowVertexArrayVertexOffsetEXT(GPVERTEXARRAYVERTEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
 // }
 // static void  glowVertexAttrib1d(GPVERTEXATTRIB1D fnptr, GLuint  index, GLdouble  x) {
 //   (*fnptr)(index, x);
@@ -2762,8 +4896,14 @@ package gl
 // static void  glowVertexAttribBinding(GPVERTEXATTRIBBINDING fnptr, GLuint  attribindex, GLuint  bindingindex) {
 //   (*fnptr)(attribindex, bindingindex);
 // }
+// static void  glowVertexAttribDivisorARB(GPVERTEXATTRIBDIVISORARB fnptr, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(index, divisor);
+// }
 // static void  glowVertexAttribFormat(GPVERTEXATTRIBFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexAttribFormatNV(GPVERTEXATTRIBFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride) {
+//   (*fnptr)(index, size, type, normalized, stride);
 // }
 // static void  glowVertexAttribI1i(GPVERTEXATTRIBI1I fnptr, GLuint  index, GLint  x) {
 //   (*fnptr)(index, x);
@@ -2828,6 +4968,9 @@ package gl
 // static void  glowVertexAttribIFormat(GPVERTEXATTRIBIFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexAttribIFormatNV(GPVERTEXATTRIBIFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
+// }
 // static void  glowVertexAttribIPointer(GPVERTEXATTRIBIPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
 // }
@@ -2837,10 +4980,22 @@ package gl
 // static void  glowVertexAttribL1dv(GPVERTEXATTRIBL1DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL1i64NV(GPVERTEXATTRIBL1I64NV fnptr, GLuint  index, GLint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
+// static void  glowVertexAttribL1i64vNV(GPVERTEXATTRIBL1I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL1ui64ARB(GPVERTEXATTRIBL1UI64ARB fnptr, GLuint  index, GLuint64EXT  x) {
 //   (*fnptr)(index, x);
 // }
+// static void  glowVertexAttribL1ui64NV(GPVERTEXATTRIBL1UI64NV fnptr, GLuint  index, GLuint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
 // static void  glowVertexAttribL1ui64vARB(GPVERTEXATTRIBL1UI64VARB fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL1ui64vNV(GPVERTEXATTRIBL1UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL2d(GPVERTEXATTRIBL2D fnptr, GLuint  index, GLdouble  x, GLdouble  y) {
@@ -2849,10 +5004,34 @@ package gl
 // static void  glowVertexAttribL2dv(GPVERTEXATTRIBL2DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL2i64NV(GPVERTEXATTRIBL2I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2i64vNV(GPVERTEXATTRIBL2I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL2ui64NV(GPVERTEXATTRIBL2UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2ui64vNV(GPVERTEXATTRIBL2UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL3d(GPVERTEXATTRIBL3D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z) {
 //   (*fnptr)(index, x, y, z);
 // }
 // static void  glowVertexAttribL3dv(GPVERTEXATTRIBL3DV fnptr, GLuint  index, const GLdouble * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3i64NV(GPVERTEXATTRIBL3I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3i64vNV(GPVERTEXATTRIBL3I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3ui64NV(GPVERTEXATTRIBL3UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3ui64vNV(GPVERTEXATTRIBL3UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL4d(GPVERTEXATTRIBL4D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
@@ -2861,8 +5040,23 @@ package gl
 // static void  glowVertexAttribL4dv(GPVERTEXATTRIBL4DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL4i64NV(GPVERTEXATTRIBL4I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4i64vNV(GPVERTEXATTRIBL4I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL4ui64NV(GPVERTEXATTRIBL4UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4ui64vNV(GPVERTEXATTRIBL4UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribLFormat(GPVERTEXATTRIBLFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexAttribLFormatNV(GPVERTEXATTRIBLFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
 // }
 // static void  glowVertexAttribLPointer(GPVERTEXATTRIBLPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
@@ -2897,6 +5091,9 @@ package gl
 // static void  glowVertexBindingDivisor(GPVERTEXBINDINGDIVISOR fnptr, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(bindingindex, divisor);
 // }
+// static void  glowVertexFormatNV(GPVERTEXFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
 // static void  glowViewport(GPVIEWPORT fnptr, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(x, y, width, height);
 // }
@@ -2909,8 +5106,23 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
+//   (*fnptr)(resultPath, numPaths, paths, weights);
+// }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
 // }
 import "C"
 import (
@@ -2919,10 +5131,12 @@ import (
 )
 
 const (
+	ACCUM_ADJACENT_PAIRS_NV                                    = 0x90AD
 	ACTIVE_ATOMIC_COUNTER_BUFFERS                              = 0x92D9
 	ACTIVE_ATTRIBUTES                                          = 0x8B89
 	ACTIVE_ATTRIBUTE_MAX_LENGTH                                = 0x8B8A
 	ACTIVE_PROGRAM                                             = 0x8259
+	ACTIVE_PROGRAM_EXT                                         = 0x8B8D
 	ACTIVE_RESOURCES                                           = 0x92F5
 	ACTIVE_SUBROUTINES                                         = 0x8DE5
 	ACTIVE_SUBROUTINE_MAX_LENGTH                               = 0x8E48
@@ -2935,10 +5149,15 @@ const (
 	ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH                       = 0x8A35
 	ACTIVE_UNIFORM_MAX_LENGTH                                  = 0x8B87
 	ACTIVE_VARIABLES                                           = 0x9305
+	ADJACENT_PAIRS_NV                                          = 0x90AE
+	AFFINE_2D_NV                                               = 0x9092
+	AFFINE_3D_NV                                               = 0x9094
 	ALIASED_LINE_WIDTH_RANGE                                   = 0x846E
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
+	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALPHA                                                      = 0x1906
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	AND                                                        = 0x1501
@@ -2946,6 +5165,7 @@ const (
 	AND_REVERSE                                                = 0x1502
 	ANY_SAMPLES_PASSED                                         = 0x8C2F
 	ANY_SAMPLES_PASSED_CONSERVATIVE                            = 0x8D6A
+	ARC_TO_NV                                                  = 0xFE
 	ARRAY_BUFFER                                               = 0x8892
 	ARRAY_BUFFER_BINDING                                       = 0x8894
 	ARRAY_SIZE                                                 = 0x92FB
@@ -2966,43 +5186,56 @@ const (
 	ATOMIC_COUNTER_BUFFER_SIZE                                 = 0x92C3
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	AUTO_GENERATE_MIPMAP                                       = 0x8295
 	BACK                                                       = 0x0405
 	BACK_LEFT                                                  = 0x0402
 	BACK_RIGHT                                                 = 0x0403
+	BEVEL_NV                                                   = 0x90A6
 	BGR                                                        = 0x80E0
 	BGRA                                                       = 0x80E1
 	BGRA_INTEGER                                               = 0x8D9B
 	BGR_INTEGER                                                = 0x8D9A
 	BLEND                                                      = 0x0BE2
+	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
+	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
 	BLEND_DST_RGB                                              = 0x80C8
 	BLEND_EQUATION                                             = 0x8009
 	BLEND_EQUATION_ALPHA                                       = 0x883D
 	BLEND_EQUATION_RGB                                         = 0x8009
+	BLEND_OVERLAP_NV                                           = 0x9281
+	BLEND_PREMULTIPLIED_SRC_NV                                 = 0x9280
 	BLEND_SRC                                                  = 0x0BE1
 	BLEND_SRC_ALPHA                                            = 0x80CB
 	BLEND_SRC_RGB                                              = 0x80C9
 	BLOCK_INDEX                                                = 0x92FD
 	BLUE                                                       = 0x1905
 	BLUE_INTEGER                                               = 0x8D96
+	BLUE_NV                                                    = 0x1905
+	BOLD_BIT_NV                                                = 0x01
 	BOOL                                                       = 0x8B56
 	BOOL_VEC2                                                  = 0x8B57
 	BOOL_VEC3                                                  = 0x8B58
 	BOOL_VEC4                                                  = 0x8B59
+	BOUNDING_BOX_NV                                            = 0x908D
+	BOUNDING_BOX_OF_BOUNDING_BOXES_NV                          = 0x909C
 	BUFFER                                                     = 0x82E0
 	BUFFER_ACCESS                                              = 0x88BB
 	BUFFER_ACCESS_FLAGS                                        = 0x911F
 	BUFFER_BINDING                                             = 0x9302
 	BUFFER_DATA_SIZE                                           = 0x9303
+	BUFFER_GPU_ADDRESS_NV                                      = 0x8F1D
 	BUFFER_IMMUTABLE_STORAGE                                   = 0x821F
 	BUFFER_KHR                                                 = 0x82E0
 	BUFFER_MAPPED                                              = 0x88BC
 	BUFFER_MAP_LENGTH                                          = 0x9120
 	BUFFER_MAP_OFFSET                                          = 0x9121
 	BUFFER_MAP_POINTER                                         = 0x88BD
+	BUFFER_OBJECT_EXT                                          = 0x9151
 	BUFFER_SIZE                                                = 0x8764
 	BUFFER_STORAGE_FLAGS                                       = 0x8220
 	BUFFER_UPDATE_BARRIER_BIT                                  = 0x00000200
@@ -3011,8 +5244,12 @@ const (
 	BYTE                                                       = 0x1400
 	CAVEAT_SUPPORT                                             = 0x82B8
 	CCW                                                        = 0x0901
+	CIRCULAR_CCW_ARC_TO_NV                                     = 0xF8
+	CIRCULAR_CW_ARC_TO_NV                                      = 0xFA
+	CIRCULAR_TANGENT_ARC_TO_NV                                 = 0xFC
 	CLAMP_READ_COLOR                                           = 0x891C
 	CLAMP_TO_BORDER                                            = 0x812D
+	CLAMP_TO_BORDER_ARB                                        = 0x812D
 	CLAMP_TO_EDGE                                              = 0x812F
 	CLEAR                                                      = 0x1500
 	CLEAR_BUFFER                                               = 0x82B4
@@ -3031,7 +5268,14 @@ const (
 	CLIP_DISTANCE6                                             = 0x3006
 	CLIP_DISTANCE7                                             = 0x3007
 	CLIP_ORIGIN                                                = 0x935C
+	CLOSE_PATH_NV                                              = 0x00
 	COLOR                                                      = 0x1800
+	COLORBURN_KHR                                              = 0x929A
+	COLORBURN_NV                                               = 0x929A
+	COLORDODGE_KHR                                             = 0x9299
+	COLORDODGE_NV                                              = 0x9299
+	COLOR_ARRAY_ADDRESS_NV                                     = 0x8F23
+	COLOR_ARRAY_LENGTH_NV                                      = 0x8F2D
 	COLOR_ATTACHMENT0                                          = 0x8CE0
 	COLOR_ATTACHMENT1                                          = 0x8CE1
 	COLOR_ATTACHMENT10                                         = 0x8CEA
@@ -3040,8 +5284,24 @@ const (
 	COLOR_ATTACHMENT13                                         = 0x8CED
 	COLOR_ATTACHMENT14                                         = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT5                                          = 0x8CE5
 	COLOR_ATTACHMENT6                                          = 0x8CE6
@@ -3054,11 +5314,14 @@ const (
 	COLOR_ENCODING                                             = 0x8296
 	COLOR_LOGIC_OP                                             = 0x0BF2
 	COLOR_RENDERABLE                                           = 0x8286
+	COLOR_SAMPLES_NV                                           = 0x8E20
 	COLOR_WRITEMASK                                            = 0x0C23
 	COMMAND_BARRIER_BIT                                        = 0x00000040
 	COMPARE_REF_TO_TEXTURE                                     = 0x884E
 	COMPATIBLE_SUBROUTINES                                     = 0x8E4B
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_R11_EAC                                         = 0x9270
 	COMPRESSED_RED                                             = 0x8225
 	COMPRESSED_RED_RGTC1                                       = 0x8DBB
@@ -3084,8 +5347,12 @@ const (
 	COMPRESSED_RGBA_ASTC_8x6_KHR                               = 0x93B6
 	COMPRESSED_RGBA_ASTC_8x8_KHR                               = 0x93B7
 	COMPRESSED_RGBA_BPTC_UNORM_ARB                             = 0x8E8C
+	COMPRESSED_RGBA_S3TC_DXT1_EXT                              = 0x83F1
+	COMPRESSED_RGBA_S3TC_DXT3_EXT                              = 0x83F2
+	COMPRESSED_RGBA_S3TC_DXT5_EXT                              = 0x83F3
 	COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB                       = 0x8E8E
 	COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB                     = 0x8E8F
+	COMPRESSED_RGB_S3TC_DXT1_EXT                               = 0x83F0
 	COMPRESSED_RG_RGTC2                                        = 0x8DBD
 	COMPRESSED_SIGNED_R11_EAC                                  = 0x9271
 	COMPRESSED_SIGNED_RED_RGTC1                                = 0x8DBC
@@ -3120,6 +5387,18 @@ const (
 	COMPUTE_TEXTURE                                            = 0x82A0
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
+	CONIC_CURVE_TO_NV                                          = 0x1A
+	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSTANT_ALPHA                                             = 0x8003
 	CONSTANT_COLOR                                             = 0x8001
 	CONTEXT_COMPATIBILITY_PROFILE_BIT                          = 0x00000002
@@ -3128,6 +5407,7 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
 	CONTEXT_LOST_KHR                                           = 0x0507
@@ -3138,18 +5418,28 @@ const (
 	CONTEXT_RELEASE_BEHAVIOR_KHR                               = 0x82FB
 	CONTEXT_ROBUST_ACCESS                                      = 0x90F3
 	CONTEXT_ROBUST_ACCESS_KHR                                  = 0x90F3
+	CONTRAST_NV                                                = 0x92A1
+	CONVEX_HULL_NV                                             = 0x908B
 	COPY                                                       = 0x1503
 	COPY_INVERTED                                              = 0x150C
 	COPY_READ_BUFFER                                           = 0x8F36
-	COPY_READ_BUFFER_BINDING                                   = 0x8F36
 	COPY_WRITE_BUFFER                                          = 0x8F37
-	COPY_WRITE_BUFFER_BINDING                                  = 0x8F37
+	COUNTER_RANGE_AMD                                          = 0x8BC1
+	COUNTER_TYPE_AMD                                           = 0x8BC0
+	COUNT_DOWN_NV                                              = 0x9089
+	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
+	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CULL_FACE                                                  = 0x0B44
 	CULL_FACE_MODE                                             = 0x0B45
 	CURRENT_PROGRAM                                            = 0x8B8D
 	CURRENT_QUERY                                              = 0x8865
 	CURRENT_VERTEX_ATTRIB                                      = 0x8626
 	CW                                                         = 0x0900
+	DARKEN_KHR                                                 = 0x9297
+	DARKEN_NV                                                  = 0x9297
 	DEBUG_CALLBACK_FUNCTION                                    = 0x8244
 	DEBUG_CALLBACK_FUNCTION_ARB                                = 0x8244
 	DEBUG_CALLBACK_FUNCTION_KHR                                = 0x8244
@@ -3222,6 +5512,7 @@ const (
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR                              = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_ARB                          = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_KHR                          = 0x824E
+	DECODE_EXT                                                 = 0x8A49
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DELETE_STATUS                                              = 0x8B80
@@ -3241,11 +5532,15 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
 	DEPTH_STENCIL_TEXTURE_MODE                                 = 0x90EA
 	DEPTH_TEST                                                 = 0x0B71
 	DEPTH_WRITEMASK                                            = 0x0B72
+	DIFFERENCE_KHR                                             = 0x929E
+	DIFFERENCE_NV                                              = 0x929E
+	DISJOINT_NV                                                = 0x9283
 	DISPATCH_INDIRECT_BUFFER                                   = 0x90EE
 	DISPATCH_INDIRECT_BUFFER_BINDING                           = 0x90EF
 	DITHER                                                     = 0x0BD0
@@ -3264,6 +5559,9 @@ const (
 	DOUBLE_VEC2                                                = 0x8FFC
 	DOUBLE_VEC3                                                = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER1                                               = 0x8826
@@ -3281,30 +5579,62 @@ const (
 	DRAW_BUFFER7                                               = 0x882C
 	DRAW_BUFFER8                                               = 0x882D
 	DRAW_BUFFER9                                               = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
+	DRAW_INDIRECT_ADDRESS_NV                                   = 0x8F41
 	DRAW_INDIRECT_BUFFER                                       = 0x8F3F
 	DRAW_INDIRECT_BUFFER_BINDING                               = 0x8F43
+	DRAW_INDIRECT_LENGTH_NV                                    = 0x8F42
+	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DST_ALPHA                                                  = 0x0304
+	DST_ATOP_NV                                                = 0x928F
 	DST_COLOR                                                  = 0x0306
+	DST_IN_NV                                                  = 0x928B
+	DST_NV                                                     = 0x9287
+	DST_OUT_NV                                                 = 0x928D
+	DST_OVER_NV                                                = 0x9289
+	DUP_FIRST_CUBIC_CURVE_TO_NV                                = 0xF2
+	DUP_LAST_CUBIC_CURVE_TO_NV                                 = 0xF4
 	DYNAMIC_COPY                                               = 0x88EA
 	DYNAMIC_DRAW                                               = 0x88E8
 	DYNAMIC_READ                                               = 0x88E9
 	DYNAMIC_STORAGE_BIT                                        = 0x0100
+	EDGE_FLAG_ARRAY_ADDRESS_NV                                 = 0x8F26
+	EDGE_FLAG_ARRAY_LENGTH_NV                                  = 0x8F30
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
+	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_BARRIER_BIT                                  = 0x00000002
 	ELEMENT_ARRAY_BUFFER                                       = 0x8893
 	ELEMENT_ARRAY_BUFFER_BINDING                               = 0x8895
+	ELEMENT_ARRAY_LENGTH_NV                                    = 0x8F33
+	ELEMENT_ARRAY_UNIFIED_NV                                   = 0x8F1F
 	EQUAL                                                      = 0x0202
 	EQUIV                                                      = 0x1509
+	EXCLUSION_KHR                                              = 0x92A0
+	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXTENSIONS                                                 = 0x1F03
+	FACTOR_MAX_AMD                                             = 0x901D
+	FACTOR_MIN_AMD                                             = 0x901C
 	FALSE                                                      = 0
 	FASTEST                                                    = 0x1101
+	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
+	FIRST_TO_REST_NV                                           = 0x90AF
 	FIRST_VERTEX_CONVENTION                                    = 0x8E4D
 	FIXED                                                      = 0x140C
 	FIXED_ONLY                                                 = 0x891D
 	FLOAT                                                      = 0x1406
+	FLOAT16_NV                                                 = 0x8FF8
+	FLOAT16_VEC2_NV                                            = 0x8FF9
+	FLOAT16_VEC3_NV                                            = 0x8FFA
+	FLOAT16_VEC4_NV                                            = 0x8FFB
 	FLOAT_32_UNSIGNED_INT_24_8_REV                             = 0x8DAD
 	FLOAT_MAT2                                                 = 0x8B5A
 	FLOAT_MAT2x3                                               = 0x8B65
@@ -3318,12 +5648,37 @@ const (
 	FLOAT_VEC2                                                 = 0x8B50
 	FLOAT_VEC3                                                 = 0x8B51
 	FLOAT_VEC4                                                 = 0x8B52
+	FOG_COORD_ARRAY_ADDRESS_NV                                 = 0x8F28
+	FOG_COORD_ARRAY_LENGTH_NV                                  = 0x8F32
+	FONT_ASCENDER_BIT_NV                                       = 0x00200000
+	FONT_DESCENDER_BIT_NV                                      = 0x00400000
+	FONT_GLYPHS_AVAILABLE_NV                                   = 0x9368
+	FONT_HAS_KERNING_BIT_NV                                    = 0x10000000
+	FONT_HEIGHT_BIT_NV                                         = 0x00800000
+	FONT_MAX_ADVANCE_HEIGHT_BIT_NV                             = 0x02000000
+	FONT_MAX_ADVANCE_WIDTH_BIT_NV                              = 0x01000000
+	FONT_NUM_GLYPH_INDICES_BIT_NV                              = 0x20000000
+	FONT_TARGET_UNAVAILABLE_NV                                 = 0x9369
+	FONT_UNAVAILABLE_NV                                        = 0x936A
+	FONT_UNDERLINE_POSITION_BIT_NV                             = 0x04000000
+	FONT_UNDERLINE_THICKNESS_BIT_NV                            = 0x08000000
+	FONT_UNINTELLIGIBLE_NV                                     = 0x936B
+	FONT_UNITS_PER_EM_BIT_NV                                   = 0x00100000
+	FONT_X_MAX_BOUNDS_BIT_NV                                   = 0x00040000
+	FONT_X_MIN_BOUNDS_BIT_NV                                   = 0x00010000
+	FONT_Y_MAX_BOUNDS_BIT_NV                                   = 0x00080000
+	FONT_Y_MIN_BOUNDS_BIT_NV                                   = 0x00020000
 	FRACTIONAL_EVEN                                            = 0x8E7C
 	FRACTIONAL_ODD                                             = 0x8E7B
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
+	FRAGMENT_INPUT_NV                                          = 0x936D
 	FRAGMENT_INTERPOLATION_OFFSET_BITS                         = 0x8E5D
 	FRAGMENT_SHADER                                            = 0x8B30
 	FRAGMENT_SHADER_BIT                                        = 0x00000002
+	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -3336,13 +5691,16 @@ const (
 	FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE                          = 0x8216
 	FRAMEBUFFER_ATTACHMENT_GREEN_SIZE                          = 0x8213
 	FRAMEBUFFER_ATTACHMENT_LAYERED                             = 0x8DA7
+	FRAMEBUFFER_ATTACHMENT_LAYERED_ARB                         = 0x8DA7
 	FRAMEBUFFER_ATTACHMENT_OBJECT_NAME                         = 0x8CD1
 	FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE                         = 0x8CD0
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
 	FRAMEBUFFER_BLEND                                          = 0x828B
@@ -3355,18 +5713,26 @@ const (
 	FRAMEBUFFER_DEFAULT_WIDTH                                  = 0x9310
 	FRAMEBUFFER_INCOMPLETE_ATTACHMENT                          = 0x8CD6
 	FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER                         = 0x8CDB
+	FRAMEBUFFER_INCOMPLETE_LAYER_COUNT_ARB                     = 0x8DA9
 	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS                       = 0x8DA8
+	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS_ARB                   = 0x8DA8
 	FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT                  = 0x8CD7
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE                         = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_UNDEFINED                                      = 0x8219
 	FRAMEBUFFER_UNSUPPORTED                                    = 0x8CDD
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_SUPPORT                                               = 0x82B7
@@ -3374,8 +5740,11 @@ const (
 	FUNC_REVERSE_SUBTRACT                                      = 0x800B
 	FUNC_SUBTRACT                                              = 0x800A
 	GEOMETRY_INPUT_TYPE                                        = 0x8917
+	GEOMETRY_INPUT_TYPE_ARB                                    = 0x8DDB
 	GEOMETRY_OUTPUT_TYPE                                       = 0x8918
+	GEOMETRY_OUTPUT_TYPE_ARB                                   = 0x8DDC
 	GEOMETRY_SHADER                                            = 0x8DD9
+	GEOMETRY_SHADER_ARB                                        = 0x8DD9
 	GEOMETRY_SHADER_BIT                                        = 0x00000004
 	GEOMETRY_SHADER_INVOCATIONS                                = 0x887F
 	GEOMETRY_SHADER_PRIMITIVES_EMITTED_ARB                     = 0x82F3
@@ -3383,18 +5752,42 @@ const (
 	GEOMETRY_SUBROUTINE_UNIFORM                                = 0x92F1
 	GEOMETRY_TEXTURE                                           = 0x829E
 	GEOMETRY_VERTICES_OUT                                      = 0x8916
+	GEOMETRY_VERTICES_OUT_ARB                                  = 0x8DDA
 	GEQUAL                                                     = 0x0206
 	GET_TEXTURE_IMAGE_FORMAT                                   = 0x8291
 	GET_TEXTURE_IMAGE_TYPE                                     = 0x8292
+	GLYPH_HAS_KERNING_BIT_NV                                   = 0x100
+	GLYPH_HEIGHT_BIT_NV                                        = 0x02
+	GLYPH_HORIZONTAL_BEARING_ADVANCE_BIT_NV                    = 0x10
+	GLYPH_HORIZONTAL_BEARING_X_BIT_NV                          = 0x04
+	GLYPH_HORIZONTAL_BEARING_Y_BIT_NV                          = 0x08
+	GLYPH_VERTICAL_BEARING_ADVANCE_BIT_NV                      = 0x80
+	GLYPH_VERTICAL_BEARING_X_BIT_NV                            = 0x20
+	GLYPH_VERTICAL_BEARING_Y_BIT_NV                            = 0x40
+	GLYPH_WIDTH_BIT_NV                                         = 0x01
+	GPU_ADDRESS_NV                                             = 0x8F34
 	GREATER                                                    = 0x0204
 	GREEN                                                      = 0x1904
 	GREEN_INTEGER                                              = 0x8D95
+	GREEN_NV                                                   = 0x1904
 	GUILTY_CONTEXT_RESET                                       = 0x8253
 	GUILTY_CONTEXT_RESET_ARB                                   = 0x8253
 	GUILTY_CONTEXT_RESET_KHR                                   = 0x8253
 	HALF_FLOAT                                                 = 0x140B
+	HARDLIGHT_KHR                                              = 0x929B
+	HARDLIGHT_NV                                               = 0x929B
+	HARDMIX_NV                                                 = 0x92A9
 	HIGH_FLOAT                                                 = 0x8DF2
 	HIGH_INT                                                   = 0x8DF5
+	HORIZONTAL_LINE_TO_NV                                      = 0x06
+	HSL_COLOR_KHR                                              = 0x92AF
+	HSL_COLOR_NV                                               = 0x92AF
+	HSL_HUE_KHR                                                = 0x92AD
+	HSL_HUE_NV                                                 = 0x92AD
+	HSL_LUMINOSITY_KHR                                         = 0x92B0
+	HSL_LUMINOSITY_NV                                          = 0x92B0
+	HSL_SATURATION_KHR                                         = 0x92AE
+	HSL_SATURATION_NV                                          = 0x92AE
 	IMAGE_1D                                                   = 0x904C
 	IMAGE_1D_ARRAY                                             = 0x9052
 	IMAGE_2D                                                   = 0x904D
@@ -3432,13 +5825,32 @@ const (
 	IMAGE_TEXEL_SIZE                                           = 0x82A7
 	IMPLEMENTATION_COLOR_READ_FORMAT                           = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
+	INDEX_ARRAY_ADDRESS_NV                                     = 0x8F24
+	INDEX_ARRAY_LENGTH_NV                                      = 0x8F2E
 	INFO_LOG_LENGTH                                            = 0x8B84
 	INNOCENT_CONTEXT_RESET                                     = 0x8254
 	INNOCENT_CONTEXT_RESET_ARB                                 = 0x8254
 	INNOCENT_CONTEXT_RESET_KHR                                 = 0x8254
 	INT                                                        = 0x1404
+	INT16_NV                                                   = 0x8FE4
+	INT16_VEC2_NV                                              = 0x8FE5
+	INT16_VEC3_NV                                              = 0x8FE6
+	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
+	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
+	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
+	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
+	INT64_VEC4_NV                                              = 0x8FEB
+	INT8_NV                                                    = 0x8FE0
+	INT8_VEC2_NV                                               = 0x8FE1
+	INT8_VEC3_NV                                               = 0x8FE2
+	INT8_VEC4_NV                                               = 0x8FE3
 	INTERLEAVED_ATTRIBS                                        = 0x8C8C
 	INTERNALFORMAT_ALPHA_SIZE                                  = 0x8274
 	INTERNALFORMAT_ALPHA_TYPE                                  = 0x827B
@@ -3487,27 +5899,41 @@ const (
 	INVALID_OPERATION                                          = 0x0502
 	INVALID_VALUE                                              = 0x0501
 	INVERT                                                     = 0x150A
+	INVERT_OVG_NV                                              = 0x92B4
+	INVERT_RGB_NV                                              = 0x92A3
 	ISOLINES                                                   = 0x8E7A
 	IS_PER_PATCH                                               = 0x92E7
 	IS_ROW_MAJOR                                               = 0x9300
+	ITALIC_BIT_NV                                              = 0x02
 	KEEP                                                       = 0x1E00
+	LARGE_CCW_ARC_TO_NV                                        = 0x16
+	LARGE_CW_ARC_TO_NV                                         = 0x18
 	LAST_VERTEX_CONVENTION                                     = 0x8E4E
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LESS                                                       = 0x0201
+	LIGHTEN_KHR                                                = 0x9298
+	LIGHTEN_NV                                                 = 0x9298
 	LINE                                                       = 0x1B01
 	LINEAR                                                     = 0x2601
+	LINEARBURN_NV                                              = 0x92A5
+	LINEARDODGE_NV                                             = 0x92A4
+	LINEARLIGHT_NV                                             = 0x92A7
 	LINEAR_MIPMAP_LINEAR                                       = 0x2703
 	LINEAR_MIPMAP_NEAREST                                      = 0x2701
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
+	LINES_ADJACENCY_ARB                                        = 0x000A
 	LINE_LOOP                                                  = 0x0002
 	LINE_SMOOTH                                                = 0x0B20
 	LINE_SMOOTH_HINT                                           = 0x0C52
 	LINE_STRIP                                                 = 0x0003
 	LINE_STRIP_ADJACENCY                                       = 0x000B
+	LINE_STRIP_ADJACENCY_ARB                                   = 0x000B
+	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -3607,12 +6033,17 @@ const (
 	MAX_GEOMETRY_INPUT_COMPONENTS                              = 0x9123
 	MAX_GEOMETRY_OUTPUT_COMPONENTS                             = 0x9124
 	MAX_GEOMETRY_OUTPUT_VERTICES                               = 0x8DE0
+	MAX_GEOMETRY_OUTPUT_VERTICES_ARB                           = 0x8DE0
 	MAX_GEOMETRY_SHADER_INVOCATIONS                            = 0x8E5A
 	MAX_GEOMETRY_SHADER_STORAGE_BLOCKS                         = 0x90D7
 	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS                           = 0x8C29
+	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS_ARB                       = 0x8C29
 	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS                       = 0x8DE1
+	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS_ARB                   = 0x8DE1
 	MAX_GEOMETRY_UNIFORM_BLOCKS                                = 0x8A2C
 	MAX_GEOMETRY_UNIFORM_COMPONENTS                            = 0x8DDF
+	MAX_GEOMETRY_UNIFORM_COMPONENTS_ARB                        = 0x8DDF
+	MAX_GEOMETRY_VARYING_COMPONENTS_ARB                        = 0x8DDD
 	MAX_HEIGHT                                                 = 0x827F
 	MAX_IMAGE_SAMPLES                                          = 0x906D
 	MAX_IMAGE_UNITS                                            = 0x8F38
@@ -3620,6 +6051,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_MULTISAMPLE_COVERAGE_MODES_NV                          = 0x8E11
 	MAX_NAME_LENGTH                                            = 0x92F6
 	MAX_NUM_ACTIVE_VARIABLES                                   = 0x92F7
 	MAX_NUM_COMPATIBLE_SUBROUTINES                             = 0x92F8
@@ -3627,16 +6059,21 @@ const (
 	MAX_PROGRAM_TEXEL_OFFSET                                   = 0x8905
 	MAX_PROGRAM_TEXTURE_GATHER_COMPONENTS_ARB                  = 0x8F9F
 	MAX_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5F
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RENDERBUFFER_SIZE                                      = 0x84E8
 	MAX_SAMPLES                                                = 0x8D57
 	MAX_SAMPLE_MASK_WORDS                                      = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
+	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SPARSE_3D_TEXTURE_SIZE_ARB                             = 0x9199
 	MAX_SPARSE_ARRAY_TEXTURE_LAYERS_ARB                        = 0x919A
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -3661,8 +6098,10 @@ const (
 	MAX_TESS_GEN_LEVEL                                         = 0x8E7E
 	MAX_TESS_PATCH_COMPONENTS                                  = 0x8E84
 	MAX_TEXTURE_BUFFER_SIZE                                    = 0x8C2B
+	MAX_TEXTURE_BUFFER_SIZE_ARB                                = 0x8C2B
 	MAX_TEXTURE_IMAGE_UNITS                                    = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TRANSFORM_FEEDBACK_BUFFERS                             = 0x8E70
 	MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS              = 0x8C8A
@@ -3687,23 +6126,42 @@ const (
 	MAX_VERTEX_UNIFORM_BLOCKS                                  = 0x8A2B
 	MAX_VERTEX_UNIFORM_COMPONENTS                              = 0x8B4A
 	MAX_VERTEX_UNIFORM_VECTORS                                 = 0x8DFB
+	MAX_VERTEX_VARYING_COMPONENTS_ARB                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
 	MINOR_VERSION                                              = 0x821C
+	MINUS_CLAMPED_NV                                           = 0x92B3
+	MINUS_NV                                                   = 0x929F
 	MIN_FRAGMENT_INTERPOLATION_OFFSET                          = 0x8E5B
 	MIN_MAP_BUFFER_ALIGNMENT                                   = 0x90BC
 	MIN_PROGRAM_TEXEL_OFFSET                                   = 0x8904
 	MIN_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5E
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
+	MIRRORED_REPEAT_ARB                                        = 0x8370
 	MIRROR_CLAMP_TO_EDGE                                       = 0x8743
+	MITER_REVERT_NV                                            = 0x90A7
+	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
+	MOVE_TO_CONTINUES_NV                                       = 0x90B6
+	MOVE_TO_NV                                                 = 0x02
+	MOVE_TO_RESETS_NV                                          = 0x90B5
+	MULTIPLY_KHR                                               = 0x9294
+	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
+	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	NAMED_STRING_LENGTH_ARB                                    = 0x8DE9
 	NAMED_STRING_TYPE_ARB                                      = 0x8DEA
 	NAME_LENGTH                                                = 0x92F9
@@ -3716,7 +6174,10 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
+	NORMAL_ARRAY_ADDRESS_NV                                    = 0x8F22
+	NORMAL_ARRAY_LENGTH_NV                                     = 0x8F2C
 	NOTEQUAL                                                   = 0x0205
 	NO_ERROR                                                   = 0
 	NO_RESET_NOTIFICATION                                      = 0x8261
@@ -3729,7 +6190,10 @@ const (
 	NUM_PROGRAM_BINARY_FORMATS                                 = 0x87FE
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_TYPE                                                = 0x9112
 	OFFSET                                                     = 0x92FC
 	ONE                                                        = 1
@@ -3745,6 +6209,8 @@ const (
 	OR_INVERTED                                                = 0x150D
 	OR_REVERSE                                                 = 0x150B
 	OUT_OF_MEMORY                                              = 0x0505
+	OVERLAY_KHR                                                = 0x9296
+	OVERLAY_NV                                                 = 0x9296
 	PACK_ALIGNMENT                                             = 0x0D05
 	PACK_COMPRESSED_BLOCK_DEPTH                                = 0x912D
 	PACK_COMPRESSED_BLOCK_HEIGHT                               = 0x912C
@@ -3763,11 +6229,90 @@ const (
 	PATCH_DEFAULT_INNER_LEVEL                                  = 0x8E73
 	PATCH_DEFAULT_OUTER_LEVEL                                  = 0x8E74
 	PATCH_VERTICES                                             = 0x8E72
+	PATH_CLIENT_LENGTH_NV                                      = 0x907F
+	PATH_COMMAND_COUNT_NV                                      = 0x909D
+	PATH_COMPUTED_LENGTH_NV                                    = 0x90A0
+	PATH_COORD_COUNT_NV                                        = 0x909E
+	PATH_COVER_DEPTH_FUNC_NV                                   = 0x90BF
+	PATH_DASH_ARRAY_COUNT_NV                                   = 0x909F
+	PATH_DASH_CAPS_NV                                          = 0x907B
+	PATH_DASH_OFFSET_NV                                        = 0x907E
+	PATH_DASH_OFFSET_RESET_NV                                  = 0x90B4
+	PATH_END_CAPS_NV                                           = 0x9076
+	PATH_ERROR_POSITION_NV                                     = 0x90AB
+	PATH_FILL_BOUNDING_BOX_NV                                  = 0x90A1
+	PATH_FILL_COVER_MODE_NV                                    = 0x9082
+	PATH_FILL_MASK_NV                                          = 0x9081
+	PATH_FILL_MODE_NV                                          = 0x9080
+	PATH_FORMAT_PS_NV                                          = 0x9071
+	PATH_FORMAT_SVG_NV                                         = 0x9070
+	PATH_GEN_COEFF_NV                                          = 0x90B1
+	PATH_GEN_COMPONENTS_NV                                     = 0x90B3
+	PATH_GEN_MODE_NV                                           = 0x90B0
+	PATH_INITIAL_DASH_CAP_NV                                   = 0x907C
+	PATH_INITIAL_END_CAP_NV                                    = 0x9077
+	PATH_JOIN_STYLE_NV                                         = 0x9079
+	PATH_MAX_MODELVIEW_STACK_DEPTH_NV                          = 0x0D36
+	PATH_MAX_PROJECTION_STACK_DEPTH_NV                         = 0x0D38
+	PATH_MITER_LIMIT_NV                                        = 0x907A
+	PATH_MODELVIEW_MATRIX_NV                                   = 0x0BA6
+	PATH_MODELVIEW_NV                                          = 0x1700
+	PATH_MODELVIEW_STACK_DEPTH_NV                              = 0x0BA3
+	PATH_OBJECT_BOUNDING_BOX_NV                                = 0x908A
+	PATH_PROJECTION_MATRIX_NV                                  = 0x0BA7
+	PATH_PROJECTION_NV                                         = 0x1701
+	PATH_PROJECTION_STACK_DEPTH_NV                             = 0x0BA4
+	PATH_STENCIL_DEPTH_OFFSET_FACTOR_NV                        = 0x90BD
+	PATH_STENCIL_DEPTH_OFFSET_UNITS_NV                         = 0x90BE
+	PATH_STENCIL_FUNC_NV                                       = 0x90B7
+	PATH_STENCIL_REF_NV                                        = 0x90B8
+	PATH_STENCIL_VALUE_MASK_NV                                 = 0x90B9
+	PATH_STROKE_BOUNDING_BOX_NV                                = 0x90A2
+	PATH_STROKE_COVER_MODE_NV                                  = 0x9083
+	PATH_STROKE_MASK_NV                                        = 0x9084
+	PATH_STROKE_WIDTH_NV                                       = 0x9075
+	PATH_TERMINAL_DASH_CAP_NV                                  = 0x907D
+	PATH_TERMINAL_END_CAP_NV                                   = 0x9078
+	PATH_TRANSPOSE_MODELVIEW_MATRIX_NV                         = 0x84E3
+	PATH_TRANSPOSE_PROJECTION_MATRIX_NV                        = 0x84E4
+	PERCENTAGE_AMD                                             = 0x8BC3
+	PERFMON_RESULT_AMD                                         = 0x8BC6
+	PERFMON_RESULT_AVAILABLE_AMD                               = 0x8BC4
+	PERFMON_RESULT_SIZE_AMD                                    = 0x8BC5
+	PERFQUERY_COUNTER_DATA_BOOL32_INTEL                        = 0x94FC
+	PERFQUERY_COUNTER_DATA_DOUBLE_INTEL                        = 0x94FB
+	PERFQUERY_COUNTER_DATA_FLOAT_INTEL                         = 0x94FA
+	PERFQUERY_COUNTER_DATA_UINT32_INTEL                        = 0x94F8
+	PERFQUERY_COUNTER_DATA_UINT64_INTEL                        = 0x94F9
+	PERFQUERY_COUNTER_DESC_LENGTH_MAX_INTEL                    = 0x94FF
+	PERFQUERY_COUNTER_DURATION_NORM_INTEL                      = 0x94F1
+	PERFQUERY_COUNTER_DURATION_RAW_INTEL                       = 0x94F2
+	PERFQUERY_COUNTER_EVENT_INTEL                              = 0x94F0
+	PERFQUERY_COUNTER_NAME_LENGTH_MAX_INTEL                    = 0x94FE
+	PERFQUERY_COUNTER_RAW_INTEL                                = 0x94F4
+	PERFQUERY_COUNTER_THROUGHPUT_INTEL                         = 0x94F3
+	PERFQUERY_COUNTER_TIMESTAMP_INTEL                          = 0x94F5
+	PERFQUERY_DONOT_FLUSH_INTEL                                = 0x83F9
+	PERFQUERY_FLUSH_INTEL                                      = 0x83FA
+	PERFQUERY_GLOBAL_CONTEXT_INTEL                             = 0x00000001
+	PERFQUERY_GPA_EXTENDED_COUNTERS_INTEL                      = 0x9500
+	PERFQUERY_QUERY_NAME_LENGTH_MAX_INTEL                      = 0x94FD
+	PERFQUERY_SINGLE_CONTEXT_INTEL                             = 0x00000000
+	PERFQUERY_WAIT_INTEL                                       = 0x83FB
+	PINLIGHT_NV                                                = 0x92A8
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_PACK_BUFFER                                          = 0x88EB
+	PIXEL_PACK_BUFFER_ARB                                      = 0x88EB
 	PIXEL_PACK_BUFFER_BINDING                                  = 0x88ED
+	PIXEL_PACK_BUFFER_BINDING_ARB                              = 0x88ED
 	PIXEL_UNPACK_BUFFER                                        = 0x88EC
+	PIXEL_UNPACK_BUFFER_ARB                                    = 0x88EC
 	PIXEL_UNPACK_BUFFER_BINDING                                = 0x88EF
+	PIXEL_UNPACK_BUFFER_BINDING_ARB                            = 0x88EF
+	PLUS_CLAMPED_ALPHA_NV                                      = 0x92B2
+	PLUS_CLAMPED_NV                                            = 0x92B1
+	PLUS_DARKER_NV                                             = 0x9292
+	PLUS_NV                                                    = 0x9291
 	POINT                                                      = 0x1B00
 	POINTS                                                     = 0x0000
 	POINT_FADE_THRESHOLD_SIZE                                  = 0x8128
@@ -3776,6 +6321,9 @@ const (
 	POINT_SIZE_RANGE                                           = 0x0B12
 	POINT_SPRITE_COORD_ORIGIN                                  = 0x8CA0
 	POLYGON_MODE                                               = 0x0B40
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FILL                                        = 0x8037
 	POLYGON_OFFSET_LINE                                        = 0x2A02
@@ -3785,20 +6333,33 @@ const (
 	POLYGON_SMOOTH_HINT                                        = 0x0C53
 	PRIMITIVES_GENERATED                                       = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
 	PRIMITIVE_RESTART_INDEX                                    = 0x8F9E
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_INPUT                                              = 0x92E3
 	PROGRAM_KHR                                                = 0x82E2
+	PROGRAM_MATRIX_EXT                                         = 0x8E2D
+	PROGRAM_MATRIX_STACK_DEPTH_EXT                             = 0x8E2F
+	PROGRAM_OBJECT_EXT                                         = 0x8B40
 	PROGRAM_OUTPUT                                             = 0x92E4
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
+	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
+	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
+	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
 	PROGRAM_SEPARABLE                                          = 0x8258
+	PROGRAM_SEPARABLE_EXT                                      = 0x8258
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROXY_TEXTURE_1D                                           = 0x8063
 	PROXY_TEXTURE_1D_ARRAY                                     = 0x8C19
@@ -3810,6 +6371,7 @@ const (
 	PROXY_TEXTURE_CUBE_MAP                                     = 0x851B
 	PROXY_TEXTURE_CUBE_MAP_ARRAY_ARB                           = 0x900B
 	PROXY_TEXTURE_RECTANGLE                                    = 0x84F7
+	QUADRATIC_CURVE_TO_NV                                      = 0x0A
 	QUADS                                                      = 0x0007
 	QUADS_FOLLOW_PROVOKING_VERTEX_CONVENTION                   = 0x8E4C
 	QUERY                                                      = 0x82E3
@@ -3818,18 +6380,23 @@ const (
 	QUERY_BUFFER_BINDING                                       = 0x9193
 	QUERY_BY_REGION_NO_WAIT                                    = 0x8E16
 	QUERY_BY_REGION_NO_WAIT_INVERTED                           = 0x8E1A
+	QUERY_BY_REGION_NO_WAIT_NV                                 = 0x8E16
 	QUERY_BY_REGION_WAIT                                       = 0x8E15
 	QUERY_BY_REGION_WAIT_INVERTED                              = 0x8E19
+	QUERY_BY_REGION_WAIT_NV                                    = 0x8E15
 	QUERY_COUNTER_BITS                                         = 0x8864
 	QUERY_KHR                                                  = 0x82E3
 	QUERY_NO_WAIT                                              = 0x8E14
 	QUERY_NO_WAIT_INVERTED                                     = 0x8E18
+	QUERY_NO_WAIT_NV                                           = 0x8E14
+	QUERY_OBJECT_EXT                                           = 0x9153
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
 	QUERY_RESULT_NO_WAIT                                       = 0x9194
 	QUERY_TARGET                                               = 0x82EA
 	QUERY_WAIT                                                 = 0x8E13
 	QUERY_WAIT_INVERTED                                        = 0x8E17
+	QUERY_WAIT_NV                                              = 0x8E13
 	R11F_G11F_B10F                                             = 0x8C3A
 	R16                                                        = 0x822A
 	R16F                                                       = 0x822D
@@ -3845,6 +6412,9 @@ const (
 	R8UI                                                       = 0x8232
 	R8_SNORM                                                   = 0x8F94
 	RASTERIZER_DISCARD                                         = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -3853,18 +6423,41 @@ const (
 	READ_PIXELS_FORMAT                                         = 0x828D
 	READ_PIXELS_TYPE                                           = 0x828E
 	READ_WRITE                                                 = 0x88BA
+	RECT_NV                                                    = 0xF6
 	RED                                                        = 0x1903
 	RED_INTEGER                                                = 0x8D94
+	RED_NV                                                     = 0x1903
 	REFERENCED_BY_COMPUTE_SHADER                               = 0x930B
 	REFERENCED_BY_FRAGMENT_SHADER                              = 0x930A
 	REFERENCED_BY_GEOMETRY_SHADER                              = 0x9309
 	REFERENCED_BY_TESS_CONTROL_SHADER                          = 0x9307
 	REFERENCED_BY_TESS_EVALUATION_SHADER                       = 0x9308
 	REFERENCED_BY_VERTEX_SHADER                                = 0x9306
+	RELATIVE_ARC_TO_NV                                         = 0xFF
+	RELATIVE_CONIC_CURVE_TO_NV                                 = 0x1B
+	RELATIVE_CUBIC_CURVE_TO_NV                                 = 0x0D
+	RELATIVE_HORIZONTAL_LINE_TO_NV                             = 0x07
+	RELATIVE_LARGE_CCW_ARC_TO_NV                               = 0x17
+	RELATIVE_LARGE_CW_ARC_TO_NV                                = 0x19
+	RELATIVE_LINE_TO_NV                                        = 0x05
+	RELATIVE_MOVE_TO_NV                                        = 0x03
+	RELATIVE_QUADRATIC_CURVE_TO_NV                             = 0x0B
+	RELATIVE_RECT_NV                                           = 0xF7
+	RELATIVE_ROUNDED_RECT2_NV                                  = 0xEB
+	RELATIVE_ROUNDED_RECT4_NV                                  = 0xED
+	RELATIVE_ROUNDED_RECT8_NV                                  = 0xEF
+	RELATIVE_ROUNDED_RECT_NV                                   = 0xE9
+	RELATIVE_SMALL_CCW_ARC_TO_NV                               = 0x13
+	RELATIVE_SMALL_CW_ARC_TO_NV                                = 0x15
+	RELATIVE_SMOOTH_CUBIC_CURVE_TO_NV                          = 0x11
+	RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV                      = 0x0F
+	RELATIVE_VERTICAL_LINE_TO_NV                               = 0x09
 	RENDERBUFFER                                               = 0x8D41
 	RENDERBUFFER_ALPHA_SIZE                                    = 0x8D53
 	RENDERBUFFER_BINDING                                       = 0x8CA7
 	RENDERBUFFER_BLUE_SIZE                                     = 0x8D52
+	RENDERBUFFER_COLOR_SAMPLES_NV                              = 0x8E10
+	RENDERBUFFER_COVERAGE_SAMPLES_NV                           = 0x8CAB
 	RENDERBUFFER_DEPTH_SIZE                                    = 0x8D54
 	RENDERBUFFER_GREEN_SIZE                                    = 0x8D51
 	RENDERBUFFER_HEIGHT                                        = 0x8D43
@@ -3879,6 +6472,7 @@ const (
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
 	RESET_NOTIFICATION_STRATEGY_ARB                            = 0x8256
 	RESET_NOTIFICATION_STRATEGY_KHR                            = 0x8256
+	RESTART_PATH_NV                                            = 0xF0
 	RG                                                         = 0x8227
 	RG16                                                       = 0x822C
 	RG16F                                                      = 0x822F
@@ -3931,9 +6525,16 @@ const (
 	RGBA8UI                                                    = 0x8D7C
 	RGBA8_SNORM                                                = 0x8F97
 	RGBA_INTEGER                                               = 0x8D99
+	RGB_422_APPLE                                              = 0x8A1F
 	RGB_INTEGER                                                = 0x8D98
+	RGB_RAW_422_APPLE                                          = 0x8A51
 	RG_INTEGER                                                 = 0x8228
 	RIGHT                                                      = 0x0407
+	ROUNDED_RECT2_NV                                           = 0xEA
+	ROUNDED_RECT4_NV                                           = 0xEC
+	ROUNDED_RECT8_NV                                           = 0xEE
+	ROUNDED_RECT_NV                                            = 0xE8
+	ROUND_NV                                                   = 0x90A4
 	SAMPLER                                                    = 0x82E6
 	SAMPLER_1D                                                 = 0x8B5D
 	SAMPLER_1D_ARRAY                                           = 0x8DC0
@@ -3963,23 +6564,39 @@ const (
 	SAMPLE_COVERAGE                                            = 0x80A0
 	SAMPLE_COVERAGE_INVERT                                     = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_VALUE                                          = 0x8E52
 	SAMPLE_POSITION                                            = 0x8E50
 	SAMPLE_SHADING_ARB                                         = 0x8C36
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
+	SCREEN_KHR                                                 = 0x9295
+	SCREEN_NV                                                  = 0x9295
+	SECONDARY_COLOR_ARRAY_ADDRESS_NV                           = 0x8F27
+	SECONDARY_COLOR_ARRAY_LENGTH_NV                            = 0x8F31
 	SEPARATE_ATTRIBS                                           = 0x8C8D
 	SET                                                        = 0x150F
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
+	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
 	SHADER_IMAGE_ACCESS_BARRIER_BIT                            = 0x00000020
 	SHADER_IMAGE_ATOMIC                                        = 0x82A6
 	SHADER_IMAGE_LOAD                                          = 0x82A4
 	SHADER_IMAGE_STORE                                         = 0x82A5
 	SHADER_INCLUDE_ARB                                         = 0x8DAE
 	SHADER_KHR                                                 = 0x82E1
+	SHADER_OBJECT_EXT                                          = 0x8B48
 	SHADER_SOURCE_LENGTH                                       = 0x8B88
 	SHADER_STORAGE_BARRIER_BIT                                 = 0x00002000
 	SHADER_STORAGE_BLOCK                                       = 0x92E6
@@ -3990,6 +6607,7 @@ const (
 	SHADER_STORAGE_BUFFER_START                                = 0x90D4
 	SHADER_TYPE                                                = 0x8B4F
 	SHADING_LANGUAGE_VERSION                                   = 0x8B8C
+	SHARED_EDGE_NV                                             = 0xC0
 	SHORT                                                      = 0x1402
 	SIGNALED                                                   = 0x9119
 	SIGNED_NORMALIZED                                          = 0x8F9C
@@ -3997,18 +6615,35 @@ const (
 	SIMULTANEOUS_TEXTURE_AND_DEPTH_WRITE                       = 0x82AE
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_TEST                      = 0x82AD
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_WRITE                     = 0x82AF
+	SKIP_DECODE_EXT                                            = 0x8A4A
+	SKIP_MISSING_GLYPH_NV                                      = 0x90A9
+	SMALL_CCW_ARC_TO_NV                                        = 0x12
+	SMALL_CW_ARC_TO_NV                                         = 0x14
+	SMOOTH_CUBIC_CURVE_TO_NV                                   = 0x10
 	SMOOTH_LINE_WIDTH_GRANULARITY                              = 0x0B23
 	SMOOTH_LINE_WIDTH_RANGE                                    = 0x0B22
 	SMOOTH_POINT_SIZE_GRANULARITY                              = 0x0B13
 	SMOOTH_POINT_SIZE_RANGE                                    = 0x0B12
+	SMOOTH_QUADRATIC_CURVE_TO_NV                               = 0x0E
+	SM_COUNT_NV                                                = 0x933B
+	SOFTLIGHT_KHR                                              = 0x929C
+	SOFTLIGHT_NV                                               = 0x929C
 	SPARSE_BUFFER_PAGE_SIZE_ARB                                = 0x82F8
 	SPARSE_STORAGE_BIT_ARB                                     = 0x0400
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
+	SQUARE_NV                                                  = 0x90A3
 	SRC1_ALPHA                                                 = 0x8589
 	SRC1_COLOR                                                 = 0x88F9
 	SRC_ALPHA                                                  = 0x0302
 	SRC_ALPHA_SATURATE                                         = 0x0308
+	SRC_ATOP_NV                                                = 0x928E
 	SRC_COLOR                                                  = 0x0300
+	SRC_IN_NV                                                  = 0x928A
+	SRC_NV                                                     = 0x9286
+	SRC_OUT_NV                                                 = 0x928C
+	SRC_OVER_NV                                                = 0x9288
 	SRGB                                                       = 0x8C40
 	SRGB8                                                      = 0x8C41
 	SRGB8_ALPHA8                                               = 0x8C43
@@ -4020,6 +6655,8 @@ const (
 	STACK_OVERFLOW_KHR                                         = 0x0503
 	STACK_UNDERFLOW                                            = 0x0504
 	STACK_UNDERFLOW_KHR                                        = 0x0504
+	STANDARD_FONT_FORMAT_NV                                    = 0x936C
+	STANDARD_FONT_NAME_NV                                      = 0x9072
 	STATIC_COPY                                                = 0x88E6
 	STATIC_DRAW                                                = 0x88E4
 	STATIC_READ                                                = 0x88E5
@@ -4045,7 +6682,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_VALUE_MASK                                         = 0x0B93
 	STENCIL_WRITEMASK                                          = 0x0B98
@@ -4054,6 +6693,10 @@ const (
 	STREAM_DRAW                                                = 0x88E0
 	STREAM_READ                                                = 0x88E1
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SYNC_CL_EVENT_ARB                                          = 0x8240
 	SYNC_CL_EVENT_COMPLETE_ARB                                 = 0x8241
 	SYNC_CONDITION                                             = 0x9113
@@ -4062,6 +6705,8 @@ const (
 	SYNC_FLUSH_COMMANDS_BIT                                    = 0x00000001
 	SYNC_GPU_COMMANDS_COMPLETE                                 = 0x9117
 	SYNC_STATUS                                                = 0x9114
+	SYSTEM_FONT_NAME_NV                                        = 0x9073
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
 	TESS_CONTROL_SHADER                                        = 0x8E88
 	TESS_CONTROL_SHADER_BIT                                    = 0x00000008
@@ -4122,7 +6767,6 @@ const (
 	TEXTURE_ALPHA_SIZE                                         = 0x805F
 	TEXTURE_ALPHA_TYPE                                         = 0x8C13
 	TEXTURE_BASE_LEVEL                                         = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_2D                                         = 0x8069
@@ -4131,6 +6775,7 @@ const (
 	TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY                       = 0x9105
 	TEXTURE_BINDING_3D                                         = 0x806A
 	TEXTURE_BINDING_BUFFER                                     = 0x8C2C
+	TEXTURE_BINDING_BUFFER_ARB                                 = 0x8C2C
 	TEXTURE_BINDING_CUBE_MAP                                   = 0x8514
 	TEXTURE_BINDING_CUBE_MAP_ARRAY                             = 0x900A
 	TEXTURE_BINDING_CUBE_MAP_ARRAY_ARB                         = 0x900A
@@ -4139,7 +6784,10 @@ const (
 	TEXTURE_BLUE_TYPE                                          = 0x8C12
 	TEXTURE_BORDER_COLOR                                       = 0x1004
 	TEXTURE_BUFFER                                             = 0x8C2A
+	TEXTURE_BUFFER_ARB                                         = 0x8C2A
 	TEXTURE_BUFFER_DATA_STORE_BINDING                          = 0x8C2D
+	TEXTURE_BUFFER_DATA_STORE_BINDING_ARB                      = 0x8C2D
+	TEXTURE_BUFFER_FORMAT_ARB                                  = 0x8C2E
 	TEXTURE_BUFFER_OFFSET                                      = 0x919D
 	TEXTURE_BUFFER_OFFSET_ALIGNMENT                            = 0x919F
 	TEXTURE_BUFFER_SIZE                                        = 0x919E
@@ -4151,6 +6799,8 @@ const (
 	TEXTURE_COMPRESSED_BLOCK_WIDTH                             = 0x82B1
 	TEXTURE_COMPRESSED_IMAGE_SIZE                              = 0x86A0
 	TEXTURE_COMPRESSION_HINT                                   = 0x84EF
+	TEXTURE_COORD_ARRAY_ADDRESS_NV                             = 0x8F25
+	TEXTURE_COORD_ARRAY_LENGTH_NV                              = 0x8F2F
 	TEXTURE_CUBE_MAP                                           = 0x8513
 	TEXTURE_CUBE_MAP_ARRAY                                     = 0x9009
 	TEXTURE_CUBE_MAP_ARRAY_ARB                                 = 0x9009
@@ -4178,17 +6828,21 @@ const (
 	TEXTURE_INTERNAL_FORMAT                                    = 0x1003
 	TEXTURE_LOD_BIAS                                           = 0x8501
 	TEXTURE_MAG_FILTER                                         = 0x2800
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_LEVEL                                          = 0x813D
 	TEXTURE_MAX_LOD                                            = 0x813B
 	TEXTURE_MIN_FILTER                                         = 0x2801
 	TEXTURE_MIN_LOD                                            = 0x813A
 	TEXTURE_RECTANGLE                                          = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
 	TEXTURE_SAMPLES                                            = 0x9106
 	TEXTURE_SHADOW                                             = 0x82A1
 	TEXTURE_SHARED_SIZE                                        = 0x8C3F
 	TEXTURE_SPARSE_ARB                                         = 0x91A6
+	TEXTURE_SRGB_DECODE_EXT                                    = 0x8A48
 	TEXTURE_STENCIL_SIZE                                       = 0x88F1
 	TEXTURE_SWIZZLE_A                                          = 0x8E45
 	TEXTURE_SWIZZLE_B                                          = 0x8E44
@@ -4213,7 +6867,6 @@ const (
 	TOP_LEVEL_ARRAY_SIZE                                       = 0x930C
 	TOP_LEVEL_ARRAY_STRIDE                                     = 0x930D
 	TRANSFORM_FEEDBACK                                         = 0x8E22
-	TRANSFORM_FEEDBACK_ACTIVE                                  = 0x8E24
 	TRANSFORM_FEEDBACK_BARRIER_BIT                             = 0x00000800
 	TRANSFORM_FEEDBACK_BINDING                                 = 0x8E25
 	TRANSFORM_FEEDBACK_BUFFER                                  = 0x8C8E
@@ -4226,21 +6879,32 @@ const (
 	TRANSFORM_FEEDBACK_BUFFER_START                            = 0x8C84
 	TRANSFORM_FEEDBACK_BUFFER_STRIDE                           = 0x934C
 	TRANSFORM_FEEDBACK_OVERFLOW_ARB                            = 0x82EC
-	TRANSFORM_FEEDBACK_PAUSED                                  = 0x8E23
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN                      = 0x8C88
 	TRANSFORM_FEEDBACK_STREAM_OVERFLOW_ARB                     = 0x82ED
 	TRANSFORM_FEEDBACK_VARYING                                 = 0x92F4
 	TRANSFORM_FEEDBACK_VARYINGS                                = 0x8C83
 	TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH                      = 0x8C76
+	TRANSLATE_2D_NV                                            = 0x9090
+	TRANSLATE_3D_NV                                            = 0x9091
+	TRANSLATE_X_NV                                             = 0x908E
+	TRANSLATE_Y_NV                                             = 0x908F
+	TRANSPOSE_AFFINE_2D_NV                                     = 0x9096
+	TRANSPOSE_AFFINE_3D_NV                                     = 0x9098
+	TRANSPOSE_PROGRAM_MATRIX_EXT                               = 0x8E2E
 	TRIANGLES                                                  = 0x0004
 	TRIANGLES_ADJACENCY                                        = 0x000C
+	TRIANGLES_ADJACENCY_ARB                                    = 0x000C
 	TRIANGLE_FAN                                               = 0x0006
 	TRIANGLE_STRIP                                             = 0x0005
 	TRIANGLE_STRIP_ADJACENCY                                   = 0x000D
+	TRIANGLE_STRIP_ADJACENCY_ARB                               = 0x000D
+	TRIANGULAR_NV                                              = 0x90A5
 	TRUE                                                       = 1
 	TYPE                                                       = 0x92FA
+	UNCORRELATED_NV                                            = 0x9282
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -4258,10 +6922,13 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -4288,7 +6955,23 @@ const (
 	UNSIGNED_BYTE_2_3_3_REV                                    = 0x8362
 	UNSIGNED_BYTE_3_3_2                                        = 0x8032
 	UNSIGNED_INT                                               = 0x1405
+	UNSIGNED_INT16_NV                                          = 0x8FF0
+	UNSIGNED_INT16_VEC2_NV                                     = 0x8FF1
+	UNSIGNED_INT16_VEC3_NV                                     = 0x8FF2
+	UNSIGNED_INT16_VEC4_NV                                     = 0x8FF3
+	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
+	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
+	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
+	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
+	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
+	UNSIGNED_INT8_NV                                           = 0x8FEC
+	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
+	UNSIGNED_INT8_VEC3_NV                                      = 0x8FEE
+	UNSIGNED_INT8_VEC4_NV                                      = 0x8FEF
 	UNSIGNED_INT_10F_11F_11F_REV                               = 0x8C3B
 	UNSIGNED_INT_10_10_10_2                                    = 0x8036
 	UNSIGNED_INT_24_8                                          = 0x84FA
@@ -4330,22 +7013,34 @@ const (
 	UNSIGNED_SHORT_5_5_5_1                                     = 0x8034
 	UNSIGNED_SHORT_5_6_5                                       = 0x8363
 	UNSIGNED_SHORT_5_6_5_REV                                   = 0x8364
+	UNSIGNED_SHORT_8_8_APPLE                                   = 0x85BA
+	UNSIGNED_SHORT_8_8_REV_APPLE                               = 0x85BB
 	UPPER_LEFT                                                 = 0x8CA2
+	USE_MISSING_GLYPH_NV                                       = 0x90AA
+	UTF16_NV                                                   = 0x909B
+	UTF8_NV                                                    = 0x909A
 	VALIDATE_STATUS                                            = 0x8B83
 	VENDOR                                                     = 0x1F00
 	VERSION                                                    = 0x1F02
 	VERTEX_ARRAY                                               = 0x8074
+	VERTEX_ARRAY_ADDRESS_NV                                    = 0x8F21
 	VERTEX_ARRAY_BINDING                                       = 0x85B5
 	VERTEX_ARRAY_KHR                                           = 0x8074
+	VERTEX_ARRAY_LENGTH_NV                                     = 0x8F2B
+	VERTEX_ARRAY_OBJECT_EXT                                    = 0x9154
+	VERTEX_ATTRIB_ARRAY_ADDRESS_NV                             = 0x8F20
 	VERTEX_ATTRIB_ARRAY_BARRIER_BIT                            = 0x00000001
 	VERTEX_ATTRIB_ARRAY_BUFFER_BINDING                         = 0x889F
+	VERTEX_ATTRIB_ARRAY_DIVISOR_ARB                            = 0x88FE
 	VERTEX_ATTRIB_ARRAY_ENABLED                                = 0x8622
 	VERTEX_ATTRIB_ARRAY_INTEGER                                = 0x88FD
+	VERTEX_ATTRIB_ARRAY_LENGTH_NV                              = 0x8F2A
 	VERTEX_ATTRIB_ARRAY_NORMALIZED                             = 0x886A
 	VERTEX_ATTRIB_ARRAY_POINTER                                = 0x8645
 	VERTEX_ATTRIB_ARRAY_SIZE                                   = 0x8623
 	VERTEX_ATTRIB_ARRAY_STRIDE                                 = 0x8624
 	VERTEX_ATTRIB_ARRAY_TYPE                                   = 0x8625
+	VERTEX_ATTRIB_ARRAY_UNIFIED_NV                             = 0x8F1E
 	VERTEX_ATTRIB_BINDING                                      = 0x82D4
 	VERTEX_ATTRIB_RELATIVE_OFFSET                              = 0x82D5
 	VERTEX_BINDING_DIVISOR                                     = 0x82D6
@@ -4354,15 +7049,33 @@ const (
 	VERTEX_PROGRAM_POINT_SIZE                                  = 0x8642
 	VERTEX_SHADER                                              = 0x8B31
 	VERTEX_SHADER_BIT                                          = 0x00000001
+	VERTEX_SHADER_BIT_EXT                                      = 0x00000001
 	VERTEX_SHADER_INVOCATIONS_ARB                              = 0x82F0
 	VERTEX_SUBROUTINE                                          = 0x92E8
 	VERTEX_SUBROUTINE_UNIFORM                                  = 0x92EE
 	VERTEX_TEXTURE                                             = 0x829B
+	VERTICAL_LINE_TO_NV                                        = 0x08
 	VERTICES_SUBMITTED_ARB                                     = 0x82EE
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -4384,717 +7097,1278 @@ const (
 	VIRTUAL_PAGE_SIZE_X_ARB                                    = 0x9195
 	VIRTUAL_PAGE_SIZE_Y_ARB                                    = 0x9196
 	VIRTUAL_PAGE_SIZE_Z_ARB                                    = 0x9197
+	VIVIDLIGHT_NV                                              = 0x92A6
 	WAIT_FAILED                                                = 0x911D
+	WARPS_PER_SM_NV                                            = 0x933A
+	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRITE_ONLY                                                 = 0x88B9
 	XOR                                                        = 0x1506
+	XOR_NV                                                     = 0x1506
 	ZERO                                                       = 0
 	ZERO_TO_ONE                                                = 0x935F
 )
 
 var (
-	gpActiveShaderProgram                         C.GPACTIVESHADERPROGRAM
-	gpActiveTexture                               C.GPACTIVETEXTURE
-	gpAttachShader                                C.GPATTACHSHADER
-	gpBeginConditionalRender                      C.GPBEGINCONDITIONALRENDER
-	gpBeginQuery                                  C.GPBEGINQUERY
-	gpBeginQueryIndexed                           C.GPBEGINQUERYINDEXED
-	gpBeginTransformFeedback                      C.GPBEGINTRANSFORMFEEDBACK
-	gpBindAttribLocation                          C.GPBINDATTRIBLOCATION
-	gpBindBuffer                                  C.GPBINDBUFFER
-	gpBindBufferBase                              C.GPBINDBUFFERBASE
-	gpBindBufferRange                             C.GPBINDBUFFERRANGE
-	gpBindBuffersBase                             C.GPBINDBUFFERSBASE
-	gpBindBuffersRange                            C.GPBINDBUFFERSRANGE
-	gpBindFragDataLocation                        C.GPBINDFRAGDATALOCATION
-	gpBindFragDataLocationIndexed                 C.GPBINDFRAGDATALOCATIONINDEXED
-	gpBindFramebuffer                             C.GPBINDFRAMEBUFFER
-	gpBindImageTexture                            C.GPBINDIMAGETEXTURE
-	gpBindImageTextures                           C.GPBINDIMAGETEXTURES
-	gpBindProgramPipeline                         C.GPBINDPROGRAMPIPELINE
-	gpBindRenderbuffer                            C.GPBINDRENDERBUFFER
-	gpBindSampler                                 C.GPBINDSAMPLER
-	gpBindSamplers                                C.GPBINDSAMPLERS
-	gpBindTexture                                 C.GPBINDTEXTURE
-	gpBindTextureUnit                             C.GPBINDTEXTUREUNIT
-	gpBindTextures                                C.GPBINDTEXTURES
-	gpBindTransformFeedback                       C.GPBINDTRANSFORMFEEDBACK
-	gpBindVertexArray                             C.GPBINDVERTEXARRAY
-	gpBindVertexBuffer                            C.GPBINDVERTEXBUFFER
-	gpBindVertexBuffers                           C.GPBINDVERTEXBUFFERS
-	gpBlendColor                                  C.GPBLENDCOLOR
-	gpBlendEquation                               C.GPBLENDEQUATION
-	gpBlendEquationSeparate                       C.GPBLENDEQUATIONSEPARATE
-	gpBlendEquationSeparateiARB                   C.GPBLENDEQUATIONSEPARATEIARB
-	gpBlendEquationiARB                           C.GPBLENDEQUATIONIARB
-	gpBlendFunc                                   C.GPBLENDFUNC
-	gpBlendFuncSeparate                           C.GPBLENDFUNCSEPARATE
-	gpBlendFuncSeparateiARB                       C.GPBLENDFUNCSEPARATEIARB
-	gpBlendFunciARB                               C.GPBLENDFUNCIARB
-	gpBlitFramebuffer                             C.GPBLITFRAMEBUFFER
-	gpBlitNamedFramebuffer                        C.GPBLITNAMEDFRAMEBUFFER
-	gpBufferData                                  C.GPBUFFERDATA
-	gpBufferPageCommitmentARB                     C.GPBUFFERPAGECOMMITMENTARB
-	gpBufferStorage                               C.GPBUFFERSTORAGE
-	gpBufferSubData                               C.GPBUFFERSUBDATA
-	gpCheckFramebufferStatus                      C.GPCHECKFRAMEBUFFERSTATUS
-	gpCheckNamedFramebufferStatus                 C.GPCHECKNAMEDFRAMEBUFFERSTATUS
-	gpClampColor                                  C.GPCLAMPCOLOR
-	gpClear                                       C.GPCLEAR
-	gpClearBufferData                             C.GPCLEARBUFFERDATA
-	gpClearBufferSubData                          C.GPCLEARBUFFERSUBDATA
-	gpClearBufferfi                               C.GPCLEARBUFFERFI
-	gpClearBufferfv                               C.GPCLEARBUFFERFV
-	gpClearBufferiv                               C.GPCLEARBUFFERIV
-	gpClearBufferuiv                              C.GPCLEARBUFFERUIV
-	gpClearColor                                  C.GPCLEARCOLOR
-	gpClearDepth                                  C.GPCLEARDEPTH
-	gpClearDepthf                                 C.GPCLEARDEPTHF
-	gpClearNamedBufferData                        C.GPCLEARNAMEDBUFFERDATA
-	gpClearNamedBufferSubData                     C.GPCLEARNAMEDBUFFERSUBDATA
-	gpClearNamedFramebufferfi                     C.GPCLEARNAMEDFRAMEBUFFERFI
-	gpClearNamedFramebufferfv                     C.GPCLEARNAMEDFRAMEBUFFERFV
-	gpClearNamedFramebufferiv                     C.GPCLEARNAMEDFRAMEBUFFERIV
-	gpClearNamedFramebufferuiv                    C.GPCLEARNAMEDFRAMEBUFFERUIV
-	gpClearStencil                                C.GPCLEARSTENCIL
-	gpClearTexImage                               C.GPCLEARTEXIMAGE
-	gpClearTexSubImage                            C.GPCLEARTEXSUBIMAGE
-	gpClientWaitSync                              C.GPCLIENTWAITSYNC
-	gpClipControl                                 C.GPCLIPCONTROL
-	gpColorMask                                   C.GPCOLORMASK
-	gpColorMaski                                  C.GPCOLORMASKI
-	gpCompileShader                               C.GPCOMPILESHADER
-	gpCompileShaderIncludeARB                     C.GPCOMPILESHADERINCLUDEARB
-	gpCompressedTexImage1D                        C.GPCOMPRESSEDTEXIMAGE1D
-	gpCompressedTexImage2D                        C.GPCOMPRESSEDTEXIMAGE2D
-	gpCompressedTexImage3D                        C.GPCOMPRESSEDTEXIMAGE3D
-	gpCompressedTexSubImage1D                     C.GPCOMPRESSEDTEXSUBIMAGE1D
-	gpCompressedTexSubImage2D                     C.GPCOMPRESSEDTEXSUBIMAGE2D
-	gpCompressedTexSubImage3D                     C.GPCOMPRESSEDTEXSUBIMAGE3D
-	gpCompressedTextureSubImage1D                 C.GPCOMPRESSEDTEXTURESUBIMAGE1D
-	gpCompressedTextureSubImage2D                 C.GPCOMPRESSEDTEXTURESUBIMAGE2D
-	gpCompressedTextureSubImage3D                 C.GPCOMPRESSEDTEXTURESUBIMAGE3D
-	gpCopyBufferSubData                           C.GPCOPYBUFFERSUBDATA
-	gpCopyImageSubData                            C.GPCOPYIMAGESUBDATA
-	gpCopyNamedBufferSubData                      C.GPCOPYNAMEDBUFFERSUBDATA
-	gpCopyTexImage1D                              C.GPCOPYTEXIMAGE1D
-	gpCopyTexImage2D                              C.GPCOPYTEXIMAGE2D
-	gpCopyTexSubImage1D                           C.GPCOPYTEXSUBIMAGE1D
-	gpCopyTexSubImage2D                           C.GPCOPYTEXSUBIMAGE2D
-	gpCopyTexSubImage3D                           C.GPCOPYTEXSUBIMAGE3D
-	gpCopyTextureSubImage1D                       C.GPCOPYTEXTURESUBIMAGE1D
-	gpCopyTextureSubImage2D                       C.GPCOPYTEXTURESUBIMAGE2D
-	gpCopyTextureSubImage3D                       C.GPCOPYTEXTURESUBIMAGE3D
-	gpCreateBuffers                               C.GPCREATEBUFFERS
-	gpCreateFramebuffers                          C.GPCREATEFRAMEBUFFERS
-	gpCreateProgram                               C.GPCREATEPROGRAM
-	gpCreateProgramPipelines                      C.GPCREATEPROGRAMPIPELINES
-	gpCreateQueries                               C.GPCREATEQUERIES
-	gpCreateRenderbuffers                         C.GPCREATERENDERBUFFERS
-	gpCreateSamplers                              C.GPCREATESAMPLERS
-	gpCreateShader                                C.GPCREATESHADER
-	gpCreateShaderProgramv                        C.GPCREATESHADERPROGRAMV
-	gpCreateSyncFromCLeventARB                    C.GPCREATESYNCFROMCLEVENTARB
-	gpCreateTextures                              C.GPCREATETEXTURES
-	gpCreateTransformFeedbacks                    C.GPCREATETRANSFORMFEEDBACKS
-	gpCreateVertexArrays                          C.GPCREATEVERTEXARRAYS
-	gpCullFace                                    C.GPCULLFACE
-	gpDebugMessageCallback                        C.GPDEBUGMESSAGECALLBACK
-	gpDebugMessageCallbackARB                     C.GPDEBUGMESSAGECALLBACKARB
-	gpDebugMessageCallbackKHR                     C.GPDEBUGMESSAGECALLBACKKHR
-	gpDebugMessageControl                         C.GPDEBUGMESSAGECONTROL
-	gpDebugMessageControlARB                      C.GPDEBUGMESSAGECONTROLARB
-	gpDebugMessageControlKHR                      C.GPDEBUGMESSAGECONTROLKHR
-	gpDebugMessageInsert                          C.GPDEBUGMESSAGEINSERT
-	gpDebugMessageInsertARB                       C.GPDEBUGMESSAGEINSERTARB
-	gpDebugMessageInsertKHR                       C.GPDEBUGMESSAGEINSERTKHR
-	gpDeleteBuffers                               C.GPDELETEBUFFERS
-	gpDeleteFramebuffers                          C.GPDELETEFRAMEBUFFERS
-	gpDeleteNamedStringARB                        C.GPDELETENAMEDSTRINGARB
-	gpDeleteProgram                               C.GPDELETEPROGRAM
-	gpDeleteProgramPipelines                      C.GPDELETEPROGRAMPIPELINES
-	gpDeleteQueries                               C.GPDELETEQUERIES
-	gpDeleteRenderbuffers                         C.GPDELETERENDERBUFFERS
-	gpDeleteSamplers                              C.GPDELETESAMPLERS
-	gpDeleteShader                                C.GPDELETESHADER
-	gpDeleteSync                                  C.GPDELETESYNC
-	gpDeleteTextures                              C.GPDELETETEXTURES
-	gpDeleteTransformFeedbacks                    C.GPDELETETRANSFORMFEEDBACKS
-	gpDeleteVertexArrays                          C.GPDELETEVERTEXARRAYS
-	gpDepthFunc                                   C.GPDEPTHFUNC
-	gpDepthMask                                   C.GPDEPTHMASK
-	gpDepthRange                                  C.GPDEPTHRANGE
-	gpDepthRangeArrayv                            C.GPDEPTHRANGEARRAYV
-	gpDepthRangeIndexed                           C.GPDEPTHRANGEINDEXED
-	gpDepthRangef                                 C.GPDEPTHRANGEF
-	gpDetachShader                                C.GPDETACHSHADER
-	gpDisable                                     C.GPDISABLE
-	gpDisableVertexArrayAttrib                    C.GPDISABLEVERTEXARRAYATTRIB
-	gpDisableVertexAttribArray                    C.GPDISABLEVERTEXATTRIBARRAY
-	gpDisablei                                    C.GPDISABLEI
-	gpDispatchCompute                             C.GPDISPATCHCOMPUTE
-	gpDispatchComputeGroupSizeARB                 C.GPDISPATCHCOMPUTEGROUPSIZEARB
-	gpDispatchComputeIndirect                     C.GPDISPATCHCOMPUTEINDIRECT
-	gpDrawArrays                                  C.GPDRAWARRAYS
-	gpDrawArraysIndirect                          C.GPDRAWARRAYSINDIRECT
-	gpDrawArraysInstanced                         C.GPDRAWARRAYSINSTANCED
-	gpDrawArraysInstancedBaseInstance             C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
-	gpDrawBuffer                                  C.GPDRAWBUFFER
-	gpDrawBuffers                                 C.GPDRAWBUFFERS
-	gpDrawElements                                C.GPDRAWELEMENTS
-	gpDrawElementsBaseVertex                      C.GPDRAWELEMENTSBASEVERTEX
-	gpDrawElementsIndirect                        C.GPDRAWELEMENTSINDIRECT
-	gpDrawElementsInstanced                       C.GPDRAWELEMENTSINSTANCED
-	gpDrawElementsInstancedBaseInstance           C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
-	gpDrawElementsInstancedBaseVertex             C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
-	gpDrawElementsInstancedBaseVertexBaseInstance C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
-	gpDrawRangeElements                           C.GPDRAWRANGEELEMENTS
-	gpDrawRangeElementsBaseVertex                 C.GPDRAWRANGEELEMENTSBASEVERTEX
-	gpDrawTransformFeedback                       C.GPDRAWTRANSFORMFEEDBACK
-	gpDrawTransformFeedbackInstanced              C.GPDRAWTRANSFORMFEEDBACKINSTANCED
-	gpDrawTransformFeedbackStream                 C.GPDRAWTRANSFORMFEEDBACKSTREAM
-	gpDrawTransformFeedbackStreamInstanced        C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
-	gpEnable                                      C.GPENABLE
-	gpEnableVertexArrayAttrib                     C.GPENABLEVERTEXARRAYATTRIB
-	gpEnableVertexAttribArray                     C.GPENABLEVERTEXATTRIBARRAY
-	gpEnablei                                     C.GPENABLEI
-	gpEndConditionalRender                        C.GPENDCONDITIONALRENDER
-	gpEndQuery                                    C.GPENDQUERY
-	gpEndQueryIndexed                             C.GPENDQUERYINDEXED
-	gpEndTransformFeedback                        C.GPENDTRANSFORMFEEDBACK
-	gpFenceSync                                   C.GPFENCESYNC
-	gpFinish                                      C.GPFINISH
-	gpFlush                                       C.GPFLUSH
-	gpFlushMappedBufferRange                      C.GPFLUSHMAPPEDBUFFERRANGE
-	gpFlushMappedNamedBufferRange                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
-	gpFramebufferParameteri                       C.GPFRAMEBUFFERPARAMETERI
-	gpFramebufferRenderbuffer                     C.GPFRAMEBUFFERRENDERBUFFER
-	gpFramebufferTexture                          C.GPFRAMEBUFFERTEXTURE
-	gpFramebufferTexture1D                        C.GPFRAMEBUFFERTEXTURE1D
-	gpFramebufferTexture2D                        C.GPFRAMEBUFFERTEXTURE2D
-	gpFramebufferTexture3D                        C.GPFRAMEBUFFERTEXTURE3D
-	gpFramebufferTextureLayer                     C.GPFRAMEBUFFERTEXTURELAYER
-	gpFrontFace                                   C.GPFRONTFACE
-	gpGenBuffers                                  C.GPGENBUFFERS
-	gpGenFramebuffers                             C.GPGENFRAMEBUFFERS
-	gpGenProgramPipelines                         C.GPGENPROGRAMPIPELINES
-	gpGenQueries                                  C.GPGENQUERIES
-	gpGenRenderbuffers                            C.GPGENRENDERBUFFERS
-	gpGenSamplers                                 C.GPGENSAMPLERS
-	gpGenTextures                                 C.GPGENTEXTURES
-	gpGenTransformFeedbacks                       C.GPGENTRANSFORMFEEDBACKS
-	gpGenVertexArrays                             C.GPGENVERTEXARRAYS
-	gpGenerateMipmap                              C.GPGENERATEMIPMAP
-	gpGenerateTextureMipmap                       C.GPGENERATETEXTUREMIPMAP
-	gpGetActiveAtomicCounterBufferiv              C.GPGETACTIVEATOMICCOUNTERBUFFERIV
-	gpGetActiveAttrib                             C.GPGETACTIVEATTRIB
-	gpGetActiveSubroutineName                     C.GPGETACTIVESUBROUTINENAME
-	gpGetActiveSubroutineUniformName              C.GPGETACTIVESUBROUTINEUNIFORMNAME
-	gpGetActiveSubroutineUniformiv                C.GPGETACTIVESUBROUTINEUNIFORMIV
-	gpGetActiveUniform                            C.GPGETACTIVEUNIFORM
-	gpGetActiveUniformBlockName                   C.GPGETACTIVEUNIFORMBLOCKNAME
-	gpGetActiveUniformBlockiv                     C.GPGETACTIVEUNIFORMBLOCKIV
-	gpGetActiveUniformName                        C.GPGETACTIVEUNIFORMNAME
-	gpGetActiveUniformsiv                         C.GPGETACTIVEUNIFORMSIV
-	gpGetAttachedShaders                          C.GPGETATTACHEDSHADERS
-	gpGetAttribLocation                           C.GPGETATTRIBLOCATION
-	gpGetBooleani_v                               C.GPGETBOOLEANI_V
-	gpGetBooleanv                                 C.GPGETBOOLEANV
-	gpGetBufferParameteri64v                      C.GPGETBUFFERPARAMETERI64V
-	gpGetBufferParameteriv                        C.GPGETBUFFERPARAMETERIV
-	gpGetBufferPointerv                           C.GPGETBUFFERPOINTERV
-	gpGetBufferSubData                            C.GPGETBUFFERSUBDATA
-	gpGetCompressedTexImage                       C.GPGETCOMPRESSEDTEXIMAGE
-	gpGetCompressedTextureImage                   C.GPGETCOMPRESSEDTEXTUREIMAGE
-	gpGetCompressedTextureSubImage                C.GPGETCOMPRESSEDTEXTURESUBIMAGE
-	gpGetDebugMessageLog                          C.GPGETDEBUGMESSAGELOG
-	gpGetDebugMessageLogARB                       C.GPGETDEBUGMESSAGELOGARB
-	gpGetDebugMessageLogKHR                       C.GPGETDEBUGMESSAGELOGKHR
-	gpGetDoublei_v                                C.GPGETDOUBLEI_V
-	gpGetDoublev                                  C.GPGETDOUBLEV
-	gpGetError                                    C.GPGETERROR
-	gpGetFloati_v                                 C.GPGETFLOATI_V
-	gpGetFloatv                                   C.GPGETFLOATV
-	gpGetFragDataIndex                            C.GPGETFRAGDATAINDEX
-	gpGetFragDataLocation                         C.GPGETFRAGDATALOCATION
-	gpGetFramebufferAttachmentParameteriv         C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetFramebufferParameteriv                   C.GPGETFRAMEBUFFERPARAMETERIV
-	gpGetGraphicsResetStatus                      C.GPGETGRAPHICSRESETSTATUS
-	gpGetGraphicsResetStatusARB                   C.GPGETGRAPHICSRESETSTATUSARB
-	gpGetGraphicsResetStatusKHR                   C.GPGETGRAPHICSRESETSTATUSKHR
-	gpGetImageHandleARB                           C.GPGETIMAGEHANDLEARB
-	gpGetInteger64i_v                             C.GPGETINTEGER64I_V
-	gpGetInteger64v                               C.GPGETINTEGER64V
-	gpGetIntegeri_v                               C.GPGETINTEGERI_V
-	gpGetIntegerv                                 C.GPGETINTEGERV
-	gpGetInternalformati64v                       C.GPGETINTERNALFORMATI64V
-	gpGetInternalformativ                         C.GPGETINTERNALFORMATIV
-	gpGetMultisamplefv                            C.GPGETMULTISAMPLEFV
-	gpGetNamedBufferParameteri64v                 C.GPGETNAMEDBUFFERPARAMETERI64V
-	gpGetNamedBufferParameteriv                   C.GPGETNAMEDBUFFERPARAMETERIV
-	gpGetNamedBufferPointerv                      C.GPGETNAMEDBUFFERPOINTERV
-	gpGetNamedBufferSubData                       C.GPGETNAMEDBUFFERSUBDATA
-	gpGetNamedFramebufferAttachmentParameteriv    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetNamedFramebufferParameteriv              C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
-	gpGetNamedRenderbufferParameteriv             C.GPGETNAMEDRENDERBUFFERPARAMETERIV
-	gpGetNamedStringARB                           C.GPGETNAMEDSTRINGARB
-	gpGetNamedStringivARB                         C.GPGETNAMEDSTRINGIVARB
-	gpGetObjectLabel                              C.GPGETOBJECTLABEL
-	gpGetObjectLabelKHR                           C.GPGETOBJECTLABELKHR
-	gpGetObjectPtrLabel                           C.GPGETOBJECTPTRLABEL
-	gpGetObjectPtrLabelKHR                        C.GPGETOBJECTPTRLABELKHR
-	gpGetPointerv                                 C.GPGETPOINTERV
-	gpGetPointervKHR                              C.GPGETPOINTERVKHR
-	gpGetProgramBinary                            C.GPGETPROGRAMBINARY
-	gpGetProgramInfoLog                           C.GPGETPROGRAMINFOLOG
-	gpGetProgramInterfaceiv                       C.GPGETPROGRAMINTERFACEIV
-	gpGetProgramPipelineInfoLog                   C.GPGETPROGRAMPIPELINEINFOLOG
-	gpGetProgramPipelineiv                        C.GPGETPROGRAMPIPELINEIV
-	gpGetProgramResourceIndex                     C.GPGETPROGRAMRESOURCEINDEX
-	gpGetProgramResourceLocation                  C.GPGETPROGRAMRESOURCELOCATION
-	gpGetProgramResourceLocationIndex             C.GPGETPROGRAMRESOURCELOCATIONINDEX
-	gpGetProgramResourceName                      C.GPGETPROGRAMRESOURCENAME
-	gpGetProgramResourceiv                        C.GPGETPROGRAMRESOURCEIV
-	gpGetProgramStageiv                           C.GPGETPROGRAMSTAGEIV
-	gpGetProgramiv                                C.GPGETPROGRAMIV
-	gpGetQueryIndexediv                           C.GPGETQUERYINDEXEDIV
-	gpGetQueryObjecti64v                          C.GPGETQUERYOBJECTI64V
-	gpGetQueryObjectiv                            C.GPGETQUERYOBJECTIV
-	gpGetQueryObjectui64v                         C.GPGETQUERYOBJECTUI64V
-	gpGetQueryObjectuiv                           C.GPGETQUERYOBJECTUIV
-	gpGetQueryiv                                  C.GPGETQUERYIV
-	gpGetRenderbufferParameteriv                  C.GPGETRENDERBUFFERPARAMETERIV
-	gpGetSamplerParameterIiv                      C.GPGETSAMPLERPARAMETERIIV
-	gpGetSamplerParameterIuiv                     C.GPGETSAMPLERPARAMETERIUIV
-	gpGetSamplerParameterfv                       C.GPGETSAMPLERPARAMETERFV
-	gpGetSamplerParameteriv                       C.GPGETSAMPLERPARAMETERIV
-	gpGetShaderInfoLog                            C.GPGETSHADERINFOLOG
-	gpGetShaderPrecisionFormat                    C.GPGETSHADERPRECISIONFORMAT
-	gpGetShaderSource                             C.GPGETSHADERSOURCE
-	gpGetShaderiv                                 C.GPGETSHADERIV
-	gpGetString                                   C.GPGETSTRING
-	gpGetStringi                                  C.GPGETSTRINGI
-	gpGetSubroutineIndex                          C.GPGETSUBROUTINEINDEX
-	gpGetSubroutineUniformLocation                C.GPGETSUBROUTINEUNIFORMLOCATION
-	gpGetSynciv                                   C.GPGETSYNCIV
-	gpGetTexImage                                 C.GPGETTEXIMAGE
-	gpGetTexLevelParameterfv                      C.GPGETTEXLEVELPARAMETERFV
-	gpGetTexLevelParameteriv                      C.GPGETTEXLEVELPARAMETERIV
-	gpGetTexParameterIiv                          C.GPGETTEXPARAMETERIIV
-	gpGetTexParameterIuiv                         C.GPGETTEXPARAMETERIUIV
-	gpGetTexParameterfv                           C.GPGETTEXPARAMETERFV
-	gpGetTexParameteriv                           C.GPGETTEXPARAMETERIV
-	gpGetTextureHandleARB                         C.GPGETTEXTUREHANDLEARB
-	gpGetTextureImage                             C.GPGETTEXTUREIMAGE
-	gpGetTextureLevelParameterfv                  C.GPGETTEXTURELEVELPARAMETERFV
-	gpGetTextureLevelParameteriv                  C.GPGETTEXTURELEVELPARAMETERIV
-	gpGetTextureParameterIiv                      C.GPGETTEXTUREPARAMETERIIV
-	gpGetTextureParameterIuiv                     C.GPGETTEXTUREPARAMETERIUIV
-	gpGetTextureParameterfv                       C.GPGETTEXTUREPARAMETERFV
-	gpGetTextureParameteriv                       C.GPGETTEXTUREPARAMETERIV
-	gpGetTextureSamplerHandleARB                  C.GPGETTEXTURESAMPLERHANDLEARB
-	gpGetTextureSubImage                          C.GPGETTEXTURESUBIMAGE
-	gpGetTransformFeedbackVarying                 C.GPGETTRANSFORMFEEDBACKVARYING
-	gpGetTransformFeedbacki64_v                   C.GPGETTRANSFORMFEEDBACKI64_V
-	gpGetTransformFeedbacki_v                     C.GPGETTRANSFORMFEEDBACKI_V
-	gpGetTransformFeedbackiv                      C.GPGETTRANSFORMFEEDBACKIV
-	gpGetUniformBlockIndex                        C.GPGETUNIFORMBLOCKINDEX
-	gpGetUniformIndices                           C.GPGETUNIFORMINDICES
-	gpGetUniformLocation                          C.GPGETUNIFORMLOCATION
-	gpGetUniformSubroutineuiv                     C.GPGETUNIFORMSUBROUTINEUIV
-	gpGetUniformdv                                C.GPGETUNIFORMDV
-	gpGetUniformfv                                C.GPGETUNIFORMFV
-	gpGetUniformiv                                C.GPGETUNIFORMIV
-	gpGetUniformuiv                               C.GPGETUNIFORMUIV
-	gpGetVertexArrayIndexed64iv                   C.GPGETVERTEXARRAYINDEXED64IV
-	gpGetVertexArrayIndexediv                     C.GPGETVERTEXARRAYINDEXEDIV
-	gpGetVertexArrayiv                            C.GPGETVERTEXARRAYIV
-	gpGetVertexAttribIiv                          C.GPGETVERTEXATTRIBIIV
-	gpGetVertexAttribIuiv                         C.GPGETVERTEXATTRIBIUIV
-	gpGetVertexAttribLdv                          C.GPGETVERTEXATTRIBLDV
-	gpGetVertexAttribLui64vARB                    C.GPGETVERTEXATTRIBLUI64VARB
-	gpGetVertexAttribPointerv                     C.GPGETVERTEXATTRIBPOINTERV
-	gpGetVertexAttribdv                           C.GPGETVERTEXATTRIBDV
-	gpGetVertexAttribfv                           C.GPGETVERTEXATTRIBFV
-	gpGetVertexAttribiv                           C.GPGETVERTEXATTRIBIV
-	gpGetnCompressedTexImageARB                   C.GPGETNCOMPRESSEDTEXIMAGEARB
-	gpGetnTexImageARB                             C.GPGETNTEXIMAGEARB
-	gpGetnUniformdvARB                            C.GPGETNUNIFORMDVARB
-	gpGetnUniformfv                               C.GPGETNUNIFORMFV
-	gpGetnUniformfvARB                            C.GPGETNUNIFORMFVARB
-	gpGetnUniformfvKHR                            C.GPGETNUNIFORMFVKHR
-	gpGetnUniformiv                               C.GPGETNUNIFORMIV
-	gpGetnUniformivARB                            C.GPGETNUNIFORMIVARB
-	gpGetnUniformivKHR                            C.GPGETNUNIFORMIVKHR
-	gpGetnUniformuiv                              C.GPGETNUNIFORMUIV
-	gpGetnUniformuivARB                           C.GPGETNUNIFORMUIVARB
-	gpGetnUniformuivKHR                           C.GPGETNUNIFORMUIVKHR
-	gpHint                                        C.GPHINT
-	gpInvalidateBufferData                        C.GPINVALIDATEBUFFERDATA
-	gpInvalidateBufferSubData                     C.GPINVALIDATEBUFFERSUBDATA
-	gpInvalidateFramebuffer                       C.GPINVALIDATEFRAMEBUFFER
-	gpInvalidateNamedFramebufferData              C.GPINVALIDATENAMEDFRAMEBUFFERDATA
-	gpInvalidateNamedFramebufferSubData           C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
-	gpInvalidateSubFramebuffer                    C.GPINVALIDATESUBFRAMEBUFFER
-	gpInvalidateTexImage                          C.GPINVALIDATETEXIMAGE
-	gpInvalidateTexSubImage                       C.GPINVALIDATETEXSUBIMAGE
-	gpIsBuffer                                    C.GPISBUFFER
-	gpIsEnabled                                   C.GPISENABLED
-	gpIsEnabledi                                  C.GPISENABLEDI
-	gpIsFramebuffer                               C.GPISFRAMEBUFFER
-	gpIsImageHandleResidentARB                    C.GPISIMAGEHANDLERESIDENTARB
-	gpIsNamedStringARB                            C.GPISNAMEDSTRINGARB
-	gpIsProgram                                   C.GPISPROGRAM
-	gpIsProgramPipeline                           C.GPISPROGRAMPIPELINE
-	gpIsQuery                                     C.GPISQUERY
-	gpIsRenderbuffer                              C.GPISRENDERBUFFER
-	gpIsSampler                                   C.GPISSAMPLER
-	gpIsShader                                    C.GPISSHADER
-	gpIsSync                                      C.GPISSYNC
-	gpIsTexture                                   C.GPISTEXTURE
-	gpIsTextureHandleResidentARB                  C.GPISTEXTUREHANDLERESIDENTARB
-	gpIsTransformFeedback                         C.GPISTRANSFORMFEEDBACK
-	gpIsVertexArray                               C.GPISVERTEXARRAY
-	gpLineWidth                                   C.GPLINEWIDTH
-	gpLinkProgram                                 C.GPLINKPROGRAM
-	gpLogicOp                                     C.GPLOGICOP
-	gpMakeImageHandleNonResidentARB               C.GPMAKEIMAGEHANDLENONRESIDENTARB
-	gpMakeImageHandleResidentARB                  C.GPMAKEIMAGEHANDLERESIDENTARB
-	gpMakeTextureHandleNonResidentARB             C.GPMAKETEXTUREHANDLENONRESIDENTARB
-	gpMakeTextureHandleResidentARB                C.GPMAKETEXTUREHANDLERESIDENTARB
-	gpMapBuffer                                   C.GPMAPBUFFER
-	gpMapBufferRange                              C.GPMAPBUFFERRANGE
-	gpMapNamedBuffer                              C.GPMAPNAMEDBUFFER
-	gpMapNamedBufferRange                         C.GPMAPNAMEDBUFFERRANGE
-	gpMemoryBarrier                               C.GPMEMORYBARRIER
-	gpMemoryBarrierByRegion                       C.GPMEMORYBARRIERBYREGION
-	gpMinSampleShadingARB                         C.GPMINSAMPLESHADINGARB
-	gpMultiDrawArrays                             C.GPMULTIDRAWARRAYS
-	gpMultiDrawArraysIndirect                     C.GPMULTIDRAWARRAYSINDIRECT
-	gpMultiDrawArraysIndirectCountARB             C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
-	gpMultiDrawElements                           C.GPMULTIDRAWELEMENTS
-	gpMultiDrawElementsBaseVertex                 C.GPMULTIDRAWELEMENTSBASEVERTEX
-	gpMultiDrawElementsIndirect                   C.GPMULTIDRAWELEMENTSINDIRECT
-	gpMultiDrawElementsIndirectCountARB           C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
-	gpNamedBufferData                             C.GPNAMEDBUFFERDATA
-	gpNamedBufferPageCommitmentARB                C.GPNAMEDBUFFERPAGECOMMITMENTARB
-	gpNamedBufferPageCommitmentEXT                C.GPNAMEDBUFFERPAGECOMMITMENTEXT
-	gpNamedBufferStorage                          C.GPNAMEDBUFFERSTORAGE
-	gpNamedBufferSubData                          C.GPNAMEDBUFFERSUBDATA
-	gpNamedFramebufferDrawBuffer                  C.GPNAMEDFRAMEBUFFERDRAWBUFFER
-	gpNamedFramebufferDrawBuffers                 C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
-	gpNamedFramebufferParameteri                  C.GPNAMEDFRAMEBUFFERPARAMETERI
-	gpNamedFramebufferReadBuffer                  C.GPNAMEDFRAMEBUFFERREADBUFFER
-	gpNamedFramebufferRenderbuffer                C.GPNAMEDFRAMEBUFFERRENDERBUFFER
-	gpNamedFramebufferTexture                     C.GPNAMEDFRAMEBUFFERTEXTURE
-	gpNamedFramebufferTextureLayer                C.GPNAMEDFRAMEBUFFERTEXTURELAYER
-	gpNamedRenderbufferStorage                    C.GPNAMEDRENDERBUFFERSTORAGE
-	gpNamedRenderbufferStorageMultisample         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
-	gpNamedStringARB                              C.GPNAMEDSTRINGARB
-	gpObjectLabel                                 C.GPOBJECTLABEL
-	gpObjectLabelKHR                              C.GPOBJECTLABELKHR
-	gpObjectPtrLabel                              C.GPOBJECTPTRLABEL
-	gpObjectPtrLabelKHR                           C.GPOBJECTPTRLABELKHR
-	gpPatchParameterfv                            C.GPPATCHPARAMETERFV
-	gpPatchParameteri                             C.GPPATCHPARAMETERI
-	gpPauseTransformFeedback                      C.GPPAUSETRANSFORMFEEDBACK
-	gpPixelStoref                                 C.GPPIXELSTOREF
-	gpPixelStorei                                 C.GPPIXELSTOREI
-	gpPointParameterf                             C.GPPOINTPARAMETERF
-	gpPointParameterfv                            C.GPPOINTPARAMETERFV
-	gpPointParameteri                             C.GPPOINTPARAMETERI
-	gpPointParameteriv                            C.GPPOINTPARAMETERIV
-	gpPointSize                                   C.GPPOINTSIZE
-	gpPolygonMode                                 C.GPPOLYGONMODE
-	gpPolygonOffset                               C.GPPOLYGONOFFSET
-	gpPopDebugGroup                               C.GPPOPDEBUGGROUP
-	gpPopDebugGroupKHR                            C.GPPOPDEBUGGROUPKHR
-	gpPrimitiveRestartIndex                       C.GPPRIMITIVERESTARTINDEX
-	gpProgramBinary                               C.GPPROGRAMBINARY
-	gpProgramParameteri                           C.GPPROGRAMPARAMETERI
-	gpProgramUniform1d                            C.GPPROGRAMUNIFORM1D
-	gpProgramUniform1dv                           C.GPPROGRAMUNIFORM1DV
-	gpProgramUniform1f                            C.GPPROGRAMUNIFORM1F
-	gpProgramUniform1fv                           C.GPPROGRAMUNIFORM1FV
-	gpProgramUniform1i                            C.GPPROGRAMUNIFORM1I
-	gpProgramUniform1iv                           C.GPPROGRAMUNIFORM1IV
-	gpProgramUniform1ui                           C.GPPROGRAMUNIFORM1UI
-	gpProgramUniform1uiv                          C.GPPROGRAMUNIFORM1UIV
-	gpProgramUniform2d                            C.GPPROGRAMUNIFORM2D
-	gpProgramUniform2dv                           C.GPPROGRAMUNIFORM2DV
-	gpProgramUniform2f                            C.GPPROGRAMUNIFORM2F
-	gpProgramUniform2fv                           C.GPPROGRAMUNIFORM2FV
-	gpProgramUniform2i                            C.GPPROGRAMUNIFORM2I
-	gpProgramUniform2iv                           C.GPPROGRAMUNIFORM2IV
-	gpProgramUniform2ui                           C.GPPROGRAMUNIFORM2UI
-	gpProgramUniform2uiv                          C.GPPROGRAMUNIFORM2UIV
-	gpProgramUniform3d                            C.GPPROGRAMUNIFORM3D
-	gpProgramUniform3dv                           C.GPPROGRAMUNIFORM3DV
-	gpProgramUniform3f                            C.GPPROGRAMUNIFORM3F
-	gpProgramUniform3fv                           C.GPPROGRAMUNIFORM3FV
-	gpProgramUniform3i                            C.GPPROGRAMUNIFORM3I
-	gpProgramUniform3iv                           C.GPPROGRAMUNIFORM3IV
-	gpProgramUniform3ui                           C.GPPROGRAMUNIFORM3UI
-	gpProgramUniform3uiv                          C.GPPROGRAMUNIFORM3UIV
-	gpProgramUniform4d                            C.GPPROGRAMUNIFORM4D
-	gpProgramUniform4dv                           C.GPPROGRAMUNIFORM4DV
-	gpProgramUniform4f                            C.GPPROGRAMUNIFORM4F
-	gpProgramUniform4fv                           C.GPPROGRAMUNIFORM4FV
-	gpProgramUniform4i                            C.GPPROGRAMUNIFORM4I
-	gpProgramUniform4iv                           C.GPPROGRAMUNIFORM4IV
-	gpProgramUniform4ui                           C.GPPROGRAMUNIFORM4UI
-	gpProgramUniform4uiv                          C.GPPROGRAMUNIFORM4UIV
-	gpProgramUniformHandleui64ARB                 C.GPPROGRAMUNIFORMHANDLEUI64ARB
-	gpProgramUniformHandleui64vARB                C.GPPROGRAMUNIFORMHANDLEUI64VARB
-	gpProgramUniformMatrix2dv                     C.GPPROGRAMUNIFORMMATRIX2DV
-	gpProgramUniformMatrix2fv                     C.GPPROGRAMUNIFORMMATRIX2FV
-	gpProgramUniformMatrix2x3dv                   C.GPPROGRAMUNIFORMMATRIX2X3DV
-	gpProgramUniformMatrix2x3fv                   C.GPPROGRAMUNIFORMMATRIX2X3FV
-	gpProgramUniformMatrix2x4dv                   C.GPPROGRAMUNIFORMMATRIX2X4DV
-	gpProgramUniformMatrix2x4fv                   C.GPPROGRAMUNIFORMMATRIX2X4FV
-	gpProgramUniformMatrix3dv                     C.GPPROGRAMUNIFORMMATRIX3DV
-	gpProgramUniformMatrix3fv                     C.GPPROGRAMUNIFORMMATRIX3FV
-	gpProgramUniformMatrix3x2dv                   C.GPPROGRAMUNIFORMMATRIX3X2DV
-	gpProgramUniformMatrix3x2fv                   C.GPPROGRAMUNIFORMMATRIX3X2FV
-	gpProgramUniformMatrix3x4dv                   C.GPPROGRAMUNIFORMMATRIX3X4DV
-	gpProgramUniformMatrix3x4fv                   C.GPPROGRAMUNIFORMMATRIX3X4FV
-	gpProgramUniformMatrix4dv                     C.GPPROGRAMUNIFORMMATRIX4DV
-	gpProgramUniformMatrix4fv                     C.GPPROGRAMUNIFORMMATRIX4FV
-	gpProgramUniformMatrix4x2dv                   C.GPPROGRAMUNIFORMMATRIX4X2DV
-	gpProgramUniformMatrix4x2fv                   C.GPPROGRAMUNIFORMMATRIX4X2FV
-	gpProgramUniformMatrix4x3dv                   C.GPPROGRAMUNIFORMMATRIX4X3DV
-	gpProgramUniformMatrix4x3fv                   C.GPPROGRAMUNIFORMMATRIX4X3FV
-	gpProvokingVertex                             C.GPPROVOKINGVERTEX
-	gpPushDebugGroup                              C.GPPUSHDEBUGGROUP
-	gpPushDebugGroupKHR                           C.GPPUSHDEBUGGROUPKHR
-	gpQueryCounter                                C.GPQUERYCOUNTER
-	gpReadBuffer                                  C.GPREADBUFFER
-	gpReadPixels                                  C.GPREADPIXELS
-	gpReadnPixels                                 C.GPREADNPIXELS
-	gpReadnPixelsARB                              C.GPREADNPIXELSARB
-	gpReadnPixelsKHR                              C.GPREADNPIXELSKHR
-	gpReleaseShaderCompiler                       C.GPRELEASESHADERCOMPILER
-	gpRenderbufferStorage                         C.GPRENDERBUFFERSTORAGE
-	gpRenderbufferStorageMultisample              C.GPRENDERBUFFERSTORAGEMULTISAMPLE
-	gpResumeTransformFeedback                     C.GPRESUMETRANSFORMFEEDBACK
-	gpSampleCoverage                              C.GPSAMPLECOVERAGE
-	gpSampleMaski                                 C.GPSAMPLEMASKI
-	gpSamplerParameterIiv                         C.GPSAMPLERPARAMETERIIV
-	gpSamplerParameterIuiv                        C.GPSAMPLERPARAMETERIUIV
-	gpSamplerParameterf                           C.GPSAMPLERPARAMETERF
-	gpSamplerParameterfv                          C.GPSAMPLERPARAMETERFV
-	gpSamplerParameteri                           C.GPSAMPLERPARAMETERI
-	gpSamplerParameteriv                          C.GPSAMPLERPARAMETERIV
-	gpScissor                                     C.GPSCISSOR
-	gpScissorArrayv                               C.GPSCISSORARRAYV
-	gpScissorIndexed                              C.GPSCISSORINDEXED
-	gpScissorIndexedv                             C.GPSCISSORINDEXEDV
-	gpShaderBinary                                C.GPSHADERBINARY
-	gpShaderSource                                C.GPSHADERSOURCE
-	gpShaderStorageBlockBinding                   C.GPSHADERSTORAGEBLOCKBINDING
-	gpStencilFunc                                 C.GPSTENCILFUNC
-	gpStencilFuncSeparate                         C.GPSTENCILFUNCSEPARATE
-	gpStencilMask                                 C.GPSTENCILMASK
-	gpStencilMaskSeparate                         C.GPSTENCILMASKSEPARATE
-	gpStencilOp                                   C.GPSTENCILOP
-	gpStencilOpSeparate                           C.GPSTENCILOPSEPARATE
-	gpTexBuffer                                   C.GPTEXBUFFER
-	gpTexBufferRange                              C.GPTEXBUFFERRANGE
-	gpTexImage1D                                  C.GPTEXIMAGE1D
-	gpTexImage2D                                  C.GPTEXIMAGE2D
-	gpTexImage2DMultisample                       C.GPTEXIMAGE2DMULTISAMPLE
-	gpTexImage3D                                  C.GPTEXIMAGE3D
-	gpTexImage3DMultisample                       C.GPTEXIMAGE3DMULTISAMPLE
-	gpTexPageCommitmentARB                        C.GPTEXPAGECOMMITMENTARB
-	gpTexParameterIiv                             C.GPTEXPARAMETERIIV
-	gpTexParameterIuiv                            C.GPTEXPARAMETERIUIV
-	gpTexParameterf                               C.GPTEXPARAMETERF
-	gpTexParameterfv                              C.GPTEXPARAMETERFV
-	gpTexParameteri                               C.GPTEXPARAMETERI
-	gpTexParameteriv                              C.GPTEXPARAMETERIV
-	gpTexStorage1D                                C.GPTEXSTORAGE1D
-	gpTexStorage2D                                C.GPTEXSTORAGE2D
-	gpTexStorage2DMultisample                     C.GPTEXSTORAGE2DMULTISAMPLE
-	gpTexStorage3D                                C.GPTEXSTORAGE3D
-	gpTexStorage3DMultisample                     C.GPTEXSTORAGE3DMULTISAMPLE
-	gpTexSubImage1D                               C.GPTEXSUBIMAGE1D
-	gpTexSubImage2D                               C.GPTEXSUBIMAGE2D
-	gpTexSubImage3D                               C.GPTEXSUBIMAGE3D
-	gpTextureBarrier                              C.GPTEXTUREBARRIER
-	gpTextureBuffer                               C.GPTEXTUREBUFFER
-	gpTextureBufferRange                          C.GPTEXTUREBUFFERRANGE
-	gpTextureParameterIiv                         C.GPTEXTUREPARAMETERIIV
-	gpTextureParameterIuiv                        C.GPTEXTUREPARAMETERIUIV
-	gpTextureParameterf                           C.GPTEXTUREPARAMETERF
-	gpTextureParameterfv                          C.GPTEXTUREPARAMETERFV
-	gpTextureParameteri                           C.GPTEXTUREPARAMETERI
-	gpTextureParameteriv                          C.GPTEXTUREPARAMETERIV
-	gpTextureStorage1D                            C.GPTEXTURESTORAGE1D
-	gpTextureStorage2D                            C.GPTEXTURESTORAGE2D
-	gpTextureStorage2DMultisample                 C.GPTEXTURESTORAGE2DMULTISAMPLE
-	gpTextureStorage3D                            C.GPTEXTURESTORAGE3D
-	gpTextureStorage3DMultisample                 C.GPTEXTURESTORAGE3DMULTISAMPLE
-	gpTextureSubImage1D                           C.GPTEXTURESUBIMAGE1D
-	gpTextureSubImage2D                           C.GPTEXTURESUBIMAGE2D
-	gpTextureSubImage3D                           C.GPTEXTURESUBIMAGE3D
-	gpTextureView                                 C.GPTEXTUREVIEW
-	gpTransformFeedbackBufferBase                 C.GPTRANSFORMFEEDBACKBUFFERBASE
-	gpTransformFeedbackBufferRange                C.GPTRANSFORMFEEDBACKBUFFERRANGE
-	gpTransformFeedbackVaryings                   C.GPTRANSFORMFEEDBACKVARYINGS
-	gpUniform1d                                   C.GPUNIFORM1D
-	gpUniform1dv                                  C.GPUNIFORM1DV
-	gpUniform1f                                   C.GPUNIFORM1F
-	gpUniform1fv                                  C.GPUNIFORM1FV
-	gpUniform1i                                   C.GPUNIFORM1I
-	gpUniform1iv                                  C.GPUNIFORM1IV
-	gpUniform1ui                                  C.GPUNIFORM1UI
-	gpUniform1uiv                                 C.GPUNIFORM1UIV
-	gpUniform2d                                   C.GPUNIFORM2D
-	gpUniform2dv                                  C.GPUNIFORM2DV
-	gpUniform2f                                   C.GPUNIFORM2F
-	gpUniform2fv                                  C.GPUNIFORM2FV
-	gpUniform2i                                   C.GPUNIFORM2I
-	gpUniform2iv                                  C.GPUNIFORM2IV
-	gpUniform2ui                                  C.GPUNIFORM2UI
-	gpUniform2uiv                                 C.GPUNIFORM2UIV
-	gpUniform3d                                   C.GPUNIFORM3D
-	gpUniform3dv                                  C.GPUNIFORM3DV
-	gpUniform3f                                   C.GPUNIFORM3F
-	gpUniform3fv                                  C.GPUNIFORM3FV
-	gpUniform3i                                   C.GPUNIFORM3I
-	gpUniform3iv                                  C.GPUNIFORM3IV
-	gpUniform3ui                                  C.GPUNIFORM3UI
-	gpUniform3uiv                                 C.GPUNIFORM3UIV
-	gpUniform4d                                   C.GPUNIFORM4D
-	gpUniform4dv                                  C.GPUNIFORM4DV
-	gpUniform4f                                   C.GPUNIFORM4F
-	gpUniform4fv                                  C.GPUNIFORM4FV
-	gpUniform4i                                   C.GPUNIFORM4I
-	gpUniform4iv                                  C.GPUNIFORM4IV
-	gpUniform4ui                                  C.GPUNIFORM4UI
-	gpUniform4uiv                                 C.GPUNIFORM4UIV
-	gpUniformBlockBinding                         C.GPUNIFORMBLOCKBINDING
-	gpUniformHandleui64ARB                        C.GPUNIFORMHANDLEUI64ARB
-	gpUniformHandleui64vARB                       C.GPUNIFORMHANDLEUI64VARB
-	gpUniformMatrix2dv                            C.GPUNIFORMMATRIX2DV
-	gpUniformMatrix2fv                            C.GPUNIFORMMATRIX2FV
-	gpUniformMatrix2x3dv                          C.GPUNIFORMMATRIX2X3DV
-	gpUniformMatrix2x3fv                          C.GPUNIFORMMATRIX2X3FV
-	gpUniformMatrix2x4dv                          C.GPUNIFORMMATRIX2X4DV
-	gpUniformMatrix2x4fv                          C.GPUNIFORMMATRIX2X4FV
-	gpUniformMatrix3dv                            C.GPUNIFORMMATRIX3DV
-	gpUniformMatrix3fv                            C.GPUNIFORMMATRIX3FV
-	gpUniformMatrix3x2dv                          C.GPUNIFORMMATRIX3X2DV
-	gpUniformMatrix3x2fv                          C.GPUNIFORMMATRIX3X2FV
-	gpUniformMatrix3x4dv                          C.GPUNIFORMMATRIX3X4DV
-	gpUniformMatrix3x4fv                          C.GPUNIFORMMATRIX3X4FV
-	gpUniformMatrix4dv                            C.GPUNIFORMMATRIX4DV
-	gpUniformMatrix4fv                            C.GPUNIFORMMATRIX4FV
-	gpUniformMatrix4x2dv                          C.GPUNIFORMMATRIX4X2DV
-	gpUniformMatrix4x2fv                          C.GPUNIFORMMATRIX4X2FV
-	gpUniformMatrix4x3dv                          C.GPUNIFORMMATRIX4X3DV
-	gpUniformMatrix4x3fv                          C.GPUNIFORMMATRIX4X3FV
-	gpUniformSubroutinesuiv                       C.GPUNIFORMSUBROUTINESUIV
-	gpUnmapBuffer                                 C.GPUNMAPBUFFER
-	gpUnmapNamedBuffer                            C.GPUNMAPNAMEDBUFFER
-	gpUseProgram                                  C.GPUSEPROGRAM
-	gpUseProgramStages                            C.GPUSEPROGRAMSTAGES
-	gpValidateProgram                             C.GPVALIDATEPROGRAM
-	gpValidateProgramPipeline                     C.GPVALIDATEPROGRAMPIPELINE
-	gpVertexArrayAttribBinding                    C.GPVERTEXARRAYATTRIBBINDING
-	gpVertexArrayAttribFormat                     C.GPVERTEXARRAYATTRIBFORMAT
-	gpVertexArrayAttribIFormat                    C.GPVERTEXARRAYATTRIBIFORMAT
-	gpVertexArrayAttribLFormat                    C.GPVERTEXARRAYATTRIBLFORMAT
-	gpVertexArrayBindingDivisor                   C.GPVERTEXARRAYBINDINGDIVISOR
-	gpVertexArrayElementBuffer                    C.GPVERTEXARRAYELEMENTBUFFER
-	gpVertexArrayVertexBuffer                     C.GPVERTEXARRAYVERTEXBUFFER
-	gpVertexArrayVertexBuffers                    C.GPVERTEXARRAYVERTEXBUFFERS
-	gpVertexAttrib1d                              C.GPVERTEXATTRIB1D
-	gpVertexAttrib1dv                             C.GPVERTEXATTRIB1DV
-	gpVertexAttrib1f                              C.GPVERTEXATTRIB1F
-	gpVertexAttrib1fv                             C.GPVERTEXATTRIB1FV
-	gpVertexAttrib1s                              C.GPVERTEXATTRIB1S
-	gpVertexAttrib1sv                             C.GPVERTEXATTRIB1SV
-	gpVertexAttrib2d                              C.GPVERTEXATTRIB2D
-	gpVertexAttrib2dv                             C.GPVERTEXATTRIB2DV
-	gpVertexAttrib2f                              C.GPVERTEXATTRIB2F
-	gpVertexAttrib2fv                             C.GPVERTEXATTRIB2FV
-	gpVertexAttrib2s                              C.GPVERTEXATTRIB2S
-	gpVertexAttrib2sv                             C.GPVERTEXATTRIB2SV
-	gpVertexAttrib3d                              C.GPVERTEXATTRIB3D
-	gpVertexAttrib3dv                             C.GPVERTEXATTRIB3DV
-	gpVertexAttrib3f                              C.GPVERTEXATTRIB3F
-	gpVertexAttrib3fv                             C.GPVERTEXATTRIB3FV
-	gpVertexAttrib3s                              C.GPVERTEXATTRIB3S
-	gpVertexAttrib3sv                             C.GPVERTEXATTRIB3SV
-	gpVertexAttrib4Nbv                            C.GPVERTEXATTRIB4NBV
-	gpVertexAttrib4Niv                            C.GPVERTEXATTRIB4NIV
-	gpVertexAttrib4Nsv                            C.GPVERTEXATTRIB4NSV
-	gpVertexAttrib4Nub                            C.GPVERTEXATTRIB4NUB
-	gpVertexAttrib4Nubv                           C.GPVERTEXATTRIB4NUBV
-	gpVertexAttrib4Nuiv                           C.GPVERTEXATTRIB4NUIV
-	gpVertexAttrib4Nusv                           C.GPVERTEXATTRIB4NUSV
-	gpVertexAttrib4bv                             C.GPVERTEXATTRIB4BV
-	gpVertexAttrib4d                              C.GPVERTEXATTRIB4D
-	gpVertexAttrib4dv                             C.GPVERTEXATTRIB4DV
-	gpVertexAttrib4f                              C.GPVERTEXATTRIB4F
-	gpVertexAttrib4fv                             C.GPVERTEXATTRIB4FV
-	gpVertexAttrib4iv                             C.GPVERTEXATTRIB4IV
-	gpVertexAttrib4s                              C.GPVERTEXATTRIB4S
-	gpVertexAttrib4sv                             C.GPVERTEXATTRIB4SV
-	gpVertexAttrib4ubv                            C.GPVERTEXATTRIB4UBV
-	gpVertexAttrib4uiv                            C.GPVERTEXATTRIB4UIV
-	gpVertexAttrib4usv                            C.GPVERTEXATTRIB4USV
-	gpVertexAttribBinding                         C.GPVERTEXATTRIBBINDING
-	gpVertexAttribFormat                          C.GPVERTEXATTRIBFORMAT
-	gpVertexAttribI1i                             C.GPVERTEXATTRIBI1I
-	gpVertexAttribI1iv                            C.GPVERTEXATTRIBI1IV
-	gpVertexAttribI1ui                            C.GPVERTEXATTRIBI1UI
-	gpVertexAttribI1uiv                           C.GPVERTEXATTRIBI1UIV
-	gpVertexAttribI2i                             C.GPVERTEXATTRIBI2I
-	gpVertexAttribI2iv                            C.GPVERTEXATTRIBI2IV
-	gpVertexAttribI2ui                            C.GPVERTEXATTRIBI2UI
-	gpVertexAttribI2uiv                           C.GPVERTEXATTRIBI2UIV
-	gpVertexAttribI3i                             C.GPVERTEXATTRIBI3I
-	gpVertexAttribI3iv                            C.GPVERTEXATTRIBI3IV
-	gpVertexAttribI3ui                            C.GPVERTEXATTRIBI3UI
-	gpVertexAttribI3uiv                           C.GPVERTEXATTRIBI3UIV
-	gpVertexAttribI4bv                            C.GPVERTEXATTRIBI4BV
-	gpVertexAttribI4i                             C.GPVERTEXATTRIBI4I
-	gpVertexAttribI4iv                            C.GPVERTEXATTRIBI4IV
-	gpVertexAttribI4sv                            C.GPVERTEXATTRIBI4SV
-	gpVertexAttribI4ubv                           C.GPVERTEXATTRIBI4UBV
-	gpVertexAttribI4ui                            C.GPVERTEXATTRIBI4UI
-	gpVertexAttribI4uiv                           C.GPVERTEXATTRIBI4UIV
-	gpVertexAttribI4usv                           C.GPVERTEXATTRIBI4USV
-	gpVertexAttribIFormat                         C.GPVERTEXATTRIBIFORMAT
-	gpVertexAttribIPointer                        C.GPVERTEXATTRIBIPOINTER
-	gpVertexAttribL1d                             C.GPVERTEXATTRIBL1D
-	gpVertexAttribL1dv                            C.GPVERTEXATTRIBL1DV
-	gpVertexAttribL1ui64ARB                       C.GPVERTEXATTRIBL1UI64ARB
-	gpVertexAttribL1ui64vARB                      C.GPVERTEXATTRIBL1UI64VARB
-	gpVertexAttribL2d                             C.GPVERTEXATTRIBL2D
-	gpVertexAttribL2dv                            C.GPVERTEXATTRIBL2DV
-	gpVertexAttribL3d                             C.GPVERTEXATTRIBL3D
-	gpVertexAttribL3dv                            C.GPVERTEXATTRIBL3DV
-	gpVertexAttribL4d                             C.GPVERTEXATTRIBL4D
-	gpVertexAttribL4dv                            C.GPVERTEXATTRIBL4DV
-	gpVertexAttribLFormat                         C.GPVERTEXATTRIBLFORMAT
-	gpVertexAttribLPointer                        C.GPVERTEXATTRIBLPOINTER
-	gpVertexAttribP1ui                            C.GPVERTEXATTRIBP1UI
-	gpVertexAttribP1uiv                           C.GPVERTEXATTRIBP1UIV
-	gpVertexAttribP2ui                            C.GPVERTEXATTRIBP2UI
-	gpVertexAttribP2uiv                           C.GPVERTEXATTRIBP2UIV
-	gpVertexAttribP3ui                            C.GPVERTEXATTRIBP3UI
-	gpVertexAttribP3uiv                           C.GPVERTEXATTRIBP3UIV
-	gpVertexAttribP4ui                            C.GPVERTEXATTRIBP4UI
-	gpVertexAttribP4uiv                           C.GPVERTEXATTRIBP4UIV
-	gpVertexAttribPointer                         C.GPVERTEXATTRIBPOINTER
-	gpVertexBindingDivisor                        C.GPVERTEXBINDINGDIVISOR
-	gpViewport                                    C.GPVIEWPORT
-	gpViewportArrayv                              C.GPVIEWPORTARRAYV
-	gpViewportIndexedf                            C.GPVIEWPORTINDEXEDF
-	gpViewportIndexedfv                           C.GPVIEWPORTINDEXEDFV
-	gpWaitSync                                    C.GPWAITSYNC
+	gpActiveProgramEXT                               C.GPACTIVEPROGRAMEXT
+	gpActiveShaderProgram                            C.GPACTIVESHADERPROGRAM
+	gpActiveShaderProgramEXT                         C.GPACTIVESHADERPROGRAMEXT
+	gpActiveTexture                                  C.GPACTIVETEXTURE
+	gpApplyFramebufferAttachmentCMAAINTEL            C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
+	gpAttachShader                                   C.GPATTACHSHADER
+	gpBeginConditionalRender                         C.GPBEGINCONDITIONALRENDER
+	gpBeginConditionalRenderNV                       C.GPBEGINCONDITIONALRENDERNV
+	gpBeginPerfMonitorAMD                            C.GPBEGINPERFMONITORAMD
+	gpBeginPerfQueryINTEL                            C.GPBEGINPERFQUERYINTEL
+	gpBeginQuery                                     C.GPBEGINQUERY
+	gpBeginQueryIndexed                              C.GPBEGINQUERYINDEXED
+	gpBeginTransformFeedback                         C.GPBEGINTRANSFORMFEEDBACK
+	gpBindAttribLocation                             C.GPBINDATTRIBLOCATION
+	gpBindBuffer                                     C.GPBINDBUFFER
+	gpBindBufferBase                                 C.GPBINDBUFFERBASE
+	gpBindBufferRange                                C.GPBINDBUFFERRANGE
+	gpBindBuffersBase                                C.GPBINDBUFFERSBASE
+	gpBindBuffersRange                               C.GPBINDBUFFERSRANGE
+	gpBindFragDataLocation                           C.GPBINDFRAGDATALOCATION
+	gpBindFragDataLocationIndexed                    C.GPBINDFRAGDATALOCATIONINDEXED
+	gpBindFramebuffer                                C.GPBINDFRAMEBUFFER
+	gpBindImageTexture                               C.GPBINDIMAGETEXTURE
+	gpBindImageTextures                              C.GPBINDIMAGETEXTURES
+	gpBindMultiTextureEXT                            C.GPBINDMULTITEXTUREEXT
+	gpBindProgramPipeline                            C.GPBINDPROGRAMPIPELINE
+	gpBindProgramPipelineEXT                         C.GPBINDPROGRAMPIPELINEEXT
+	gpBindRenderbuffer                               C.GPBINDRENDERBUFFER
+	gpBindSampler                                    C.GPBINDSAMPLER
+	gpBindSamplers                                   C.GPBINDSAMPLERS
+	gpBindTexture                                    C.GPBINDTEXTURE
+	gpBindTextureUnit                                C.GPBINDTEXTUREUNIT
+	gpBindTextures                                   C.GPBINDTEXTURES
+	gpBindTransformFeedback                          C.GPBINDTRANSFORMFEEDBACK
+	gpBindVertexArray                                C.GPBINDVERTEXARRAY
+	gpBindVertexBuffer                               C.GPBINDVERTEXBUFFER
+	gpBindVertexBuffers                              C.GPBINDVERTEXBUFFERS
+	gpBlendBarrierKHR                                C.GPBLENDBARRIERKHR
+	gpBlendBarrierNV                                 C.GPBLENDBARRIERNV
+	gpBlendColor                                     C.GPBLENDCOLOR
+	gpBlendEquation                                  C.GPBLENDEQUATION
+	gpBlendEquationSeparate                          C.GPBLENDEQUATIONSEPARATE
+	gpBlendEquationSeparateiARB                      C.GPBLENDEQUATIONSEPARATEIARB
+	gpBlendEquationiARB                              C.GPBLENDEQUATIONIARB
+	gpBlendFunc                                      C.GPBLENDFUNC
+	gpBlendFuncSeparate                              C.GPBLENDFUNCSEPARATE
+	gpBlendFuncSeparateiARB                          C.GPBLENDFUNCSEPARATEIARB
+	gpBlendFunciARB                                  C.GPBLENDFUNCIARB
+	gpBlendParameteriNV                              C.GPBLENDPARAMETERINV
+	gpBlitFramebuffer                                C.GPBLITFRAMEBUFFER
+	gpBlitNamedFramebuffer                           C.GPBLITNAMEDFRAMEBUFFER
+	gpBufferAddressRangeNV                           C.GPBUFFERADDRESSRANGENV
+	gpBufferData                                     C.GPBUFFERDATA
+	gpBufferPageCommitmentARB                        C.GPBUFFERPAGECOMMITMENTARB
+	gpBufferStorage                                  C.GPBUFFERSTORAGE
+	gpBufferSubData                                  C.GPBUFFERSUBDATA
+	gpCallCommandListNV                              C.GPCALLCOMMANDLISTNV
+	gpCheckFramebufferStatus                         C.GPCHECKFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatus                    C.GPCHECKNAMEDFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatusEXT                 C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT
+	gpClampColor                                     C.GPCLAMPCOLOR
+	gpClear                                          C.GPCLEAR
+	gpClearBufferData                                C.GPCLEARBUFFERDATA
+	gpClearBufferSubData                             C.GPCLEARBUFFERSUBDATA
+	gpClearBufferfi                                  C.GPCLEARBUFFERFI
+	gpClearBufferfv                                  C.GPCLEARBUFFERFV
+	gpClearBufferiv                                  C.GPCLEARBUFFERIV
+	gpClearBufferuiv                                 C.GPCLEARBUFFERUIV
+	gpClearColor                                     C.GPCLEARCOLOR
+	gpClearDepth                                     C.GPCLEARDEPTH
+	gpClearDepthf                                    C.GPCLEARDEPTHF
+	gpClearNamedBufferData                           C.GPCLEARNAMEDBUFFERDATA
+	gpClearNamedBufferDataEXT                        C.GPCLEARNAMEDBUFFERDATAEXT
+	gpClearNamedBufferSubData                        C.GPCLEARNAMEDBUFFERSUBDATA
+	gpClearNamedBufferSubDataEXT                     C.GPCLEARNAMEDBUFFERSUBDATAEXT
+	gpClearNamedFramebufferfi                        C.GPCLEARNAMEDFRAMEBUFFERFI
+	gpClearNamedFramebufferfv                        C.GPCLEARNAMEDFRAMEBUFFERFV
+	gpClearNamedFramebufferiv                        C.GPCLEARNAMEDFRAMEBUFFERIV
+	gpClearNamedFramebufferuiv                       C.GPCLEARNAMEDFRAMEBUFFERUIV
+	gpClearStencil                                   C.GPCLEARSTENCIL
+	gpClearTexImage                                  C.GPCLEARTEXIMAGE
+	gpClearTexSubImage                               C.GPCLEARTEXSUBIMAGE
+	gpClientAttribDefaultEXT                         C.GPCLIENTATTRIBDEFAULTEXT
+	gpClientWaitSync                                 C.GPCLIENTWAITSYNC
+	gpClipControl                                    C.GPCLIPCONTROL
+	gpColorFormatNV                                  C.GPCOLORFORMATNV
+	gpColorMask                                      C.GPCOLORMASK
+	gpColorMaski                                     C.GPCOLORMASKI
+	gpCommandListSegmentsNV                          C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                           C.GPCOMPILECOMMANDLISTNV
+	gpCompileShader                                  C.GPCOMPILESHADER
+	gpCompileShaderIncludeARB                        C.GPCOMPILESHADERINCLUDEARB
+	gpCompressedMultiTexImage1DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE1DEXT
+	gpCompressedMultiTexImage2DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE2DEXT
+	gpCompressedMultiTexImage3DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE3DEXT
+	gpCompressedMultiTexSubImage1DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT
+	gpCompressedMultiTexSubImage2DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT
+	gpCompressedMultiTexSubImage3DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT
+	gpCompressedTexImage1D                           C.GPCOMPRESSEDTEXIMAGE1D
+	gpCompressedTexImage2D                           C.GPCOMPRESSEDTEXIMAGE2D
+	gpCompressedTexImage3D                           C.GPCOMPRESSEDTEXIMAGE3D
+	gpCompressedTexSubImage1D                        C.GPCOMPRESSEDTEXSUBIMAGE1D
+	gpCompressedTexSubImage2D                        C.GPCOMPRESSEDTEXSUBIMAGE2D
+	gpCompressedTexSubImage3D                        C.GPCOMPRESSEDTEXSUBIMAGE3D
+	gpCompressedTextureImage1DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE1DEXT
+	gpCompressedTextureImage2DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE2DEXT
+	gpCompressedTextureImage3DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE3DEXT
+	gpCompressedTextureSubImage1D                    C.GPCOMPRESSEDTEXTURESUBIMAGE1D
+	gpCompressedTextureSubImage1DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT
+	gpCompressedTextureSubImage2D                    C.GPCOMPRESSEDTEXTURESUBIMAGE2D
+	gpCompressedTextureSubImage2DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
+	gpCompressedTextureSubImage3D                    C.GPCOMPRESSEDTEXTURESUBIMAGE3D
+	gpCompressedTextureSubImage3DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                 C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                 C.GPCONSERVATIVERASTERPARAMETERINV
+	gpCopyBufferSubData                              C.GPCOPYBUFFERSUBDATA
+	gpCopyImageSubData                               C.GPCOPYIMAGESUBDATA
+	gpCopyMultiTexImage1DEXT                         C.GPCOPYMULTITEXIMAGE1DEXT
+	gpCopyMultiTexImage2DEXT                         C.GPCOPYMULTITEXIMAGE2DEXT
+	gpCopyMultiTexSubImage1DEXT                      C.GPCOPYMULTITEXSUBIMAGE1DEXT
+	gpCopyMultiTexSubImage2DEXT                      C.GPCOPYMULTITEXSUBIMAGE2DEXT
+	gpCopyMultiTexSubImage3DEXT                      C.GPCOPYMULTITEXSUBIMAGE3DEXT
+	gpCopyNamedBufferSubData                         C.GPCOPYNAMEDBUFFERSUBDATA
+	gpCopyPathNV                                     C.GPCOPYPATHNV
+	gpCopyTexImage1D                                 C.GPCOPYTEXIMAGE1D
+	gpCopyTexImage2D                                 C.GPCOPYTEXIMAGE2D
+	gpCopyTexSubImage1D                              C.GPCOPYTEXSUBIMAGE1D
+	gpCopyTexSubImage2D                              C.GPCOPYTEXSUBIMAGE2D
+	gpCopyTexSubImage3D                              C.GPCOPYTEXSUBIMAGE3D
+	gpCopyTextureImage1DEXT                          C.GPCOPYTEXTUREIMAGE1DEXT
+	gpCopyTextureImage2DEXT                          C.GPCOPYTEXTUREIMAGE2DEXT
+	gpCopyTextureSubImage1D                          C.GPCOPYTEXTURESUBIMAGE1D
+	gpCopyTextureSubImage1DEXT                       C.GPCOPYTEXTURESUBIMAGE1DEXT
+	gpCopyTextureSubImage2D                          C.GPCOPYTEXTURESUBIMAGE2D
+	gpCopyTextureSubImage2DEXT                       C.GPCOPYTEXTURESUBIMAGE2DEXT
+	gpCopyTextureSubImage3D                          C.GPCOPYTEXTURESUBIMAGE3D
+	gpCopyTextureSubImage3DEXT                       C.GPCOPYTEXTURESUBIMAGE3DEXT
+	gpCoverFillPathInstancedNV                       C.GPCOVERFILLPATHINSTANCEDNV
+	gpCoverFillPathNV                                C.GPCOVERFILLPATHNV
+	gpCoverStrokePathInstancedNV                     C.GPCOVERSTROKEPATHINSTANCEDNV
+	gpCoverStrokePathNV                              C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                           C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                      C.GPCOVERAGEMODULATIONTABLENV
+	gpCreateBuffers                                  C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                           C.GPCREATECOMMANDLISTSNV
+	gpCreateFramebuffers                             C.GPCREATEFRAMEBUFFERS
+	gpCreatePerfQueryINTEL                           C.GPCREATEPERFQUERYINTEL
+	gpCreateProgram                                  C.GPCREATEPROGRAM
+	gpCreateProgramPipelines                         C.GPCREATEPROGRAMPIPELINES
+	gpCreateQueries                                  C.GPCREATEQUERIES
+	gpCreateRenderbuffers                            C.GPCREATERENDERBUFFERS
+	gpCreateSamplers                                 C.GPCREATESAMPLERS
+	gpCreateShader                                   C.GPCREATESHADER
+	gpCreateShaderProgramEXT                         C.GPCREATESHADERPROGRAMEXT
+	gpCreateShaderProgramv                           C.GPCREATESHADERPROGRAMV
+	gpCreateShaderProgramvEXT                        C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                 C.GPCREATESTATESNV
+	gpCreateSyncFromCLeventARB                       C.GPCREATESYNCFROMCLEVENTARB
+	gpCreateTextures                                 C.GPCREATETEXTURES
+	gpCreateTransformFeedbacks                       C.GPCREATETRANSFORMFEEDBACKS
+	gpCreateVertexArrays                             C.GPCREATEVERTEXARRAYS
+	gpCullFace                                       C.GPCULLFACE
+	gpDebugMessageCallback                           C.GPDEBUGMESSAGECALLBACK
+	gpDebugMessageCallbackARB                        C.GPDEBUGMESSAGECALLBACKARB
+	gpDebugMessageCallbackKHR                        C.GPDEBUGMESSAGECALLBACKKHR
+	gpDebugMessageControl                            C.GPDEBUGMESSAGECONTROL
+	gpDebugMessageControlARB                         C.GPDEBUGMESSAGECONTROLARB
+	gpDebugMessageControlKHR                         C.GPDEBUGMESSAGECONTROLKHR
+	gpDebugMessageInsert                             C.GPDEBUGMESSAGEINSERT
+	gpDebugMessageInsertARB                          C.GPDEBUGMESSAGEINSERTARB
+	gpDebugMessageInsertKHR                          C.GPDEBUGMESSAGEINSERTKHR
+	gpDeleteBuffers                                  C.GPDELETEBUFFERS
+	gpDeleteCommandListsNV                           C.GPDELETECOMMANDLISTSNV
+	gpDeleteFramebuffers                             C.GPDELETEFRAMEBUFFERS
+	gpDeleteNamedStringARB                           C.GPDELETENAMEDSTRINGARB
+	gpDeletePathsNV                                  C.GPDELETEPATHSNV
+	gpDeletePerfMonitorsAMD                          C.GPDELETEPERFMONITORSAMD
+	gpDeletePerfQueryINTEL                           C.GPDELETEPERFQUERYINTEL
+	gpDeleteProgram                                  C.GPDELETEPROGRAM
+	gpDeleteProgramPipelines                         C.GPDELETEPROGRAMPIPELINES
+	gpDeleteProgramPipelinesEXT                      C.GPDELETEPROGRAMPIPELINESEXT
+	gpDeleteQueries                                  C.GPDELETEQUERIES
+	gpDeleteRenderbuffers                            C.GPDELETERENDERBUFFERS
+	gpDeleteSamplers                                 C.GPDELETESAMPLERS
+	gpDeleteShader                                   C.GPDELETESHADER
+	gpDeleteStatesNV                                 C.GPDELETESTATESNV
+	gpDeleteSync                                     C.GPDELETESYNC
+	gpDeleteTextures                                 C.GPDELETETEXTURES
+	gpDeleteTransformFeedbacks                       C.GPDELETETRANSFORMFEEDBACKS
+	gpDeleteVertexArrays                             C.GPDELETEVERTEXARRAYS
+	gpDepthFunc                                      C.GPDEPTHFUNC
+	gpDepthMask                                      C.GPDEPTHMASK
+	gpDepthRange                                     C.GPDEPTHRANGE
+	gpDepthRangeArrayv                               C.GPDEPTHRANGEARRAYV
+	gpDepthRangeIndexed                              C.GPDEPTHRANGEINDEXED
+	gpDepthRangef                                    C.GPDEPTHRANGEF
+	gpDetachShader                                   C.GPDETACHSHADER
+	gpDisable                                        C.GPDISABLE
+	gpDisableClientStateIndexedEXT                   C.GPDISABLECLIENTSTATEINDEXEDEXT
+	gpDisableClientStateiEXT                         C.GPDISABLECLIENTSTATEIEXT
+	gpDisableIndexedEXT                              C.GPDISABLEINDEXEDEXT
+	gpDisableVertexArrayAttrib                       C.GPDISABLEVERTEXARRAYATTRIB
+	gpDisableVertexArrayAttribEXT                    C.GPDISABLEVERTEXARRAYATTRIBEXT
+	gpDisableVertexArrayEXT                          C.GPDISABLEVERTEXARRAYEXT
+	gpDisableVertexAttribArray                       C.GPDISABLEVERTEXATTRIBARRAY
+	gpDisablei                                       C.GPDISABLEI
+	gpDispatchCompute                                C.GPDISPATCHCOMPUTE
+	gpDispatchComputeGroupSizeARB                    C.GPDISPATCHCOMPUTEGROUPSIZEARB
+	gpDispatchComputeIndirect                        C.GPDISPATCHCOMPUTEINDIRECT
+	gpDrawArrays                                     C.GPDRAWARRAYS
+	gpDrawArraysIndirect                             C.GPDRAWARRAYSINDIRECT
+	gpDrawArraysInstanced                            C.GPDRAWARRAYSINSTANCED
+	gpDrawArraysInstancedARB                         C.GPDRAWARRAYSINSTANCEDARB
+	gpDrawArraysInstancedBaseInstance                C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
+	gpDrawArraysInstancedEXT                         C.GPDRAWARRAYSINSTANCEDEXT
+	gpDrawBuffer                                     C.GPDRAWBUFFER
+	gpDrawBuffers                                    C.GPDRAWBUFFERS
+	gpDrawCommandsAddressNV                          C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                 C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                    C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                           C.GPDRAWCOMMANDSSTATESNV
+	gpDrawElements                                   C.GPDRAWELEMENTS
+	gpDrawElementsBaseVertex                         C.GPDRAWELEMENTSBASEVERTEX
+	gpDrawElementsIndirect                           C.GPDRAWELEMENTSINDIRECT
+	gpDrawElementsInstanced                          C.GPDRAWELEMENTSINSTANCED
+	gpDrawElementsInstancedARB                       C.GPDRAWELEMENTSINSTANCEDARB
+	gpDrawElementsInstancedBaseInstance              C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
+	gpDrawElementsInstancedBaseVertex                C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
+	gpDrawElementsInstancedBaseVertexBaseInstance    C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
+	gpDrawElementsInstancedEXT                       C.GPDRAWELEMENTSINSTANCEDEXT
+	gpDrawRangeElements                              C.GPDRAWRANGEELEMENTS
+	gpDrawRangeElementsBaseVertex                    C.GPDRAWRANGEELEMENTSBASEVERTEX
+	gpDrawTransformFeedback                          C.GPDRAWTRANSFORMFEEDBACK
+	gpDrawTransformFeedbackInstanced                 C.GPDRAWTRANSFORMFEEDBACKINSTANCED
+	gpDrawTransformFeedbackStream                    C.GPDRAWTRANSFORMFEEDBACKSTREAM
+	gpDrawTransformFeedbackStreamInstanced           C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                  C.GPDRAWVKIMAGENV
+	gpEdgeFlagFormatNV                               C.GPEDGEFLAGFORMATNV
+	gpEnable                                         C.GPENABLE
+	gpEnableClientStateIndexedEXT                    C.GPENABLECLIENTSTATEINDEXEDEXT
+	gpEnableClientStateiEXT                          C.GPENABLECLIENTSTATEIEXT
+	gpEnableIndexedEXT                               C.GPENABLEINDEXEDEXT
+	gpEnableVertexArrayAttrib                        C.GPENABLEVERTEXARRAYATTRIB
+	gpEnableVertexArrayAttribEXT                     C.GPENABLEVERTEXARRAYATTRIBEXT
+	gpEnableVertexArrayEXT                           C.GPENABLEVERTEXARRAYEXT
+	gpEnableVertexAttribArray                        C.GPENABLEVERTEXATTRIBARRAY
+	gpEnablei                                        C.GPENABLEI
+	gpEndConditionalRender                           C.GPENDCONDITIONALRENDER
+	gpEndConditionalRenderNV                         C.GPENDCONDITIONALRENDERNV
+	gpEndPerfMonitorAMD                              C.GPENDPERFMONITORAMD
+	gpEndPerfQueryINTEL                              C.GPENDPERFQUERYINTEL
+	gpEndQuery                                       C.GPENDQUERY
+	gpEndQueryIndexed                                C.GPENDQUERYINDEXED
+	gpEndTransformFeedback                           C.GPENDTRANSFORMFEEDBACK
+	gpEvaluateDepthValuesARB                         C.GPEVALUATEDEPTHVALUESARB
+	gpFenceSync                                      C.GPFENCESYNC
+	gpFinish                                         C.GPFINISH
+	gpFlush                                          C.GPFLUSH
+	gpFlushMappedBufferRange                         C.GPFLUSHMAPPEDBUFFERRANGE
+	gpFlushMappedNamedBufferRange                    C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
+	gpFlushMappedNamedBufferRangeEXT                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT
+	gpFogCoordFormatNV                               C.GPFOGCOORDFORMATNV
+	gpFragmentCoverageColorNV                        C.GPFRAGMENTCOVERAGECOLORNV
+	gpFramebufferDrawBufferEXT                       C.GPFRAMEBUFFERDRAWBUFFEREXT
+	gpFramebufferDrawBuffersEXT                      C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                     C.GPFRAMEBUFFERFETCHBARRIEREXT
+	gpFramebufferParameteri                          C.GPFRAMEBUFFERPARAMETERI
+	gpFramebufferReadBufferEXT                       C.GPFRAMEBUFFERREADBUFFEREXT
+	gpFramebufferRenderbuffer                        C.GPFRAMEBUFFERRENDERBUFFER
+	gpFramebufferSampleLocationsfvARB                C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                 C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferTexture                             C.GPFRAMEBUFFERTEXTURE
+	gpFramebufferTexture1D                           C.GPFRAMEBUFFERTEXTURE1D
+	gpFramebufferTexture2D                           C.GPFRAMEBUFFERTEXTURE2D
+	gpFramebufferTexture3D                           C.GPFRAMEBUFFERTEXTURE3D
+	gpFramebufferTextureARB                          C.GPFRAMEBUFFERTEXTUREARB
+	gpFramebufferTextureFaceARB                      C.GPFRAMEBUFFERTEXTUREFACEARB
+	gpFramebufferTextureLayer                        C.GPFRAMEBUFFERTEXTURELAYER
+	gpFramebufferTextureLayerARB                     C.GPFRAMEBUFFERTEXTURELAYERARB
+	gpFramebufferTextureMultiviewOVR                 C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
+	gpFrontFace                                      C.GPFRONTFACE
+	gpGenBuffers                                     C.GPGENBUFFERS
+	gpGenFramebuffers                                C.GPGENFRAMEBUFFERS
+	gpGenPathsNV                                     C.GPGENPATHSNV
+	gpGenPerfMonitorsAMD                             C.GPGENPERFMONITORSAMD
+	gpGenProgramPipelines                            C.GPGENPROGRAMPIPELINES
+	gpGenProgramPipelinesEXT                         C.GPGENPROGRAMPIPELINESEXT
+	gpGenQueries                                     C.GPGENQUERIES
+	gpGenRenderbuffers                               C.GPGENRENDERBUFFERS
+	gpGenSamplers                                    C.GPGENSAMPLERS
+	gpGenTextures                                    C.GPGENTEXTURES
+	gpGenTransformFeedbacks                          C.GPGENTRANSFORMFEEDBACKS
+	gpGenVertexArrays                                C.GPGENVERTEXARRAYS
+	gpGenerateMipmap                                 C.GPGENERATEMIPMAP
+	gpGenerateMultiTexMipmapEXT                      C.GPGENERATEMULTITEXMIPMAPEXT
+	gpGenerateTextureMipmap                          C.GPGENERATETEXTUREMIPMAP
+	gpGenerateTextureMipmapEXT                       C.GPGENERATETEXTUREMIPMAPEXT
+	gpGetActiveAtomicCounterBufferiv                 C.GPGETACTIVEATOMICCOUNTERBUFFERIV
+	gpGetActiveAttrib                                C.GPGETACTIVEATTRIB
+	gpGetActiveSubroutineName                        C.GPGETACTIVESUBROUTINENAME
+	gpGetActiveSubroutineUniformName                 C.GPGETACTIVESUBROUTINEUNIFORMNAME
+	gpGetActiveSubroutineUniformiv                   C.GPGETACTIVESUBROUTINEUNIFORMIV
+	gpGetActiveUniform                               C.GPGETACTIVEUNIFORM
+	gpGetActiveUniformBlockName                      C.GPGETACTIVEUNIFORMBLOCKNAME
+	gpGetActiveUniformBlockiv                        C.GPGETACTIVEUNIFORMBLOCKIV
+	gpGetActiveUniformName                           C.GPGETACTIVEUNIFORMNAME
+	gpGetActiveUniformsiv                            C.GPGETACTIVEUNIFORMSIV
+	gpGetAttachedShaders                             C.GPGETATTACHEDSHADERS
+	gpGetAttribLocation                              C.GPGETATTRIBLOCATION
+	gpGetBooleanIndexedvEXT                          C.GPGETBOOLEANINDEXEDVEXT
+	gpGetBooleani_v                                  C.GPGETBOOLEANI_V
+	gpGetBooleanv                                    C.GPGETBOOLEANV
+	gpGetBufferParameteri64v                         C.GPGETBUFFERPARAMETERI64V
+	gpGetBufferParameteriv                           C.GPGETBUFFERPARAMETERIV
+	gpGetBufferParameterui64vNV                      C.GPGETBUFFERPARAMETERUI64VNV
+	gpGetBufferPointerv                              C.GPGETBUFFERPOINTERV
+	gpGetBufferSubData                               C.GPGETBUFFERSUBDATA
+	gpGetCommandHeaderNV                             C.GPGETCOMMANDHEADERNV
+	gpGetCompressedMultiTexImageEXT                  C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
+	gpGetCompressedTexImage                          C.GPGETCOMPRESSEDTEXIMAGE
+	gpGetCompressedTextureImage                      C.GPGETCOMPRESSEDTEXTUREIMAGE
+	gpGetCompressedTextureImageEXT                   C.GPGETCOMPRESSEDTEXTUREIMAGEEXT
+	gpGetCompressedTextureSubImage                   C.GPGETCOMPRESSEDTEXTURESUBIMAGE
+	gpGetCoverageModulationTableNV                   C.GPGETCOVERAGEMODULATIONTABLENV
+	gpGetDebugMessageLog                             C.GPGETDEBUGMESSAGELOG
+	gpGetDebugMessageLogARB                          C.GPGETDEBUGMESSAGELOGARB
+	gpGetDebugMessageLogKHR                          C.GPGETDEBUGMESSAGELOGKHR
+	gpGetDoubleIndexedvEXT                           C.GPGETDOUBLEINDEXEDVEXT
+	gpGetDoublei_v                                   C.GPGETDOUBLEI_V
+	gpGetDoublei_vEXT                                C.GPGETDOUBLEI_VEXT
+	gpGetDoublev                                     C.GPGETDOUBLEV
+	gpGetError                                       C.GPGETERROR
+	gpGetFirstPerfQueryIdINTEL                       C.GPGETFIRSTPERFQUERYIDINTEL
+	gpGetFloatIndexedvEXT                            C.GPGETFLOATINDEXEDVEXT
+	gpGetFloati_v                                    C.GPGETFLOATI_V
+	gpGetFloati_vEXT                                 C.GPGETFLOATI_VEXT
+	gpGetFloatv                                      C.GPGETFLOATV
+	gpGetFragDataIndex                               C.GPGETFRAGDATAINDEX
+	gpGetFragDataLocation                            C.GPGETFRAGDATALOCATION
+	gpGetFramebufferAttachmentParameteriv            C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetFramebufferParameteriv                      C.GPGETFRAMEBUFFERPARAMETERIV
+	gpGetFramebufferParameterivEXT                   C.GPGETFRAMEBUFFERPARAMETERIVEXT
+	gpGetGraphicsResetStatus                         C.GPGETGRAPHICSRESETSTATUS
+	gpGetGraphicsResetStatusARB                      C.GPGETGRAPHICSRESETSTATUSARB
+	gpGetGraphicsResetStatusKHR                      C.GPGETGRAPHICSRESETSTATUSKHR
+	gpGetImageHandleARB                              C.GPGETIMAGEHANDLEARB
+	gpGetImageHandleNV                               C.GPGETIMAGEHANDLENV
+	gpGetInteger64i_v                                C.GPGETINTEGER64I_V
+	gpGetInteger64v                                  C.GPGETINTEGER64V
+	gpGetIntegerIndexedvEXT                          C.GPGETINTEGERINDEXEDVEXT
+	gpGetIntegeri_v                                  C.GPGETINTEGERI_V
+	gpGetIntegerui64i_vNV                            C.GPGETINTEGERUI64I_VNV
+	gpGetIntegerui64vNV                              C.GPGETINTEGERUI64VNV
+	gpGetIntegerv                                    C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                    C.GPGETINTERNALFORMATSAMPLEIVNV
+	gpGetInternalformati64v                          C.GPGETINTERNALFORMATI64V
+	gpGetInternalformativ                            C.GPGETINTERNALFORMATIV
+	gpGetMultiTexEnvfvEXT                            C.GPGETMULTITEXENVFVEXT
+	gpGetMultiTexEnvivEXT                            C.GPGETMULTITEXENVIVEXT
+	gpGetMultiTexGendvEXT                            C.GPGETMULTITEXGENDVEXT
+	gpGetMultiTexGenfvEXT                            C.GPGETMULTITEXGENFVEXT
+	gpGetMultiTexGenivEXT                            C.GPGETMULTITEXGENIVEXT
+	gpGetMultiTexImageEXT                            C.GPGETMULTITEXIMAGEEXT
+	gpGetMultiTexLevelParameterfvEXT                 C.GPGETMULTITEXLEVELPARAMETERFVEXT
+	gpGetMultiTexLevelParameterivEXT                 C.GPGETMULTITEXLEVELPARAMETERIVEXT
+	gpGetMultiTexParameterIivEXT                     C.GPGETMULTITEXPARAMETERIIVEXT
+	gpGetMultiTexParameterIuivEXT                    C.GPGETMULTITEXPARAMETERIUIVEXT
+	gpGetMultiTexParameterfvEXT                      C.GPGETMULTITEXPARAMETERFVEXT
+	gpGetMultiTexParameterivEXT                      C.GPGETMULTITEXPARAMETERIVEXT
+	gpGetMultisamplefv                               C.GPGETMULTISAMPLEFV
+	gpGetNamedBufferParameteri64v                    C.GPGETNAMEDBUFFERPARAMETERI64V
+	gpGetNamedBufferParameteriv                      C.GPGETNAMEDBUFFERPARAMETERIV
+	gpGetNamedBufferParameterivEXT                   C.GPGETNAMEDBUFFERPARAMETERIVEXT
+	gpGetNamedBufferParameterui64vNV                 C.GPGETNAMEDBUFFERPARAMETERUI64VNV
+	gpGetNamedBufferPointerv                         C.GPGETNAMEDBUFFERPOINTERV
+	gpGetNamedBufferPointervEXT                      C.GPGETNAMEDBUFFERPOINTERVEXT
+	gpGetNamedBufferSubData                          C.GPGETNAMEDBUFFERSUBDATA
+	gpGetNamedBufferSubDataEXT                       C.GPGETNAMEDBUFFERSUBDATAEXT
+	gpGetNamedFramebufferAttachmentParameteriv       C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetNamedFramebufferAttachmentParameterivEXT    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameteriv                 C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
+	gpGetNamedFramebufferParameterivEXT              C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
+	gpGetNamedProgramLocalParameterIivEXT            C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
+	gpGetNamedProgramLocalParameterIuivEXT           C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT
+	gpGetNamedProgramLocalParameterdvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT
+	gpGetNamedProgramLocalParameterfvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT
+	gpGetNamedProgramStringEXT                       C.GPGETNAMEDPROGRAMSTRINGEXT
+	gpGetNamedProgramivEXT                           C.GPGETNAMEDPROGRAMIVEXT
+	gpGetNamedRenderbufferParameteriv                C.GPGETNAMEDRENDERBUFFERPARAMETERIV
+	gpGetNamedRenderbufferParameterivEXT             C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT
+	gpGetNamedStringARB                              C.GPGETNAMEDSTRINGARB
+	gpGetNamedStringivARB                            C.GPGETNAMEDSTRINGIVARB
+	gpGetNextPerfQueryIdINTEL                        C.GPGETNEXTPERFQUERYIDINTEL
+	gpGetObjectLabel                                 C.GPGETOBJECTLABEL
+	gpGetObjectLabelEXT                              C.GPGETOBJECTLABELEXT
+	gpGetObjectLabelKHR                              C.GPGETOBJECTLABELKHR
+	gpGetObjectPtrLabel                              C.GPGETOBJECTPTRLABEL
+	gpGetObjectPtrLabelKHR                           C.GPGETOBJECTPTRLABELKHR
+	gpGetPathCommandsNV                              C.GPGETPATHCOMMANDSNV
+	gpGetPathCoordsNV                                C.GPGETPATHCOORDSNV
+	gpGetPathDashArrayNV                             C.GPGETPATHDASHARRAYNV
+	gpGetPathLengthNV                                C.GPGETPATHLENGTHNV
+	gpGetPathMetricRangeNV                           C.GPGETPATHMETRICRANGENV
+	gpGetPathMetricsNV                               C.GPGETPATHMETRICSNV
+	gpGetPathParameterfvNV                           C.GPGETPATHPARAMETERFVNV
+	gpGetPathParameterivNV                           C.GPGETPATHPARAMETERIVNV
+	gpGetPathSpacingNV                               C.GPGETPATHSPACINGNV
+	gpGetPerfCounterInfoINTEL                        C.GPGETPERFCOUNTERINFOINTEL
+	gpGetPerfMonitorCounterDataAMD                   C.GPGETPERFMONITORCOUNTERDATAAMD
+	gpGetPerfMonitorCounterInfoAMD                   C.GPGETPERFMONITORCOUNTERINFOAMD
+	gpGetPerfMonitorCounterStringAMD                 C.GPGETPERFMONITORCOUNTERSTRINGAMD
+	gpGetPerfMonitorCountersAMD                      C.GPGETPERFMONITORCOUNTERSAMD
+	gpGetPerfMonitorGroupStringAMD                   C.GPGETPERFMONITORGROUPSTRINGAMD
+	gpGetPerfMonitorGroupsAMD                        C.GPGETPERFMONITORGROUPSAMD
+	gpGetPerfQueryDataINTEL                          C.GPGETPERFQUERYDATAINTEL
+	gpGetPerfQueryIdByNameINTEL                      C.GPGETPERFQUERYIDBYNAMEINTEL
+	gpGetPerfQueryInfoINTEL                          C.GPGETPERFQUERYINFOINTEL
+	gpGetPointerIndexedvEXT                          C.GPGETPOINTERINDEXEDVEXT
+	gpGetPointeri_vEXT                               C.GPGETPOINTERI_VEXT
+	gpGetPointerv                                    C.GPGETPOINTERV
+	gpGetPointervKHR                                 C.GPGETPOINTERVKHR
+	gpGetProgramBinary                               C.GPGETPROGRAMBINARY
+	gpGetProgramInfoLog                              C.GPGETPROGRAMINFOLOG
+	gpGetProgramInterfaceiv                          C.GPGETPROGRAMINTERFACEIV
+	gpGetProgramPipelineInfoLog                      C.GPGETPROGRAMPIPELINEINFOLOG
+	gpGetProgramPipelineInfoLogEXT                   C.GPGETPROGRAMPIPELINEINFOLOGEXT
+	gpGetProgramPipelineiv                           C.GPGETPROGRAMPIPELINEIV
+	gpGetProgramPipelineivEXT                        C.GPGETPROGRAMPIPELINEIVEXT
+	gpGetProgramResourceIndex                        C.GPGETPROGRAMRESOURCEINDEX
+	gpGetProgramResourceLocation                     C.GPGETPROGRAMRESOURCELOCATION
+	gpGetProgramResourceLocationIndex                C.GPGETPROGRAMRESOURCELOCATIONINDEX
+	gpGetProgramResourceName                         C.GPGETPROGRAMRESOURCENAME
+	gpGetProgramResourcefvNV                         C.GPGETPROGRAMRESOURCEFVNV
+	gpGetProgramResourceiv                           C.GPGETPROGRAMRESOURCEIV
+	gpGetProgramStageiv                              C.GPGETPROGRAMSTAGEIV
+	gpGetProgramiv                                   C.GPGETPROGRAMIV
+	gpGetQueryBufferObjecti64v                       C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                         C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                      C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                        C.GPGETQUERYBUFFEROBJECTUIV
+	gpGetQueryIndexediv                              C.GPGETQUERYINDEXEDIV
+	gpGetQueryObjecti64v                             C.GPGETQUERYOBJECTI64V
+	gpGetQueryObjectiv                               C.GPGETQUERYOBJECTIV
+	gpGetQueryObjectui64v                            C.GPGETQUERYOBJECTUI64V
+	gpGetQueryObjectuiv                              C.GPGETQUERYOBJECTUIV
+	gpGetQueryiv                                     C.GPGETQUERYIV
+	gpGetRenderbufferParameteriv                     C.GPGETRENDERBUFFERPARAMETERIV
+	gpGetSamplerParameterIiv                         C.GPGETSAMPLERPARAMETERIIV
+	gpGetSamplerParameterIuiv                        C.GPGETSAMPLERPARAMETERIUIV
+	gpGetSamplerParameterfv                          C.GPGETSAMPLERPARAMETERFV
+	gpGetSamplerParameteriv                          C.GPGETSAMPLERPARAMETERIV
+	gpGetShaderInfoLog                               C.GPGETSHADERINFOLOG
+	gpGetShaderPrecisionFormat                       C.GPGETSHADERPRECISIONFORMAT
+	gpGetShaderSource                                C.GPGETSHADERSOURCE
+	gpGetShaderiv                                    C.GPGETSHADERIV
+	gpGetStageIndexNV                                C.GPGETSTAGEINDEXNV
+	gpGetString                                      C.GPGETSTRING
+	gpGetStringi                                     C.GPGETSTRINGI
+	gpGetSubroutineIndex                             C.GPGETSUBROUTINEINDEX
+	gpGetSubroutineUniformLocation                   C.GPGETSUBROUTINEUNIFORMLOCATION
+	gpGetSynciv                                      C.GPGETSYNCIV
+	gpGetTexImage                                    C.GPGETTEXIMAGE
+	gpGetTexLevelParameterfv                         C.GPGETTEXLEVELPARAMETERFV
+	gpGetTexLevelParameteriv                         C.GPGETTEXLEVELPARAMETERIV
+	gpGetTexParameterIiv                             C.GPGETTEXPARAMETERIIV
+	gpGetTexParameterIuiv                            C.GPGETTEXPARAMETERIUIV
+	gpGetTexParameterfv                              C.GPGETTEXPARAMETERFV
+	gpGetTexParameteriv                              C.GPGETTEXPARAMETERIV
+	gpGetTextureHandleARB                            C.GPGETTEXTUREHANDLEARB
+	gpGetTextureHandleNV                             C.GPGETTEXTUREHANDLENV
+	gpGetTextureImage                                C.GPGETTEXTUREIMAGE
+	gpGetTextureImageEXT                             C.GPGETTEXTUREIMAGEEXT
+	gpGetTextureLevelParameterfv                     C.GPGETTEXTURELEVELPARAMETERFV
+	gpGetTextureLevelParameterfvEXT                  C.GPGETTEXTURELEVELPARAMETERFVEXT
+	gpGetTextureLevelParameteriv                     C.GPGETTEXTURELEVELPARAMETERIV
+	gpGetTextureLevelParameterivEXT                  C.GPGETTEXTURELEVELPARAMETERIVEXT
+	gpGetTextureParameterIiv                         C.GPGETTEXTUREPARAMETERIIV
+	gpGetTextureParameterIivEXT                      C.GPGETTEXTUREPARAMETERIIVEXT
+	gpGetTextureParameterIuiv                        C.GPGETTEXTUREPARAMETERIUIV
+	gpGetTextureParameterIuivEXT                     C.GPGETTEXTUREPARAMETERIUIVEXT
+	gpGetTextureParameterfv                          C.GPGETTEXTUREPARAMETERFV
+	gpGetTextureParameterfvEXT                       C.GPGETTEXTUREPARAMETERFVEXT
+	gpGetTextureParameteriv                          C.GPGETTEXTUREPARAMETERIV
+	gpGetTextureParameterivEXT                       C.GPGETTEXTUREPARAMETERIVEXT
+	gpGetTextureSamplerHandleARB                     C.GPGETTEXTURESAMPLERHANDLEARB
+	gpGetTextureSamplerHandleNV                      C.GPGETTEXTURESAMPLERHANDLENV
+	gpGetTextureSubImage                             C.GPGETTEXTURESUBIMAGE
+	gpGetTransformFeedbackVarying                    C.GPGETTRANSFORMFEEDBACKVARYING
+	gpGetTransformFeedbacki64_v                      C.GPGETTRANSFORMFEEDBACKI64_V
+	gpGetTransformFeedbacki_v                        C.GPGETTRANSFORMFEEDBACKI_V
+	gpGetTransformFeedbackiv                         C.GPGETTRANSFORMFEEDBACKIV
+	gpGetUniformBlockIndex                           C.GPGETUNIFORMBLOCKINDEX
+	gpGetUniformIndices                              C.GPGETUNIFORMINDICES
+	gpGetUniformLocation                             C.GPGETUNIFORMLOCATION
+	gpGetUniformSubroutineuiv                        C.GPGETUNIFORMSUBROUTINEUIV
+	gpGetUniformdv                                   C.GPGETUNIFORMDV
+	gpGetUniformfv                                   C.GPGETUNIFORMFV
+	gpGetUniformi64vARB                              C.GPGETUNIFORMI64VARB
+	gpGetUniformi64vNV                               C.GPGETUNIFORMI64VNV
+	gpGetUniformiv                                   C.GPGETUNIFORMIV
+	gpGetUniformui64vARB                             C.GPGETUNIFORMUI64VARB
+	gpGetUniformui64vNV                              C.GPGETUNIFORMUI64VNV
+	gpGetUniformuiv                                  C.GPGETUNIFORMUIV
+	gpGetVertexArrayIndexed64iv                      C.GPGETVERTEXARRAYINDEXED64IV
+	gpGetVertexArrayIndexediv                        C.GPGETVERTEXARRAYINDEXEDIV
+	gpGetVertexArrayIntegeri_vEXT                    C.GPGETVERTEXARRAYINTEGERI_VEXT
+	gpGetVertexArrayIntegervEXT                      C.GPGETVERTEXARRAYINTEGERVEXT
+	gpGetVertexArrayPointeri_vEXT                    C.GPGETVERTEXARRAYPOINTERI_VEXT
+	gpGetVertexArrayPointervEXT                      C.GPGETVERTEXARRAYPOINTERVEXT
+	gpGetVertexArrayiv                               C.GPGETVERTEXARRAYIV
+	gpGetVertexAttribIiv                             C.GPGETVERTEXATTRIBIIV
+	gpGetVertexAttribIuiv                            C.GPGETVERTEXATTRIBIUIV
+	gpGetVertexAttribLdv                             C.GPGETVERTEXATTRIBLDV
+	gpGetVertexAttribLi64vNV                         C.GPGETVERTEXATTRIBLI64VNV
+	gpGetVertexAttribLui64vARB                       C.GPGETVERTEXATTRIBLUI64VARB
+	gpGetVertexAttribLui64vNV                        C.GPGETVERTEXATTRIBLUI64VNV
+	gpGetVertexAttribPointerv                        C.GPGETVERTEXATTRIBPOINTERV
+	gpGetVertexAttribdv                              C.GPGETVERTEXATTRIBDV
+	gpGetVertexAttribfv                              C.GPGETVERTEXATTRIBFV
+	gpGetVertexAttribiv                              C.GPGETVERTEXATTRIBIV
+	gpGetVkProcAddrNV                                C.GPGETVKPROCADDRNV
+	gpGetnCompressedTexImageARB                      C.GPGETNCOMPRESSEDTEXIMAGEARB
+	gpGetnTexImageARB                                C.GPGETNTEXIMAGEARB
+	gpGetnUniformdvARB                               C.GPGETNUNIFORMDVARB
+	gpGetnUniformfv                                  C.GPGETNUNIFORMFV
+	gpGetnUniformfvARB                               C.GPGETNUNIFORMFVARB
+	gpGetnUniformfvKHR                               C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                             C.GPGETNUNIFORMI64VARB
+	gpGetnUniformiv                                  C.GPGETNUNIFORMIV
+	gpGetnUniformivARB                               C.GPGETNUNIFORMIVARB
+	gpGetnUniformivKHR                               C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                            C.GPGETNUNIFORMUI64VARB
+	gpGetnUniformuiv                                 C.GPGETNUNIFORMUIV
+	gpGetnUniformuivARB                              C.GPGETNUNIFORMUIVARB
+	gpGetnUniformuivKHR                              C.GPGETNUNIFORMUIVKHR
+	gpHint                                           C.GPHINT
+	gpIndexFormatNV                                  C.GPINDEXFORMATNV
+	gpInsertEventMarkerEXT                           C.GPINSERTEVENTMARKEREXT
+	gpInterpolatePathsNV                             C.GPINTERPOLATEPATHSNV
+	gpInvalidateBufferData                           C.GPINVALIDATEBUFFERDATA
+	gpInvalidateBufferSubData                        C.GPINVALIDATEBUFFERSUBDATA
+	gpInvalidateFramebuffer                          C.GPINVALIDATEFRAMEBUFFER
+	gpInvalidateNamedFramebufferData                 C.GPINVALIDATENAMEDFRAMEBUFFERDATA
+	gpInvalidateNamedFramebufferSubData              C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
+	gpInvalidateSubFramebuffer                       C.GPINVALIDATESUBFRAMEBUFFER
+	gpInvalidateTexImage                             C.GPINVALIDATETEXIMAGE
+	gpInvalidateTexSubImage                          C.GPINVALIDATETEXSUBIMAGE
+	gpIsBuffer                                       C.GPISBUFFER
+	gpIsBufferResidentNV                             C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                C.GPISCOMMANDLISTNV
+	gpIsEnabled                                      C.GPISENABLED
+	gpIsEnabledIndexedEXT                            C.GPISENABLEDINDEXEDEXT
+	gpIsEnabledi                                     C.GPISENABLEDI
+	gpIsFramebuffer                                  C.GPISFRAMEBUFFER
+	gpIsImageHandleResidentARB                       C.GPISIMAGEHANDLERESIDENTARB
+	gpIsImageHandleResidentNV                        C.GPISIMAGEHANDLERESIDENTNV
+	gpIsNamedBufferResidentNV                        C.GPISNAMEDBUFFERRESIDENTNV
+	gpIsNamedStringARB                               C.GPISNAMEDSTRINGARB
+	gpIsPathNV                                       C.GPISPATHNV
+	gpIsPointInFillPathNV                            C.GPISPOINTINFILLPATHNV
+	gpIsPointInStrokePathNV                          C.GPISPOINTINSTROKEPATHNV
+	gpIsProgram                                      C.GPISPROGRAM
+	gpIsProgramPipeline                              C.GPISPROGRAMPIPELINE
+	gpIsProgramPipelineEXT                           C.GPISPROGRAMPIPELINEEXT
+	gpIsQuery                                        C.GPISQUERY
+	gpIsRenderbuffer                                 C.GPISRENDERBUFFER
+	gpIsSampler                                      C.GPISSAMPLER
+	gpIsShader                                       C.GPISSHADER
+	gpIsStateNV                                      C.GPISSTATENV
+	gpIsSync                                         C.GPISSYNC
+	gpIsTexture                                      C.GPISTEXTURE
+	gpIsTextureHandleResidentARB                     C.GPISTEXTUREHANDLERESIDENTARB
+	gpIsTextureHandleResidentNV                      C.GPISTEXTUREHANDLERESIDENTNV
+	gpIsTransformFeedback                            C.GPISTRANSFORMFEEDBACK
+	gpIsVertexArray                                  C.GPISVERTEXARRAY
+	gpLabelObjectEXT                                 C.GPLABELOBJECTEXT
+	gpLineWidth                                      C.GPLINEWIDTH
+	gpLinkProgram                                    C.GPLINKPROGRAM
+	gpListDrawCommandsStatesClientNV                 C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
+	gpLogicOp                                        C.GPLOGICOP
+	gpMakeBufferNonResidentNV                        C.GPMAKEBUFFERNONRESIDENTNV
+	gpMakeBufferResidentNV                           C.GPMAKEBUFFERRESIDENTNV
+	gpMakeImageHandleNonResidentARB                  C.GPMAKEIMAGEHANDLENONRESIDENTARB
+	gpMakeImageHandleNonResidentNV                   C.GPMAKEIMAGEHANDLENONRESIDENTNV
+	gpMakeImageHandleResidentARB                     C.GPMAKEIMAGEHANDLERESIDENTARB
+	gpMakeImageHandleResidentNV                      C.GPMAKEIMAGEHANDLERESIDENTNV
+	gpMakeNamedBufferNonResidentNV                   C.GPMAKENAMEDBUFFERNONRESIDENTNV
+	gpMakeNamedBufferResidentNV                      C.GPMAKENAMEDBUFFERRESIDENTNV
+	gpMakeTextureHandleNonResidentARB                C.GPMAKETEXTUREHANDLENONRESIDENTARB
+	gpMakeTextureHandleNonResidentNV                 C.GPMAKETEXTUREHANDLENONRESIDENTNV
+	gpMakeTextureHandleResidentARB                   C.GPMAKETEXTUREHANDLERESIDENTARB
+	gpMakeTextureHandleResidentNV                    C.GPMAKETEXTUREHANDLERESIDENTNV
+	gpMapBuffer                                      C.GPMAPBUFFER
+	gpMapBufferRange                                 C.GPMAPBUFFERRANGE
+	gpMapNamedBuffer                                 C.GPMAPNAMEDBUFFER
+	gpMapNamedBufferEXT                              C.GPMAPNAMEDBUFFEREXT
+	gpMapNamedBufferRange                            C.GPMAPNAMEDBUFFERRANGE
+	gpMapNamedBufferRangeEXT                         C.GPMAPNAMEDBUFFERRANGEEXT
+	gpMatrixFrustumEXT                               C.GPMATRIXFRUSTUMEXT
+	gpMatrixLoad3x2fNV                               C.GPMATRIXLOAD3X2FNV
+	gpMatrixLoad3x3fNV                               C.GPMATRIXLOAD3X3FNV
+	gpMatrixLoadIdentityEXT                          C.GPMATRIXLOADIDENTITYEXT
+	gpMatrixLoadTranspose3x3fNV                      C.GPMATRIXLOADTRANSPOSE3X3FNV
+	gpMatrixLoadTransposedEXT                        C.GPMATRIXLOADTRANSPOSEDEXT
+	gpMatrixLoadTransposefEXT                        C.GPMATRIXLOADTRANSPOSEFEXT
+	gpMatrixLoaddEXT                                 C.GPMATRIXLOADDEXT
+	gpMatrixLoadfEXT                                 C.GPMATRIXLOADFEXT
+	gpMatrixMult3x2fNV                               C.GPMATRIXMULT3X2FNV
+	gpMatrixMult3x3fNV                               C.GPMATRIXMULT3X3FNV
+	gpMatrixMultTranspose3x3fNV                      C.GPMATRIXMULTTRANSPOSE3X3FNV
+	gpMatrixMultTransposedEXT                        C.GPMATRIXMULTTRANSPOSEDEXT
+	gpMatrixMultTransposefEXT                        C.GPMATRIXMULTTRANSPOSEFEXT
+	gpMatrixMultdEXT                                 C.GPMATRIXMULTDEXT
+	gpMatrixMultfEXT                                 C.GPMATRIXMULTFEXT
+	gpMatrixOrthoEXT                                 C.GPMATRIXORTHOEXT
+	gpMatrixPopEXT                                   C.GPMATRIXPOPEXT
+	gpMatrixPushEXT                                  C.GPMATRIXPUSHEXT
+	gpMatrixRotatedEXT                               C.GPMATRIXROTATEDEXT
+	gpMatrixRotatefEXT                               C.GPMATRIXROTATEFEXT
+	gpMatrixScaledEXT                                C.GPMATRIXSCALEDEXT
+	gpMatrixScalefEXT                                C.GPMATRIXSCALEFEXT
+	gpMatrixTranslatedEXT                            C.GPMATRIXTRANSLATEDEXT
+	gpMatrixTranslatefEXT                            C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                    C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                    C.GPMAXSHADERCOMPILERTHREADSKHR
+	gpMemoryBarrier                                  C.GPMEMORYBARRIER
+	gpMemoryBarrierByRegion                          C.GPMEMORYBARRIERBYREGION
+	gpMinSampleShadingARB                            C.GPMINSAMPLESHADINGARB
+	gpMultiDrawArrays                                C.GPMULTIDRAWARRAYS
+	gpMultiDrawArraysIndirect                        C.GPMULTIDRAWARRAYSINDIRECT
+	gpMultiDrawArraysIndirectBindlessCountNV         C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawArraysIndirectBindlessNV              C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV
+	gpMultiDrawArraysIndirectCountARB                C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
+	gpMultiDrawElements                              C.GPMULTIDRAWELEMENTS
+	gpMultiDrawElementsBaseVertex                    C.GPMULTIDRAWELEMENTSBASEVERTEX
+	gpMultiDrawElementsIndirect                      C.GPMULTIDRAWELEMENTSINDIRECT
+	gpMultiDrawElementsIndirectBindlessCountNV       C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawElementsIndirectBindlessNV            C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV
+	gpMultiDrawElementsIndirectCountARB              C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
+	gpMultiTexBufferEXT                              C.GPMULTITEXBUFFEREXT
+	gpMultiTexCoordPointerEXT                        C.GPMULTITEXCOORDPOINTEREXT
+	gpMultiTexEnvfEXT                                C.GPMULTITEXENVFEXT
+	gpMultiTexEnvfvEXT                               C.GPMULTITEXENVFVEXT
+	gpMultiTexEnviEXT                                C.GPMULTITEXENVIEXT
+	gpMultiTexEnvivEXT                               C.GPMULTITEXENVIVEXT
+	gpMultiTexGendEXT                                C.GPMULTITEXGENDEXT
+	gpMultiTexGendvEXT                               C.GPMULTITEXGENDVEXT
+	gpMultiTexGenfEXT                                C.GPMULTITEXGENFEXT
+	gpMultiTexGenfvEXT                               C.GPMULTITEXGENFVEXT
+	gpMultiTexGeniEXT                                C.GPMULTITEXGENIEXT
+	gpMultiTexGenivEXT                               C.GPMULTITEXGENIVEXT
+	gpMultiTexImage1DEXT                             C.GPMULTITEXIMAGE1DEXT
+	gpMultiTexImage2DEXT                             C.GPMULTITEXIMAGE2DEXT
+	gpMultiTexImage3DEXT                             C.GPMULTITEXIMAGE3DEXT
+	gpMultiTexParameterIivEXT                        C.GPMULTITEXPARAMETERIIVEXT
+	gpMultiTexParameterIuivEXT                       C.GPMULTITEXPARAMETERIUIVEXT
+	gpMultiTexParameterfEXT                          C.GPMULTITEXPARAMETERFEXT
+	gpMultiTexParameterfvEXT                         C.GPMULTITEXPARAMETERFVEXT
+	gpMultiTexParameteriEXT                          C.GPMULTITEXPARAMETERIEXT
+	gpMultiTexParameterivEXT                         C.GPMULTITEXPARAMETERIVEXT
+	gpMultiTexRenderbufferEXT                        C.GPMULTITEXRENDERBUFFEREXT
+	gpMultiTexSubImage1DEXT                          C.GPMULTITEXSUBIMAGE1DEXT
+	gpMultiTexSubImage2DEXT                          C.GPMULTITEXSUBIMAGE2DEXT
+	gpMultiTexSubImage3DEXT                          C.GPMULTITEXSUBIMAGE3DEXT
+	gpNamedBufferData                                C.GPNAMEDBUFFERDATA
+	gpNamedBufferDataEXT                             C.GPNAMEDBUFFERDATAEXT
+	gpNamedBufferPageCommitmentARB                   C.GPNAMEDBUFFERPAGECOMMITMENTARB
+	gpNamedBufferPageCommitmentEXT                   C.GPNAMEDBUFFERPAGECOMMITMENTEXT
+	gpNamedBufferStorage                             C.GPNAMEDBUFFERSTORAGE
+	gpNamedBufferStorageEXT                          C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferSubData                             C.GPNAMEDBUFFERSUBDATA
+	gpNamedBufferSubDataEXT                          C.GPNAMEDBUFFERSUBDATAEXT
+	gpNamedCopyBufferSubDataEXT                      C.GPNAMEDCOPYBUFFERSUBDATAEXT
+	gpNamedFramebufferDrawBuffer                     C.GPNAMEDFRAMEBUFFERDRAWBUFFER
+	gpNamedFramebufferDrawBuffers                    C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
+	gpNamedFramebufferParameteri                     C.GPNAMEDFRAMEBUFFERPARAMETERI
+	gpNamedFramebufferParameteriEXT                  C.GPNAMEDFRAMEBUFFERPARAMETERIEXT
+	gpNamedFramebufferReadBuffer                     C.GPNAMEDFRAMEBUFFERREADBUFFER
+	gpNamedFramebufferRenderbuffer                   C.GPNAMEDFRAMEBUFFERRENDERBUFFER
+	gpNamedFramebufferRenderbufferEXT                C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB           C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV            C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferTexture                        C.GPNAMEDFRAMEBUFFERTEXTURE
+	gpNamedFramebufferTexture1DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
+	gpNamedFramebufferTexture2DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
+	gpNamedFramebufferTexture3DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT
+	gpNamedFramebufferTextureEXT                     C.GPNAMEDFRAMEBUFFERTEXTUREEXT
+	gpNamedFramebufferTextureFaceEXT                 C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT
+	gpNamedFramebufferTextureLayer                   C.GPNAMEDFRAMEBUFFERTEXTURELAYER
+	gpNamedFramebufferTextureLayerEXT                C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT
+	gpNamedProgramLocalParameter4dEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT
+	gpNamedProgramLocalParameter4dvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT
+	gpNamedProgramLocalParameter4fEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT
+	gpNamedProgramLocalParameter4fvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT
+	gpNamedProgramLocalParameterI4iEXT               C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT
+	gpNamedProgramLocalParameterI4ivEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT
+	gpNamedProgramLocalParameterI4uiEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT
+	gpNamedProgramLocalParameterI4uivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT
+	gpNamedProgramLocalParameters4fvEXT              C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT
+	gpNamedProgramLocalParametersI4ivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT
+	gpNamedProgramLocalParametersI4uivEXT            C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT
+	gpNamedProgramStringEXT                          C.GPNAMEDPROGRAMSTRINGEXT
+	gpNamedRenderbufferStorage                       C.GPNAMEDRENDERBUFFERSTORAGE
+	gpNamedRenderbufferStorageEXT                    C.GPNAMEDRENDERBUFFERSTORAGEEXT
+	gpNamedRenderbufferStorageMultisample            C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
+	gpNamedRenderbufferStorageMultisampleCoverageEXT C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT
+	gpNamedRenderbufferStorageMultisampleEXT         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT
+	gpNamedStringARB                                 C.GPNAMEDSTRINGARB
+	gpNormalFormatNV                                 C.GPNORMALFORMATNV
+	gpObjectLabel                                    C.GPOBJECTLABEL
+	gpObjectLabelKHR                                 C.GPOBJECTLABELKHR
+	gpObjectPtrLabel                                 C.GPOBJECTPTRLABEL
+	gpObjectPtrLabelKHR                              C.GPOBJECTPTRLABELKHR
+	gpPatchParameterfv                               C.GPPATCHPARAMETERFV
+	gpPatchParameteri                                C.GPPATCHPARAMETERI
+	gpPathCommandsNV                                 C.GPPATHCOMMANDSNV
+	gpPathCoordsNV                                   C.GPPATHCOORDSNV
+	gpPathCoverDepthFuncNV                           C.GPPATHCOVERDEPTHFUNCNV
+	gpPathDashArrayNV                                C.GPPATHDASHARRAYNV
+	gpPathGlyphIndexArrayNV                          C.GPPATHGLYPHINDEXARRAYNV
+	gpPathGlyphIndexRangeNV                          C.GPPATHGLYPHINDEXRANGENV
+	gpPathGlyphRangeNV                               C.GPPATHGLYPHRANGENV
+	gpPathGlyphsNV                                   C.GPPATHGLYPHSNV
+	gpPathMemoryGlyphIndexArrayNV                    C.GPPATHMEMORYGLYPHINDEXARRAYNV
+	gpPathParameterfNV                               C.GPPATHPARAMETERFNV
+	gpPathParameterfvNV                              C.GPPATHPARAMETERFVNV
+	gpPathParameteriNV                               C.GPPATHPARAMETERINV
+	gpPathParameterivNV                              C.GPPATHPARAMETERIVNV
+	gpPathStencilDepthOffsetNV                       C.GPPATHSTENCILDEPTHOFFSETNV
+	gpPathStencilFuncNV                              C.GPPATHSTENCILFUNCNV
+	gpPathStringNV                                   C.GPPATHSTRINGNV
+	gpPathSubCommandsNV                              C.GPPATHSUBCOMMANDSNV
+	gpPathSubCoordsNV                                C.GPPATHSUBCOORDSNV
+	gpPauseTransformFeedback                         C.GPPAUSETRANSFORMFEEDBACK
+	gpPixelStoref                                    C.GPPIXELSTOREF
+	gpPixelStorei                                    C.GPPIXELSTOREI
+	gpPointAlongPathNV                               C.GPPOINTALONGPATHNV
+	gpPointParameterf                                C.GPPOINTPARAMETERF
+	gpPointParameterfv                               C.GPPOINTPARAMETERFV
+	gpPointParameteri                                C.GPPOINTPARAMETERI
+	gpPointParameteriv                               C.GPPOINTPARAMETERIV
+	gpPointSize                                      C.GPPOINTSIZE
+	gpPolygonMode                                    C.GPPOLYGONMODE
+	gpPolygonOffset                                  C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                             C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                          C.GPPOLYGONOFFSETCLAMPEXT
+	gpPopDebugGroup                                  C.GPPOPDEBUGGROUP
+	gpPopDebugGroupKHR                               C.GPPOPDEBUGGROUPKHR
+	gpPopGroupMarkerEXT                              C.GPPOPGROUPMARKEREXT
+	gpPrimitiveBoundingBoxARB                        C.GPPRIMITIVEBOUNDINGBOXARB
+	gpPrimitiveRestartIndex                          C.GPPRIMITIVERESTARTINDEX
+	gpProgramBinary                                  C.GPPROGRAMBINARY
+	gpProgramParameteri                              C.GPPROGRAMPARAMETERI
+	gpProgramParameteriARB                           C.GPPROGRAMPARAMETERIARB
+	gpProgramParameteriEXT                           C.GPPROGRAMPARAMETERIEXT
+	gpProgramPathFragmentInputGenNV                  C.GPPROGRAMPATHFRAGMENTINPUTGENNV
+	gpProgramUniform1d                               C.GPPROGRAMUNIFORM1D
+	gpProgramUniform1dEXT                            C.GPPROGRAMUNIFORM1DEXT
+	gpProgramUniform1dv                              C.GPPROGRAMUNIFORM1DV
+	gpProgramUniform1dvEXT                           C.GPPROGRAMUNIFORM1DVEXT
+	gpProgramUniform1f                               C.GPPROGRAMUNIFORM1F
+	gpProgramUniform1fEXT                            C.GPPROGRAMUNIFORM1FEXT
+	gpProgramUniform1fv                              C.GPPROGRAMUNIFORM1FV
+	gpProgramUniform1fvEXT                           C.GPPROGRAMUNIFORM1FVEXT
+	gpProgramUniform1i                               C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                          C.GPPROGRAMUNIFORM1I64ARB
+	gpProgramUniform1i64NV                           C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                         C.GPPROGRAMUNIFORM1I64VARB
+	gpProgramUniform1i64vNV                          C.GPPROGRAMUNIFORM1I64VNV
+	gpProgramUniform1iEXT                            C.GPPROGRAMUNIFORM1IEXT
+	gpProgramUniform1iv                              C.GPPROGRAMUNIFORM1IV
+	gpProgramUniform1ivEXT                           C.GPPROGRAMUNIFORM1IVEXT
+	gpProgramUniform1ui                              C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                         C.GPPROGRAMUNIFORM1UI64ARB
+	gpProgramUniform1ui64NV                          C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                        C.GPPROGRAMUNIFORM1UI64VARB
+	gpProgramUniform1ui64vNV                         C.GPPROGRAMUNIFORM1UI64VNV
+	gpProgramUniform1uiEXT                           C.GPPROGRAMUNIFORM1UIEXT
+	gpProgramUniform1uiv                             C.GPPROGRAMUNIFORM1UIV
+	gpProgramUniform1uivEXT                          C.GPPROGRAMUNIFORM1UIVEXT
+	gpProgramUniform2d                               C.GPPROGRAMUNIFORM2D
+	gpProgramUniform2dEXT                            C.GPPROGRAMUNIFORM2DEXT
+	gpProgramUniform2dv                              C.GPPROGRAMUNIFORM2DV
+	gpProgramUniform2dvEXT                           C.GPPROGRAMUNIFORM2DVEXT
+	gpProgramUniform2f                               C.GPPROGRAMUNIFORM2F
+	gpProgramUniform2fEXT                            C.GPPROGRAMUNIFORM2FEXT
+	gpProgramUniform2fv                              C.GPPROGRAMUNIFORM2FV
+	gpProgramUniform2fvEXT                           C.GPPROGRAMUNIFORM2FVEXT
+	gpProgramUniform2i                               C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                          C.GPPROGRAMUNIFORM2I64ARB
+	gpProgramUniform2i64NV                           C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                         C.GPPROGRAMUNIFORM2I64VARB
+	gpProgramUniform2i64vNV                          C.GPPROGRAMUNIFORM2I64VNV
+	gpProgramUniform2iEXT                            C.GPPROGRAMUNIFORM2IEXT
+	gpProgramUniform2iv                              C.GPPROGRAMUNIFORM2IV
+	gpProgramUniform2ivEXT                           C.GPPROGRAMUNIFORM2IVEXT
+	gpProgramUniform2ui                              C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                         C.GPPROGRAMUNIFORM2UI64ARB
+	gpProgramUniform2ui64NV                          C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                        C.GPPROGRAMUNIFORM2UI64VARB
+	gpProgramUniform2ui64vNV                         C.GPPROGRAMUNIFORM2UI64VNV
+	gpProgramUniform2uiEXT                           C.GPPROGRAMUNIFORM2UIEXT
+	gpProgramUniform2uiv                             C.GPPROGRAMUNIFORM2UIV
+	gpProgramUniform2uivEXT                          C.GPPROGRAMUNIFORM2UIVEXT
+	gpProgramUniform3d                               C.GPPROGRAMUNIFORM3D
+	gpProgramUniform3dEXT                            C.GPPROGRAMUNIFORM3DEXT
+	gpProgramUniform3dv                              C.GPPROGRAMUNIFORM3DV
+	gpProgramUniform3dvEXT                           C.GPPROGRAMUNIFORM3DVEXT
+	gpProgramUniform3f                               C.GPPROGRAMUNIFORM3F
+	gpProgramUniform3fEXT                            C.GPPROGRAMUNIFORM3FEXT
+	gpProgramUniform3fv                              C.GPPROGRAMUNIFORM3FV
+	gpProgramUniform3fvEXT                           C.GPPROGRAMUNIFORM3FVEXT
+	gpProgramUniform3i                               C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                          C.GPPROGRAMUNIFORM3I64ARB
+	gpProgramUniform3i64NV                           C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                         C.GPPROGRAMUNIFORM3I64VARB
+	gpProgramUniform3i64vNV                          C.GPPROGRAMUNIFORM3I64VNV
+	gpProgramUniform3iEXT                            C.GPPROGRAMUNIFORM3IEXT
+	gpProgramUniform3iv                              C.GPPROGRAMUNIFORM3IV
+	gpProgramUniform3ivEXT                           C.GPPROGRAMUNIFORM3IVEXT
+	gpProgramUniform3ui                              C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                         C.GPPROGRAMUNIFORM3UI64ARB
+	gpProgramUniform3ui64NV                          C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                        C.GPPROGRAMUNIFORM3UI64VARB
+	gpProgramUniform3ui64vNV                         C.GPPROGRAMUNIFORM3UI64VNV
+	gpProgramUniform3uiEXT                           C.GPPROGRAMUNIFORM3UIEXT
+	gpProgramUniform3uiv                             C.GPPROGRAMUNIFORM3UIV
+	gpProgramUniform3uivEXT                          C.GPPROGRAMUNIFORM3UIVEXT
+	gpProgramUniform4d                               C.GPPROGRAMUNIFORM4D
+	gpProgramUniform4dEXT                            C.GPPROGRAMUNIFORM4DEXT
+	gpProgramUniform4dv                              C.GPPROGRAMUNIFORM4DV
+	gpProgramUniform4dvEXT                           C.GPPROGRAMUNIFORM4DVEXT
+	gpProgramUniform4f                               C.GPPROGRAMUNIFORM4F
+	gpProgramUniform4fEXT                            C.GPPROGRAMUNIFORM4FEXT
+	gpProgramUniform4fv                              C.GPPROGRAMUNIFORM4FV
+	gpProgramUniform4fvEXT                           C.GPPROGRAMUNIFORM4FVEXT
+	gpProgramUniform4i                               C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                          C.GPPROGRAMUNIFORM4I64ARB
+	gpProgramUniform4i64NV                           C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                         C.GPPROGRAMUNIFORM4I64VARB
+	gpProgramUniform4i64vNV                          C.GPPROGRAMUNIFORM4I64VNV
+	gpProgramUniform4iEXT                            C.GPPROGRAMUNIFORM4IEXT
+	gpProgramUniform4iv                              C.GPPROGRAMUNIFORM4IV
+	gpProgramUniform4ivEXT                           C.GPPROGRAMUNIFORM4IVEXT
+	gpProgramUniform4ui                              C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                         C.GPPROGRAMUNIFORM4UI64ARB
+	gpProgramUniform4ui64NV                          C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                        C.GPPROGRAMUNIFORM4UI64VARB
+	gpProgramUniform4ui64vNV                         C.GPPROGRAMUNIFORM4UI64VNV
+	gpProgramUniform4uiEXT                           C.GPPROGRAMUNIFORM4UIEXT
+	gpProgramUniform4uiv                             C.GPPROGRAMUNIFORM4UIV
+	gpProgramUniform4uivEXT                          C.GPPROGRAMUNIFORM4UIVEXT
+	gpProgramUniformHandleui64ARB                    C.GPPROGRAMUNIFORMHANDLEUI64ARB
+	gpProgramUniformHandleui64NV                     C.GPPROGRAMUNIFORMHANDLEUI64NV
+	gpProgramUniformHandleui64vARB                   C.GPPROGRAMUNIFORMHANDLEUI64VARB
+	gpProgramUniformHandleui64vNV                    C.GPPROGRAMUNIFORMHANDLEUI64VNV
+	gpProgramUniformMatrix2dv                        C.GPPROGRAMUNIFORMMATRIX2DV
+	gpProgramUniformMatrix2dvEXT                     C.GPPROGRAMUNIFORMMATRIX2DVEXT
+	gpProgramUniformMatrix2fv                        C.GPPROGRAMUNIFORMMATRIX2FV
+	gpProgramUniformMatrix2fvEXT                     C.GPPROGRAMUNIFORMMATRIX2FVEXT
+	gpProgramUniformMatrix2x3dv                      C.GPPROGRAMUNIFORMMATRIX2X3DV
+	gpProgramUniformMatrix2x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3DVEXT
+	gpProgramUniformMatrix2x3fv                      C.GPPROGRAMUNIFORMMATRIX2X3FV
+	gpProgramUniformMatrix2x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3FVEXT
+	gpProgramUniformMatrix2x4dv                      C.GPPROGRAMUNIFORMMATRIX2X4DV
+	gpProgramUniformMatrix2x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4DVEXT
+	gpProgramUniformMatrix2x4fv                      C.GPPROGRAMUNIFORMMATRIX2X4FV
+	gpProgramUniformMatrix2x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4FVEXT
+	gpProgramUniformMatrix3dv                        C.GPPROGRAMUNIFORMMATRIX3DV
+	gpProgramUniformMatrix3dvEXT                     C.GPPROGRAMUNIFORMMATRIX3DVEXT
+	gpProgramUniformMatrix3fv                        C.GPPROGRAMUNIFORMMATRIX3FV
+	gpProgramUniformMatrix3fvEXT                     C.GPPROGRAMUNIFORMMATRIX3FVEXT
+	gpProgramUniformMatrix3x2dv                      C.GPPROGRAMUNIFORMMATRIX3X2DV
+	gpProgramUniformMatrix3x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2DVEXT
+	gpProgramUniformMatrix3x2fv                      C.GPPROGRAMUNIFORMMATRIX3X2FV
+	gpProgramUniformMatrix3x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2FVEXT
+	gpProgramUniformMatrix3x4dv                      C.GPPROGRAMUNIFORMMATRIX3X4DV
+	gpProgramUniformMatrix3x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4DVEXT
+	gpProgramUniformMatrix3x4fv                      C.GPPROGRAMUNIFORMMATRIX3X4FV
+	gpProgramUniformMatrix3x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4FVEXT
+	gpProgramUniformMatrix4dv                        C.GPPROGRAMUNIFORMMATRIX4DV
+	gpProgramUniformMatrix4dvEXT                     C.GPPROGRAMUNIFORMMATRIX4DVEXT
+	gpProgramUniformMatrix4fv                        C.GPPROGRAMUNIFORMMATRIX4FV
+	gpProgramUniformMatrix4fvEXT                     C.GPPROGRAMUNIFORMMATRIX4FVEXT
+	gpProgramUniformMatrix4x2dv                      C.GPPROGRAMUNIFORMMATRIX4X2DV
+	gpProgramUniformMatrix4x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2DVEXT
+	gpProgramUniformMatrix4x2fv                      C.GPPROGRAMUNIFORMMATRIX4X2FV
+	gpProgramUniformMatrix4x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2FVEXT
+	gpProgramUniformMatrix4x3dv                      C.GPPROGRAMUNIFORMMATRIX4X3DV
+	gpProgramUniformMatrix4x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3DVEXT
+	gpProgramUniformMatrix4x3fv                      C.GPPROGRAMUNIFORMMATRIX4X3FV
+	gpProgramUniformMatrix4x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3FVEXT
+	gpProgramUniformui64NV                           C.GPPROGRAMUNIFORMUI64NV
+	gpProgramUniformui64vNV                          C.GPPROGRAMUNIFORMUI64VNV
+	gpProvokingVertex                                C.GPPROVOKINGVERTEX
+	gpPushClientAttribDefaultEXT                     C.GPPUSHCLIENTATTRIBDEFAULTEXT
+	gpPushDebugGroup                                 C.GPPUSHDEBUGGROUP
+	gpPushDebugGroupKHR                              C.GPPUSHDEBUGGROUPKHR
+	gpPushGroupMarkerEXT                             C.GPPUSHGROUPMARKEREXT
+	gpQueryCounter                                   C.GPQUERYCOUNTER
+	gpRasterSamplesEXT                               C.GPRASTERSAMPLESEXT
+	gpReadBuffer                                     C.GPREADBUFFER
+	gpReadPixels                                     C.GPREADPIXELS
+	gpReadnPixels                                    C.GPREADNPIXELS
+	gpReadnPixelsARB                                 C.GPREADNPIXELSARB
+	gpReadnPixelsKHR                                 C.GPREADNPIXELSKHR
+	gpReleaseShaderCompiler                          C.GPRELEASESHADERCOMPILER
+	gpRenderbufferStorage                            C.GPRENDERBUFFERSTORAGE
+	gpRenderbufferStorageMultisample                 C.GPRENDERBUFFERSTORAGEMULTISAMPLE
+	gpRenderbufferStorageMultisampleCoverageNV       C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV
+	gpResolveDepthValuesNV                           C.GPRESOLVEDEPTHVALUESNV
+	gpResumeTransformFeedback                        C.GPRESUMETRANSFORMFEEDBACK
+	gpSampleCoverage                                 C.GPSAMPLECOVERAGE
+	gpSampleMaski                                    C.GPSAMPLEMASKI
+	gpSamplerParameterIiv                            C.GPSAMPLERPARAMETERIIV
+	gpSamplerParameterIuiv                           C.GPSAMPLERPARAMETERIUIV
+	gpSamplerParameterf                              C.GPSAMPLERPARAMETERF
+	gpSamplerParameterfv                             C.GPSAMPLERPARAMETERFV
+	gpSamplerParameteri                              C.GPSAMPLERPARAMETERI
+	gpSamplerParameteriv                             C.GPSAMPLERPARAMETERIV
+	gpScissor                                        C.GPSCISSOR
+	gpScissorArrayv                                  C.GPSCISSORARRAYV
+	gpScissorIndexed                                 C.GPSCISSORINDEXED
+	gpScissorIndexedv                                C.GPSCISSORINDEXEDV
+	gpSecondaryColorFormatNV                         C.GPSECONDARYCOLORFORMATNV
+	gpSelectPerfMonitorCountersAMD                   C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpShaderBinary                                   C.GPSHADERBINARY
+	gpShaderSource                                   C.GPSHADERSOURCE
+	gpShaderStorageBlockBinding                      C.GPSHADERSTORAGEBLOCKBINDING
+	gpSignalVkFenceNV                                C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                            C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                            C.GPSPECIALIZESHADERARB
+	gpStateCaptureNV                                 C.GPSTATECAPTURENV
+	gpStencilFillPathInstancedNV                     C.GPSTENCILFILLPATHINSTANCEDNV
+	gpStencilFillPathNV                              C.GPSTENCILFILLPATHNV
+	gpStencilFunc                                    C.GPSTENCILFUNC
+	gpStencilFuncSeparate                            C.GPSTENCILFUNCSEPARATE
+	gpStencilMask                                    C.GPSTENCILMASK
+	gpStencilMaskSeparate                            C.GPSTENCILMASKSEPARATE
+	gpStencilOp                                      C.GPSTENCILOP
+	gpStencilOpSeparate                              C.GPSTENCILOPSEPARATE
+	gpStencilStrokePathInstancedNV                   C.GPSTENCILSTROKEPATHINSTANCEDNV
+	gpStencilStrokePathNV                            C.GPSTENCILSTROKEPATHNV
+	gpStencilThenCoverFillPathInstancedNV            C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV
+	gpStencilThenCoverFillPathNV                     C.GPSTENCILTHENCOVERFILLPATHNV
+	gpStencilThenCoverStrokePathInstancedNV          C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV
+	gpStencilThenCoverStrokePathNV                   C.GPSTENCILTHENCOVERSTROKEPATHNV
+	gpSubpixelPrecisionBiasNV                        C.GPSUBPIXELPRECISIONBIASNV
+	gpTexBuffer                                      C.GPTEXBUFFER
+	gpTexBufferARB                                   C.GPTEXBUFFERARB
+	gpTexBufferRange                                 C.GPTEXBUFFERRANGE
+	gpTexCoordFormatNV                               C.GPTEXCOORDFORMATNV
+	gpTexImage1D                                     C.GPTEXIMAGE1D
+	gpTexImage2D                                     C.GPTEXIMAGE2D
+	gpTexImage2DMultisample                          C.GPTEXIMAGE2DMULTISAMPLE
+	gpTexImage3D                                     C.GPTEXIMAGE3D
+	gpTexImage3DMultisample                          C.GPTEXIMAGE3DMULTISAMPLE
+	gpTexPageCommitmentARB                           C.GPTEXPAGECOMMITMENTARB
+	gpTexParameterIiv                                C.GPTEXPARAMETERIIV
+	gpTexParameterIuiv                               C.GPTEXPARAMETERIUIV
+	gpTexParameterf                                  C.GPTEXPARAMETERF
+	gpTexParameterfv                                 C.GPTEXPARAMETERFV
+	gpTexParameteri                                  C.GPTEXPARAMETERI
+	gpTexParameteriv                                 C.GPTEXPARAMETERIV
+	gpTexStorage1D                                   C.GPTEXSTORAGE1D
+	gpTexStorage2D                                   C.GPTEXSTORAGE2D
+	gpTexStorage2DMultisample                        C.GPTEXSTORAGE2DMULTISAMPLE
+	gpTexStorage3D                                   C.GPTEXSTORAGE3D
+	gpTexStorage3DMultisample                        C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexSubImage1D                                  C.GPTEXSUBIMAGE1D
+	gpTexSubImage2D                                  C.GPTEXSUBIMAGE2D
+	gpTexSubImage3D                                  C.GPTEXSUBIMAGE3D
+	gpTextureBarrier                                 C.GPTEXTUREBARRIER
+	gpTextureBarrierNV                               C.GPTEXTUREBARRIERNV
+	gpTextureBuffer                                  C.GPTEXTUREBUFFER
+	gpTextureBufferEXT                               C.GPTEXTUREBUFFEREXT
+	gpTextureBufferRange                             C.GPTEXTUREBUFFERRANGE
+	gpTextureBufferRangeEXT                          C.GPTEXTUREBUFFERRANGEEXT
+	gpTextureImage1DEXT                              C.GPTEXTUREIMAGE1DEXT
+	gpTextureImage2DEXT                              C.GPTEXTUREIMAGE2DEXT
+	gpTextureImage3DEXT                              C.GPTEXTUREIMAGE3DEXT
+	gpTexturePageCommitmentEXT                       C.GPTEXTUREPAGECOMMITMENTEXT
+	gpTextureParameterIiv                            C.GPTEXTUREPARAMETERIIV
+	gpTextureParameterIivEXT                         C.GPTEXTUREPARAMETERIIVEXT
+	gpTextureParameterIuiv                           C.GPTEXTUREPARAMETERIUIV
+	gpTextureParameterIuivEXT                        C.GPTEXTUREPARAMETERIUIVEXT
+	gpTextureParameterf                              C.GPTEXTUREPARAMETERF
+	gpTextureParameterfEXT                           C.GPTEXTUREPARAMETERFEXT
+	gpTextureParameterfv                             C.GPTEXTUREPARAMETERFV
+	gpTextureParameterfvEXT                          C.GPTEXTUREPARAMETERFVEXT
+	gpTextureParameteri                              C.GPTEXTUREPARAMETERI
+	gpTextureParameteriEXT                           C.GPTEXTUREPARAMETERIEXT
+	gpTextureParameteriv                             C.GPTEXTUREPARAMETERIV
+	gpTextureParameterivEXT                          C.GPTEXTUREPARAMETERIVEXT
+	gpTextureRenderbufferEXT                         C.GPTEXTURERENDERBUFFEREXT
+	gpTextureStorage1D                               C.GPTEXTURESTORAGE1D
+	gpTextureStorage1DEXT                            C.GPTEXTURESTORAGE1DEXT
+	gpTextureStorage2D                               C.GPTEXTURESTORAGE2D
+	gpTextureStorage2DEXT                            C.GPTEXTURESTORAGE2DEXT
+	gpTextureStorage2DMultisample                    C.GPTEXTURESTORAGE2DMULTISAMPLE
+	gpTextureStorage2DMultisampleEXT                 C.GPTEXTURESTORAGE2DMULTISAMPLEEXT
+	gpTextureStorage3D                               C.GPTEXTURESTORAGE3D
+	gpTextureStorage3DEXT                            C.GPTEXTURESTORAGE3DEXT
+	gpTextureStorage3DMultisample                    C.GPTEXTURESTORAGE3DMULTISAMPLE
+	gpTextureStorage3DMultisampleEXT                 C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureSubImage1D                              C.GPTEXTURESUBIMAGE1D
+	gpTextureSubImage1DEXT                           C.GPTEXTURESUBIMAGE1DEXT
+	gpTextureSubImage2D                              C.GPTEXTURESUBIMAGE2D
+	gpTextureSubImage2DEXT                           C.GPTEXTURESUBIMAGE2DEXT
+	gpTextureSubImage3D                              C.GPTEXTURESUBIMAGE3D
+	gpTextureSubImage3DEXT                           C.GPTEXTURESUBIMAGE3DEXT
+	gpTextureView                                    C.GPTEXTUREVIEW
+	gpTransformFeedbackBufferBase                    C.GPTRANSFORMFEEDBACKBUFFERBASE
+	gpTransformFeedbackBufferRange                   C.GPTRANSFORMFEEDBACKBUFFERRANGE
+	gpTransformFeedbackVaryings                      C.GPTRANSFORMFEEDBACKVARYINGS
+	gpTransformPathNV                                C.GPTRANSFORMPATHNV
+	gpUniform1d                                      C.GPUNIFORM1D
+	gpUniform1dv                                     C.GPUNIFORM1DV
+	gpUniform1f                                      C.GPUNIFORM1F
+	gpUniform1fv                                     C.GPUNIFORM1FV
+	gpUniform1i                                      C.GPUNIFORM1I
+	gpUniform1i64ARB                                 C.GPUNIFORM1I64ARB
+	gpUniform1i64NV                                  C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                C.GPUNIFORM1I64VARB
+	gpUniform1i64vNV                                 C.GPUNIFORM1I64VNV
+	gpUniform1iv                                     C.GPUNIFORM1IV
+	gpUniform1ui                                     C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                C.GPUNIFORM1UI64ARB
+	gpUniform1ui64NV                                 C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                               C.GPUNIFORM1UI64VARB
+	gpUniform1ui64vNV                                C.GPUNIFORM1UI64VNV
+	gpUniform1uiv                                    C.GPUNIFORM1UIV
+	gpUniform2d                                      C.GPUNIFORM2D
+	gpUniform2dv                                     C.GPUNIFORM2DV
+	gpUniform2f                                      C.GPUNIFORM2F
+	gpUniform2fv                                     C.GPUNIFORM2FV
+	gpUniform2i                                      C.GPUNIFORM2I
+	gpUniform2i64ARB                                 C.GPUNIFORM2I64ARB
+	gpUniform2i64NV                                  C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                C.GPUNIFORM2I64VARB
+	gpUniform2i64vNV                                 C.GPUNIFORM2I64VNV
+	gpUniform2iv                                     C.GPUNIFORM2IV
+	gpUniform2ui                                     C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                C.GPUNIFORM2UI64ARB
+	gpUniform2ui64NV                                 C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                               C.GPUNIFORM2UI64VARB
+	gpUniform2ui64vNV                                C.GPUNIFORM2UI64VNV
+	gpUniform2uiv                                    C.GPUNIFORM2UIV
+	gpUniform3d                                      C.GPUNIFORM3D
+	gpUniform3dv                                     C.GPUNIFORM3DV
+	gpUniform3f                                      C.GPUNIFORM3F
+	gpUniform3fv                                     C.GPUNIFORM3FV
+	gpUniform3i                                      C.GPUNIFORM3I
+	gpUniform3i64ARB                                 C.GPUNIFORM3I64ARB
+	gpUniform3i64NV                                  C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                C.GPUNIFORM3I64VARB
+	gpUniform3i64vNV                                 C.GPUNIFORM3I64VNV
+	gpUniform3iv                                     C.GPUNIFORM3IV
+	gpUniform3ui                                     C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                C.GPUNIFORM3UI64ARB
+	gpUniform3ui64NV                                 C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                               C.GPUNIFORM3UI64VARB
+	gpUniform3ui64vNV                                C.GPUNIFORM3UI64VNV
+	gpUniform3uiv                                    C.GPUNIFORM3UIV
+	gpUniform4d                                      C.GPUNIFORM4D
+	gpUniform4dv                                     C.GPUNIFORM4DV
+	gpUniform4f                                      C.GPUNIFORM4F
+	gpUniform4fv                                     C.GPUNIFORM4FV
+	gpUniform4i                                      C.GPUNIFORM4I
+	gpUniform4i64ARB                                 C.GPUNIFORM4I64ARB
+	gpUniform4i64NV                                  C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                C.GPUNIFORM4I64VARB
+	gpUniform4i64vNV                                 C.GPUNIFORM4I64VNV
+	gpUniform4iv                                     C.GPUNIFORM4IV
+	gpUniform4ui                                     C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                C.GPUNIFORM4UI64ARB
+	gpUniform4ui64NV                                 C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                               C.GPUNIFORM4UI64VARB
+	gpUniform4ui64vNV                                C.GPUNIFORM4UI64VNV
+	gpUniform4uiv                                    C.GPUNIFORM4UIV
+	gpUniformBlockBinding                            C.GPUNIFORMBLOCKBINDING
+	gpUniformHandleui64ARB                           C.GPUNIFORMHANDLEUI64ARB
+	gpUniformHandleui64NV                            C.GPUNIFORMHANDLEUI64NV
+	gpUniformHandleui64vARB                          C.GPUNIFORMHANDLEUI64VARB
+	gpUniformHandleui64vNV                           C.GPUNIFORMHANDLEUI64VNV
+	gpUniformMatrix2dv                               C.GPUNIFORMMATRIX2DV
+	gpUniformMatrix2fv                               C.GPUNIFORMMATRIX2FV
+	gpUniformMatrix2x3dv                             C.GPUNIFORMMATRIX2X3DV
+	gpUniformMatrix2x3fv                             C.GPUNIFORMMATRIX2X3FV
+	gpUniformMatrix2x4dv                             C.GPUNIFORMMATRIX2X4DV
+	gpUniformMatrix2x4fv                             C.GPUNIFORMMATRIX2X4FV
+	gpUniformMatrix3dv                               C.GPUNIFORMMATRIX3DV
+	gpUniformMatrix3fv                               C.GPUNIFORMMATRIX3FV
+	gpUniformMatrix3x2dv                             C.GPUNIFORMMATRIX3X2DV
+	gpUniformMatrix3x2fv                             C.GPUNIFORMMATRIX3X2FV
+	gpUniformMatrix3x4dv                             C.GPUNIFORMMATRIX3X4DV
+	gpUniformMatrix3x4fv                             C.GPUNIFORMMATRIX3X4FV
+	gpUniformMatrix4dv                               C.GPUNIFORMMATRIX4DV
+	gpUniformMatrix4fv                               C.GPUNIFORMMATRIX4FV
+	gpUniformMatrix4x2dv                             C.GPUNIFORMMATRIX4X2DV
+	gpUniformMatrix4x2fv                             C.GPUNIFORMMATRIX4X2FV
+	gpUniformMatrix4x3dv                             C.GPUNIFORMMATRIX4X3DV
+	gpUniformMatrix4x3fv                             C.GPUNIFORMMATRIX4X3FV
+	gpUniformSubroutinesuiv                          C.GPUNIFORMSUBROUTINESUIV
+	gpUniformui64NV                                  C.GPUNIFORMUI64NV
+	gpUniformui64vNV                                 C.GPUNIFORMUI64VNV
+	gpUnmapBuffer                                    C.GPUNMAPBUFFER
+	gpUnmapNamedBuffer                               C.GPUNMAPNAMEDBUFFER
+	gpUnmapNamedBufferEXT                            C.GPUNMAPNAMEDBUFFEREXT
+	gpUseProgram                                     C.GPUSEPROGRAM
+	gpUseProgramStages                               C.GPUSEPROGRAMSTAGES
+	gpUseProgramStagesEXT                            C.GPUSEPROGRAMSTAGESEXT
+	gpUseShaderProgramEXT                            C.GPUSESHADERPROGRAMEXT
+	gpValidateProgram                                C.GPVALIDATEPROGRAM
+	gpValidateProgramPipeline                        C.GPVALIDATEPROGRAMPIPELINE
+	gpValidateProgramPipelineEXT                     C.GPVALIDATEPROGRAMPIPELINEEXT
+	gpVertexArrayAttribBinding                       C.GPVERTEXARRAYATTRIBBINDING
+	gpVertexArrayAttribFormat                        C.GPVERTEXARRAYATTRIBFORMAT
+	gpVertexArrayAttribIFormat                       C.GPVERTEXARRAYATTRIBIFORMAT
+	gpVertexArrayAttribLFormat                       C.GPVERTEXARRAYATTRIBLFORMAT
+	gpVertexArrayBindVertexBufferEXT                 C.GPVERTEXARRAYBINDVERTEXBUFFEREXT
+	gpVertexArrayBindingDivisor                      C.GPVERTEXARRAYBINDINGDIVISOR
+	gpVertexArrayColorOffsetEXT                      C.GPVERTEXARRAYCOLOROFFSETEXT
+	gpVertexArrayEdgeFlagOffsetEXT                   C.GPVERTEXARRAYEDGEFLAGOFFSETEXT
+	gpVertexArrayElementBuffer                       C.GPVERTEXARRAYELEMENTBUFFER
+	gpVertexArrayFogCoordOffsetEXT                   C.GPVERTEXARRAYFOGCOORDOFFSETEXT
+	gpVertexArrayIndexOffsetEXT                      C.GPVERTEXARRAYINDEXOFFSETEXT
+	gpVertexArrayMultiTexCoordOffsetEXT              C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT
+	gpVertexArrayNormalOffsetEXT                     C.GPVERTEXARRAYNORMALOFFSETEXT
+	gpVertexArraySecondaryColorOffsetEXT             C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT
+	gpVertexArrayTexCoordOffsetEXT                   C.GPVERTEXARRAYTEXCOORDOFFSETEXT
+	gpVertexArrayVertexAttribBindingEXT              C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT
+	gpVertexArrayVertexAttribDivisorEXT              C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT
+	gpVertexArrayVertexAttribFormatEXT               C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT
+	gpVertexArrayVertexAttribIFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT
+	gpVertexArrayVertexAttribIOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT
+	gpVertexArrayVertexAttribLFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT
+	gpVertexArrayVertexAttribLOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT
+	gpVertexArrayVertexAttribOffsetEXT               C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT
+	gpVertexArrayVertexBindingDivisorEXT             C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT
+	gpVertexArrayVertexBuffer                        C.GPVERTEXARRAYVERTEXBUFFER
+	gpVertexArrayVertexBuffers                       C.GPVERTEXARRAYVERTEXBUFFERS
+	gpVertexArrayVertexOffsetEXT                     C.GPVERTEXARRAYVERTEXOFFSETEXT
+	gpVertexAttrib1d                                 C.GPVERTEXATTRIB1D
+	gpVertexAttrib1dv                                C.GPVERTEXATTRIB1DV
+	gpVertexAttrib1f                                 C.GPVERTEXATTRIB1F
+	gpVertexAttrib1fv                                C.GPVERTEXATTRIB1FV
+	gpVertexAttrib1s                                 C.GPVERTEXATTRIB1S
+	gpVertexAttrib1sv                                C.GPVERTEXATTRIB1SV
+	gpVertexAttrib2d                                 C.GPVERTEXATTRIB2D
+	gpVertexAttrib2dv                                C.GPVERTEXATTRIB2DV
+	gpVertexAttrib2f                                 C.GPVERTEXATTRIB2F
+	gpVertexAttrib2fv                                C.GPVERTEXATTRIB2FV
+	gpVertexAttrib2s                                 C.GPVERTEXATTRIB2S
+	gpVertexAttrib2sv                                C.GPVERTEXATTRIB2SV
+	gpVertexAttrib3d                                 C.GPVERTEXATTRIB3D
+	gpVertexAttrib3dv                                C.GPVERTEXATTRIB3DV
+	gpVertexAttrib3f                                 C.GPVERTEXATTRIB3F
+	gpVertexAttrib3fv                                C.GPVERTEXATTRIB3FV
+	gpVertexAttrib3s                                 C.GPVERTEXATTRIB3S
+	gpVertexAttrib3sv                                C.GPVERTEXATTRIB3SV
+	gpVertexAttrib4Nbv                               C.GPVERTEXATTRIB4NBV
+	gpVertexAttrib4Niv                               C.GPVERTEXATTRIB4NIV
+	gpVertexAttrib4Nsv                               C.GPVERTEXATTRIB4NSV
+	gpVertexAttrib4Nub                               C.GPVERTEXATTRIB4NUB
+	gpVertexAttrib4Nubv                              C.GPVERTEXATTRIB4NUBV
+	gpVertexAttrib4Nuiv                              C.GPVERTEXATTRIB4NUIV
+	gpVertexAttrib4Nusv                              C.GPVERTEXATTRIB4NUSV
+	gpVertexAttrib4bv                                C.GPVERTEXATTRIB4BV
+	gpVertexAttrib4d                                 C.GPVERTEXATTRIB4D
+	gpVertexAttrib4dv                                C.GPVERTEXATTRIB4DV
+	gpVertexAttrib4f                                 C.GPVERTEXATTRIB4F
+	gpVertexAttrib4fv                                C.GPVERTEXATTRIB4FV
+	gpVertexAttrib4iv                                C.GPVERTEXATTRIB4IV
+	gpVertexAttrib4s                                 C.GPVERTEXATTRIB4S
+	gpVertexAttrib4sv                                C.GPVERTEXATTRIB4SV
+	gpVertexAttrib4ubv                               C.GPVERTEXATTRIB4UBV
+	gpVertexAttrib4uiv                               C.GPVERTEXATTRIB4UIV
+	gpVertexAttrib4usv                               C.GPVERTEXATTRIB4USV
+	gpVertexAttribBinding                            C.GPVERTEXATTRIBBINDING
+	gpVertexAttribDivisorARB                         C.GPVERTEXATTRIBDIVISORARB
+	gpVertexAttribFormat                             C.GPVERTEXATTRIBFORMAT
+	gpVertexAttribFormatNV                           C.GPVERTEXATTRIBFORMATNV
+	gpVertexAttribI1i                                C.GPVERTEXATTRIBI1I
+	gpVertexAttribI1iv                               C.GPVERTEXATTRIBI1IV
+	gpVertexAttribI1ui                               C.GPVERTEXATTRIBI1UI
+	gpVertexAttribI1uiv                              C.GPVERTEXATTRIBI1UIV
+	gpVertexAttribI2i                                C.GPVERTEXATTRIBI2I
+	gpVertexAttribI2iv                               C.GPVERTEXATTRIBI2IV
+	gpVertexAttribI2ui                               C.GPVERTEXATTRIBI2UI
+	gpVertexAttribI2uiv                              C.GPVERTEXATTRIBI2UIV
+	gpVertexAttribI3i                                C.GPVERTEXATTRIBI3I
+	gpVertexAttribI3iv                               C.GPVERTEXATTRIBI3IV
+	gpVertexAttribI3ui                               C.GPVERTEXATTRIBI3UI
+	gpVertexAttribI3uiv                              C.GPVERTEXATTRIBI3UIV
+	gpVertexAttribI4bv                               C.GPVERTEXATTRIBI4BV
+	gpVertexAttribI4i                                C.GPVERTEXATTRIBI4I
+	gpVertexAttribI4iv                               C.GPVERTEXATTRIBI4IV
+	gpVertexAttribI4sv                               C.GPVERTEXATTRIBI4SV
+	gpVertexAttribI4ubv                              C.GPVERTEXATTRIBI4UBV
+	gpVertexAttribI4ui                               C.GPVERTEXATTRIBI4UI
+	gpVertexAttribI4uiv                              C.GPVERTEXATTRIBI4UIV
+	gpVertexAttribI4usv                              C.GPVERTEXATTRIBI4USV
+	gpVertexAttribIFormat                            C.GPVERTEXATTRIBIFORMAT
+	gpVertexAttribIFormatNV                          C.GPVERTEXATTRIBIFORMATNV
+	gpVertexAttribIPointer                           C.GPVERTEXATTRIBIPOINTER
+	gpVertexAttribL1d                                C.GPVERTEXATTRIBL1D
+	gpVertexAttribL1dv                               C.GPVERTEXATTRIBL1DV
+	gpVertexAttribL1i64NV                            C.GPVERTEXATTRIBL1I64NV
+	gpVertexAttribL1i64vNV                           C.GPVERTEXATTRIBL1I64VNV
+	gpVertexAttribL1ui64ARB                          C.GPVERTEXATTRIBL1UI64ARB
+	gpVertexAttribL1ui64NV                           C.GPVERTEXATTRIBL1UI64NV
+	gpVertexAttribL1ui64vARB                         C.GPVERTEXATTRIBL1UI64VARB
+	gpVertexAttribL1ui64vNV                          C.GPVERTEXATTRIBL1UI64VNV
+	gpVertexAttribL2d                                C.GPVERTEXATTRIBL2D
+	gpVertexAttribL2dv                               C.GPVERTEXATTRIBL2DV
+	gpVertexAttribL2i64NV                            C.GPVERTEXATTRIBL2I64NV
+	gpVertexAttribL2i64vNV                           C.GPVERTEXATTRIBL2I64VNV
+	gpVertexAttribL2ui64NV                           C.GPVERTEXATTRIBL2UI64NV
+	gpVertexAttribL2ui64vNV                          C.GPVERTEXATTRIBL2UI64VNV
+	gpVertexAttribL3d                                C.GPVERTEXATTRIBL3D
+	gpVertexAttribL3dv                               C.GPVERTEXATTRIBL3DV
+	gpVertexAttribL3i64NV                            C.GPVERTEXATTRIBL3I64NV
+	gpVertexAttribL3i64vNV                           C.GPVERTEXATTRIBL3I64VNV
+	gpVertexAttribL3ui64NV                           C.GPVERTEXATTRIBL3UI64NV
+	gpVertexAttribL3ui64vNV                          C.GPVERTEXATTRIBL3UI64VNV
+	gpVertexAttribL4d                                C.GPVERTEXATTRIBL4D
+	gpVertexAttribL4dv                               C.GPVERTEXATTRIBL4DV
+	gpVertexAttribL4i64NV                            C.GPVERTEXATTRIBL4I64NV
+	gpVertexAttribL4i64vNV                           C.GPVERTEXATTRIBL4I64VNV
+	gpVertexAttribL4ui64NV                           C.GPVERTEXATTRIBL4UI64NV
+	gpVertexAttribL4ui64vNV                          C.GPVERTEXATTRIBL4UI64VNV
+	gpVertexAttribLFormat                            C.GPVERTEXATTRIBLFORMAT
+	gpVertexAttribLFormatNV                          C.GPVERTEXATTRIBLFORMATNV
+	gpVertexAttribLPointer                           C.GPVERTEXATTRIBLPOINTER
+	gpVertexAttribP1ui                               C.GPVERTEXATTRIBP1UI
+	gpVertexAttribP1uiv                              C.GPVERTEXATTRIBP1UIV
+	gpVertexAttribP2ui                               C.GPVERTEXATTRIBP2UI
+	gpVertexAttribP2uiv                              C.GPVERTEXATTRIBP2UIV
+	gpVertexAttribP3ui                               C.GPVERTEXATTRIBP3UI
+	gpVertexAttribP3uiv                              C.GPVERTEXATTRIBP3UIV
+	gpVertexAttribP4ui                               C.GPVERTEXATTRIBP4UI
+	gpVertexAttribP4uiv                              C.GPVERTEXATTRIBP4UIV
+	gpVertexAttribPointer                            C.GPVERTEXATTRIBPOINTER
+	gpVertexBindingDivisor                           C.GPVERTEXBINDINGDIVISOR
+	gpVertexFormatNV                                 C.GPVERTEXFORMATNV
+	gpViewport                                       C.GPVIEWPORT
+	gpViewportArrayv                                 C.GPVIEWPORTARRAYV
+	gpViewportIndexedf                               C.GPVIEWPORTINDEXEDF
+	gpViewportIndexedfv                              C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                       C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                              C.GPVIEWPORTSWIZZLENV
+	gpWaitSync                                       C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                              C.GPWAITVKSEMAPHORENV
+	gpWeightPathsNV                                  C.GPWEIGHTPATHSNV
+	gpWindowRectanglesEXT                            C.GPWINDOWRECTANGLESEXT
 )
 
 // Helper functions
@@ -5104,15 +8378,24 @@ func boolToInt(b bool) int {
 	}
 	return 0
 }
+func ActiveProgramEXT(program uint32) {
+	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
+}
 
 // set the active program object for a program pipeline object
 func ActiveShaderProgram(pipeline uint32, program uint32) {
 	C.glowActiveShaderProgram(gpActiveShaderProgram, (C.GLuint)(pipeline), (C.GLuint)(program))
 }
+func ActiveShaderProgramEXT(pipeline uint32, program uint32) {
+	C.glowActiveShaderProgramEXT(gpActiveShaderProgramEXT, (C.GLuint)(pipeline), (C.GLuint)(program))
+}
 
 // select active texture unit
 func ActiveTexture(texture uint32) {
 	C.glowActiveTexture(gpActiveTexture, (C.GLenum)(texture))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 
 // Attaches a shader object to a program object
@@ -5123,6 +8406,15 @@ func AttachShader(program uint32, shader uint32) {
 // start conditional rendering
 func BeginConditionalRender(id uint32, mode uint32) {
 	C.glowBeginConditionalRender(gpBeginConditionalRender, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginConditionalRenderNV(id uint32, mode uint32) {
+	C.glowBeginConditionalRenderNV(gpBeginConditionalRenderNV, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginPerfMonitorAMD(monitor uint32) {
+	C.glowBeginPerfMonitorAMD(gpBeginPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func BeginPerfQueryINTEL(queryHandle uint32) {
+	C.glowBeginPerfQueryINTEL(gpBeginPerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // delimit the boundaries of a query object
@@ -5192,10 +8484,16 @@ func BindImageTexture(unit uint32, texture uint32, level int32, layered bool, la
 func BindImageTextures(first uint32, count int32, textures *uint32) {
 	C.glowBindImageTextures(gpBindImageTextures, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(textures)))
 }
+func BindMultiTextureEXT(texunit uint32, target uint32, texture uint32) {
+	C.glowBindMultiTextureEXT(gpBindMultiTextureEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(texture))
+}
 
 // bind a program pipeline to the current context
 func BindProgramPipeline(pipeline uint32) {
 	C.glowBindProgramPipeline(gpBindProgramPipeline, (C.GLuint)(pipeline))
+}
+func BindProgramPipelineEXT(pipeline uint32) {
+	C.glowBindProgramPipelineEXT(gpBindProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 
 // bind a renderbuffer to a renderbuffer target
@@ -5247,6 +8545,12 @@ func BindVertexBuffer(bindingindex uint32, buffer uint32, offset int, stride int
 func BindVertexBuffers(first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowBindVertexBuffers(gpBindVertexBuffers, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
 }
+func BlendBarrierKHR() {
+	C.glowBlendBarrierKHR(gpBlendBarrierKHR)
+}
+func BlendBarrierNV() {
+	C.glowBlendBarrierNV(gpBlendBarrierNV)
+}
 
 // set the blend color
 func BlendColor(red float32, green float32, blue float32, alpha float32) {
@@ -5284,6 +8588,9 @@ func BlendFuncSeparateiARB(buf uint32, srcRGB uint32, dstRGB uint32, srcAlpha ui
 func BlendFunciARB(buf uint32, src uint32, dst uint32) {
 	C.glowBlendFunciARB(gpBlendFunciARB, (C.GLuint)(buf), (C.GLenum)(src), (C.GLenum)(dst))
 }
+func BlendParameteriNV(pname uint32, value int32) {
+	C.glowBlendParameteriNV(gpBlendParameteriNV, (C.GLenum)(pname), (C.GLint)(value))
+}
 
 // copy a block of pixels from one framebuffer object to another
 func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
@@ -5294,13 +8601,16 @@ func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 i
 func BlitNamedFramebuffer(readFramebuffer uint32, drawFramebuffer uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
 	C.glowBlitNamedFramebuffer(gpBlitNamedFramebuffer, (C.GLuint)(readFramebuffer), (C.GLuint)(drawFramebuffer), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
 }
+func BufferAddressRangeNV(pname uint32, index uint32, address uint64, length int) {
+	C.glowBufferAddressRangeNV(gpBufferAddressRangeNV, (C.GLenum)(pname), (C.GLuint)(index), (C.GLuint64EXT)(address), (C.GLsizeiptr)(length))
+}
 
 // creates and initializes a buffer object's data     store
 func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferData(gpBufferData, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
@@ -5312,6 +8622,9 @@ func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubData(gpBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
+}
 
 // check the completeness status of a framebuffer
 func CheckFramebufferStatus(target uint32) uint32 {
@@ -5322,6 +8635,10 @@ func CheckFramebufferStatus(target uint32) uint32 {
 // check the completeness status of a framebuffer
 func CheckNamedFramebufferStatus(framebuffer uint32, target uint32) uint32 {
 	ret := C.glowCheckNamedFramebufferStatus(gpCheckNamedFramebufferStatus, (C.GLuint)(framebuffer), (C.GLenum)(target))
+	return (uint32)(ret)
+}
+func CheckNamedFramebufferStatusEXT(framebuffer uint32, target uint32) uint32 {
+	ret := C.glowCheckNamedFramebufferStatusEXT(gpCheckNamedFramebufferStatusEXT, (C.GLuint)(framebuffer), (C.GLenum)(target))
 	return (uint32)(ret)
 }
 
@@ -5366,6 +8683,8 @@ func ClearColor(red float32, green float32, blue float32, alpha float32) {
 func ClearDepth(depth float64) {
 	C.glowClearDepth(gpClearDepth, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -5374,13 +8693,19 @@ func ClearDepthf(d float32) {
 func ClearNamedBufferData(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferData(gpClearNamedBufferData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferDataEXT(gpClearNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -5406,9 +8731,12 @@ func ClearTexImage(texture uint32, level int32, format uint32, xtype uint32, dat
 func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearTexSubImage(gpClearTexSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClientAttribDefaultEXT(mask uint32) {
+	C.glowClientAttribDefaultEXT(gpClientAttribDefaultEXT, (C.GLbitfield)(mask))
+}
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -5417,11 +8745,20 @@ func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
 func ClipControl(origin uint32, depth uint32) {
 	C.glowClipControl(gpClipControl, (C.GLenum)(origin), (C.GLenum)(depth))
 }
+func ColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowColorFormatNV(gpColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func ColorMask(red bool, green bool, blue bool, alpha bool) {
 	C.glowColorMask(gpColorMask, (C.GLboolean)(boolToInt(red)), (C.GLboolean)(boolToInt(green)), (C.GLboolean)(boolToInt(blue)), (C.GLboolean)(boolToInt(alpha)))
 }
 func ColorMaski(index uint32, r bool, g bool, b bool, a bool) {
 	C.glowColorMaski(gpColorMaski, (C.GLuint)(index), (C.GLboolean)(boolToInt(r)), (C.GLboolean)(boolToInt(g)), (C.GLboolean)(boolToInt(b)), (C.GLboolean)(boolToInt(a)))
+}
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
 }
 
 // Compiles a shader object
@@ -5430,6 +8767,24 @@ func CompileShader(shader uint32) {
 }
 func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
+}
+func CompressedMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage1DEXT(gpCompressedMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage2DEXT(gpCompressedMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage3DEXT(gpCompressedMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage1DEXT(gpCompressedMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage2DEXT(gpCompressedMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage3DEXT(gpCompressedMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a one-dimensional texture image in a compressed format
@@ -5461,20 +8816,44 @@ func CompressedTexSubImage2D(target uint32, level int32, xoffset int32, yoffset 
 func CompressedTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTexSubImage3D(gpCompressedTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage1DEXT(gpCompressedTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage2DEXT(gpCompressedTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage3DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage3DEXT(gpCompressedTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a one-dimensional texture subimage in a compressed     format
 func CompressedTextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage1D(gpCompressedTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage1DEXT(gpCompressedTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a two-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage2D(gpCompressedTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage2DEXT(gpCompressedTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a three-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3D(gpCompressedTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
@@ -5486,10 +8865,28 @@ func CopyBufferSubData(readTarget uint32, writeTarget uint32, readOffset int, wr
 func CopyImageSubData(srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
 	C.glowCopyImageSubData(gpCopyImageSubData, (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
 }
+func CopyMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyMultiTexImage1DEXT(gpCopyMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyMultiTexImage2DEXT(gpCopyMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
+func CopyMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyMultiTexSubImage1DEXT(gpCopyMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage2DEXT(gpCopyMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage3DEXT(gpCopyMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func CopyPathNV(resultPath uint32, srcPath uint32) {
+	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
 }
 
 // copy pixels into a 1D texture image
@@ -5516,30 +8913,69 @@ func CopyTexSubImage2D(target uint32, level int32, xoffset int32, yoffset int32,
 func CopyTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTexSubImage3D(gpCopyTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyTextureImage1DEXT(gpCopyTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyTextureImage2DEXT(gpCopyTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
 
 // copy a one-dimensional texture subimage
 func CopyTextureSubImage1D(texture uint32, level int32, xoffset int32, x int32, y int32, width int32) {
 	C.glowCopyTextureSubImage1D(gpCopyTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyTextureSubImage1DEXT(gpCopyTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
 }
 
 // copy a two-dimensional texture subimage
 func CopyTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage2D(gpCopyTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage2DEXT(gpCopyTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy a three-dimensional texture subimage
 func CopyTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage3D(gpCopyTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage3DEXT(gpCopyTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverFillPathInstancedNV(gpCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverFillPathNV(path uint32, coverMode uint32) {
+	C.glowCoverFillPathNV(gpCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverStrokePathInstancedNV(gpCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverStrokePathNV(path uint32, coverMode uint32) {
+	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
+	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
 }
 
 // Creates a program object
@@ -5573,15 +9009,26 @@ func CreateShader(xtype uint32) uint32 {
 	ret := C.glowCreateShader(gpCreateShader, (C.GLenum)(xtype))
 	return (uint32)(ret)
 }
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
+	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
+	return (uint32)(ret)
+}
 
 // create a stand-alone program from an array of null-terminated source code strings
 func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
+	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
+	return (uint32)(ret)
+}
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -5644,6 +9091,9 @@ func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint
 func DeleteBuffers(n int32, buffers *uint32) {
 	C.glowDeleteBuffers(gpDeleteBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // delete framebuffer objects
 func DeleteFramebuffers(n int32, framebuffers *uint32) {
@@ -5651,6 +9101,15 @@ func DeleteFramebuffers(n int32, framebuffers *uint32) {
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+}
+func DeletePathsNV(path uint32, xrange int32) {
+	C.glowDeletePathsNV(gpDeletePathsNV, (C.GLuint)(path), (C.GLsizei)(xrange))
+}
+func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowDeletePerfMonitorsAMD(gpDeletePerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
+func DeletePerfQueryINTEL(queryHandle uint32) {
+	C.glowDeletePerfQueryINTEL(gpDeletePerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // Deletes a program object
@@ -5661,6 +9120,9 @@ func DeleteProgram(program uint32) {
 // delete program pipeline objects
 func DeleteProgramPipelines(n int32, pipelines *uint32) {
 	C.glowDeleteProgramPipelines(gpDeleteProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func DeleteProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowDeleteProgramPipelinesEXT(gpDeleteProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // delete named query objects
@@ -5682,9 +9144,12 @@ func DeleteSamplers(count int32, samplers *uint32) {
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -5725,6 +9190,8 @@ func DepthRangeArrayv(first uint32, count int32, v *float64) {
 func DepthRangeIndexed(index uint32, n float64, f float64) {
 	C.glowDepthRangeIndexed(gpDepthRangeIndexed, (C.GLuint)(index), (C.GLdouble)(n), (C.GLdouble)(f))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -5736,10 +9203,25 @@ func DetachShader(program uint32, shader uint32) {
 func Disable(cap uint32) {
 	C.glowDisable(gpDisable, (C.GLenum)(cap))
 }
+func DisableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowDisableClientStateIndexedEXT(gpDisableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableClientStateiEXT(array uint32, index uint32) {
+	C.glowDisableClientStateiEXT(gpDisableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableIndexedEXT(target uint32, index uint32) {
+	C.glowDisableIndexedEXT(gpDisableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func DisableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowDisableVertexArrayAttrib(gpDisableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowDisableVertexArrayAttribEXT(gpDisableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowDisableVertexArrayEXT(gpDisableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -5777,10 +9259,16 @@ func DrawArraysIndirect(mode uint32, indirect unsafe.Pointer) {
 func DrawArraysInstanced(mode uint32, first int32, count int32, instancecount int32) {
 	C.glowDrawArraysInstanced(gpDrawArraysInstanced, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount))
 }
+func DrawArraysInstancedARB(mode uint32, first int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedARB(gpDrawArraysInstancedARB, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a range of elements with offset applied to instanced attributes
 func DrawArraysInstancedBaseInstance(mode uint32, first int32, count int32, instancecount int32, baseinstance uint32) {
 	C.glowDrawArraysInstancedBaseInstance(gpDrawArraysInstancedBaseInstance, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount), (C.GLuint)(baseinstance))
+}
+func DrawArraysInstancedEXT(mode uint32, start int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedEXT(gpDrawArraysInstancedEXT, (C.GLenum)(mode), (C.GLint)(start), (C.GLsizei)(count), (C.GLsizei)(primcount))
 }
 
 // specify which color buffers are to be drawn into
@@ -5791,6 +9279,18 @@ func DrawBuffer(buf uint32) {
 // Specifies a list of color buffers to be drawn     into
 func DrawBuffers(n int32, bufs *uint32) {
 	C.glowDrawBuffers(gpDrawBuffers, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 
 // render primitives from array data
@@ -5812,6 +9312,9 @@ func DrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer) {
 func DrawElementsInstanced(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32) {
 	C.glowDrawElementsInstanced(gpDrawElementsInstanced, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount))
 }
+func DrawElementsInstancedARB(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedARB(gpDrawElementsInstancedARB, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a set of elements with offset applied to instanced attributes
 func DrawElementsInstancedBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, baseinstance uint32) {
@@ -5826,6 +9329,9 @@ func DrawElementsInstancedBaseVertex(mode uint32, count int32, xtype uint32, ind
 // render multiple instances of a set of primitives from array data with a per-element offset
 func DrawElementsInstancedBaseVertexBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, basevertex int32, baseinstance uint32) {
 	C.glowDrawElementsInstancedBaseVertexBaseInstance(gpDrawElementsInstancedBaseVertexBaseInstance, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount), (C.GLint)(basevertex), (C.GLuint)(baseinstance))
+}
+func DrawElementsInstancedEXT(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedEXT(gpDrawElementsInstancedEXT, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
 }
 
 // render primitives from array data
@@ -5857,15 +9363,36 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
 }
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
+}
+func EdgeFlagFormatNV(stride int32) {
+	C.glowEdgeFlagFormatNV(gpEdgeFlagFormatNV, (C.GLsizei)(stride))
+}
 
 // enable or disable server-side GL capabilities
 func Enable(cap uint32) {
 	C.glowEnable(gpEnable, (C.GLenum)(cap))
 }
+func EnableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowEnableClientStateIndexedEXT(gpEnableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableClientStateiEXT(array uint32, index uint32) {
+	C.glowEnableClientStateiEXT(gpEnableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableIndexedEXT(target uint32, index uint32) {
+	C.glowEnableIndexedEXT(gpEnableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func EnableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowEnableVertexArrayAttrib(gpEnableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowEnableVertexArrayAttribEXT(gpEnableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowEnableVertexArrayEXT(gpEnableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -5878,6 +9405,15 @@ func Enablei(target uint32, index uint32) {
 func EndConditionalRender() {
 	C.glowEndConditionalRender(gpEndConditionalRender)
 }
+func EndConditionalRenderNV() {
+	C.glowEndConditionalRenderNV(gpEndConditionalRenderNV)
+}
+func EndPerfMonitorAMD(monitor uint32) {
+	C.glowEndPerfMonitorAMD(gpEndPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func EndPerfQueryINTEL(queryHandle uint32) {
+	C.glowEndPerfQueryINTEL(gpEndPerfQueryINTEL, (C.GLuint)(queryHandle))
+}
 func EndQuery(target uint32) {
 	C.glowEndQuery(gpEndQuery, (C.GLenum)(target))
 }
@@ -5887,11 +9423,14 @@ func EndQueryIndexed(target uint32, index uint32) {
 func EndTransformFeedback() {
 	C.glowEndTransformFeedback(gpEndTransformFeedback)
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -5910,18 +9449,45 @@ func FlushMappedBufferRange(target uint32, offset int, length int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FogCoordFormatNV(xtype uint32, stride int32) {
+	C.glowFogCoordFormatNV(gpFogCoordFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
+func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferDrawBufferEXT(gpFramebufferDrawBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
+func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
+	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
 }
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
 	C.glowFramebufferParameteri(gpFramebufferParameteri, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
 }
+func FramebufferReadBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferReadBufferEXT(gpFramebufferReadBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
 
 // attach a renderbuffer as a logical buffer of a framebuffer object
 func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbuffer(gpFramebufferRenderbuffer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
@@ -5931,16 +9497,30 @@ func FramebufferTexture(target uint32, attachment uint32, texture uint32, level 
 func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1D(gpFramebufferTexture1D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
 func FramebufferTexture3D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
 	C.glowFramebufferTexture3D(gpFramebufferTexture3D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
 }
+func FramebufferTextureARB(target uint32, attachment uint32, texture uint32, level int32) {
+	C.glowFramebufferTextureARB(gpFramebufferTextureARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func FramebufferTextureFaceARB(target uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowFramebufferTextureFaceARB(gpFramebufferTextureFaceARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
+}
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func FramebufferTextureLayer(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayer(gpFramebufferTextureLayer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowFramebufferTextureLayerARB(gpFramebufferTextureLayerARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 
 // define front- and back-facing polygons
@@ -5957,10 +9537,20 @@ func GenBuffers(n int32, buffers *uint32) {
 func GenFramebuffers(n int32, framebuffers *uint32) {
 	C.glowGenFramebuffers(gpGenFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
 }
+func GenPathsNV(xrange int32) uint32 {
+	ret := C.glowGenPathsNV(gpGenPathsNV, (C.GLsizei)(xrange))
+	return (uint32)(ret)
+}
+func GenPerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowGenPerfMonitorsAMD(gpGenPerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
 
 // reserve program pipeline object names
 func GenProgramPipelines(n int32, pipelines *uint32) {
 	C.glowGenProgramPipelines(gpGenProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func GenProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowGenProgramPipelinesEXT(gpGenProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // generate query object names
@@ -5997,10 +9587,16 @@ func GenVertexArrays(n int32, arrays *uint32) {
 func GenerateMipmap(target uint32) {
 	C.glowGenerateMipmap(gpGenerateMipmap, (C.GLenum)(target))
 }
+func GenerateMultiTexMipmapEXT(texunit uint32, target uint32) {
+	C.glowGenerateMultiTexMipmapEXT(gpGenerateMultiTexMipmapEXT, (C.GLenum)(texunit), (C.GLenum)(target))
+}
 
 // generate mipmaps for a specified texture object
 func GenerateTextureMipmap(texture uint32) {
 	C.glowGenerateTextureMipmap(gpGenerateTextureMipmap, (C.GLuint)(texture))
+}
+func GenerateTextureMipmapEXT(texture uint32, target uint32) {
+	C.glowGenerateTextureMipmapEXT(gpGenerateTextureMipmapEXT, (C.GLuint)(texture), (C.GLenum)(target))
 }
 
 // retrieve information about the set of active atomic counter buffers for a program
@@ -6035,6 +9631,8 @@ func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6059,6 +9657,9 @@ func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
+func GetBooleanIndexedvEXT(target uint32, index uint32, data *bool) {
+	C.glowGetBooleanIndexedvEXT(gpGetBooleanIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
+}
 func GetBooleani_v(target uint32, index uint32, data *bool) {
 	C.glowGetBooleani_v(gpGetBooleani_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
 }
@@ -6075,6 +9676,9 @@ func GetBufferParameteri64v(target uint32, pname uint32, params *int64) {
 func GetBufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetBufferParameteriv(gpGetBufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetBufferParameterui64vNV(target uint32, pname uint32, params *uint64) {
+	C.glowGetBufferParameterui64vNV(gpGetBufferParameterui64vNV, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
@@ -6084,6 +9688,13 @@ func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
 // returns a subset of a buffer object's data store
 func GetBufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetBufferSubData(gpGetBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
+func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
 
 // return a compressed texture image
@@ -6095,10 +9706,16 @@ func GetCompressedTexImage(target uint32, level int32, img unsafe.Pointer) {
 func GetCompressedTextureImage(texture uint32, level int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureImage(gpGetCompressedTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLsizei)(bufSize), pixels)
 }
+func GetCompressedTextureImageEXT(texture uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedTextureImageEXT(gpGetCompressedTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(lod), img)
+}
 
 // retrieve a sub-region of a compressed texture image from a     compressed texture object
 func GetCompressedTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureSubImage(gpGetCompressedTextureSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(bufSize), pixels)
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -6114,8 +9731,14 @@ func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
+func GetDoubleIndexedvEXT(target uint32, index uint32, data *float64) {
+	C.glowGetDoubleIndexedvEXT(gpGetDoubleIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
 func GetDoublei_v(target uint32, index uint32, data *float64) {
 	C.glowGetDoublei_v(gpGetDoublei_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
+func GetDoublei_vEXT(pname uint32, index uint32, params *float64) {
+	C.glowGetDoublei_vEXT(gpGetDoublei_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
 }
 func GetDoublev(pname uint32, data *float64) {
 	C.glowGetDoublev(gpGetDoublev, (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(data)))
@@ -6126,8 +9749,17 @@ func GetError() uint32 {
 	ret := C.glowGetError(gpGetError)
 	return (uint32)(ret)
 }
+func GetFirstPerfQueryIdINTEL(queryId *uint32) {
+	C.glowGetFirstPerfQueryIdINTEL(gpGetFirstPerfQueryIdINTEL, (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetFloatIndexedvEXT(target uint32, index uint32, data *float32) {
+	C.glowGetFloatIndexedvEXT(gpGetFloatIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
 func GetFloati_v(target uint32, index uint32, data *float32) {
 	C.glowGetFloati_v(gpGetFloati_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
+func GetFloati_vEXT(pname uint32, index uint32, params *float32) {
+	C.glowGetFloati_vEXT(gpGetFloati_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetFloatv(pname uint32, data *float32) {
 	C.glowGetFloatv(gpGetFloatv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(data)))
@@ -6145,14 +9777,17 @@ func GetFragDataLocation(program uint32, name *uint8) int32 {
 	return (int32)(ret)
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetFramebufferParameterivEXT(gpGetFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // check if the rendering context has not been lost due to software or hardware issues
@@ -6172,23 +9807,77 @@ func GetImageHandleARB(texture uint32, level int32, layered bool, layer int32, f
 	ret := C.glowGetImageHandleARB(gpGetImageHandleARB, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
 	return (uint64)(ret)
 }
+func GetImageHandleNV(texture uint32, level int32, layered bool, layer int32, format uint32) uint64 {
+	ret := C.glowGetImageHandleNV(gpGetImageHandleNV, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
+	return (uint64)(ret)
+}
 func GetInteger64i_v(target uint32, index uint32, data *int64) {
 	C.glowGetInteger64i_v(gpGetInteger64i_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint64)(unsafe.Pointer(data)))
 }
 func GetInteger64v(pname uint32, data *int64) {
 	C.glowGetInteger64v(gpGetInteger64v, (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(data)))
 }
+func GetIntegerIndexedvEXT(target uint32, index uint32, data *int32) {
+	C.glowGetIntegerIndexedvEXT(gpGetIntegerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
 func GetIntegeri_v(target uint32, index uint32, data *int32) {
 	C.glowGetIntegeri_v(gpGetIntegeri_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
+func GetIntegerui64i_vNV(value uint32, index uint32, result *uint64) {
+	C.glowGetIntegerui64i_vNV(gpGetIntegerui64i_vNV, (C.GLenum)(value), (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(result)))
+}
+func GetIntegerui64vNV(value uint32, result *uint64) {
+	C.glowGetIntegerui64vNV(gpGetIntegerui64vNV, (C.GLenum)(value), (*C.GLuint64EXT)(unsafe.Pointer(result)))
 }
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexEnvfvEXT(gpGetMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexEnvivEXT(gpGetMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowGetMultiTexGendvEXT(gpGetMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexGenfvEXT(gpGetMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexGenivEXT(gpGetMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexImageEXT(texunit uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetMultiTexImageEXT(gpGetMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func GetMultiTexLevelParameterfvEXT(texunit uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetMultiTexLevelParameterfvEXT(gpGetMultiTexLevelParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexLevelParameterivEXT(texunit uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetMultiTexLevelParameterivEXT(gpGetMultiTexLevelParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterIivEXT(gpGetMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetMultiTexParameterIuivEXT(gpGetMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexParameterfvEXT(gpGetMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterivEXT(gpGetMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // retrieve the location of a sample
@@ -6205,30 +9894,69 @@ func GetNamedBufferParameteri64v(buffer uint32, pname uint32, params *int64) {
 func GetNamedBufferParameteriv(buffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedBufferParameteriv(gpGetNamedBufferParameteriv, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedBufferParameterivEXT(buffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedBufferParameterivEXT(gpGetNamedBufferParameterivEXT, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedBufferParameterui64vNV(buffer uint32, pname uint32, params *uint64) {
+	C.glowGetNamedBufferParameterui64vNV(gpGetNamedBufferParameterui64vNV, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetNamedBufferPointerv(buffer uint32, pname uint32, params *unsafe.Pointer) {
 	C.glowGetNamedBufferPointerv(gpGetNamedBufferPointerv, (C.GLuint)(buffer), (C.GLenum)(pname), params)
 }
+func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Pointer) {
+	C.glowGetNamedBufferPointervEXT(gpGetNamedBufferPointervEXT, (C.GLuint)(buffer), (C.GLenum)(pname), params)
+}
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 
 // retrieve information about attachments of a framebuffer object
 func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameteriv(gpGetNamedFramebufferAttachmentParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a framebuffer object
 func GetNamedFramebufferParameteriv(framebuffer uint32, pname uint32, param *int32) {
 	C.glowGetNamedFramebufferParameteriv(gpGetNamedFramebufferParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
 }
+func GetNamedFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferParameterivEXT(gpGetNamedFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowGetNamedProgramLocalParameterIivEXT(gpGetNamedProgramLocalParameterIivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIuivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowGetNamedProgramLocalParameterIuivEXT(gpGetNamedProgramLocalParameterIuivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterdvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowGetNamedProgramLocalParameterdvEXT(gpGetNamedProgramLocalParameterdvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterfvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowGetNamedProgramLocalParameterfvEXT(gpGetNamedProgramLocalParameterfvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetNamedProgramStringEXT(program uint32, target uint32, pname uint32, xstring unsafe.Pointer) {
+	C.glowGetNamedProgramStringEXT(gpGetNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), xstring)
+}
+func GetNamedProgramivEXT(program uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetNamedProgramivEXT(gpGetNamedProgramivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a renderbuffer object
 func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameteriv(gpGetNamedRenderbufferParameteriv, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedRenderbufferParameterivEXT(renderbuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedRenderbufferParameterivEXT(gpGetNamedRenderbufferParameterivEXT, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
@@ -6236,10 +9964,16 @@ func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int
 func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
+	C.glowGetNextPerfQueryIdINTEL(gpGetNextPerfQueryIdINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(nextQueryId)))
+}
 
 // retrieve the label of a named object identified within a namespace
 func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
+	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
@@ -6251,6 +9985,70 @@ func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *
 }
 func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetPathCommandsNV(path uint32, commands *uint8) {
+	C.glowGetPathCommandsNV(gpGetPathCommandsNV, (C.GLuint)(path), (*C.GLubyte)(unsafe.Pointer(commands)))
+}
+func GetPathCoordsNV(path uint32, coords *float32) {
+	C.glowGetPathCoordsNV(gpGetPathCoordsNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(coords)))
+}
+func GetPathDashArrayNV(path uint32, dashArray *float32) {
+	C.glowGetPathDashArrayNV(gpGetPathDashArrayNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func GetPathLengthNV(path uint32, startSegment int32, numSegments int32) float32 {
+	ret := C.glowGetPathLengthNV(gpGetPathLengthNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments))
+	return (float32)(ret)
+}
+func GetPathMetricRangeNV(metricQueryMask uint32, firstPathName uint32, numPaths int32, stride int32, metrics *float32) {
+	C.glowGetPathMetricRangeNV(gpGetPathMetricRangeNV, (C.GLbitfield)(metricQueryMask), (C.GLuint)(firstPathName), (C.GLsizei)(numPaths), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathMetricsNV(metricQueryMask uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, stride int32, metrics *float32) {
+	C.glowGetPathMetricsNV(gpGetPathMetricsNV, (C.GLbitfield)(metricQueryMask), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowGetPathParameterfvNV(gpGetPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func GetPathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowGetPathParameterivNV(gpGetPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func GetPathSpacingNV(pathListMode uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, advanceScale float32, kerningScale float32, transformType uint32, returnedSpacing *float32) {
+	C.glowGetPathSpacingNV(gpGetPathSpacingNV, (C.GLenum)(pathListMode), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLfloat)(advanceScale), (C.GLfloat)(kerningScale), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(returnedSpacing)))
+}
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
+}
+func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
+	C.glowGetPerfMonitorCounterDataAMD(gpGetPerfMonitorCounterDataAMD, (C.GLuint)(monitor), (C.GLenum)(pname), (C.GLsizei)(dataSize), (*C.GLuint)(unsafe.Pointer(data)), (*C.GLint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
+	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
+}
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
+	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
+}
+func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
+	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
+}
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
+	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
+}
+func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
+	C.glowGetPerfMonitorGroupsAMD(gpGetPerfMonitorGroupsAMD, (*C.GLint)(unsafe.Pointer(numGroups)), (C.GLsizei)(groupsSize), (*C.GLuint)(unsafe.Pointer(groups)))
+}
+func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
+	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
+	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
+}
+func GetPointerIndexedvEXT(target uint32, index uint32, data *unsafe.Pointer) {
+	C.glowGetPointerIndexedvEXT(gpGetPointerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), data)
+}
+func GetPointeri_vEXT(pname uint32, index uint32, params *unsafe.Pointer) {
+	C.glowGetPointeri_vEXT(gpGetPointeri_vEXT, (C.GLenum)(pname), (C.GLuint)(index), params)
 }
 
 // return the address of the specified pointer
@@ -6278,8 +10076,14 @@ func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32
 func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
+	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
+}
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
 	C.glowGetProgramPipelineiv(gpGetProgramPipelineiv, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
+	C.glowGetProgramPipelineivEXT(gpGetProgramPipelineivEXT, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // query the index of a named resource within a program
@@ -6304,6 +10108,9 @@ func GetProgramResourceLocationIndex(program uint32, programInterface uint32, na
 func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
+func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
+	C.glowGetProgramResourcefvNV(gpGetProgramResourcefvNV, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLfloat)(unsafe.Pointer(params)))
+}
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
 	C.glowGetProgramResourceiv(gpGetProgramResourceiv, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6314,6 +10121,18 @@ func GetProgramStageiv(program uint32, shadertype uint32, pname uint32, values *
 // Returns a parameter from a program object
 func GetProgramiv(program uint32, pname uint32, params *int32) {
 	C.glowGetProgramiv(gpGetProgramiv, (C.GLuint)(program), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
 }
 
 // return parameters of an indexed query object target
@@ -6329,6 +10148,8 @@ func GetQueryObjectiv(id uint32, pname uint32, params *int32) {
 func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64v(gpGetQueryObjectui64v, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -6338,7 +10159,7 @@ func GetQueryiv(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryiv(gpGetQueryiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6374,6 +10195,10 @@ func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8)
 func GetShaderiv(shader uint32, pname uint32, params *int32) {
 	C.glowGetShaderiv(gpGetShaderiv, (C.GLuint)(shader), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -6398,7 +10223,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 
@@ -6428,31 +10253,60 @@ func GetTextureHandleARB(texture uint32) uint64 {
 	ret := C.glowGetTextureHandleARB(gpGetTextureHandleARB, (C.GLuint)(texture))
 	return (uint64)(ret)
 }
+func GetTextureHandleNV(texture uint32) uint64 {
+	ret := C.glowGetTextureHandleNV(gpGetTextureHandleNV, (C.GLuint)(texture))
+	return (uint64)(ret)
+}
 
 // return a texture image
 func GetTextureImage(texture uint32, level int32, format uint32, xtype uint32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetTextureImage(gpGetTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), pixels)
 }
+func GetTextureImageEXT(texture uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetTextureImageEXT(gpGetTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 func GetTextureLevelParameterfv(texture uint32, level int32, pname uint32, params *float32) {
 	C.glowGetTextureLevelParameterfv(gpGetTextureLevelParameterfv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureLevelParameterfvEXT(texture uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetTextureLevelParameterfvEXT(gpGetTextureLevelParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureLevelParameteriv(texture uint32, level int32, pname uint32, params *int32) {
 	C.glowGetTextureLevelParameteriv(gpGetTextureLevelParameteriv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureLevelParameterivEXT(texture uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetTextureLevelParameterivEXT(gpGetTextureLevelParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameterIiv(gpGetTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetTextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterIivEXT(gpGetTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetTextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowGetTextureParameterIuiv(gpGetTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetTextureParameterIuivEXT(gpGetTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterfv(texture uint32, pname uint32, params *float32) {
 	C.glowGetTextureParameterfv(gpGetTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetTextureParameterfvEXT(gpGetTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureParameteriv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameteriv(gpGetTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterivEXT(gpGetTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureSamplerHandleARB(texture uint32, sampler uint32) uint64 {
 	ret := C.glowGetTextureSamplerHandleARB(gpGetTextureSamplerHandleARB, (C.GLuint)(texture), (C.GLuint)(sampler))
+	return (uint64)(ret)
+}
+func GetTextureSamplerHandleNV(texture uint32, sampler uint32) uint64 {
+	ret := C.glowGetTextureSamplerHandleNV(gpGetTextureSamplerHandleNV, (C.GLuint)(texture), (C.GLuint)(sampler))
 	return (uint64)(ret)
 }
 
@@ -6504,10 +10358,22 @@ func GetUniformdv(program uint32, location int32, params *float64) {
 func GetUniformfv(program uint32, location int32, params *float32) {
 	C.glowGetUniformfv(gpGetUniformfv, (C.GLuint)(program), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func GetUniformi64vNV(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 
 // Returns the value of a uniform variable
 func GetUniformiv(program uint32, location int32, params *int32) {
 	C.glowGetUniformiv(gpGetUniformiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func GetUniformui64vNV(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 func GetUniformuiv(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuiv(gpGetUniformuiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
@@ -6517,6 +10383,18 @@ func GetVertexArrayIndexed64iv(vaobj uint32, index uint32, pname uint32, param *
 }
 func GetVertexArrayIndexediv(vaobj uint32, index uint32, pname uint32, param *int32) {
 	C.glowGetVertexArrayIndexediv(gpGetVertexArrayIndexediv, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegeri_vEXT(vaobj uint32, index uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegeri_vEXT(gpGetVertexArrayIntegeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegervEXT(vaobj uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegervEXT(gpGetVertexArrayIntegervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayPointeri_vEXT(vaobj uint32, index uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointeri_vEXT(gpGetVertexArrayPointeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), param)
+}
+func GetVertexArrayPointervEXT(vaobj uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointervEXT(gpGetVertexArrayPointervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), param)
 }
 
 // retrieve parameters of a vertex array object
@@ -6538,8 +10416,14 @@ func GetVertexAttribIuiv(index uint32, pname uint32, params *uint32) {
 func GetVertexAttribLdv(index uint32, pname uint32, params *float64) {
 	C.glowGetVertexAttribLdv(gpGetVertexAttribLdv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
 }
+func GetVertexAttribLi64vNV(index uint32, pname uint32, params *int64) {
+	C.glowGetVertexAttribLi64vNV(gpGetVertexAttribLi64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 func GetVertexAttribLui64vARB(index uint32, pname uint32, params *uint64) {
 	C.glowGetVertexAttribLui64vARB(gpGetVertexAttribLui64vARB, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
+func GetVertexAttribLui64vNV(index uint32, pname uint32, params *uint64) {
+	C.glowGetVertexAttribLui64vNV(gpGetVertexAttribLui64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 
 // return the address of the specified generic vertex attribute pointer
@@ -6561,6 +10445,10 @@ func GetVertexAttribfv(index uint32, pname uint32, params *float32) {
 func GetVertexAttribiv(index uint32, pname uint32, params *int32) {
 	C.glowGetVertexAttribiv(gpGetVertexAttribiv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
+}
 func GetnCompressedTexImageARB(target uint32, lod int32, bufSize int32, img unsafe.Pointer) {
 	C.glowGetnCompressedTexImageARB(gpGetnCompressedTexImageARB, (C.GLenum)(target), (C.GLint)(lod), (C.GLsizei)(bufSize), img)
 }
@@ -6579,6 +10467,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6587,6 +10478,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -6601,6 +10495,15 @@ func GetnUniformuivKHR(program uint32, location int32, bufSize int32, params *ui
 // specify implementation-specific hints
 func Hint(target uint32, mode uint32) {
 	C.glowHint(gpHint, (C.GLenum)(target), (C.GLenum)(mode))
+}
+func IndexFormatNV(xtype uint32, stride int32) {
+	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func InsertEventMarkerEXT(length int32, marker *uint8) {
+	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
+func InterpolatePathsNV(resultPath uint32, pathA uint32, pathB uint32, weight float32) {
+	C.glowInterpolatePathsNV(gpInterpolatePathsNV, (C.GLuint)(resultPath), (C.GLuint)(pathA), (C.GLuint)(pathB), (C.GLfloat)(weight))
 }
 
 // invalidate the content of a buffer object's data store
@@ -6648,8 +10551,20 @@ func IsBuffer(buffer uint32) bool {
 	ret := C.glowIsBuffer(gpIsBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func IsBufferResidentNV(target uint32) bool {
+	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
+	return ret == TRUE
+}
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
+	return ret == TRUE
+}
+func IsEnabledIndexedEXT(target uint32, index uint32) bool {
+	ret := C.glowIsEnabledIndexedEXT(gpIsEnabledIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
 	return ret == TRUE
 }
 func IsEnabledi(target uint32, index uint32) bool {
@@ -6666,8 +10581,28 @@ func IsImageHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsImageHandleResidentARB(gpIsImageHandleResidentARB, (C.GLuint64)(handle))
 	return ret == TRUE
 }
+func IsImageHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsImageHandleResidentNV(gpIsImageHandleResidentNV, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsNamedBufferResidentNV(buffer uint32) bool {
+	ret := C.glowIsNamedBufferResidentNV(gpIsNamedBufferResidentNV, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+	return ret == TRUE
+}
+func IsPathNV(path uint32) bool {
+	ret := C.glowIsPathNV(gpIsPathNV, (C.GLuint)(path))
+	return ret == TRUE
+}
+func IsPointInFillPathNV(path uint32, mask uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInFillPathNV(gpIsPointInFillPathNV, (C.GLuint)(path), (C.GLuint)(mask), (C.GLfloat)(x), (C.GLfloat)(y))
+	return ret == TRUE
+}
+func IsPointInStrokePathNV(path uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInStrokePathNV(gpIsPointInStrokePathNV, (C.GLuint)(path), (C.GLfloat)(x), (C.GLfloat)(y))
 	return ret == TRUE
 }
 
@@ -6680,6 +10615,10 @@ func IsProgram(program uint32) bool {
 // determine if a name corresponds to a program pipeline object
 func IsProgramPipeline(pipeline uint32) bool {
 	ret := C.glowIsProgramPipeline(gpIsProgramPipeline, (C.GLuint)(pipeline))
+	return ret == TRUE
+}
+func IsProgramPipelineEXT(pipeline uint32) bool {
+	ret := C.glowIsProgramPipelineEXT(gpIsProgramPipelineEXT, (C.GLuint)(pipeline))
 	return ret == TRUE
 }
 
@@ -6706,9 +10645,13 @@ func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -6720,6 +10663,10 @@ func IsTexture(texture uint32) bool {
 }
 func IsTextureHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsTextureHandleResidentARB(gpIsTextureHandleResidentARB, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsTextureHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsTextureHandleResidentNV(gpIsTextureHandleResidentNV, (C.GLuint64)(handle))
 	return ret == TRUE
 }
 
@@ -6734,6 +10681,9 @@ func IsVertexArray(array uint32) bool {
 	ret := C.glowIsVertexArray(gpIsVertexArray, (C.GLuint)(array))
 	return ret == TRUE
 }
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
+	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
+}
 
 // specify the width of rasterized lines
 func LineWidth(width float32) {
@@ -6744,22 +10694,49 @@ func LineWidth(width float32) {
 func LinkProgram(program uint32) {
 	C.glowLinkProgram(gpLinkProgram, (C.GLuint)(program))
 }
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 
 // specify a logical pixel operation for rendering
 func LogicOp(opcode uint32) {
 	C.glowLogicOp(gpLogicOp, (C.GLenum)(opcode))
 }
+func MakeBufferNonResidentNV(target uint32) {
+	C.glowMakeBufferNonResidentNV(gpMakeBufferNonResidentNV, (C.GLenum)(target))
+}
+func MakeBufferResidentNV(target uint32, access uint32) {
+	C.glowMakeBufferResidentNV(gpMakeBufferResidentNV, (C.GLenum)(target), (C.GLenum)(access))
+}
 func MakeImageHandleNonResidentARB(handle uint64) {
 	C.glowMakeImageHandleNonResidentARB(gpMakeImageHandleNonResidentARB, (C.GLuint64)(handle))
+}
+func MakeImageHandleNonResidentNV(handle uint64) {
+	C.glowMakeImageHandleNonResidentNV(gpMakeImageHandleNonResidentNV, (C.GLuint64)(handle))
 }
 func MakeImageHandleResidentARB(handle uint64, access uint32) {
 	C.glowMakeImageHandleResidentARB(gpMakeImageHandleResidentARB, (C.GLuint64)(handle), (C.GLenum)(access))
 }
+func MakeImageHandleResidentNV(handle uint64, access uint32) {
+	C.glowMakeImageHandleResidentNV(gpMakeImageHandleResidentNV, (C.GLuint64)(handle), (C.GLenum)(access))
+}
+func MakeNamedBufferNonResidentNV(buffer uint32) {
+	C.glowMakeNamedBufferNonResidentNV(gpMakeNamedBufferNonResidentNV, (C.GLuint)(buffer))
+}
+func MakeNamedBufferResidentNV(buffer uint32, access uint32) {
+	C.glowMakeNamedBufferResidentNV(gpMakeNamedBufferResidentNV, (C.GLuint)(buffer), (C.GLenum)(access))
+}
 func MakeTextureHandleNonResidentARB(handle uint64) {
 	C.glowMakeTextureHandleNonResidentARB(gpMakeTextureHandleNonResidentARB, (C.GLuint64)(handle))
 }
+func MakeTextureHandleNonResidentNV(handle uint64) {
+	C.glowMakeTextureHandleNonResidentNV(gpMakeTextureHandleNonResidentNV, (C.GLuint64)(handle))
+}
 func MakeTextureHandleResidentARB(handle uint64) {
 	C.glowMakeTextureHandleResidentARB(gpMakeTextureHandleResidentARB, (C.GLuint64)(handle))
+}
+func MakeTextureHandleResidentNV(handle uint64) {
+	C.glowMakeTextureHandleResidentNV(gpMakeTextureHandleResidentNV, (C.GLuint64)(handle))
 }
 
 // map all of a buffer object's data store into the client's address space
@@ -6779,11 +10756,100 @@ func MapNamedBuffer(buffer uint32, access uint32) unsafe.Pointer {
 	ret := C.glowMapNamedBuffer(gpMapNamedBuffer, (C.GLuint)(buffer), (C.GLenum)(access))
 	return (unsafe.Pointer)(ret)
 }
+func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferEXT(gpMapNamedBufferEXT, (C.GLuint)(buffer), (C.GLenum)(access))
+	return (unsafe.Pointer)(ret)
+}
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
+}
+func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRangeEXT(gpMapNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
+	return (unsafe.Pointer)(ret)
+}
+func MatrixFrustumEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixFrustumEXT(gpMatrixFrustumEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixLoad3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x2fNV(gpMatrixLoad3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoad3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x3fNV(gpMatrixLoad3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadIdentityEXT(mode uint32) {
+	C.glowMatrixLoadIdentityEXT(gpMatrixLoadIdentityEXT, (C.GLenum)(mode))
+}
+func MatrixLoadTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoadTranspose3x3fNV(gpMatrixLoadTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixLoadTransposedEXT(gpMatrixLoadTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadTransposefEXT(gpMatrixLoadTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoaddEXT(mode uint32, m *float64) {
+	C.glowMatrixLoaddEXT(gpMatrixLoaddEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadfEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadfEXT(gpMatrixLoadfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x2fNV(gpMatrixMult3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x3fNV(gpMatrixMult3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMultTranspose3x3fNV(gpMatrixMultTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixMultTransposedEXT(gpMatrixMultTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixMultTransposefEXT(gpMatrixMultTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultdEXT(mode uint32, m *float64) {
+	C.glowMatrixMultdEXT(gpMatrixMultdEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultfEXT(mode uint32, m *float32) {
+	C.glowMatrixMultfEXT(gpMatrixMultfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixOrthoEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixOrthoEXT(gpMatrixOrthoEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixPopEXT(mode uint32) {
+	C.glowMatrixPopEXT(gpMatrixPopEXT, (C.GLenum)(mode))
+}
+func MatrixPushEXT(mode uint32) {
+	C.glowMatrixPushEXT(gpMatrixPushEXT, (C.GLenum)(mode))
+}
+func MatrixRotatedEXT(mode uint32, angle float64, x float64, y float64, z float64) {
+	C.glowMatrixRotatedEXT(gpMatrixRotatedEXT, (C.GLenum)(mode), (C.GLdouble)(angle), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixRotatefEXT(mode uint32, angle float32, x float32, y float32, z float32) {
+	C.glowMatrixRotatefEXT(gpMatrixRotatefEXT, (C.GLenum)(mode), (C.GLfloat)(angle), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixScaledEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixScaledEXT(gpMatrixScaledEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixScalefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixScalefEXT(gpMatrixScalefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixTranslatedEXT(gpMatrixTranslatedEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
 }
 
 // defines a barrier ordering memory transactions
@@ -6806,8 +10872,14 @@ func MultiDrawArrays(mode uint32, first *int32, count *int32, drawcount int32) {
 func MultiDrawArraysIndirect(mode uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawArraysIndirect(gpMultiDrawArraysIndirect, (C.GLenum)(mode), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessCountNV(gpMultiDrawArraysIndirectBindlessCountNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 
 // render multiple sets of primitives by specifying indices of array data elements
@@ -6824,29 +10896,122 @@ func MultiDrawElementsBaseVertex(mode uint32, count *int32, xtype uint32, indice
 func MultiDrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawElementsIndirect(gpMultiDrawElementsIndirect, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessCountNV(gpMultiDrawElementsIndirectBindlessCountNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+}
+func MultiTexBufferEXT(texunit uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowMultiTexBufferEXT(gpMultiTexBufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
+func MultiTexCoordPointerEXT(texunit uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
+	C.glowMultiTexCoordPointerEXT(gpMultiTexCoordPointerEXT, (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
+}
+func MultiTexEnvfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexEnvfEXT(gpMultiTexEnvfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexEnvfvEXT(gpMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexEnviEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexEnviEXT(gpMultiTexEnviEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexEnvivEXT(gpMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexGendEXT(texunit uint32, coord uint32, pname uint32, param float64) {
+	C.glowMultiTexGendEXT(gpMultiTexGendEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLdouble)(param))
+}
+func MultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowMultiTexGendvEXT(gpMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func MultiTexGenfEXT(texunit uint32, coord uint32, pname uint32, param float32) {
+	C.glowMultiTexGenfEXT(gpMultiTexGenfEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowMultiTexGenfvEXT(gpMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexGeniEXT(texunit uint32, coord uint32, pname uint32, param int32) {
+	C.glowMultiTexGeniEXT(gpMultiTexGeniEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowMultiTexGenivEXT(gpMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage1DEXT(gpMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage2DEXT(gpMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage3DEXT(gpMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterIivEXT(gpMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowMultiTexParameterIuivEXT(gpMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexParameterfEXT(gpMultiTexParameterfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexParameterfvEXT(gpMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexParameteriEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexParameteriEXT(gpMultiTexParameteriEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterivEXT(gpMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexRenderbufferEXT(texunit uint32, target uint32, renderbuffer uint32) {
+	C.glowMultiTexRenderbufferEXT(gpMultiTexRenderbufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(renderbuffer))
+}
+func MultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage1DEXT(gpMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage2DEXT(gpMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
+}
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
+}
+func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedCopyBufferSubDataEXT(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowNamedCopyBufferSubDataEXT(gpNamedCopyBufferSubDataEXT, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 
 // specify which color buffers are to be drawn into
@@ -6863,6 +11028,9 @@ func NamedFramebufferDrawBuffers(framebuffer uint32, n int32, bufs *uint32) {
 func NamedFramebufferParameteri(framebuffer uint32, pname uint32, param int32) {
 	C.glowNamedFramebufferParameteri(gpNamedFramebufferParameteri, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
 }
+func NamedFramebufferParameteriEXT(framebuffer uint32, pname uint32, param int32) {
+	C.glowNamedFramebufferParameteriEXT(gpNamedFramebufferParameteriEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // select a color buffer source for pixels
 func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
@@ -6873,26 +11041,101 @@ func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
 func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbuffer(gpNamedFramebufferRenderbuffer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
+	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture1DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture1DEXT(gpNamedFramebufferTexture1DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture2DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture2DEXT(gpNamedFramebufferTexture2DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture3DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
+	C.glowNamedFramebufferTexture3DEXT(gpNamedFramebufferTexture3DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
+}
+func NamedFramebufferTextureEXT(framebuffer uint32, attachment uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTextureEXT(gpNamedFramebufferTextureEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTextureFaceEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowNamedFramebufferTextureFaceEXT(gpNamedFramebufferTextureFaceEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
 }
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func NamedFramebufferTextureLayer(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowNamedFramebufferTextureLayer(gpNamedFramebufferTextureLayer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
 }
+func NamedFramebufferTextureLayerEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowNamedFramebufferTextureLayerEXT(gpNamedFramebufferTextureLayerEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func NamedProgramLocalParameter4dEXT(program uint32, target uint32, index uint32, x float64, y float64, z float64, w float64) {
+	C.glowNamedProgramLocalParameter4dEXT(gpNamedProgramLocalParameter4dEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
+func NamedProgramLocalParameter4dvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowNamedProgramLocalParameter4dvEXT(gpNamedProgramLocalParameter4dvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameter4fEXT(program uint32, target uint32, index uint32, x float32, y float32, z float32, w float32) {
+	C.glowNamedProgramLocalParameter4fEXT(gpNamedProgramLocalParameter4fEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z), (C.GLfloat)(w))
+}
+func NamedProgramLocalParameter4fvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowNamedProgramLocalParameter4fvEXT(gpNamedProgramLocalParameter4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4iEXT(program uint32, target uint32, index uint32, x int32, y int32, z int32, w int32) {
+	C.glowNamedProgramLocalParameterI4iEXT(gpNamedProgramLocalParameterI4iEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLint)(x), (C.GLint)(y), (C.GLint)(z), (C.GLint)(w))
+}
+func NamedProgramLocalParameterI4ivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowNamedProgramLocalParameterI4ivEXT(gpNamedProgramLocalParameterI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4uiEXT(program uint32, target uint32, index uint32, x uint32, y uint32, z uint32, w uint32) {
+	C.glowNamedProgramLocalParameterI4uiEXT(gpNamedProgramLocalParameterI4uiEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(x), (C.GLuint)(y), (C.GLuint)(z), (C.GLuint)(w))
+}
+func NamedProgramLocalParameterI4uivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowNamedProgramLocalParameterI4uivEXT(gpNamedProgramLocalParameterI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameters4fvEXT(program uint32, target uint32, index uint32, count int32, params *float32) {
+	C.glowNamedProgramLocalParameters4fvEXT(gpNamedProgramLocalParameters4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4ivEXT(program uint32, target uint32, index uint32, count int32, params *int32) {
+	C.glowNamedProgramLocalParametersI4ivEXT(gpNamedProgramLocalParametersI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4uivEXT(program uint32, target uint32, index uint32, count int32, params *uint32) {
+	C.glowNamedProgramLocalParametersI4uivEXT(gpNamedProgramLocalParametersI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramStringEXT(program uint32, target uint32, format uint32, len int32, xstring unsafe.Pointer) {
+	C.glowNamedProgramStringEXT(gpNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(format), (C.GLsizei)(len), xstring)
+}
 
 // establish data storage, format and dimensions of a     renderbuffer object's image
 func NamedRenderbufferStorage(renderbuffer uint32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorage(gpNamedRenderbufferStorage, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageEXT(renderbuffer uint32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageEXT(gpNamedRenderbufferStorageEXT, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func NamedRenderbufferStorageMultisample(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisample(gpNamedRenderbufferStorageMultisample, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func NamedRenderbufferStorageMultisampleCoverageEXT(renderbuffer uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleCoverageEXT(gpNamedRenderbufferStorageMultisampleCoverageEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageMultisampleEXT(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleEXT(gpNamedRenderbufferStorageMultisampleEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
+}
+func NormalFormatNV(xtype uint32, stride int32) {
+	C.glowNormalFormatNV(gpNormalFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // label a named object identified within a namespace
@@ -6913,8 +11156,67 @@ func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathCommandsNV(path uint32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCommandsNV(gpPathCommandsNV, (C.GLuint)(path), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoordsNV(path uint32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCoordsNV(gpPathCoordsNV, (C.GLuint)(path), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoverDepthFuncNV(xfunc uint32) {
+	C.glowPathCoverDepthFuncNV(gpPathCoverDepthFuncNV, (C.GLenum)(xfunc))
+}
+func PathDashArrayNV(path uint32, dashCount int32, dashArray *float32) {
+	C.glowPathDashArrayNV(gpPathDashArrayNV, (C.GLuint)(path), (C.GLsizei)(dashCount), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func PathGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathGlyphIndexArrayNV(gpPathGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathGlyphIndexRangeNV(fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, pathParameterTemplate uint32, emScale float32, baseAndCount *uint32) uint32 {
+	ret := C.glowPathGlyphIndexRangeNV(gpPathGlyphIndexRangeNV, (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale), (*C.GLuint)(unsafe.Pointer(baseAndCount)))
+	return (uint32)(ret)
+}
+func PathGlyphRangeNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyph uint32, numGlyphs int32, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphRangeNV(gpPathGlyphRangeNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyph), (C.GLsizei)(numGlyphs), (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathGlyphsNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, numGlyphs int32, xtype uint32, charcodes unsafe.Pointer, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphsNV(gpPathGlyphsNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLsizei)(numGlyphs), (C.GLenum)(xtype), charcodes, (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathMemoryGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontSize int, fontData unsafe.Pointer, faceIndex int32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathMemoryGlyphIndexArrayNV(gpPathMemoryGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), (C.GLsizeiptr)(fontSize), fontData, (C.GLsizei)(faceIndex), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathParameterfNV(path uint32, pname uint32, value float32) {
+	C.glowPathParameterfNV(gpPathParameterfNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func PathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowPathParameterfvNV(gpPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func PathParameteriNV(path uint32, pname uint32, value int32) {
+	C.glowPathParameteriNV(gpPathParameteriNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowPathParameterivNV(gpPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func PathStencilDepthOffsetNV(factor float32, units float32) {
+	C.glowPathStencilDepthOffsetNV(gpPathStencilDepthOffsetNV, (C.GLfloat)(factor), (C.GLfloat)(units))
+}
+func PathStencilFuncNV(xfunc uint32, ref int32, mask uint32) {
+	C.glowPathStencilFuncNV(gpPathStencilFuncNV, (C.GLenum)(xfunc), (C.GLint)(ref), (C.GLuint)(mask))
+}
+func PathStringNV(path uint32, format uint32, length int32, pathString unsafe.Pointer) {
+	C.glowPathStringNV(gpPathStringNV, (C.GLuint)(path), (C.GLenum)(format), (C.GLsizei)(length), pathString)
+}
+func PathSubCommandsNV(path uint32, commandStart int32, commandsToDelete int32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCommandsNV(gpPathSubCommandsNV, (C.GLuint)(path), (C.GLsizei)(commandStart), (C.GLsizei)(commandsToDelete), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathSubCoordsNV(path uint32, coordStart int32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCoordsNV(gpPathSubCoordsNV, (C.GLuint)(path), (C.GLsizei)(coordStart), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
 }
 
 // pause transform feedback operations
@@ -6924,8 +11226,14 @@ func PauseTransformFeedback() {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
+}
+func PointAlongPathNV(path uint32, startSegment int32, numSegments int32, distance float32, x *float32, y *float32, tangentX *float32, tangentY *float32) bool {
+	ret := C.glowPointAlongPathNV(gpPointAlongPathNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments), (C.GLfloat)(distance), (*C.GLfloat)(unsafe.Pointer(x)), (*C.GLfloat)(unsafe.Pointer(y)), (*C.GLfloat)(unsafe.Pointer(tangentX)), (*C.GLfloat)(unsafe.Pointer(tangentY)))
+	return ret == TRUE
 }
 func PointParameterf(pname uint32, param float32) {
 	C.glowPointParameterf(gpPointParameterf, (C.GLenum)(pname), (C.GLfloat)(param))
@@ -6954,6 +11262,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 
 // pop the active debug group
 func PopDebugGroup() {
@@ -6961,6 +11275,12 @@ func PopDebugGroup() {
 }
 func PopDebugGroupKHR() {
 	C.glowPopDebugGroupKHR(gpPopDebugGroupKHR)
+}
+func PopGroupMarkerEXT() {
+	C.glowPopGroupMarkerEXT(gpPopGroupMarkerEXT)
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -6972,235 +11292,507 @@ func PrimitiveRestartIndex(index uint32) {
 func ProgramBinary(program uint32, binaryFormat uint32, binary unsafe.Pointer, length int32) {
 	C.glowProgramBinary(gpProgramBinary, (C.GLuint)(program), (C.GLenum)(binaryFormat), binary, (C.GLsizei)(length))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriARB(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriARB(gpProgramParameteriARB, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriEXT(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriEXT(gpProgramParameteriEXT, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramPathFragmentInputGenNV(program uint32, location int32, genMode uint32, components int32, coeffs *float32) {
+	C.glowProgramPathFragmentInputGenNV(gpProgramPathFragmentInputGenNV, (C.GLuint)(program), (C.GLint)(location), (C.GLenum)(genMode), (C.GLint)(components), (*C.GLfloat)(unsafe.Pointer(coeffs)))
 }
 func ProgramUniform1d(program uint32, location int32, v0 float64) {
 	C.glowProgramUniform1d(gpProgramUniform1d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0))
 }
+func ProgramUniform1dEXT(program uint32, location int32, x float64) {
+	C.glowProgramUniform1dEXT(gpProgramUniform1dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x))
+}
 func ProgramUniform1dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform1dv(gpProgramUniform1dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform1dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform1dvEXT(gpProgramUniform1dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1f(program uint32, location int32, v0 float32) {
 	C.glowProgramUniform1f(gpProgramUniform1f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
 }
+func ProgramUniform1fEXT(program uint32, location int32, v0 float32) {
+	C.glowProgramUniform1fEXT(gpProgramUniform1fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform1fv(gpProgramUniform1fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform1fvEXT(gpProgramUniform1fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
+func ProgramUniform1i64NV(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1iEXT(program uint32, location int32, v0 int32) {
+	C.glowProgramUniform1iEXT(gpProgramUniform1iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform1iv(gpProgramUniform1iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform1ivEXT(gpProgramUniform1ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
+func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1uiEXT(program uint32, location int32, v0 uint32) {
+	C.glowProgramUniform1uiEXT(gpProgramUniform1uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform1uiv(gpProgramUniform1uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform1uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform1uivEXT(gpProgramUniform1uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform2d(program uint32, location int32, v0 float64, v1 float64) {
 	C.glowProgramUniform2d(gpProgramUniform2d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1))
 }
+func ProgramUniform2dEXT(program uint32, location int32, x float64, y float64) {
+	C.glowProgramUniform2dEXT(gpProgramUniform2dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y))
+}
 func ProgramUniform2dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform2dv(gpProgramUniform2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform2dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform2dvEXT(gpProgramUniform2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2f(program uint32, location int32, v0 float32, v1 float32) {
 	C.glowProgramUniform2f(gpProgramUniform2f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
 }
+func ProgramUniform2fEXT(program uint32, location int32, v0 float32, v1 float32) {
+	C.glowProgramUniform2fEXT(gpProgramUniform2fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform2fv(gpProgramUniform2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform2fvEXT(gpProgramUniform2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2iEXT(program uint32, location int32, v0 int32, v1 int32) {
+	C.glowProgramUniform2iEXT(gpProgramUniform2iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform2iv(gpProgramUniform2iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform2ivEXT(gpProgramUniform2ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2uiEXT(program uint32, location int32, v0 uint32, v1 uint32) {
+	C.glowProgramUniform2uiEXT(gpProgramUniform2uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform2uiv(gpProgramUniform2uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform2uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform2uivEXT(gpProgramUniform2uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform3d(program uint32, location int32, v0 float64, v1 float64, v2 float64) {
 	C.glowProgramUniform3d(gpProgramUniform3d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2))
 }
+func ProgramUniform3dEXT(program uint32, location int32, x float64, y float64, z float64) {
+	C.glowProgramUniform3dEXT(gpProgramUniform3dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
 func ProgramUniform3dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform3dv(gpProgramUniform3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform3dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform3dvEXT(gpProgramUniform3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3f(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
 	C.glowProgramUniform3f(gpProgramUniform3f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
 }
+func ProgramUniform3fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
+	C.glowProgramUniform3fEXT(gpProgramUniform3fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform3fv(gpProgramUniform3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform3fvEXT(gpProgramUniform3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
+	C.glowProgramUniform3iEXT(gpProgramUniform3iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform3iv(gpProgramUniform3iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform3ivEXT(gpProgramUniform3ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
+	C.glowProgramUniform3uiEXT(gpProgramUniform3uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform3uiv(gpProgramUniform3uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform3uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform3uivEXT(gpProgramUniform3uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform4d(program uint32, location int32, v0 float64, v1 float64, v2 float64, v3 float64) {
 	C.glowProgramUniform4d(gpProgramUniform4d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2), (C.GLdouble)(v3))
 }
+func ProgramUniform4dEXT(program uint32, location int32, x float64, y float64, z float64, w float64) {
+	C.glowProgramUniform4dEXT(gpProgramUniform4dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
 func ProgramUniform4dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform4dv(gpProgramUniform4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform4dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform4dvEXT(gpProgramUniform4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4f(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
 	C.glowProgramUniform4f(gpProgramUniform4f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
 }
+func ProgramUniform4fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
+	C.glowProgramUniform4fEXT(gpProgramUniform4fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform4fv(gpProgramUniform4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform4fvEXT(gpProgramUniform4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
+	C.glowProgramUniform4iEXT(gpProgramUniform4iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform4iv(gpProgramUniform4iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform4ivEXT(gpProgramUniform4ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
+	C.glowProgramUniform4uiEXT(gpProgramUniform4uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform4uiv(gpProgramUniform4uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform4uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform4uivEXT(gpProgramUniform4uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniformHandleui64ARB(program uint32, location int32, value uint64) {
 	C.glowProgramUniformHandleui64ARB(gpProgramUniformHandleui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
+}
+func ProgramUniformHandleui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformHandleui64NV(gpProgramUniformHandleui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
 }
 func ProgramUniformHandleui64vARB(program uint32, location int32, count int32, values *uint64) {
 	C.glowProgramUniformHandleui64vARB(gpProgramUniformHandleui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
 }
+func ProgramUniformHandleui64vNV(program uint32, location int32, count int32, values *uint64) {
+	C.glowProgramUniformHandleui64vNV(gpProgramUniformHandleui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
+}
 func ProgramUniformMatrix2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2dv(gpProgramUniformMatrix2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2dvEXT(gpProgramUniformMatrix2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2fv(gpProgramUniformMatrix2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2fvEXT(gpProgramUniformMatrix2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x3dv(gpProgramUniformMatrix2x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x3dvEXT(gpProgramUniformMatrix2x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x3fv(gpProgramUniformMatrix2x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x3fvEXT(gpProgramUniformMatrix2x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x4dv(gpProgramUniformMatrix2x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x4dvEXT(gpProgramUniformMatrix2x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x4fv(gpProgramUniformMatrix2x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x4fvEXT(gpProgramUniformMatrix2x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3dv(gpProgramUniformMatrix3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3dvEXT(gpProgramUniformMatrix3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3fv(gpProgramUniformMatrix3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3fvEXT(gpProgramUniformMatrix3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x2dv(gpProgramUniformMatrix3x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x2dvEXT(gpProgramUniformMatrix3x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x2fv(gpProgramUniformMatrix3x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x2fvEXT(gpProgramUniformMatrix3x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x4dv(gpProgramUniformMatrix3x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x4dvEXT(gpProgramUniformMatrix3x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x4fv(gpProgramUniformMatrix3x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x4fvEXT(gpProgramUniformMatrix3x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4dv(gpProgramUniformMatrix4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4dvEXT(gpProgramUniformMatrix4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4fv(gpProgramUniformMatrix4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4fvEXT(gpProgramUniformMatrix4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x2dv(gpProgramUniformMatrix4x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x2dvEXT(gpProgramUniformMatrix4x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x2fv(gpProgramUniformMatrix4x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x2fvEXT(gpProgramUniformMatrix4x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x3dv(gpProgramUniformMatrix4x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x3dvEXT(gpProgramUniformMatrix4x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x3fv(gpProgramUniformMatrix4x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x3fvEXT(gpProgramUniformMatrix4x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniformui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformui64NV(gpProgramUniformui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func ProgramUniformui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniformui64vNV(gpProgramUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // specifiy the vertex to be used as the source of data for flat shaded varyings
 func ProvokingVertex(mode uint32) {
 	C.glowProvokingVertex(gpProvokingVertex, (C.GLenum)(mode))
+}
+func PushClientAttribDefaultEXT(mask uint32) {
+	C.glowPushClientAttribDefaultEXT(gpPushClientAttribDefaultEXT, (C.GLbitfield)(mask))
 }
 
 // push a named debug group into the command stream
@@ -7210,10 +11802,16 @@ func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
+func PushGroupMarkerEXT(length int32, marker *uint8) {
+	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
 
 // record the GL time into a query object after all previous commands have reached the GL server but have not yet necessarily executed.
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
+}
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
 
 // select a color buffer source for pixels
@@ -7250,6 +11848,12 @@ func RenderbufferStorage(target uint32, internalformat uint32, width int32, heig
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func RenderbufferStorageMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowRenderbufferStorageMultisample(gpRenderbufferStorageMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func RenderbufferStorageMultisampleCoverageNV(target uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowRenderbufferStorageMultisampleCoverageNV(gpRenderbufferStorageMultisampleCoverageNV, (C.GLenum)(target), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
 }
 
 // resume transform feedback operations
@@ -7300,6 +11904,12 @@ func ScissorIndexed(index uint32, left int32, bottom int32, width int32, height 
 func ScissorIndexedv(index uint32, v *int32) {
 	C.glowScissorIndexedv(gpScissorIndexedv, (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(v)))
 }
+func SecondaryColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowSecondaryColorFormatNV(gpSecondaryColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
+	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
+}
 
 // load pre-compiled shader binaries
 func ShaderBinary(count int32, shaders *uint32, binaryformat uint32, binary unsafe.Pointer, length int32) {
@@ -7314,6 +11924,24 @@ func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 // change an active shader storage block binding
 func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storageBlockBinding uint32) {
 	C.glowShaderStorageBlockBinding(gpShaderStorageBlockBinding, (C.GLuint)(program), (C.GLuint)(storageBlockIndex), (C.GLuint)(storageBlockBinding))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
+}
+func StencilFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilFillPathInstancedNV(gpStencilFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilFillPathNV(path uint32, fillMode uint32, mask uint32) {
+	C.glowStencilFillPathNV(gpStencilFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask))
 }
 
 // set front and back function and reference value for stencil testing
@@ -7345,15 +11973,42 @@ func StencilOp(fail uint32, zfail uint32, zpass uint32) {
 func StencilOpSeparate(face uint32, sfail uint32, dpfail uint32, dppass uint32) {
 	C.glowStencilOpSeparate(gpStencilOpSeparate, (C.GLenum)(face), (C.GLenum)(sfail), (C.GLenum)(dpfail), (C.GLenum)(dppass))
 }
+func StencilStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilStrokePathInstancedNV(gpStencilStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilStrokePathNV(path uint32, reference int32, mask uint32) {
+	C.glowStencilStrokePathNV(gpStencilStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask))
+}
+func StencilThenCoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverFillPathInstancedNV(gpStencilThenCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverFillPathNV(path uint32, fillMode uint32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverFillPathNV(gpStencilThenCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func StencilThenCoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverStrokePathInstancedNV(gpStencilThenCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverStrokePathNV(path uint32, reference int32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverStrokePathNV(gpStencilThenCoverStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TexBuffer(target uint32, internalformat uint32, buffer uint32) {
 	C.glowTexBuffer(gpTexBuffer, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TexBufferARB(target uint32, internalformat uint32, buffer uint32) {
+	C.glowTexBufferARB(gpTexBufferARB, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
 func TexBufferRange(target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTexBufferRange(gpTexBufferRange, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TexCoordFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowTexCoordFormatNV(gpTexCoordFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // specify a one-dimensional texture image
@@ -7380,8 +12035,8 @@ func TexImage3D(target uint32, level int32, internalformat int32, width int32, h
 func TexImage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexImage3DMultisample(gpTexImage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -7446,73 +12101,139 @@ func TexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zof
 func TextureBarrier() {
 	C.glowTextureBarrier(gpTextureBarrier)
 }
+func TextureBarrierNV() {
+	C.glowTextureBarrierNV(gpTextureBarrierNV)
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TextureBuffer(texture uint32, internalformat uint32, buffer uint32) {
 	C.glowTextureBuffer(gpTextureBuffer, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowTextureBufferEXT(gpTextureBufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureImage1DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage1DEXT(gpTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage2DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage2DEXT(gpTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage3DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage3DEXT(gpTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func TextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterIivEXT(gpTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func TextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowTextureParameterIuiv(gpTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func TextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowTextureParameterIuivEXT(gpTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
 func TextureParameterf(texture uint32, pname uint32, param float32) {
 	C.glowTextureParameterf(gpTextureParameterf, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLfloat)(param))
 }
+func TextureParameterfEXT(texture uint32, target uint32, pname uint32, param float32) {
+	C.glowTextureParameterfEXT(gpTextureParameterfEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
 func TextureParameterfv(texture uint32, pname uint32, param *float32) {
 	C.glowTextureParameterfv(gpTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(param)))
+}
+func TextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowTextureParameterfvEXT(gpTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func TextureParameteri(texture uint32, pname uint32, param int32) {
 	C.glowTextureParameteri(gpTextureParameteri, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLint)(param))
 }
+func TextureParameteriEXT(texture uint32, target uint32, pname uint32, param int32) {
+	C.glowTextureParameteriEXT(gpTextureParameteriEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
 func TextureParameteriv(texture uint32, pname uint32, param *int32) {
 	C.glowTextureParameteriv(gpTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func TextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterivEXT(gpTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func TextureRenderbufferEXT(texture uint32, target uint32, renderbuffer uint32) {
+	C.glowTextureRenderbufferEXT(gpTextureRenderbufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLuint)(renderbuffer))
 }
 
 // simultaneously specify storage for all levels of a one-dimensional texture
 func TextureStorage1D(texture uint32, levels int32, internalformat uint32, width int32) {
 	C.glowTextureStorage1D(gpTextureStorage1D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
 }
+func TextureStorage1DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32) {
+	C.glowTextureStorage1DEXT(gpTextureStorage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
+}
 
 // simultaneously specify storage for all levels of a two-dimensional or one-dimensional array texture
 func TextureStorage2D(texture uint32, levels int32, internalformat uint32, width int32, height int32) {
 	C.glowTextureStorage2D(gpTextureStorage2D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func TextureStorage2DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32) {
+	C.glowTextureStorage2DEXT(gpTextureStorage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // specify storage for a two-dimensional multisample texture
 func TextureStorage2DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
 	C.glowTextureStorage2DMultisample(gpTextureStorage2DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage2DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
+	C.glowTextureStorage2DMultisampleEXT(gpTextureStorage2DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // simultaneously specify storage for all levels of a three-dimensional, two-dimensional array or cube-map array texture
 func TextureStorage3D(texture uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
 	C.glowTextureStorage3D(gpTextureStorage3D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func TextureStorage3DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
+	C.glowTextureStorage3DEXT(gpTextureStorage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
 }
 
 // specify storage for a two-dimensional multisample array texture
 func TextureStorage3DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisample(gpTextureStorage3DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
+	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // specify a one-dimensional texture subimage
 func TextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage1D(gpTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage1DEXT(gpTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // specify a two-dimensional texture subimage
 func TextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage2D(gpTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func TextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage2DEXT(gpTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 
 // specify a three-dimensional texture subimage
 func TextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage3D(gpTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage3DEXT(gpTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // initialize a texture as a data alias of another texture's data store
@@ -7526,13 +12247,16 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 
 // specify values to record in transform feedback buffers
 func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
+}
+func TransformPathNV(resultPath uint32, srcPath uint32, transformType uint32, transformValues *float32) {
+	C.glowTransformPathNV(gpTransformPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
 }
 func Uniform1d(location int32, x float64) {
 	C.glowUniform1d(gpUniform1d, (C.GLint)(location), (C.GLdouble)(x))
@@ -7555,6 +12279,18 @@ func Uniform1fv(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
+func Uniform1i64NV(location int32, x int64) {
+	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform1i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform1iv(location int32, count int32, value *int32) {
@@ -7564,6 +12300,18 @@ func Uniform1iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
+}
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
+func Uniform1ui64NV(location int32, x uint64) {
+	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform1ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7591,6 +12339,18 @@ func Uniform2fv(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func Uniform2i64NV(location int32, x int64, y int64) {
+	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform2i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform2iv(location int32, count int32, value *int32) {
@@ -7600,6 +12360,18 @@ func Uniform2iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func Uniform2ui64NV(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform2ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7627,6 +12399,18 @@ func Uniform3fv(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func Uniform3i64NV(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform3i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform3iv(location int32, count int32, value *int32) {
@@ -7636,6 +12420,18 @@ func Uniform3iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform3ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7663,6 +12459,18 @@ func Uniform4fv(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform4i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform4iv(location int32, count int32, value *int32) {
@@ -7672,6 +12480,18 @@ func Uniform4iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform4ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7686,8 +12506,14 @@ func UniformBlockBinding(program uint32, uniformBlockIndex uint32, uniformBlockB
 func UniformHandleui64ARB(location int32, value uint64) {
 	C.glowUniformHandleui64ARB(gpUniformHandleui64ARB, (C.GLint)(location), (C.GLuint64)(value))
 }
+func UniformHandleui64NV(location int32, value uint64) {
+	C.glowUniformHandleui64NV(gpUniformHandleui64NV, (C.GLint)(location), (C.GLuint64)(value))
+}
 func UniformHandleui64vARB(location int32, count int32, value *uint64) {
 	C.glowUniformHandleui64vARB(gpUniformHandleui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func UniformHandleui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformHandleui64vNV(gpUniformHandleui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func UniformMatrix2dv(location int32, count int32, transpose bool, value *float64) {
 	C.glowUniformMatrix2dv(gpUniformMatrix2dv, (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
@@ -7764,6 +12590,12 @@ func UniformMatrix4x3fv(location int32, count int32, transpose bool, value *floa
 func UniformSubroutinesuiv(shadertype uint32, count int32, indices *uint32) {
 	C.glowUniformSubroutinesuiv(gpUniformSubroutinesuiv, (C.GLenum)(shadertype), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(indices)))
 }
+func Uniformui64NV(location int32, value uint64) {
+	C.glowUniformui64NV(gpUniformui64NV, (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func Uniformui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformui64vNV(gpUniformui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // release the mapping of a buffer object's data store into the client's address space
 func UnmapBuffer(target uint32) bool {
@@ -7776,6 +12608,10 @@ func UnmapNamedBuffer(buffer uint32) bool {
 	ret := C.glowUnmapNamedBuffer(gpUnmapNamedBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func UnmapNamedBufferEXT(buffer uint32) bool {
+	ret := C.glowUnmapNamedBufferEXT(gpUnmapNamedBufferEXT, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 
 // Installs a program object as part of current rendering state
 func UseProgram(program uint32) {
@@ -7786,6 +12622,12 @@ func UseProgram(program uint32) {
 func UseProgramStages(pipeline uint32, stages uint32, program uint32) {
 	C.glowUseProgramStages(gpUseProgramStages, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
 }
+func UseProgramStagesEXT(pipeline uint32, stages uint32, program uint32) {
+	C.glowUseProgramStagesEXT(gpUseProgramStagesEXT, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
+}
+func UseShaderProgramEXT(xtype uint32, program uint32) {
+	C.glowUseShaderProgramEXT(gpUseShaderProgramEXT, (C.GLenum)(xtype), (C.GLuint)(program))
+}
 
 // Validates a program object
 func ValidateProgram(program uint32) {
@@ -7795,6 +12637,9 @@ func ValidateProgram(program uint32) {
 // validate a program pipeline object against current GL state
 func ValidateProgramPipeline(pipeline uint32) {
 	C.glowValidateProgramPipeline(gpValidateProgramPipeline, (C.GLuint)(pipeline))
+}
+func ValidateProgramPipelineEXT(pipeline uint32) {
+	C.glowValidateProgramPipelineEXT(gpValidateProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 func VertexArrayAttribBinding(vaobj uint32, attribindex uint32, bindingindex uint32) {
 	C.glowVertexArrayAttribBinding(gpVertexArrayAttribBinding, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
@@ -7810,15 +12655,69 @@ func VertexArrayAttribIFormat(vaobj uint32, attribindex uint32, size int32, xtyp
 func VertexArrayAttribLFormat(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexArrayAttribLFormat(gpVertexArrayAttribLFormat, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexArrayBindVertexBufferEXT(vaobj uint32, bindingindex uint32, buffer uint32, offset int, stride int32) {
+	C.glowVertexArrayBindVertexBufferEXT(gpVertexArrayBindVertexBufferEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(stride))
+}
 
 // modify the rate at which generic vertex attributes     advance
 func VertexArrayBindingDivisor(vaobj uint32, bindingindex uint32, divisor uint32) {
 	C.glowVertexArrayBindingDivisor(gpVertexArrayBindingDivisor, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexArrayColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayColorOffsetEXT(gpVertexArrayColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayEdgeFlagOffsetEXT(vaobj uint32, buffer uint32, stride int32, offset int) {
+	C.glowVertexArrayEdgeFlagOffsetEXT(gpVertexArrayEdgeFlagOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
 
 // configures element array buffer binding of a vertex array object
 func VertexArrayElementBuffer(vaobj uint32, buffer uint32) {
 	C.glowVertexArrayElementBuffer(gpVertexArrayElementBuffer, (C.GLuint)(vaobj), (C.GLuint)(buffer))
+}
+func VertexArrayFogCoordOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayFogCoordOffsetEXT(gpVertexArrayFogCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayIndexOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayIndexOffsetEXT(gpVertexArrayIndexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayMultiTexCoordOffsetEXT(vaobj uint32, buffer uint32, texunit uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayMultiTexCoordOffsetEXT(gpVertexArrayMultiTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayNormalOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayNormalOffsetEXT(gpVertexArrayNormalOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArraySecondaryColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArraySecondaryColorOffsetEXT(gpVertexArraySecondaryColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayTexCoordOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayTexCoordOffsetEXT(gpVertexArrayTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribBindingEXT(vaobj uint32, attribindex uint32, bindingindex uint32) {
+	C.glowVertexArrayVertexAttribBindingEXT(gpVertexArrayVertexAttribBindingEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
+}
+func VertexArrayVertexAttribDivisorEXT(vaobj uint32, index uint32, divisor uint32) {
+	C.glowVertexArrayVertexAttribDivisorEXT(gpVertexArrayVertexAttribDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLuint)(divisor))
+}
+func VertexArrayVertexAttribFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribFormatEXT(gpVertexArrayVertexAttribFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribIFormatEXT(gpVertexArrayVertexAttribIFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribIOffsetEXT(gpVertexArrayVertexAttribIOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribLFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribLFormatEXT(gpVertexArrayVertexAttribLFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribLOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribLOffsetEXT(gpVertexArrayVertexAttribLOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, normalized bool, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribOffsetEXT(gpVertexArrayVertexAttribOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexBindingDivisorEXT(vaobj uint32, bindingindex uint32, divisor uint32) {
+	C.glowVertexArrayVertexBindingDivisorEXT(gpVertexArrayVertexBindingDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
 
 // bind a buffer to a vertex buffer bind point
@@ -7829,6 +12728,9 @@ func VertexArrayVertexBuffer(vaobj uint32, bindingindex uint32, buffer uint32, o
 // attach multiple buffer objects to a vertex array object
 func VertexArrayVertexBuffers(vaobj uint32, first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowVertexArrayVertexBuffers(gpVertexArrayVertexBuffers, (C.GLuint)(vaobj), (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
+}
+func VertexArrayVertexOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexOffsetEXT(gpVertexArrayVertexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
 }
 func VertexAttrib1d(index uint32, x float64) {
 	C.glowVertexAttrib1d(gpVertexAttrib1d, (C.GLuint)(index), (C.GLdouble)(x))
@@ -7943,10 +12845,16 @@ func VertexAttrib4usv(index uint32, v *uint16) {
 func VertexAttribBinding(attribindex uint32, bindingindex uint32) {
 	C.glowVertexAttribBinding(gpVertexAttribBinding, (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
 }
+func VertexAttribDivisorARB(index uint32, divisor uint32) {
+	C.glowVertexAttribDivisorARB(gpVertexAttribDivisorARB, (C.GLuint)(index), (C.GLuint)(divisor))
+}
 
 // specify the organization of vertex arrays
 func VertexAttribFormat(attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
 	C.glowVertexAttribFormat(gpVertexAttribFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexAttribFormatNV(index uint32, size int32, xtype uint32, normalized bool, stride int32) {
+	C.glowVertexAttribFormatNV(gpVertexAttribFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride))
 }
 func VertexAttribI1i(index uint32, x int32) {
 	C.glowVertexAttribI1i(gpVertexAttribI1i, (C.GLuint)(index), (C.GLint)(x))
@@ -8011,6 +12919,9 @@ func VertexAttribI4usv(index uint32, v *uint16) {
 func VertexAttribIFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribIFormat(gpVertexAttribIFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexAttribIFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribIFormatNV(gpVertexAttribIFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func VertexAttribIPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribIPointer(gpVertexAttribIPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
 }
@@ -8020,11 +12931,23 @@ func VertexAttribL1d(index uint32, x float64) {
 func VertexAttribL1dv(index uint32, v *float64) {
 	C.glowVertexAttribL1dv(gpVertexAttribL1dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL1i64NV(index uint32, x int64) {
+	C.glowVertexAttribL1i64NV(gpVertexAttribL1i64NV, (C.GLuint)(index), (C.GLint64EXT)(x))
+}
+func VertexAttribL1i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL1i64vNV(gpVertexAttribL1i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL1ui64ARB(index uint32, x uint64) {
 	C.glowVertexAttribL1ui64ARB(gpVertexAttribL1ui64ARB, (C.GLuint)(index), (C.GLuint64EXT)(x))
 }
+func VertexAttribL1ui64NV(index uint32, x uint64) {
+	C.glowVertexAttribL1ui64NV(gpVertexAttribL1ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x))
+}
 func VertexAttribL1ui64vARB(index uint32, v *uint64) {
 	C.glowVertexAttribL1ui64vARB(gpVertexAttribL1ui64vARB, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL1ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL1ui64vNV(gpVertexAttribL1ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL2d(index uint32, x float64, y float64) {
 	C.glowVertexAttribL2d(gpVertexAttribL2d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y))
@@ -8032,11 +12955,35 @@ func VertexAttribL2d(index uint32, x float64, y float64) {
 func VertexAttribL2dv(index uint32, v *float64) {
 	C.glowVertexAttribL2dv(gpVertexAttribL2dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL2i64NV(index uint32, x int64, y int64) {
+	C.glowVertexAttribL2i64NV(gpVertexAttribL2i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func VertexAttribL2i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL2i64vNV(gpVertexAttribL2i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL2ui64NV(index uint32, x uint64, y uint64) {
+	C.glowVertexAttribL2ui64NV(gpVertexAttribL2ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func VertexAttribL2ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL2ui64vNV(gpVertexAttribL2ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL3d(index uint32, x float64, y float64, z float64) {
 	C.glowVertexAttribL3d(gpVertexAttribL3d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
 }
 func VertexAttribL3dv(index uint32, v *float64) {
 	C.glowVertexAttribL3dv(gpVertexAttribL3dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
+}
+func VertexAttribL3i64NV(index uint32, x int64, y int64, z int64) {
+	C.glowVertexAttribL3i64NV(gpVertexAttribL3i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func VertexAttribL3i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL3i64vNV(gpVertexAttribL3i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL3ui64NV(index uint32, x uint64, y uint64, z uint64) {
+	C.glowVertexAttribL3ui64NV(gpVertexAttribL3ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func VertexAttribL3ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL3ui64vNV(gpVertexAttribL3ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 	C.glowVertexAttribL4d(gpVertexAttribL4d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
@@ -8044,8 +12991,23 @@ func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 func VertexAttribL4dv(index uint32, v *float64) {
 	C.glowVertexAttribL4dv(gpVertexAttribL4dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL4i64NV(index uint32, x int64, y int64, z int64, w int64) {
+	C.glowVertexAttribL4i64NV(gpVertexAttribL4i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func VertexAttribL4i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL4i64vNV(gpVertexAttribL4i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL4ui64NV(index uint32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowVertexAttribL4ui64NV(gpVertexAttribL4ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func VertexAttribL4ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL4ui64vNV(gpVertexAttribL4ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribLFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribLFormat(gpVertexAttribLFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexAttribLFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribLFormatNV(gpVertexAttribLFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 func VertexAttribLPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribLPointer(gpVertexAttribLPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
@@ -8084,6 +13046,9 @@ func VertexAttribPointer(index uint32, size int32, xtype uint32, normalized bool
 func VertexBindingDivisor(bindingindex uint32, divisor uint32) {
 	C.glowVertexBindingDivisor(gpVertexBindingDivisor, (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowVertexFormatNV(gpVertexFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 
 // set the viewport
 func Viewport(x int32, y int32, width int32, height int32) {
@@ -8098,10 +13063,25 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
+	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
+}
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
 }
 
 // Init initializes the OpenGL bindings by loading the function pointers (for
@@ -8131,11 +13111,14 @@ func Init() error {
 // function pointer loading function. For more cases Init should be used
 // instead.
 func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
+	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
+	gpActiveShaderProgramEXT = (C.GPACTIVESHADERPROGRAMEXT)(getProcAddr("glActiveShaderProgramEXT"))
 	gpActiveTexture = (C.GPACTIVETEXTURE)(getProcAddr("glActiveTexture"))
 	if gpActiveTexture == nil {
 		return errors.New("glActiveTexture")
 	}
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpAttachShader = (C.GPATTACHSHADER)(getProcAddr("glAttachShader"))
 	if gpAttachShader == nil {
 		return errors.New("glAttachShader")
@@ -8144,6 +13127,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBeginConditionalRender == nil {
 		return errors.New("glBeginConditionalRender")
 	}
+	gpBeginConditionalRenderNV = (C.GPBEGINCONDITIONALRENDERNV)(getProcAddr("glBeginConditionalRenderNV"))
+	gpBeginPerfMonitorAMD = (C.GPBEGINPERFMONITORAMD)(getProcAddr("glBeginPerfMonitorAMD"))
+	gpBeginPerfQueryINTEL = (C.GPBEGINPERFQUERYINTEL)(getProcAddr("glBeginPerfQueryINTEL"))
 	gpBeginQuery = (C.GPBEGINQUERY)(getProcAddr("glBeginQuery"))
 	if gpBeginQuery == nil {
 		return errors.New("glBeginQuery")
@@ -8182,7 +13168,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpBindImageTexture = (C.GPBINDIMAGETEXTURE)(getProcAddr("glBindImageTexture"))
 	gpBindImageTextures = (C.GPBINDIMAGETEXTURES)(getProcAddr("glBindImageTextures"))
+	gpBindMultiTextureEXT = (C.GPBINDMULTITEXTUREEXT)(getProcAddr("glBindMultiTextureEXT"))
 	gpBindProgramPipeline = (C.GPBINDPROGRAMPIPELINE)(getProcAddr("glBindProgramPipeline"))
+	gpBindProgramPipelineEXT = (C.GPBINDPROGRAMPIPELINEEXT)(getProcAddr("glBindProgramPipelineEXT"))
 	gpBindRenderbuffer = (C.GPBINDRENDERBUFFER)(getProcAddr("glBindRenderbuffer"))
 	if gpBindRenderbuffer == nil {
 		return errors.New("glBindRenderbuffer")
@@ -8202,6 +13190,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpBindVertexBuffer = (C.GPBINDVERTEXBUFFER)(getProcAddr("glBindVertexBuffer"))
 	gpBindVertexBuffers = (C.GPBINDVERTEXBUFFERS)(getProcAddr("glBindVertexBuffers"))
+	gpBlendBarrierKHR = (C.GPBLENDBARRIERKHR)(getProcAddr("glBlendBarrierKHR"))
+	gpBlendBarrierNV = (C.GPBLENDBARRIERNV)(getProcAddr("glBlendBarrierNV"))
 	gpBlendColor = (C.GPBLENDCOLOR)(getProcAddr("glBlendColor"))
 	if gpBlendColor == nil {
 		return errors.New("glBlendColor")
@@ -8226,11 +13216,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpBlendFuncSeparateiARB = (C.GPBLENDFUNCSEPARATEIARB)(getProcAddr("glBlendFuncSeparateiARB"))
 	gpBlendFunciARB = (C.GPBLENDFUNCIARB)(getProcAddr("glBlendFunciARB"))
+	gpBlendParameteriNV = (C.GPBLENDPARAMETERINV)(getProcAddr("glBlendParameteriNV"))
 	gpBlitFramebuffer = (C.GPBLITFRAMEBUFFER)(getProcAddr("glBlitFramebuffer"))
 	if gpBlitFramebuffer == nil {
 		return errors.New("glBlitFramebuffer")
 	}
 	gpBlitNamedFramebuffer = (C.GPBLITNAMEDFRAMEBUFFER)(getProcAddr("glBlitNamedFramebuffer"))
+	gpBufferAddressRangeNV = (C.GPBUFFERADDRESSRANGENV)(getProcAddr("glBufferAddressRangeNV"))
 	gpBufferData = (C.GPBUFFERDATA)(getProcAddr("glBufferData"))
 	if gpBufferData == nil {
 		return errors.New("glBufferData")
@@ -8241,11 +13233,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCheckFramebufferStatus = (C.GPCHECKFRAMEBUFFERSTATUS)(getProcAddr("glCheckFramebufferStatus"))
 	if gpCheckFramebufferStatus == nil {
 		return errors.New("glCheckFramebufferStatus")
 	}
 	gpCheckNamedFramebufferStatus = (C.GPCHECKNAMEDFRAMEBUFFERSTATUS)(getProcAddr("glCheckNamedFramebufferStatus"))
+	gpCheckNamedFramebufferStatusEXT = (C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(getProcAddr("glCheckNamedFramebufferStatusEXT"))
 	gpClampColor = (C.GPCLAMPCOLOR)(getProcAddr("glClampColor"))
 	if gpClampColor == nil {
 		return errors.New("glClampColor")
@@ -8282,7 +13276,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpClearDepthf = (C.GPCLEARDEPTHF)(getProcAddr("glClearDepthf"))
 	gpClearNamedBufferData = (C.GPCLEARNAMEDBUFFERDATA)(getProcAddr("glClearNamedBufferData"))
+	gpClearNamedBufferDataEXT = (C.GPCLEARNAMEDBUFFERDATAEXT)(getProcAddr("glClearNamedBufferDataEXT"))
 	gpClearNamedBufferSubData = (C.GPCLEARNAMEDBUFFERSUBDATA)(getProcAddr("glClearNamedBufferSubData"))
+	gpClearNamedBufferSubDataEXT = (C.GPCLEARNAMEDBUFFERSUBDATAEXT)(getProcAddr("glClearNamedBufferSubDataEXT"))
 	gpClearNamedFramebufferfi = (C.GPCLEARNAMEDFRAMEBUFFERFI)(getProcAddr("glClearNamedFramebufferfi"))
 	gpClearNamedFramebufferfv = (C.GPCLEARNAMEDFRAMEBUFFERFV)(getProcAddr("glClearNamedFramebufferfv"))
 	gpClearNamedFramebufferiv = (C.GPCLEARNAMEDFRAMEBUFFERIV)(getProcAddr("glClearNamedFramebufferiv"))
@@ -8293,11 +13289,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpClearTexImage = (C.GPCLEARTEXIMAGE)(getProcAddr("glClearTexImage"))
 	gpClearTexSubImage = (C.GPCLEARTEXSUBIMAGE)(getProcAddr("glClearTexSubImage"))
+	gpClientAttribDefaultEXT = (C.GPCLIENTATTRIBDEFAULTEXT)(getProcAddr("glClientAttribDefaultEXT"))
 	gpClientWaitSync = (C.GPCLIENTWAITSYNC)(getProcAddr("glClientWaitSync"))
 	if gpClientWaitSync == nil {
 		return errors.New("glClientWaitSync")
 	}
 	gpClipControl = (C.GPCLIPCONTROL)(getProcAddr("glClipControl"))
+	gpColorFormatNV = (C.GPCOLORFORMATNV)(getProcAddr("glColorFormatNV"))
 	gpColorMask = (C.GPCOLORMASK)(getProcAddr("glColorMask"))
 	if gpColorMask == nil {
 		return errors.New("glColorMask")
@@ -8306,11 +13304,19 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpColorMaski == nil {
 		return errors.New("glColorMaski")
 	}
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
 	}
 	gpCompileShaderIncludeARB = (C.GPCOMPILESHADERINCLUDEARB)(getProcAddr("glCompileShaderIncludeARB"))
+	gpCompressedMultiTexImage1DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE1DEXT)(getProcAddr("glCompressedMultiTexImage1DEXT"))
+	gpCompressedMultiTexImage2DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE2DEXT)(getProcAddr("glCompressedMultiTexImage2DEXT"))
+	gpCompressedMultiTexImage3DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE3DEXT)(getProcAddr("glCompressedMultiTexImage3DEXT"))
+	gpCompressedMultiTexSubImage1DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCompressedMultiTexSubImage1DEXT"))
+	gpCompressedMultiTexSubImage2DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCompressedMultiTexSubImage2DEXT"))
+	gpCompressedMultiTexSubImage3DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCompressedMultiTexSubImage3DEXT"))
 	gpCompressedTexImage1D = (C.GPCOMPRESSEDTEXIMAGE1D)(getProcAddr("glCompressedTexImage1D"))
 	if gpCompressedTexImage1D == nil {
 		return errors.New("glCompressedTexImage1D")
@@ -8335,15 +13341,29 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCompressedTexSubImage3D == nil {
 		return errors.New("glCompressedTexSubImage3D")
 	}
+	gpCompressedTextureImage1DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE1DEXT)(getProcAddr("glCompressedTextureImage1DEXT"))
+	gpCompressedTextureImage2DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE2DEXT)(getProcAddr("glCompressedTextureImage2DEXT"))
+	gpCompressedTextureImage3DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE3DEXT)(getProcAddr("glCompressedTextureImage3DEXT"))
 	gpCompressedTextureSubImage1D = (C.GPCOMPRESSEDTEXTURESUBIMAGE1D)(getProcAddr("glCompressedTextureSubImage1D"))
+	gpCompressedTextureSubImage1DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(getProcAddr("glCompressedTextureSubImage1DEXT"))
 	gpCompressedTextureSubImage2D = (C.GPCOMPRESSEDTEXTURESUBIMAGE2D)(getProcAddr("glCompressedTextureSubImage2D"))
+	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
+	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpCopyBufferSubData = (C.GPCOPYBUFFERSUBDATA)(getProcAddr("glCopyBufferSubData"))
 	if gpCopyBufferSubData == nil {
 		return errors.New("glCopyBufferSubData")
 	}
 	gpCopyImageSubData = (C.GPCOPYIMAGESUBDATA)(getProcAddr("glCopyImageSubData"))
+	gpCopyMultiTexImage1DEXT = (C.GPCOPYMULTITEXIMAGE1DEXT)(getProcAddr("glCopyMultiTexImage1DEXT"))
+	gpCopyMultiTexImage2DEXT = (C.GPCOPYMULTITEXIMAGE2DEXT)(getProcAddr("glCopyMultiTexImage2DEXT"))
+	gpCopyMultiTexSubImage1DEXT = (C.GPCOPYMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCopyMultiTexSubImage1DEXT"))
+	gpCopyMultiTexSubImage2DEXT = (C.GPCOPYMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCopyMultiTexSubImage2DEXT"))
+	gpCopyMultiTexSubImage3DEXT = (C.GPCOPYMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCopyMultiTexSubImage3DEXT"))
 	gpCopyNamedBufferSubData = (C.GPCOPYNAMEDBUFFERSUBDATA)(getProcAddr("glCopyNamedBufferSubData"))
+	gpCopyPathNV = (C.GPCOPYPATHNV)(getProcAddr("glCopyPathNV"))
 	gpCopyTexImage1D = (C.GPCOPYTEXIMAGE1D)(getProcAddr("glCopyTexImage1D"))
 	if gpCopyTexImage1D == nil {
 		return errors.New("glCopyTexImage1D")
@@ -8364,11 +13384,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCopyTexSubImage3D == nil {
 		return errors.New("glCopyTexSubImage3D")
 	}
+	gpCopyTextureImage1DEXT = (C.GPCOPYTEXTUREIMAGE1DEXT)(getProcAddr("glCopyTextureImage1DEXT"))
+	gpCopyTextureImage2DEXT = (C.GPCOPYTEXTUREIMAGE2DEXT)(getProcAddr("glCopyTextureImage2DEXT"))
 	gpCopyTextureSubImage1D = (C.GPCOPYTEXTURESUBIMAGE1D)(getProcAddr("glCopyTextureSubImage1D"))
+	gpCopyTextureSubImage1DEXT = (C.GPCOPYTEXTURESUBIMAGE1DEXT)(getProcAddr("glCopyTextureSubImage1DEXT"))
 	gpCopyTextureSubImage2D = (C.GPCOPYTEXTURESUBIMAGE2D)(getProcAddr("glCopyTextureSubImage2D"))
+	gpCopyTextureSubImage2DEXT = (C.GPCOPYTEXTURESUBIMAGE2DEXT)(getProcAddr("glCopyTextureSubImage2DEXT"))
 	gpCopyTextureSubImage3D = (C.GPCOPYTEXTURESUBIMAGE3D)(getProcAddr("glCopyTextureSubImage3D"))
+	gpCopyTextureSubImage3DEXT = (C.GPCOPYTEXTURESUBIMAGE3DEXT)(getProcAddr("glCopyTextureSubImage3DEXT"))
+	gpCoverFillPathInstancedNV = (C.GPCOVERFILLPATHINSTANCEDNV)(getProcAddr("glCoverFillPathInstancedNV"))
+	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
+	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
+	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
+	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
 		return errors.New("glCreateProgram")
@@ -8381,7 +13414,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCreateShader == nil {
 		return errors.New("glCreateShader")
 	}
+	gpCreateShaderProgramEXT = (C.GPCREATESHADERPROGRAMEXT)(getProcAddr("glCreateShaderProgramEXT"))
 	gpCreateShaderProgramv = (C.GPCREATESHADERPROGRAMV)(getProcAddr("glCreateShaderProgramv"))
+	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	gpCreateTransformFeedbacks = (C.GPCREATETRANSFORMFEEDBACKS)(getProcAddr("glCreateTransformFeedbacks"))
@@ -8403,16 +13439,21 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteBuffers == nil {
 		return errors.New("glDeleteBuffers")
 	}
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFramebuffers = (C.GPDELETEFRAMEBUFFERS)(getProcAddr("glDeleteFramebuffers"))
 	if gpDeleteFramebuffers == nil {
 		return errors.New("glDeleteFramebuffers")
 	}
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
+	gpDeletePathsNV = (C.GPDELETEPATHSNV)(getProcAddr("glDeletePathsNV"))
+	gpDeletePerfMonitorsAMD = (C.GPDELETEPERFMONITORSAMD)(getProcAddr("glDeletePerfMonitorsAMD"))
+	gpDeletePerfQueryINTEL = (C.GPDELETEPERFQUERYINTEL)(getProcAddr("glDeletePerfQueryINTEL"))
 	gpDeleteProgram = (C.GPDELETEPROGRAM)(getProcAddr("glDeleteProgram"))
 	if gpDeleteProgram == nil {
 		return errors.New("glDeleteProgram")
 	}
 	gpDeleteProgramPipelines = (C.GPDELETEPROGRAMPIPELINES)(getProcAddr("glDeleteProgramPipelines"))
+	gpDeleteProgramPipelinesEXT = (C.GPDELETEPROGRAMPIPELINESEXT)(getProcAddr("glDeleteProgramPipelinesEXT"))
 	gpDeleteQueries = (C.GPDELETEQUERIES)(getProcAddr("glDeleteQueries"))
 	if gpDeleteQueries == nil {
 		return errors.New("glDeleteQueries")
@@ -8426,6 +13467,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	if gpDeleteSync == nil {
 		return errors.New("glDeleteSync")
@@ -8462,7 +13504,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDisable == nil {
 		return errors.New("glDisable")
 	}
+	gpDisableClientStateIndexedEXT = (C.GPDISABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glDisableClientStateIndexedEXT"))
+	gpDisableClientStateiEXT = (C.GPDISABLECLIENTSTATEIEXT)(getProcAddr("glDisableClientStateiEXT"))
+	gpDisableIndexedEXT = (C.GPDISABLEINDEXEDEXT)(getProcAddr("glDisableIndexedEXT"))
 	gpDisableVertexArrayAttrib = (C.GPDISABLEVERTEXARRAYATTRIB)(getProcAddr("glDisableVertexArrayAttrib"))
+	gpDisableVertexArrayAttribEXT = (C.GPDISABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glDisableVertexArrayAttribEXT"))
+	gpDisableVertexArrayEXT = (C.GPDISABLEVERTEXARRAYEXT)(getProcAddr("glDisableVertexArrayEXT"))
 	gpDisableVertexAttribArray = (C.GPDISABLEVERTEXATTRIBARRAY)(getProcAddr("glDisableVertexAttribArray"))
 	if gpDisableVertexAttribArray == nil {
 		return errors.New("glDisableVertexAttribArray")
@@ -8483,7 +13530,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawArraysInstanced == nil {
 		return errors.New("glDrawArraysInstanced")
 	}
+	gpDrawArraysInstancedARB = (C.GPDRAWARRAYSINSTANCEDARB)(getProcAddr("glDrawArraysInstancedARB"))
 	gpDrawArraysInstancedBaseInstance = (C.GPDRAWARRAYSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawArraysInstancedBaseInstance"))
+	gpDrawArraysInstancedEXT = (C.GPDRAWARRAYSINSTANCEDEXT)(getProcAddr("glDrawArraysInstancedEXT"))
 	gpDrawBuffer = (C.GPDRAWBUFFER)(getProcAddr("glDrawBuffer"))
 	if gpDrawBuffer == nil {
 		return errors.New("glDrawBuffer")
@@ -8492,6 +13541,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawBuffers == nil {
 		return errors.New("glDrawBuffers")
 	}
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
 	if gpDrawElements == nil {
 		return errors.New("glDrawElements")
@@ -8505,12 +13558,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawElementsInstanced == nil {
 		return errors.New("glDrawElementsInstanced")
 	}
+	gpDrawElementsInstancedARB = (C.GPDRAWELEMENTSINSTANCEDARB)(getProcAddr("glDrawElementsInstancedARB"))
 	gpDrawElementsInstancedBaseInstance = (C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawElementsInstancedBaseInstance"))
 	gpDrawElementsInstancedBaseVertex = (C.GPDRAWELEMENTSINSTANCEDBASEVERTEX)(getProcAddr("glDrawElementsInstancedBaseVertex"))
 	if gpDrawElementsInstancedBaseVertex == nil {
 		return errors.New("glDrawElementsInstancedBaseVertex")
 	}
 	gpDrawElementsInstancedBaseVertexBaseInstance = (C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE)(getProcAddr("glDrawElementsInstancedBaseVertexBaseInstance"))
+	gpDrawElementsInstancedEXT = (C.GPDRAWELEMENTSINSTANCEDEXT)(getProcAddr("glDrawElementsInstancedEXT"))
 	gpDrawRangeElements = (C.GPDRAWRANGEELEMENTS)(getProcAddr("glDrawRangeElements"))
 	if gpDrawRangeElements == nil {
 		return errors.New("glDrawRangeElements")
@@ -8523,11 +13578,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpDrawTransformFeedbackInstanced = (C.GPDRAWTRANSFORMFEEDBACKINSTANCED)(getProcAddr("glDrawTransformFeedbackInstanced"))
 	gpDrawTransformFeedbackStream = (C.GPDRAWTRANSFORMFEEDBACKSTREAM)(getProcAddr("glDrawTransformFeedbackStream"))
 	gpDrawTransformFeedbackStreamInstanced = (C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(getProcAddr("glDrawTransformFeedbackStreamInstanced"))
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
+	gpEdgeFlagFormatNV = (C.GPEDGEFLAGFORMATNV)(getProcAddr("glEdgeFlagFormatNV"))
 	gpEnable = (C.GPENABLE)(getProcAddr("glEnable"))
 	if gpEnable == nil {
 		return errors.New("glEnable")
 	}
+	gpEnableClientStateIndexedEXT = (C.GPENABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glEnableClientStateIndexedEXT"))
+	gpEnableClientStateiEXT = (C.GPENABLECLIENTSTATEIEXT)(getProcAddr("glEnableClientStateiEXT"))
+	gpEnableIndexedEXT = (C.GPENABLEINDEXEDEXT)(getProcAddr("glEnableIndexedEXT"))
 	gpEnableVertexArrayAttrib = (C.GPENABLEVERTEXARRAYATTRIB)(getProcAddr("glEnableVertexArrayAttrib"))
+	gpEnableVertexArrayAttribEXT = (C.GPENABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glEnableVertexArrayAttribEXT"))
+	gpEnableVertexArrayEXT = (C.GPENABLEVERTEXARRAYEXT)(getProcAddr("glEnableVertexArrayEXT"))
 	gpEnableVertexAttribArray = (C.GPENABLEVERTEXATTRIBARRAY)(getProcAddr("glEnableVertexAttribArray"))
 	if gpEnableVertexAttribArray == nil {
 		return errors.New("glEnableVertexAttribArray")
@@ -8540,6 +13602,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEndConditionalRender == nil {
 		return errors.New("glEndConditionalRender")
 	}
+	gpEndConditionalRenderNV = (C.GPENDCONDITIONALRENDERNV)(getProcAddr("glEndConditionalRenderNV"))
+	gpEndPerfMonitorAMD = (C.GPENDPERFMONITORAMD)(getProcAddr("glEndPerfMonitorAMD"))
+	gpEndPerfQueryINTEL = (C.GPENDPERFQUERYINTEL)(getProcAddr("glEndPerfQueryINTEL"))
 	gpEndQuery = (C.GPENDQUERY)(getProcAddr("glEndQuery"))
 	if gpEndQuery == nil {
 		return errors.New("glEndQuery")
@@ -8549,6 +13614,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEndTransformFeedback == nil {
 		return errors.New("glEndTransformFeedback")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpFenceSync = (C.GPFENCESYNC)(getProcAddr("glFenceSync"))
 	if gpFenceSync == nil {
 		return errors.New("glFenceSync")
@@ -8566,11 +13632,20 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glFlushMappedBufferRange")
 	}
 	gpFlushMappedNamedBufferRange = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGE)(getProcAddr("glFlushMappedNamedBufferRange"))
+	gpFlushMappedNamedBufferRangeEXT = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(getProcAddr("glFlushMappedNamedBufferRangeEXT"))
+	gpFogCoordFormatNV = (C.GPFOGCOORDFORMATNV)(getProcAddr("glFogCoordFormatNV"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
+	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
+	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
+	gpFramebufferReadBufferEXT = (C.GPFRAMEBUFFERREADBUFFEREXT)(getProcAddr("glFramebufferReadBufferEXT"))
 	gpFramebufferRenderbuffer = (C.GPFRAMEBUFFERRENDERBUFFER)(getProcAddr("glFramebufferRenderbuffer"))
 	if gpFramebufferRenderbuffer == nil {
 		return errors.New("glFramebufferRenderbuffer")
 	}
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	if gpFramebufferTexture == nil {
 		return errors.New("glFramebufferTexture")
@@ -8587,10 +13662,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpFramebufferTexture3D == nil {
 		return errors.New("glFramebufferTexture3D")
 	}
+	gpFramebufferTextureARB = (C.GPFRAMEBUFFERTEXTUREARB)(getProcAddr("glFramebufferTextureARB"))
+	gpFramebufferTextureFaceARB = (C.GPFRAMEBUFFERTEXTUREFACEARB)(getProcAddr("glFramebufferTextureFaceARB"))
 	gpFramebufferTextureLayer = (C.GPFRAMEBUFFERTEXTURELAYER)(getProcAddr("glFramebufferTextureLayer"))
 	if gpFramebufferTextureLayer == nil {
 		return errors.New("glFramebufferTextureLayer")
 	}
+	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
 		return errors.New("glFrontFace")
@@ -8603,7 +13682,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenFramebuffers == nil {
 		return errors.New("glGenFramebuffers")
 	}
+	gpGenPathsNV = (C.GPGENPATHSNV)(getProcAddr("glGenPathsNV"))
+	gpGenPerfMonitorsAMD = (C.GPGENPERFMONITORSAMD)(getProcAddr("glGenPerfMonitorsAMD"))
 	gpGenProgramPipelines = (C.GPGENPROGRAMPIPELINES)(getProcAddr("glGenProgramPipelines"))
+	gpGenProgramPipelinesEXT = (C.GPGENPROGRAMPIPELINESEXT)(getProcAddr("glGenProgramPipelinesEXT"))
 	gpGenQueries = (C.GPGENQUERIES)(getProcAddr("glGenQueries"))
 	if gpGenQueries == nil {
 		return errors.New("glGenQueries")
@@ -8626,7 +13708,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenerateMipmap == nil {
 		return errors.New("glGenerateMipmap")
 	}
+	gpGenerateMultiTexMipmapEXT = (C.GPGENERATEMULTITEXMIPMAPEXT)(getProcAddr("glGenerateMultiTexMipmapEXT"))
 	gpGenerateTextureMipmap = (C.GPGENERATETEXTUREMIPMAP)(getProcAddr("glGenerateTextureMipmap"))
+	gpGenerateTextureMipmapEXT = (C.GPGENERATETEXTUREMIPMAPEXT)(getProcAddr("glGenerateTextureMipmapEXT"))
 	gpGetActiveAtomicCounterBufferiv = (C.GPGETACTIVEATOMICCOUNTERBUFFERIV)(getProcAddr("glGetActiveAtomicCounterBufferiv"))
 	gpGetActiveAttrib = (C.GPGETACTIVEATTRIB)(getProcAddr("glGetActiveAttrib"))
 	if gpGetActiveAttrib == nil {
@@ -8663,6 +13747,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetAttribLocation == nil {
 		return errors.New("glGetAttribLocation")
 	}
+	gpGetBooleanIndexedvEXT = (C.GPGETBOOLEANINDEXEDVEXT)(getProcAddr("glGetBooleanIndexedvEXT"))
 	gpGetBooleani_v = (C.GPGETBOOLEANI_V)(getProcAddr("glGetBooleani_v"))
 	if gpGetBooleani_v == nil {
 		return errors.New("glGetBooleani_v")
@@ -8679,6 +13764,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetBufferParameteriv == nil {
 		return errors.New("glGetBufferParameteriv")
 	}
+	gpGetBufferParameterui64vNV = (C.GPGETBUFFERPARAMETERUI64VNV)(getProcAddr("glGetBufferParameterui64vNV"))
 	gpGetBufferPointerv = (C.GPGETBUFFERPOINTERV)(getProcAddr("glGetBufferPointerv"))
 	if gpGetBufferPointerv == nil {
 		return errors.New("glGetBufferPointerv")
@@ -8687,16 +13773,22 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetBufferSubData == nil {
 		return errors.New("glGetBufferSubData")
 	}
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
+	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
 		return errors.New("glGetCompressedTexImage")
 	}
 	gpGetCompressedTextureImage = (C.GPGETCOMPRESSEDTEXTUREIMAGE)(getProcAddr("glGetCompressedTextureImage"))
+	gpGetCompressedTextureImageEXT = (C.GPGETCOMPRESSEDTEXTUREIMAGEEXT)(getProcAddr("glGetCompressedTextureImageEXT"))
 	gpGetCompressedTextureSubImage = (C.GPGETCOMPRESSEDTEXTURESUBIMAGE)(getProcAddr("glGetCompressedTextureSubImage"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	gpGetDebugMessageLogARB = (C.GPGETDEBUGMESSAGELOGARB)(getProcAddr("glGetDebugMessageLogARB"))
 	gpGetDebugMessageLogKHR = (C.GPGETDEBUGMESSAGELOGKHR)(getProcAddr("glGetDebugMessageLogKHR"))
+	gpGetDoubleIndexedvEXT = (C.GPGETDOUBLEINDEXEDVEXT)(getProcAddr("glGetDoubleIndexedvEXT"))
 	gpGetDoublei_v = (C.GPGETDOUBLEI_V)(getProcAddr("glGetDoublei_v"))
+	gpGetDoublei_vEXT = (C.GPGETDOUBLEI_VEXT)(getProcAddr("glGetDoublei_vEXT"))
 	gpGetDoublev = (C.GPGETDOUBLEV)(getProcAddr("glGetDoublev"))
 	if gpGetDoublev == nil {
 		return errors.New("glGetDoublev")
@@ -8705,7 +13797,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetError == nil {
 		return errors.New("glGetError")
 	}
+	gpGetFirstPerfQueryIdINTEL = (C.GPGETFIRSTPERFQUERYIDINTEL)(getProcAddr("glGetFirstPerfQueryIdINTEL"))
+	gpGetFloatIndexedvEXT = (C.GPGETFLOATINDEXEDVEXT)(getProcAddr("glGetFloatIndexedvEXT"))
 	gpGetFloati_v = (C.GPGETFLOATI_V)(getProcAddr("glGetFloati_v"))
+	gpGetFloati_vEXT = (C.GPGETFLOATI_VEXT)(getProcAddr("glGetFloati_vEXT"))
 	gpGetFloatv = (C.GPGETFLOATV)(getProcAddr("glGetFloatv"))
 	if gpGetFloatv == nil {
 		return errors.New("glGetFloatv")
@@ -8720,10 +13815,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetFramebufferAttachmentParameteriv")
 	}
 	gpGetFramebufferParameteriv = (C.GPGETFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetFramebufferParameteriv"))
+	gpGetFramebufferParameterivEXT = (C.GPGETFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetFramebufferParameterivEXT"))
 	gpGetGraphicsResetStatus = (C.GPGETGRAPHICSRESETSTATUS)(getProcAddr("glGetGraphicsResetStatus"))
 	gpGetGraphicsResetStatusARB = (C.GPGETGRAPHICSRESETSTATUSARB)(getProcAddr("glGetGraphicsResetStatusARB"))
 	gpGetGraphicsResetStatusKHR = (C.GPGETGRAPHICSRESETSTATUSKHR)(getProcAddr("glGetGraphicsResetStatusKHR"))
 	gpGetImageHandleARB = (C.GPGETIMAGEHANDLEARB)(getProcAddr("glGetImageHandleARB"))
+	gpGetImageHandleNV = (C.GPGETIMAGEHANDLENV)(getProcAddr("glGetImageHandleNV"))
 	gpGetInteger64i_v = (C.GPGETINTEGER64I_V)(getProcAddr("glGetInteger64i_v"))
 	if gpGetInteger64i_v == nil {
 		return errors.New("glGetInteger64i_v")
@@ -8732,33 +13829,85 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetInteger64v == nil {
 		return errors.New("glGetInteger64v")
 	}
+	gpGetIntegerIndexedvEXT = (C.GPGETINTEGERINDEXEDVEXT)(getProcAddr("glGetIntegerIndexedvEXT"))
 	gpGetIntegeri_v = (C.GPGETINTEGERI_V)(getProcAddr("glGetIntegeri_v"))
 	if gpGetIntegeri_v == nil {
 		return errors.New("glGetIntegeri_v")
 	}
+	gpGetIntegerui64i_vNV = (C.GPGETINTEGERUI64I_VNV)(getProcAddr("glGetIntegerui64i_vNV"))
+	gpGetIntegerui64vNV = (C.GPGETINTEGERUI64VNV)(getProcAddr("glGetIntegerui64vNV"))
 	gpGetIntegerv = (C.GPGETINTEGERV)(getProcAddr("glGetIntegerv"))
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	gpGetInternalformativ = (C.GPGETINTERNALFORMATIV)(getProcAddr("glGetInternalformativ"))
+	gpGetMultiTexEnvfvEXT = (C.GPGETMULTITEXENVFVEXT)(getProcAddr("glGetMultiTexEnvfvEXT"))
+	gpGetMultiTexEnvivEXT = (C.GPGETMULTITEXENVIVEXT)(getProcAddr("glGetMultiTexEnvivEXT"))
+	gpGetMultiTexGendvEXT = (C.GPGETMULTITEXGENDVEXT)(getProcAddr("glGetMultiTexGendvEXT"))
+	gpGetMultiTexGenfvEXT = (C.GPGETMULTITEXGENFVEXT)(getProcAddr("glGetMultiTexGenfvEXT"))
+	gpGetMultiTexGenivEXT = (C.GPGETMULTITEXGENIVEXT)(getProcAddr("glGetMultiTexGenivEXT"))
+	gpGetMultiTexImageEXT = (C.GPGETMULTITEXIMAGEEXT)(getProcAddr("glGetMultiTexImageEXT"))
+	gpGetMultiTexLevelParameterfvEXT = (C.GPGETMULTITEXLEVELPARAMETERFVEXT)(getProcAddr("glGetMultiTexLevelParameterfvEXT"))
+	gpGetMultiTexLevelParameterivEXT = (C.GPGETMULTITEXLEVELPARAMETERIVEXT)(getProcAddr("glGetMultiTexLevelParameterivEXT"))
+	gpGetMultiTexParameterIivEXT = (C.GPGETMULTITEXPARAMETERIIVEXT)(getProcAddr("glGetMultiTexParameterIivEXT"))
+	gpGetMultiTexParameterIuivEXT = (C.GPGETMULTITEXPARAMETERIUIVEXT)(getProcAddr("glGetMultiTexParameterIuivEXT"))
+	gpGetMultiTexParameterfvEXT = (C.GPGETMULTITEXPARAMETERFVEXT)(getProcAddr("glGetMultiTexParameterfvEXT"))
+	gpGetMultiTexParameterivEXT = (C.GPGETMULTITEXPARAMETERIVEXT)(getProcAddr("glGetMultiTexParameterivEXT"))
 	gpGetMultisamplefv = (C.GPGETMULTISAMPLEFV)(getProcAddr("glGetMultisamplefv"))
 	if gpGetMultisamplefv == nil {
 		return errors.New("glGetMultisamplefv")
 	}
 	gpGetNamedBufferParameteri64v = (C.GPGETNAMEDBUFFERPARAMETERI64V)(getProcAddr("glGetNamedBufferParameteri64v"))
 	gpGetNamedBufferParameteriv = (C.GPGETNAMEDBUFFERPARAMETERIV)(getProcAddr("glGetNamedBufferParameteriv"))
+	gpGetNamedBufferParameterivEXT = (C.GPGETNAMEDBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedBufferParameterivEXT"))
+	gpGetNamedBufferParameterui64vNV = (C.GPGETNAMEDBUFFERPARAMETERUI64VNV)(getProcAddr("glGetNamedBufferParameterui64vNV"))
 	gpGetNamedBufferPointerv = (C.GPGETNAMEDBUFFERPOINTERV)(getProcAddr("glGetNamedBufferPointerv"))
+	gpGetNamedBufferPointervEXT = (C.GPGETNAMEDBUFFERPOINTERVEXT)(getProcAddr("glGetNamedBufferPointervEXT"))
 	gpGetNamedBufferSubData = (C.GPGETNAMEDBUFFERSUBDATA)(getProcAddr("glGetNamedBufferSubData"))
+	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
+	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
+	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
+	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
+	gpGetNamedProgramLocalParameterIuivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIuivEXT"))
+	gpGetNamedProgramLocalParameterdvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(getProcAddr("glGetNamedProgramLocalParameterdvEXT"))
+	gpGetNamedProgramLocalParameterfvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(getProcAddr("glGetNamedProgramLocalParameterfvEXT"))
+	gpGetNamedProgramStringEXT = (C.GPGETNAMEDPROGRAMSTRINGEXT)(getProcAddr("glGetNamedProgramStringEXT"))
+	gpGetNamedProgramivEXT = (C.GPGETNAMEDPROGRAMIVEXT)(getProcAddr("glGetNamedProgramivEXT"))
 	gpGetNamedRenderbufferParameteriv = (C.GPGETNAMEDRENDERBUFFERPARAMETERIV)(getProcAddr("glGetNamedRenderbufferParameteriv"))
+	gpGetNamedRenderbufferParameterivEXT = (C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedRenderbufferParameterivEXT"))
 	gpGetNamedStringARB = (C.GPGETNAMEDSTRINGARB)(getProcAddr("glGetNamedStringARB"))
 	gpGetNamedStringivARB = (C.GPGETNAMEDSTRINGIVARB)(getProcAddr("glGetNamedStringivARB"))
+	gpGetNextPerfQueryIdINTEL = (C.GPGETNEXTPERFQUERYIDINTEL)(getProcAddr("glGetNextPerfQueryIdINTEL"))
 	gpGetObjectLabel = (C.GPGETOBJECTLABEL)(getProcAddr("glGetObjectLabel"))
+	gpGetObjectLabelEXT = (C.GPGETOBJECTLABELEXT)(getProcAddr("glGetObjectLabelEXT"))
 	gpGetObjectLabelKHR = (C.GPGETOBJECTLABELKHR)(getProcAddr("glGetObjectLabelKHR"))
 	gpGetObjectPtrLabel = (C.GPGETOBJECTPTRLABEL)(getProcAddr("glGetObjectPtrLabel"))
 	gpGetObjectPtrLabelKHR = (C.GPGETOBJECTPTRLABELKHR)(getProcAddr("glGetObjectPtrLabelKHR"))
+	gpGetPathCommandsNV = (C.GPGETPATHCOMMANDSNV)(getProcAddr("glGetPathCommandsNV"))
+	gpGetPathCoordsNV = (C.GPGETPATHCOORDSNV)(getProcAddr("glGetPathCoordsNV"))
+	gpGetPathDashArrayNV = (C.GPGETPATHDASHARRAYNV)(getProcAddr("glGetPathDashArrayNV"))
+	gpGetPathLengthNV = (C.GPGETPATHLENGTHNV)(getProcAddr("glGetPathLengthNV"))
+	gpGetPathMetricRangeNV = (C.GPGETPATHMETRICRANGENV)(getProcAddr("glGetPathMetricRangeNV"))
+	gpGetPathMetricsNV = (C.GPGETPATHMETRICSNV)(getProcAddr("glGetPathMetricsNV"))
+	gpGetPathParameterfvNV = (C.GPGETPATHPARAMETERFVNV)(getProcAddr("glGetPathParameterfvNV"))
+	gpGetPathParameterivNV = (C.GPGETPATHPARAMETERIVNV)(getProcAddr("glGetPathParameterivNV"))
+	gpGetPathSpacingNV = (C.GPGETPATHSPACINGNV)(getProcAddr("glGetPathSpacingNV"))
+	gpGetPerfCounterInfoINTEL = (C.GPGETPERFCOUNTERINFOINTEL)(getProcAddr("glGetPerfCounterInfoINTEL"))
+	gpGetPerfMonitorCounterDataAMD = (C.GPGETPERFMONITORCOUNTERDATAAMD)(getProcAddr("glGetPerfMonitorCounterDataAMD"))
+	gpGetPerfMonitorCounterInfoAMD = (C.GPGETPERFMONITORCOUNTERINFOAMD)(getProcAddr("glGetPerfMonitorCounterInfoAMD"))
+	gpGetPerfMonitorCounterStringAMD = (C.GPGETPERFMONITORCOUNTERSTRINGAMD)(getProcAddr("glGetPerfMonitorCounterStringAMD"))
+	gpGetPerfMonitorCountersAMD = (C.GPGETPERFMONITORCOUNTERSAMD)(getProcAddr("glGetPerfMonitorCountersAMD"))
+	gpGetPerfMonitorGroupStringAMD = (C.GPGETPERFMONITORGROUPSTRINGAMD)(getProcAddr("glGetPerfMonitorGroupStringAMD"))
+	gpGetPerfMonitorGroupsAMD = (C.GPGETPERFMONITORGROUPSAMD)(getProcAddr("glGetPerfMonitorGroupsAMD"))
+	gpGetPerfQueryDataINTEL = (C.GPGETPERFQUERYDATAINTEL)(getProcAddr("glGetPerfQueryDataINTEL"))
+	gpGetPerfQueryIdByNameINTEL = (C.GPGETPERFQUERYIDBYNAMEINTEL)(getProcAddr("glGetPerfQueryIdByNameINTEL"))
+	gpGetPerfQueryInfoINTEL = (C.GPGETPERFQUERYINFOINTEL)(getProcAddr("glGetPerfQueryInfoINTEL"))
+	gpGetPointerIndexedvEXT = (C.GPGETPOINTERINDEXEDVEXT)(getProcAddr("glGetPointerIndexedvEXT"))
+	gpGetPointeri_vEXT = (C.GPGETPOINTERI_VEXT)(getProcAddr("glGetPointeri_vEXT"))
 	gpGetPointerv = (C.GPGETPOINTERV)(getProcAddr("glGetPointerv"))
 	gpGetPointervKHR = (C.GPGETPOINTERVKHR)(getProcAddr("glGetPointervKHR"))
 	gpGetProgramBinary = (C.GPGETPROGRAMBINARY)(getProcAddr("glGetProgramBinary"))
@@ -8768,17 +13917,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetProgramInterfaceiv = (C.GPGETPROGRAMINTERFACEIV)(getProcAddr("glGetProgramInterfaceiv"))
 	gpGetProgramPipelineInfoLog = (C.GPGETPROGRAMPIPELINEINFOLOG)(getProcAddr("glGetProgramPipelineInfoLog"))
+	gpGetProgramPipelineInfoLogEXT = (C.GPGETPROGRAMPIPELINEINFOLOGEXT)(getProcAddr("glGetProgramPipelineInfoLogEXT"))
 	gpGetProgramPipelineiv = (C.GPGETPROGRAMPIPELINEIV)(getProcAddr("glGetProgramPipelineiv"))
+	gpGetProgramPipelineivEXT = (C.GPGETPROGRAMPIPELINEIVEXT)(getProcAddr("glGetProgramPipelineivEXT"))
 	gpGetProgramResourceIndex = (C.GPGETPROGRAMRESOURCEINDEX)(getProcAddr("glGetProgramResourceIndex"))
 	gpGetProgramResourceLocation = (C.GPGETPROGRAMRESOURCELOCATION)(getProcAddr("glGetProgramResourceLocation"))
 	gpGetProgramResourceLocationIndex = (C.GPGETPROGRAMRESOURCELOCATIONINDEX)(getProcAddr("glGetProgramResourceLocationIndex"))
 	gpGetProgramResourceName = (C.GPGETPROGRAMRESOURCENAME)(getProcAddr("glGetProgramResourceName"))
+	gpGetProgramResourcefvNV = (C.GPGETPROGRAMRESOURCEFVNV)(getProcAddr("glGetProgramResourcefvNV"))
 	gpGetProgramResourceiv = (C.GPGETPROGRAMRESOURCEIV)(getProcAddr("glGetProgramResourceiv"))
 	gpGetProgramStageiv = (C.GPGETPROGRAMSTAGEIV)(getProcAddr("glGetProgramStageiv"))
 	gpGetProgramiv = (C.GPGETPROGRAMIV)(getProcAddr("glGetProgramiv"))
 	if gpGetProgramiv == nil {
 		return errors.New("glGetProgramiv")
 	}
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	gpGetQueryObjecti64v = (C.GPGETQUERYOBJECTI64V)(getProcAddr("glGetQueryObjecti64v"))
 	gpGetQueryObjectiv = (C.GPGETQUERYOBJECTIV)(getProcAddr("glGetQueryObjectiv"))
@@ -8815,6 +13971,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetShaderiv == nil {
 		return errors.New("glGetShaderiv")
 	}
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -8858,14 +14015,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetTexParameteriv")
 	}
 	gpGetTextureHandleARB = (C.GPGETTEXTUREHANDLEARB)(getProcAddr("glGetTextureHandleARB"))
+	gpGetTextureHandleNV = (C.GPGETTEXTUREHANDLENV)(getProcAddr("glGetTextureHandleNV"))
 	gpGetTextureImage = (C.GPGETTEXTUREIMAGE)(getProcAddr("glGetTextureImage"))
+	gpGetTextureImageEXT = (C.GPGETTEXTUREIMAGEEXT)(getProcAddr("glGetTextureImageEXT"))
 	gpGetTextureLevelParameterfv = (C.GPGETTEXTURELEVELPARAMETERFV)(getProcAddr("glGetTextureLevelParameterfv"))
+	gpGetTextureLevelParameterfvEXT = (C.GPGETTEXTURELEVELPARAMETERFVEXT)(getProcAddr("glGetTextureLevelParameterfvEXT"))
 	gpGetTextureLevelParameteriv = (C.GPGETTEXTURELEVELPARAMETERIV)(getProcAddr("glGetTextureLevelParameteriv"))
+	gpGetTextureLevelParameterivEXT = (C.GPGETTEXTURELEVELPARAMETERIVEXT)(getProcAddr("glGetTextureLevelParameterivEXT"))
 	gpGetTextureParameterIiv = (C.GPGETTEXTUREPARAMETERIIV)(getProcAddr("glGetTextureParameterIiv"))
+	gpGetTextureParameterIivEXT = (C.GPGETTEXTUREPARAMETERIIVEXT)(getProcAddr("glGetTextureParameterIivEXT"))
 	gpGetTextureParameterIuiv = (C.GPGETTEXTUREPARAMETERIUIV)(getProcAddr("glGetTextureParameterIuiv"))
+	gpGetTextureParameterIuivEXT = (C.GPGETTEXTUREPARAMETERIUIVEXT)(getProcAddr("glGetTextureParameterIuivEXT"))
 	gpGetTextureParameterfv = (C.GPGETTEXTUREPARAMETERFV)(getProcAddr("glGetTextureParameterfv"))
+	gpGetTextureParameterfvEXT = (C.GPGETTEXTUREPARAMETERFVEXT)(getProcAddr("glGetTextureParameterfvEXT"))
 	gpGetTextureParameteriv = (C.GPGETTEXTUREPARAMETERIV)(getProcAddr("glGetTextureParameteriv"))
+	gpGetTextureParameterivEXT = (C.GPGETTEXTUREPARAMETERIVEXT)(getProcAddr("glGetTextureParameterivEXT"))
 	gpGetTextureSamplerHandleARB = (C.GPGETTEXTURESAMPLERHANDLEARB)(getProcAddr("glGetTextureSamplerHandleARB"))
+	gpGetTextureSamplerHandleNV = (C.GPGETTEXTURESAMPLERHANDLENV)(getProcAddr("glGetTextureSamplerHandleNV"))
 	gpGetTextureSubImage = (C.GPGETTEXTURESUBIMAGE)(getProcAddr("glGetTextureSubImage"))
 	gpGetTransformFeedbackVarying = (C.GPGETTRANSFORMFEEDBACKVARYING)(getProcAddr("glGetTransformFeedbackVarying"))
 	if gpGetTransformFeedbackVarying == nil {
@@ -8892,16 +14058,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetUniformfv == nil {
 		return errors.New("glGetUniformfv")
 	}
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
+	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
+	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
 	}
 	gpGetVertexArrayIndexed64iv = (C.GPGETVERTEXARRAYINDEXED64IV)(getProcAddr("glGetVertexArrayIndexed64iv"))
 	gpGetVertexArrayIndexediv = (C.GPGETVERTEXARRAYINDEXEDIV)(getProcAddr("glGetVertexArrayIndexediv"))
+	gpGetVertexArrayIntegeri_vEXT = (C.GPGETVERTEXARRAYINTEGERI_VEXT)(getProcAddr("glGetVertexArrayIntegeri_vEXT"))
+	gpGetVertexArrayIntegervEXT = (C.GPGETVERTEXARRAYINTEGERVEXT)(getProcAddr("glGetVertexArrayIntegervEXT"))
+	gpGetVertexArrayPointeri_vEXT = (C.GPGETVERTEXARRAYPOINTERI_VEXT)(getProcAddr("glGetVertexArrayPointeri_vEXT"))
+	gpGetVertexArrayPointervEXT = (C.GPGETVERTEXARRAYPOINTERVEXT)(getProcAddr("glGetVertexArrayPointervEXT"))
 	gpGetVertexArrayiv = (C.GPGETVERTEXARRAYIV)(getProcAddr("glGetVertexArrayiv"))
 	gpGetVertexAttribIiv = (C.GPGETVERTEXATTRIBIIV)(getProcAddr("glGetVertexAttribIiv"))
 	if gpGetVertexAttribIiv == nil {
@@ -8912,7 +14086,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetVertexAttribIuiv")
 	}
 	gpGetVertexAttribLdv = (C.GPGETVERTEXATTRIBLDV)(getProcAddr("glGetVertexAttribLdv"))
+	gpGetVertexAttribLi64vNV = (C.GPGETVERTEXATTRIBLI64VNV)(getProcAddr("glGetVertexAttribLi64vNV"))
 	gpGetVertexAttribLui64vARB = (C.GPGETVERTEXATTRIBLUI64VARB)(getProcAddr("glGetVertexAttribLui64vARB"))
+	gpGetVertexAttribLui64vNV = (C.GPGETVERTEXATTRIBLUI64VNV)(getProcAddr("glGetVertexAttribLui64vNV"))
 	gpGetVertexAttribPointerv = (C.GPGETVERTEXATTRIBPOINTERV)(getProcAddr("glGetVertexAttribPointerv"))
 	if gpGetVertexAttribPointerv == nil {
 		return errors.New("glGetVertexAttribPointerv")
@@ -8929,15 +14105,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetVertexAttribiv == nil {
 		return errors.New("glGetVertexAttribiv")
 	}
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnCompressedTexImageARB = (C.GPGETNCOMPRESSEDTEXIMAGEARB)(getProcAddr("glGetnCompressedTexImageARB"))
 	gpGetnTexImageARB = (C.GPGETNTEXIMAGEARB)(getProcAddr("glGetnTexImageARB"))
 	gpGetnUniformdvARB = (C.GPGETNUNIFORMDVARB)(getProcAddr("glGetnUniformdvARB"))
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	gpGetnUniformuivARB = (C.GPGETNUNIFORMUIVARB)(getProcAddr("glGetnUniformuivARB"))
 	gpGetnUniformuivKHR = (C.GPGETNUNIFORMUIVKHR)(getProcAddr("glGetnUniformuivKHR"))
@@ -8945,6 +14124,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpHint == nil {
 		return errors.New("glHint")
 	}
+	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
+	gpInsertEventMarkerEXT = (C.GPINSERTEVENTMARKEREXT)(getProcAddr("glInsertEventMarkerEXT"))
+	gpInterpolatePathsNV = (C.GPINTERPOLATEPATHSNV)(getProcAddr("glInterpolatePathsNV"))
 	gpInvalidateBufferData = (C.GPINVALIDATEBUFFERDATA)(getProcAddr("glInvalidateBufferData"))
 	gpInvalidateBufferSubData = (C.GPINVALIDATEBUFFERSUBDATA)(getProcAddr("glInvalidateBufferSubData"))
 	gpInvalidateFramebuffer = (C.GPINVALIDATEFRAMEBUFFER)(getProcAddr("glInvalidateFramebuffer"))
@@ -8957,10 +14139,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsBuffer == nil {
 		return errors.New("glIsBuffer")
 	}
+	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
 	}
+	gpIsEnabledIndexedEXT = (C.GPISENABLEDINDEXEDEXT)(getProcAddr("glIsEnabledIndexedEXT"))
 	gpIsEnabledi = (C.GPISENABLEDI)(getProcAddr("glIsEnabledi"))
 	if gpIsEnabledi == nil {
 		return errors.New("glIsEnabledi")
@@ -8970,12 +14155,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsFramebuffer")
 	}
 	gpIsImageHandleResidentARB = (C.GPISIMAGEHANDLERESIDENTARB)(getProcAddr("glIsImageHandleResidentARB"))
+	gpIsImageHandleResidentNV = (C.GPISIMAGEHANDLERESIDENTNV)(getProcAddr("glIsImageHandleResidentNV"))
+	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
+	gpIsPathNV = (C.GPISPATHNV)(getProcAddr("glIsPathNV"))
+	gpIsPointInFillPathNV = (C.GPISPOINTINFILLPATHNV)(getProcAddr("glIsPointInFillPathNV"))
+	gpIsPointInStrokePathNV = (C.GPISPOINTINSTROKEPATHNV)(getProcAddr("glIsPointInStrokePathNV"))
 	gpIsProgram = (C.GPISPROGRAM)(getProcAddr("glIsProgram"))
 	if gpIsProgram == nil {
 		return errors.New("glIsProgram")
 	}
 	gpIsProgramPipeline = (C.GPISPROGRAMPIPELINE)(getProcAddr("glIsProgramPipeline"))
+	gpIsProgramPipelineEXT = (C.GPISPROGRAMPIPELINEEXT)(getProcAddr("glIsProgramPipelineEXT"))
 	gpIsQuery = (C.GPISQUERY)(getProcAddr("glIsQuery"))
 	if gpIsQuery == nil {
 		return errors.New("glIsQuery")
@@ -8989,6 +14180,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	if gpIsSync == nil {
 		return errors.New("glIsSync")
@@ -8998,11 +14190,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsTexture")
 	}
 	gpIsTextureHandleResidentARB = (C.GPISTEXTUREHANDLERESIDENTARB)(getProcAddr("glIsTextureHandleResidentARB"))
+	gpIsTextureHandleResidentNV = (C.GPISTEXTUREHANDLERESIDENTNV)(getProcAddr("glIsTextureHandleResidentNV"))
 	gpIsTransformFeedback = (C.GPISTRANSFORMFEEDBACK)(getProcAddr("glIsTransformFeedback"))
 	gpIsVertexArray = (C.GPISVERTEXARRAY)(getProcAddr("glIsVertexArray"))
 	if gpIsVertexArray == nil {
 		return errors.New("glIsVertexArray")
 	}
+	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLineWidth = (C.GPLINEWIDTH)(getProcAddr("glLineWidth"))
 	if gpLineWidth == nil {
 		return errors.New("glLineWidth")
@@ -9011,14 +14205,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpLinkProgram == nil {
 		return errors.New("glLinkProgram")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpLogicOp = (C.GPLOGICOP)(getProcAddr("glLogicOp"))
 	if gpLogicOp == nil {
 		return errors.New("glLogicOp")
 	}
+	gpMakeBufferNonResidentNV = (C.GPMAKEBUFFERNONRESIDENTNV)(getProcAddr("glMakeBufferNonResidentNV"))
+	gpMakeBufferResidentNV = (C.GPMAKEBUFFERRESIDENTNV)(getProcAddr("glMakeBufferResidentNV"))
 	gpMakeImageHandleNonResidentARB = (C.GPMAKEIMAGEHANDLENONRESIDENTARB)(getProcAddr("glMakeImageHandleNonResidentARB"))
+	gpMakeImageHandleNonResidentNV = (C.GPMAKEIMAGEHANDLENONRESIDENTNV)(getProcAddr("glMakeImageHandleNonResidentNV"))
 	gpMakeImageHandleResidentARB = (C.GPMAKEIMAGEHANDLERESIDENTARB)(getProcAddr("glMakeImageHandleResidentARB"))
+	gpMakeImageHandleResidentNV = (C.GPMAKEIMAGEHANDLERESIDENTNV)(getProcAddr("glMakeImageHandleResidentNV"))
+	gpMakeNamedBufferNonResidentNV = (C.GPMAKENAMEDBUFFERNONRESIDENTNV)(getProcAddr("glMakeNamedBufferNonResidentNV"))
+	gpMakeNamedBufferResidentNV = (C.GPMAKENAMEDBUFFERRESIDENTNV)(getProcAddr("glMakeNamedBufferResidentNV"))
 	gpMakeTextureHandleNonResidentARB = (C.GPMAKETEXTUREHANDLENONRESIDENTARB)(getProcAddr("glMakeTextureHandleNonResidentARB"))
+	gpMakeTextureHandleNonResidentNV = (C.GPMAKETEXTUREHANDLENONRESIDENTNV)(getProcAddr("glMakeTextureHandleNonResidentNV"))
 	gpMakeTextureHandleResidentARB = (C.GPMAKETEXTUREHANDLERESIDENTARB)(getProcAddr("glMakeTextureHandleResidentARB"))
+	gpMakeTextureHandleResidentNV = (C.GPMAKETEXTUREHANDLERESIDENTNV)(getProcAddr("glMakeTextureHandleResidentNV"))
 	gpMapBuffer = (C.GPMAPBUFFER)(getProcAddr("glMapBuffer"))
 	if gpMapBuffer == nil {
 		return errors.New("glMapBuffer")
@@ -9028,7 +14231,36 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMapBufferRange")
 	}
 	gpMapNamedBuffer = (C.GPMAPNAMEDBUFFER)(getProcAddr("glMapNamedBuffer"))
+	gpMapNamedBufferEXT = (C.GPMAPNAMEDBUFFEREXT)(getProcAddr("glMapNamedBufferEXT"))
 	gpMapNamedBufferRange = (C.GPMAPNAMEDBUFFERRANGE)(getProcAddr("glMapNamedBufferRange"))
+	gpMapNamedBufferRangeEXT = (C.GPMAPNAMEDBUFFERRANGEEXT)(getProcAddr("glMapNamedBufferRangeEXT"))
+	gpMatrixFrustumEXT = (C.GPMATRIXFRUSTUMEXT)(getProcAddr("glMatrixFrustumEXT"))
+	gpMatrixLoad3x2fNV = (C.GPMATRIXLOAD3X2FNV)(getProcAddr("glMatrixLoad3x2fNV"))
+	gpMatrixLoad3x3fNV = (C.GPMATRIXLOAD3X3FNV)(getProcAddr("glMatrixLoad3x3fNV"))
+	gpMatrixLoadIdentityEXT = (C.GPMATRIXLOADIDENTITYEXT)(getProcAddr("glMatrixLoadIdentityEXT"))
+	gpMatrixLoadTranspose3x3fNV = (C.GPMATRIXLOADTRANSPOSE3X3FNV)(getProcAddr("glMatrixLoadTranspose3x3fNV"))
+	gpMatrixLoadTransposedEXT = (C.GPMATRIXLOADTRANSPOSEDEXT)(getProcAddr("glMatrixLoadTransposedEXT"))
+	gpMatrixLoadTransposefEXT = (C.GPMATRIXLOADTRANSPOSEFEXT)(getProcAddr("glMatrixLoadTransposefEXT"))
+	gpMatrixLoaddEXT = (C.GPMATRIXLOADDEXT)(getProcAddr("glMatrixLoaddEXT"))
+	gpMatrixLoadfEXT = (C.GPMATRIXLOADFEXT)(getProcAddr("glMatrixLoadfEXT"))
+	gpMatrixMult3x2fNV = (C.GPMATRIXMULT3X2FNV)(getProcAddr("glMatrixMult3x2fNV"))
+	gpMatrixMult3x3fNV = (C.GPMATRIXMULT3X3FNV)(getProcAddr("glMatrixMult3x3fNV"))
+	gpMatrixMultTranspose3x3fNV = (C.GPMATRIXMULTTRANSPOSE3X3FNV)(getProcAddr("glMatrixMultTranspose3x3fNV"))
+	gpMatrixMultTransposedEXT = (C.GPMATRIXMULTTRANSPOSEDEXT)(getProcAddr("glMatrixMultTransposedEXT"))
+	gpMatrixMultTransposefEXT = (C.GPMATRIXMULTTRANSPOSEFEXT)(getProcAddr("glMatrixMultTransposefEXT"))
+	gpMatrixMultdEXT = (C.GPMATRIXMULTDEXT)(getProcAddr("glMatrixMultdEXT"))
+	gpMatrixMultfEXT = (C.GPMATRIXMULTFEXT)(getProcAddr("glMatrixMultfEXT"))
+	gpMatrixOrthoEXT = (C.GPMATRIXORTHOEXT)(getProcAddr("glMatrixOrthoEXT"))
+	gpMatrixPopEXT = (C.GPMATRIXPOPEXT)(getProcAddr("glMatrixPopEXT"))
+	gpMatrixPushEXT = (C.GPMATRIXPUSHEXT)(getProcAddr("glMatrixPushEXT"))
+	gpMatrixRotatedEXT = (C.GPMATRIXROTATEDEXT)(getProcAddr("glMatrixRotatedEXT"))
+	gpMatrixRotatefEXT = (C.GPMATRIXROTATEFEXT)(getProcAddr("glMatrixRotatefEXT"))
+	gpMatrixScaledEXT = (C.GPMATRIXSCALEDEXT)(getProcAddr("glMatrixScaledEXT"))
+	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
+	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
+	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	gpMemoryBarrierByRegion = (C.GPMEMORYBARRIERBYREGION)(getProcAddr("glMemoryBarrierByRegion"))
 	gpMinSampleShadingARB = (C.GPMINSAMPLESHADINGARB)(getProcAddr("glMinSampleShadingARB"))
@@ -9037,6 +14269,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMultiDrawArrays")
 	}
 	gpMultiDrawArraysIndirect = (C.GPMULTIDRAWARRAYSINDIRECT)(getProcAddr("glMultiDrawArraysIndirect"))
+	gpMultiDrawArraysIndirectBindlessCountNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawArraysIndirectBindlessCountNV"))
+	gpMultiDrawArraysIndirectBindlessNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawArraysIndirectBindlessNV"))
 	gpMultiDrawArraysIndirectCountARB = (C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawArraysIndirectCountARB"))
 	gpMultiDrawElements = (C.GPMULTIDRAWELEMENTS)(getProcAddr("glMultiDrawElements"))
 	if gpMultiDrawElements == nil {
@@ -9047,28 +14281,103 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMultiDrawElementsBaseVertex")
 	}
 	gpMultiDrawElementsIndirect = (C.GPMULTIDRAWELEMENTSINDIRECT)(getProcAddr("glMultiDrawElementsIndirect"))
+	gpMultiDrawElementsIndirectBindlessCountNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawElementsIndirectBindlessCountNV"))
+	gpMultiDrawElementsIndirectBindlessNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawElementsIndirectBindlessNV"))
 	gpMultiDrawElementsIndirectCountARB = (C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawElementsIndirectCountARB"))
+	gpMultiTexBufferEXT = (C.GPMULTITEXBUFFEREXT)(getProcAddr("glMultiTexBufferEXT"))
+	gpMultiTexCoordPointerEXT = (C.GPMULTITEXCOORDPOINTEREXT)(getProcAddr("glMultiTexCoordPointerEXT"))
+	gpMultiTexEnvfEXT = (C.GPMULTITEXENVFEXT)(getProcAddr("glMultiTexEnvfEXT"))
+	gpMultiTexEnvfvEXT = (C.GPMULTITEXENVFVEXT)(getProcAddr("glMultiTexEnvfvEXT"))
+	gpMultiTexEnviEXT = (C.GPMULTITEXENVIEXT)(getProcAddr("glMultiTexEnviEXT"))
+	gpMultiTexEnvivEXT = (C.GPMULTITEXENVIVEXT)(getProcAddr("glMultiTexEnvivEXT"))
+	gpMultiTexGendEXT = (C.GPMULTITEXGENDEXT)(getProcAddr("glMultiTexGendEXT"))
+	gpMultiTexGendvEXT = (C.GPMULTITEXGENDVEXT)(getProcAddr("glMultiTexGendvEXT"))
+	gpMultiTexGenfEXT = (C.GPMULTITEXGENFEXT)(getProcAddr("glMultiTexGenfEXT"))
+	gpMultiTexGenfvEXT = (C.GPMULTITEXGENFVEXT)(getProcAddr("glMultiTexGenfvEXT"))
+	gpMultiTexGeniEXT = (C.GPMULTITEXGENIEXT)(getProcAddr("glMultiTexGeniEXT"))
+	gpMultiTexGenivEXT = (C.GPMULTITEXGENIVEXT)(getProcAddr("glMultiTexGenivEXT"))
+	gpMultiTexImage1DEXT = (C.GPMULTITEXIMAGE1DEXT)(getProcAddr("glMultiTexImage1DEXT"))
+	gpMultiTexImage2DEXT = (C.GPMULTITEXIMAGE2DEXT)(getProcAddr("glMultiTexImage2DEXT"))
+	gpMultiTexImage3DEXT = (C.GPMULTITEXIMAGE3DEXT)(getProcAddr("glMultiTexImage3DEXT"))
+	gpMultiTexParameterIivEXT = (C.GPMULTITEXPARAMETERIIVEXT)(getProcAddr("glMultiTexParameterIivEXT"))
+	gpMultiTexParameterIuivEXT = (C.GPMULTITEXPARAMETERIUIVEXT)(getProcAddr("glMultiTexParameterIuivEXT"))
+	gpMultiTexParameterfEXT = (C.GPMULTITEXPARAMETERFEXT)(getProcAddr("glMultiTexParameterfEXT"))
+	gpMultiTexParameterfvEXT = (C.GPMULTITEXPARAMETERFVEXT)(getProcAddr("glMultiTexParameterfvEXT"))
+	gpMultiTexParameteriEXT = (C.GPMULTITEXPARAMETERIEXT)(getProcAddr("glMultiTexParameteriEXT"))
+	gpMultiTexParameterivEXT = (C.GPMULTITEXPARAMETERIVEXT)(getProcAddr("glMultiTexParameterivEXT"))
+	gpMultiTexRenderbufferEXT = (C.GPMULTITEXRENDERBUFFEREXT)(getProcAddr("glMultiTexRenderbufferEXT"))
+	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
+	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
+	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
+	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
+	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
+	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
+	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
 	gpNamedFramebufferDrawBuffer = (C.GPNAMEDFRAMEBUFFERDRAWBUFFER)(getProcAddr("glNamedFramebufferDrawBuffer"))
 	gpNamedFramebufferDrawBuffers = (C.GPNAMEDFRAMEBUFFERDRAWBUFFERS)(getProcAddr("glNamedFramebufferDrawBuffers"))
 	gpNamedFramebufferParameteri = (C.GPNAMEDFRAMEBUFFERPARAMETERI)(getProcAddr("glNamedFramebufferParameteri"))
+	gpNamedFramebufferParameteriEXT = (C.GPNAMEDFRAMEBUFFERPARAMETERIEXT)(getProcAddr("glNamedFramebufferParameteriEXT"))
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	gpNamedFramebufferRenderbuffer = (C.GPNAMEDFRAMEBUFFERRENDERBUFFER)(getProcAddr("glNamedFramebufferRenderbuffer"))
+	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
+	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
+	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
+	gpNamedFramebufferTexture3DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(getProcAddr("glNamedFramebufferTexture3DEXT"))
+	gpNamedFramebufferTextureEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREEXT)(getProcAddr("glNamedFramebufferTextureEXT"))
+	gpNamedFramebufferTextureFaceEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(getProcAddr("glNamedFramebufferTextureFaceEXT"))
 	gpNamedFramebufferTextureLayer = (C.GPNAMEDFRAMEBUFFERTEXTURELAYER)(getProcAddr("glNamedFramebufferTextureLayer"))
+	gpNamedFramebufferTextureLayerEXT = (C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glNamedFramebufferTextureLayerEXT"))
+	gpNamedProgramLocalParameter4dEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(getProcAddr("glNamedProgramLocalParameter4dEXT"))
+	gpNamedProgramLocalParameter4dvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(getProcAddr("glNamedProgramLocalParameter4dvEXT"))
+	gpNamedProgramLocalParameter4fEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(getProcAddr("glNamedProgramLocalParameter4fEXT"))
+	gpNamedProgramLocalParameter4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(getProcAddr("glNamedProgramLocalParameter4fvEXT"))
+	gpNamedProgramLocalParameterI4iEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(getProcAddr("glNamedProgramLocalParameterI4iEXT"))
+	gpNamedProgramLocalParameterI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(getProcAddr("glNamedProgramLocalParameterI4ivEXT"))
+	gpNamedProgramLocalParameterI4uiEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(getProcAddr("glNamedProgramLocalParameterI4uiEXT"))
+	gpNamedProgramLocalParameterI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(getProcAddr("glNamedProgramLocalParameterI4uivEXT"))
+	gpNamedProgramLocalParameters4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(getProcAddr("glNamedProgramLocalParameters4fvEXT"))
+	gpNamedProgramLocalParametersI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(getProcAddr("glNamedProgramLocalParametersI4ivEXT"))
+	gpNamedProgramLocalParametersI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(getProcAddr("glNamedProgramLocalParametersI4uivEXT"))
+	gpNamedProgramStringEXT = (C.GPNAMEDPROGRAMSTRINGEXT)(getProcAddr("glNamedProgramStringEXT"))
 	gpNamedRenderbufferStorage = (C.GPNAMEDRENDERBUFFERSTORAGE)(getProcAddr("glNamedRenderbufferStorage"))
+	gpNamedRenderbufferStorageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEEXT)(getProcAddr("glNamedRenderbufferStorageEXT"))
 	gpNamedRenderbufferStorageMultisample = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(getProcAddr("glNamedRenderbufferStorageMultisample"))
+	gpNamedRenderbufferStorageMultisampleCoverageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleCoverageEXT"))
+	gpNamedRenderbufferStorageMultisampleEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleEXT"))
 	gpNamedStringARB = (C.GPNAMEDSTRINGARB)(getProcAddr("glNamedStringARB"))
+	gpNormalFormatNV = (C.GPNORMALFORMATNV)(getProcAddr("glNormalFormatNV"))
 	gpObjectLabel = (C.GPOBJECTLABEL)(getProcAddr("glObjectLabel"))
 	gpObjectLabelKHR = (C.GPOBJECTLABELKHR)(getProcAddr("glObjectLabelKHR"))
 	gpObjectPtrLabel = (C.GPOBJECTPTRLABEL)(getProcAddr("glObjectPtrLabel"))
 	gpObjectPtrLabelKHR = (C.GPOBJECTPTRLABELKHR)(getProcAddr("glObjectPtrLabelKHR"))
 	gpPatchParameterfv = (C.GPPATCHPARAMETERFV)(getProcAddr("glPatchParameterfv"))
 	gpPatchParameteri = (C.GPPATCHPARAMETERI)(getProcAddr("glPatchParameteri"))
+	gpPathCommandsNV = (C.GPPATHCOMMANDSNV)(getProcAddr("glPathCommandsNV"))
+	gpPathCoordsNV = (C.GPPATHCOORDSNV)(getProcAddr("glPathCoordsNV"))
+	gpPathCoverDepthFuncNV = (C.GPPATHCOVERDEPTHFUNCNV)(getProcAddr("glPathCoverDepthFuncNV"))
+	gpPathDashArrayNV = (C.GPPATHDASHARRAYNV)(getProcAddr("glPathDashArrayNV"))
+	gpPathGlyphIndexArrayNV = (C.GPPATHGLYPHINDEXARRAYNV)(getProcAddr("glPathGlyphIndexArrayNV"))
+	gpPathGlyphIndexRangeNV = (C.GPPATHGLYPHINDEXRANGENV)(getProcAddr("glPathGlyphIndexRangeNV"))
+	gpPathGlyphRangeNV = (C.GPPATHGLYPHRANGENV)(getProcAddr("glPathGlyphRangeNV"))
+	gpPathGlyphsNV = (C.GPPATHGLYPHSNV)(getProcAddr("glPathGlyphsNV"))
+	gpPathMemoryGlyphIndexArrayNV = (C.GPPATHMEMORYGLYPHINDEXARRAYNV)(getProcAddr("glPathMemoryGlyphIndexArrayNV"))
+	gpPathParameterfNV = (C.GPPATHPARAMETERFNV)(getProcAddr("glPathParameterfNV"))
+	gpPathParameterfvNV = (C.GPPATHPARAMETERFVNV)(getProcAddr("glPathParameterfvNV"))
+	gpPathParameteriNV = (C.GPPATHPARAMETERINV)(getProcAddr("glPathParameteriNV"))
+	gpPathParameterivNV = (C.GPPATHPARAMETERIVNV)(getProcAddr("glPathParameterivNV"))
+	gpPathStencilDepthOffsetNV = (C.GPPATHSTENCILDEPTHOFFSETNV)(getProcAddr("glPathStencilDepthOffsetNV"))
+	gpPathStencilFuncNV = (C.GPPATHSTENCILFUNCNV)(getProcAddr("glPathStencilFuncNV"))
+	gpPathStringNV = (C.GPPATHSTRINGNV)(getProcAddr("glPathStringNV"))
+	gpPathSubCommandsNV = (C.GPPATHSUBCOMMANDSNV)(getProcAddr("glPathSubCommandsNV"))
+	gpPathSubCoordsNV = (C.GPPATHSUBCOORDSNV)(getProcAddr("glPathSubCoordsNV"))
 	gpPauseTransformFeedback = (C.GPPAUSETRANSFORMFEEDBACK)(getProcAddr("glPauseTransformFeedback"))
 	gpPixelStoref = (C.GPPIXELSTOREF)(getProcAddr("glPixelStoref"))
 	if gpPixelStoref == nil {
@@ -9078,6 +14387,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPixelStorei == nil {
 		return errors.New("glPixelStorei")
 	}
+	gpPointAlongPathNV = (C.GPPOINTALONGPATHNV)(getProcAddr("glPointAlongPathNV"))
 	gpPointParameterf = (C.GPPOINTPARAMETERF)(getProcAddr("glPointParameterf"))
 	if gpPointParameterf == nil {
 		return errors.New("glPointParameterf")
@@ -9106,73 +14416,169 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPopDebugGroup = (C.GPPOPDEBUGGROUP)(getProcAddr("glPopDebugGroup"))
 	gpPopDebugGroupKHR = (C.GPPOPDEBUGGROUPKHR)(getProcAddr("glPopDebugGroupKHR"))
+	gpPopGroupMarkerEXT = (C.GPPOPGROUPMARKEREXT)(getProcAddr("glPopGroupMarkerEXT"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	if gpPrimitiveRestartIndex == nil {
 		return errors.New("glPrimitiveRestartIndex")
 	}
 	gpProgramBinary = (C.GPPROGRAMBINARY)(getProcAddr("glProgramBinary"))
 	gpProgramParameteri = (C.GPPROGRAMPARAMETERI)(getProcAddr("glProgramParameteri"))
+	gpProgramParameteriARB = (C.GPPROGRAMPARAMETERIARB)(getProcAddr("glProgramParameteriARB"))
+	gpProgramParameteriEXT = (C.GPPROGRAMPARAMETERIEXT)(getProcAddr("glProgramParameteriEXT"))
+	gpProgramPathFragmentInputGenNV = (C.GPPROGRAMPATHFRAGMENTINPUTGENNV)(getProcAddr("glProgramPathFragmentInputGenNV"))
 	gpProgramUniform1d = (C.GPPROGRAMUNIFORM1D)(getProcAddr("glProgramUniform1d"))
+	gpProgramUniform1dEXT = (C.GPPROGRAMUNIFORM1DEXT)(getProcAddr("glProgramUniform1dEXT"))
 	gpProgramUniform1dv = (C.GPPROGRAMUNIFORM1DV)(getProcAddr("glProgramUniform1dv"))
+	gpProgramUniform1dvEXT = (C.GPPROGRAMUNIFORM1DVEXT)(getProcAddr("glProgramUniform1dvEXT"))
 	gpProgramUniform1f = (C.GPPROGRAMUNIFORM1F)(getProcAddr("glProgramUniform1f"))
+	gpProgramUniform1fEXT = (C.GPPROGRAMUNIFORM1FEXT)(getProcAddr("glProgramUniform1fEXT"))
 	gpProgramUniform1fv = (C.GPPROGRAMUNIFORM1FV)(getProcAddr("glProgramUniform1fv"))
+	gpProgramUniform1fvEXT = (C.GPPROGRAMUNIFORM1FVEXT)(getProcAddr("glProgramUniform1fvEXT"))
 	gpProgramUniform1i = (C.GPPROGRAMUNIFORM1I)(getProcAddr("glProgramUniform1i"))
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
+	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
+	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
+	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
+	gpProgramUniform1ivEXT = (C.GPPROGRAMUNIFORM1IVEXT)(getProcAddr("glProgramUniform1ivEXT"))
 	gpProgramUniform1ui = (C.GPPROGRAMUNIFORM1UI)(getProcAddr("glProgramUniform1ui"))
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
+	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
+	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
+	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
+	gpProgramUniform1uivEXT = (C.GPPROGRAMUNIFORM1UIVEXT)(getProcAddr("glProgramUniform1uivEXT"))
 	gpProgramUniform2d = (C.GPPROGRAMUNIFORM2D)(getProcAddr("glProgramUniform2d"))
+	gpProgramUniform2dEXT = (C.GPPROGRAMUNIFORM2DEXT)(getProcAddr("glProgramUniform2dEXT"))
 	gpProgramUniform2dv = (C.GPPROGRAMUNIFORM2DV)(getProcAddr("glProgramUniform2dv"))
+	gpProgramUniform2dvEXT = (C.GPPROGRAMUNIFORM2DVEXT)(getProcAddr("glProgramUniform2dvEXT"))
 	gpProgramUniform2f = (C.GPPROGRAMUNIFORM2F)(getProcAddr("glProgramUniform2f"))
+	gpProgramUniform2fEXT = (C.GPPROGRAMUNIFORM2FEXT)(getProcAddr("glProgramUniform2fEXT"))
 	gpProgramUniform2fv = (C.GPPROGRAMUNIFORM2FV)(getProcAddr("glProgramUniform2fv"))
+	gpProgramUniform2fvEXT = (C.GPPROGRAMUNIFORM2FVEXT)(getProcAddr("glProgramUniform2fvEXT"))
 	gpProgramUniform2i = (C.GPPROGRAMUNIFORM2I)(getProcAddr("glProgramUniform2i"))
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
+	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
+	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
+	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
+	gpProgramUniform2ivEXT = (C.GPPROGRAMUNIFORM2IVEXT)(getProcAddr("glProgramUniform2ivEXT"))
 	gpProgramUniform2ui = (C.GPPROGRAMUNIFORM2UI)(getProcAddr("glProgramUniform2ui"))
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
+	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
+	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
+	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
+	gpProgramUniform2uivEXT = (C.GPPROGRAMUNIFORM2UIVEXT)(getProcAddr("glProgramUniform2uivEXT"))
 	gpProgramUniform3d = (C.GPPROGRAMUNIFORM3D)(getProcAddr("glProgramUniform3d"))
+	gpProgramUniform3dEXT = (C.GPPROGRAMUNIFORM3DEXT)(getProcAddr("glProgramUniform3dEXT"))
 	gpProgramUniform3dv = (C.GPPROGRAMUNIFORM3DV)(getProcAddr("glProgramUniform3dv"))
+	gpProgramUniform3dvEXT = (C.GPPROGRAMUNIFORM3DVEXT)(getProcAddr("glProgramUniform3dvEXT"))
 	gpProgramUniform3f = (C.GPPROGRAMUNIFORM3F)(getProcAddr("glProgramUniform3f"))
+	gpProgramUniform3fEXT = (C.GPPROGRAMUNIFORM3FEXT)(getProcAddr("glProgramUniform3fEXT"))
 	gpProgramUniform3fv = (C.GPPROGRAMUNIFORM3FV)(getProcAddr("glProgramUniform3fv"))
+	gpProgramUniform3fvEXT = (C.GPPROGRAMUNIFORM3FVEXT)(getProcAddr("glProgramUniform3fvEXT"))
 	gpProgramUniform3i = (C.GPPROGRAMUNIFORM3I)(getProcAddr("glProgramUniform3i"))
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
+	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
+	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
+	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
+	gpProgramUniform3ivEXT = (C.GPPROGRAMUNIFORM3IVEXT)(getProcAddr("glProgramUniform3ivEXT"))
 	gpProgramUniform3ui = (C.GPPROGRAMUNIFORM3UI)(getProcAddr("glProgramUniform3ui"))
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
+	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
+	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
+	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
+	gpProgramUniform3uivEXT = (C.GPPROGRAMUNIFORM3UIVEXT)(getProcAddr("glProgramUniform3uivEXT"))
 	gpProgramUniform4d = (C.GPPROGRAMUNIFORM4D)(getProcAddr("glProgramUniform4d"))
+	gpProgramUniform4dEXT = (C.GPPROGRAMUNIFORM4DEXT)(getProcAddr("glProgramUniform4dEXT"))
 	gpProgramUniform4dv = (C.GPPROGRAMUNIFORM4DV)(getProcAddr("glProgramUniform4dv"))
+	gpProgramUniform4dvEXT = (C.GPPROGRAMUNIFORM4DVEXT)(getProcAddr("glProgramUniform4dvEXT"))
 	gpProgramUniform4f = (C.GPPROGRAMUNIFORM4F)(getProcAddr("glProgramUniform4f"))
+	gpProgramUniform4fEXT = (C.GPPROGRAMUNIFORM4FEXT)(getProcAddr("glProgramUniform4fEXT"))
 	gpProgramUniform4fv = (C.GPPROGRAMUNIFORM4FV)(getProcAddr("glProgramUniform4fv"))
+	gpProgramUniform4fvEXT = (C.GPPROGRAMUNIFORM4FVEXT)(getProcAddr("glProgramUniform4fvEXT"))
 	gpProgramUniform4i = (C.GPPROGRAMUNIFORM4I)(getProcAddr("glProgramUniform4i"))
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
+	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
+	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
+	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
+	gpProgramUniform4ivEXT = (C.GPPROGRAMUNIFORM4IVEXT)(getProcAddr("glProgramUniform4ivEXT"))
 	gpProgramUniform4ui = (C.GPPROGRAMUNIFORM4UI)(getProcAddr("glProgramUniform4ui"))
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
+	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
+	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
+	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
+	gpProgramUniform4uivEXT = (C.GPPROGRAMUNIFORM4UIVEXT)(getProcAddr("glProgramUniform4uivEXT"))
 	gpProgramUniformHandleui64ARB = (C.GPPROGRAMUNIFORMHANDLEUI64ARB)(getProcAddr("glProgramUniformHandleui64ARB"))
+	gpProgramUniformHandleui64NV = (C.GPPROGRAMUNIFORMHANDLEUI64NV)(getProcAddr("glProgramUniformHandleui64NV"))
 	gpProgramUniformHandleui64vARB = (C.GPPROGRAMUNIFORMHANDLEUI64VARB)(getProcAddr("glProgramUniformHandleui64vARB"))
+	gpProgramUniformHandleui64vNV = (C.GPPROGRAMUNIFORMHANDLEUI64VNV)(getProcAddr("glProgramUniformHandleui64vNV"))
 	gpProgramUniformMatrix2dv = (C.GPPROGRAMUNIFORMMATRIX2DV)(getProcAddr("glProgramUniformMatrix2dv"))
+	gpProgramUniformMatrix2dvEXT = (C.GPPROGRAMUNIFORMMATRIX2DVEXT)(getProcAddr("glProgramUniformMatrix2dvEXT"))
 	gpProgramUniformMatrix2fv = (C.GPPROGRAMUNIFORMMATRIX2FV)(getProcAddr("glProgramUniformMatrix2fv"))
+	gpProgramUniformMatrix2fvEXT = (C.GPPROGRAMUNIFORMMATRIX2FVEXT)(getProcAddr("glProgramUniformMatrix2fvEXT"))
 	gpProgramUniformMatrix2x3dv = (C.GPPROGRAMUNIFORMMATRIX2X3DV)(getProcAddr("glProgramUniformMatrix2x3dv"))
+	gpProgramUniformMatrix2x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3DVEXT)(getProcAddr("glProgramUniformMatrix2x3dvEXT"))
 	gpProgramUniformMatrix2x3fv = (C.GPPROGRAMUNIFORMMATRIX2X3FV)(getProcAddr("glProgramUniformMatrix2x3fv"))
+	gpProgramUniformMatrix2x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3FVEXT)(getProcAddr("glProgramUniformMatrix2x3fvEXT"))
 	gpProgramUniformMatrix2x4dv = (C.GPPROGRAMUNIFORMMATRIX2X4DV)(getProcAddr("glProgramUniformMatrix2x4dv"))
+	gpProgramUniformMatrix2x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4DVEXT)(getProcAddr("glProgramUniformMatrix2x4dvEXT"))
 	gpProgramUniformMatrix2x4fv = (C.GPPROGRAMUNIFORMMATRIX2X4FV)(getProcAddr("glProgramUniformMatrix2x4fv"))
+	gpProgramUniformMatrix2x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4FVEXT)(getProcAddr("glProgramUniformMatrix2x4fvEXT"))
 	gpProgramUniformMatrix3dv = (C.GPPROGRAMUNIFORMMATRIX3DV)(getProcAddr("glProgramUniformMatrix3dv"))
+	gpProgramUniformMatrix3dvEXT = (C.GPPROGRAMUNIFORMMATRIX3DVEXT)(getProcAddr("glProgramUniformMatrix3dvEXT"))
 	gpProgramUniformMatrix3fv = (C.GPPROGRAMUNIFORMMATRIX3FV)(getProcAddr("glProgramUniformMatrix3fv"))
+	gpProgramUniformMatrix3fvEXT = (C.GPPROGRAMUNIFORMMATRIX3FVEXT)(getProcAddr("glProgramUniformMatrix3fvEXT"))
 	gpProgramUniformMatrix3x2dv = (C.GPPROGRAMUNIFORMMATRIX3X2DV)(getProcAddr("glProgramUniformMatrix3x2dv"))
+	gpProgramUniformMatrix3x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2DVEXT)(getProcAddr("glProgramUniformMatrix3x2dvEXT"))
 	gpProgramUniformMatrix3x2fv = (C.GPPROGRAMUNIFORMMATRIX3X2FV)(getProcAddr("glProgramUniformMatrix3x2fv"))
+	gpProgramUniformMatrix3x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2FVEXT)(getProcAddr("glProgramUniformMatrix3x2fvEXT"))
 	gpProgramUniformMatrix3x4dv = (C.GPPROGRAMUNIFORMMATRIX3X4DV)(getProcAddr("glProgramUniformMatrix3x4dv"))
+	gpProgramUniformMatrix3x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4DVEXT)(getProcAddr("glProgramUniformMatrix3x4dvEXT"))
 	gpProgramUniformMatrix3x4fv = (C.GPPROGRAMUNIFORMMATRIX3X4FV)(getProcAddr("glProgramUniformMatrix3x4fv"))
+	gpProgramUniformMatrix3x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4FVEXT)(getProcAddr("glProgramUniformMatrix3x4fvEXT"))
 	gpProgramUniformMatrix4dv = (C.GPPROGRAMUNIFORMMATRIX4DV)(getProcAddr("glProgramUniformMatrix4dv"))
+	gpProgramUniformMatrix4dvEXT = (C.GPPROGRAMUNIFORMMATRIX4DVEXT)(getProcAddr("glProgramUniformMatrix4dvEXT"))
 	gpProgramUniformMatrix4fv = (C.GPPROGRAMUNIFORMMATRIX4FV)(getProcAddr("glProgramUniformMatrix4fv"))
+	gpProgramUniformMatrix4fvEXT = (C.GPPROGRAMUNIFORMMATRIX4FVEXT)(getProcAddr("glProgramUniformMatrix4fvEXT"))
 	gpProgramUniformMatrix4x2dv = (C.GPPROGRAMUNIFORMMATRIX4X2DV)(getProcAddr("glProgramUniformMatrix4x2dv"))
+	gpProgramUniformMatrix4x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2DVEXT)(getProcAddr("glProgramUniformMatrix4x2dvEXT"))
 	gpProgramUniformMatrix4x2fv = (C.GPPROGRAMUNIFORMMATRIX4X2FV)(getProcAddr("glProgramUniformMatrix4x2fv"))
+	gpProgramUniformMatrix4x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2FVEXT)(getProcAddr("glProgramUniformMatrix4x2fvEXT"))
 	gpProgramUniformMatrix4x3dv = (C.GPPROGRAMUNIFORMMATRIX4X3DV)(getProcAddr("glProgramUniformMatrix4x3dv"))
+	gpProgramUniformMatrix4x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3DVEXT)(getProcAddr("glProgramUniformMatrix4x3dvEXT"))
 	gpProgramUniformMatrix4x3fv = (C.GPPROGRAMUNIFORMMATRIX4X3FV)(getProcAddr("glProgramUniformMatrix4x3fv"))
+	gpProgramUniformMatrix4x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3FVEXT)(getProcAddr("glProgramUniformMatrix4x3fvEXT"))
+	gpProgramUniformui64NV = (C.GPPROGRAMUNIFORMUI64NV)(getProcAddr("glProgramUniformui64NV"))
+	gpProgramUniformui64vNV = (C.GPPROGRAMUNIFORMUI64VNV)(getProcAddr("glProgramUniformui64vNV"))
 	gpProvokingVertex = (C.GPPROVOKINGVERTEX)(getProcAddr("glProvokingVertex"))
 	if gpProvokingVertex == nil {
 		return errors.New("glProvokingVertex")
 	}
+	gpPushClientAttribDefaultEXT = (C.GPPUSHCLIENTATTRIBDEFAULTEXT)(getProcAddr("glPushClientAttribDefaultEXT"))
 	gpPushDebugGroup = (C.GPPUSHDEBUGGROUP)(getProcAddr("glPushDebugGroup"))
 	gpPushDebugGroupKHR = (C.GPPUSHDEBUGGROUPKHR)(getProcAddr("glPushDebugGroupKHR"))
+	gpPushGroupMarkerEXT = (C.GPPUSHGROUPMARKEREXT)(getProcAddr("glPushGroupMarkerEXT"))
 	gpQueryCounter = (C.GPQUERYCOUNTER)(getProcAddr("glQueryCounter"))
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -9193,6 +14599,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpRenderbufferStorageMultisample == nil {
 		return errors.New("glRenderbufferStorageMultisample")
 	}
+	gpRenderbufferStorageMultisampleCoverageNV = (C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(getProcAddr("glRenderbufferStorageMultisampleCoverageNV"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	gpSampleCoverage = (C.GPSAMPLECOVERAGE)(getProcAddr("glSampleCoverage"))
 	if gpSampleCoverage == nil {
@@ -9215,12 +14623,20 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpScissorArrayv = (C.GPSCISSORARRAYV)(getProcAddr("glScissorArrayv"))
 	gpScissorIndexed = (C.GPSCISSORINDEXED)(getProcAddr("glScissorIndexed"))
 	gpScissorIndexedv = (C.GPSCISSORINDEXEDV)(getProcAddr("glScissorIndexedv"))
+	gpSecondaryColorFormatNV = (C.GPSECONDARYCOLORFORMATNV)(getProcAddr("glSecondaryColorFormatNV"))
+	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
 	gpShaderBinary = (C.GPSHADERBINARY)(getProcAddr("glShaderBinary"))
 	gpShaderSource = (C.GPSHADERSOURCE)(getProcAddr("glShaderSource"))
 	if gpShaderSource == nil {
 		return errors.New("glShaderSource")
 	}
 	gpShaderStorageBlockBinding = (C.GPSHADERSTORAGEBLOCKBINDING)(getProcAddr("glShaderStorageBlockBinding"))
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
+	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
+	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
 	gpStencilFunc = (C.GPSTENCILFUNC)(getProcAddr("glStencilFunc"))
 	if gpStencilFunc == nil {
 		return errors.New("glStencilFunc")
@@ -9245,11 +14661,20 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpStencilOpSeparate == nil {
 		return errors.New("glStencilOpSeparate")
 	}
+	gpStencilStrokePathInstancedNV = (C.GPSTENCILSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilStrokePathInstancedNV"))
+	gpStencilStrokePathNV = (C.GPSTENCILSTROKEPATHNV)(getProcAddr("glStencilStrokePathNV"))
+	gpStencilThenCoverFillPathInstancedNV = (C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverFillPathInstancedNV"))
+	gpStencilThenCoverFillPathNV = (C.GPSTENCILTHENCOVERFILLPATHNV)(getProcAddr("glStencilThenCoverFillPathNV"))
+	gpStencilThenCoverStrokePathInstancedNV = (C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverStrokePathInstancedNV"))
+	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpTexBuffer = (C.GPTEXBUFFER)(getProcAddr("glTexBuffer"))
 	if gpTexBuffer == nil {
 		return errors.New("glTexBuffer")
 	}
+	gpTexBufferARB = (C.GPTEXBUFFERARB)(getProcAddr("glTexBufferARB"))
 	gpTexBufferRange = (C.GPTEXBUFFERRANGE)(getProcAddr("glTexBufferRange"))
+	gpTexCoordFormatNV = (C.GPTEXCOORDFORMATNV)(getProcAddr("glTexCoordFormatNV"))
 	gpTexImage1D = (C.GPTEXIMAGE1D)(getProcAddr("glTexImage1D"))
 	if gpTexImage1D == nil {
 		return errors.New("glTexImage1D")
@@ -9313,22 +14738,44 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glTexSubImage3D")
 	}
 	gpTextureBarrier = (C.GPTEXTUREBARRIER)(getProcAddr("glTextureBarrier"))
+	gpTextureBarrierNV = (C.GPTEXTUREBARRIERNV)(getProcAddr("glTextureBarrierNV"))
 	gpTextureBuffer = (C.GPTEXTUREBUFFER)(getProcAddr("glTextureBuffer"))
+	gpTextureBufferEXT = (C.GPTEXTUREBUFFEREXT)(getProcAddr("glTextureBufferEXT"))
 	gpTextureBufferRange = (C.GPTEXTUREBUFFERRANGE)(getProcAddr("glTextureBufferRange"))
+	gpTextureBufferRangeEXT = (C.GPTEXTUREBUFFERRANGEEXT)(getProcAddr("glTextureBufferRangeEXT"))
+	gpTextureImage1DEXT = (C.GPTEXTUREIMAGE1DEXT)(getProcAddr("glTextureImage1DEXT"))
+	gpTextureImage2DEXT = (C.GPTEXTUREIMAGE2DEXT)(getProcAddr("glTextureImage2DEXT"))
+	gpTextureImage3DEXT = (C.GPTEXTUREIMAGE3DEXT)(getProcAddr("glTextureImage3DEXT"))
+	gpTexturePageCommitmentEXT = (C.GPTEXTUREPAGECOMMITMENTEXT)(getProcAddr("glTexturePageCommitmentEXT"))
 	gpTextureParameterIiv = (C.GPTEXTUREPARAMETERIIV)(getProcAddr("glTextureParameterIiv"))
+	gpTextureParameterIivEXT = (C.GPTEXTUREPARAMETERIIVEXT)(getProcAddr("glTextureParameterIivEXT"))
 	gpTextureParameterIuiv = (C.GPTEXTUREPARAMETERIUIV)(getProcAddr("glTextureParameterIuiv"))
+	gpTextureParameterIuivEXT = (C.GPTEXTUREPARAMETERIUIVEXT)(getProcAddr("glTextureParameterIuivEXT"))
 	gpTextureParameterf = (C.GPTEXTUREPARAMETERF)(getProcAddr("glTextureParameterf"))
+	gpTextureParameterfEXT = (C.GPTEXTUREPARAMETERFEXT)(getProcAddr("glTextureParameterfEXT"))
 	gpTextureParameterfv = (C.GPTEXTUREPARAMETERFV)(getProcAddr("glTextureParameterfv"))
+	gpTextureParameterfvEXT = (C.GPTEXTUREPARAMETERFVEXT)(getProcAddr("glTextureParameterfvEXT"))
 	gpTextureParameteri = (C.GPTEXTUREPARAMETERI)(getProcAddr("glTextureParameteri"))
+	gpTextureParameteriEXT = (C.GPTEXTUREPARAMETERIEXT)(getProcAddr("glTextureParameteriEXT"))
 	gpTextureParameteriv = (C.GPTEXTUREPARAMETERIV)(getProcAddr("glTextureParameteriv"))
+	gpTextureParameterivEXT = (C.GPTEXTUREPARAMETERIVEXT)(getProcAddr("glTextureParameterivEXT"))
+	gpTextureRenderbufferEXT = (C.GPTEXTURERENDERBUFFEREXT)(getProcAddr("glTextureRenderbufferEXT"))
 	gpTextureStorage1D = (C.GPTEXTURESTORAGE1D)(getProcAddr("glTextureStorage1D"))
+	gpTextureStorage1DEXT = (C.GPTEXTURESTORAGE1DEXT)(getProcAddr("glTextureStorage1DEXT"))
 	gpTextureStorage2D = (C.GPTEXTURESTORAGE2D)(getProcAddr("glTextureStorage2D"))
+	gpTextureStorage2DEXT = (C.GPTEXTURESTORAGE2DEXT)(getProcAddr("glTextureStorage2DEXT"))
 	gpTextureStorage2DMultisample = (C.GPTEXTURESTORAGE2DMULTISAMPLE)(getProcAddr("glTextureStorage2DMultisample"))
+	gpTextureStorage2DMultisampleEXT = (C.GPTEXTURESTORAGE2DMULTISAMPLEEXT)(getProcAddr("glTextureStorage2DMultisampleEXT"))
 	gpTextureStorage3D = (C.GPTEXTURESTORAGE3D)(getProcAddr("glTextureStorage3D"))
+	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
+	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
+	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
 	gpTextureSubImage2D = (C.GPTEXTURESUBIMAGE2D)(getProcAddr("glTextureSubImage2D"))
+	gpTextureSubImage2DEXT = (C.GPTEXTURESUBIMAGE2DEXT)(getProcAddr("glTextureSubImage2DEXT"))
 	gpTextureSubImage3D = (C.GPTEXTURESUBIMAGE3D)(getProcAddr("glTextureSubImage3D"))
+	gpTextureSubImage3DEXT = (C.GPTEXTURESUBIMAGE3DEXT)(getProcAddr("glTextureSubImage3DEXT"))
 	gpTextureView = (C.GPTEXTUREVIEW)(getProcAddr("glTextureView"))
 	gpTransformFeedbackBufferBase = (C.GPTRANSFORMFEEDBACKBUFFERBASE)(getProcAddr("glTransformFeedbackBufferBase"))
 	gpTransformFeedbackBufferRange = (C.GPTRANSFORMFEEDBACKBUFFERRANGE)(getProcAddr("glTransformFeedbackBufferRange"))
@@ -9336,6 +14783,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpTransformFeedbackVaryings == nil {
 		return errors.New("glTransformFeedbackVaryings")
 	}
+	gpTransformPathNV = (C.GPTRANSFORMPATHNV)(getProcAddr("glTransformPathNV"))
 	gpUniform1d = (C.GPUNIFORM1D)(getProcAddr("glUniform1d"))
 	gpUniform1dv = (C.GPUNIFORM1DV)(getProcAddr("glUniform1dv"))
 	gpUniform1f = (C.GPUNIFORM1F)(getProcAddr("glUniform1f"))
@@ -9350,6 +14798,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
+	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
+	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
 	if gpUniform1iv == nil {
 		return errors.New("glUniform1iv")
@@ -9358,6 +14810,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
+	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
+	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
 	if gpUniform1uiv == nil {
 		return errors.New("glUniform1uiv")
@@ -9376,6 +14832,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
+	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
+	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
 	if gpUniform2iv == nil {
 		return errors.New("glUniform2iv")
@@ -9384,6 +14844,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
+	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
+	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
 	if gpUniform2uiv == nil {
 		return errors.New("glUniform2uiv")
@@ -9402,6 +14866,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
+	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
+	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
 	if gpUniform3iv == nil {
 		return errors.New("glUniform3iv")
@@ -9410,6 +14878,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
+	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
+	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
 	if gpUniform3uiv == nil {
 		return errors.New("glUniform3uiv")
@@ -9428,6 +14900,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
+	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
+	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
 	if gpUniform4iv == nil {
 		return errors.New("glUniform4iv")
@@ -9436,6 +14912,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
+	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
+	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
 	if gpUniform4uiv == nil {
 		return errors.New("glUniform4uiv")
@@ -9445,7 +14925,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glUniformBlockBinding")
 	}
 	gpUniformHandleui64ARB = (C.GPUNIFORMHANDLEUI64ARB)(getProcAddr("glUniformHandleui64ARB"))
+	gpUniformHandleui64NV = (C.GPUNIFORMHANDLEUI64NV)(getProcAddr("glUniformHandleui64NV"))
 	gpUniformHandleui64vARB = (C.GPUNIFORMHANDLEUI64VARB)(getProcAddr("glUniformHandleui64vARB"))
+	gpUniformHandleui64vNV = (C.GPUNIFORMHANDLEUI64VNV)(getProcAddr("glUniformHandleui64vNV"))
 	gpUniformMatrix2dv = (C.GPUNIFORMMATRIX2DV)(getProcAddr("glUniformMatrix2dv"))
 	gpUniformMatrix2fv = (C.GPUNIFORMMATRIX2FV)(getProcAddr("glUniformMatrix2fv"))
 	if gpUniformMatrix2fv == nil {
@@ -9492,29 +14974,54 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glUniformMatrix4x3fv")
 	}
 	gpUniformSubroutinesuiv = (C.GPUNIFORMSUBROUTINESUIV)(getProcAddr("glUniformSubroutinesuiv"))
+	gpUniformui64NV = (C.GPUNIFORMUI64NV)(getProcAddr("glUniformui64NV"))
+	gpUniformui64vNV = (C.GPUNIFORMUI64VNV)(getProcAddr("glUniformui64vNV"))
 	gpUnmapBuffer = (C.GPUNMAPBUFFER)(getProcAddr("glUnmapBuffer"))
 	if gpUnmapBuffer == nil {
 		return errors.New("glUnmapBuffer")
 	}
 	gpUnmapNamedBuffer = (C.GPUNMAPNAMEDBUFFER)(getProcAddr("glUnmapNamedBuffer"))
+	gpUnmapNamedBufferEXT = (C.GPUNMAPNAMEDBUFFEREXT)(getProcAddr("glUnmapNamedBufferEXT"))
 	gpUseProgram = (C.GPUSEPROGRAM)(getProcAddr("glUseProgram"))
 	if gpUseProgram == nil {
 		return errors.New("glUseProgram")
 	}
 	gpUseProgramStages = (C.GPUSEPROGRAMSTAGES)(getProcAddr("glUseProgramStages"))
+	gpUseProgramStagesEXT = (C.GPUSEPROGRAMSTAGESEXT)(getProcAddr("glUseProgramStagesEXT"))
+	gpUseShaderProgramEXT = (C.GPUSESHADERPROGRAMEXT)(getProcAddr("glUseShaderProgramEXT"))
 	gpValidateProgram = (C.GPVALIDATEPROGRAM)(getProcAddr("glValidateProgram"))
 	if gpValidateProgram == nil {
 		return errors.New("glValidateProgram")
 	}
 	gpValidateProgramPipeline = (C.GPVALIDATEPROGRAMPIPELINE)(getProcAddr("glValidateProgramPipeline"))
+	gpValidateProgramPipelineEXT = (C.GPVALIDATEPROGRAMPIPELINEEXT)(getProcAddr("glValidateProgramPipelineEXT"))
 	gpVertexArrayAttribBinding = (C.GPVERTEXARRAYATTRIBBINDING)(getProcAddr("glVertexArrayAttribBinding"))
 	gpVertexArrayAttribFormat = (C.GPVERTEXARRAYATTRIBFORMAT)(getProcAddr("glVertexArrayAttribFormat"))
 	gpVertexArrayAttribIFormat = (C.GPVERTEXARRAYATTRIBIFORMAT)(getProcAddr("glVertexArrayAttribIFormat"))
 	gpVertexArrayAttribLFormat = (C.GPVERTEXARRAYATTRIBLFORMAT)(getProcAddr("glVertexArrayAttribLFormat"))
+	gpVertexArrayBindVertexBufferEXT = (C.GPVERTEXARRAYBINDVERTEXBUFFEREXT)(getProcAddr("glVertexArrayBindVertexBufferEXT"))
 	gpVertexArrayBindingDivisor = (C.GPVERTEXARRAYBINDINGDIVISOR)(getProcAddr("glVertexArrayBindingDivisor"))
+	gpVertexArrayColorOffsetEXT = (C.GPVERTEXARRAYCOLOROFFSETEXT)(getProcAddr("glVertexArrayColorOffsetEXT"))
+	gpVertexArrayEdgeFlagOffsetEXT = (C.GPVERTEXARRAYEDGEFLAGOFFSETEXT)(getProcAddr("glVertexArrayEdgeFlagOffsetEXT"))
 	gpVertexArrayElementBuffer = (C.GPVERTEXARRAYELEMENTBUFFER)(getProcAddr("glVertexArrayElementBuffer"))
+	gpVertexArrayFogCoordOffsetEXT = (C.GPVERTEXARRAYFOGCOORDOFFSETEXT)(getProcAddr("glVertexArrayFogCoordOffsetEXT"))
+	gpVertexArrayIndexOffsetEXT = (C.GPVERTEXARRAYINDEXOFFSETEXT)(getProcAddr("glVertexArrayIndexOffsetEXT"))
+	gpVertexArrayMultiTexCoordOffsetEXT = (C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayMultiTexCoordOffsetEXT"))
+	gpVertexArrayNormalOffsetEXT = (C.GPVERTEXARRAYNORMALOFFSETEXT)(getProcAddr("glVertexArrayNormalOffsetEXT"))
+	gpVertexArraySecondaryColorOffsetEXT = (C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(getProcAddr("glVertexArraySecondaryColorOffsetEXT"))
+	gpVertexArrayTexCoordOffsetEXT = (C.GPVERTEXARRAYTEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayTexCoordOffsetEXT"))
+	gpVertexArrayVertexAttribBindingEXT = (C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(getProcAddr("glVertexArrayVertexAttribBindingEXT"))
+	gpVertexArrayVertexAttribDivisorEXT = (C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(getProcAddr("glVertexArrayVertexAttribDivisorEXT"))
+	gpVertexArrayVertexAttribFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(getProcAddr("glVertexArrayVertexAttribFormatEXT"))
+	gpVertexArrayVertexAttribIFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(getProcAddr("glVertexArrayVertexAttribIFormatEXT"))
+	gpVertexArrayVertexAttribIOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribIOffsetEXT"))
+	gpVertexArrayVertexAttribLFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(getProcAddr("glVertexArrayVertexAttribLFormatEXT"))
+	gpVertexArrayVertexAttribLOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribLOffsetEXT"))
+	gpVertexArrayVertexAttribOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribOffsetEXT"))
+	gpVertexArrayVertexBindingDivisorEXT = (C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(getProcAddr("glVertexArrayVertexBindingDivisorEXT"))
 	gpVertexArrayVertexBuffer = (C.GPVERTEXARRAYVERTEXBUFFER)(getProcAddr("glVertexArrayVertexBuffer"))
 	gpVertexArrayVertexBuffers = (C.GPVERTEXARRAYVERTEXBUFFERS)(getProcAddr("glVertexArrayVertexBuffers"))
+	gpVertexArrayVertexOffsetEXT = (C.GPVERTEXARRAYVERTEXOFFSETEXT)(getProcAddr("glVertexArrayVertexOffsetEXT"))
 	gpVertexAttrib1d = (C.GPVERTEXATTRIB1D)(getProcAddr("glVertexAttrib1d"))
 	if gpVertexAttrib1d == nil {
 		return errors.New("glVertexAttrib1d")
@@ -9660,7 +15167,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glVertexAttrib4usv")
 	}
 	gpVertexAttribBinding = (C.GPVERTEXATTRIBBINDING)(getProcAddr("glVertexAttribBinding"))
+	gpVertexAttribDivisorARB = (C.GPVERTEXATTRIBDIVISORARB)(getProcAddr("glVertexAttribDivisorARB"))
 	gpVertexAttribFormat = (C.GPVERTEXATTRIBFORMAT)(getProcAddr("glVertexAttribFormat"))
+	gpVertexAttribFormatNV = (C.GPVERTEXATTRIBFORMATNV)(getProcAddr("glVertexAttribFormatNV"))
 	gpVertexAttribI1i = (C.GPVERTEXATTRIBI1I)(getProcAddr("glVertexAttribI1i"))
 	if gpVertexAttribI1i == nil {
 		return errors.New("glVertexAttribI1i")
@@ -9742,21 +15251,39 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glVertexAttribI4usv")
 	}
 	gpVertexAttribIFormat = (C.GPVERTEXATTRIBIFORMAT)(getProcAddr("glVertexAttribIFormat"))
+	gpVertexAttribIFormatNV = (C.GPVERTEXATTRIBIFORMATNV)(getProcAddr("glVertexAttribIFormatNV"))
 	gpVertexAttribIPointer = (C.GPVERTEXATTRIBIPOINTER)(getProcAddr("glVertexAttribIPointer"))
 	if gpVertexAttribIPointer == nil {
 		return errors.New("glVertexAttribIPointer")
 	}
 	gpVertexAttribL1d = (C.GPVERTEXATTRIBL1D)(getProcAddr("glVertexAttribL1d"))
 	gpVertexAttribL1dv = (C.GPVERTEXATTRIBL1DV)(getProcAddr("glVertexAttribL1dv"))
+	gpVertexAttribL1i64NV = (C.GPVERTEXATTRIBL1I64NV)(getProcAddr("glVertexAttribL1i64NV"))
+	gpVertexAttribL1i64vNV = (C.GPVERTEXATTRIBL1I64VNV)(getProcAddr("glVertexAttribL1i64vNV"))
 	gpVertexAttribL1ui64ARB = (C.GPVERTEXATTRIBL1UI64ARB)(getProcAddr("glVertexAttribL1ui64ARB"))
+	gpVertexAttribL1ui64NV = (C.GPVERTEXATTRIBL1UI64NV)(getProcAddr("glVertexAttribL1ui64NV"))
 	gpVertexAttribL1ui64vARB = (C.GPVERTEXATTRIBL1UI64VARB)(getProcAddr("glVertexAttribL1ui64vARB"))
+	gpVertexAttribL1ui64vNV = (C.GPVERTEXATTRIBL1UI64VNV)(getProcAddr("glVertexAttribL1ui64vNV"))
 	gpVertexAttribL2d = (C.GPVERTEXATTRIBL2D)(getProcAddr("glVertexAttribL2d"))
 	gpVertexAttribL2dv = (C.GPVERTEXATTRIBL2DV)(getProcAddr("glVertexAttribL2dv"))
+	gpVertexAttribL2i64NV = (C.GPVERTEXATTRIBL2I64NV)(getProcAddr("glVertexAttribL2i64NV"))
+	gpVertexAttribL2i64vNV = (C.GPVERTEXATTRIBL2I64VNV)(getProcAddr("glVertexAttribL2i64vNV"))
+	gpVertexAttribL2ui64NV = (C.GPVERTEXATTRIBL2UI64NV)(getProcAddr("glVertexAttribL2ui64NV"))
+	gpVertexAttribL2ui64vNV = (C.GPVERTEXATTRIBL2UI64VNV)(getProcAddr("glVertexAttribL2ui64vNV"))
 	gpVertexAttribL3d = (C.GPVERTEXATTRIBL3D)(getProcAddr("glVertexAttribL3d"))
 	gpVertexAttribL3dv = (C.GPVERTEXATTRIBL3DV)(getProcAddr("glVertexAttribL3dv"))
+	gpVertexAttribL3i64NV = (C.GPVERTEXATTRIBL3I64NV)(getProcAddr("glVertexAttribL3i64NV"))
+	gpVertexAttribL3i64vNV = (C.GPVERTEXATTRIBL3I64VNV)(getProcAddr("glVertexAttribL3i64vNV"))
+	gpVertexAttribL3ui64NV = (C.GPVERTEXATTRIBL3UI64NV)(getProcAddr("glVertexAttribL3ui64NV"))
+	gpVertexAttribL3ui64vNV = (C.GPVERTEXATTRIBL3UI64VNV)(getProcAddr("glVertexAttribL3ui64vNV"))
 	gpVertexAttribL4d = (C.GPVERTEXATTRIBL4D)(getProcAddr("glVertexAttribL4d"))
 	gpVertexAttribL4dv = (C.GPVERTEXATTRIBL4DV)(getProcAddr("glVertexAttribL4dv"))
+	gpVertexAttribL4i64NV = (C.GPVERTEXATTRIBL4I64NV)(getProcAddr("glVertexAttribL4i64NV"))
+	gpVertexAttribL4i64vNV = (C.GPVERTEXATTRIBL4I64VNV)(getProcAddr("glVertexAttribL4i64vNV"))
+	gpVertexAttribL4ui64NV = (C.GPVERTEXATTRIBL4UI64NV)(getProcAddr("glVertexAttribL4ui64NV"))
+	gpVertexAttribL4ui64vNV = (C.GPVERTEXATTRIBL4UI64VNV)(getProcAddr("glVertexAttribL4ui64vNV"))
 	gpVertexAttribLFormat = (C.GPVERTEXATTRIBLFORMAT)(getProcAddr("glVertexAttribLFormat"))
+	gpVertexAttribLFormatNV = (C.GPVERTEXATTRIBLFORMATNV)(getProcAddr("glVertexAttribLFormatNV"))
 	gpVertexAttribLPointer = (C.GPVERTEXATTRIBLPOINTER)(getProcAddr("glVertexAttribLPointer"))
 	gpVertexAttribP1ui = (C.GPVERTEXATTRIBP1UI)(getProcAddr("glVertexAttribP1ui"))
 	gpVertexAttribP1uiv = (C.GPVERTEXATTRIBP1UIV)(getProcAddr("glVertexAttribP1uiv"))
@@ -9771,6 +15298,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glVertexAttribPointer")
 	}
 	gpVertexBindingDivisor = (C.GPVERTEXBINDINGDIVISOR)(getProcAddr("glVertexBindingDivisor"))
+	gpVertexFormatNV = (C.GPVERTEXFORMATNV)(getProcAddr("glVertexFormatNV"))
 	gpViewport = (C.GPVIEWPORT)(getProcAddr("glViewport"))
 	if gpViewport == nil {
 		return errors.New("glViewport")
@@ -9778,9 +15306,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpViewportArrayv = (C.GPVIEWPORTARRAYV)(getProcAddr("glViewportArrayv"))
 	gpViewportIndexedf = (C.GPVIEWPORTINDEXEDF)(getProcAddr("glViewportIndexedf"))
 	gpViewportIndexedfv = (C.GPVIEWPORTINDEXEDFV)(getProcAddr("glViewportIndexedfv"))
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
+	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	return nil
 }

--- a/v3.2-core/gl/procaddr.go
+++ b/v3.2-core/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcore32(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v3.3-compatibility/gl/package.go
+++ b/v3.3-compatibility/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -75,7 +73,6 @@ package gl
 // typedef unsigned int GLenum;
 // typedef unsigned char GLboolean;
 // typedef unsigned int GLbitfield;
-// typedef void GLvoid;
 // typedef signed char GLbyte;
 // typedef short GLshort;
 // typedef int GLint;
@@ -88,6 +85,7 @@ package gl
 // typedef float GLclampf;
 // typedef double GLdouble;
 // typedef double GLclampd;
+// typedef void *GLeglClientBufferEXT;
 // typedef char GLchar;
 // typedef char GLcharARB;
 // #ifdef __APPLE__
@@ -104,7 +102,7 @@ package gl
 // typedef ptrdiff_t GLsizeiptrARB;
 // typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
@@ -113,12 +111,14 @@ package gl
 // typedef void (APIENTRY *GLDEBUGPROCAMD)(GLuint id,GLenum category,GLenum severity,GLsizei length,const GLchar *message,void *userParam);
 // typedef unsigned short GLhalfNV;
 // typedef GLintptr GLvdpauSurfaceNV;
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcompatibility33(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcompatibility33(source, type, id, severity, length, message, userParam);
 // }
 // typedef void  (APIENTRYP GPACCUM)(GLenum  op, GLfloat  value);
 // typedef void  (APIENTRYP GPACCUMXOES)(GLenum  op, GLfixed  value);
+// typedef GLboolean  (APIENTRYP GPACQUIREKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key, GLuint  timeout);
 // typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
@@ -131,6 +131,8 @@ package gl
 // typedef void  (APIENTRYP GPALPHAFRAGMENTOP3ATI)(GLenum  op, GLuint  dst, GLuint  dstMod, GLuint  arg1, GLuint  arg1Rep, GLuint  arg1Mod, GLuint  arg2, GLuint  arg2Rep, GLuint  arg2Mod, GLuint  arg3, GLuint  arg3Rep, GLuint  arg3Mod);
 // typedef void  (APIENTRYP GPALPHAFUNC)(GLenum  func, GLfloat  ref);
 // typedef void  (APIENTRYP GPALPHAFUNCXOES)(GLenum  func, GLfixed  ref);
+// typedef void  (APIENTRYP GPALPHATOCOVERAGEDITHERCONTROLNV)(GLenum  mode);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPAPPLYTEXTUREEXT)(GLenum  mode);
 // typedef GLboolean  (APIENTRYP GPAREPROGRAMSRESIDENTNV)(GLsizei  n, const GLuint * programs, GLboolean * residences);
 // typedef GLboolean  (APIENTRYP GPARETEXTURESRESIDENT)(GLsizei  n, const GLuint * textures, GLboolean * residences);
@@ -248,11 +250,14 @@ package gl
 // typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPBUFFERDATAARB)(GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERPARAMETERIAPPLE)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEEXTERNALEXT)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEMEMEXT)(GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPBUFFERSUBDATAARB)(GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLIST)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLISTS)(GLsizei  n, GLenum  type, const void * lists);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
@@ -282,9 +287,9 @@ package gl
 // typedef void  (APIENTRYP GPCLEARINDEX)(GLfloat  c);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
@@ -380,6 +385,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERIVNV)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERARB)(GLhandleARB  shaderObj);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
@@ -410,6 +417,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER2D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * image);
@@ -440,7 +449,7 @@ package gl
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  type);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
@@ -465,8 +474,12 @@ package gl
 // typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEMEMORYOBJECTSEXT)(GLsizei  n, GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef GLhandleARB  (APIENTRYP GPCREATEPROGRAMOBJECTARB)();
@@ -479,6 +492,7 @@ package gl
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -505,12 +519,14 @@ package gl
 // typedef void  (APIENTRYP GPDELETEASYNCMARKERSSGIX)(GLuint  marker, GLsizei  range);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
 // typedef void  (APIENTRYP GPDELETEBUFFERSARB)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFENCESAPPLE)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFENCESNV)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFRAGMENTSHADERATI)(GLuint  id);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERSEXT)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETELISTS)(GLuint  list, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEMEMORYOBJECTSEXT)(GLsizei  n, const GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
 // typedef void  (APIENTRYP GPDELETENAMESAMD)(GLenum  identifier, GLuint  num, const GLuint * names);
 // typedef void  (APIENTRYP GPDELETEOBJECTARB)(GLhandleARB  obj);
@@ -525,10 +541,13 @@ package gl
 // typedef void  (APIENTRYP GPDELETEPROGRAMSNV)(GLsizei  n, const GLuint * programs);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETEQUERIESARB)(GLsizei  n, const GLuint * ids);
+// typedef void  (APIENTRYP GPDELETEQUERYRESOURCETAGNV)(GLsizei  n, const GLint * tagIds);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERSEXT)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
+// typedef void  (APIENTRYP GPDELETESEMAPHORESEXT)(GLsizei  n, const GLuint * semaphores);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETEXTURESEXT)(GLsizei  n, const GLuint * textures);
@@ -578,6 +597,10 @@ package gl
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSARB)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSATI)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYAPPLE)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYATI)(GLenum  mode, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
@@ -602,6 +625,7 @@ package gl
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKNV)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
 // typedef void  (APIENTRYP GPEDGEFLAG)(GLboolean  flag);
 // typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPEDGEFLAGPOINTER)(GLsizei  stride, const void * pointer);
@@ -657,6 +681,7 @@ package gl
 // typedef void  (APIENTRYP GPEVALMESH2)(GLenum  mode, GLint  i1, GLint  i2, GLint  j1, GLint  j2);
 // typedef void  (APIENTRYP GPEVALPOINT1)(GLint  i);
 // typedef void  (APIENTRYP GPEVALPOINT2)(GLint  i, GLint  j);
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef void  (APIENTRYP GPEXECUTEPROGRAMNV)(GLenum  target, GLuint  id, const GLfloat * params);
 // typedef void  (APIENTRYP GPEXTRACTCOMPONENTEXT)(GLuint  res, GLuint  src, GLuint  num);
 // typedef void  (APIENTRYP GPFEEDBACKBUFFER)(GLsizei  size, GLenum  type, GLfloat * buffer);
@@ -672,7 +697,7 @@ package gl
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGEAPPLE)(GLenum  target, GLintptr  offset, GLsizeiptr  size);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHPIXELDATARANGENV)(GLenum  target);
 // typedef void  (APIENTRYP GPFLUSHRASTERSGIX)();
@@ -701,6 +726,7 @@ package gl
 // typedef void  (APIENTRYP GPFOGXOES)(GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPFOGXVOES)(GLenum  pname, const GLfixed * param);
 // typedef void  (APIENTRYP GPFRAGMENTCOLORMATERIALSGIX)(GLenum  face, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELISGIX)(GLenum  pname, GLint  param);
@@ -717,10 +743,14 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEZOOMSGIX)(GLint  factor);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFEREXT)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1DEXT)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -735,6 +765,7 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYEREXT)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFREEOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPFRUSTUM)(GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
@@ -759,9 +790,11 @@ package gl
 // typedef void  (APIENTRYP GPGENPROGRAMSNV)(GLsizei  n, GLuint * programs);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENQUERIESARB)(GLsizei  n, GLuint * ids);
+// typedef void  (APIENTRYP GPGENQUERYRESOURCETAGNV)(GLsizei  n, GLint * tagIds);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERSEXT)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
+// typedef void  (APIENTRYP GPGENSEMAPHORESEXT)(GLsizei  n, GLuint * semaphores);
 // typedef GLuint  (APIENTRYP GPGENSYMBOLSEXT)(GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components);
 // typedef void  (APIENTRYP GPGENTEXTURES)(GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPGENTEXTURESEXT)(GLsizei  n, GLuint * textures);
@@ -822,6 +855,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERFVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERIVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, GLfloat * params);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  level, void * img);
@@ -835,6 +869,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIVEXT)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERXVOES)(GLenum  target, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGAMD)(GLuint  count, GLsizei  bufsize, GLenum * categories, GLuint * severities, GLuint * ids, GLsizei * lengths, GLchar * message);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
@@ -864,6 +899,7 @@ package gl
 // typedef void  (APIENTRYP GPGETFRAGMENTMATERIALIVSGIX)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERFVAMD)(GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
@@ -890,6 +926,7 @@ package gl
 // typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -917,6 +954,7 @@ package gl
 // typedef void  (APIENTRYP GPGETMATERIALIV)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMATERIALXOES)(GLenum  face, GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPGETMATERIALXVOES)(GLenum  face, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMINMAX)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXEXT)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
@@ -943,10 +981,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
@@ -992,7 +1031,7 @@ package gl
 // typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
-// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
 // typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
 // typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
 // typedef void  (APIENTRYP GPGETPIXELMAPFV)(GLenum  map, GLfloat * values);
@@ -1041,6 +1080,10 @@ package gl
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVARB)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVNV)(GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64VEXT)(GLuint  id, GLenum  pname, GLint64 * params);
@@ -1058,6 +1101,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIUIV)(GLuint  sampler, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERFV)(GLuint  sampler, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIV)(GLuint  sampler, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTER)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTEREXT)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSHADERINFOLOG)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
@@ -1066,6 +1110,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERSOURCEARB)(GLhandleARB  obj, GLsizei  maxLength, GLsizei * length, GLcharARB * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETSHARPENTEXFUNCSGIS)(GLenum  target, GLfloat * points);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -1129,12 +1174,16 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFVARB)(GLhandleARB  programObj, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIVARB)(GLhandleARB  programObj, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIVEXT)(GLuint  program, GLint  location, GLuint * params);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEI_VEXT)(GLenum  target, GLuint  index, GLubyte * data);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEVEXT)(GLenum  pname, GLubyte * data);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTFVATI)(GLuint  id, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTIVATI)(GLuint  id, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -1180,6 +1229,7 @@ package gl
 // typedef void  (APIENTRYP GPGETVIDEOIVNV)(GLuint  video_slot, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVIDEOUI64VNV)(GLuint  video_slot, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVIDEOUIVNV)(GLuint  video_slot, GLenum  pname, GLuint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOLORTABLEARB)(GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNCONVOLUTIONFILTERARB)(GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * image);
@@ -1198,9 +1248,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
@@ -1221,6 +1273,12 @@ package gl
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERFVHP)(GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIHP)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIVHP)(GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPIMPORTMEMORYFDEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32HANDLEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32NAMEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, const void * name);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREFDEXT)(GLuint  semaphore, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32HANDLEEXT)(GLuint  semaphore, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32NAMEEXT)(GLuint  semaphore, GLenum  handleType, const void * name);
 // typedef GLsync  (APIENTRYP GPIMPORTSYNCEXT)(GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags);
 // typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPINDEXFUNCEXT)(GLenum  func, GLclampf  ref);
@@ -1259,6 +1317,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERARB)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
 // typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
@@ -1269,6 +1328,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISLIST)(GLuint  list);
+// typedef GLboolean  (APIENTRYP GPISMEMORYOBJECTEXT)(GLuint  memoryObject);
 // typedef GLboolean  (APIENTRYP GPISNAMEAMD)(GLenum  identifier, GLuint  name);
 // typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
@@ -1287,7 +1347,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFEREXT)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
+// typedef GLboolean  (APIENTRYP GPISSEMAPHOREEXT)(GLuint  semaphore);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREEXT)(GLuint  texture);
@@ -1299,6 +1361,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAYAPPLE)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXATTRIBENABLEDAPPLE)(GLuint  index, GLenum  pname);
+// typedef void  (APIENTRYP GPLGPUCOPYIMAGESUBDATANVX)(GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPLGPUINTERLOCKNVX)();
+// typedef void  (APIENTRYP GPLGPUNAMEDBUFFERSUBDATANVX)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLIGHTENVISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPLIGHTMODELF)(GLenum  pname, GLfloat  param);
@@ -1319,6 +1384,7 @@ package gl
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPLINKPROGRAMARB)(GLhandleARB  programObj);
 // typedef void  (APIENTRYP GPLISTBASE)(GLuint  base);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLISTPARAMETERFSGIX)(GLuint  list, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPLISTPARAMETERFVSGIX)(GLuint  list, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPLISTPARAMETERISGIX)(GLuint  list, GLenum  pname, GLint  param);
@@ -1367,7 +1433,7 @@ package gl
 // typedef void  (APIENTRYP GPMAPGRID2XOES)(GLint  n, GLfixed  u1, GLfixed  u2, GLfixed  v1, GLfixed  v2);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPMAPPARAMETERFVNV)(GLenum  target, GLenum  pname, const GLfloat * params);
@@ -1413,9 +1479,12 @@ package gl
 // typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIEREXT)(GLbitfield  barriers);
+// typedef void  (APIENTRYP GPMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINMAX)(GLenum  target, GLenum  internalformat, GLboolean  sink);
 // typedef void  (APIENTRYP GPMINMAXEXT)(GLenum  target, GLenum  internalformat, GLboolean  sink);
@@ -1433,7 +1502,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTAMD)(GLenum  mode, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTARRAYAPPLE)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
@@ -1442,7 +1511,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTAMD)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWRANGEELEMENTARRAYAPPLE)(GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWARRAYSIBM)(const GLenum * mode, const GLint * first, const GLsizei * count, GLsizei  primcount, GLint  modestride);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWELEMENTSIBM)(const GLenum * mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  primcount, GLint  modestride);
@@ -1567,13 +1636,26 @@ package gl
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPMULTICASTBARRIERNV)();
+// typedef void  (APIENTRYP GPMULTICASTBLITFRAMEBUFFERNV)(GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPMULTICASTBUFFERSUBDATANV)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPMULTICASTCOPYBUFFERSUBDATANV)(GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPMULTICASTCOPYIMAGESUBDATANV)(GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
+// typedef void  (APIENTRYP GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPMULTICASTWAITSYNCNV)(GLuint  signalGpu, GLbitfield  waitGpuMask);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXTERNALEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEMEMEXT)(GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
@@ -1583,6 +1665,9 @@ package gl
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -1726,6 +1811,8 @@ package gl
 // typedef GLint  (APIENTRYP GPPOLLINSTRUMENTSSGIX)(GLint * marker_p);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETEXT)(GLfloat  factor, GLfloat  bias);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETXOES)(GLfixed  factor, GLfixed  units);
 // typedef void  (APIENTRYP GPPOLYGONSTIPPLE)(const GLubyte * mask);
@@ -1738,6 +1825,7 @@ package gl
 // typedef void  (APIENTRYP GPPOPNAME)();
 // typedef void  (APIENTRYP GPPRESENTFRAMEDUALFILLNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLenum  target1, GLuint  fill1, GLenum  target2, GLuint  fill2, GLenum  target3, GLuint  fill3);
 // typedef void  (APIENTRYP GPPRESENTFRAMEKEYEDNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1);
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEXNV)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTNV)();
@@ -1795,13 +1883,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1815,13 +1907,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1835,13 +1931,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1855,13 +1955,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1922,6 +2026,8 @@ package gl
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
 // typedef GLbitfield  (APIENTRYP GPQUERYMATRIXXOES)(GLfixed * mantissa, GLint * exponent);
 // typedef void  (APIENTRYP GPQUERYOBJECTPARAMETERUIAMD)(GLenum  target, GLuint  id, GLenum  pname, GLuint  param);
+// typedef GLint  (APIENTRYP GPQUERYRESOURCENV)(GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer);
+// typedef void  (APIENTRYP GPQUERYRESOURCETAGNV)(GLint  tagId, const GLchar * tagString);
 // typedef void  (APIENTRYP GPRASTERPOS2D)(GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPRASTERPOS2DV)(const GLdouble * v);
 // typedef void  (APIENTRYP GPRASTERPOS2F)(GLfloat  x, GLfloat  y);
@@ -1952,6 +2058,7 @@ package gl
 // typedef void  (APIENTRYP GPRASTERPOS4SV)(const GLshort * v);
 // typedef void  (APIENTRYP GPRASTERPOS4XOES)(GLfixed  x, GLfixed  y, GLfixed  z, GLfixed  w);
 // typedef void  (APIENTRYP GPRASTERPOS4XVOES)(const GLfixed * coords);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
@@ -1969,7 +2076,9 @@ package gl
 // typedef void  (APIENTRYP GPRECTXOES)(GLfixed  x1, GLfixed  y1, GLfixed  x2, GLfixed  y2);
 // typedef void  (APIENTRYP GPRECTXVOES)(const GLfixed * v1, const GLfixed * v2);
 // typedef void  (APIENTRYP GPREFERENCEPLANESGIX)(const GLdouble * equation);
+// typedef GLboolean  (APIENTRYP GPRELEASEKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key);
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
+// typedef void  (APIENTRYP GPRENDERGPUMASKNV)(GLbitfield  mask);
 // typedef GLint  (APIENTRYP GPRENDERMODE)(GLenum  mode);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
@@ -2005,6 +2114,7 @@ package gl
 // typedef void  (APIENTRYP GPRESETMINMAX)(GLenum  target);
 // typedef void  (APIENTRYP GPRESETMINMAXEXT)(GLenum  target);
 // typedef void  (APIENTRYP GPRESIZEBUFFERSMESA)();
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACKNV)();
 // typedef void  (APIENTRYP GPROTATED)(GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
@@ -2012,7 +2122,6 @@ package gl
 // typedef void  (APIENTRYP GPROTATEXOES)(GLfixed  angle, GLfixed  x, GLfixed  y, GLfixed  z);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEARB)(GLfloat  value, GLboolean  invert);
-// typedef void  (APIENTRYP GPSAMPLECOVERAGEOES)(GLfixed  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEXOES)(GLclampx  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMAPATI)(GLuint  dst, GLuint  interp, GLenum  swizzle);
 // typedef void  (APIENTRYP GPSAMPLEMASKEXT)(GLclampf  value, GLboolean  invert);
@@ -2076,6 +2185,7 @@ package gl
 // typedef void  (APIENTRYP GPSECONDARYCOLORPOINTERLISTIBM)(GLint  size, GLenum  type, GLint  stride, const void ** pointer, GLint  ptrstride);
 // typedef void  (APIENTRYP GPSELECTBUFFER)(GLsizei  size, GLuint * buffer);
 // typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
+// typedef void  (APIENTRYP GPSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, const GLuint64 * params);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSETFENCEAPPLE)(GLuint  fence);
@@ -2093,11 +2203,16 @@ package gl
 // typedef void  (APIENTRYP GPSHADERSOURCEARB)(GLhandleARB  shaderObj, GLsizei  count, const GLcharARB ** string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
 // typedef void  (APIENTRYP GPSHARPENTEXFUNCSGIS)(GLenum  target, GLsizei  n, const GLfloat * points);
+// typedef void  (APIENTRYP GPSIGNALSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERIVSGIX)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPSTARTINSTRUMENTSSGIX)();
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
 // typedef void  (APIENTRYP GPSTENCILCLEARTAGEXT)(GLsizei  stencilTagBits, GLuint  stencilClearTag);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
@@ -2118,6 +2233,7 @@ package gl
 // typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
 // typedef void  (APIENTRYP GPSTOPINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPSTRINGMARKERGREMEDY)(GLsizei  len, const void * string);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPSWIZZLEEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // typedef void  (APIENTRYP GPSYNCTEXTUREINTEL)(GLuint  texture);
 // typedef void  (APIENTRYP GPTAGSAMPLEBUFFERSGIX)();
@@ -2251,7 +2367,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLint  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations);
 // typedef void  (APIENTRYP GPTEXIMAGE4DSGIS)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIVEXT)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
@@ -2268,6 +2384,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXSTORAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXSTORAGE3D)(GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXSTORAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM1DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXSTORAGESPARSEAMD)(GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1DEXT)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2280,7 +2401,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTURECOLORMASKSGIS)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
@@ -2293,7 +2414,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURELIGHTEXT)(GLenum  pname);
 // typedef void  (APIENTRYP GPTEXTUREMATERIALEXT)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPTEXTURENORMALEXT)(GLenum  mode);
-// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
@@ -2318,6 +2439,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM1DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXTURESTORAGESPARSEAMD)(GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2329,7 +2455,7 @@ package gl
 // typedef void  (APIENTRYP GPTRACKMATRIXNV)(GLenum  target, GLuint  address, GLenum  matrix, GLenum  transform);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKATTRIBSNV)(GLsizei  count, const GLint * attribs, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKSTREAMATTRIBSNV)(GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGSEXT)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
@@ -2345,13 +2471,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IARB)(GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIEXT)(GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2363,13 +2493,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IARB)(GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIEXT)(GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2381,13 +2515,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2399,13 +2537,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2832,7 +2974,11 @@ package gl
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
+// typedef void  (APIENTRYP GPWAITSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
 // typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
 // typedef void  (APIENTRYP GPWEIGHTPOINTERARB)(GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPWEIGHTBVARB)(GLint  size, const GLbyte * weights);
@@ -2899,12 +3045,16 @@ package gl
 // typedef void  (APIENTRYP GPWINDOWPOS4IVMESA)(const GLint * v);
 // typedef void  (APIENTRYP GPWINDOWPOS4SMESA)(GLshort  x, GLshort  y, GLshort  z, GLshort  w);
 // typedef void  (APIENTRYP GPWINDOWPOS4SVMESA)(const GLshort * v);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
 // typedef void  (APIENTRYP GPWRITEMASKEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // static void  glowAccum(GPACCUM fnptr, GLenum  op, GLfloat  value) {
 //   (*fnptr)(op, value);
 // }
 // static void  glowAccumxOES(GPACCUMXOES fnptr, GLenum  op, GLfixed  value) {
 //   (*fnptr)(op, value);
+// }
+// static GLboolean  glowAcquireKeyedMutexWin32EXT(GPACQUIREKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key, GLuint  timeout) {
+//   return (*fnptr)(memory, key, timeout);
 // }
 // static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
 //   (*fnptr)(program);
@@ -2941,6 +3091,12 @@ package gl
 // }
 // static void  glowAlphaFuncxOES(GPALPHAFUNCXOES fnptr, GLenum  func, GLfixed  ref) {
 //   (*fnptr)(func, ref);
+// }
+// static void  glowAlphaToCoverageDitherControlNV(GPALPHATOCOVERAGEDITHERCONTROLNV fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowApplyTextureEXT(GPAPPLYTEXTUREEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -3293,7 +3449,7 @@ package gl
 // static void  glowBufferDataARB(GPBUFFERDATAARB fnptr, GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferParameteriAPPLE(GPBUFFERPARAMETERIAPPLE fnptr, GLenum  target, GLenum  pname, GLint  param) {
@@ -3302,11 +3458,20 @@ package gl
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(target, size, data, flags);
 // }
+// static void  glowBufferStorageExternalEXT(GPBUFFERSTORAGEEXTERNALEXT fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(target, offset, size, clientBuffer, flags);
+// }
+// static void  glowBufferStorageMemEXT(GPBUFFERSTORAGEMEMEXT fnptr, GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, size, memory, offset);
+// }
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
 // static void  glowBufferSubDataARB(GPBUFFERSUBDATAARB fnptr, GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
 // }
 // static void  glowCallList(GPCALLLIST fnptr, GLuint  list) {
 //   (*fnptr)(list);
@@ -3395,14 +3560,14 @@ package gl
 // static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
 // static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -3689,6 +3854,12 @@ package gl
 // static void  glowCombinerStageParameterfvNV(GPCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, const GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
@@ -3778,6 +3949,12 @@ package gl
 // }
 // static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
 //   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowConvolutionFilter1D(GPCONVOLUTIONFILTER1D fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image) {
 //   (*fnptr)(target, internalformat, width, format, type, image);
@@ -3869,7 +4046,7 @@ package gl
 // static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
@@ -3944,11 +4121,23 @@ package gl
 // static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
 //   (*fnptr)(path, coverMode);
 // }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
+// }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreateMemoryObjectsEXT(GPCREATEMEMORYOBJECTSEXT fnptr, GLsizei  n, GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
 //   (*fnptr)(queryId, queryHandle);
@@ -3985,6 +4174,9 @@ package gl
 // }
 // static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -4064,6 +4256,9 @@ package gl
 // static void  glowDeleteBuffersARB(GPDELETEBUFFERSARB fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFencesAPPLE(GPDELETEFENCESAPPLE fnptr, GLsizei  n, const GLuint * fences) {
 //   (*fnptr)(n, fences);
 // }
@@ -4081,6 +4276,9 @@ package gl
 // }
 // static void  glowDeleteLists(GPDELETELISTS fnptr, GLuint  list, GLsizei  range) {
 //   (*fnptr)(list, range);
+// }
+// static void  glowDeleteMemoryObjectsEXT(GPDELETEMEMORYOBJECTSEXT fnptr, GLsizei  n, const GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
@@ -4124,6 +4322,9 @@ package gl
 // static void  glowDeleteQueriesARB(GPDELETEQUERIESARB fnptr, GLsizei  n, const GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowDeleteQueryResourceTagNV(GPDELETEQUERYRESOURCETAGNV fnptr, GLsizei  n, const GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowDeleteRenderbuffers(GPDELETERENDERBUFFERS fnptr, GLsizei  n, const GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4133,8 +4334,14 @@ package gl
 // static void  glowDeleteSamplers(GPDELETESAMPLERS fnptr, GLsizei  count, const GLuint * samplers) {
 //   (*fnptr)(count, samplers);
 // }
+// static void  glowDeleteSemaphoresEXT(GPDELETESEMAPHORESEXT fnptr, GLsizei  n, const GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
+// }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -4283,6 +4490,18 @@ package gl
 // static void  glowDrawBuffersATI(GPDRAWBUFFERSATI fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
 // }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
+// }
 // static void  glowDrawElementArrayAPPLE(GPDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, GLint  first, GLsizei  count) {
 //   (*fnptr)(mode, first, count);
 // }
@@ -4354,6 +4573,9 @@ package gl
 // }
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
+// }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
 // }
 // static void  glowEdgeFlag(GPEDGEFLAG fnptr, GLboolean  flag) {
 //   (*fnptr)(flag);
@@ -4520,6 +4742,9 @@ package gl
 // static void  glowEvalPoint2(GPEVALPOINT2 fnptr, GLint  i, GLint  j) {
 //   (*fnptr)(i, j);
 // }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowExecuteProgramNV(GPEXECUTEPROGRAMNV fnptr, GLenum  target, GLuint  id, const GLfloat * params) {
 //   (*fnptr)(target, id, params);
 // }
@@ -4565,7 +4790,7 @@ package gl
 // static void  glowFlushMappedBufferRangeAPPLE(GPFLUSHMAPPEDBUFFERRANGEAPPLE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, offset, size);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
 // }
 // static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
@@ -4652,6 +4877,9 @@ package gl
 // static void  glowFragmentColorMaterialSGIX(GPFRAGMENTCOLORMATERIALSGIX fnptr, GLenum  face, GLenum  mode) {
 //   (*fnptr)(face, mode);
 // }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
 // static void  glowFragmentLightModelfSGIX(GPFRAGMENTLIGHTMODELFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -4700,6 +4928,9 @@ package gl
 // static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(framebuffer, n, bufs);
 // }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
@@ -4711,6 +4942,15 @@ package gl
 // }
 // static void  glowFramebufferRenderbufferEXT(GPFRAMEBUFFERRENDERBUFFEREXT fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSamplePositionsfvAMD(GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(target, numsamples, pixelindex, values);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -4753,6 +4993,9 @@ package gl
 // }
 // static void  glowFramebufferTextureLayerEXT(GPFRAMEBUFFERTEXTURELAYEREXT fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFreeObjectBufferATI(GPFREEOBJECTBUFFERATI fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -4826,6 +5069,9 @@ package gl
 // static void  glowGenQueriesARB(GPGENQUERIESARB fnptr, GLsizei  n, GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowGenQueryResourceTagNV(GPGENQUERYRESOURCETAGNV fnptr, GLsizei  n, GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowGenRenderbuffers(GPGENRENDERBUFFERS fnptr, GLsizei  n, GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4834,6 +5080,9 @@ package gl
 // }
 // static void  glowGenSamplers(GPGENSAMPLERS fnptr, GLsizei  count, GLuint * samplers) {
 //   (*fnptr)(count, samplers);
+// }
+// static void  glowGenSemaphoresEXT(GPGENSEMAPHORESEXT fnptr, GLsizei  n, GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
 // }
 // static GLuint  glowGenSymbolsEXT(GPGENSYMBOLSEXT fnptr, GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components) {
 //   return (*fnptr)(datatype, storagetype, range, components);
@@ -5015,6 +5264,9 @@ package gl
 // static void  glowGetCombinerStageParameterfvNV(GPGETCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
 // static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
 //   (*fnptr)(texunit, target, lod, img);
 // }
@@ -5053,6 +5305,9 @@ package gl
 // }
 // static void  glowGetConvolutionParameterxvOES(GPGETCONVOLUTIONPARAMETERXVOES fnptr, GLenum  target, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -5141,6 +5396,9 @@ package gl
 // static void  glowGetFramebufferAttachmentParameterivEXT(GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLenum  target, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, attachment, pname, params);
 // }
+// static void  glowGetFramebufferParameterfvAMD(GPGETFRAMEBUFFERPARAMETERFVAMD fnptr, GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(target, pname, numsamples, pixelindex, size, values);
+// }
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
@@ -5218,6 +5476,9 @@ package gl
 // }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
@@ -5300,6 +5561,9 @@ package gl
 // static void  glowGetMaterialxvOES(GPGETMATERIALXVOES fnptr, GLenum  face, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(face, pname, params);
 // }
+// static void  glowGetMemoryObjectParameterivEXT(GPGETMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
+// }
 // static void  glowGetMinmax(GPGETMINMAX fnptr, GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values) {
 //   (*fnptr)(target, reset, format, type, values);
 // }
@@ -5378,7 +5642,7 @@ package gl
 // static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
@@ -5389,6 +5653,9 @@ package gl
 // }
 // static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
+// }
+// static void  glowGetNamedFramebufferParameterfvAMD(GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD fnptr, GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(framebuffer, pname, numsamples, pixelindex, size, values);
 // }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
@@ -5525,7 +5792,7 @@ package gl
 // static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
 //   (*fnptr)(numGroups, groupsSize, groups);
 // }
-// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten) {
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
 //   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
 // }
 // static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
@@ -5672,6 +5939,18 @@ package gl
 // static void  glowGetProgramivNV(GPGETPROGRAMIVNV fnptr, GLuint  id, GLenum  pname, GLint * params) {
 //   (*fnptr)(id, pname, params);
 // }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
 // }
@@ -5723,6 +6002,9 @@ package gl
 // static void  glowGetSamplerParameteriv(GPGETSAMPLERPARAMETERIV fnptr, GLuint  sampler, GLenum  pname, GLint * params) {
 //   (*fnptr)(sampler, pname, params);
 // }
+// static void  glowGetSemaphoreParameterui64vEXT(GPGETSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowGetSeparableFilter(GPGETSEPARABLEFILTER fnptr, GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span) {
 //   (*fnptr)(target, format, type, row, column, span);
 // }
@@ -5746,6 +6028,9 @@ package gl
 // }
 // static void  glowGetSharpenTexFuncSGIS(GPGETSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLfloat * points) {
 //   (*fnptr)(target, points);
+// }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
 // }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
@@ -5936,6 +6221,9 @@ package gl
 // static void  glowGetUniformfvARB(GPGETUNIFORMFVARB fnptr, GLhandleARB  programObj, GLint  location, GLfloat * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5945,6 +6233,9 @@ package gl
 // static void  glowGetUniformivARB(GPGETUNIFORMIVARB fnptr, GLhandleARB  programObj, GLint  location, GLint * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5953,6 +6244,12 @@ package gl
 // }
 // static void  glowGetUniformuivEXT(GPGETUNIFORMUIVEXT fnptr, GLuint  program, GLint  location, GLuint * params) {
 //   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUnsignedBytei_vEXT(GPGETUNSIGNEDBYTEI_VEXT fnptr, GLenum  target, GLuint  index, GLubyte * data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetUnsignedBytevEXT(GPGETUNSIGNEDBYTEVEXT fnptr, GLenum  pname, GLubyte * data) {
+//   (*fnptr)(pname, data);
 // }
 // static void  glowGetVariantArrayObjectfvATI(GPGETVARIANTARRAYOBJECTFVATI fnptr, GLuint  id, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(id, pname, params);
@@ -6089,6 +6386,9 @@ package gl
 // static void  glowGetVideouivNV(GPGETVIDEOUIVNV fnptr, GLuint  video_slot, GLenum  pname, GLuint * params) {
 //   (*fnptr)(video_slot, pname, params);
 // }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
+// }
 // static void  glowGetnColorTableARB(GPGETNCOLORTABLEARB fnptr, GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table) {
 //   (*fnptr)(target, format, type, bufSize, table);
 // }
@@ -6143,6 +6443,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -6150,6 +6453,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -6211,6 +6517,24 @@ package gl
 // }
 // static void  glowImageTransformParameterivHP(GPIMAGETRANSFORMPARAMETERIVHP fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowImportMemoryFdEXT(GPIMPORTMEMORYFDEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(memory, size, handleType, fd);
+// }
+// static void  glowImportMemoryWin32HandleEXT(GPIMPORTMEMORYWIN32HANDLEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, void * handle) {
+//   (*fnptr)(memory, size, handleType, handle);
+// }
+// static void  glowImportMemoryWin32NameEXT(GPIMPORTMEMORYWIN32NAMEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, const void * name) {
+//   (*fnptr)(memory, size, handleType, name);
+// }
+// static void  glowImportSemaphoreFdEXT(GPIMPORTSEMAPHOREFDEXT fnptr, GLuint  semaphore, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(semaphore, handleType, fd);
+// }
+// static void  glowImportSemaphoreWin32HandleEXT(GPIMPORTSEMAPHOREWIN32HANDLEEXT fnptr, GLuint  semaphore, GLenum  handleType, void * handle) {
+//   (*fnptr)(semaphore, handleType, handle);
+// }
+// static void  glowImportSemaphoreWin32NameEXT(GPIMPORTSEMAPHOREWIN32NAMEEXT fnptr, GLuint  semaphore, GLenum  handleType, const void * name) {
+//   (*fnptr)(semaphore, handleType, name);
 // }
 // static GLsync  glowImportSyncEXT(GPIMPORTSYNCEXT fnptr, GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags) {
 //   return (*fnptr)(external_sync_type, external_sync, flags);
@@ -6326,6 +6650,9 @@ package gl
 // static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
 // }
@@ -6355,6 +6682,9 @@ package gl
 // }
 // static GLboolean  glowIsList(GPISLIST fnptr, GLuint  list) {
 //   return (*fnptr)(list);
+// }
+// static GLboolean  glowIsMemoryObjectEXT(GPISMEMORYOBJECTEXT fnptr, GLuint  memoryObject) {
+//   return (*fnptr)(memoryObject);
 // }
 // static GLboolean  glowIsNameAMD(GPISNAMEAMD fnptr, GLenum  identifier, GLuint  name) {
 //   return (*fnptr)(identifier, name);
@@ -6410,8 +6740,14 @@ package gl
 // static GLboolean  glowIsSampler(GPISSAMPLER fnptr, GLuint  sampler) {
 //   return (*fnptr)(sampler);
 // }
+// static GLboolean  glowIsSemaphoreEXT(GPISSEMAPHOREEXT fnptr, GLuint  semaphore) {
+//   return (*fnptr)(semaphore);
+// }
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
+// }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
 // }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
@@ -6445,6 +6781,15 @@ package gl
 // }
 // static GLboolean  glowIsVertexAttribEnabledAPPLE(GPISVERTEXATTRIBENABLEDAPPLE fnptr, GLuint  index, GLenum  pname) {
 //   return (*fnptr)(index, pname);
+// }
+// static void  glowLGPUCopyImageSubDataNVX(GPLGPUCOPYIMAGESUBDATANVX fnptr, GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(sourceGpu, destinationGpuMask, srcName, srcTarget, srcLevel, srcX, srxY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, width, height, depth);
+// }
+// static void  glowLGPUInterlockNVX(GPLGPUINTERLOCKNVX fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowLGPUNamedBufferSubDataNVX(GPLGPUNAMEDBUFFERSUBDATANVX fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
 // }
 // static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(type, object, length, label);
@@ -6505,6 +6850,9 @@ package gl
 // }
 // static void  glowListBase(GPLISTBASE fnptr, GLuint  base) {
 //   (*fnptr)(base);
+// }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
 // }
 // static void  glowListParameterfSGIX(GPLISTPARAMETERFSGIX fnptr, GLuint  list, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(list, pname, param);
@@ -6650,7 +6998,7 @@ package gl
 // static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
 // }
 // static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
@@ -6788,6 +7136,12 @@ package gl
 // static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
 //   (*fnptr)(mode, x, y, z);
 // }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
 // }
@@ -6796,6 +7150,9 @@ package gl
 // }
 // static void  glowMemoryBarrierEXT(GPMEMORYBARRIEREXT fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
+// }
+// static void  glowMemoryObjectParameterivEXT(GPMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, const GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
 // }
 // static void  glowMinSampleShadingARB(GPMINSAMPLESHADINGARB fnptr, GLfloat  value) {
 //   (*fnptr)(value);
@@ -6848,7 +7205,7 @@ package gl
 // static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElementArrayAPPLE(GPMULTIDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -6875,7 +7232,7 @@ package gl
 // static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawRangeElementArrayAPPLE(GPMULTIDRAWRANGEELEMENTARRAYAPPLE fnptr, GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -7250,25 +7607,64 @@ package gl
 // static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMulticastBarrierNV(GPMULTICASTBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowMulticastBlitFramebufferNV(GPMULTICASTBLITFRAMEBUFFERNV fnptr, GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
+//   (*fnptr)(srcGpu, dstGpu, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+// }
+// static void  glowMulticastBufferSubDataNV(GPMULTICASTBUFFERSUBDATANV fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
+// }
+// static void  glowMulticastCopyBufferSubDataNV(GPMULTICASTCOPYBUFFERSUBDATANV fnptr, GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readGpu, writeGpuMask, readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowMulticastCopyImageSubDataNV(GPMULTICASTCOPYIMAGESUBDATANV fnptr, GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
+//   (*fnptr)(srcGpu, dstGpuMask, srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
+// }
+// static void  glowMulticastFramebufferSampleLocationsfvNV(GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(gpu, framebuffer, start, count, v);
+// }
+// static void  glowMulticastGetQueryObjecti64vNV(GPMULTICASTGETQUERYOBJECTI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectivNV(GPMULTICASTGETQUERYOBJECTIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectui64vNV(GPMULTICASTGETQUERYOBJECTUI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectuivNV(GPMULTICASTGETQUERYOBJECTUIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastWaitSyncNV(GPMULTICASTWAITSYNCNV fnptr, GLuint  signalGpu, GLbitfield  waitGpuMask) {
+//   (*fnptr)(signalGpu, waitGpuMask);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
 // static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
 // static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageExternalEXT(GPNAMEDBUFFERSTORAGEEXTERNALEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(buffer, offset, size, clientBuffer, flags);
+// }
+// static void  glowNamedBufferStorageMemEXT(GPNAMEDBUFFERSTORAGEMEMEXT fnptr, GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(buffer, size, memory, offset);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
@@ -7297,6 +7693,15 @@ package gl
 // }
 // static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSamplePositionsfvAMD(GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(framebuffer, numsamples, pixelindex, values);
 // }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
@@ -7727,6 +8132,12 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPolygonOffsetEXT(GPPOLYGONOFFSETEXT fnptr, GLfloat  factor, GLfloat  bias) {
 //   (*fnptr)(factor, bias);
 // }
@@ -7762,6 +8173,9 @@ package gl
 // }
 // static void  glowPresentFrameKeyedNV(GPPRESENTFRAMEKEYEDNV fnptr, GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1) {
 //   (*fnptr)(video_slot, minPresentTime, beginPresentTimeId, presentDurationId, type, target0, fill0, key0, target1, fill1, key1);
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -7934,8 +8348,14 @@ package gl
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7952,8 +8372,14 @@ package gl
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7994,8 +8420,14 @@ package gl
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8012,8 +8444,14 @@ package gl
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8054,8 +8492,14 @@ package gl
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8072,8 +8516,14 @@ package gl
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8114,8 +8564,14 @@ package gl
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8132,8 +8588,14 @@ package gl
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8315,6 +8777,12 @@ package gl
 // static void  glowQueryObjectParameteruiAMD(GPQUERYOBJECTPARAMETERUIAMD fnptr, GLenum  target, GLuint  id, GLenum  pname, GLuint  param) {
 //   (*fnptr)(target, id, pname, param);
 // }
+// static GLint  glowQueryResourceNV(GPQUERYRESOURCENV fnptr, GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer) {
+//   return (*fnptr)(queryType, tagId, bufSize, buffer);
+// }
+// static void  glowQueryResourceTagNV(GPQUERYRESOURCETAGNV fnptr, GLint  tagId, const GLchar * tagString) {
+//   (*fnptr)(tagId, tagString);
+// }
 // static void  glowRasterPos2d(GPRASTERPOS2D fnptr, GLdouble  x, GLdouble  y) {
 //   (*fnptr)(x, y);
 // }
@@ -8405,6 +8873,9 @@ package gl
 // static void  glowRasterPos4xvOES(GPRASTERPOS4XVOES fnptr, const GLfixed * coords) {
 //   (*fnptr)(coords);
 // }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
+// }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
 // }
@@ -8456,8 +8927,14 @@ package gl
 // static void  glowReferencePlaneSGIX(GPREFERENCEPLANESGIX fnptr, const GLdouble * equation) {
 //   (*fnptr)(equation);
 // }
+// static GLboolean  glowReleaseKeyedMutexWin32EXT(GPRELEASEKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key) {
+//   return (*fnptr)(memory, key);
+// }
 // static void  glowReleaseShaderCompiler(GPRELEASESHADERCOMPILER fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowRenderGpuMaskNV(GPRENDERGPUMASKNV fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static GLint  glowRenderMode(GPRENDERMODE fnptr, GLenum  mode) {
 //   return (*fnptr)(mode);
@@ -8564,6 +9041,9 @@ package gl
 // static void  glowResizeBuffersMESA(GPRESIZEBUFFERSMESA fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -8583,9 +9063,6 @@ package gl
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoverageARB(GPSAMPLECOVERAGEARB fnptr, GLfloat  value, GLboolean  invert) {
-//   (*fnptr)(value, invert);
-// }
-// static void  glowSampleCoverageOES(GPSAMPLECOVERAGEOES fnptr, GLfixed  value, GLboolean  invert) {
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoveragexOES(GPSAMPLECOVERAGEXOES fnptr, GLclampx  value, GLboolean  invert) {
@@ -8777,6 +9254,9 @@ package gl
 // static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
 //   (*fnptr)(monitor, enable, group, numCounters, counterList);
 // }
+// static void  glowSemaphoreParameterui64vEXT(GPSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, const GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowSeparableFilter2D(GPSEPARABLEFILTER2D fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column) {
 //   (*fnptr)(target, internalformat, width, height, format, type, row, column);
 // }
@@ -8828,6 +9308,18 @@ package gl
 // static void  glowSharpenTexFuncSGIS(GPSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLsizei  n, const GLfloat * points) {
 //   (*fnptr)(target, n, points);
 // }
+// static void  glowSignalSemaphoreEXT(GPSIGNALSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, dstLayouts);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
 // static void  glowSpriteParameterfSGIX(GPSPRITEPARAMETERFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -8842,6 +9334,9 @@ package gl
 // }
 // static void  glowStartInstrumentsSGIX(GPSTARTINSTRUMENTSSGIX fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
 // }
 // static void  glowStencilClearTagEXT(GPSTENCILCLEARTAGEXT fnptr, GLsizei  stencilTagBits, GLuint  stencilClearTag) {
 //   (*fnptr)(stencilTagBits, stencilClearTag);
@@ -8902,6 +9397,9 @@ package gl
 // }
 // static void  glowStringMarkerGREMEDY(GPSTRINGMARKERGREMEDY fnptr, GLsizei  len, const void * string) {
 //   (*fnptr)(len, string);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
 // }
 // static void  glowSwizzleEXT(GPSWIZZLEEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
@@ -9302,8 +9800,8 @@ package gl
 // static void  glowTexImage4DSGIS(GPTEXIMAGE4DSGIS fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, height, depth, size4d, border, format, type, pixels);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -9353,6 +9851,21 @@ package gl
 // static void  glowTexStorage3DMultisample(GPTEXSTORAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTexStorageMem1DEXT(GPTEXSTORAGEMEM1DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTexStorageMem2DEXT(GPTEXSTORAGEMEM2DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTexStorageMem2DMultisampleEXT(GPTEXSTORAGEMEM2DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTexStorageMem3DEXT(GPTEXSTORAGEMEM3DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTexStorageMem3DMultisampleEXT(GPTEXSTORAGEMEM3DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTexStorageSparseAMD(GPTEXSTORAGESPARSEAMD fnptr, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9389,7 +9902,7 @@ package gl
 // static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, target, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
 // }
 // static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
@@ -9428,8 +9941,8 @@ package gl
 // static void  glowTextureNormalEXT(GPTEXTURENORMALEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
 // }
-// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
@@ -9503,6 +10016,21 @@ package gl
 // static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorageMem1DEXT(GPTEXTURESTORAGEMEM1DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTextureStorageMem2DEXT(GPTEXTURESTORAGEMEM2DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTextureStorageMem2DMultisampleEXT(GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTextureStorageMem3DEXT(GPTEXTURESTORAGEMEM3DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTextureStorageMem3DMultisampleEXT(GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTextureStorageSparseAMD(GPTEXTURESTORAGESPARSEAMD fnptr, GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(texture, target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9536,7 +10064,7 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackStreamAttribsNV(GPTRANSFORMFEEDBACKSTREAMATTRIBSNV fnptr, GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode) {
@@ -9584,8 +10112,14 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9602,8 +10136,14 @@ package gl
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9638,8 +10178,14 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9656,8 +10202,14 @@ package gl
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9692,8 +10244,14 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9710,8 +10268,14 @@ package gl
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9746,8 +10310,14 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9764,8 +10334,14 @@ package gl
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -11045,8 +11621,20 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
+// static void  glowWaitSemaphoreEXT(GPWAITSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, srcLayouts);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
 // }
 // static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
 //   (*fnptr)(resultPath, numPaths, paths, weights);
@@ -11246,6 +11834,9 @@ package gl
 // static void  glowWindowPos4svMESA(GPWINDOWPOS4SVMESA fnptr, const GLshort * v) {
 //   (*fnptr)(v);
 // }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
+// }
 // static void  glowWriteMaskEXT(GPWRITEMASKEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
 // }
@@ -11337,6 +11928,7 @@ const (
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_BARRIER_BITS_EXT                                       = 0xFFFFFFFF
 	ALL_COMPLETED_NV                                           = 0x84F2
+	ALL_PIXELS_AMD                                             = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
 	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALL_STATIC_DATA_IBM                                        = 103060
@@ -11371,11 +11963,16 @@ const (
 	ALPHA_MAX_SGIX                                             = 0x8321
 	ALPHA_MIN_CLAMP_INGR                                       = 0x8563
 	ALPHA_MIN_SGIX                                             = 0x8320
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALPHA_SCALE                                                = 0x0D1C
 	ALPHA_SNORM                                                = 0x9010
 	ALPHA_TEST                                                 = 0x0BC0
 	ALPHA_TEST_FUNC                                            = 0x0BC1
 	ALPHA_TEST_REF                                             = 0x0BC2
+	ALPHA_TO_COVERAGE_DITHER_DEFAULT_NV                        = 0x934D
+	ALPHA_TO_COVERAGE_DITHER_DISABLE_NV                        = 0x934F
+	ALPHA_TO_COVERAGE_DITHER_ENABLE_NV                         = 0x934E
+	ALPHA_TO_COVERAGE_DITHER_MODE_NV                           = 0x92BF
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	ALWAYS_FAST_HINT_PGI                                       = 0x1A20C
@@ -11421,6 +12018,7 @@ const (
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
 	ATTENUATION_EXT                                            = 0x834D
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	ATTRIB_ARRAY_POINTER_NV                                    = 0x8645
 	ATTRIB_ARRAY_SIZE_NV                                       = 0x8623
 	ATTRIB_ARRAY_STRIDE_NV                                     = 0x8624
@@ -11463,6 +12061,7 @@ const (
 	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
 	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_COLOR_EXT                                            = 0x8005
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
@@ -11640,10 +12239,26 @@ const (
 	COLOR_ATTACHMENT14_EXT                                     = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
 	COLOR_ATTACHMENT15_EXT                                     = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT1_EXT                                      = 0x8CE1
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT2_EXT                                      = 0x8CE2
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT3_EXT                                      = 0x8CE3
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT4_EXT                                      = 0x8CE4
@@ -11747,6 +12362,8 @@ const (
 	COMPILE                                                    = 0x1300
 	COMPILE_AND_EXECUTE                                        = 0x1301
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_ALPHA                                           = 0x84E9
 	COMPRESSED_ALPHA_ARB                                       = 0x84E9
 	COMPRESSED_INTENSITY                                       = 0x84EC
@@ -11846,8 +12463,18 @@ const (
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	COMP_BIT_ATI                                               = 0x00000002
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
 	CONIC_CURVE_TO_NV                                          = 0x1A
 	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSERVE_MEMORY_HINT_PGI                                   = 0x1A1FD
 	CONSTANT                                                   = 0x8576
 	CONSTANT_ALPHA                                             = 0x8003
@@ -11869,6 +12496,7 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
 	CONTEXT_LOST_KHR                                           = 0x0507
@@ -11940,13 +12568,14 @@ const (
 	COPY_INVERTED                                              = 0x150C
 	COPY_PIXEL_TOKEN                                           = 0x0706
 	COPY_READ_BUFFER                                           = 0x8F36
-	COPY_READ_BUFFER_BINDING                                   = 0x8F36
 	COPY_WRITE_BUFFER                                          = 0x8F37
-	COPY_WRITE_BUFFER_BINDING                                  = 0x8F37
 	COUNTER_RANGE_AMD                                          = 0x8BC1
 	COUNTER_TYPE_AMD                                           = 0x8BC0
 	COUNT_DOWN_NV                                              = 0x9089
 	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
 	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CUBIC_EXT                                                  = 0x8334
 	CUBIC_HP                                                   = 0x815F
@@ -11996,6 +12625,7 @@ const (
 	CURRENT_VERTEX_WEIGHT_EXT                                  = 0x850B
 	CURRENT_WEIGHT_ARB                                         = 0x86A8
 	CW                                                         = 0x0900
+	D3D12_FENCE_VALUE_EXT                                      = 0x9595
 	DARKEN_KHR                                                 = 0x9297
 	DARKEN_NV                                                  = 0x9297
 	DATA_BUFFER_AMD                                            = 0x9151
@@ -12088,6 +12718,7 @@ const (
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DECR_WRAP_EXT                                              = 0x8508
+	DEDICATED_MEMORY_OBJECT_EXT                                = 0x9581
 	DEFORMATIONS_MASK_SGIX                                     = 0x8196
 	DELETE_STATUS                                              = 0x8B80
 	DEPENDENT_AR_TEXTURE_2D_NV                                 = 0x86E9
@@ -12129,6 +12760,7 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_SCALE                                                = 0x0D1E
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
@@ -12146,6 +12778,9 @@ const (
 	DETAIL_TEXTURE_FUNC_POINTS_SGIS                            = 0x809C
 	DETAIL_TEXTURE_LEVEL_SGIS                                  = 0x809A
 	DETAIL_TEXTURE_MODE_SGIS                                   = 0x809B
+	DEVICE_LUID_EXT                                            = 0x9599
+	DEVICE_NODE_MASK_EXT                                       = 0x959A
+	DEVICE_UUID_EXT                                            = 0x9597
 	DIFFERENCE_KHR                                             = 0x929E
 	DIFFERENCE_NV                                              = 0x929E
 	DIFFUSE                                                    = 0x1201
@@ -12208,6 +12843,9 @@ const (
 	DOUBLE_VEC3_EXT                                            = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
 	DOUBLE_VEC4_EXT                                            = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER0_ARB                                           = 0x8825
@@ -12257,6 +12895,9 @@ const (
 	DRAW_BUFFER9                                               = 0x882E
 	DRAW_BUFFER9_ARB                                           = 0x882E
 	DRAW_BUFFER9_ATI                                           = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
 	DRAW_FRAMEBUFFER_BINDING_EXT                               = 0x8CA6
@@ -12268,6 +12909,7 @@ const (
 	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DRAW_PIXELS_APPLE                                          = 0x8A0A
 	DRAW_PIXEL_TOKEN                                           = 0x0705
+	DRIVER_UUID_EXT                                            = 0x9598
 	DSDT8_MAG8_INTENSITY8_NV                                   = 0x870B
 	DSDT8_MAG8_NV                                              = 0x870A
 	DSDT8_NV                                                   = 0x8709
@@ -12328,7 +12970,9 @@ const (
 	EDGE_FLAG_ARRAY_POINTER_EXT                                = 0x8093
 	EDGE_FLAG_ARRAY_STRIDE                                     = 0x808C
 	EDGE_FLAG_ARRAY_STRIDE_EXT                                 = 0x808C
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
 	EIGHTH_BIT_ATI                                             = 0x00000020
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
 	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_APPLE                                        = 0x8A0C
 	ELEMENT_ARRAY_ATI                                          = 0x8768
@@ -12373,6 +13017,7 @@ const (
 	EVAL_VERTEX_ATTRIB9_NV                                     = 0x86CF
 	EXCLUSION_KHR                                              = 0x92A0
 	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXP                                                        = 0x0800
 	EXP2                                                       = 0x0801
 	EXPAND_NEGATE_NV                                           = 0x8539
@@ -12406,6 +13051,7 @@ const (
 	FIELD_UPPER_NV                                             = 0x9022
 	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
 	FILTER4_SGIS                                               = 0x8146
 	FIRST_TO_REST_NV                                           = 0x90AF
@@ -12417,6 +13063,15 @@ const (
 	FIXED_ONLY_ARB                                             = 0x891D
 	FLAT                                                       = 0x1D00
 	FLOAT                                                      = 0x1406
+	FLOAT16_MAT2_AMD                                           = 0x91C5
+	FLOAT16_MAT2x3_AMD                                         = 0x91C8
+	FLOAT16_MAT2x4_AMD                                         = 0x91C9
+	FLOAT16_MAT3_AMD                                           = 0x91C6
+	FLOAT16_MAT3x2_AMD                                         = 0x91CA
+	FLOAT16_MAT3x4_AMD                                         = 0x91CB
+	FLOAT16_MAT4_AMD                                           = 0x91C7
+	FLOAT16_MAT4x2_AMD                                         = 0x91CC
+	FLOAT16_MAT4x3_AMD                                         = 0x91CD
 	FLOAT16_NV                                                 = 0x8FF8
 	FLOAT16_VEC2_NV                                            = 0x8FF9
 	FLOAT16_VEC3_NV                                            = 0x8FFA
@@ -12522,6 +13177,8 @@ const (
 	FRAGMENT_COLOR_MATERIAL_FACE_SGIX                          = 0x8402
 	FRAGMENT_COLOR_MATERIAL_PARAMETER_SGIX                     = 0x8403
 	FRAGMENT_COLOR_MATERIAL_SGIX                               = 0x8401
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
 	FRAGMENT_DEPTH                                             = 0x8452
 	FRAGMENT_DEPTH_EXT                                         = 0x8452
 	FRAGMENT_INPUT_NV                                          = 0x936D
@@ -12553,6 +13210,7 @@ const (
 	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
 	FRAGMENT_SHADER_DERIVATIVE_HINT_ARB                        = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -12574,12 +13232,14 @@ const (
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_3D_ZOFFSET_EXT              = 0x8CD4
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE_EXT           = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER_EXT                   = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL_EXT                   = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BARRIER_BIT_EXT                                = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
@@ -12611,8 +13271,13 @@ const (
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_EXT                     = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER_EXT                     = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_SRGB_CAPABLE_EXT                               = 0x8DBA
 	FRAMEBUFFER_SRGB_EXT                                       = 0x8DB9
@@ -12625,6 +13290,7 @@ const (
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_RANGE_EXT                                             = 0x87E1
@@ -12704,6 +13370,14 @@ const (
 	HALF_FLOAT                                                 = 0x140B
 	HALF_FLOAT_ARB                                             = 0x140B
 	HALF_FLOAT_NV                                              = 0x140B
+	HANDLE_TYPE_D3D11_IMAGE_EXT                                = 0x958B
+	HANDLE_TYPE_D3D11_IMAGE_KMT_EXT                            = 0x958C
+	HANDLE_TYPE_D3D12_FENCE_EXT                                = 0x9594
+	HANDLE_TYPE_D3D12_RESOURCE_EXT                             = 0x958A
+	HANDLE_TYPE_D3D12_TILEPOOL_EXT                             = 0x9589
+	HANDLE_TYPE_OPAQUE_FD_EXT                                  = 0x9586
+	HANDLE_TYPE_OPAQUE_WIN32_EXT                               = 0x9587
+	HANDLE_TYPE_OPAQUE_WIN32_KMT_EXT                           = 0x9588
 	HARDLIGHT_KHR                                              = 0x929B
 	HARDLIGHT_NV                                               = 0x929B
 	HARDMIX_NV                                                 = 0x92A9
@@ -12811,6 +13485,7 @@ const (
 	IMPLEMENTATION_COLOR_READ_FORMAT_OES                       = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
 	IMPLEMENTATION_COLOR_READ_TYPE_OES                         = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
 	INCR_WRAP_EXT                                              = 0x8507
@@ -12855,9 +13530,13 @@ const (
 	INT16_VEC2_NV                                              = 0x8FE5
 	INT16_VEC3_NV                                              = 0x8FE6
 	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
 	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
 	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
 	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
 	INT64_VEC4_NV                                              = 0x8FEB
 	INT8_NV                                                    = 0x8FE0
 	INT8_VEC2_NV                                               = 0x8FE1
@@ -12995,13 +13674,23 @@ const (
 	LAST_VIDEO_CAPTURE_STATUS_NV                               = 0x9027
 	LAYER_NV                                                   = 0x8DAA
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
+	LAYOUT_COLOR_ATTACHMENT_EXT                                = 0x958E
 	LAYOUT_DEFAULT_INTEL                                       = 0
+	LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT              = 0x9531
+	LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT              = 0x9530
+	LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT                        = 0x958F
+	LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT                         = 0x9590
+	LAYOUT_GENERAL_EXT                                         = 0x958D
 	LAYOUT_LINEAR_CPU_CACHED_INTEL                             = 2
 	LAYOUT_LINEAR_INTEL                                        = 1
+	LAYOUT_SHADER_READ_ONLY_EXT                                = 0x9591
+	LAYOUT_TRANSFER_DST_EXT                                    = 0x9593
+	LAYOUT_TRANSFER_SRC_EXT                                    = 0x9592
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LERP_ATI                                                   = 0x8969
 	LESS                                                       = 0x0201
+	LGPU_SEPARATE_STORAGE_BIT_NVX                              = 0x0800
 	LIGHT0                                                     = 0x4000
 	LIGHT1                                                     = 0x4001
 	LIGHT2                                                     = 0x4002
@@ -13037,6 +13726,7 @@ const (
 	LINEAR_SHARPEN_ALPHA_SGIS                                  = 0x80AE
 	LINEAR_SHARPEN_COLOR_SGIS                                  = 0x80AF
 	LINEAR_SHARPEN_SGIS                                        = 0x80AD
+	LINEAR_TILING_EXT                                          = 0x9585
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
 	LINES_ADJACENCY_ARB                                        = 0x000A
@@ -13056,6 +13746,7 @@ const (
 	LINE_TOKEN                                                 = 0x0702
 	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -13082,6 +13773,7 @@ const (
 	LOW_INT                                                    = 0x8DF3
 	LO_BIAS_NV                                                 = 0x8715
 	LO_SCALE_NV                                                = 0x870F
+	LUID_SIZE_EXT                                              = 8
 	LUMINANCE                                                  = 0x1909
 	LUMINANCE12                                                = 0x8041
 	LUMINANCE12_ALPHA12                                        = 0x8047
@@ -13415,6 +14107,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_LGPU_GPUS_NVX                                          = 0x92BA
 	MAX_LIGHTS                                                 = 0x0D31
 	MAX_LIST_NESTING                                           = 0x0B31
 	MAX_MAP_TESSELLATION_NV                                    = 0x86D6
@@ -13478,6 +14171,7 @@ const (
 	MAX_PROGRAM_TEX_INSTRUCTIONS_ARB                           = 0x880C
 	MAX_PROGRAM_TOTAL_OUTPUT_COMPONENTS_NV                     = 0x8C28
 	MAX_PROJECTION_STACK_DEPTH                                 = 0x0D38
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RATIONAL_EVAL_ORDER_NV                                 = 0x86D7
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RECTANGLE_TEXTURE_SIZE_ARB                             = 0x84F8
@@ -13490,6 +14184,8 @@ const (
 	MAX_SAMPLE_MASK_WORDS_NV                                   = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
 	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SHININESS_NV                                           = 0x8504
@@ -13500,6 +14196,7 @@ const (
 	MAX_SPARSE_TEXTURE_SIZE_AMD                                = 0x9198
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
 	MAX_SPOT_EXPONENT_NV                                       = 0x8505
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -13534,6 +14231,7 @@ const (
 	MAX_TEXTURE_IMAGE_UNITS_NV                                 = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
 	MAX_TEXTURE_LOD_BIAS_EXT                                   = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_MAX_ANISOTROPY_EXT                             = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TEXTURE_STACK_DEPTH                                    = 0x0D39
@@ -13589,7 +14287,9 @@ const (
 	MAX_VERTEX_VARYING_COMPONENTS_EXT                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
@@ -13614,7 +14314,6 @@ const (
 	MIN_PROGRAM_TEXTURE_GATHER_OFFSET_NV                       = 0x8E5E
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
 	MIN_SPARSE_LEVEL_AMD                                       = 0x919B
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
 	MIRRORED_REPEAT_ARB                                        = 0x8370
@@ -13627,6 +14326,8 @@ const (
 	MIRROR_CLAMP_TO_EDGE_EXT                                   = 0x8743
 	MITER_REVERT_NV                                            = 0x90A7
 	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
 	MODELVIEW                                                  = 0x1700
 	MODELVIEW0_ARB                                             = 0x1700
 	MODELVIEW0_EXT                                             = 0x1700
@@ -13678,9 +14379,12 @@ const (
 	MOVE_TO_RESETS_NV                                          = 0x90B5
 	MOV_ATI                                                    = 0x8961
 	MULT                                                       = 0x0103
+	MULTICAST_GPUS_NV                                          = 0x92BA
+	MULTICAST_PROGRAMMABLE_SAMPLE_LOCATION_NV                  = 0x9549
 	MULTIPLY_KHR                                               = 0x9294
 	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
 	MULTISAMPLE_3DFX                                           = 0x86B2
 	MULTISAMPLE_ARB                                            = 0x809D
 	MULTISAMPLE_BIT                                            = 0x20000000
@@ -13690,6 +14394,9 @@ const (
 	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
 	MULTISAMPLE_EXT                                            = 0x809D
 	MULTISAMPLE_FILTER_HINT_NV                                 = 0x8534
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	MULTISAMPLE_SGIS                                           = 0x809D
 	MUL_ATI                                                    = 0x8964
 	MVP_MATRIX_EXT                                             = 0x87E3
@@ -13720,6 +14427,7 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
 	NORMALIZE                                                  = 0x0BA1
 	NORMALIZED_RANGE_EXT                                       = 0x87E0
@@ -13753,6 +14461,7 @@ const (
 	NUM_COMPATIBLE_SUBROUTINES                                 = 0x8E4A
 	NUM_COMPRESSED_TEXTURE_FORMATS                             = 0x86A2
 	NUM_COMPRESSED_TEXTURE_FORMATS_ARB                         = 0x86A2
+	NUM_DEVICE_UUIDS_EXT                                       = 0x9596
 	NUM_EXTENSIONS                                             = 0x821D
 	NUM_FILL_STREAMS_NV                                        = 0x8E29
 	NUM_FRAGMENT_CONSTANTS_ATI                                 = 0x896F
@@ -13766,8 +14475,12 @@ const (
 	NUM_PROGRAM_BINARY_FORMATS                                 = 0x87FE
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
+	NUM_TILING_TYPES_EXT                                       = 0x9582
 	NUM_VIDEO_CAPTURE_STREAMS_NV                               = 0x9024
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_ACTIVE_ATTRIBUTES_ARB                               = 0x8B89
 	OBJECT_ACTIVE_ATTRIBUTE_MAX_LENGTH_ARB                     = 0x8B8A
 	OBJECT_ACTIVE_UNIFORMS_ARB                                 = 0x8B86
@@ -13844,6 +14557,7 @@ const (
 	OPERAND2_RGB_EXT                                           = 0x8592
 	OPERAND3_ALPHA_NV                                          = 0x859B
 	OPERAND3_RGB_NV                                            = 0x8593
+	OPTIMAL_TILING_EXT                                         = 0x9584
 	OP_ADD_EXT                                                 = 0x8787
 	OP_CLAMP_EXT                                               = 0x878E
 	OP_CROSS_PRODUCT_EXT                                       = 0x8797
@@ -13923,7 +14637,7 @@ const (
 	PACK_INVERT_MESA                                           = 0x8758
 	PACK_LSB_FIRST                                             = 0x0D01
 	PACK_RESAMPLE_OML                                          = 0x8984
-	PACK_RESAMPLE_SGIX                                         = 0x842C
+	PACK_RESAMPLE_SGIX                                         = 0x842E
 	PACK_ROW_BYTES_APPLE                                       = 0x8A15
 	PACK_ROW_LENGTH                                            = 0x0D02
 	PACK_SKIP_IMAGES                                           = 0x806B
@@ -14028,10 +14742,14 @@ const (
 	PERFQUERY_WAIT_INTEL                                       = 0x83FB
 	PERSPECTIVE_CORRECTION_HINT                                = 0x0C50
 	PERTURB_EXT                                                = 0x85AE
+	PER_GPU_STORAGE_BIT_NV                                     = 0x0800
+	PER_GPU_STORAGE_NV                                         = 0x9548
 	PER_STAGE_CONSTANTS_NV                                     = 0x8535
 	PHONG_HINT_WIN                                             = 0x80EB
 	PHONG_WIN                                                  = 0x80EA
 	PINLIGHT_NV                                                = 0x92A8
+	PIXELS_PER_SAMPLE_PATTERN_X_AMD                            = 0x91AE
+	PIXELS_PER_SAMPLE_PATTERN_Y_AMD                            = 0x91AF
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_BUFFER_BARRIER_BIT_EXT                               = 0x00000080
 	PIXEL_COUNTER_BITS_NV                                      = 0x8864
@@ -14137,6 +14855,9 @@ const (
 	POLYGON_BIT                                                = 0x00000008
 	POLYGON_MODE                                               = 0x0B40
 	POLYGON_OFFSET_BIAS_EXT                                    = 0x8039
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_EXT                                         = 0x8037
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FACTOR_EXT                                  = 0x8038
@@ -14207,6 +14928,7 @@ const (
 	PRIMITIVES_GENERATED_EXT                                   = 0x8C87
 	PRIMITIVES_GENERATED_NV                                    = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_ID_NV                                            = 0x8C7C
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
@@ -14214,11 +14936,16 @@ const (
 	PRIMITIVE_RESTART_INDEX_NV                                 = 0x8559
 	PRIMITIVE_RESTART_NV                                       = 0x8558
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_ADDRESS_REGISTERS_ARB                              = 0x88B0
 	PROGRAM_ALU_INSTRUCTIONS_ARB                               = 0x8805
 	PROGRAM_ATTRIBS_ARB                                        = 0x88AC
 	PROGRAM_ATTRIB_COMPONENTS_NV                               = 0x8906
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
+	PROGRAM_BINARY_FORMAT_MESA                                 = 0x875F
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_BINDING_ARB                                        = 0x8677
@@ -14251,6 +14978,7 @@ const (
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
 	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
 	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
 	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
@@ -14269,6 +14997,7 @@ const (
 	PROJECTION                                                 = 0x1701
 	PROJECTION_MATRIX                                          = 0x0BA7
 	PROJECTION_STACK_DEPTH                                     = 0x0BA4
+	PROTECTED_MEMORY_OBJECT_EXT                                = 0x959B
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROVOKING_VERTEX_EXT                                       = 0x8E4F
 	PROXY_COLOR_TABLE                                          = 0x80D3
@@ -14304,6 +15033,7 @@ const (
 	PROXY_TEXTURE_RECTANGLE_ARB                                = 0x84F7
 	PROXY_TEXTURE_RECTANGLE_NV                                 = 0x84F7
 	PURGEABLE_APPLE                                            = 0x8A1D
+	PURGED_CONTEXT_RESET_NV                                    = 0x92BB
 	Q                                                          = 0x2003
 	QUADRATIC_ATTENUATION                                      = 0x1209
 	QUADRATIC_CURVE_TO_NV                                      = 0x0A
@@ -14344,6 +15074,12 @@ const (
 	QUERY_NO_WAIT_NV                                           = 0x8E14
 	QUERY_OBJECT_AMD                                           = 0x9153
 	QUERY_OBJECT_EXT                                           = 0x9153
+	QUERY_RESOURCE_BUFFEROBJECT_NV                             = 0x9547
+	QUERY_RESOURCE_MEMTYPE_VIDMEM_NV                           = 0x9542
+	QUERY_RESOURCE_RENDERBUFFER_NV                             = 0x9546
+	QUERY_RESOURCE_SYS_RESERVED_NV                             = 0x9544
+	QUERY_RESOURCE_TEXTURE_NV                                  = 0x9545
+	QUERY_RESOURCE_TYPE_VIDMEM_ALLOC_NV                        = 0x9540
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_ARB                                           = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
@@ -14382,7 +15118,10 @@ const (
 	RASTERIZER_DISCARD                                         = 0x8C89
 	RASTERIZER_DISCARD_EXT                                     = 0x8C89
 	RASTERIZER_DISCARD_NV                                      = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
 	RASTER_POSITION_UNCLIPPED_IBM                              = 0x19262
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -14507,6 +15246,7 @@ const (
 	RENDERBUFFER_WIDTH                                         = 0x8D42
 	RENDERBUFFER_WIDTH_EXT                                     = 0x8D42
 	RENDERER                                                   = 0x1F01
+	RENDER_GPU_MASK_NV                                         = 0x9558
 	RENDER_MODE                                                = 0x0C40
 	REPEAT                                                     = 0x2901
 	REPLACE                                                    = 0x1E01
@@ -14525,9 +15265,9 @@ const (
 	RESAMPLE_DECIMATE_OML                                      = 0x8989
 	RESAMPLE_DECIMATE_SGIX                                     = 0x8430
 	RESAMPLE_REPLICATE_OML                                     = 0x8986
-	RESAMPLE_REPLICATE_SGIX                                    = 0x842E
+	RESAMPLE_REPLICATE_SGIX                                    = 0x8433
 	RESAMPLE_ZERO_FILL_OML                                     = 0x8987
-	RESAMPLE_ZERO_FILL_SGIX                                    = 0x842F
+	RESAMPLE_ZERO_FILL_SGIX                                    = 0x8434
 	RESCALE_NORMAL                                             = 0x803A
 	RESCALE_NORMAL_EXT                                         = 0x803A
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
@@ -14723,6 +15463,14 @@ const (
 	SAMPLE_COVERAGE_INVERT_ARB                                 = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
 	SAMPLE_COVERAGE_VALUE_ARB                                  = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_EXT                                            = 0x80A0
 	SAMPLE_MASK_INVERT_EXT                                     = 0x80AB
@@ -14748,6 +15496,7 @@ const (
 	SCALE_BY_TWO_NV                                            = 0x853E
 	SCISSOR_BIT                                                = 0x00080000
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
 	SCREEN_COORDINATES_REND                                    = 0x8490
 	SCREEN_KHR                                                 = 0x9295
@@ -14784,6 +15533,7 @@ const (
 	SET_AMD                                                    = 0x874A
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
 	SHADER_CONSISTENT_NV                                       = 0x86DD
 	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
@@ -14811,6 +15561,7 @@ const (
 	SHADING_LANGUAGE_VERSION_ARB                               = 0x8B8C
 	SHADOW_AMBIENT_SGIX                                        = 0x80BF
 	SHADOW_ATTENUATION_EXT                                     = 0x834E
+	SHARED_EDGE_NV                                             = 0xC0
 	SHARED_TEXTURE_PALETTE_EXT                                 = 0x81FB
 	SHARPEN_TEXTURE_FUNC_POINTS_SGIS                           = 0x80B0
 	SHININESS                                                  = 0x1601
@@ -14897,6 +15648,8 @@ const (
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
 	SPECULAR                                                   = 0x1202
 	SPHERE_MAP                                                 = 0x2402
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
 	SPOT_CUTOFF                                                = 0x1206
 	SPOT_DIRECTION                                             = 0x1204
 	SPOT_EXPONENT                                              = 0x1205
@@ -14983,7 +15736,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TAG_BITS_EXT                                       = 0x88F2
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_TEST_TWO_SIDE_EXT                                  = 0x8910
@@ -15005,11 +15760,15 @@ const (
 	STRICT_LIGHTING_HINT_PGI                                   = 0x1A217
 	STRICT_SCISSOR_HINT_PGI                                    = 0x1A218
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
 	SUBSAMPLE_DISTANCE_AMD                                     = 0x883F
 	SUBTRACT                                                   = 0x84E7
 	SUBTRACT_ARB                                               = 0x84E7
 	SUB_ATI                                                    = 0x8965
 	SUCCESS_NV                                                 = 0x902F
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SURFACE_MAPPED_NV                                          = 0x8700
 	SURFACE_REGISTERED_NV                                      = 0x86FD
 	SURFACE_STATE_NV                                           = 0x86EB
@@ -15047,6 +15806,7 @@ const (
 	TANGENT_ARRAY_POINTER_EXT                                  = 0x8442
 	TANGENT_ARRAY_STRIDE_EXT                                   = 0x843F
 	TANGENT_ARRAY_TYPE_EXT                                     = 0x843E
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESSELLATION_FACTOR_AMD                                    = 0x9005
 	TESSELLATION_MODE_AMD                                      = 0x9004
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
@@ -15166,7 +15926,6 @@ const (
 	TEXTURE_APPLICATION_MODE_EXT                               = 0x834F
 	TEXTURE_BASE_LEVEL                                         = 0x813C
 	TEXTURE_BASE_LEVEL_SGIS                                    = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_1D_ARRAY_EXT                               = 0x8C1C
@@ -15342,6 +16101,7 @@ const (
 	TEXTURE_MATERIAL_FACE_EXT                                  = 0x8351
 	TEXTURE_MATERIAL_PARAMETER_EXT                             = 0x8352
 	TEXTURE_MATRIX                                             = 0x0BA8
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_ANISOTROPY_EXT                                 = 0x84FE
 	TEXTURE_MAX_CLAMP_R_SGIX                                   = 0x836B
 	TEXTURE_MAX_CLAMP_S_SGIX                                   = 0x8369
@@ -15365,6 +16125,8 @@ const (
 	TEXTURE_RECTANGLE                                          = 0x84F5
 	TEXTURE_RECTANGLE_ARB                                      = 0x84F5
 	TEXTURE_RECTANGLE_NV                                       = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_SIZE_EXT                                       = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
@@ -15396,6 +16158,7 @@ const (
 	TEXTURE_SWIZZLE_RGBA_EXT                                   = 0x8E46
 	TEXTURE_SWIZZLE_R_EXT                                      = 0x8E42
 	TEXTURE_TARGET                                             = 0x1006
+	TEXTURE_TILING_EXT                                         = 0x9580
 	TEXTURE_TOO_LARGE_EXT                                      = 0x8065
 	TEXTURE_UNSIGNED_REMAP_MODE_NV                             = 0x888F
 	TEXTURE_UPDATE_BARRIER_BIT                                 = 0x00000100
@@ -15412,6 +16175,10 @@ const (
 	TEXTURE_WRAP_S                                             = 0x2802
 	TEXTURE_WRAP_T                                             = 0x2803
 	TEXT_FRAGMENT_SHADER_ATI                                   = 0x8200
+	TILE_RASTER_ORDER_FIXED_MESA                               = 0x8BB8
+	TILE_RASTER_ORDER_INCREASING_X_MESA                        = 0x8BB9
+	TILE_RASTER_ORDER_INCREASING_Y_MESA                        = 0x8BBA
+	TILING_TYPES_EXT                                           = 0x9583
 	TIMEOUT_EXPIRED                                            = 0x911B
 	TIMEOUT_IGNORED                                            = 0xFFFFFFFFFFFFFFFF
 	TIMESTAMP                                                  = 0x8E28
@@ -15423,7 +16190,6 @@ const (
 	TRACK_MATRIX_TRANSFORM_NV                                  = 0x8649
 	TRANSFORM_BIT                                              = 0x00001000
 	TRANSFORM_FEEDBACK                                         = 0x8E22
-	TRANSFORM_FEEDBACK_ACTIVE                                  = 0x8E24
 	TRANSFORM_FEEDBACK_ATTRIBS_NV                              = 0x8C7E
 	TRANSFORM_FEEDBACK_BARRIER_BIT                             = 0x00000800
 	TRANSFORM_FEEDBACK_BARRIER_BIT_EXT                         = 0x00000800
@@ -15452,7 +16218,6 @@ const (
 	TRANSFORM_FEEDBACK_BUFFER_STRIDE                           = 0x934C
 	TRANSFORM_FEEDBACK_NV                                      = 0x8E22
 	TRANSFORM_FEEDBACK_OVERFLOW_ARB                            = 0x82EC
-	TRANSFORM_FEEDBACK_PAUSED                                  = 0x8E23
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN                      = 0x8C88
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN_EXT                  = 0x8C88
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN_NV                   = 0x8C88
@@ -15500,6 +16265,7 @@ const (
 	UNDEFINED_APPLE                                            = 0x8A1C
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -15518,12 +16284,15 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
 	UNIFORM_BUFFER_BINDING_EXT                                 = 0x8DEF
 	UNIFORM_BUFFER_EXT                                         = 0x8DEE
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -15546,7 +16315,7 @@ const (
 	UNPACK_IMAGE_HEIGHT_EXT                                    = 0x806E
 	UNPACK_LSB_FIRST                                           = 0x0CF1
 	UNPACK_RESAMPLE_OML                                        = 0x8985
-	UNPACK_RESAMPLE_SGIX                                       = 0x842D
+	UNPACK_RESAMPLE_SGIX                                       = 0x842F
 	UNPACK_ROW_BYTES_APPLE                                     = 0x8A16
 	UNPACK_ROW_LENGTH                                          = 0x0CF2
 	UNPACK_SKIP_IMAGES                                         = 0x806D
@@ -15570,8 +16339,11 @@ const (
 	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
 	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
 	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
 	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
 	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
 	UNSIGNED_INT8_NV                                           = 0x8FEC
 	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
@@ -15662,6 +16434,7 @@ const (
 	USE_MISSING_GLYPH_NV                                       = 0x90AA
 	UTF16_NV                                                   = 0x909B
 	UTF8_NV                                                    = 0x909A
+	UUID_SIZE_EXT                                              = 16
 	V2F                                                        = 0x2A20
 	V3F                                                        = 0x2A21
 	VALIDATE_STATUS                                            = 0x8B83
@@ -15843,8 +16616,24 @@ const (
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BIT                                               = 0x00000800
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -15874,6 +16663,8 @@ const (
 	WAIT_FAILED                                                = 0x911D
 	WARPS_PER_SM_NV                                            = 0x933A
 	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
 	WEIGHT_ARRAY_ARB                                           = 0x86AD
 	WEIGHT_ARRAY_BUFFER_BINDING                                = 0x889E
 	WEIGHT_ARRAY_BUFFER_BINDING_ARB                            = 0x889E
@@ -15883,6 +16674,8 @@ const (
 	WEIGHT_ARRAY_TYPE_ARB                                      = 0x86A9
 	WEIGHT_SUM_UNITY_ARB                                       = 0x86A6
 	WIDE_LINE_HINT_PGI                                         = 0x1A222
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRAP_BORDER_SUN                                            = 0x81D4
 	WRITE_DISCARD_NV                                           = 0x88BE
 	WRITE_ONLY                                                 = 0x88B9
@@ -15919,6 +16712,7 @@ const (
 var (
 	gpAccum                                                  C.GPACCUM
 	gpAccumxOES                                              C.GPACCUMXOES
+	gpAcquireKeyedMutexWin32EXT                              C.GPACQUIREKEYEDMUTEXWIN32EXT
 	gpActiveProgramEXT                                       C.GPACTIVEPROGRAMEXT
 	gpActiveShaderProgram                                    C.GPACTIVESHADERPROGRAM
 	gpActiveShaderProgramEXT                                 C.GPACTIVESHADERPROGRAMEXT
@@ -15931,6 +16725,8 @@ var (
 	gpAlphaFragmentOp3ATI                                    C.GPALPHAFRAGMENTOP3ATI
 	gpAlphaFunc                                              C.GPALPHAFUNC
 	gpAlphaFuncxOES                                          C.GPALPHAFUNCXOES
+	gpAlphaToCoverageDitherControlNV                         C.GPALPHATOCOVERAGEDITHERCONTROLNV
+	gpApplyFramebufferAttachmentCMAAINTEL                    C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
 	gpApplyTextureEXT                                        C.GPAPPLYTEXTUREEXT
 	gpAreProgramsResidentNV                                  C.GPAREPROGRAMSRESIDENTNV
 	gpAreTexturesResident                                    C.GPARETEXTURESRESIDENT
@@ -16051,8 +16847,11 @@ var (
 	gpBufferPageCommitmentARB                                C.GPBUFFERPAGECOMMITMENTARB
 	gpBufferParameteriAPPLE                                  C.GPBUFFERPARAMETERIAPPLE
 	gpBufferStorage                                          C.GPBUFFERSTORAGE
+	gpBufferStorageExternalEXT                               C.GPBUFFERSTORAGEEXTERNALEXT
+	gpBufferStorageMemEXT                                    C.GPBUFFERSTORAGEMEMEXT
 	gpBufferSubData                                          C.GPBUFFERSUBDATA
 	gpBufferSubDataARB                                       C.GPBUFFERSUBDATAARB
+	gpCallCommandListNV                                      C.GPCALLCOMMANDLISTNV
 	gpCallList                                               C.GPCALLLIST
 	gpCallLists                                              C.GPCALLLISTS
 	gpCheckFramebufferStatus                                 C.GPCHECKFRAMEBUFFERSTATUS
@@ -16180,6 +16979,8 @@ var (
 	gpCombinerParameteriNV                                   C.GPCOMBINERPARAMETERINV
 	gpCombinerParameterivNV                                  C.GPCOMBINERPARAMETERIVNV
 	gpCombinerStageParameterfvNV                             C.GPCOMBINERSTAGEPARAMETERFVNV
+	gpCommandListSegmentsNV                                  C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                                   C.GPCOMPILECOMMANDLISTNV
 	gpCompileShader                                          C.GPCOMPILESHADER
 	gpCompileShaderARB                                       C.GPCOMPILESHADERARB
 	gpCompileShaderIncludeARB                                C.GPCOMPILESHADERINCLUDEARB
@@ -16210,6 +17011,8 @@ var (
 	gpCompressedTextureSubImage2DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
 	gpCompressedTextureSubImage3D                            C.GPCOMPRESSEDTEXTURESUBIMAGE3D
 	gpCompressedTextureSubImage3DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                         C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                         C.GPCONSERVATIVERASTERPARAMETERINV
 	gpConvolutionFilter1D                                    C.GPCONVOLUTIONFILTER1D
 	gpConvolutionFilter1DEXT                                 C.GPCONVOLUTIONFILTER1DEXT
 	gpConvolutionFilter2D                                    C.GPCONVOLUTIONFILTER2D
@@ -16265,8 +17068,12 @@ var (
 	gpCoverFillPathNV                                        C.GPCOVERFILLPATHNV
 	gpCoverStrokePathInstancedNV                             C.GPCOVERSTROKEPATHINSTANCEDNV
 	gpCoverStrokePathNV                                      C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                                   C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                              C.GPCOVERAGEMODULATIONTABLENV
 	gpCreateBuffers                                          C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                                   C.GPCREATECOMMANDLISTSNV
 	gpCreateFramebuffers                                     C.GPCREATEFRAMEBUFFERS
+	gpCreateMemoryObjectsEXT                                 C.GPCREATEMEMORYOBJECTSEXT
 	gpCreatePerfQueryINTEL                                   C.GPCREATEPERFQUERYINTEL
 	gpCreateProgram                                          C.GPCREATEPROGRAM
 	gpCreateProgramObjectARB                                 C.GPCREATEPROGRAMOBJECTARB
@@ -16279,6 +17086,7 @@ var (
 	gpCreateShaderProgramEXT                                 C.GPCREATESHADERPROGRAMEXT
 	gpCreateShaderProgramv                                   C.GPCREATESHADERPROGRAMV
 	gpCreateShaderProgramvEXT                                C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                         C.GPCREATESTATESNV
 	gpCreateSyncFromCLeventARB                               C.GPCREATESYNCFROMCLEVENTARB
 	gpCreateTextures                                         C.GPCREATETEXTURES
 	gpCreateTransformFeedbacks                               C.GPCREATETRANSFORMFEEDBACKS
@@ -16305,12 +17113,14 @@ var (
 	gpDeleteAsyncMarkersSGIX                                 C.GPDELETEASYNCMARKERSSGIX
 	gpDeleteBuffers                                          C.GPDELETEBUFFERS
 	gpDeleteBuffersARB                                       C.GPDELETEBUFFERSARB
+	gpDeleteCommandListsNV                                   C.GPDELETECOMMANDLISTSNV
 	gpDeleteFencesAPPLE                                      C.GPDELETEFENCESAPPLE
 	gpDeleteFencesNV                                         C.GPDELETEFENCESNV
 	gpDeleteFragmentShaderATI                                C.GPDELETEFRAGMENTSHADERATI
 	gpDeleteFramebuffers                                     C.GPDELETEFRAMEBUFFERS
 	gpDeleteFramebuffersEXT                                  C.GPDELETEFRAMEBUFFERSEXT
 	gpDeleteLists                                            C.GPDELETELISTS
+	gpDeleteMemoryObjectsEXT                                 C.GPDELETEMEMORYOBJECTSEXT
 	gpDeleteNamedStringARB                                   C.GPDELETENAMEDSTRINGARB
 	gpDeleteNamesAMD                                         C.GPDELETENAMESAMD
 	gpDeleteObjectARB                                        C.GPDELETEOBJECTARB
@@ -16325,10 +17135,13 @@ var (
 	gpDeleteProgramsNV                                       C.GPDELETEPROGRAMSNV
 	gpDeleteQueries                                          C.GPDELETEQUERIES
 	gpDeleteQueriesARB                                       C.GPDELETEQUERIESARB
+	gpDeleteQueryResourceTagNV                               C.GPDELETEQUERYRESOURCETAGNV
 	gpDeleteRenderbuffers                                    C.GPDELETERENDERBUFFERS
 	gpDeleteRenderbuffersEXT                                 C.GPDELETERENDERBUFFERSEXT
 	gpDeleteSamplers                                         C.GPDELETESAMPLERS
+	gpDeleteSemaphoresEXT                                    C.GPDELETESEMAPHORESEXT
 	gpDeleteShader                                           C.GPDELETESHADER
+	gpDeleteStatesNV                                         C.GPDELETESTATESNV
 	gpDeleteSync                                             C.GPDELETESYNC
 	gpDeleteTextures                                         C.GPDELETETEXTURES
 	gpDeleteTexturesEXT                                      C.GPDELETETEXTURESEXT
@@ -16378,6 +17191,10 @@ var (
 	gpDrawBuffers                                            C.GPDRAWBUFFERS
 	gpDrawBuffersARB                                         C.GPDRAWBUFFERSARB
 	gpDrawBuffersATI                                         C.GPDRAWBUFFERSATI
+	gpDrawCommandsAddressNV                                  C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                         C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                            C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                                   C.GPDRAWCOMMANDSSTATESNV
 	gpDrawElementArrayAPPLE                                  C.GPDRAWELEMENTARRAYAPPLE
 	gpDrawElementArrayATI                                    C.GPDRAWELEMENTARRAYATI
 	gpDrawElements                                           C.GPDRAWELEMENTS
@@ -16402,6 +17219,7 @@ var (
 	gpDrawTransformFeedbackNV                                C.GPDRAWTRANSFORMFEEDBACKNV
 	gpDrawTransformFeedbackStream                            C.GPDRAWTRANSFORMFEEDBACKSTREAM
 	gpDrawTransformFeedbackStreamInstanced                   C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                          C.GPDRAWVKIMAGENV
 	gpEdgeFlag                                               C.GPEDGEFLAG
 	gpEdgeFlagFormatNV                                       C.GPEDGEFLAGFORMATNV
 	gpEdgeFlagPointer                                        C.GPEDGEFLAGPOINTER
@@ -16457,6 +17275,7 @@ var (
 	gpEvalMesh2                                              C.GPEVALMESH2
 	gpEvalPoint1                                             C.GPEVALPOINT1
 	gpEvalPoint2                                             C.GPEVALPOINT2
+	gpEvaluateDepthValuesARB                                 C.GPEVALUATEDEPTHVALUESARB
 	gpExecuteProgramNV                                       C.GPEXECUTEPROGRAMNV
 	gpExtractComponentEXT                                    C.GPEXTRACTCOMPONENTEXT
 	gpFeedbackBuffer                                         C.GPFEEDBACKBUFFER
@@ -16501,6 +17320,7 @@ var (
 	gpFogxOES                                                C.GPFOGXOES
 	gpFogxvOES                                               C.GPFOGXVOES
 	gpFragmentColorMaterialSGIX                              C.GPFRAGMENTCOLORMATERIALSGIX
+	gpFragmentCoverageColorNV                                C.GPFRAGMENTCOVERAGECOLORNV
 	gpFragmentLightModelfSGIX                                C.GPFRAGMENTLIGHTMODELFSGIX
 	gpFragmentLightModelfvSGIX                               C.GPFRAGMENTLIGHTMODELFVSGIX
 	gpFragmentLightModeliSGIX                                C.GPFRAGMENTLIGHTMODELISGIX
@@ -16517,10 +17337,14 @@ var (
 	gpFrameZoomSGIX                                          C.GPFRAMEZOOMSGIX
 	gpFramebufferDrawBufferEXT                               C.GPFRAMEBUFFERDRAWBUFFEREXT
 	gpFramebufferDrawBuffersEXT                              C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                             C.GPFRAMEBUFFERFETCHBARRIEREXT
 	gpFramebufferParameteri                                  C.GPFRAMEBUFFERPARAMETERI
 	gpFramebufferReadBufferEXT                               C.GPFRAMEBUFFERREADBUFFEREXT
 	gpFramebufferRenderbuffer                                C.GPFRAMEBUFFERRENDERBUFFER
 	gpFramebufferRenderbufferEXT                             C.GPFRAMEBUFFERRENDERBUFFEREXT
+	gpFramebufferSampleLocationsfvARB                        C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                         C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferSamplePositionsfvAMD                        C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpFramebufferTexture                                     C.GPFRAMEBUFFERTEXTURE
 	gpFramebufferTexture1D                                   C.GPFRAMEBUFFERTEXTURE1D
 	gpFramebufferTexture1DEXT                                C.GPFRAMEBUFFERTEXTURE1DEXT
@@ -16535,6 +17359,7 @@ var (
 	gpFramebufferTextureLayer                                C.GPFRAMEBUFFERTEXTURELAYER
 	gpFramebufferTextureLayerARB                             C.GPFRAMEBUFFERTEXTURELAYERARB
 	gpFramebufferTextureLayerEXT                             C.GPFRAMEBUFFERTEXTURELAYEREXT
+	gpFramebufferTextureMultiviewOVR                         C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
 	gpFreeObjectBufferATI                                    C.GPFREEOBJECTBUFFERATI
 	gpFrontFace                                              C.GPFRONTFACE
 	gpFrustum                                                C.GPFRUSTUM
@@ -16559,9 +17384,11 @@ var (
 	gpGenProgramsNV                                          C.GPGENPROGRAMSNV
 	gpGenQueries                                             C.GPGENQUERIES
 	gpGenQueriesARB                                          C.GPGENQUERIESARB
+	gpGenQueryResourceTagNV                                  C.GPGENQUERYRESOURCETAGNV
 	gpGenRenderbuffers                                       C.GPGENRENDERBUFFERS
 	gpGenRenderbuffersEXT                                    C.GPGENRENDERBUFFERSEXT
 	gpGenSamplers                                            C.GPGENSAMPLERS
+	gpGenSemaphoresEXT                                       C.GPGENSEMAPHORESEXT
 	gpGenSymbolsEXT                                          C.GPGENSYMBOLSEXT
 	gpGenTextures                                            C.GPGENTEXTURES
 	gpGenTexturesEXT                                         C.GPGENTEXTURESEXT
@@ -16622,6 +17449,7 @@ var (
 	gpGetCombinerOutputParameterfvNV                         C.GPGETCOMBINEROUTPUTPARAMETERFVNV
 	gpGetCombinerOutputParameterivNV                         C.GPGETCOMBINEROUTPUTPARAMETERIVNV
 	gpGetCombinerStageParameterfvNV                          C.GPGETCOMBINERSTAGEPARAMETERFVNV
+	gpGetCommandHeaderNV                                     C.GPGETCOMMANDHEADERNV
 	gpGetCompressedMultiTexImageEXT                          C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
 	gpGetCompressedTexImage                                  C.GPGETCOMPRESSEDTEXIMAGE
 	gpGetCompressedTexImageARB                               C.GPGETCOMPRESSEDTEXIMAGEARB
@@ -16635,6 +17463,7 @@ var (
 	gpGetConvolutionParameteriv                              C.GPGETCONVOLUTIONPARAMETERIV
 	gpGetConvolutionParameterivEXT                           C.GPGETCONVOLUTIONPARAMETERIVEXT
 	gpGetConvolutionParameterxvOES                           C.GPGETCONVOLUTIONPARAMETERXVOES
+	gpGetCoverageModulationTableNV                           C.GPGETCOVERAGEMODULATIONTABLENV
 	gpGetDebugMessageLog                                     C.GPGETDEBUGMESSAGELOG
 	gpGetDebugMessageLogAMD                                  C.GPGETDEBUGMESSAGELOGAMD
 	gpGetDebugMessageLogARB                                  C.GPGETDEBUGMESSAGELOGARB
@@ -16664,6 +17493,7 @@ var (
 	gpGetFragmentMaterialivSGIX                              C.GPGETFRAGMENTMATERIALIVSGIX
 	gpGetFramebufferAttachmentParameteriv                    C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetFramebufferAttachmentParameterivEXT                 C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetFramebufferParameterfvAMD                           C.GPGETFRAMEBUFFERPARAMETERFVAMD
 	gpGetFramebufferParameteriv                              C.GPGETFRAMEBUFFERPARAMETERIV
 	gpGetFramebufferParameterivEXT                           C.GPGETFRAMEBUFFERPARAMETERIVEXT
 	gpGetGraphicsResetStatus                                 C.GPGETGRAPHICSRESETSTATUS
@@ -16690,6 +17520,7 @@ var (
 	gpGetIntegerui64i_vNV                                    C.GPGETINTEGERUI64I_VNV
 	gpGetIntegerui64vNV                                      C.GPGETINTEGERUI64VNV
 	gpGetIntegerv                                            C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                            C.GPGETINTERNALFORMATSAMPLEIVNV
 	gpGetInternalformati64v                                  C.GPGETINTERNALFORMATI64V
 	gpGetInternalformativ                                    C.GPGETINTERNALFORMATIV
 	gpGetInvariantBooleanvEXT                                C.GPGETINVARIANTBOOLEANVEXT
@@ -16717,6 +17548,7 @@ var (
 	gpGetMaterialiv                                          C.GPGETMATERIALIV
 	gpGetMaterialxOES                                        C.GPGETMATERIALXOES
 	gpGetMaterialxvOES                                       C.GPGETMATERIALXVOES
+	gpGetMemoryObjectParameterivEXT                          C.GPGETMEMORYOBJECTPARAMETERIVEXT
 	gpGetMinmax                                              C.GPGETMINMAX
 	gpGetMinmaxEXT                                           C.GPGETMINMAXEXT
 	gpGetMinmaxParameterfv                                   C.GPGETMINMAXPARAMETERFV
@@ -16747,6 +17579,7 @@ var (
 	gpGetNamedBufferSubDataEXT                               C.GPGETNAMEDBUFFERSUBDATAEXT
 	gpGetNamedFramebufferAttachmentParameteriv               C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetNamedFramebufferAttachmentParameterivEXT            C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameterfvAMD                      C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD
 	gpGetNamedFramebufferParameteriv                         C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
 	gpGetNamedFramebufferParameterivEXT                      C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
 	gpGetNamedProgramLocalParameterIivEXT                    C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
@@ -16841,6 +17674,10 @@ var (
 	gpGetProgramiv                                           C.GPGETPROGRAMIV
 	gpGetProgramivARB                                        C.GPGETPROGRAMIVARB
 	gpGetProgramivNV                                         C.GPGETPROGRAMIVNV
+	gpGetQueryBufferObjecti64v                               C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                                 C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                              C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                                C.GPGETQUERYBUFFEROBJECTUIV
 	gpGetQueryIndexediv                                      C.GPGETQUERYINDEXEDIV
 	gpGetQueryObjecti64v                                     C.GPGETQUERYOBJECTI64V
 	gpGetQueryObjecti64vEXT                                  C.GPGETQUERYOBJECTI64VEXT
@@ -16858,6 +17695,7 @@ var (
 	gpGetSamplerParameterIuiv                                C.GPGETSAMPLERPARAMETERIUIV
 	gpGetSamplerParameterfv                                  C.GPGETSAMPLERPARAMETERFV
 	gpGetSamplerParameteriv                                  C.GPGETSAMPLERPARAMETERIV
+	gpGetSemaphoreParameterui64vEXT                          C.GPGETSEMAPHOREPARAMETERUI64VEXT
 	gpGetSeparableFilter                                     C.GPGETSEPARABLEFILTER
 	gpGetSeparableFilterEXT                                  C.GPGETSEPARABLEFILTEREXT
 	gpGetShaderInfoLog                                       C.GPGETSHADERINFOLOG
@@ -16866,6 +17704,7 @@ var (
 	gpGetShaderSourceARB                                     C.GPGETSHADERSOURCEARB
 	gpGetShaderiv                                            C.GPGETSHADERIV
 	gpGetSharpenTexFuncSGIS                                  C.GPGETSHARPENTEXFUNCSGIS
+	gpGetStageIndexNV                                        C.GPGETSTAGEINDEXNV
 	gpGetString                                              C.GPGETSTRING
 	gpGetStringi                                             C.GPGETSTRINGI
 	gpGetSubroutineIndex                                     C.GPGETSUBROUTINEINDEX
@@ -16929,12 +17768,16 @@ var (
 	gpGetUniformdv                                           C.GPGETUNIFORMDV
 	gpGetUniformfv                                           C.GPGETUNIFORMFV
 	gpGetUniformfvARB                                        C.GPGETUNIFORMFVARB
+	gpGetUniformi64vARB                                      C.GPGETUNIFORMI64VARB
 	gpGetUniformi64vNV                                       C.GPGETUNIFORMI64VNV
 	gpGetUniformiv                                           C.GPGETUNIFORMIV
 	gpGetUniformivARB                                        C.GPGETUNIFORMIVARB
+	gpGetUniformui64vARB                                     C.GPGETUNIFORMUI64VARB
 	gpGetUniformui64vNV                                      C.GPGETUNIFORMUI64VNV
 	gpGetUniformuiv                                          C.GPGETUNIFORMUIV
 	gpGetUniformuivEXT                                       C.GPGETUNIFORMUIVEXT
+	gpGetUnsignedBytei_vEXT                                  C.GPGETUNSIGNEDBYTEI_VEXT
+	gpGetUnsignedBytevEXT                                    C.GPGETUNSIGNEDBYTEVEXT
 	gpGetVariantArrayObjectfvATI                             C.GPGETVARIANTARRAYOBJECTFVATI
 	gpGetVariantArrayObjectivATI                             C.GPGETVARIANTARRAYOBJECTIVATI
 	gpGetVariantBooleanvEXT                                  C.GPGETVARIANTBOOLEANVEXT
@@ -16980,6 +17823,7 @@ var (
 	gpGetVideoivNV                                           C.GPGETVIDEOIVNV
 	gpGetVideoui64vNV                                        C.GPGETVIDEOUI64VNV
 	gpGetVideouivNV                                          C.GPGETVIDEOUIVNV
+	gpGetVkProcAddrNV                                        C.GPGETVKPROCADDRNV
 	gpGetnColorTableARB                                      C.GPGETNCOLORTABLEARB
 	gpGetnCompressedTexImageARB                              C.GPGETNCOMPRESSEDTEXIMAGEARB
 	gpGetnConvolutionFilterARB                               C.GPGETNCONVOLUTIONFILTERARB
@@ -16998,9 +17842,11 @@ var (
 	gpGetnUniformfv                                          C.GPGETNUNIFORMFV
 	gpGetnUniformfvARB                                       C.GPGETNUNIFORMFVARB
 	gpGetnUniformfvKHR                                       C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                                     C.GPGETNUNIFORMI64VARB
 	gpGetnUniformiv                                          C.GPGETNUNIFORMIV
 	gpGetnUniformivARB                                       C.GPGETNUNIFORMIVARB
 	gpGetnUniformivKHR                                       C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                                    C.GPGETNUNIFORMUI64VARB
 	gpGetnUniformuiv                                         C.GPGETNUNIFORMUIV
 	gpGetnUniformuivARB                                      C.GPGETNUNIFORMUIVARB
 	gpGetnUniformuivKHR                                      C.GPGETNUNIFORMUIVKHR
@@ -17021,6 +17867,12 @@ var (
 	gpImageTransformParameterfvHP                            C.GPIMAGETRANSFORMPARAMETERFVHP
 	gpImageTransformParameteriHP                             C.GPIMAGETRANSFORMPARAMETERIHP
 	gpImageTransformParameterivHP                            C.GPIMAGETRANSFORMPARAMETERIVHP
+	gpImportMemoryFdEXT                                      C.GPIMPORTMEMORYFDEXT
+	gpImportMemoryWin32HandleEXT                             C.GPIMPORTMEMORYWIN32HANDLEEXT
+	gpImportMemoryWin32NameEXT                               C.GPIMPORTMEMORYWIN32NAMEEXT
+	gpImportSemaphoreFdEXT                                   C.GPIMPORTSEMAPHOREFDEXT
+	gpImportSemaphoreWin32HandleEXT                          C.GPIMPORTSEMAPHOREWIN32HANDLEEXT
+	gpImportSemaphoreWin32NameEXT                            C.GPIMPORTSEMAPHOREWIN32NAMEEXT
 	gpImportSyncEXT                                          C.GPIMPORTSYNCEXT
 	gpIndexFormatNV                                          C.GPINDEXFORMATNV
 	gpIndexFuncEXT                                           C.GPINDEXFUNCEXT
@@ -17059,6 +17911,7 @@ var (
 	gpIsBuffer                                               C.GPISBUFFER
 	gpIsBufferARB                                            C.GPISBUFFERARB
 	gpIsBufferResidentNV                                     C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                        C.GPISCOMMANDLISTNV
 	gpIsEnabled                                              C.GPISENABLED
 	gpIsEnabledIndexedEXT                                    C.GPISENABLEDINDEXEDEXT
 	gpIsEnabledi                                             C.GPISENABLEDI
@@ -17069,6 +17922,7 @@ var (
 	gpIsImageHandleResidentARB                               C.GPISIMAGEHANDLERESIDENTARB
 	gpIsImageHandleResidentNV                                C.GPISIMAGEHANDLERESIDENTNV
 	gpIsList                                                 C.GPISLIST
+	gpIsMemoryObjectEXT                                      C.GPISMEMORYOBJECTEXT
 	gpIsNameAMD                                              C.GPISNAMEAMD
 	gpIsNamedBufferResidentNV                                C.GPISNAMEDBUFFERRESIDENTNV
 	gpIsNamedStringARB                                       C.GPISNAMEDSTRINGARB
@@ -17087,7 +17941,9 @@ var (
 	gpIsRenderbuffer                                         C.GPISRENDERBUFFER
 	gpIsRenderbufferEXT                                      C.GPISRENDERBUFFEREXT
 	gpIsSampler                                              C.GPISSAMPLER
+	gpIsSemaphoreEXT                                         C.GPISSEMAPHOREEXT
 	gpIsShader                                               C.GPISSHADER
+	gpIsStateNV                                              C.GPISSTATENV
 	gpIsSync                                                 C.GPISSYNC
 	gpIsTexture                                              C.GPISTEXTURE
 	gpIsTextureEXT                                           C.GPISTEXTUREEXT
@@ -17099,6 +17955,9 @@ var (
 	gpIsVertexArray                                          C.GPISVERTEXARRAY
 	gpIsVertexArrayAPPLE                                     C.GPISVERTEXARRAYAPPLE
 	gpIsVertexAttribEnabledAPPLE                             C.GPISVERTEXATTRIBENABLEDAPPLE
+	gpLGPUCopyImageSubDataNVX                                C.GPLGPUCOPYIMAGESUBDATANVX
+	gpLGPUInterlockNVX                                       C.GPLGPUINTERLOCKNVX
+	gpLGPUNamedBufferSubDataNVX                              C.GPLGPUNAMEDBUFFERSUBDATANVX
 	gpLabelObjectEXT                                         C.GPLABELOBJECTEXT
 	gpLightEnviSGIX                                          C.GPLIGHTENVISGIX
 	gpLightModelf                                            C.GPLIGHTMODELF
@@ -17119,6 +17978,7 @@ var (
 	gpLinkProgram                                            C.GPLINKPROGRAM
 	gpLinkProgramARB                                         C.GPLINKPROGRAMARB
 	gpListBase                                               C.GPLISTBASE
+	gpListDrawCommandsStatesClientNV                         C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
 	gpListParameterfSGIX                                     C.GPLISTPARAMETERFSGIX
 	gpListParameterfvSGIX                                    C.GPLISTPARAMETERFVSGIX
 	gpListParameteriSGIX                                     C.GPLISTPARAMETERISGIX
@@ -17213,9 +18073,12 @@ var (
 	gpMatrixScalefEXT                                        C.GPMATRIXSCALEFEXT
 	gpMatrixTranslatedEXT                                    C.GPMATRIXTRANSLATEDEXT
 	gpMatrixTranslatefEXT                                    C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                            C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                            C.GPMAXSHADERCOMPILERTHREADSKHR
 	gpMemoryBarrier                                          C.GPMEMORYBARRIER
 	gpMemoryBarrierByRegion                                  C.GPMEMORYBARRIERBYREGION
 	gpMemoryBarrierEXT                                       C.GPMEMORYBARRIEREXT
+	gpMemoryObjectParameterivEXT                             C.GPMEMORYOBJECTPARAMETERIVEXT
 	gpMinSampleShadingARB                                    C.GPMINSAMPLESHADINGARB
 	gpMinmax                                                 C.GPMINMAX
 	gpMinmaxEXT                                              C.GPMINMAXEXT
@@ -17367,12 +18230,25 @@ var (
 	gpMultiTexSubImage1DEXT                                  C.GPMULTITEXSUBIMAGE1DEXT
 	gpMultiTexSubImage2DEXT                                  C.GPMULTITEXSUBIMAGE2DEXT
 	gpMultiTexSubImage3DEXT                                  C.GPMULTITEXSUBIMAGE3DEXT
+	gpMulticastBarrierNV                                     C.GPMULTICASTBARRIERNV
+	gpMulticastBlitFramebufferNV                             C.GPMULTICASTBLITFRAMEBUFFERNV
+	gpMulticastBufferSubDataNV                               C.GPMULTICASTBUFFERSUBDATANV
+	gpMulticastCopyBufferSubDataNV                           C.GPMULTICASTCOPYBUFFERSUBDATANV
+	gpMulticastCopyImageSubDataNV                            C.GPMULTICASTCOPYIMAGESUBDATANV
+	gpMulticastFramebufferSampleLocationsfvNV                C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpMulticastGetQueryObjecti64vNV                          C.GPMULTICASTGETQUERYOBJECTI64VNV
+	gpMulticastGetQueryObjectivNV                            C.GPMULTICASTGETQUERYOBJECTIVNV
+	gpMulticastGetQueryObjectui64vNV                         C.GPMULTICASTGETQUERYOBJECTUI64VNV
+	gpMulticastGetQueryObjectuivNV                           C.GPMULTICASTGETQUERYOBJECTUIVNV
+	gpMulticastWaitSyncNV                                    C.GPMULTICASTWAITSYNCNV
 	gpNamedBufferData                                        C.GPNAMEDBUFFERDATA
 	gpNamedBufferDataEXT                                     C.GPNAMEDBUFFERDATAEXT
 	gpNamedBufferPageCommitmentARB                           C.GPNAMEDBUFFERPAGECOMMITMENTARB
 	gpNamedBufferPageCommitmentEXT                           C.GPNAMEDBUFFERPAGECOMMITMENTEXT
 	gpNamedBufferStorage                                     C.GPNAMEDBUFFERSTORAGE
 	gpNamedBufferStorageEXT                                  C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferStorageExternalEXT                          C.GPNAMEDBUFFERSTORAGEEXTERNALEXT
+	gpNamedBufferStorageMemEXT                               C.GPNAMEDBUFFERSTORAGEMEMEXT
 	gpNamedBufferSubData                                     C.GPNAMEDBUFFERSUBDATA
 	gpNamedBufferSubDataEXT                                  C.GPNAMEDBUFFERSUBDATAEXT
 	gpNamedCopyBufferSubDataEXT                              C.GPNAMEDCOPYBUFFERSUBDATAEXT
@@ -17383,6 +18259,9 @@ var (
 	gpNamedFramebufferReadBuffer                             C.GPNAMEDFRAMEBUFFERREADBUFFER
 	gpNamedFramebufferRenderbuffer                           C.GPNAMEDFRAMEBUFFERRENDERBUFFER
 	gpNamedFramebufferRenderbufferEXT                        C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB                   C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV                    C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferSamplePositionsfvAMD                   C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpNamedFramebufferTexture                                C.GPNAMEDFRAMEBUFFERTEXTURE
 	gpNamedFramebufferTexture1DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
 	gpNamedFramebufferTexture2DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
@@ -17526,6 +18405,8 @@ var (
 	gpPollInstrumentsSGIX                                    C.GPPOLLINSTRUMENTSSGIX
 	gpPolygonMode                                            C.GPPOLYGONMODE
 	gpPolygonOffset                                          C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                                     C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                                  C.GPPOLYGONOFFSETCLAMPEXT
 	gpPolygonOffsetEXT                                       C.GPPOLYGONOFFSETEXT
 	gpPolygonOffsetxOES                                      C.GPPOLYGONOFFSETXOES
 	gpPolygonStipple                                         C.GPPOLYGONSTIPPLE
@@ -17538,6 +18419,7 @@ var (
 	gpPopName                                                C.GPPOPNAME
 	gpPresentFrameDualFillNV                                 C.GPPRESENTFRAMEDUALFILLNV
 	gpPresentFrameKeyedNV                                    C.GPPRESENTFRAMEKEYEDNV
+	gpPrimitiveBoundingBoxARB                                C.GPPRIMITIVEBOUNDINGBOXARB
 	gpPrimitiveRestartIndex                                  C.GPPRIMITIVERESTARTINDEX
 	gpPrimitiveRestartIndexNV                                C.GPPRIMITIVERESTARTINDEXNV
 	gpPrimitiveRestartNV                                     C.GPPRIMITIVERESTARTNV
@@ -17595,13 +18477,17 @@ var (
 	gpProgramUniform1fv                                      C.GPPROGRAMUNIFORM1FV
 	gpProgramUniform1fvEXT                                   C.GPPROGRAMUNIFORM1FVEXT
 	gpProgramUniform1i                                       C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                                  C.GPPROGRAMUNIFORM1I64ARB
 	gpProgramUniform1i64NV                                   C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                                 C.GPPROGRAMUNIFORM1I64VARB
 	gpProgramUniform1i64vNV                                  C.GPPROGRAMUNIFORM1I64VNV
 	gpProgramUniform1iEXT                                    C.GPPROGRAMUNIFORM1IEXT
 	gpProgramUniform1iv                                      C.GPPROGRAMUNIFORM1IV
 	gpProgramUniform1ivEXT                                   C.GPPROGRAMUNIFORM1IVEXT
 	gpProgramUniform1ui                                      C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                                 C.GPPROGRAMUNIFORM1UI64ARB
 	gpProgramUniform1ui64NV                                  C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                                C.GPPROGRAMUNIFORM1UI64VARB
 	gpProgramUniform1ui64vNV                                 C.GPPROGRAMUNIFORM1UI64VNV
 	gpProgramUniform1uiEXT                                   C.GPPROGRAMUNIFORM1UIEXT
 	gpProgramUniform1uiv                                     C.GPPROGRAMUNIFORM1UIV
@@ -17615,13 +18501,17 @@ var (
 	gpProgramUniform2fv                                      C.GPPROGRAMUNIFORM2FV
 	gpProgramUniform2fvEXT                                   C.GPPROGRAMUNIFORM2FVEXT
 	gpProgramUniform2i                                       C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                                  C.GPPROGRAMUNIFORM2I64ARB
 	gpProgramUniform2i64NV                                   C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                                 C.GPPROGRAMUNIFORM2I64VARB
 	gpProgramUniform2i64vNV                                  C.GPPROGRAMUNIFORM2I64VNV
 	gpProgramUniform2iEXT                                    C.GPPROGRAMUNIFORM2IEXT
 	gpProgramUniform2iv                                      C.GPPROGRAMUNIFORM2IV
 	gpProgramUniform2ivEXT                                   C.GPPROGRAMUNIFORM2IVEXT
 	gpProgramUniform2ui                                      C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                                 C.GPPROGRAMUNIFORM2UI64ARB
 	gpProgramUniform2ui64NV                                  C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                                C.GPPROGRAMUNIFORM2UI64VARB
 	gpProgramUniform2ui64vNV                                 C.GPPROGRAMUNIFORM2UI64VNV
 	gpProgramUniform2uiEXT                                   C.GPPROGRAMUNIFORM2UIEXT
 	gpProgramUniform2uiv                                     C.GPPROGRAMUNIFORM2UIV
@@ -17635,13 +18525,17 @@ var (
 	gpProgramUniform3fv                                      C.GPPROGRAMUNIFORM3FV
 	gpProgramUniform3fvEXT                                   C.GPPROGRAMUNIFORM3FVEXT
 	gpProgramUniform3i                                       C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                                  C.GPPROGRAMUNIFORM3I64ARB
 	gpProgramUniform3i64NV                                   C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                                 C.GPPROGRAMUNIFORM3I64VARB
 	gpProgramUniform3i64vNV                                  C.GPPROGRAMUNIFORM3I64VNV
 	gpProgramUniform3iEXT                                    C.GPPROGRAMUNIFORM3IEXT
 	gpProgramUniform3iv                                      C.GPPROGRAMUNIFORM3IV
 	gpProgramUniform3ivEXT                                   C.GPPROGRAMUNIFORM3IVEXT
 	gpProgramUniform3ui                                      C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                                 C.GPPROGRAMUNIFORM3UI64ARB
 	gpProgramUniform3ui64NV                                  C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                                C.GPPROGRAMUNIFORM3UI64VARB
 	gpProgramUniform3ui64vNV                                 C.GPPROGRAMUNIFORM3UI64VNV
 	gpProgramUniform3uiEXT                                   C.GPPROGRAMUNIFORM3UIEXT
 	gpProgramUniform3uiv                                     C.GPPROGRAMUNIFORM3UIV
@@ -17655,13 +18549,17 @@ var (
 	gpProgramUniform4fv                                      C.GPPROGRAMUNIFORM4FV
 	gpProgramUniform4fvEXT                                   C.GPPROGRAMUNIFORM4FVEXT
 	gpProgramUniform4i                                       C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                                  C.GPPROGRAMUNIFORM4I64ARB
 	gpProgramUniform4i64NV                                   C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                                 C.GPPROGRAMUNIFORM4I64VARB
 	gpProgramUniform4i64vNV                                  C.GPPROGRAMUNIFORM4I64VNV
 	gpProgramUniform4iEXT                                    C.GPPROGRAMUNIFORM4IEXT
 	gpProgramUniform4iv                                      C.GPPROGRAMUNIFORM4IV
 	gpProgramUniform4ivEXT                                   C.GPPROGRAMUNIFORM4IVEXT
 	gpProgramUniform4ui                                      C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                                 C.GPPROGRAMUNIFORM4UI64ARB
 	gpProgramUniform4ui64NV                                  C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                                C.GPPROGRAMUNIFORM4UI64VARB
 	gpProgramUniform4ui64vNV                                 C.GPPROGRAMUNIFORM4UI64VNV
 	gpProgramUniform4uiEXT                                   C.GPPROGRAMUNIFORM4UIEXT
 	gpProgramUniform4uiv                                     C.GPPROGRAMUNIFORM4UIV
@@ -17722,6 +18620,8 @@ var (
 	gpQueryCounter                                           C.GPQUERYCOUNTER
 	gpQueryMatrixxOES                                        C.GPQUERYMATRIXXOES
 	gpQueryObjectParameteruiAMD                              C.GPQUERYOBJECTPARAMETERUIAMD
+	gpQueryResourceNV                                        C.GPQUERYRESOURCENV
+	gpQueryResourceTagNV                                     C.GPQUERYRESOURCETAGNV
 	gpRasterPos2d                                            C.GPRASTERPOS2D
 	gpRasterPos2dv                                           C.GPRASTERPOS2DV
 	gpRasterPos2f                                            C.GPRASTERPOS2F
@@ -17752,6 +18652,7 @@ var (
 	gpRasterPos4sv                                           C.GPRASTERPOS4SV
 	gpRasterPos4xOES                                         C.GPRASTERPOS4XOES
 	gpRasterPos4xvOES                                        C.GPRASTERPOS4XVOES
+	gpRasterSamplesEXT                                       C.GPRASTERSAMPLESEXT
 	gpReadBuffer                                             C.GPREADBUFFER
 	gpReadInstrumentsSGIX                                    C.GPREADINSTRUMENTSSGIX
 	gpReadPixels                                             C.GPREADPIXELS
@@ -17769,7 +18670,9 @@ var (
 	gpRectxOES                                               C.GPRECTXOES
 	gpRectxvOES                                              C.GPRECTXVOES
 	gpReferencePlaneSGIX                                     C.GPREFERENCEPLANESGIX
+	gpReleaseKeyedMutexWin32EXT                              C.GPRELEASEKEYEDMUTEXWIN32EXT
 	gpReleaseShaderCompiler                                  C.GPRELEASESHADERCOMPILER
+	gpRenderGpuMaskNV                                        C.GPRENDERGPUMASKNV
 	gpRenderMode                                             C.GPRENDERMODE
 	gpRenderbufferStorage                                    C.GPRENDERBUFFERSTORAGE
 	gpRenderbufferStorageEXT                                 C.GPRENDERBUFFERSTORAGEEXT
@@ -17805,6 +18708,7 @@ var (
 	gpResetMinmax                                            C.GPRESETMINMAX
 	gpResetMinmaxEXT                                         C.GPRESETMINMAXEXT
 	gpResizeBuffersMESA                                      C.GPRESIZEBUFFERSMESA
+	gpResolveDepthValuesNV                                   C.GPRESOLVEDEPTHVALUESNV
 	gpResumeTransformFeedback                                C.GPRESUMETRANSFORMFEEDBACK
 	gpResumeTransformFeedbackNV                              C.GPRESUMETRANSFORMFEEDBACKNV
 	gpRotated                                                C.GPROTATED
@@ -17812,7 +18716,6 @@ var (
 	gpRotatexOES                                             C.GPROTATEXOES
 	gpSampleCoverage                                         C.GPSAMPLECOVERAGE
 	gpSampleCoverageARB                                      C.GPSAMPLECOVERAGEARB
-	gpSampleCoverageOES                                      C.GPSAMPLECOVERAGEOES
 	gpSampleCoveragexOES                                     C.GPSAMPLECOVERAGEXOES
 	gpSampleMapATI                                           C.GPSAMPLEMAPATI
 	gpSampleMaskEXT                                          C.GPSAMPLEMASKEXT
@@ -17876,6 +18779,7 @@ var (
 	gpSecondaryColorPointerListIBM                           C.GPSECONDARYCOLORPOINTERLISTIBM
 	gpSelectBuffer                                           C.GPSELECTBUFFER
 	gpSelectPerfMonitorCountersAMD                           C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpSemaphoreParameterui64vEXT                             C.GPSEMAPHOREPARAMETERUI64VEXT
 	gpSeparableFilter2D                                      C.GPSEPARABLEFILTER2D
 	gpSeparableFilter2DEXT                                   C.GPSEPARABLEFILTER2DEXT
 	gpSetFenceAPPLE                                          C.GPSETFENCEAPPLE
@@ -17893,11 +18797,16 @@ var (
 	gpShaderSourceARB                                        C.GPSHADERSOURCEARB
 	gpShaderStorageBlockBinding                              C.GPSHADERSTORAGEBLOCKBINDING
 	gpSharpenTexFuncSGIS                                     C.GPSHARPENTEXFUNCSGIS
+	gpSignalSemaphoreEXT                                     C.GPSIGNALSEMAPHOREEXT
+	gpSignalVkFenceNV                                        C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                                    C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                                    C.GPSPECIALIZESHADERARB
 	gpSpriteParameterfSGIX                                   C.GPSPRITEPARAMETERFSGIX
 	gpSpriteParameterfvSGIX                                  C.GPSPRITEPARAMETERFVSGIX
 	gpSpriteParameteriSGIX                                   C.GPSPRITEPARAMETERISGIX
 	gpSpriteParameterivSGIX                                  C.GPSPRITEPARAMETERIVSGIX
 	gpStartInstrumentsSGIX                                   C.GPSTARTINSTRUMENTSSGIX
+	gpStateCaptureNV                                         C.GPSTATECAPTURENV
 	gpStencilClearTagEXT                                     C.GPSTENCILCLEARTAGEXT
 	gpStencilFillPathInstancedNV                             C.GPSTENCILFILLPATHINSTANCEDNV
 	gpStencilFillPathNV                                      C.GPSTENCILFILLPATHNV
@@ -17918,6 +18827,7 @@ var (
 	gpStencilThenCoverStrokePathNV                           C.GPSTENCILTHENCOVERSTROKEPATHNV
 	gpStopInstrumentsSGIX                                    C.GPSTOPINSTRUMENTSSGIX
 	gpStringMarkerGREMEDY                                    C.GPSTRINGMARKERGREMEDY
+	gpSubpixelPrecisionBiasNV                                C.GPSUBPIXELPRECISIONBIASNV
 	gpSwizzleEXT                                             C.GPSWIZZLEEXT
 	gpSyncTextureINTEL                                       C.GPSYNCTEXTUREINTEL
 	gpTagSampleBufferSGIX                                    C.GPTAGSAMPLEBUFFERSGIX
@@ -18068,6 +18978,11 @@ var (
 	gpTexStorage2DMultisample                                C.GPTEXSTORAGE2DMULTISAMPLE
 	gpTexStorage3D                                           C.GPTEXSTORAGE3D
 	gpTexStorage3DMultisample                                C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexStorageMem1DEXT                                     C.GPTEXSTORAGEMEM1DEXT
+	gpTexStorageMem2DEXT                                     C.GPTEXSTORAGEMEM2DEXT
+	gpTexStorageMem2DMultisampleEXT                          C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT
+	gpTexStorageMem3DEXT                                     C.GPTEXSTORAGEMEM3DEXT
+	gpTexStorageMem3DMultisampleEXT                          C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT
 	gpTexStorageSparseAMD                                    C.GPTEXSTORAGESPARSEAMD
 	gpTexSubImage1D                                          C.GPTEXSUBIMAGE1D
 	gpTexSubImage1DEXT                                       C.GPTEXSUBIMAGE1DEXT
@@ -18118,6 +19033,11 @@ var (
 	gpTextureStorage3DEXT                                    C.GPTEXTURESTORAGE3DEXT
 	gpTextureStorage3DMultisample                            C.GPTEXTURESTORAGE3DMULTISAMPLE
 	gpTextureStorage3DMultisampleEXT                         C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureStorageMem1DEXT                                 C.GPTEXTURESTORAGEMEM1DEXT
+	gpTextureStorageMem2DEXT                                 C.GPTEXTURESTORAGEMEM2DEXT
+	gpTextureStorageMem2DMultisampleEXT                      C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT
+	gpTextureStorageMem3DEXT                                 C.GPTEXTURESTORAGEMEM3DEXT
+	gpTextureStorageMem3DMultisampleEXT                      C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT
 	gpTextureStorageSparseAMD                                C.GPTEXTURESTORAGESPARSEAMD
 	gpTextureSubImage1D                                      C.GPTEXTURESUBIMAGE1D
 	gpTextureSubImage1DEXT                                   C.GPTEXTURESUBIMAGE1DEXT
@@ -18145,13 +19065,17 @@ var (
 	gpUniform1fv                                             C.GPUNIFORM1FV
 	gpUniform1fvARB                                          C.GPUNIFORM1FVARB
 	gpUniform1i                                              C.GPUNIFORM1I
+	gpUniform1i64ARB                                         C.GPUNIFORM1I64ARB
 	gpUniform1i64NV                                          C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                        C.GPUNIFORM1I64VARB
 	gpUniform1i64vNV                                         C.GPUNIFORM1I64VNV
 	gpUniform1iARB                                           C.GPUNIFORM1IARB
 	gpUniform1iv                                             C.GPUNIFORM1IV
 	gpUniform1ivARB                                          C.GPUNIFORM1IVARB
 	gpUniform1ui                                             C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                        C.GPUNIFORM1UI64ARB
 	gpUniform1ui64NV                                         C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                                       C.GPUNIFORM1UI64VARB
 	gpUniform1ui64vNV                                        C.GPUNIFORM1UI64VNV
 	gpUniform1uiEXT                                          C.GPUNIFORM1UIEXT
 	gpUniform1uiv                                            C.GPUNIFORM1UIV
@@ -18163,13 +19087,17 @@ var (
 	gpUniform2fv                                             C.GPUNIFORM2FV
 	gpUniform2fvARB                                          C.GPUNIFORM2FVARB
 	gpUniform2i                                              C.GPUNIFORM2I
+	gpUniform2i64ARB                                         C.GPUNIFORM2I64ARB
 	gpUniform2i64NV                                          C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                        C.GPUNIFORM2I64VARB
 	gpUniform2i64vNV                                         C.GPUNIFORM2I64VNV
 	gpUniform2iARB                                           C.GPUNIFORM2IARB
 	gpUniform2iv                                             C.GPUNIFORM2IV
 	gpUniform2ivARB                                          C.GPUNIFORM2IVARB
 	gpUniform2ui                                             C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                        C.GPUNIFORM2UI64ARB
 	gpUniform2ui64NV                                         C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                                       C.GPUNIFORM2UI64VARB
 	gpUniform2ui64vNV                                        C.GPUNIFORM2UI64VNV
 	gpUniform2uiEXT                                          C.GPUNIFORM2UIEXT
 	gpUniform2uiv                                            C.GPUNIFORM2UIV
@@ -18181,13 +19109,17 @@ var (
 	gpUniform3fv                                             C.GPUNIFORM3FV
 	gpUniform3fvARB                                          C.GPUNIFORM3FVARB
 	gpUniform3i                                              C.GPUNIFORM3I
+	gpUniform3i64ARB                                         C.GPUNIFORM3I64ARB
 	gpUniform3i64NV                                          C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                        C.GPUNIFORM3I64VARB
 	gpUniform3i64vNV                                         C.GPUNIFORM3I64VNV
 	gpUniform3iARB                                           C.GPUNIFORM3IARB
 	gpUniform3iv                                             C.GPUNIFORM3IV
 	gpUniform3ivARB                                          C.GPUNIFORM3IVARB
 	gpUniform3ui                                             C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                        C.GPUNIFORM3UI64ARB
 	gpUniform3ui64NV                                         C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                                       C.GPUNIFORM3UI64VARB
 	gpUniform3ui64vNV                                        C.GPUNIFORM3UI64VNV
 	gpUniform3uiEXT                                          C.GPUNIFORM3UIEXT
 	gpUniform3uiv                                            C.GPUNIFORM3UIV
@@ -18199,13 +19131,17 @@ var (
 	gpUniform4fv                                             C.GPUNIFORM4FV
 	gpUniform4fvARB                                          C.GPUNIFORM4FVARB
 	gpUniform4i                                              C.GPUNIFORM4I
+	gpUniform4i64ARB                                         C.GPUNIFORM4I64ARB
 	gpUniform4i64NV                                          C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                        C.GPUNIFORM4I64VARB
 	gpUniform4i64vNV                                         C.GPUNIFORM4I64VNV
 	gpUniform4iARB                                           C.GPUNIFORM4IARB
 	gpUniform4iv                                             C.GPUNIFORM4IV
 	gpUniform4ivARB                                          C.GPUNIFORM4IVARB
 	gpUniform4ui                                             C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                        C.GPUNIFORM4UI64ARB
 	gpUniform4ui64NV                                         C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                                       C.GPUNIFORM4UI64VARB
 	gpUniform4ui64vNV                                        C.GPUNIFORM4UI64VNV
 	gpUniform4uiEXT                                          C.GPUNIFORM4UIEXT
 	gpUniform4uiv                                            C.GPUNIFORM4UIV
@@ -18632,7 +19568,11 @@ var (
 	gpViewportArrayv                                         C.GPVIEWPORTARRAYV
 	gpViewportIndexedf                                       C.GPVIEWPORTINDEXEDF
 	gpViewportIndexedfv                                      C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                               C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                                      C.GPVIEWPORTSWIZZLENV
+	gpWaitSemaphoreEXT                                       C.GPWAITSEMAPHOREEXT
 	gpWaitSync                                               C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                                      C.GPWAITVKSEMAPHORENV
 	gpWeightPathsNV                                          C.GPWEIGHTPATHSNV
 	gpWeightPointerARB                                       C.GPWEIGHTPOINTERARB
 	gpWeightbvARB                                            C.GPWEIGHTBVARB
@@ -18699,6 +19639,7 @@ var (
 	gpWindowPos4ivMESA                                       C.GPWINDOWPOS4IVMESA
 	gpWindowPos4sMESA                                        C.GPWINDOWPOS4SMESA
 	gpWindowPos4svMESA                                       C.GPWINDOWPOS4SVMESA
+	gpWindowRectanglesEXT                                    C.GPWINDOWRECTANGLESEXT
 	gpWriteMaskEXT                                           C.GPWRITEMASKEXT
 )
 
@@ -18716,6 +19657,10 @@ func Accum(op uint32, value float32) {
 }
 func AccumxOES(op uint32, value int32) {
 	C.glowAccumxOES(gpAccumxOES, (C.GLenum)(op), (C.GLfixed)(value))
+}
+func AcquireKeyedMutexWin32EXT(memory uint32, key uint64, timeout uint32) bool {
+	ret := C.glowAcquireKeyedMutexWin32EXT(gpAcquireKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key), (C.GLuint)(timeout))
+	return ret == TRUE
 }
 func ActiveProgramEXT(program uint32) {
 	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
@@ -18758,6 +19703,12 @@ func AlphaFunc(xfunc uint32, ref float32) {
 }
 func AlphaFuncxOES(xfunc uint32, ref int32) {
 	C.glowAlphaFuncxOES(gpAlphaFuncxOES, (C.GLenum)(xfunc), (C.GLfixed)(ref))
+}
+func AlphaToCoverageDitherControlNV(mode uint32) {
+	C.glowAlphaToCoverageDitherControlNV(gpAlphaToCoverageDitherControlNV, (C.GLenum)(mode))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 func ApplyTextureEXT(mode uint32) {
 	C.glowApplyTextureEXT(gpApplyTextureEXT, (C.GLenum)(mode))
@@ -19194,8 +20145,8 @@ func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 func BufferDataARB(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferDataARB(gpBufferDataARB, (C.GLenum)(target), (C.GLsizeiptrARB)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 	C.glowBufferParameteriAPPLE(gpBufferParameteriAPPLE, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
@@ -19205,6 +20156,12 @@ func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowBufferStorage(gpBufferStorage, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func BufferStorageExternalEXT(target uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowBufferStorageExternalEXT(gpBufferStorageExternalEXT, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func BufferStorageMemEXT(target uint32, size int, memory uint32, offset uint64) {
+	C.glowBufferStorageMemEXT(gpBufferStorageMemEXT, (C.GLenum)(target), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
@@ -19212,6 +20169,9 @@ func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 }
 func BufferSubDataARB(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubDataARB(gpBufferSubDataARB, (C.GLenum)(target), (C.GLintptrARB)(offset), (C.GLsizeiptrARB)(size), data)
+}
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
 }
 
 // execute a display list
@@ -19308,6 +20268,8 @@ func ClearDepth(depth float64) {
 func ClearDepthdNV(depth float64) {
 	C.glowClearDepthdNV(gpClearDepthdNV, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -19332,14 +20294,14 @@ func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32
 }
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
 func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -19381,7 +20343,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -19649,6 +20611,12 @@ func CombinerParameterivNV(pname uint32, params *int32) {
 func CombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowCombinerStageParameterfvNV(gpCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
+}
 
 // Compiles a shader object
 func CompileShader(shader uint32) {
@@ -19759,6 +20727,12 @@ func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yof
 func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // define a one-dimensional convolution filter
 func ConvolutionFilter1D(target uint32, internalformat uint32, width int32, format uint32, xtype uint32, image unsafe.Pointer) {
@@ -19867,8 +20841,8 @@ func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffs
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 func CopyPathNV(resultPath uint32, srcPath uint32) {
 	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
@@ -19960,15 +20934,27 @@ func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsaf
 func CoverStrokePathNV(path uint32, coverMode uint32) {
 	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
 }
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreateMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowCreateMemoryObjectsEXT(gpCreateMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
 	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
@@ -20027,9 +21013,12 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -20125,6 +21114,9 @@ func DeleteBuffers(n int32, buffers *uint32) {
 func DeleteBuffersARB(n int32, buffers *uint32) {
 	C.glowDeleteBuffersARB(gpDeleteBuffersARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 func DeleteFencesAPPLE(n int32, fences *uint32) {
 	C.glowDeleteFencesAPPLE(gpDeleteFencesAPPLE, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(fences)))
 }
@@ -20146,6 +21138,9 @@ func DeleteFramebuffersEXT(n int32, framebuffers *uint32) {
 // delete a contiguous group of display lists
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
+}
+func DeleteMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowDeleteMemoryObjectsEXT(gpDeleteMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
@@ -20195,6 +21190,9 @@ func DeleteQueries(n int32, ids *uint32) {
 func DeleteQueriesARB(n int32, ids *uint32) {
 	C.glowDeleteQueriesARB(gpDeleteQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func DeleteQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowDeleteQueryResourceTagNV(gpDeleteQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // delete renderbuffer objects
 func DeleteRenderbuffers(n int32, renderbuffers *uint32) {
@@ -20208,14 +21206,20 @@ func DeleteRenderbuffersEXT(n int32, renderbuffers *uint32) {
 func DeleteSamplers(count int32, samplers *uint32) {
 	C.glowDeleteSamplers(gpDeleteSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
 }
+func DeleteSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowDeleteSemaphoresEXT(gpDeleteSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
+}
 
 // Deletes a shader object
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -20277,6 +21281,8 @@ func DepthRangeIndexed(index uint32, n float64, f float64) {
 func DepthRangedNV(zNear float64, zFar float64) {
 	C.glowDepthRangedNV(gpDepthRangedNV, (C.GLdouble)(zNear), (C.GLdouble)(zFar))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -20398,6 +21404,18 @@ func DrawBuffersARB(n int32, bufs *uint32) {
 func DrawBuffersATI(n int32, bufs *uint32) {
 	C.glowDrawBuffersATI(gpDrawBuffersATI, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 func DrawElementArrayAPPLE(mode uint32, first int32, count int32) {
 	C.glowDrawElementArrayAPPLE(gpDrawElementArrayAPPLE, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count))
 }
@@ -20497,6 +21515,9 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 // render multiple instances of primitives using a count derived from a specifed stream of a transform feedback object
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
+}
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
 }
 
 // flag edges as either boundary or nonboundary
@@ -20675,6 +21696,9 @@ func EvalPoint1(i int32) {
 func EvalPoint2(i int32, j int32) {
 	C.glowEvalPoint2(gpEvalPoint2, (C.GLint)(i), (C.GLint)(j))
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 func ExecuteProgramNV(target uint32, id uint32, params *float32) {
 	C.glowExecuteProgramNV(gpExecuteProgramNV, (C.GLenum)(target), (C.GLuint)(id), (*C.GLfloat)(unsafe.Pointer(params)))
 }
@@ -20691,9 +21715,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -20734,8 +21758,8 @@ func FlushMappedBufferRangeAPPLE(target uint32, offset int, size int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
 }
 func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
 	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
@@ -20823,6 +21847,9 @@ func FogxvOES(pname uint32, param *int32) {
 func FragmentColorMaterialSGIX(face uint32, mode uint32) {
 	C.glowFragmentColorMaterialSGIX(gpFragmentColorMaterialSGIX, (C.GLenum)(face), (C.GLenum)(mode))
 }
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
 func FragmentLightModelfSGIX(pname uint32, param float32) {
 	C.glowFragmentLightModelfSGIX(gpFragmentLightModelfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -20871,6 +21898,9 @@ func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
 func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
 	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
+}
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
@@ -20887,6 +21917,15 @@ func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarge
 func FramebufferRenderbufferEXT(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbufferEXT(gpFramebufferRenderbufferEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSamplePositionsfvAMD(target uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowFramebufferSamplePositionsfvAMD(gpFramebufferSamplePositionsfvAMD, (C.GLenum)(target), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
 func FramebufferTexture(target uint32, attachment uint32, texture uint32, level int32) {
@@ -20898,6 +21937,8 @@ func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, te
 func FramebufferTexture1DEXT(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1DEXT(gpFramebufferTexture1DEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
@@ -20932,6 +21973,9 @@ func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32
 }
 func FramebufferTextureLayerEXT(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayerEXT(gpFramebufferTextureLayerEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 func FreeObjectBufferATI(buffer uint32) {
 	C.glowFreeObjectBufferATI(gpFreeObjectBufferATI, (C.GLuint)(buffer))
@@ -21023,6 +22067,9 @@ func GenQueries(n int32, ids *uint32) {
 func GenQueriesARB(n int32, ids *uint32) {
 	C.glowGenQueriesARB(gpGenQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func GenQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowGenQueryResourceTagNV(gpGenQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // generate renderbuffer object names
 func GenRenderbuffers(n int32, renderbuffers *uint32) {
@@ -21035,6 +22082,9 @@ func GenRenderbuffersEXT(n int32, renderbuffers *uint32) {
 // generate sampler object names
 func GenSamplers(count int32, samplers *uint32) {
 	C.glowGenSamplers(gpGenSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
+}
+func GenSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowGenSemaphoresEXT(gpGenSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
 }
 func GenSymbolsEXT(datatype uint32, storagetype uint32, xrange uint32, components uint32) uint32 {
 	ret := C.glowGenSymbolsEXT(gpGenSymbolsEXT, (C.GLenum)(datatype), (C.GLenum)(storagetype), (C.GLenum)(xrange), (C.GLuint)(components))
@@ -21126,6 +22176,8 @@ func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, leng
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21262,6 +22314,10 @@ func GetCombinerOutputParameterivNV(stage uint32, portion uint32, pname uint32, 
 func GetCombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowGetCombinerStageParameterfvNV(gpGetCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
 func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
 	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
@@ -21308,6 +22364,9 @@ func GetConvolutionParameterivEXT(target uint32, pname uint32, params *int32) {
 }
 func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 	C.glowGetConvolutionParameterxvOES(gpGetConvolutionParameterxvOES, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -21407,15 +22466,18 @@ func GetFragmentMaterialivSGIX(face uint32, pname uint32, params *int32) {
 	C.glowGetFragmentMaterialivSGIX(gpGetFragmentMaterialivSGIX, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetFramebufferAttachmentParameterivEXT(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameterivEXT(gpGetFramebufferAttachmentParameterivEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetFramebufferParameterfvAMD(target uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetFramebufferParameterfvAMD(gpGetFramebufferParameterfvAMD, (C.GLenum)(target), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21505,9 +22567,14 @@ func GetIntegerui64vNV(value uint32, result *uint64) {
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21585,6 +22652,9 @@ func GetMaterialxOES(face uint32, pname uint32, param int32) {
 }
 func GetMaterialxvOES(face uint32, pname uint32, params *int32) {
 	C.glowGetMaterialxvOES(gpGetMaterialxvOES, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetMemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowGetMemoryObjectParameterivEXT(gpGetMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // get minimum and maximum pixel values
@@ -21676,8 +22746,8 @@ func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Point
 }
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -21689,6 +22759,9 @@ func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uin
 }
 func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedFramebufferParameterfvAMD(framebuffer uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetNamedFramebufferParameterfvAMD(gpGetNamedFramebufferParameterfvAMD, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 
 // query a named parameter of a framebuffer object
@@ -22004,6 +23077,18 @@ func GetProgramivARB(target uint32, pname uint32, params *int32) {
 func GetProgramivNV(id uint32, pname uint32, params *int32) {
 	C.glowGetProgramivNV(gpGetProgramivNV, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
 
 // return parameters of an indexed query object target
 func GetQueryIndexediv(target uint32, index uint32, pname uint32, params *int32) {
@@ -22027,6 +23112,8 @@ func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 func GetQueryObjectui64vEXT(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64vEXT(gpGetQueryObjectui64vEXT, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -22042,7 +23129,7 @@ func GetQueryivARB(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryivARB(gpGetQueryivARB, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -22060,6 +23147,9 @@ func GetSamplerParameterfv(sampler uint32, pname uint32, params *float32) {
 }
 func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 	C.glowGetSamplerParameteriv(gpGetSamplerParameteriv, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetSemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowGetSemaphoreParameterui64vEXT(gpGetSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 
 // get separable convolution filter kernel images
@@ -22095,6 +23185,10 @@ func GetShaderiv(shader uint32, pname uint32, params *int32) {
 func GetSharpenTexFuncSGIS(target uint32, points *float32) {
 	C.glowGetSharpenTexFuncSGIS(gpGetSharpenTexFuncSGIS, (C.GLenum)(target), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -22119,7 +23213,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -22323,6 +23417,9 @@ func GetUniformfv(program uint32, location int32, params *float32) {
 func GetUniformfvARB(programObj uintptr, location int32, params *float32) {
 	C.glowGetUniformfvARB(gpGetUniformfvARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetUniformi64vNV(program uint32, location int32, params *int64) {
 	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
 }
@@ -22334,6 +23431,9 @@ func GetUniformiv(program uint32, location int32, params *int32) {
 func GetUniformivARB(programObj uintptr, location int32, params *int32) {
 	C.glowGetUniformivARB(gpGetUniformivARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 func GetUniformui64vNV(program uint32, location int32, params *uint64) {
 	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
@@ -22342,6 +23442,12 @@ func GetUniformuiv(program uint32, location int32, params *uint32) {
 }
 func GetUniformuivEXT(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuivEXT(gpGetUniformuivEXT, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetUnsignedBytei_vEXT(target uint32, index uint32, data *uint8) {
+	C.glowGetUnsignedBytei_vEXT(gpGetUnsignedBytei_vEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLubyte)(unsafe.Pointer(data)))
+}
+func GetUnsignedBytevEXT(pname uint32, data *uint8) {
+	C.glowGetUnsignedBytevEXT(gpGetUnsignedBytevEXT, (C.GLenum)(pname), (*C.GLubyte)(unsafe.Pointer(data)))
 }
 func GetVariantArrayObjectfvATI(id uint32, pname uint32, params *float32) {
 	C.glowGetVariantArrayObjectfvATI(gpGetVariantArrayObjectfvATI, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
@@ -22495,6 +23601,10 @@ func GetVideoui64vNV(video_slot uint32, pname uint32, params *uint64) {
 func GetVideouivNV(video_slot uint32, pname uint32, params *uint32) {
 	C.glowGetVideouivNV(gpGetVideouivNV, (C.GLuint)(video_slot), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
+}
 func GetnColorTableARB(target uint32, format uint32, xtype uint32, bufSize int32, table unsafe.Pointer) {
 	C.glowGetnColorTableARB(gpGetnColorTableARB, (C.GLenum)(target), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), table)
 }
@@ -22549,6 +23659,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -22557,6 +23670,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -22622,9 +23738,27 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportMemoryFdEXT(memory uint32, size uint64, handleType uint32, fd int32) {
+	C.glowImportMemoryFdEXT(gpImportMemoryFdEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportMemoryWin32HandleEXT(memory uint32, size uint64, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportMemoryWin32HandleEXT(gpImportMemoryWin32HandleEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), handle)
+}
+func ImportMemoryWin32NameEXT(memory uint32, size uint64, handleType uint32, name unsafe.Pointer) {
+	C.glowImportMemoryWin32NameEXT(gpImportMemoryWin32NameEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), name)
+}
+func ImportSemaphoreFdEXT(semaphore uint32, handleType uint32, fd int32) {
+	C.glowImportSemaphoreFdEXT(gpImportSemaphoreFdEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportSemaphoreWin32HandleEXT(semaphore uint32, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportSemaphoreWin32HandleEXT(gpImportSemaphoreWin32HandleEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), handle)
+}
+func ImportSemaphoreWin32NameEXT(semaphore uint32, handleType uint32, name unsafe.Pointer) {
+	C.glowImportSemaphoreWin32NameEXT(gpImportSemaphoreWin32NameEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), name)
+}
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -22767,6 +23901,10 @@ func IsBufferResidentNV(target uint32) bool {
 	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
 	return ret == TRUE
 }
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
 	return ret == TRUE
@@ -22809,6 +23947,10 @@ func IsImageHandleResidentNV(handle uint64) bool {
 // determine if a name corresponds to a display list
 func IsList(list uint32) bool {
 	ret := C.glowIsList(gpIsList, (C.GLuint)(list))
+	return ret == TRUE
+}
+func IsMemoryObjectEXT(memoryObject uint32) bool {
+	ret := C.glowIsMemoryObjectEXT(gpIsMemoryObjectEXT, (C.GLuint)(memoryObject))
 	return ret == TRUE
 }
 func IsNameAMD(identifier uint32, name uint32) bool {
@@ -22893,15 +24035,23 @@ func IsSampler(sampler uint32) bool {
 	ret := C.glowIsSampler(gpIsSampler, (C.GLuint)(sampler))
 	return ret == TRUE
 }
+func IsSemaphoreEXT(semaphore uint32) bool {
+	ret := C.glowIsSemaphoreEXT(gpIsSemaphoreEXT, (C.GLuint)(semaphore))
+	return ret == TRUE
+}
 
 // Determines if a name corresponds to a shader object
 func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -22950,6 +24100,15 @@ func IsVertexArrayAPPLE(array uint32) bool {
 func IsVertexAttribEnabledAPPLE(index uint32, pname uint32) bool {
 	ret := C.glowIsVertexAttribEnabledAPPLE(gpIsVertexAttribEnabledAPPLE, (C.GLuint)(index), (C.GLenum)(pname))
 	return ret == TRUE
+}
+func LGPUCopyImageSubDataNVX(sourceGpu uint32, destinationGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srxY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, width int32, height int32, depth int32) {
+	C.glowLGPUCopyImageSubDataNVX(gpLGPUCopyImageSubDataNVX, (C.GLuint)(sourceGpu), (C.GLbitfield)(destinationGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srxY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func LGPUInterlockNVX() {
+	C.glowLGPUInterlockNVX(gpLGPUInterlockNVX)
+}
+func LGPUNamedBufferSubDataNVX(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowLGPUNamedBufferSubDataNVX(gpLGPUNamedBufferSubDataNVX, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
@@ -23018,6 +24177,9 @@ func LinkProgramARB(programObj uintptr) {
 // set the display-list base for
 func ListBase(base uint32) {
 	C.glowListBase(gpListBase, (C.GLuint)(base))
+}
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 func ListParameterfSGIX(list uint32, pname uint32, param float32) {
 	C.glowListParameterfSGIX(gpListParameterfSGIX, (C.GLuint)(list), (C.GLenum)(pname), (C.GLfloat)(param))
@@ -23182,8 +24344,8 @@ func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
 }
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
 }
 func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
@@ -23326,6 +24488,12 @@ func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
 func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
 	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
 }
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
+}
 
 // defines a barrier ordering memory transactions
 func MemoryBarrier(barriers uint32) {
@@ -23336,6 +24504,9 @@ func MemoryBarrierByRegion(barriers uint32) {
 }
 func MemoryBarrierEXT(barriers uint32) {
 	C.glowMemoryBarrierEXT(gpMemoryBarrierEXT, (C.GLbitfield)(barriers))
+}
+func MemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowMemoryObjectParameterivEXT(gpMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func MinSampleShadingARB(value float32) {
 	C.glowMinSampleShadingARB(gpMinSampleShadingARB, (C.GLfloat)(value))
@@ -23394,8 +24565,8 @@ func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer
 func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawElementArrayAPPLE(mode uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawElementArrayAPPLE(gpMultiDrawElementArrayAPPLE, (C.GLenum)(mode), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -23427,8 +24598,8 @@ func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirec
 func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawRangeElementArrayAPPLE(mode uint32, start uint32, end uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawRangeElementArrayAPPLE(gpMultiDrawRangeElementArrayAPPLE, (C.GLenum)(mode), (C.GLuint)(start), (C.GLuint)(end), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -23802,32 +24973,71 @@ func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset i
 func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func MulticastBarrierNV() {
+	C.glowMulticastBarrierNV(gpMulticastBarrierNV)
+}
+func MulticastBlitFramebufferNV(srcGpu uint32, dstGpu uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
+	C.glowMulticastBlitFramebufferNV(gpMulticastBlitFramebufferNV, (C.GLuint)(srcGpu), (C.GLuint)(dstGpu), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
+}
+func MulticastBufferSubDataNV(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowMulticastBufferSubDataNV(gpMulticastBufferSubDataNV, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func MulticastCopyBufferSubDataNV(readGpu uint32, writeGpuMask uint32, readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowMulticastCopyBufferSubDataNV(gpMulticastCopyBufferSubDataNV, (C.GLuint)(readGpu), (C.GLbitfield)(writeGpuMask), (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func MulticastCopyImageSubDataNV(srcGpu uint32, dstGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
+	C.glowMulticastCopyImageSubDataNV(gpMulticastCopyImageSubDataNV, (C.GLuint)(srcGpu), (C.GLbitfield)(dstGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
+}
+func MulticastFramebufferSampleLocationsfvNV(gpu uint32, framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowMulticastFramebufferSampleLocationsfvNV(gpMulticastFramebufferSampleLocationsfvNV, (C.GLuint)(gpu), (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func MulticastGetQueryObjecti64vNV(gpu uint32, id uint32, pname uint32, params *int64) {
+	C.glowMulticastGetQueryObjecti64vNV(gpMulticastGetQueryObjecti64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectivNV(gpu uint32, id uint32, pname uint32, params *int32) {
+	C.glowMulticastGetQueryObjectivNV(gpMulticastGetQueryObjectivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectui64vNV(gpu uint32, id uint32, pname uint32, params *uint64) {
+	C.glowMulticastGetQueryObjectui64vNV(gpMulticastGetQueryObjectui64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectuivNV(gpu uint32, id uint32, pname uint32, params *uint32) {
+	C.glowMulticastGetQueryObjectuivNV(gpMulticastGetQueryObjectuivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MulticastWaitSyncNV(signalGpu uint32, waitGpuMask uint32) {
+	C.glowMulticastWaitSyncNV(gpMulticastWaitSyncNV, (C.GLuint)(signalGpu), (C.GLbitfield)(waitGpuMask))
+}
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
 func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func NamedBufferStorageExternalEXT(buffer uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowNamedBufferStorageExternalEXT(gpNamedBufferStorageExternalEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func NamedBufferStorageMemEXT(buffer uint32, size int, memory uint32, offset uint64) {
+	C.glowNamedBufferStorageMemEXT(gpNamedBufferStorageMemEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -23865,6 +25075,15 @@ func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderb
 }
 func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSamplePositionsfvAMD(framebuffer uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowNamedFramebufferSamplePositionsfvAMD(gpNamedFramebufferSamplePositionsfvAMD, (C.GLuint)(framebuffer), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
@@ -24115,6 +25334,8 @@ func PassThroughxOES(token int32) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -24210,6 +25431,8 @@ func PixelMapx(xmap uint32, size int32, values *int32) {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
 }
@@ -24332,6 +25555,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 func PolygonOffsetEXT(factor float32, bias float32) {
 	C.glowPolygonOffsetEXT(gpPolygonOffsetEXT, (C.GLfloat)(factor), (C.GLfloat)(bias))
 }
@@ -24371,6 +25600,9 @@ func PresentFrameDualFillNV(video_slot uint32, minPresentTime uint64, beginPrese
 }
 func PresentFrameKeyedNV(video_slot uint32, minPresentTime uint64, beginPresentTimeId uint32, presentDurationId uint32, xtype uint32, target0 uint32, fill0 uint32, key0 uint32, target1 uint32, fill1 uint32, key1 uint32) {
 	C.glowPresentFrameKeyedNV(gpPresentFrameKeyedNV, (C.GLuint)(video_slot), (C.GLuint64EXT)(minPresentTime), (C.GLuint)(beginPresentTimeId), (C.GLuint)(presentDurationId), (C.GLenum)(xtype), (C.GLenum)(target0), (C.GLuint)(fill0), (C.GLuint)(key0), (C.GLenum)(target1), (C.GLuint)(fill1), (C.GLuint)(key1))
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -24498,6 +25730,8 @@ func ProgramParameter4fNV(target uint32, index uint32, x float32, y float32, z f
 func ProgramParameter4fvNV(target uint32, index uint32, v *float32) {
 	C.glowProgramParameter4fvNV(gpProgramParameter4fvNV, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -24555,8 +25789,14 @@ func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
 func ProgramUniform1i64NV(program uint32, location int32, x int64) {
 	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24577,8 +25817,14 @@ func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
 func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
 	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24627,8 +25873,14 @@ func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
 	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24649,8 +25901,14 @@ func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
 	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24699,8 +25957,14 @@ func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
 	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24721,8 +25985,14 @@ func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
 	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24771,8 +26041,14 @@ func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
 	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24793,8 +26069,14 @@ func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -25004,12 +26286,21 @@ func PushName(name uint32) {
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
 }
+
+// return the values of the current matrix
 func QueryMatrixxOES(mantissa *int32, exponent *int32) uint32 {
 	ret := C.glowQueryMatrixxOES(gpQueryMatrixxOES, (*C.GLfixed)(unsafe.Pointer(mantissa)), (*C.GLint)(unsafe.Pointer(exponent)))
 	return (uint32)(ret)
 }
 func QueryObjectParameteruiAMD(target uint32, id uint32, pname uint32, param uint32) {
 	C.glowQueryObjectParameteruiAMD(gpQueryObjectParameteruiAMD, (C.GLenum)(target), (C.GLuint)(id), (C.GLenum)(pname), (C.GLuint)(param))
+}
+func QueryResourceNV(queryType uint32, tagId int32, bufSize uint32, buffer *int32) int32 {
+	ret := C.glowQueryResourceNV(gpQueryResourceNV, (C.GLenum)(queryType), (C.GLint)(tagId), (C.GLuint)(bufSize), (*C.GLint)(unsafe.Pointer(buffer)))
+	return (int32)(ret)
+}
+func QueryResourceTagNV(tagId int32, tagString *uint8) {
+	C.glowQueryResourceTagNV(gpQueryResourceTagNV, (C.GLint)(tagId), (*C.GLchar)(unsafe.Pointer(tagString)))
 }
 func RasterPos2d(x float64, y float64) {
 	C.glowRasterPos2d(gpRasterPos2d, (C.GLdouble)(x), (C.GLdouble)(y))
@@ -25101,6 +26392,9 @@ func RasterPos4xOES(x int32, y int32, z int32, w int32) {
 func RasterPos4xvOES(coords *int32) {
 	C.glowRasterPos4xvOES(gpRasterPos4xvOES, (*C.GLfixed)(unsafe.Pointer(coords)))
 }
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // select a color buffer source for pixels
 func ReadBuffer(src uint32) {
@@ -25158,10 +26452,17 @@ func RectxvOES(v1 *int32, v2 *int32) {
 func ReferencePlaneSGIX(equation *float64) {
 	C.glowReferencePlaneSGIX(gpReferencePlaneSGIX, (*C.GLdouble)(unsafe.Pointer(equation)))
 }
+func ReleaseKeyedMutexWin32EXT(memory uint32, key uint64) bool {
+	ret := C.glowReleaseKeyedMutexWin32EXT(gpReleaseKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key))
+	return ret == TRUE
+}
 
 // release resources consumed by the implementation's shader compiler
 func ReleaseShaderCompiler() {
 	C.glowReleaseShaderCompiler(gpReleaseShaderCompiler)
+}
+func RenderGpuMaskNV(mask uint32) {
+	C.glowRenderGpuMaskNV(gpRenderGpuMaskNV, (C.GLbitfield)(mask))
 }
 
 // set rasterization mode
@@ -25279,6 +26580,9 @@ func ResetMinmaxEXT(target uint32) {
 func ResizeBuffersMESA() {
 	C.glowResizeBuffersMESA(gpResizeBuffersMESA)
 }
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
+}
 
 // resume transform feedback operations
 func ResumeTransformFeedback() {
@@ -25303,9 +26607,6 @@ func SampleCoverage(value float32, invert bool) {
 }
 func SampleCoverageARB(value float32, invert bool) {
 	C.glowSampleCoverageARB(gpSampleCoverageARB, (C.GLfloat)(value), (C.GLboolean)(boolToInt(invert)))
-}
-func SampleCoverageOES(value int32, invert bool) {
-	C.glowSampleCoverageOES(gpSampleCoverageOES, (C.GLfixed)(value), (C.GLboolean)(boolToInt(invert)))
 }
 func SampleCoveragexOES(value int32, invert bool) {
 	C.glowSampleCoveragexOES(gpSampleCoveragexOES, (C.GLclampx)(value), (C.GLboolean)(boolToInt(invert)))
@@ -25506,6 +26807,9 @@ func SelectBuffer(size int32, buffer *uint32) {
 func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
 	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
 }
+func SemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowSemaphoreParameterui64vEXT(gpSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 
 // define a separable two-dimensional convolution filter
 func SeparableFilter2D(target uint32, internalformat uint32, width int32, height int32, format uint32, xtype uint32, row unsafe.Pointer, column unsafe.Pointer) {
@@ -25567,6 +26871,18 @@ func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storage
 func SharpenTexFuncSGIS(target uint32, n int32, points *float32) {
 	C.glowSharpenTexFuncSGIS(gpSharpenTexFuncSGIS, (C.GLenum)(target), (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func SignalSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, dstLayouts *uint32) {
+	C.glowSignalSemaphoreEXT(gpSignalSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(dstLayouts)))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
 func SpriteParameterfSGIX(pname uint32, param float32) {
 	C.glowSpriteParameterfSGIX(gpSpriteParameterfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -25581,6 +26897,9 @@ func SpriteParameterivSGIX(pname uint32, params *int32) {
 }
 func StartInstrumentsSGIX() {
 	C.glowStartInstrumentsSGIX(gpStartInstrumentsSGIX)
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
 }
 func StencilClearTagEXT(stencilTagBits int32, stencilClearTag uint32) {
 	C.glowStencilClearTagEXT(gpStencilClearTagEXT, (C.GLsizei)(stencilTagBits), (C.GLuint)(stencilClearTag))
@@ -25653,6 +26972,9 @@ func StopInstrumentsSGIX(marker int32) {
 }
 func StringMarkerGREMEDY(len int32, xstring unsafe.Pointer) {
 	C.glowStringMarkerGREMEDY(gpStringMarkerGREMEDY, (C.GLsizei)(len), xstring)
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
 }
 func SwizzleEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowSwizzleEXT(gpSwizzleEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
@@ -26072,8 +27394,8 @@ func TexImage3DMultisampleCoverageNV(target uint32, coverageSamples int32, color
 func TexImage4DSGIS(target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, size4d int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTexImage4DSGIS(gpTexImage4DSGIS, (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(size4d), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -26133,6 +27455,21 @@ func TexStorage3D(target uint32, levels int32, internalformat uint32, width int3
 func TexStorage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexStorage3DMultisample(gpTexStorage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TexStorageMem1DEXT(target uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem1DEXT(gpTexStorageMem1DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DEXT(gpTexStorageMem2DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DMultisampleEXT(gpTexStorageMem2DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DEXT(gpTexStorageMem3DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DMultisampleEXT(gpTexStorageMem3DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TexStorageSparseAMD(target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTexStorageSparseAMD(gpTexStorageSparseAMD, (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -26181,8 +27518,8 @@ func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buff
 }
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
@@ -26220,8 +27557,8 @@ func TextureMaterialEXT(face uint32, mode uint32) {
 func TextureNormalEXT(mode uint32) {
 	C.glowTextureNormalEXT(gpTextureNormalEXT, (C.GLenum)(mode))
 }
-func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -26305,6 +27642,21 @@ func TextureStorage3DMultisample(texture uint32, samples int32, internalformat u
 func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorageMem1DEXT(texture uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem1DEXT(gpTextureStorageMem1DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DEXT(gpTextureStorageMem2DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DMultisampleEXT(gpTextureStorageMem2DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DEXT(gpTextureStorageMem3DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DMultisampleEXT(gpTextureStorageMem3DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TextureStorageSparseAMD(texture uint32, target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTextureStorageSparseAMD(gpTextureStorageSparseAMD, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -26350,8 +27702,8 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TransformFeedbackStreamAttribsNV(count int32, attribs *int32, nbuffers int32, bufstreams *int32, bufferMode uint32) {
 	C.glowTransformFeedbackStreamAttribsNV(gpTransformFeedbackStreamAttribsNV, (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(attribs)), (C.GLsizei)(nbuffers), (*C.GLint)(unsafe.Pointer(bufstreams)), (C.GLenum)(bufferMode))
@@ -26406,8 +27758,14 @@ func Uniform1fvARB(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
 func Uniform1i64NV(location int32, x int64) {
 	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform1i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26428,8 +27786,14 @@ func Uniform1ivARB(location int32, count int32, value *int32) {
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
 }
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
 func Uniform1ui64NV(location int32, x uint64) {
 	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform1ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26472,8 +27836,14 @@ func Uniform2fvARB(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func Uniform2i64NV(location int32, x int64, y int64) {
 	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform2i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26494,8 +27864,14 @@ func Uniform2ivARB(location int32, count int32, value *int32) {
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func Uniform2ui64NV(location int32, x uint64, y uint64) {
 	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform2ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26538,8 +27914,14 @@ func Uniform3fvARB(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func Uniform3i64NV(location int32, x int64, y int64, z int64) {
 	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform3i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26560,8 +27942,14 @@ func Uniform3ivARB(location int32, count int32, value *int32) {
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
 	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform3ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26604,8 +27992,14 @@ func Uniform4fvARB(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
 	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform4i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26626,8 +28020,14 @@ func Uniform4ivARB(location int32, count int32, value *int32) {
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform4ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -27973,10 +29373,22 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
+func WaitSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, srcLayouts *uint32) {
+	C.glowWaitSemaphoreEXT(gpWaitSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(srcLayouts)))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
 	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
@@ -28176,6 +29588,9 @@ func WindowPos4sMESA(x int16, y int16, z int16, w int16) {
 func WindowPos4svMESA(v *int16) {
 	C.glowWindowPos4svMESA(gpWindowPos4svMESA, (*C.GLshort)(unsafe.Pointer(v)))
 }
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
+}
 func WriteMaskEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowWriteMaskEXT(gpWriteMaskEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
 }
@@ -28212,6 +29627,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAccum")
 	}
 	gpAccumxOES = (C.GPACCUMXOES)(getProcAddr("glAccumxOES"))
+	gpAcquireKeyedMutexWin32EXT = (C.GPACQUIREKEYEDMUTEXWIN32EXT)(getProcAddr("glAcquireKeyedMutexWin32EXT"))
 	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
 	gpActiveShaderProgramEXT = (C.GPACTIVESHADERPROGRAMEXT)(getProcAddr("glActiveShaderProgramEXT"))
@@ -28230,6 +29646,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAlphaFunc")
 	}
 	gpAlphaFuncxOES = (C.GPALPHAFUNCXOES)(getProcAddr("glAlphaFuncxOES"))
+	gpAlphaToCoverageDitherControlNV = (C.GPALPHATOCOVERAGEDITHERCONTROLNV)(getProcAddr("glAlphaToCoverageDitherControlNV"))
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpApplyTextureEXT = (C.GPAPPLYTEXTUREEXT)(getProcAddr("glApplyTextureEXT"))
 	gpAreProgramsResidentNV = (C.GPAREPROGRAMSRESIDENTNV)(getProcAddr("glAreProgramsResidentNV"))
 	gpAreTexturesResident = (C.GPARETEXTURESRESIDENT)(getProcAddr("glAreTexturesResident"))
@@ -28428,11 +29846,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpBufferPageCommitmentARB = (C.GPBUFFERPAGECOMMITMENTARB)(getProcAddr("glBufferPageCommitmentARB"))
 	gpBufferParameteriAPPLE = (C.GPBUFFERPARAMETERIAPPLE)(getProcAddr("glBufferParameteriAPPLE"))
 	gpBufferStorage = (C.GPBUFFERSTORAGE)(getProcAddr("glBufferStorage"))
+	gpBufferStorageExternalEXT = (C.GPBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glBufferStorageExternalEXT"))
+	gpBufferStorageMemEXT = (C.GPBUFFERSTORAGEMEMEXT)(getProcAddr("glBufferStorageMemEXT"))
 	gpBufferSubData = (C.GPBUFFERSUBDATA)(getProcAddr("glBufferSubData"))
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
 	gpBufferSubDataARB = (C.GPBUFFERSUBDATAARB)(getProcAddr("glBufferSubDataARB"))
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCallList = (C.GPCALLLIST)(getProcAddr("glCallList"))
 	if gpCallList == nil {
 		return errors.New("glCallList")
@@ -28731,6 +30152,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCombinerParameteriNV = (C.GPCOMBINERPARAMETERINV)(getProcAddr("glCombinerParameteriNV"))
 	gpCombinerParameterivNV = (C.GPCOMBINERPARAMETERIVNV)(getProcAddr("glCombinerParameterivNV"))
 	gpCombinerStageParameterfvNV = (C.GPCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glCombinerStageParameterfvNV"))
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
@@ -28782,6 +30205,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
 	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpConvolutionFilter1D = (C.GPCONVOLUTIONFILTER1D)(getProcAddr("glConvolutionFilter1D"))
 	gpConvolutionFilter1DEXT = (C.GPCONVOLUTIONFILTER1DEXT)(getProcAddr("glConvolutionFilter1DEXT"))
 	gpConvolutionFilter2D = (C.GPCONVOLUTIONFILTER2D)(getProcAddr("glConvolutionFilter2D"))
@@ -28858,8 +30283,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
 	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
 	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
+	gpCreateMemoryObjectsEXT = (C.GPCREATEMEMORYOBJECTSEXT)(getProcAddr("glCreateMemoryObjectsEXT"))
 	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
@@ -28878,6 +30307,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCreateShaderProgramEXT = (C.GPCREATESHADERPROGRAMEXT)(getProcAddr("glCreateShaderProgramEXT"))
 	gpCreateShaderProgramv = (C.GPCREATESHADERPROGRAMV)(getProcAddr("glCreateShaderProgramv"))
 	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	gpCreateTransformFeedbacks = (C.GPCREATETRANSFORMFEEDBACKS)(getProcAddr("glCreateTransformFeedbacks"))
@@ -28910,6 +30340,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteBuffers")
 	}
 	gpDeleteBuffersARB = (C.GPDELETEBUFFERSARB)(getProcAddr("glDeleteBuffersARB"))
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFencesAPPLE = (C.GPDELETEFENCESAPPLE)(getProcAddr("glDeleteFencesAPPLE"))
 	gpDeleteFencesNV = (C.GPDELETEFENCESNV)(getProcAddr("glDeleteFencesNV"))
 	gpDeleteFragmentShaderATI = (C.GPDELETEFRAGMENTSHADERATI)(getProcAddr("glDeleteFragmentShaderATI"))
@@ -28922,6 +30353,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteLists == nil {
 		return errors.New("glDeleteLists")
 	}
+	gpDeleteMemoryObjectsEXT = (C.GPDELETEMEMORYOBJECTSEXT)(getProcAddr("glDeleteMemoryObjectsEXT"))
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
 	gpDeleteNamesAMD = (C.GPDELETENAMESAMD)(getProcAddr("glDeleteNamesAMD"))
 	gpDeleteObjectARB = (C.GPDELETEOBJECTARB)(getProcAddr("glDeleteObjectARB"))
@@ -28942,6 +30374,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteQueries")
 	}
 	gpDeleteQueriesARB = (C.GPDELETEQUERIESARB)(getProcAddr("glDeleteQueriesARB"))
+	gpDeleteQueryResourceTagNV = (C.GPDELETEQUERYRESOURCETAGNV)(getProcAddr("glDeleteQueryResourceTagNV"))
 	gpDeleteRenderbuffers = (C.GPDELETERENDERBUFFERS)(getProcAddr("glDeleteRenderbuffers"))
 	if gpDeleteRenderbuffers == nil {
 		return errors.New("glDeleteRenderbuffers")
@@ -28951,10 +30384,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteSamplers == nil {
 		return errors.New("glDeleteSamplers")
 	}
+	gpDeleteSemaphoresEXT = (C.GPDELETESEMAPHORESEXT)(getProcAddr("glDeleteSemaphoresEXT"))
 	gpDeleteShader = (C.GPDELETESHADER)(getProcAddr("glDeleteShader"))
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	if gpDeleteSync == nil {
 		return errors.New("glDeleteSync")
@@ -29049,6 +30484,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpDrawBuffersARB = (C.GPDRAWBUFFERSARB)(getProcAddr("glDrawBuffersARB"))
 	gpDrawBuffersATI = (C.GPDRAWBUFFERSATI)(getProcAddr("glDrawBuffersATI"))
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElementArrayAPPLE = (C.GPDRAWELEMENTARRAYAPPLE)(getProcAddr("glDrawElementArrayAPPLE"))
 	gpDrawElementArrayATI = (C.GPDRAWELEMENTARRAYATI)(getProcAddr("glDrawElementArrayATI"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
@@ -29094,6 +30533,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpDrawTransformFeedbackNV = (C.GPDRAWTRANSFORMFEEDBACKNV)(getProcAddr("glDrawTransformFeedbackNV"))
 	gpDrawTransformFeedbackStream = (C.GPDRAWTRANSFORMFEEDBACKSTREAM)(getProcAddr("glDrawTransformFeedbackStream"))
 	gpDrawTransformFeedbackStreamInstanced = (C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(getProcAddr("glDrawTransformFeedbackStreamInstanced"))
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
 	gpEdgeFlag = (C.GPEDGEFLAG)(getProcAddr("glEdgeFlag"))
 	if gpEdgeFlag == nil {
 		return errors.New("glEdgeFlag")
@@ -29221,6 +30661,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEvalPoint2 == nil {
 		return errors.New("glEvalPoint2")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpExecuteProgramNV = (C.GPEXECUTEPROGRAMNV)(getProcAddr("glExecuteProgramNV"))
 	gpExtractComponentEXT = (C.GPEXTRACTCOMPONENTEXT)(getProcAddr("glExtractComponentEXT"))
 	gpFeedbackBuffer = (C.GPFEEDBACKBUFFER)(getProcAddr("glFeedbackBuffer"))
@@ -29307,6 +30748,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFogxOES = (C.GPFOGXOES)(getProcAddr("glFogxOES"))
 	gpFogxvOES = (C.GPFOGXVOES)(getProcAddr("glFogxvOES"))
 	gpFragmentColorMaterialSGIX = (C.GPFRAGMENTCOLORMATERIALSGIX)(getProcAddr("glFragmentColorMaterialSGIX"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
 	gpFragmentLightModelfSGIX = (C.GPFRAGMENTLIGHTMODELFSGIX)(getProcAddr("glFragmentLightModelfSGIX"))
 	gpFragmentLightModelfvSGIX = (C.GPFRAGMENTLIGHTMODELFVSGIX)(getProcAddr("glFragmentLightModelfvSGIX"))
 	gpFragmentLightModeliSGIX = (C.GPFRAGMENTLIGHTMODELISGIX)(getProcAddr("glFragmentLightModeliSGIX"))
@@ -29323,6 +30765,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFrameZoomSGIX = (C.GPFRAMEZOOMSGIX)(getProcAddr("glFrameZoomSGIX"))
 	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
 	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
 	gpFramebufferReadBufferEXT = (C.GPFRAMEBUFFERREADBUFFEREXT)(getProcAddr("glFramebufferReadBufferEXT"))
 	gpFramebufferRenderbuffer = (C.GPFRAMEBUFFERRENDERBUFFER)(getProcAddr("glFramebufferRenderbuffer"))
@@ -29330,6 +30773,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glFramebufferRenderbuffer")
 	}
 	gpFramebufferRenderbufferEXT = (C.GPFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glFramebufferRenderbufferEXT"))
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
+	gpFramebufferSamplePositionsfvAMD = (C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glFramebufferSamplePositionsfvAMD"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	if gpFramebufferTexture == nil {
 		return errors.New("glFramebufferTexture")
@@ -29359,6 +30805,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
 	gpFramebufferTextureLayerEXT = (C.GPFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glFramebufferTextureLayerEXT"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFreeObjectBufferATI = (C.GPFREEOBJECTBUFFERATI)(getProcAddr("glFreeObjectBufferATI"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
@@ -29401,6 +30848,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGenQueries")
 	}
 	gpGenQueriesARB = (C.GPGENQUERIESARB)(getProcAddr("glGenQueriesARB"))
+	gpGenQueryResourceTagNV = (C.GPGENQUERYRESOURCETAGNV)(getProcAddr("glGenQueryResourceTagNV"))
 	gpGenRenderbuffers = (C.GPGENRENDERBUFFERS)(getProcAddr("glGenRenderbuffers"))
 	if gpGenRenderbuffers == nil {
 		return errors.New("glGenRenderbuffers")
@@ -29410,6 +30858,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenSamplers == nil {
 		return errors.New("glGenSamplers")
 	}
+	gpGenSemaphoresEXT = (C.GPGENSEMAPHORESEXT)(getProcAddr("glGenSemaphoresEXT"))
 	gpGenSymbolsEXT = (C.GPGENSYMBOLSEXT)(getProcAddr("glGenSymbolsEXT"))
 	gpGenTextures = (C.GPGENTEXTURES)(getProcAddr("glGenTextures"))
 	if gpGenTextures == nil {
@@ -29524,6 +30973,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetCombinerOutputParameterfvNV = (C.GPGETCOMBINEROUTPUTPARAMETERFVNV)(getProcAddr("glGetCombinerOutputParameterfvNV"))
 	gpGetCombinerOutputParameterivNV = (C.GPGETCOMBINEROUTPUTPARAMETERIVNV)(getProcAddr("glGetCombinerOutputParameterivNV"))
 	gpGetCombinerStageParameterfvNV = (C.GPGETCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glGetCombinerStageParameterfvNV"))
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
 	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
@@ -29540,6 +30990,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetConvolutionParameteriv = (C.GPGETCONVOLUTIONPARAMETERIV)(getProcAddr("glGetConvolutionParameteriv"))
 	gpGetConvolutionParameterivEXT = (C.GPGETCONVOLUTIONPARAMETERIVEXT)(getProcAddr("glGetConvolutionParameterivEXT"))
 	gpGetConvolutionParameterxvOES = (C.GPGETCONVOLUTIONPARAMETERXVOES)(getProcAddr("glGetConvolutionParameterxvOES"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	gpGetDebugMessageLogAMD = (C.GPGETDEBUGMESSAGELOGAMD)(getProcAddr("glGetDebugMessageLogAMD"))
 	gpGetDebugMessageLogARB = (C.GPGETDEBUGMESSAGELOGARB)(getProcAddr("glGetDebugMessageLogARB"))
@@ -29587,6 +31038,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetFramebufferAttachmentParameteriv")
 	}
 	gpGetFramebufferAttachmentParameterivEXT = (C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetFramebufferAttachmentParameterivEXT"))
+	gpGetFramebufferParameterfvAMD = (C.GPGETFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetFramebufferParameterfvAMD"))
 	gpGetFramebufferParameteriv = (C.GPGETFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetFramebufferParameteriv"))
 	gpGetFramebufferParameterivEXT = (C.GPGETFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetFramebufferParameterivEXT"))
 	gpGetGraphicsResetStatus = (C.GPGETGRAPHICSRESETSTATUS)(getProcAddr("glGetGraphicsResetStatus"))
@@ -29625,6 +31077,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	gpGetInternalformativ = (C.GPGETINTERNALFORMATIV)(getProcAddr("glGetInternalformativ"))
 	gpGetInvariantBooleanvEXT = (C.GPGETINVARIANTBOOLEANVEXT)(getProcAddr("glGetInvariantBooleanvEXT"))
@@ -29673,6 +31126,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetMaterialxOES = (C.GPGETMATERIALXOES)(getProcAddr("glGetMaterialxOES"))
 	gpGetMaterialxvOES = (C.GPGETMATERIALXVOES)(getProcAddr("glGetMaterialxvOES"))
+	gpGetMemoryObjectParameterivEXT = (C.GPGETMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glGetMemoryObjectParameterivEXT"))
 	gpGetMinmax = (C.GPGETMINMAX)(getProcAddr("glGetMinmax"))
 	gpGetMinmaxEXT = (C.GPGETMINMAXEXT)(getProcAddr("glGetMinmaxEXT"))
 	gpGetMinmaxParameterfv = (C.GPGETMINMAXPARAMETERFV)(getProcAddr("glGetMinmaxParameterfv"))
@@ -29706,6 +31160,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
 	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
+	gpGetNamedFramebufferParameterfvAMD = (C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetNamedFramebufferParameterfvAMD"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
 	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
 	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
@@ -29821,6 +31276,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetProgramivARB = (C.GPGETPROGRAMIVARB)(getProcAddr("glGetProgramivARB"))
 	gpGetProgramivNV = (C.GPGETPROGRAMIVNV)(getProcAddr("glGetProgramivNV"))
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	gpGetQueryObjecti64v = (C.GPGETQUERYOBJECTI64V)(getProcAddr("glGetQueryObjecti64v"))
 	if gpGetQueryObjecti64v == nil {
@@ -29868,6 +31327,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetSamplerParameteriv == nil {
 		return errors.New("glGetSamplerParameteriv")
 	}
+	gpGetSemaphoreParameterui64vEXT = (C.GPGETSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glGetSemaphoreParameterui64vEXT"))
 	gpGetSeparableFilter = (C.GPGETSEPARABLEFILTER)(getProcAddr("glGetSeparableFilter"))
 	gpGetSeparableFilterEXT = (C.GPGETSEPARABLEFILTEREXT)(getProcAddr("glGetSeparableFilterEXT"))
 	gpGetShaderInfoLog = (C.GPGETSHADERINFOLOG)(getProcAddr("glGetShaderInfoLog"))
@@ -29885,6 +31345,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetShaderiv")
 	}
 	gpGetSharpenTexFuncSGIS = (C.GPGETSHARPENTEXFUNCSGIS)(getProcAddr("glGetSharpenTexFuncSGIS"))
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -30008,18 +31469,22 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetUniformfv")
 	}
 	gpGetUniformfvARB = (C.GPGETUNIFORMFVARB)(getProcAddr("glGetUniformfvARB"))
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
 	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
 	gpGetUniformivARB = (C.GPGETUNIFORMIVARB)(getProcAddr("glGetUniformivARB"))
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
 	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
 	}
 	gpGetUniformuivEXT = (C.GPGETUNIFORMUIVEXT)(getProcAddr("glGetUniformuivEXT"))
+	gpGetUnsignedBytei_vEXT = (C.GPGETUNSIGNEDBYTEI_VEXT)(getProcAddr("glGetUnsignedBytei_vEXT"))
+	gpGetUnsignedBytevEXT = (C.GPGETUNSIGNEDBYTEVEXT)(getProcAddr("glGetUnsignedBytevEXT"))
 	gpGetVariantArrayObjectfvATI = (C.GPGETVARIANTARRAYOBJECTFVATI)(getProcAddr("glGetVariantArrayObjectfvATI"))
 	gpGetVariantArrayObjectivATI = (C.GPGETVARIANTARRAYOBJECTIVATI)(getProcAddr("glGetVariantArrayObjectivATI"))
 	gpGetVariantBooleanvEXT = (C.GPGETVARIANTBOOLEANVEXT)(getProcAddr("glGetVariantBooleanvEXT"))
@@ -30083,6 +31548,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetVideoivNV = (C.GPGETVIDEOIVNV)(getProcAddr("glGetVideoivNV"))
 	gpGetVideoui64vNV = (C.GPGETVIDEOUI64VNV)(getProcAddr("glGetVideoui64vNV"))
 	gpGetVideouivNV = (C.GPGETVIDEOUIVNV)(getProcAddr("glGetVideouivNV"))
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnColorTableARB = (C.GPGETNCOLORTABLEARB)(getProcAddr("glGetnColorTableARB"))
 	gpGetnCompressedTexImageARB = (C.GPGETNCOMPRESSEDTEXIMAGEARB)(getProcAddr("glGetnCompressedTexImageARB"))
 	gpGetnConvolutionFilterARB = (C.GPGETNCONVOLUTIONFILTERARB)(getProcAddr("glGetnConvolutionFilterARB"))
@@ -30101,9 +31567,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	gpGetnUniformuivARB = (C.GPGETNUNIFORMUIVARB)(getProcAddr("glGetnUniformuivARB"))
 	gpGetnUniformuivKHR = (C.GPGETNUNIFORMUIVKHR)(getProcAddr("glGetnUniformuivKHR"))
@@ -30127,6 +31595,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpImageTransformParameterfvHP = (C.GPIMAGETRANSFORMPARAMETERFVHP)(getProcAddr("glImageTransformParameterfvHP"))
 	gpImageTransformParameteriHP = (C.GPIMAGETRANSFORMPARAMETERIHP)(getProcAddr("glImageTransformParameteriHP"))
 	gpImageTransformParameterivHP = (C.GPIMAGETRANSFORMPARAMETERIVHP)(getProcAddr("glImageTransformParameterivHP"))
+	gpImportMemoryFdEXT = (C.GPIMPORTMEMORYFDEXT)(getProcAddr("glImportMemoryFdEXT"))
+	gpImportMemoryWin32HandleEXT = (C.GPIMPORTMEMORYWIN32HANDLEEXT)(getProcAddr("glImportMemoryWin32HandleEXT"))
+	gpImportMemoryWin32NameEXT = (C.GPIMPORTMEMORYWIN32NAMEEXT)(getProcAddr("glImportMemoryWin32NameEXT"))
+	gpImportSemaphoreFdEXT = (C.GPIMPORTSEMAPHOREFDEXT)(getProcAddr("glImportSemaphoreFdEXT"))
+	gpImportSemaphoreWin32HandleEXT = (C.GPIMPORTSEMAPHOREWIN32HANDLEEXT)(getProcAddr("glImportSemaphoreWin32HandleEXT"))
+	gpImportSemaphoreWin32NameEXT = (C.GPIMPORTSEMAPHOREWIN32NAMEEXT)(getProcAddr("glImportSemaphoreWin32NameEXT"))
 	gpImportSyncEXT = (C.GPIMPORTSYNCEXT)(getProcAddr("glImportSyncEXT"))
 	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
 	gpIndexFuncEXT = (C.GPINDEXFUNCEXT)(getProcAddr("glIndexFuncEXT"))
@@ -30210,6 +31684,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsBufferARB = (C.GPISBUFFERARB)(getProcAddr("glIsBufferARB"))
 	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
@@ -30232,6 +31707,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsList == nil {
 		return errors.New("glIsList")
 	}
+	gpIsMemoryObjectEXT = (C.GPISMEMORYOBJECTEXT)(getProcAddr("glIsMemoryObjectEXT"))
 	gpIsNameAMD = (C.GPISNAMEAMD)(getProcAddr("glIsNameAMD"))
 	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
@@ -30262,10 +31738,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsSampler == nil {
 		return errors.New("glIsSampler")
 	}
+	gpIsSemaphoreEXT = (C.GPISSEMAPHOREEXT)(getProcAddr("glIsSemaphoreEXT"))
 	gpIsShader = (C.GPISSHADER)(getProcAddr("glIsShader"))
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	if gpIsSync == nil {
 		return errors.New("glIsSync")
@@ -30286,6 +31764,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsVertexArrayAPPLE = (C.GPISVERTEXARRAYAPPLE)(getProcAddr("glIsVertexArrayAPPLE"))
 	gpIsVertexAttribEnabledAPPLE = (C.GPISVERTEXATTRIBENABLEDAPPLE)(getProcAddr("glIsVertexAttribEnabledAPPLE"))
+	gpLGPUCopyImageSubDataNVX = (C.GPLGPUCOPYIMAGESUBDATANVX)(getProcAddr("glLGPUCopyImageSubDataNVX"))
+	gpLGPUInterlockNVX = (C.GPLGPUINTERLOCKNVX)(getProcAddr("glLGPUInterlockNVX"))
+	gpLGPUNamedBufferSubDataNVX = (C.GPLGPUNAMEDBUFFERSUBDATANVX)(getProcAddr("glLGPUNamedBufferSubDataNVX"))
 	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLightEnviSGIX = (C.GPLIGHTENVISGIX)(getProcAddr("glLightEnviSGIX"))
 	gpLightModelf = (C.GPLIGHTMODELF)(getProcAddr("glLightModelf"))
@@ -30342,6 +31823,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpListBase == nil {
 		return errors.New("glListBase")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpListParameterfSGIX = (C.GPLISTPARAMETERFSGIX)(getProcAddr("glListParameterfSGIX"))
 	gpListParameterfvSGIX = (C.GPLISTPARAMETERFVSGIX)(getProcAddr("glListParameterfvSGIX"))
 	gpListParameteriSGIX = (C.GPLISTPARAMETERISGIX)(getProcAddr("glListParameteriSGIX"))
@@ -30502,9 +31984,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
 	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
 	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	gpMemoryBarrierByRegion = (C.GPMEMORYBARRIERBYREGION)(getProcAddr("glMemoryBarrierByRegion"))
 	gpMemoryBarrierEXT = (C.GPMEMORYBARRIEREXT)(getProcAddr("glMemoryBarrierEXT"))
+	gpMemoryObjectParameterivEXT = (C.GPMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glMemoryObjectParameterivEXT"))
 	gpMinSampleShadingARB = (C.GPMINSAMPLESHADINGARB)(getProcAddr("glMinSampleShadingARB"))
 	gpMinmax = (C.GPMINMAX)(getProcAddr("glMinmax"))
 	gpMinmaxEXT = (C.GPMINMAXEXT)(getProcAddr("glMinmaxEXT"))
@@ -30797,12 +32282,25 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
 	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
 	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
+	gpMulticastBarrierNV = (C.GPMULTICASTBARRIERNV)(getProcAddr("glMulticastBarrierNV"))
+	gpMulticastBlitFramebufferNV = (C.GPMULTICASTBLITFRAMEBUFFERNV)(getProcAddr("glMulticastBlitFramebufferNV"))
+	gpMulticastBufferSubDataNV = (C.GPMULTICASTBUFFERSUBDATANV)(getProcAddr("glMulticastBufferSubDataNV"))
+	gpMulticastCopyBufferSubDataNV = (C.GPMULTICASTCOPYBUFFERSUBDATANV)(getProcAddr("glMulticastCopyBufferSubDataNV"))
+	gpMulticastCopyImageSubDataNV = (C.GPMULTICASTCOPYIMAGESUBDATANV)(getProcAddr("glMulticastCopyImageSubDataNV"))
+	gpMulticastFramebufferSampleLocationsfvNV = (C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glMulticastFramebufferSampleLocationsfvNV"))
+	gpMulticastGetQueryObjecti64vNV = (C.GPMULTICASTGETQUERYOBJECTI64VNV)(getProcAddr("glMulticastGetQueryObjecti64vNV"))
+	gpMulticastGetQueryObjectivNV = (C.GPMULTICASTGETQUERYOBJECTIVNV)(getProcAddr("glMulticastGetQueryObjectivNV"))
+	gpMulticastGetQueryObjectui64vNV = (C.GPMULTICASTGETQUERYOBJECTUI64VNV)(getProcAddr("glMulticastGetQueryObjectui64vNV"))
+	gpMulticastGetQueryObjectuivNV = (C.GPMULTICASTGETQUERYOBJECTUIVNV)(getProcAddr("glMulticastGetQueryObjectuivNV"))
+	gpMulticastWaitSyncNV = (C.GPMULTICASTWAITSYNCNV)(getProcAddr("glMulticastWaitSyncNV"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
 	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
 	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
+	gpNamedBufferStorageExternalEXT = (C.GPNAMEDBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glNamedBufferStorageExternalEXT"))
+	gpNamedBufferStorageMemEXT = (C.GPNAMEDBUFFERSTORAGEMEMEXT)(getProcAddr("glNamedBufferStorageMemEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
 	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
 	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
@@ -30813,6 +32311,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	gpNamedFramebufferRenderbuffer = (C.GPNAMEDFRAMEBUFFERRENDERBUFFER)(getProcAddr("glNamedFramebufferRenderbuffer"))
 	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
+	gpNamedFramebufferSamplePositionsfvAMD = (C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glNamedFramebufferSamplePositionsfvAMD"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
 	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
 	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
@@ -31049,6 +32550,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPolygonOffsetEXT = (C.GPPOLYGONOFFSETEXT)(getProcAddr("glPolygonOffsetEXT"))
 	gpPolygonOffsetxOES = (C.GPPOLYGONOFFSETXOES)(getProcAddr("glPolygonOffsetxOES"))
 	gpPolygonStipple = (C.GPPOLYGONSTIPPLE)(getProcAddr("glPolygonStipple"))
@@ -31076,6 +32579,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpPresentFrameDualFillNV = (C.GPPRESENTFRAMEDUALFILLNV)(getProcAddr("glPresentFrameDualFillNV"))
 	gpPresentFrameKeyedNV = (C.GPPRESENTFRAMEKEYEDNV)(getProcAddr("glPresentFrameKeyedNV"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	if gpPrimitiveRestartIndex == nil {
 		return errors.New("glPrimitiveRestartIndex")
@@ -31139,13 +32643,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpProgramUniform1fv = (C.GPPROGRAMUNIFORM1FV)(getProcAddr("glProgramUniform1fv"))
 	gpProgramUniform1fvEXT = (C.GPPROGRAMUNIFORM1FVEXT)(getProcAddr("glProgramUniform1fvEXT"))
 	gpProgramUniform1i = (C.GPPROGRAMUNIFORM1I)(getProcAddr("glProgramUniform1i"))
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
 	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
 	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
 	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
 	gpProgramUniform1ivEXT = (C.GPPROGRAMUNIFORM1IVEXT)(getProcAddr("glProgramUniform1ivEXT"))
 	gpProgramUniform1ui = (C.GPPROGRAMUNIFORM1UI)(getProcAddr("glProgramUniform1ui"))
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
 	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
 	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
 	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
@@ -31159,13 +32667,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpProgramUniform2fv = (C.GPPROGRAMUNIFORM2FV)(getProcAddr("glProgramUniform2fv"))
 	gpProgramUniform2fvEXT = (C.GPPROGRAMUNIFORM2FVEXT)(getProcAddr("glProgramUniform2fvEXT"))
 	gpProgramUniform2i = (C.GPPROGRAMUNIFORM2I)(getProcAddr("glProgramUniform2i"))
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
 	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
 	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
 	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
 	gpProgramUniform2ivEXT = (C.GPPROGRAMUNIFORM2IVEXT)(getProcAddr("glProgramUniform2ivEXT"))
 	gpProgramUniform2ui = (C.GPPROGRAMUNIFORM2UI)(getProcAddr("glProgramUniform2ui"))
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
 	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
 	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
 	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
@@ -31179,13 +32691,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpProgramUniform3fv = (C.GPPROGRAMUNIFORM3FV)(getProcAddr("glProgramUniform3fv"))
 	gpProgramUniform3fvEXT = (C.GPPROGRAMUNIFORM3FVEXT)(getProcAddr("glProgramUniform3fvEXT"))
 	gpProgramUniform3i = (C.GPPROGRAMUNIFORM3I)(getProcAddr("glProgramUniform3i"))
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
 	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
 	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
 	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
 	gpProgramUniform3ivEXT = (C.GPPROGRAMUNIFORM3IVEXT)(getProcAddr("glProgramUniform3ivEXT"))
 	gpProgramUniform3ui = (C.GPPROGRAMUNIFORM3UI)(getProcAddr("glProgramUniform3ui"))
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
 	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
 	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
 	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
@@ -31199,13 +32715,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpProgramUniform4fv = (C.GPPROGRAMUNIFORM4FV)(getProcAddr("glProgramUniform4fv"))
 	gpProgramUniform4fvEXT = (C.GPPROGRAMUNIFORM4FVEXT)(getProcAddr("glProgramUniform4fvEXT"))
 	gpProgramUniform4i = (C.GPPROGRAMUNIFORM4I)(getProcAddr("glProgramUniform4i"))
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
 	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
 	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
 	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
 	gpProgramUniform4ivEXT = (C.GPPROGRAMUNIFORM4IVEXT)(getProcAddr("glProgramUniform4ivEXT"))
 	gpProgramUniform4ui = (C.GPPROGRAMUNIFORM4UI)(getProcAddr("glProgramUniform4ui"))
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
 	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
 	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
 	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
@@ -31284,6 +32804,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpQueryMatrixxOES = (C.GPQUERYMATRIXXOES)(getProcAddr("glQueryMatrixxOES"))
 	gpQueryObjectParameteruiAMD = (C.GPQUERYOBJECTPARAMETERUIAMD)(getProcAddr("glQueryObjectParameteruiAMD"))
+	gpQueryResourceNV = (C.GPQUERYRESOURCENV)(getProcAddr("glQueryResourceNV"))
+	gpQueryResourceTagNV = (C.GPQUERYRESOURCETAGNV)(getProcAddr("glQueryResourceTagNV"))
 	gpRasterPos2d = (C.GPRASTERPOS2D)(getProcAddr("glRasterPos2d"))
 	if gpRasterPos2d == nil {
 		return errors.New("glRasterPos2d")
@@ -31386,6 +32908,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpRasterPos4xOES = (C.GPRASTERPOS4XOES)(getProcAddr("glRasterPos4xOES"))
 	gpRasterPos4xvOES = (C.GPRASTERPOS4XVOES)(getProcAddr("glRasterPos4xvOES"))
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -31433,7 +32956,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpRectxOES = (C.GPRECTXOES)(getProcAddr("glRectxOES"))
 	gpRectxvOES = (C.GPRECTXVOES)(getProcAddr("glRectxvOES"))
 	gpReferencePlaneSGIX = (C.GPREFERENCEPLANESGIX)(getProcAddr("glReferencePlaneSGIX"))
+	gpReleaseKeyedMutexWin32EXT = (C.GPRELEASEKEYEDMUTEXWIN32EXT)(getProcAddr("glReleaseKeyedMutexWin32EXT"))
 	gpReleaseShaderCompiler = (C.GPRELEASESHADERCOMPILER)(getProcAddr("glReleaseShaderCompiler"))
+	gpRenderGpuMaskNV = (C.GPRENDERGPUMASKNV)(getProcAddr("glRenderGpuMaskNV"))
 	gpRenderMode = (C.GPRENDERMODE)(getProcAddr("glRenderMode"))
 	if gpRenderMode == nil {
 		return errors.New("glRenderMode")
@@ -31478,6 +33003,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpResetMinmax = (C.GPRESETMINMAX)(getProcAddr("glResetMinmax"))
 	gpResetMinmaxEXT = (C.GPRESETMINMAXEXT)(getProcAddr("glResetMinmaxEXT"))
 	gpResizeBuffersMESA = (C.GPRESIZEBUFFERSMESA)(getProcAddr("glResizeBuffersMESA"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	gpResumeTransformFeedbackNV = (C.GPRESUMETRANSFORMFEEDBACKNV)(getProcAddr("glResumeTransformFeedbackNV"))
 	gpRotated = (C.GPROTATED)(getProcAddr("glRotated"))
@@ -31494,7 +33020,6 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSampleCoverage")
 	}
 	gpSampleCoverageARB = (C.GPSAMPLECOVERAGEARB)(getProcAddr("glSampleCoverageARB"))
-	gpSampleCoverageOES = (C.GPSAMPLECOVERAGEOES)(getProcAddr("glSampleCoverageOES"))
 	gpSampleCoveragexOES = (C.GPSAMPLECOVERAGEXOES)(getProcAddr("glSampleCoveragexOES"))
 	gpSampleMapATI = (C.GPSAMPLEMAPATI)(getProcAddr("glSampleMapATI"))
 	gpSampleMaskEXT = (C.GPSAMPLEMASKEXT)(getProcAddr("glSampleMaskEXT"))
@@ -31648,6 +33173,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSelectBuffer")
 	}
 	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
+	gpSemaphoreParameterui64vEXT = (C.GPSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glSemaphoreParameterui64vEXT"))
 	gpSeparableFilter2D = (C.GPSEPARABLEFILTER2D)(getProcAddr("glSeparableFilter2D"))
 	gpSeparableFilter2DEXT = (C.GPSEPARABLEFILTER2DEXT)(getProcAddr("glSeparableFilter2DEXT"))
 	gpSetFenceAPPLE = (C.GPSETFENCEAPPLE)(getProcAddr("glSetFenceAPPLE"))
@@ -31671,11 +33197,16 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpShaderSourceARB = (C.GPSHADERSOURCEARB)(getProcAddr("glShaderSourceARB"))
 	gpShaderStorageBlockBinding = (C.GPSHADERSTORAGEBLOCKBINDING)(getProcAddr("glShaderStorageBlockBinding"))
 	gpSharpenTexFuncSGIS = (C.GPSHARPENTEXFUNCSGIS)(getProcAddr("glSharpenTexFuncSGIS"))
+	gpSignalSemaphoreEXT = (C.GPSIGNALSEMAPHOREEXT)(getProcAddr("glSignalSemaphoreEXT"))
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
 	gpSpriteParameterfSGIX = (C.GPSPRITEPARAMETERFSGIX)(getProcAddr("glSpriteParameterfSGIX"))
 	gpSpriteParameterfvSGIX = (C.GPSPRITEPARAMETERFVSGIX)(getProcAddr("glSpriteParameterfvSGIX"))
 	gpSpriteParameteriSGIX = (C.GPSPRITEPARAMETERISGIX)(getProcAddr("glSpriteParameteriSGIX"))
 	gpSpriteParameterivSGIX = (C.GPSPRITEPARAMETERIVSGIX)(getProcAddr("glSpriteParameterivSGIX"))
 	gpStartInstrumentsSGIX = (C.GPSTARTINSTRUMENTSSGIX)(getProcAddr("glStartInstrumentsSGIX"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
 	gpStencilClearTagEXT = (C.GPSTENCILCLEARTAGEXT)(getProcAddr("glStencilClearTagEXT"))
 	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
 	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
@@ -31714,6 +33245,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
 	gpStopInstrumentsSGIX = (C.GPSTOPINSTRUMENTSSGIX)(getProcAddr("glStopInstrumentsSGIX"))
 	gpStringMarkerGREMEDY = (C.GPSTRINGMARKERGREMEDY)(getProcAddr("glStringMarkerGREMEDY"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpSwizzleEXT = (C.GPSWIZZLEEXT)(getProcAddr("glSwizzleEXT"))
 	gpSyncTextureINTEL = (C.GPSYNCTEXTUREINTEL)(getProcAddr("glSyncTextureINTEL"))
 	gpTagSampleBufferSGIX = (C.GPTAGSAMPLEBUFFERSGIX)(getProcAddr("glTagSampleBufferSGIX"))
@@ -32053,6 +33585,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpTexStorage2DMultisample = (C.GPTEXSTORAGE2DMULTISAMPLE)(getProcAddr("glTexStorage2DMultisample"))
 	gpTexStorage3D = (C.GPTEXSTORAGE3D)(getProcAddr("glTexStorage3D"))
 	gpTexStorage3DMultisample = (C.GPTEXSTORAGE3DMULTISAMPLE)(getProcAddr("glTexStorage3DMultisample"))
+	gpTexStorageMem1DEXT = (C.GPTEXSTORAGEMEM1DEXT)(getProcAddr("glTexStorageMem1DEXT"))
+	gpTexStorageMem2DEXT = (C.GPTEXSTORAGEMEM2DEXT)(getProcAddr("glTexStorageMem2DEXT"))
+	gpTexStorageMem2DMultisampleEXT = (C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem2DMultisampleEXT"))
+	gpTexStorageMem3DEXT = (C.GPTEXSTORAGEMEM3DEXT)(getProcAddr("glTexStorageMem3DEXT"))
+	gpTexStorageMem3DMultisampleEXT = (C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem3DMultisampleEXT"))
 	gpTexStorageSparseAMD = (C.GPTEXSTORAGESPARSEAMD)(getProcAddr("glTexStorageSparseAMD"))
 	gpTexSubImage1D = (C.GPTEXSUBIMAGE1D)(getProcAddr("glTexSubImage1D"))
 	if gpTexSubImage1D == nil {
@@ -32112,6 +33649,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
 	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
+	gpTextureStorageMem1DEXT = (C.GPTEXTURESTORAGEMEM1DEXT)(getProcAddr("glTextureStorageMem1DEXT"))
+	gpTextureStorageMem2DEXT = (C.GPTEXTURESTORAGEMEM2DEXT)(getProcAddr("glTextureStorageMem2DEXT"))
+	gpTextureStorageMem2DMultisampleEXT = (C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem2DMultisampleEXT"))
+	gpTextureStorageMem3DEXT = (C.GPTEXTURESTORAGEMEM3DEXT)(getProcAddr("glTextureStorageMem3DEXT"))
+	gpTextureStorageMem3DMultisampleEXT = (C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem3DMultisampleEXT"))
 	gpTextureStorageSparseAMD = (C.GPTEXTURESTORAGESPARSEAMD)(getProcAddr("glTextureStorageSparseAMD"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
 	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
@@ -32157,7 +33699,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
 	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
 	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iARB = (C.GPUNIFORM1IARB)(getProcAddr("glUniform1iARB"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
@@ -32169,7 +33713,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
 	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
 	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiEXT = (C.GPUNIFORM1UIEXT)(getProcAddr("glUniform1uiEXT"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
@@ -32193,7 +33739,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
 	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
 	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iARB = (C.GPUNIFORM2IARB)(getProcAddr("glUniform2iARB"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
@@ -32205,7 +33753,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
 	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
 	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiEXT = (C.GPUNIFORM2UIEXT)(getProcAddr("glUniform2uiEXT"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
@@ -32229,7 +33779,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
 	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
 	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iARB = (C.GPUNIFORM3IARB)(getProcAddr("glUniform3iARB"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
@@ -32241,7 +33793,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
 	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
 	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiEXT = (C.GPUNIFORM3UIEXT)(getProcAddr("glUniform3uiEXT"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
@@ -32265,7 +33819,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
 	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
 	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iARB = (C.GPUNIFORM4IARB)(getProcAddr("glUniform4iARB"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
@@ -32277,7 +33833,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
 	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
 	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiEXT = (C.GPUNIFORM4UIEXT)(getProcAddr("glUniform4uiEXT"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
@@ -33043,10 +34601,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpViewportArrayv = (C.GPVIEWPORTARRAYV)(getProcAddr("glViewportArrayv"))
 	gpViewportIndexedf = (C.GPVIEWPORTINDEXEDF)(getProcAddr("glViewportIndexedf"))
 	gpViewportIndexedfv = (C.GPVIEWPORTINDEXEDFV)(getProcAddr("glViewportIndexedfv"))
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
+	gpWaitSemaphoreEXT = (C.GPWAITSEMAPHOREEXT)(getProcAddr("glWaitSemaphoreEXT"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
 	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
 	gpWeightPointerARB = (C.GPWEIGHTPOINTERARB)(getProcAddr("glWeightPointerARB"))
 	gpWeightbvARB = (C.GPWEIGHTBVARB)(getProcAddr("glWeightbvARB"))
@@ -33161,6 +34723,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpWindowPos4ivMESA = (C.GPWINDOWPOS4IVMESA)(getProcAddr("glWindowPos4ivMESA"))
 	gpWindowPos4sMESA = (C.GPWINDOWPOS4SMESA)(getProcAddr("glWindowPos4sMESA"))
 	gpWindowPos4svMESA = (C.GPWINDOWPOS4SVMESA)(getProcAddr("glWindowPos4svMESA"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	gpWriteMaskEXT = (C.GPWRITEMASKEXT)(getProcAddr("glWriteMaskEXT"))
 	return nil
 }

--- a/v3.3-compatibility/gl/procaddr.go
+++ b/v3.3-compatibility/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcompatibility33(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v3.3-core/gl/package.go
+++ b/v3.3-core/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -89,21 +87,29 @@ package gl
 // typedef ptrdiff_t GLsizeiptr;
 // typedef int64_t GLint64;
 // typedef uint64_t GLuint64;
+// typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCARB)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCKHR)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcore33(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcore33(source, type, id, severity, length, message, userParam);
 // }
+// typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
+// typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVETEXTURE)(GLenum  texture);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPATTACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPBEGINCONDITIONALRENDER)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINCONDITIONALRENDERNV)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPBEGINPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPBEGINQUERY)(GLenum  target, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINQUERYINDEXED)(GLenum  target, GLuint  index, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINTRANSFORMFEEDBACK)(GLenum  primitiveMode);
@@ -118,7 +124,9 @@ package gl
 // typedef void  (APIENTRYP GPBINDFRAMEBUFFER)(GLenum  target, GLuint  framebuffer);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURE)(GLuint  unit, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  access, GLenum  format);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURES)(GLuint  first, GLsizei  count, const GLuint * textures);
+// typedef void  (APIENTRYP GPBINDMULTITEXTUREEXT)(GLenum  texunit, GLenum  target, GLuint  texture);
 // typedef void  (APIENTRYP GPBINDPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPBINDPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPBINDRENDERBUFFER)(GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPBINDSAMPLER)(GLuint  unit, GLuint  sampler);
 // typedef void  (APIENTRYP GPBINDSAMPLERS)(GLuint  first, GLsizei  count, const GLuint * samplers);
@@ -129,6 +137,8 @@ package gl
 // typedef void  (APIENTRYP GPBINDVERTEXARRAY)(GLuint  array);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFER)(GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFERS)(GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPBLENDBARRIERKHR)();
+// typedef void  (APIENTRYP GPBLENDBARRIERNV)();
 // typedef void  (APIENTRYP GPBLENDCOLOR)(GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha);
 // typedef void  (APIENTRYP GPBLENDEQUATION)(GLenum  mode);
 // typedef void  (APIENTRYP GPBLENDEQUATIONSEPARATE)(GLenum  modeRGB, GLenum  modeAlpha);
@@ -138,14 +148,18 @@ package gl
 // typedef void  (APIENTRYP GPBLENDFUNCSEPARATE)(GLenum  sfactorRGB, GLenum  dfactorRGB, GLenum  sfactorAlpha, GLenum  dfactorAlpha);
 // typedef void  (APIENTRYP GPBLENDFUNCSEPARATEIARB)(GLuint  buf, GLenum  srcRGB, GLenum  dstRGB, GLenum  srcAlpha, GLenum  dstAlpha);
 // typedef void  (APIENTRYP GPBLENDFUNCIARB)(GLuint  buf, GLenum  src, GLenum  dst);
+// typedef void  (APIENTRYP GPBLENDPARAMETERINV)(GLenum  pname, GLint  value);
 // typedef void  (APIENTRYP GPBLITFRAMEBUFFER)(GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
 // typedef void  (APIENTRYP GPBLITNAMEDFRAMEBUFFER)(GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
 // typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUS)(GLuint  framebuffer, GLenum  target);
+// typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(GLuint  framebuffer, GLenum  target);
 // typedef void  (APIENTRYP GPCLAMPCOLOR)(GLenum  target, GLenum  clamp);
 // typedef void  (APIENTRYP GPCLEAR)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPCLEARBUFFERDATA)(GLenum  target, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
@@ -158,49 +172,91 @@ package gl
 // typedef void  (APIENTRYP GPCLEARDEPTH)(GLdouble  depth);
 // typedef void  (APIENTRYP GPCLEARDEPTHF)(GLfloat  d);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
 // typedef void  (APIENTRYP GPCLEARSTENCIL)(GLint  s);
 // typedef void  (APIENTRYP GPCLEARTEXIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARTEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef GLenum  (APIENTRYP GPCLIENTWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
 // typedef void  (APIENTRYP GPCLIPCONTROL)(GLenum  origin, GLenum  depth);
+// typedef void  (APIENTRYP GPCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPCOLORMASK)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPCOLORMASKI)(GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE3D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOPYBUFFERSUBDATA)(GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYIMAGESUBDATA)(GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef void  (APIENTRYP GPCREATEPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPCREATEQUERIES)(GLenum  target, GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPCREATERENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPCREATESAMPLERS)(GLsizei  n, GLuint * samplers);
 // typedef GLuint  (APIENTRYP GPCREATESHADER)(GLenum  type);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -216,14 +272,20 @@ package gl
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTARB)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTKHR)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef void  (APIENTRYP GPDELETEPATHSNV)(GLuint  path, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
+// typedef void  (APIENTRYP GPDELETEPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPDELETEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINES)(GLsizei  n, const GLuint * pipelines);
+// typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINESEXT)(GLsizei  n, const GLuint * pipelines);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETRANSFORMFEEDBACKS)(GLsizei  n, const GLuint * ids);
@@ -236,7 +298,12 @@ package gl
 // typedef void  (APIENTRYP GPDEPTHRANGEF)(GLfloat  n, GLfloat  f);
 // typedef void  (APIENTRYP GPDETACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPDISABLE)(GLenum  cap);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPDISABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISPATCHCOMPUTE)(GLuint  num_groups_x, GLuint  num_groups_y, GLuint  num_groups_z);
@@ -245,46 +312,81 @@ package gl
 // typedef void  (APIENTRYP GPDRAWARRAYS)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCED)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDARB)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDBASEINSTANCE)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDEXT)(GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWBUFFER)(GLenum  buf);
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWELEMENTSBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCED)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDARB)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDEXT)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTS)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTSBASEVERTEX)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACK)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKINSTANCED)(GLenum  mode, GLuint  id, GLsizei  instancecount);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
+// typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPENABLE)(GLenum  cap);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPENABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPENABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDCONDITIONALRENDER)();
+// typedef void  (APIENTRYP GPENDCONDITIONALRENDERNV)();
+// typedef void  (APIENTRYP GPENDPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPENDPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPENDQUERY)(GLenum  target);
 // typedef void  (APIENTRYP GPENDQUERYINDEXED)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDTRANSFORMFEEDBACK)();
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef GLsync  (APIENTRYP GPFENCESYNC)(GLenum  condition, GLbitfield  flags);
 // typedef void  (APIENTRYP GPFINISH)();
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFOGCOORDFORMATNV)(GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE2D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE3D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREFACEARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPGENBUFFERS)(GLsizei  n, GLuint * buffers);
 // typedef void  (APIENTRYP GPGENFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef GLuint  (APIENTRYP GPGENPATHSNV)(GLsizei  range);
+// typedef void  (APIENTRYP GPGENPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
 // typedef void  (APIENTRYP GPGENPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
+// typedef void  (APIENTRYP GPGENPROGRAMPIPELINESEXT)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
@@ -292,7 +394,9 @@ package gl
 // typedef void  (APIENTRYP GPGENTRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENVERTEXARRAYS)(GLsizei  n, GLuint * arrays);
 // typedef void  (APIENTRYP GPGENERATEMIPMAP)(GLenum  target);
+// typedef void  (APIENTRYP GPGENERATEMULTITEXMIPMAPEXT)(GLenum  texunit, GLenum  target);
 // typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAP)(GLuint  texture);
+// typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAPEXT)(GLuint  texture, GLenum  target);
 // typedef void  (APIENTRYP GPGETACTIVEATOMICCOUNTERBUFFERIV)(GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETACTIVEATTRIB)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLint * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETACTIVESUBROUTINENAME)(GLuint  program, GLenum  shadertype, GLuint  index, GLsizei  bufsize, GLsizei * length, GLchar * name);
@@ -305,65 +409,137 @@ package gl
 // typedef void  (APIENTRYP GPGETACTIVEUNIFORMSIV)(GLuint  program, GLsizei  uniformCount, const GLuint * uniformIndices, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETATTACHEDSHADERS)(GLuint  program, GLsizei  maxCount, GLsizei * count, GLuint * shaders);
 // typedef GLint  (APIENTRYP GPGETATTRIBLOCATION)(GLuint  program, const GLchar * name);
+// typedef void  (APIENTRYP GPGETBOOLEANINDEXEDVEXT)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANI_V)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANV)(GLenum  pname, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERI64V)(GLenum  target, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETBUFFERPARAMETERUI64VNV)(GLenum  target, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETBUFFERPOINTERV)(GLenum  target, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGE)(GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGKHR)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
+// typedef void  (APIENTRYP GPGETDOUBLEINDEXEDVEXT)(GLenum  target, GLuint  index, GLdouble * data);
 // typedef void  (APIENTRYP GPGETDOUBLEI_V)(GLenum  target, GLuint  index, GLdouble * data);
+// typedef void  (APIENTRYP GPGETDOUBLEI_VEXT)(GLenum  pname, GLuint  index, GLdouble * params);
 // typedef void  (APIENTRYP GPGETDOUBLEV)(GLenum  pname, GLdouble * data);
 // typedef GLenum  (APIENTRYP GPGETERROR)();
+// typedef void  (APIENTRYP GPGETFIRSTPERFQUERYIDINTEL)(GLuint * queryId);
+// typedef void  (APIENTRYP GPGETFLOATINDEXEDVEXT)(GLenum  target, GLuint  index, GLfloat * data);
 // typedef void  (APIENTRYP GPGETFLOATI_V)(GLenum  target, GLuint  index, GLfloat * data);
+// typedef void  (APIENTRYP GPGETFLOATI_VEXT)(GLenum  pname, GLuint  index, GLfloat * params);
 // typedef void  (APIENTRYP GPGETFLOATV)(GLenum  pname, GLfloat * data);
 // typedef GLint  (APIENTRYP GPGETFRAGDATAINDEX)(GLuint  program, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETFRAGDATALOCATION)(GLuint  program, const GLchar * name);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSARB)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSKHR)();
 // typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLEARB)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
+// typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLENV)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
 // typedef void  (APIENTRYP GPGETINTEGER64I_V)(GLenum  target, GLuint  index, GLint64 * data);
 // typedef void  (APIENTRYP GPGETINTEGER64V)(GLenum  pname, GLint64 * data);
+// typedef void  (APIENTRYP GPGETINTEGERINDEXEDVEXT)(GLenum  target, GLuint  index, GLint * data);
 // typedef void  (APIENTRYP GPGETINTEGERI_V)(GLenum  target, GLuint  index, GLint * data);
+// typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
+// typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMULTISAMPLEFV)(GLenum  pname, GLuint  index, GLfloat * val);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERI64V)(GLuint  buffer, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIV)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIVEXT)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  pname, void * string);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMIVEXT)(GLuint  program, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIV)(GLuint  renderbuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(GLuint  renderbuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGARB)(GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGIVARB)(GLint  namelen, const GLchar * name, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNEXTPERFQUERYIDINTEL)(GLuint  queryId, GLuint * nextQueryId);
 // typedef void  (APIENTRYP GPGETOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETOBJECTLABELEXT)(GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABEL)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABELKHR)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETPATHCOMMANDSNV)(GLuint  path, GLubyte * commands);
+// typedef void  (APIENTRYP GPGETPATHCOORDSNV)(GLuint  path, GLfloat * coords);
+// typedef void  (APIENTRYP GPGETPATHDASHARRAYNV)(GLuint  path, GLfloat * dashArray);
+// typedef GLfloat  (APIENTRYP GPGETPATHLENGTHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments);
+// typedef void  (APIENTRYP GPGETPATHMETRICRANGENV)(GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHMETRICSNV)(GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, GLfloat * value);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, GLint * value);
+// typedef void  (APIENTRYP GPGETPATHSPACINGNV)(GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing);
+// typedef void  (APIENTRYP GPGETPERFCOUNTERINFOINTEL)(GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERDATAAMD)(GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERINFOAMD)(GLuint  group, GLuint  counter, GLenum  pname, void * data);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSTRINGAMD)(GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
+// typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
+// typedef void  (APIENTRYP GPGETPOINTERINDEXEDVEXT)(GLenum  target, GLuint  index, void ** data);
+// typedef void  (APIENTRYP GPGETPOINTERI_VEXT)(GLenum  pname, GLuint  index, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERV)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERVKHR)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPROGRAMBINARY)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLenum * binaryFormat, void * binary);
 // typedef void  (APIENTRYP GPGETPROGRAMINFOLOG)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMINTERFACEIV)(GLuint  program, GLenum  programInterface, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOG)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOGEXT)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIV)(GLuint  pipeline, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIVEXT)(GLuint  pipeline, GLenum  pname, GLint * params);
 // typedef GLuint  (APIENTRYP GPGETPROGRAMRESOURCEINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATION)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATIONINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCENAME)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name);
+// typedef void  (APIENTRYP GPGETPROGRAMRESOURCEFVNV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCEIV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMSTAGEIV)(GLuint  program, GLenum  shadertype, GLenum  pname, GLint * values);
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTIV)(GLuint  id, GLenum  pname, GLint * params);
@@ -379,6 +555,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERPRECISIONFORMAT)(GLenum  shadertype, GLenum  precisiontype, GLint * range, GLint * precision);
 // typedef void  (APIENTRYP GPGETSHADERSOURCE)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -392,14 +569,23 @@ package gl
 // typedef void  (APIENTRYP GPGETTEXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLEARB)(GLuint  texture);
+// typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLENV)(GLuint  texture);
 // typedef void  (APIENTRYP GPGETTEXTUREIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFV)(GLuint  texture, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIV)(GLuint  texture, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLEARB)(GLuint  texture, GLuint  sampler);
+// typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLENV)(GLuint  texture, GLuint  sampler);
 // typedef void  (APIENTRYP GPGETTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKVARYING)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLsizei * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKI64_V)(GLuint  xfb, GLenum  pname, GLuint  index, GLint64 * param);
@@ -411,32 +597,48 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMSUBROUTINEUIV)(GLenum  shadertype, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXED64IV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint64 * param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXEDIV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERVEXT)(GLuint  vaobj, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, void ** param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERVEXT)(GLuint  vaobj, GLenum  pname, void ** param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYIV)(GLuint  vaobj, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIIV)(GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIUIV)(GLuint  index, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLDV)(GLuint  index, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLI64VNV)(GLuint  index, GLenum  pname, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VARB)(GLuint  index, GLenum  pname, GLuint64EXT * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VNV)(GLuint  index, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBPOINTERV)(GLuint  index, GLenum  pname, void ** pointer);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBDV)(GLuint  index, GLenum  pname, GLdouble * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBFV)(GLuint  index, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIV)(GLuint  index, GLenum  pname, GLint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNTEXIMAGEARB)(GLenum  target, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNUNIFORMDVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLdouble * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPHINT)(GLenum  target, GLenum  mode);
+// typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPINSERTEVENTMARKEREXT)(GLsizei  length, const GLchar * marker);
+// typedef void  (APIENTRYP GPINTERPOLATEPATHSNV)(GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERDATA)(GLuint  buffer);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPINVALIDATEFRAMEBUFFER)(GLenum  target, GLsizei  numAttachments, const GLenum * attachments);
@@ -446,67 +648,195 @@ package gl
 // typedef void  (APIENTRYP GPINVALIDATETEXIMAGE)(GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPINVALIDATETEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
+// typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISFRAMEBUFFER)(GLuint  framebuffer);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef GLboolean  (APIENTRYP GPISPATHNV)(GLuint  path);
+// typedef GLboolean  (APIENTRYP GPISPOINTINFILLPATHNV)(GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y);
+// typedef GLboolean  (APIENTRYP GPISPOINTINSTROKEPATHNV)(GLuint  path, GLfloat  x, GLfloat  y);
 // typedef GLboolean  (APIENTRYP GPISPROGRAM)(GLuint  program);
 // typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef GLboolean  (APIENTRYP GPISQUERY)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISTRANSFORMFEEDBACK)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
+// typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLINEWIDTH)(GLfloat  width);
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLOGICOP)(GLenum  opcode);
+// typedef void  (APIENTRYP GPMAKEBUFFERNONRESIDENTNV)(GLenum  target);
+// typedef void  (APIENTRYP GPMAKEBUFFERRESIDENTNV)(GLenum  target, GLenum  access);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTARB)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTNV)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERNONRESIDENTNV)(GLuint  buffer);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERRESIDENTNV)(GLuint  buffer, GLenum  access);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef void * (APIENTRYP GPMAPBUFFER)(GLenum  target, GLenum  access);
 // typedef void * (APIENTRYP GPMAPBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void  (APIENTRYP GPMATRIXFRUSTUMEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADIDENTITYEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXORTHOEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXPOPEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXPUSHEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXROTATEDEXT)(GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXROTATEFEXT)(GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYS)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTITEXBUFFEREXT)(GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPMULTITEXCOORDPOINTEREXT)(GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
+// typedef void  (APIENTRYP GPMULTITEXENVFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXENVIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXGENDEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param);
+// typedef void  (APIENTRYP GPMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params);
+// typedef void  (APIENTRYP GPMULTITEXGENFEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXGENIEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXRENDERBUFFEREXT)(GLenum  texunit, GLenum  target, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFERS)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERI)(GLuint  framebuffer, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERIEXT)(GLuint  framebuffer, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYER)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLdouble * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGE)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEEXT)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDSTRINGARB)(GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string);
+// typedef void  (APIENTRYP GPNORMALFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABEL)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABELKHR)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPPATCHPARAMETERFV)(GLenum  pname, const GLfloat * values);
 // typedef void  (APIENTRYP GPPATCHPARAMETERI)(GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHCOMMANDSNV)(GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOORDSNV)(GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOVERDEPTHFUNCNV)(GLenum  func);
+// typedef void  (APIENTRYP GPPATHDASHARRAYNV)(GLuint  path, GLsizei  dashCount, const GLfloat * dashArray);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXRANGENV)(GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount);
+// typedef void  (APIENTRYP GPPATHGLYPHRANGENV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHGLYPHSNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHMEMORYGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHPARAMETERFNV)(GLuint  path, GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, const GLfloat * value);
+// typedef void  (APIENTRYP GPPATHPARAMETERINV)(GLuint  path, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, const GLint * value);
+// typedef void  (APIENTRYP GPPATHSTENCILDEPTHOFFSETNV)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPATHSTENCILFUNCNV)(GLenum  func, GLint  ref, GLuint  mask);
+// typedef void  (APIENTRYP GPPATHSTRINGNV)(GLuint  path, GLenum  format, GLsizei  length, const void * pathString);
+// typedef void  (APIENTRYP GPPATHSUBCOMMANDSNV)(GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHSUBCOORDSNV)(GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords);
 // typedef void  (APIENTRYP GPPAUSETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPPIXELSTOREF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPIXELSTOREI)(GLenum  pname, GLint  param);
+// typedef GLboolean  (APIENTRYP GPPOINTALONGPATHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY);
 // typedef void  (APIENTRYP GPPOINTPARAMETERF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPOINTPARAMETERFV)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPPOINTPARAMETERI)(GLenum  pname, GLint  param);
@@ -514,67 +844,163 @@ package gl
 // typedef void  (APIENTRYP GPPOINTSIZE)(GLfloat  size);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOPDEBUGGROUP)();
 // typedef void  (APIENTRYP GPPOPDEBUGGROUPKHR)();
+// typedef void  (APIENTRYP GPPOPGROUPMARKEREXT)();
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPROGRAMBINARY)(GLuint  program, GLenum  binaryFormat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPPROGRAMPARAMETERI)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIARB)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIEXT)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPATHFRAGMENTINPUTGENNV)(GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1D)(GLuint  program, GLint  location, GLdouble  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DEXT)(GLuint  program, GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1F)(GLuint  program, GLint  location, GLfloat  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FEXT)(GLuint  program, GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64ARB)(GLuint  program, GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64NV)(GLuint  program, GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64NV)(GLuint  program, GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROVOKINGVERTEX)(GLenum  mode);
+// typedef void  (APIENTRYP GPPUSHCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUP)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUPKHR)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
+// typedef void  (APIENTRYP GPPUSHGROUPMARKEREXT)(GLsizei  length, const GLchar * marker);
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPREADNPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, GLsizei  bufSize, void * data);
@@ -583,6 +1009,8 @@ package gl
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMASKI)(GLuint  maskNumber, GLbitfield  mask);
@@ -596,23 +1024,40 @@ package gl
 // typedef void  (APIENTRYP GPSCISSORARRAYV)(GLuint  first, GLsizei  count, const GLint * v);
 // typedef void  (APIENTRYP GPSCISSORINDEXED)(GLuint  index, GLint  left, GLint  bottom, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPSCISSORINDEXEDV)(GLuint  index, const GLint * v);
+// typedef void  (APIENTRYP GPSECONDARYCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
 // typedef void  (APIENTRYP GPSHADERBINARY)(GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPSHADERSOURCE)(GLuint  shader, GLsizei  count, const GLchar *const* string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNC)(GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNCSEPARATE)(GLenum  face, GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASK)(GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASKSEPARATE)(GLenum  face, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILOP)(GLenum  fail, GLenum  zfail, GLenum  zpass);
 // typedef void  (APIENTRYP GPSTENCILOPSEPARATE)(GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPTEXBUFFER)(GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXBUFFERARB)(GLenum  target, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXBUFFERRANGE)(GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXCOORDFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPTEXIMAGE1D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE2D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERF)(GLenum  target, GLenum  pname, GLfloat  param);
@@ -628,61 +1073,118 @@ package gl
 // typedef void  (APIENTRYP GPTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREBARRIER)();
+// typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERF)(GLuint  texture, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, const GLfloat * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERI)(GLuint  texture, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, const GLint * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTURERENDERBUFFEREXT)(GLuint  texture, GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE1D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE1DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREVIEW)(GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
+// typedef void  (APIENTRYP GPTRANSFORMPATHNV)(GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPUNIFORM1D)(GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPUNIFORM1DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM1F)(GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM2D)(GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPUNIFORM2DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM2F)(GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM3D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPUNIFORM3DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM3F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM4D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPUNIFORM4DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM4F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORMBLOCKBINDING)(GLuint  program, GLuint  uniformBlockIndex, GLuint  uniformBlockBinding);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64ARB)(GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64NV)(GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VNV)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
@@ -702,20 +1204,45 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMSUBROUTINESUIV)(GLenum  shadertype, GLsizei  count, const GLuint * indices);
+// typedef void  (APIENTRYP GPUNIFORMUI64NV)(GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPUNIFORMUI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef GLboolean  (APIENTRYP GPUNMAPBUFFER)(GLenum  target);
 // typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFEREXT)(GLuint  buffer);
 // typedef void  (APIENTRYP GPUSEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPUSEPROGRAMSTAGES)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSEPROGRAMSTAGESEXT)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSESHADERPROGRAMEXT)(GLenum  type, GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBBINDING)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBIFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBLFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYBINDVERTEXBUFFEREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYBINDINGDIVISOR)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYEDGEFLAGOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXARRAYELEMENTBUFFER)(GLuint  vaobj, GLuint  buffer);
+// typedef void  (APIENTRYP GPVERTEXARRAYFOGCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYINDEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYNORMALOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYTEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(GLuint  vaobj, GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFER)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFERS)(GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1DV)(GLuint  index, const GLdouble * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1F)(GLuint  index, GLfloat  x);
@@ -754,7 +1281,9 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIB4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBBINDING)(GLuint  attribindex, GLuint  bindingindex);
 // typedef void  (APIENTRYP GPVERTEXATTRIBDIVISOR)(GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXATTRIBDIVISORARB)(GLuint  index, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXATTRIBFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1I)(GLuint  index, GLint  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1IV)(GLuint  index, const GLint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1UI)(GLuint  index, GLuint  x);
@@ -776,18 +1305,36 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4UIV)(GLuint  index, const GLuint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBIFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64NV)(GLuint  index, GLint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64VNV)(GLuint  index, const GLint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64ARB)(GLuint  index, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64NV)(GLuint  index, GLuint64EXT  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VARB)(GLuint  index, const GLuint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2D)(GLuint  index, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBLFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UI)(GLuint  index, GLenum  type, GLboolean  normalized, GLuint  value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
@@ -799,22 +1346,46 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBP4UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBPOINTER)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXBINDINGDIVISOR)(GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVIEWPORT)(GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
+// static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
+//   (*fnptr)(program);
+// }
 // static void  glowActiveShaderProgram(GPACTIVESHADERPROGRAM fnptr, GLuint  pipeline, GLuint  program) {
+//   (*fnptr)(pipeline, program);
+// }
+// static void  glowActiveShaderProgramEXT(GPACTIVESHADERPROGRAMEXT fnptr, GLuint  pipeline, GLuint  program) {
 //   (*fnptr)(pipeline, program);
 // }
 // static void  glowActiveTexture(GPACTIVETEXTURE fnptr, GLenum  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowAttachShader(GPATTACHSHADER fnptr, GLuint  program, GLuint  shader) {
 //   (*fnptr)(program, shader);
 // }
 // static void  glowBeginConditionalRender(GPBEGINCONDITIONALRENDER fnptr, GLuint  id, GLenum  mode) {
 //   (*fnptr)(id, mode);
+// }
+// static void  glowBeginConditionalRenderNV(GPBEGINCONDITIONALRENDERNV fnptr, GLuint  id, GLenum  mode) {
+//   (*fnptr)(id, mode);
+// }
+// static void  glowBeginPerfMonitorAMD(GPBEGINPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowBeginPerfQueryINTEL(GPBEGINPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
 // }
 // static void  glowBeginQuery(GPBEGINQUERY fnptr, GLenum  target, GLuint  id) {
 //   (*fnptr)(target, id);
@@ -858,7 +1429,13 @@ package gl
 // static void  glowBindImageTextures(GPBINDIMAGETEXTURES fnptr, GLuint  first, GLsizei  count, const GLuint * textures) {
 //   (*fnptr)(first, count, textures);
 // }
+// static void  glowBindMultiTextureEXT(GPBINDMULTITEXTUREEXT fnptr, GLenum  texunit, GLenum  target, GLuint  texture) {
+//   (*fnptr)(texunit, target, texture);
+// }
 // static void  glowBindProgramPipeline(GPBINDPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowBindProgramPipelineEXT(GPBINDPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowBindRenderbuffer(GPBINDRENDERBUFFER fnptr, GLenum  target, GLuint  renderbuffer) {
@@ -891,6 +1468,12 @@ package gl
 // static void  glowBindVertexBuffers(GPBINDVERTEXBUFFERS fnptr, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(first, count, buffers, offsets, strides);
 // }
+// static void  glowBlendBarrierKHR(GPBLENDBARRIERKHR fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowBlendBarrierNV(GPBLENDBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowBlendColor(GPBLENDCOLOR fnptr, GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
 // }
@@ -918,16 +1501,22 @@ package gl
 // static void  glowBlendFunciARB(GPBLENDFUNCIARB fnptr, GLuint  buf, GLenum  src, GLenum  dst) {
 //   (*fnptr)(buf, src, dst);
 // }
+// static void  glowBlendParameteriNV(GPBLENDPARAMETERINV fnptr, GLenum  pname, GLint  value) {
+//   (*fnptr)(pname, value);
+// }
 // static void  glowBlitFramebuffer(GPBLITFRAMEBUFFER fnptr, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
 // static void  glowBlitNamedFramebuffer(GPBLITNAMEDFRAMEBUFFER fnptr, GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
+// static void  glowBufferAddressRangeNV(GPBUFFERADDRESSRANGENV fnptr, GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length) {
+//   (*fnptr)(pname, index, address, length);
+// }
 // static void  glowBufferData(GPBUFFERDATA fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
@@ -936,10 +1525,16 @@ package gl
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static GLenum  glowCheckFramebufferStatus(GPCHECKFRAMEBUFFERSTATUS fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLenum  glowCheckNamedFramebufferStatus(GPCHECKNAMEDFRAMEBUFFERSTATUS fnptr, GLuint  framebuffer, GLenum  target) {
+//   return (*fnptr)(framebuffer, target);
+// }
+// static GLenum  glowCheckNamedFramebufferStatusEXT(GPCHECKNAMEDFRAMEBUFFERSTATUSEXT fnptr, GLuint  framebuffer, GLenum  target) {
 //   return (*fnptr)(framebuffer, target);
 // }
 // static void  glowClampColor(GPCLAMPCOLOR fnptr, GLenum  target, GLenum  clamp) {
@@ -978,11 +1573,17 @@ package gl
 // static void  glowClearNamedBufferData(GPCLEARNAMEDBUFFERDATA fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, format, type, data);
+// }
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
+// }
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -1002,11 +1603,17 @@ package gl
 // static void  glowClearTexSubImage(GPCLEARTEXSUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data);
 // }
+// static void  glowClientAttribDefaultEXT(GPCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
+// }
 // static GLenum  glowClientWaitSync(GPCLIENTWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   return (*fnptr)(sync, flags, timeout);
 // }
 // static void  glowClipControl(GPCLIPCONTROL fnptr, GLenum  origin, GLenum  depth) {
 //   (*fnptr)(origin, depth);
+// }
+// static void  glowColorFormatNV(GPCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
 // }
 // static void  glowColorMask(GPCOLORMASK fnptr, GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
@@ -1014,11 +1621,35 @@ package gl
 // static void  glowColorMaski(GPCOLORMASKI fnptr, GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a) {
 //   (*fnptr)(index, r, g, b, a);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
 // static void  glowCompileShaderIncludeARB(GPCOMPILESHADERINCLUDEARB fnptr, GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length) {
 //   (*fnptr)(shader, count, path, length);
+// }
+// static void  glowCompressedMultiTexImage1DEXT(GPCOMPRESSEDMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage2DEXT(GPCOMPRESSEDMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage3DEXT(GPCOMPRESSEDMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage1DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage2DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage3DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
 // }
 // static void  glowCompressedTexImage1D(GPCOMPRESSEDTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, internalformat, width, border, imageSize, data);
@@ -1038,14 +1669,38 @@ package gl
 // static void  glowCompressedTexSubImage3D(GPCOMPRESSEDTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
 // }
+// static void  glowCompressedTextureImage1DEXT(GPCOMPRESSEDTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage2DEXT(GPCOMPRESSEDTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage3DEXT(GPCOMPRESSEDTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage1D(GPCOMPRESSEDTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, width, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage1DEXT(GPCOMPRESSEDTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, imageSize, bits);
 // }
 // static void  glowCompressedTextureSubImage2D(GPCOMPRESSEDTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, imageSize, data);
 // }
+// static void  glowCompressedTextureSubImage2DEXT(GPCOMPRESSEDTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage3D(GPCOMPRESSEDTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowCopyBufferSubData(GPCOPYBUFFERSUBDATA fnptr, GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readTarget, writeTarget, readOffset, writeOffset, size);
@@ -1053,8 +1708,26 @@ package gl
 // static void  glowCopyImageSubData(GPCOPYIMAGESUBDATA fnptr, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
 //   (*fnptr)(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyMultiTexImage1DEXT(GPCOPYMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyMultiTexImage2DEXT(GPCOPYMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, height, border);
+// }
+// static void  glowCopyMultiTexSubImage1DEXT(GPCOPYMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texunit, target, level, xoffset, x, y, width);
+// }
+// static void  glowCopyMultiTexSubImage2DEXT(GPCOPYMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, x, y, width, height);
+// }
+// static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
+//   (*fnptr)(resultPath, srcPath);
 // }
 // static void  glowCopyTexImage1D(GPCOPYTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
 //   (*fnptr)(target, level, internalformat, x, y, width, border);
@@ -1071,20 +1744,59 @@ package gl
 // static void  glowCopyTexSubImage3D(GPCOPYTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureImage1DEXT(GPCOPYTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyTextureImage2DEXT(GPCOPYTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, height, border);
+// }
 // static void  glowCopyTextureSubImage1D(GPCOPYTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
 //   (*fnptr)(texture, level, xoffset, x, y, width);
+// }
+// static void  glowCopyTextureSubImage1DEXT(GPCOPYTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texture, target, level, xoffset, x, y, width);
 // }
 // static void  glowCopyTextureSubImage2D(GPCOPYTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureSubImage2DEXT(GPCOPYTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, x, y, width, height);
+// }
 // static void  glowCopyTextureSubImage3D(GPCOPYTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyTextureSubImage3DEXT(GPCOPYTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCoverFillPathInstancedNV(GPCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverFillPathNV(GPCOVERFILLPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverStrokePathInstancedNV(GPCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
 // }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
+//   (*fnptr)(queryId, queryHandle);
 // }
 // static GLuint  glowCreateProgram(GPCREATEPROGRAM fnptr) {
 //   return (*fnptr)();
@@ -1104,8 +1816,17 @@ package gl
 // static GLuint  glowCreateShader(GPCREATESHADER fnptr, GLenum  type) {
 //   return (*fnptr)(type);
 // }
+// static GLuint  glowCreateShaderProgramEXT(GPCREATESHADERPROGRAMEXT fnptr, GLenum  type, const GLchar * string) {
+//   return (*fnptr)(type, string);
+// }
 // static GLuint  glowCreateShaderProgramv(GPCREATESHADERPROGRAMV fnptr, GLenum  type, GLsizei  count, const GLchar *const* strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
+//   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -1152,16 +1873,31 @@ package gl
 // static void  glowDeleteBuffers(GPDELETEBUFFERS fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFramebuffers(GPDELETEFRAMEBUFFERS fnptr, GLsizei  n, const GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
 // }
+// static void  glowDeletePathsNV(GPDELETEPATHSNV fnptr, GLuint  path, GLsizei  range) {
+//   (*fnptr)(path, range);
+// }
+// static void  glowDeletePerfMonitorsAMD(GPDELETEPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
+// static void  glowDeletePerfQueryINTEL(GPDELETEPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowDeleteProgram(GPDELETEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowDeleteProgramPipelines(GPDELETEPROGRAMPIPELINES fnptr, GLsizei  n, const GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowDeleteProgramPipelinesEXT(GPDELETEPROGRAMPIPELINESEXT fnptr, GLsizei  n, const GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowDeleteQueries(GPDELETEQUERIES fnptr, GLsizei  n, const GLuint * ids) {
@@ -1175,6 +1911,9 @@ package gl
 // }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -1212,8 +1951,23 @@ package gl
 // static void  glowDisable(GPDISABLE fnptr, GLenum  cap) {
 //   (*fnptr)(cap);
 // }
+// static void  glowDisableClientStateIndexedEXT(GPDISABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableClientStateiEXT(GPDISABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableIndexedEXT(GPDISABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowDisableVertexArrayAttrib(GPDISABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayAttribEXT(GPDISABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayEXT(GPDISABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowDisableVertexAttribArray(GPDISABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1239,14 +1993,32 @@ package gl
 // static void  glowDrawArraysInstanced(GPDRAWARRAYSINSTANCED fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount) {
 //   (*fnptr)(mode, first, count, instancecount);
 // }
+// static void  glowDrawArraysInstancedARB(GPDRAWARRAYSINSTANCEDARB fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, first, count, primcount);
+// }
 // static void  glowDrawArraysInstancedBaseInstance(GPDRAWARRAYSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, first, count, instancecount, baseinstance);
+// }
+// static void  glowDrawArraysInstancedEXT(GPDRAWARRAYSINSTANCEDEXT fnptr, GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, start, count, primcount);
 // }
 // static void  glowDrawBuffer(GPDRAWBUFFER fnptr, GLenum  buf) {
 //   (*fnptr)(buf);
 // }
 // static void  glowDrawBuffers(GPDRAWBUFFERS fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
+// }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
 // }
 // static void  glowDrawElements(GPDRAWELEMENTS fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, count, type, indices);
@@ -1260,6 +2032,9 @@ package gl
 // static void  glowDrawElementsInstanced(GPDRAWELEMENTSINSTANCED fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount) {
 //   (*fnptr)(mode, count, type, indices, instancecount);
 // }
+// static void  glowDrawElementsInstancedARB(GPDRAWELEMENTSINSTANCEDARB fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
+// }
 // static void  glowDrawElementsInstancedBaseInstance(GPDRAWELEMENTSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, baseinstance);
 // }
@@ -1268,6 +2043,9 @@ package gl
 // }
 // static void  glowDrawElementsInstancedBaseVertexBaseInstance(GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, basevertex, baseinstance);
+// }
+// static void  glowDrawElementsInstancedEXT(GPDRAWELEMENTSINSTANCEDEXT fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
 // }
 // static void  glowDrawRangeElements(GPDRAWRANGEELEMENTS fnptr, GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, start, end, count, type, indices);
@@ -1287,11 +2065,32 @@ package gl
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
 // }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
+// }
+// static void  glowEdgeFlagFormatNV(GPEDGEFLAGFORMATNV fnptr, GLsizei  stride) {
+//   (*fnptr)(stride);
+// }
 // static void  glowEnable(GPENABLE fnptr, GLenum  cap) {
 //   (*fnptr)(cap);
 // }
+// static void  glowEnableClientStateIndexedEXT(GPENABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableClientStateiEXT(GPENABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableIndexedEXT(GPENABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowEnableVertexArrayAttrib(GPENABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayAttribEXT(GPENABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayEXT(GPENABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowEnableVertexAttribArray(GPENABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1302,6 +2101,15 @@ package gl
 // static void  glowEndConditionalRender(GPENDCONDITIONALRENDER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowEndConditionalRenderNV(GPENDCONDITIONALRENDERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowEndPerfMonitorAMD(GPENDPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowEndPerfQueryINTEL(GPENDPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowEndQuery(GPENDQUERY fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
@@ -1309,6 +2117,9 @@ package gl
 //   (*fnptr)(target, index);
 // }
 // static void  glowEndTransformFeedback(GPENDTRANSFORMFEEDBACK fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
 //   (*fnptr)();
 // }
 // static GLsync  glowFenceSync(GPFENCESYNC fnptr, GLenum  condition, GLbitfield  flags) {
@@ -1323,14 +2134,41 @@ package gl
 // static void  glowFlushMappedBufferRange(GPFLUSHMAPPEDBUFFERRANGE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(target, offset, length);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
+//   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFogCoordFormatNV(GPFOGCOORDFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
+// static void  glowFramebufferDrawBufferEXT(GPFRAMEBUFFERDRAWBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
+// static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
+//   (*fnptr)(framebuffer, n, bufs);
+// }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
+// static void  glowFramebufferReadBufferEXT(GPFRAMEBUFFERREADBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
 // static void  glowFramebufferRenderbuffer(GPFRAMEBUFFERRENDERBUFFER fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -1344,8 +2182,20 @@ package gl
 // static void  glowFramebufferTexture3D(GPFRAMEBUFFERTEXTURE3D fnptr, GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
 //   (*fnptr)(target, attachment, textarget, texture, level, zoffset);
 // }
+// static void  glowFramebufferTextureARB(GPFRAMEBUFFERTEXTUREARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(target, attachment, texture, level);
+// }
+// static void  glowFramebufferTextureFaceARB(GPFRAMEBUFFERTEXTUREFACEARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(target, attachment, texture, level, face);
+// }
 // static void  glowFramebufferTextureLayer(GPFRAMEBUFFERTEXTURELAYER fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureLayerARB(GPFRAMEBUFFERTEXTURELAYERARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFrontFace(GPFRONTFACE fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -1356,7 +2206,16 @@ package gl
 // static void  glowGenFramebuffers(GPGENFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
+// static GLuint  glowGenPathsNV(GPGENPATHSNV fnptr, GLsizei  range) {
+//   return (*fnptr)(range);
+// }
+// static void  glowGenPerfMonitorsAMD(GPGENPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
 // static void  glowGenProgramPipelines(GPGENPROGRAMPIPELINES fnptr, GLsizei  n, GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowGenProgramPipelinesEXT(GPGENPROGRAMPIPELINESEXT fnptr, GLsizei  n, GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowGenQueries(GPGENQUERIES fnptr, GLsizei  n, GLuint * ids) {
@@ -1380,8 +2239,14 @@ package gl
 // static void  glowGenerateMipmap(GPGENERATEMIPMAP fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
+// static void  glowGenerateMultiTexMipmapEXT(GPGENERATEMULTITEXMIPMAPEXT fnptr, GLenum  texunit, GLenum  target) {
+//   (*fnptr)(texunit, target);
+// }
 // static void  glowGenerateTextureMipmap(GPGENERATETEXTUREMIPMAP fnptr, GLuint  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowGenerateTextureMipmapEXT(GPGENERATETEXTUREMIPMAPEXT fnptr, GLuint  texture, GLenum  target) {
+//   (*fnptr)(texture, target);
 // }
 // static void  glowGetActiveAtomicCounterBufferiv(GPGETACTIVEATOMICCOUNTERBUFFERIV fnptr, GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, bufferIndex, pname, params);
@@ -1419,6 +2284,9 @@ package gl
 // static GLint  glowGetAttribLocation(GPGETATTRIBLOCATION fnptr, GLuint  program, const GLchar * name) {
 //   return (*fnptr)(program, name);
 // }
+// static void  glowGetBooleanIndexedvEXT(GPGETBOOLEANINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLboolean * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetBooleani_v(GPGETBOOLEANI_V fnptr, GLenum  target, GLuint  index, GLboolean * data) {
 //   (*fnptr)(target, index, data);
 // }
@@ -1431,11 +2299,20 @@ package gl
 // static void  glowGetBufferParameteriv(GPGETBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetBufferParameterui64vNV(GPGETBUFFERPARAMETERUI64VNV fnptr, GLenum  target, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(target, pname, params);
+// }
 // static void  glowGetBufferPointerv(GPGETBUFFERPOINTERV fnptr, GLenum  target, GLenum  pname, void ** params) {
 //   (*fnptr)(target, pname, params);
 // }
 // static void  glowGetBufferSubData(GPGETBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
+// static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texunit, target, lod, img);
 // }
 // static void  glowGetCompressedTexImage(GPGETCOMPRESSEDTEXIMAGE fnptr, GLenum  target, GLint  level, void * img) {
 //   (*fnptr)(target, level, img);
@@ -1443,8 +2320,14 @@ package gl
 // static void  glowGetCompressedTextureImage(GPGETCOMPRESSEDTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, bufSize, pixels);
 // }
+// static void  glowGetCompressedTextureImageEXT(GPGETCOMPRESSEDTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texture, target, lod, img);
+// }
 // static void  glowGetCompressedTextureSubImage(GPGETCOMPRESSEDTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -1455,8 +2338,14 @@ package gl
 // static GLuint  glowGetDebugMessageLogKHR(GPGETDEBUGMESSAGELOGKHR fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
 // }
+// static void  glowGetDoubleIndexedvEXT(GPGETDOUBLEINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLdouble * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetDoublei_v(GPGETDOUBLEI_V fnptr, GLenum  target, GLuint  index, GLdouble * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetDoublei_vEXT(GPGETDOUBLEI_VEXT fnptr, GLenum  pname, GLuint  index, GLdouble * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetDoublev(GPGETDOUBLEV fnptr, GLenum  pname, GLdouble * data) {
 //   (*fnptr)(pname, data);
@@ -1464,8 +2353,17 @@ package gl
 // static GLenum  glowGetError(GPGETERROR fnptr) {
 //   return (*fnptr)();
 // }
+// static void  glowGetFirstPerfQueryIdINTEL(GPGETFIRSTPERFQUERYIDINTEL fnptr, GLuint * queryId) {
+//   (*fnptr)(queryId);
+// }
+// static void  glowGetFloatIndexedvEXT(GPGETFLOATINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLfloat * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetFloati_v(GPGETFLOATI_V fnptr, GLenum  target, GLuint  index, GLfloat * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetFloati_vEXT(GPGETFLOATI_VEXT fnptr, GLenum  pname, GLuint  index, GLfloat * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetFloatv(GPGETFLOATV fnptr, GLenum  pname, GLfloat * data) {
 //   (*fnptr)(pname, data);
@@ -1482,6 +2380,9 @@ package gl
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetFramebufferParameterivEXT(GPGETFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
 // static GLenum  glowGetGraphicsResetStatus(GPGETGRAPHICSRESETSTATUS fnptr) {
 //   return (*fnptr)();
 // }
@@ -1494,23 +2395,74 @@ package gl
 // static GLuint64  glowGetImageHandleARB(GPGETIMAGEHANDLEARB fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
 //   return (*fnptr)(texture, level, layered, layer, format);
 // }
+// static GLuint64  glowGetImageHandleNV(GPGETIMAGEHANDLENV fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
+//   return (*fnptr)(texture, level, layered, layer, format);
+// }
 // static void  glowGetInteger64i_v(GPGETINTEGER64I_V fnptr, GLenum  target, GLuint  index, GLint64 * data) {
 //   (*fnptr)(target, index, data);
 // }
 // static void  glowGetInteger64v(GPGETINTEGER64V fnptr, GLenum  pname, GLint64 * data) {
 //   (*fnptr)(pname, data);
 // }
+// static void  glowGetIntegerIndexedvEXT(GPGETINTEGERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLint * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetIntegeri_v(GPGETINTEGERI_V fnptr, GLenum  target, GLuint  index, GLint * data) {
 //   (*fnptr)(target, index, data);
 // }
+// static void  glowGetIntegerui64i_vNV(GPGETINTEGERUI64I_VNV fnptr, GLenum  value, GLuint  index, GLuint64EXT * result) {
+//   (*fnptr)(value, index, result);
+// }
+// static void  glowGetIntegerui64vNV(GPGETINTEGERUI64VNV fnptr, GLenum  value, GLuint64EXT * result) {
+//   (*fnptr)(value, result);
+// }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
 // }
 // static void  glowGetInternalformativ(GPGETINTERNALFORMATIV fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
+// }
+// static void  glowGetMultiTexEnvfvEXT(GPGETMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexEnvivEXT(GPGETMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexGendvEXT(GPGETMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenfvEXT(GPGETMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenivEXT(GPGETMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexImageEXT(GPGETMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texunit, target, level, format, type, pixels);
+// }
+// static void  glowGetMultiTexLevelParameterfvEXT(GPGETMULTITEXLEVELPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexLevelParameterivEXT(GPGETMULTITEXLEVELPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexParameterIivEXT(GPGETMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterIuivEXT(GPGETMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterfvEXT(GPGETMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterivEXT(GPGETMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
 // }
 // static void  glowGetMultisamplefv(GPGETMULTISAMPLEFV fnptr, GLenum  pname, GLuint  index, GLfloat * val) {
 //   (*fnptr)(pname, index, val);
@@ -1521,19 +2473,58 @@ package gl
 // static void  glowGetNamedBufferParameteriv(GPGETNAMEDBUFFERPARAMETERIV fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(buffer, pname, params);
 // }
+// static void  glowGetNamedBufferParameterivEXT(GPGETNAMEDBUFFERPARAMETERIVEXT fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferParameterui64vNV(GPGETNAMEDBUFFERPARAMETERUI64VNV fnptr, GLuint  buffer, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
 // static void  glowGetNamedBufferPointerv(GPGETNAMEDBUFFERPOINTERV fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedFramebufferAttachmentParameteriv(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
 // }
+// static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, attachment, pname, params);
+// }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowGetNamedFramebufferParameterivEXT(GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIuivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterdvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterfvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramStringEXT(GPGETNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, void * string) {
+//   (*fnptr)(program, target, pname, string);
+// }
+// static void  glowGetNamedProgramivEXT(GPGETNAMEDPROGRAMIVEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(program, target, pname, params);
+// }
 // static void  glowGetNamedRenderbufferParameteriv(GPGETNAMEDRENDERBUFFERPARAMETERIV fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(renderbuffer, pname, params);
+// }
+// static void  glowGetNamedRenderbufferParameterivEXT(GPGETNAMEDRENDERBUFFERPARAMETERIVEXT fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(renderbuffer, pname, params);
 // }
 // static void  glowGetNamedStringARB(GPGETNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string) {
@@ -1542,8 +2533,14 @@ package gl
 // static void  glowGetNamedStringivARB(GPGETNAMEDSTRINGIVARB fnptr, GLint  namelen, const GLchar * name, GLenum  pname, GLint * params) {
 //   (*fnptr)(namelen, name, pname, params);
 // }
+// static void  glowGetNextPerfQueryIdINTEL(GPGETNEXTPERFQUERYIDINTEL fnptr, GLuint  queryId, GLuint * nextQueryId) {
+//   (*fnptr)(queryId, nextQueryId);
+// }
 // static void  glowGetObjectLabel(GPGETOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
+// }
+// static void  glowGetObjectLabelEXT(GPGETOBJECTLABELEXT fnptr, GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label) {
+//   (*fnptr)(type, object, bufSize, length, label);
 // }
 // static void  glowGetObjectLabelKHR(GPGETOBJECTLABELKHR fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
@@ -1553,6 +2550,69 @@ package gl
 // }
 // static void  glowGetObjectPtrLabelKHR(GPGETOBJECTPTRLABELKHR fnptr, const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(ptr, bufSize, length, label);
+// }
+// static void  glowGetPathCommandsNV(GPGETPATHCOMMANDSNV fnptr, GLuint  path, GLubyte * commands) {
+//   (*fnptr)(path, commands);
+// }
+// static void  glowGetPathCoordsNV(GPGETPATHCOORDSNV fnptr, GLuint  path, GLfloat * coords) {
+//   (*fnptr)(path, coords);
+// }
+// static void  glowGetPathDashArrayNV(GPGETPATHDASHARRAYNV fnptr, GLuint  path, GLfloat * dashArray) {
+//   (*fnptr)(path, dashArray);
+// }
+// static GLfloat  glowGetPathLengthNV(GPGETPATHLENGTHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments) {
+//   return (*fnptr)(path, startSegment, numSegments);
+// }
+// static void  glowGetPathMetricRangeNV(GPGETPATHMETRICRANGENV fnptr, GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, firstPathName, numPaths, stride, metrics);
+// }
+// static void  glowGetPathMetricsNV(GPGETPATHMETRICSNV fnptr, GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, numPaths, pathNameType, paths, pathBase, stride, metrics);
+// }
+// static void  glowGetPathParameterfvNV(GPGETPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathParameterivNV(GPGETPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathSpacingNV(GPGETPATHSPACINGNV fnptr, GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing) {
+//   (*fnptr)(pathListMode, numPaths, pathNameType, paths, pathBase, advanceScale, kerningScale, transformType, returnedSpacing);
+// }
+// static void  glowGetPerfCounterInfoINTEL(GPGETPERFCOUNTERINFOINTEL fnptr, GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue) {
+//   (*fnptr)(queryId, counterId, counterNameLength, counterName, counterDescLength, counterDesc, counterOffset, counterDataSize, counterTypeEnum, counterDataTypeEnum, rawCounterMaxValue);
+// }
+// static void  glowGetPerfMonitorCounterDataAMD(GPGETPERFMONITORCOUNTERDATAAMD fnptr, GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten) {
+//   (*fnptr)(monitor, pname, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfMonitorCounterInfoAMD(GPGETPERFMONITORCOUNTERINFOAMD fnptr, GLuint  group, GLuint  counter, GLenum  pname, void * data) {
+//   (*fnptr)(group, counter, pname, data);
+// }
+// static void  glowGetPerfMonitorCounterStringAMD(GPGETPERFMONITORCOUNTERSTRINGAMD fnptr, GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString) {
+//   (*fnptr)(group, counter, bufSize, length, counterString);
+// }
+// static void  glowGetPerfMonitorCountersAMD(GPGETPERFMONITORCOUNTERSAMD fnptr, GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters) {
+//   (*fnptr)(group, numCounters, maxActiveCounters, counterSize, counters);
+// }
+// static void  glowGetPerfMonitorGroupStringAMD(GPGETPERFMONITORGROUPSTRINGAMD fnptr, GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString) {
+//   (*fnptr)(group, bufSize, length, groupString);
+// }
+// static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
+//   (*fnptr)(numGroups, groupsSize, groups);
+// }
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
+//   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
+//   (*fnptr)(queryName, queryId);
+// }
+// static void  glowGetPerfQueryInfoINTEL(GPGETPERFQUERYINFOINTEL fnptr, GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask) {
+//   (*fnptr)(queryId, queryNameLength, queryName, dataSize, noCounters, noInstances, capsMask);
+// }
+// static void  glowGetPointerIndexedvEXT(GPGETPOINTERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, void ** data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetPointeri_vEXT(GPGETPOINTERI_VEXT fnptr, GLenum  pname, GLuint  index, void ** params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetPointerv(GPGETPOINTERV fnptr, GLenum  pname, void ** params) {
 //   (*fnptr)(pname, params);
@@ -1572,7 +2632,13 @@ package gl
 // static void  glowGetProgramPipelineInfoLog(GPGETPROGRAMPIPELINEINFOLOG fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
 //   (*fnptr)(pipeline, bufSize, length, infoLog);
 // }
+// static void  glowGetProgramPipelineInfoLogEXT(GPGETPROGRAMPIPELINEINFOLOGEXT fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
+//   (*fnptr)(pipeline, bufSize, length, infoLog);
+// }
 // static void  glowGetProgramPipelineiv(GPGETPROGRAMPIPELINEIV fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
+//   (*fnptr)(pipeline, pname, params);
+// }
+// static void  glowGetProgramPipelineivEXT(GPGETPROGRAMPIPELINEIVEXT fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
 //   (*fnptr)(pipeline, pname, params);
 // }
 // static GLuint  glowGetProgramResourceIndex(GPGETPROGRAMRESOURCEINDEX fnptr, GLuint  program, GLenum  programInterface, const GLchar * name) {
@@ -1587,6 +2653,9 @@ package gl
 // static void  glowGetProgramResourceName(GPGETPROGRAMRESOURCENAME fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name) {
 //   (*fnptr)(program, programInterface, index, bufSize, length, name);
 // }
+// static void  glowGetProgramResourcefvNV(GPGETPROGRAMRESOURCEFVNV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params) {
+//   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
+// }
 // static void  glowGetProgramResourceiv(GPGETPROGRAMRESOURCEIV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params) {
 //   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
 // }
@@ -1595,6 +2664,18 @@ package gl
 // }
 // static void  glowGetProgramiv(GPGETPROGRAMIV fnptr, GLuint  program, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, pname, params);
+// }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
 // }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
@@ -1641,6 +2722,9 @@ package gl
 // static void  glowGetShaderiv(GPGETSHADERIV fnptr, GLuint  shader, GLenum  pname, GLint * params) {
 //   (*fnptr)(shader, pname, params);
 // }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
+// }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
 // }
@@ -1680,28 +2764,55 @@ package gl
 // static GLuint64  glowGetTextureHandleARB(GPGETTEXTUREHANDLEARB fnptr, GLuint  texture) {
 //   return (*fnptr)(texture);
 // }
+// static GLuint64  glowGetTextureHandleNV(GPGETTEXTUREHANDLENV fnptr, GLuint  texture) {
+//   return (*fnptr)(texture);
+// }
 // static void  glowGetTextureImage(GPGETTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, format, type, bufSize, pixels);
+// }
+// static void  glowGetTextureImageEXT(GPGETTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texture, target, level, format, type, pixels);
 // }
 // static void  glowGetTextureLevelParameterfv(GPGETTEXTURELEVELPARAMETERFV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, level, pname, params);
 // }
+// static void  glowGetTextureLevelParameterfvEXT(GPGETTEXTURELEVELPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, level, pname, params);
+// }
 // static void  glowGetTextureLevelParameteriv(GPGETTEXTURELEVELPARAMETERIV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, level, pname, params);
+// }
+// static void  glowGetTextureLevelParameterivEXT(GPGETTEXTURELEVELPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, level, pname, params);
 // }
 // static void  glowGetTextureParameterIiv(GPGETTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterIivEXT(GPGETTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameterIuiv(GPGETTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowGetTextureParameterIuivEXT(GPGETTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowGetTextureParameterfv(GPGETTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterfvEXT(GPGETTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameteriv(GPGETTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterivEXT(GPGETTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static GLuint64  glowGetTextureSamplerHandleARB(GPGETTEXTURESAMPLERHANDLEARB fnptr, GLuint  texture, GLuint  sampler) {
+//   return (*fnptr)(texture, sampler);
+// }
+// static GLuint64  glowGetTextureSamplerHandleNV(GPGETTEXTURESAMPLERHANDLENV fnptr, GLuint  texture, GLuint  sampler) {
 //   return (*fnptr)(texture, sampler);
 // }
 // static void  glowGetTextureSubImage(GPGETTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
@@ -1737,7 +2848,19 @@ package gl
 // static void  glowGetUniformfv(GPGETUNIFORMFV fnptr, GLuint  program, GLint  location, GLfloat * params) {
 //   (*fnptr)(program, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformiv(GPGETUNIFORMIV fnptr, GLuint  program, GLint  location, GLint * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
 // static void  glowGetUniformuiv(GPGETUNIFORMUIV fnptr, GLuint  program, GLint  location, GLuint * params) {
@@ -1748,6 +2871,18 @@ package gl
 // }
 // static void  glowGetVertexArrayIndexediv(GPGETVERTEXARRAYINDEXEDIV fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegeri_vEXT(GPGETVERTEXARRAYINTEGERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegervEXT(GPGETVERTEXARRAYINTEGERVEXT fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, pname, param);
+// }
+// static void  glowGetVertexArrayPointeri_vEXT(GPGETVERTEXARRAYPOINTERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayPointervEXT(GPGETVERTEXARRAYPOINTERVEXT fnptr, GLuint  vaobj, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, pname, param);
 // }
 // static void  glowGetVertexArrayiv(GPGETVERTEXARRAYIV fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, pname, param);
@@ -1761,7 +2896,13 @@ package gl
 // static void  glowGetVertexAttribLdv(GPGETVERTEXATTRIBLDV fnptr, GLuint  index, GLenum  pname, GLdouble * params) {
 //   (*fnptr)(index, pname, params);
 // }
+// static void  glowGetVertexAttribLi64vNV(GPGETVERTEXATTRIBLI64VNV fnptr, GLuint  index, GLenum  pname, GLint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
 // static void  glowGetVertexAttribLui64vARB(GPGETVERTEXATTRIBLUI64VARB fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
+// static void  glowGetVertexAttribLui64vNV(GPGETVERTEXATTRIBLUI64VNV fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
 //   (*fnptr)(index, pname, params);
 // }
 // static void  glowGetVertexAttribPointerv(GPGETVERTEXATTRIBPOINTERV fnptr, GLuint  index, GLenum  pname, void ** pointer) {
@@ -1775,6 +2916,9 @@ package gl
 // }
 // static void  glowGetVertexAttribiv(GPGETVERTEXATTRIBIV fnptr, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(index, pname, params);
+// }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
 // }
 // static void  glowGetnCompressedTexImageARB(GPGETNCOMPRESSEDTEXIMAGEARB fnptr, GLenum  target, GLint  lod, GLsizei  bufSize, void * img) {
 //   (*fnptr)(target, lod, bufSize, img);
@@ -1794,6 +2938,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -1801,6 +2948,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -1814,6 +2964,15 @@ package gl
 // }
 // static void  glowHint(GPHINT fnptr, GLenum  target, GLenum  mode) {
 //   (*fnptr)(target, mode);
+// }
+// static void  glowIndexFormatNV(GPINDEXFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
+// static void  glowInsertEventMarkerEXT(GPINSERTEVENTMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
+// static void  glowInterpolatePathsNV(GPINTERPOLATEPATHSNV fnptr, GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight) {
+//   (*fnptr)(resultPath, pathA, pathB, weight);
 // }
 // static void  glowInvalidateBufferData(GPINVALIDATEBUFFERDATA fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -1842,8 +3001,17 @@ package gl
 // static GLboolean  glowIsBuffer(GPISBUFFER fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
+// static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
+//   return (*fnptr)(target);
+// }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
+// }
+// static GLboolean  glowIsEnabledIndexedEXT(GPISENABLEDINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   return (*fnptr)(target, index);
 // }
 // static GLboolean  glowIsEnabledi(GPISENABLEDI fnptr, GLenum  target, GLuint  index) {
 //   return (*fnptr)(target, index);
@@ -1854,13 +3022,31 @@ package gl
 // static GLboolean  glowIsImageHandleResidentARB(GPISIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsImageHandleResidentNV(GPISIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
+// static GLboolean  glowIsNamedBufferResidentNV(GPISNAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
 // static GLboolean  glowIsNamedStringARB(GPISNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   return (*fnptr)(namelen, name);
+// }
+// static GLboolean  glowIsPathNV(GPISPATHNV fnptr, GLuint  path) {
+//   return (*fnptr)(path);
+// }
+// static GLboolean  glowIsPointInFillPathNV(GPISPOINTINFILLPATHNV fnptr, GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, mask, x, y);
+// }
+// static GLboolean  glowIsPointInStrokePathNV(GPISPOINTINSTROKEPATHNV fnptr, GLuint  path, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, x, y);
 // }
 // static GLboolean  glowIsProgram(GPISPROGRAM fnptr, GLuint  program) {
 //   return (*fnptr)(program);
 // }
 // static GLboolean  glowIsProgramPipeline(GPISPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   return (*fnptr)(pipeline);
+// }
+// static GLboolean  glowIsProgramPipelineEXT(GPISPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   return (*fnptr)(pipeline);
 // }
 // static GLboolean  glowIsQuery(GPISQUERY fnptr, GLuint  id) {
@@ -1875,6 +3061,9 @@ package gl
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
 // }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
+// }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
 // }
@@ -1884,11 +3073,17 @@ package gl
 // static GLboolean  glowIsTextureHandleResidentARB(GPISTEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsTextureHandleResidentNV(GPISTEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
 // static GLboolean  glowIsTransformFeedback(GPISTRANSFORMFEEDBACK fnptr, GLuint  id) {
 //   return (*fnptr)(id);
 // }
 // static GLboolean  glowIsVertexArray(GPISVERTEXARRAY fnptr, GLuint  array) {
 //   return (*fnptr)(array);
+// }
+// static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
+//   (*fnptr)(type, object, length, label);
 // }
 // static void  glowLineWidth(GPLINEWIDTH fnptr, GLfloat  width) {
 //   (*fnptr)(width);
@@ -1896,19 +3091,46 @@ package gl
 // static void  glowLinkProgram(GPLINKPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
+// }
 // static void  glowLogicOp(GPLOGICOP fnptr, GLenum  opcode) {
 //   (*fnptr)(opcode);
 // }
+// static void  glowMakeBufferNonResidentNV(GPMAKEBUFFERNONRESIDENTNV fnptr, GLenum  target) {
+//   (*fnptr)(target);
+// }
+// static void  glowMakeBufferResidentNV(GPMAKEBUFFERRESIDENTNV fnptr, GLenum  target, GLenum  access) {
+//   (*fnptr)(target, access);
+// }
 // static void  glowMakeImageHandleNonResidentARB(GPMAKEIMAGEHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeImageHandleNonResidentNV(GPMAKEIMAGEHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void  glowMakeImageHandleResidentARB(GPMAKEIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle, GLenum  access) {
 //   (*fnptr)(handle, access);
 // }
+// static void  glowMakeImageHandleResidentNV(GPMAKEIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle, GLenum  access) {
+//   (*fnptr)(handle, access);
+// }
+// static void  glowMakeNamedBufferNonResidentNV(GPMAKENAMEDBUFFERNONRESIDENTNV fnptr, GLuint  buffer) {
+//   (*fnptr)(buffer);
+// }
+// static void  glowMakeNamedBufferResidentNV(GPMAKENAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer, GLenum  access) {
+//   (*fnptr)(buffer, access);
+// }
 // static void  glowMakeTextureHandleNonResidentARB(GPMAKETEXTUREHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
+// static void  glowMakeTextureHandleNonResidentNV(GPMAKETEXTUREHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
 // static void  glowMakeTextureHandleResidentARB(GPMAKETEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeTextureHandleResidentNV(GPMAKETEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void * glowMapBuffer(GPMAPBUFFER fnptr, GLenum  target, GLenum  access) {
@@ -1920,8 +3142,95 @@ package gl
 // static void * glowMapNamedBuffer(GPMAPNAMEDBUFFER fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
+//   return (*fnptr)(buffer, access);
+// }
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
+//   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void  glowMatrixFrustumEXT(GPMATRIXFRUSTUMEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixLoad3x2fNV(GPMATRIXLOAD3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoad3x3fNV(GPMATRIXLOAD3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadIdentityEXT(GPMATRIXLOADIDENTITYEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixLoadTranspose3x3fNV(GPMATRIXLOADTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadTransposedEXT(GPMATRIXLOADTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadTransposefEXT(GPMATRIXLOADTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoaddEXT(GPMATRIXLOADDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadfEXT(GPMATRIXLOADFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMult3x2fNV(GPMATRIXMULT3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMult3x3fNV(GPMATRIXMULT3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTranspose3x3fNV(GPMATRIXMULTTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTransposedEXT(GPMATRIXMULTTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultTransposefEXT(GPMATRIXMULTTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultdEXT(GPMATRIXMULTDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultfEXT(GPMATRIXMULTFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixOrthoEXT(GPMATRIXORTHOEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixPopEXT(GPMATRIXPOPEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixPushEXT(GPMATRIXPUSHEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixRotatedEXT(GPMATRIXROTATEDEXT fnptr, GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixRotatefEXT(GPMATRIXROTATEFEXT fnptr, GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixScaledEXT(GPMATRIXSCALEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixScalefEXT(GPMATRIXSCALEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatedEXT(GPMATRIXTRANSLATEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
 // }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
@@ -1938,7 +3247,13 @@ package gl
 // static void  glowMultiDrawArraysIndirect(GPMULTIDRAWARRAYSINDIRECT fnptr, GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectBindlessCountNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElements(GPMULTIDRAWELEMENTS fnptr, GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount) {
@@ -1950,23 +3265,116 @@ package gl
 // static void  glowMultiDrawElementsIndirect(GPMULTIDRAWELEMENTSINDIRECT fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectBindlessCountNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMultiTexBufferEXT(GPMULTITEXBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texunit, target, internalformat, buffer);
+// }
+// static void  glowMultiTexCoordPointerEXT(GPMULTITEXCOORDPOINTEREXT fnptr, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
+//   (*fnptr)(texunit, size, type, stride, pointer);
+// }
+// static void  glowMultiTexEnvfEXT(GPMULTITEXENVFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvfvEXT(GPMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexEnviEXT(GPMULTITEXENVIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvivEXT(GPMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexGendEXT(GPMULTITEXGENDEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGendvEXT(GPMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGenfEXT(GPMULTITEXGENFEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenfvEXT(GPMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGeniEXT(GPMULTITEXGENIEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenivEXT(GPMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexImage1DEXT(GPMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage2DEXT(GPMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage3DEXT(GPMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowMultiTexParameterIivEXT(GPMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterIuivEXT(GPMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterfEXT(GPMULTITEXPARAMETERFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterfvEXT(GPMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameteriEXT(GPMULTITEXPARAMETERIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterivEXT(GPMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexRenderbufferEXT(GPMULTITEXRENDERBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texunit, target, renderbuffer);
+// }
+// static void  glowMultiTexSubImage1DEXT(GPMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage2DEXT(GPMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
+//   (*fnptr)(buffer, size, data, usage);
+// }
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
+//   (*fnptr)(buffer, size, data, flags);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedCopyBufferSubDataEXT(GPNAMEDCOPYBUFFERSUBDATAEXT fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowNamedFramebufferDrawBuffer(GPNAMEDFRAMEBUFFERDRAWBUFFER fnptr, GLuint  framebuffer, GLenum  buf) {
 //   (*fnptr)(framebuffer, buf);
@@ -1977,26 +3385,104 @@ package gl
 // static void  glowNamedFramebufferParameteri(GPNAMEDFRAMEBUFFERPARAMETERI fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowNamedFramebufferParameteriEXT(GPNAMEDFRAMEBUFFERPARAMETERIEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
+//   (*fnptr)(framebuffer, pname, param);
+// }
 // static void  glowNamedFramebufferReadBuffer(GPNAMEDFRAMEBUFFERREADBUFFER fnptr, GLuint  framebuffer, GLenum  src) {
 //   (*fnptr)(framebuffer, src);
 // }
 // static void  glowNamedFramebufferRenderbuffer(GPNAMEDFRAMEBUFFERRENDERBUFFER fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
 // }
+// static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
+//   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTexture1DEXT(GPNAMEDFRAMEBUFFERTEXTURE1DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture2DEXT(GPNAMEDFRAMEBUFFERTEXTURE2DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture3DEXT(GPNAMEDFRAMEBUFFERTEXTURE3DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level, zoffset);
+// }
+// static void  glowNamedFramebufferTextureEXT(GPNAMEDFRAMEBUFFERTEXTUREEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTextureFaceEXT(GPNAMEDFRAMEBUFFERTEXTUREFACEEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(framebuffer, attachment, texture, level, face);
 // }
 // static void  glowNamedFramebufferTextureLayer(GPNAMEDFRAMEBUFFERTEXTURELAYER fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(framebuffer, attachment, texture, level, layer);
 // }
+// static void  glowNamedFramebufferTextureLayerEXT(GPNAMEDFRAMEBUFFERTEXTURELAYEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(framebuffer, attachment, texture, level, layer);
+// }
+// static void  glowNamedProgramLocalParameter4dEXT(GPNAMEDPROGRAMLOCALPARAMETER4DEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4dvEXT(GPNAMEDPROGRAMLOCALPARAMETER4DVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameter4fEXT(GPNAMEDPROGRAMLOCALPARAMETER4FEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4fvEXT(GPNAMEDPROGRAMLOCALPARAMETER4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4iEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4uiEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameters4fvEXT(GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramStringEXT(GPNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string) {
+//   (*fnptr)(program, target, format, len, string);
+// }
 // static void  glowNamedRenderbufferStorage(GPNAMEDRENDERBUFFERSTORAGE fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageEXT(GPNAMEDRENDERBUFFERSTORAGEEXT fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, internalformat, width, height);
 // }
 // static void  glowNamedRenderbufferStorageMultisample(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, samples, internalformat, width, height);
 // }
+// static void  glowNamedRenderbufferStorageMultisampleCoverageEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT fnptr, GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageMultisampleEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, samples, internalformat, width, height);
+// }
 // static void  glowNamedStringARB(GPNAMEDSTRINGARB fnptr, GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string) {
 //   (*fnptr)(type, namelen, name, stringlen, string);
+// }
+// static void  glowNormalFormatNV(GPNORMALFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
 // }
 // static void  glowObjectLabel(GPOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(identifier, name, length, label);
@@ -2016,6 +3502,60 @@ package gl
 // static void  glowPatchParameteri(GPPATCHPARAMETERI fnptr, GLenum  pname, GLint  value) {
 //   (*fnptr)(pname, value);
 // }
+// static void  glowPathCommandsNV(GPPATHCOMMANDSNV fnptr, GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathCoordsNV(GPPATHCOORDSNV fnptr, GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCoords, coordType, coords);
+// }
+// static void  glowPathCoverDepthFuncNV(GPPATHCOVERDEPTHFUNCNV fnptr, GLenum  func) {
+//   (*fnptr)(func);
+// }
+// static void  glowPathDashArrayNV(GPPATHDASHARRAYNV fnptr, GLuint  path, GLsizei  dashCount, const GLfloat * dashArray) {
+//   (*fnptr)(path, dashCount, dashArray);
+// }
+// static GLenum  glowPathGlyphIndexArrayNV(GPPATHGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathGlyphIndexRangeNV(GPPATHGLYPHINDEXRANGENV fnptr, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount) {
+//   return (*fnptr)(fontTarget, fontName, fontStyle, pathParameterTemplate, emScale, baseAndCount);
+// }
+// static void  glowPathGlyphRangeNV(GPPATHGLYPHRANGENV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyph, numGlyphs, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathGlyphsNV(GPPATHGLYPHSNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, numGlyphs, type, charcodes, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathMemoryGlyphIndexArrayNV(GPPATHMEMORYGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontSize, fontData, faceIndex, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathParameterfNV(GPPATHPARAMETERFNV fnptr, GLuint  path, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterfvNV(GPPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, const GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameteriNV(GPPATHPARAMETERINV fnptr, GLuint  path, GLenum  pname, GLint  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterivNV(GPPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, const GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathStencilDepthOffsetNV(GPPATHSTENCILDEPTHOFFSETNV fnptr, GLfloat  factor, GLfloat  units) {
+//   (*fnptr)(factor, units);
+// }
+// static void  glowPathStencilFuncNV(GPPATHSTENCILFUNCNV fnptr, GLenum  func, GLint  ref, GLuint  mask) {
+//   (*fnptr)(func, ref, mask);
+// }
+// static void  glowPathStringNV(GPPATHSTRINGNV fnptr, GLuint  path, GLenum  format, GLsizei  length, const void * pathString) {
+//   (*fnptr)(path, format, length, pathString);
+// }
+// static void  glowPathSubCommandsNV(GPPATHSUBCOMMANDSNV fnptr, GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, commandStart, commandsToDelete, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathSubCoordsNV(GPPATHSUBCOORDSNV fnptr, GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, coordStart, numCoords, coordType, coords);
+// }
 // static void  glowPauseTransformFeedback(GPPAUSETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -2024,6 +3564,9 @@ package gl
 // }
 // static void  glowPixelStorei(GPPIXELSTOREI fnptr, GLenum  pname, GLint  param) {
 //   (*fnptr)(pname, param);
+// }
+// static GLboolean  glowPointAlongPathNV(GPPOINTALONGPATHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY) {
+//   return (*fnptr)(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
 // }
 // static void  glowPointParameterf(GPPOINTPARAMETERF fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
@@ -2046,11 +3589,23 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPopDebugGroup(GPPOPDEBUGGROUP fnptr) {
 //   (*fnptr)();
 // }
 // static void  glowPopDebugGroupKHR(GPPOPDEBUGGROUPKHR fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowPopGroupMarkerEXT(GPPOPGROUPMARKEREXT fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -2061,164 +3616,434 @@ package gl
 // static void  glowProgramParameteri(GPPROGRAMPARAMETERI fnptr, GLuint  program, GLenum  pname, GLint  value) {
 //   (*fnptr)(program, pname, value);
 // }
+// static void  glowProgramParameteriARB(GPPROGRAMPARAMETERIARB fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramParameteriEXT(GPPROGRAMPARAMETERIEXT fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramPathFragmentInputGenNV(GPPROGRAMPATHFRAGMENTINPUTGENNV fnptr, GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs) {
+//   (*fnptr)(program, location, genMode, components, coeffs);
+// }
 // static void  glowProgramUniform1d(GPPROGRAMUNIFORM1D fnptr, GLuint  program, GLint  location, GLdouble  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1dEXT(GPPROGRAMUNIFORM1DEXT fnptr, GLuint  program, GLint  location, GLdouble  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1dv(GPPROGRAMUNIFORM1DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1dvEXT(GPPROGRAMUNIFORM1DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1f(GPPROGRAMUNIFORM1F fnptr, GLuint  program, GLint  location, GLfloat  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1fEXT(GPPROGRAMUNIFORM1FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1fv(GPPROGRAMUNIFORM1FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1fvEXT(GPPROGRAMUNIFORM1FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1iEXT(GPPROGRAMUNIFORM1IEXT fnptr, GLuint  program, GLint  location, GLint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1iv(GPPROGRAMUNIFORM1IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ivEXT(GPPROGRAMUNIFORM1IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uiEXT(GPPROGRAMUNIFORM1UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1uiv(GPPROGRAMUNIFORM1UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uivEXT(GPPROGRAMUNIFORM1UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2d(GPPROGRAMUNIFORM2D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2dEXT(GPPROGRAMUNIFORM2DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2dv(GPPROGRAMUNIFORM2DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2dvEXT(GPPROGRAMUNIFORM2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2f(GPPROGRAMUNIFORM2F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2fEXT(GPPROGRAMUNIFORM2FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2fv(GPPROGRAMUNIFORM2FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2fvEXT(GPPROGRAMUNIFORM2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2iEXT(GPPROGRAMUNIFORM2IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2iv(GPPROGRAMUNIFORM2IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ivEXT(GPPROGRAMUNIFORM2IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uiEXT(GPPROGRAMUNIFORM2UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2uiv(GPPROGRAMUNIFORM2UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uivEXT(GPPROGRAMUNIFORM2UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3d(GPPROGRAMUNIFORM3D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3dEXT(GPPROGRAMUNIFORM3DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3dv(GPPROGRAMUNIFORM3DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3dvEXT(GPPROGRAMUNIFORM3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3f(GPPROGRAMUNIFORM3F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3fEXT(GPPROGRAMUNIFORM3FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3fv(GPPROGRAMUNIFORM3FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3fvEXT(GPPROGRAMUNIFORM3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3iEXT(GPPROGRAMUNIFORM3IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3iv(GPPROGRAMUNIFORM3IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ivEXT(GPPROGRAMUNIFORM3IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uiEXT(GPPROGRAMUNIFORM3UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3uiv(GPPROGRAMUNIFORM3UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uivEXT(GPPROGRAMUNIFORM3UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4d(GPPROGRAMUNIFORM4D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4dEXT(GPPROGRAMUNIFORM4DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4dv(GPPROGRAMUNIFORM4DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4dvEXT(GPPROGRAMUNIFORM4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4f(GPPROGRAMUNIFORM4F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4fEXT(GPPROGRAMUNIFORM4FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4fv(GPPROGRAMUNIFORM4FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4fvEXT(GPPROGRAMUNIFORM4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4iEXT(GPPROGRAMUNIFORM4IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4iv(GPPROGRAMUNIFORM4IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ivEXT(GPPROGRAMUNIFORM4IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uiEXT(GPPROGRAMUNIFORM4UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4uiv(GPPROGRAMUNIFORM4UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uivEXT(GPPROGRAMUNIFORM4UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniformHandleui64ARB(GPPROGRAMUNIFORMHANDLEUI64ARB fnptr, GLuint  program, GLint  location, GLuint64  value) {
 //   (*fnptr)(program, location, value);
 // }
+// static void  glowProgramUniformHandleui64NV(GPPROGRAMUNIFORMHANDLEUI64NV fnptr, GLuint  program, GLint  location, GLuint64  value) {
+//   (*fnptr)(program, location, value);
+// }
 // static void  glowProgramUniformHandleui64vARB(GPPROGRAMUNIFORMHANDLEUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
+//   (*fnptr)(program, location, count, values);
+// }
+// static void  glowProgramUniformHandleui64vNV(GPPROGRAMUNIFORMHANDLEUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
 //   (*fnptr)(program, location, count, values);
 // }
 // static void  glowProgramUniformMatrix2dv(GPPROGRAMUNIFORMMATRIX2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2dvEXT(GPPROGRAMUNIFORMMATRIX2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2fv(GPPROGRAMUNIFORMMATRIX2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2fvEXT(GPPROGRAMUNIFORMMATRIX2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x3dv(GPPROGRAMUNIFORMMATRIX2X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x3dvEXT(GPPROGRAMUNIFORMMATRIX2X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x3fv(GPPROGRAMUNIFORMMATRIX2X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x3fvEXT(GPPROGRAMUNIFORMMATRIX2X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x4dv(GPPROGRAMUNIFORMMATRIX2X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x4dvEXT(GPPROGRAMUNIFORMMATRIX2X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x4fv(GPPROGRAMUNIFORMMATRIX2X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x4fvEXT(GPPROGRAMUNIFORMMATRIX2X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3dv(GPPROGRAMUNIFORMMATRIX3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3dvEXT(GPPROGRAMUNIFORMMATRIX3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3fv(GPPROGRAMUNIFORMMATRIX3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3fvEXT(GPPROGRAMUNIFORMMATRIX3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x2dv(GPPROGRAMUNIFORMMATRIX3X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x2dvEXT(GPPROGRAMUNIFORMMATRIX3X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x2fv(GPPROGRAMUNIFORMMATRIX3X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x2fvEXT(GPPROGRAMUNIFORMMATRIX3X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x4dv(GPPROGRAMUNIFORMMATRIX3X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x4dvEXT(GPPROGRAMUNIFORMMATRIX3X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x4fv(GPPROGRAMUNIFORMMATRIX3X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x4fvEXT(GPPROGRAMUNIFORMMATRIX3X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4dv(GPPROGRAMUNIFORMMATRIX4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4dvEXT(GPPROGRAMUNIFORMMATRIX4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4fv(GPPROGRAMUNIFORMMATRIX4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4fvEXT(GPPROGRAMUNIFORMMATRIX4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x2dv(GPPROGRAMUNIFORMMATRIX4X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x2dvEXT(GPPROGRAMUNIFORMMATRIX4X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x2fv(GPPROGRAMUNIFORMMATRIX4X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4x2fvEXT(GPPROGRAMUNIFORMMATRIX4X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x3dv(GPPROGRAMUNIFORMMATRIX4X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3dvEXT(GPPROGRAMUNIFORMMATRIX4X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x3fv(GPPROGRAMUNIFORMMATRIX4X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3fvEXT(GPPROGRAMUNIFORMMATRIX4X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformui64NV(GPPROGRAMUNIFORMUI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(program, location, value);
+// }
+// static void  glowProgramUniformui64vNV(GPPROGRAMUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
 // static void  glowProvokingVertex(GPPROVOKINGVERTEX fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
+// }
+// static void  glowPushClientAttribDefaultEXT(GPPUSHCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static void  glowPushDebugGroup(GPPUSHDEBUGGROUP fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
@@ -2226,8 +4051,14 @@ package gl
 // static void  glowPushDebugGroupKHR(GPPUSHDEBUGGROUPKHR fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
 // }
+// static void  glowPushGroupMarkerEXT(GPPUSHGROUPMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
 // static void  glowQueryCounter(GPQUERYCOUNTER fnptr, GLuint  id, GLenum  target) {
 //   (*fnptr)(id, target);
+// }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
 // }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
@@ -2252,6 +4083,12 @@ package gl
 // }
 // static void  glowRenderbufferStorageMultisample(GPRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, samples, internalformat, width, height);
+// }
+// static void  glowRenderbufferStorageMultisampleCoverageNV(GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV fnptr, GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(target, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
@@ -2292,6 +4129,12 @@ package gl
 // static void  glowScissorIndexedv(GPSCISSORINDEXEDV fnptr, GLuint  index, const GLint * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowSecondaryColorFormatNV(GPSECONDARYCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
+// static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
+//   (*fnptr)(monitor, enable, group, numCounters, counterList);
+// }
 // static void  glowShaderBinary(GPSHADERBINARY fnptr, GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length) {
 //   (*fnptr)(count, shaders, binaryformat, binary, length);
 // }
@@ -2300,6 +4143,24 @@ package gl
 // }
 // static void  glowShaderStorageBlockBinding(GPSHADERSTORAGEBLOCKBINDING fnptr, GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding) {
 //   (*fnptr)(program, storageBlockIndex, storageBlockBinding);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
+// }
+// static void  glowStencilFillPathInstancedNV(GPSTENCILFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, transformType, transformValues);
+// }
+// static void  glowStencilFillPathNV(GPSTENCILFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask) {
+//   (*fnptr)(path, fillMode, mask);
 // }
 // static void  glowStencilFunc(GPSTENCILFUNC fnptr, GLenum  func, GLint  ref, GLuint  mask) {
 //   (*fnptr)(func, ref, mask);
@@ -2319,11 +4180,38 @@ package gl
 // static void  glowStencilOpSeparate(GPSTENCILOPSEPARATE fnptr, GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass) {
 //   (*fnptr)(face, sfail, dpfail, dppass);
 // }
+// static void  glowStencilStrokePathInstancedNV(GPSTENCILSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, transformType, transformValues);
+// }
+// static void  glowStencilStrokePathNV(GPSTENCILSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask) {
+//   (*fnptr)(path, reference, mask);
+// }
+// static void  glowStencilThenCoverFillPathInstancedNV(GPSTENCILTHENCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverFillPathNV(GPSTENCILTHENCOVERFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, fillMode, mask, coverMode);
+// }
+// static void  glowStencilThenCoverStrokePathInstancedNV(GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverStrokePathNV(GPSTENCILTHENCOVERSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, reference, mask, coverMode);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
+// }
 // static void  glowTexBuffer(GPTEXBUFFER fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(target, internalformat, buffer);
+// }
+// static void  glowTexBufferARB(GPTEXBUFFERARB fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(target, internalformat, buffer);
 // }
 // static void  glowTexBufferRange(GPTEXBUFFERRANGE fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, internalformat, buffer, offset, size);
+// }
+// static void  glowTexCoordFormatNV(GPTEXCOORDFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
 // }
 // static void  glowTexImage1D(GPTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, border, format, type, pixels);
@@ -2340,8 +4228,8 @@ package gl
 // static void  glowTexImage3DMultisample(GPTEXIMAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -2388,53 +4276,119 @@ package gl
 // static void  glowTextureBarrier(GPTEXTUREBARRIER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowTextureBarrierNV(GPTEXTUREBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowTextureBuffer(GPTEXTUREBUFFER fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texture, target, internalformat, buffer);
+// }
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
+//   (*fnptr)(texture, target, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureImage1DEXT(GPTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowTextureImage2DEXT(GPTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowTextureImage3DEXT(GPTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowTextureParameterIivEXT(GPTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowTextureParameterIuiv(GPTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, const GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowTextureParameterIuivEXT(GPTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameterf(GPTEXTUREPARAMETERF fnptr, GLuint  texture, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameterfEXT(GPTEXTUREPARAMETERFEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameterfv(GPTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, const GLfloat * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterfvEXT(GPTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameteri(GPTEXTUREPARAMETERI fnptr, GLuint  texture, GLenum  pname, GLint  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameteriEXT(GPTEXTUREPARAMETERIEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameteriv(GPTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, const GLint * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterivEXT(GPTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
+// static void  glowTextureRenderbufferEXT(GPTEXTURERENDERBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texture, target, renderbuffer);
 // }
 // static void  glowTextureStorage1D(GPTEXTURESTORAGE1D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
 //   (*fnptr)(texture, levels, internalformat, width);
 // }
+// static void  glowTextureStorage1DEXT(GPTEXTURESTORAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
+//   (*fnptr)(texture, target, levels, internalformat, width);
+// }
 // static void  glowTextureStorage2D(GPTEXTURESTORAGE2D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, levels, internalformat, width, height);
+// }
+// static void  glowTextureStorage2DEXT(GPTEXTURESTORAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height);
 // }
 // static void  glowTextureStorage2DMultisample(GPTEXTURESTORAGE2DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, fixedsamplelocations);
 // }
+// static void  glowTextureStorage2DMultisampleEXT(GPTEXTURESTORAGE2DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, fixedsamplelocations);
+// }
 // static void  glowTextureStorage3D(GPTEXTURESTORAGE3D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
 //   (*fnptr)(texture, levels, internalformat, width, height, depth);
+// }
+// static void  glowTextureStorage3DEXT(GPTEXTURESTORAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height, depth);
 // }
 // static void  glowTextureStorage3DMultisample(GPTEXTURESTORAGE3DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
+// }
 // static void  glowTextureSubImage1D(GPTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowTextureSubImage1DEXT(GPTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, type, pixels);
 // }
 // static void  glowTextureSubImage2D(GPTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, type, pixels);
 // }
+// static void  glowTextureSubImage2DEXT(GPTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
 // static void  glowTextureSubImage3D(GPTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowTextureSubImage3DEXT(GPTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
 // static void  glowTextureView(GPTEXTUREVIEW fnptr, GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers) {
 //   (*fnptr)(texture, target, origtexture, internalformat, minlevel, numlevels, minlayer, numlayers);
@@ -2442,11 +4396,14 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackVaryings(GPTRANSFORMFEEDBACKVARYINGS fnptr, GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode) {
 //   (*fnptr)(program, count, varyings, bufferMode);
+// }
+// static void  glowTransformPathNV(GPTRANSFORMPATHNV fnptr, GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(resultPath, srcPath, transformType, transformValues);
 // }
 // static void  glowUniform1d(GPUNIFORM1D fnptr, GLint  location, GLdouble  x) {
 //   (*fnptr)(location, x);
@@ -2463,11 +4420,35 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform1iv(GPUNIFORM1IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
+// }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1uiv(GPUNIFORM1UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2487,11 +4468,35 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform2iv(GPUNIFORM2IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
+// }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2uiv(GPUNIFORM2UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2511,11 +4516,35 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform3iv(GPUNIFORM3IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
+// }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3uiv(GPUNIFORM3UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2535,11 +4564,35 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform4iv(GPUNIFORM4IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
+// }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4uiv(GPUNIFORM4UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2550,7 +4603,13 @@ package gl
 // static void  glowUniformHandleui64ARB(GPUNIFORMHANDLEUI64ARB fnptr, GLint  location, GLuint64  value) {
 //   (*fnptr)(location, value);
 // }
+// static void  glowUniformHandleui64NV(GPUNIFORMHANDLEUI64NV fnptr, GLint  location, GLuint64  value) {
+//   (*fnptr)(location, value);
+// }
 // static void  glowUniformHandleui64vARB(GPUNIFORMHANDLEUI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniformHandleui64vNV(GPUNIFORMHANDLEUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniformMatrix2dv(GPUNIFORMMATRIX2DV fnptr, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
@@ -2610,10 +4669,19 @@ package gl
 // static void  glowUniformSubroutinesuiv(GPUNIFORMSUBROUTINESUIV fnptr, GLenum  shadertype, GLsizei  count, const GLuint * indices) {
 //   (*fnptr)(shadertype, count, indices);
 // }
+// static void  glowUniformui64NV(GPUNIFORMUI64NV fnptr, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(location, value);
+// }
+// static void  glowUniformui64vNV(GPUNIFORMUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static GLboolean  glowUnmapBuffer(GPUNMAPBUFFER fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLboolean  glowUnmapNamedBuffer(GPUNMAPNAMEDBUFFER fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
+// static GLboolean  glowUnmapNamedBufferEXT(GPUNMAPNAMEDBUFFEREXT fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
 // static void  glowUseProgram(GPUSEPROGRAM fnptr, GLuint  program) {
@@ -2622,10 +4690,19 @@ package gl
 // static void  glowUseProgramStages(GPUSEPROGRAMSTAGES fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
 //   (*fnptr)(pipeline, stages, program);
 // }
+// static void  glowUseProgramStagesEXT(GPUSEPROGRAMSTAGESEXT fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
+//   (*fnptr)(pipeline, stages, program);
+// }
+// static void  glowUseShaderProgramEXT(GPUSESHADERPROGRAMEXT fnptr, GLenum  type, GLuint  program) {
+//   (*fnptr)(type, program);
+// }
 // static void  glowValidateProgram(GPVALIDATEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowValidateProgramPipeline(GPVALIDATEPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowValidateProgramPipelineEXT(GPVALIDATEPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowVertexArrayAttribBinding(GPVERTEXARRAYATTRIBBINDING fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
@@ -2640,17 +4717,74 @@ package gl
 // static void  glowVertexArrayAttribLFormat(GPVERTEXARRAYATTRIBLFORMAT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexArrayBindVertexBufferEXT(GPVERTEXARRAYBINDVERTEXBUFFEREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
+//   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
+// }
 // static void  glowVertexArrayBindingDivisor(GPVERTEXARRAYBINDINGDIVISOR fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(vaobj, bindingindex, divisor);
 // }
+// static void  glowVertexArrayColorOffsetEXT(GPVERTEXARRAYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayEdgeFlagOffsetEXT(GPVERTEXARRAYEDGEFLAGOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, stride, offset);
+// }
 // static void  glowVertexArrayElementBuffer(GPVERTEXARRAYELEMENTBUFFER fnptr, GLuint  vaobj, GLuint  buffer) {
 //   (*fnptr)(vaobj, buffer);
+// }
+// static void  glowVertexArrayFogCoordOffsetEXT(GPVERTEXARRAYFOGCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayIndexOffsetEXT(GPVERTEXARRAYINDEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayMultiTexCoordOffsetEXT(GPVERTEXARRAYMULTITEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, texunit, size, type, stride, offset);
+// }
+// static void  glowVertexArrayNormalOffsetEXT(GPVERTEXARRAYNORMALOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArraySecondaryColorOffsetEXT(GPVERTEXARRAYSECONDARYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayTexCoordOffsetEXT(GPVERTEXARRAYTEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribBindingEXT(GPVERTEXARRAYVERTEXATTRIBBINDINGEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
+//   (*fnptr)(vaobj, attribindex, bindingindex);
+// }
+// static void  glowVertexArrayVertexAttribDivisorEXT(GPVERTEXARRAYVERTEXATTRIBDIVISOREXT fnptr, GLuint  vaobj, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(vaobj, index, divisor);
+// }
+// static void  glowVertexArrayVertexAttribFormatEXT(GPVERTEXARRAYVERTEXATTRIBFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIFormatEXT(GPVERTEXARRAYVERTEXATTRIBIFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIOffsetEXT(GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribLFormatEXT(GPVERTEXARRAYVERTEXATTRIBLFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribLOffsetEXT(GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribOffsetEXT(GPVERTEXARRAYVERTEXATTRIBOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, normalized, stride, offset);
+// }
+// static void  glowVertexArrayVertexBindingDivisorEXT(GPVERTEXARRAYVERTEXBINDINGDIVISOREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
+//   (*fnptr)(vaobj, bindingindex, divisor);
 // }
 // static void  glowVertexArrayVertexBuffer(GPVERTEXARRAYVERTEXBUFFER fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
 //   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
 // }
 // static void  glowVertexArrayVertexBuffers(GPVERTEXARRAYVERTEXBUFFERS fnptr, GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(vaobj, first, count, buffers, offsets, strides);
+// }
+// static void  glowVertexArrayVertexOffsetEXT(GPVERTEXARRAYVERTEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
 // }
 // static void  glowVertexAttrib1d(GPVERTEXATTRIB1D fnptr, GLuint  index, GLdouble  x) {
 //   (*fnptr)(index, x);
@@ -2766,8 +4900,14 @@ package gl
 // static void  glowVertexAttribDivisor(GPVERTEXATTRIBDIVISOR fnptr, GLuint  index, GLuint  divisor) {
 //   (*fnptr)(index, divisor);
 // }
+// static void  glowVertexAttribDivisorARB(GPVERTEXATTRIBDIVISORARB fnptr, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(index, divisor);
+// }
 // static void  glowVertexAttribFormat(GPVERTEXATTRIBFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexAttribFormatNV(GPVERTEXATTRIBFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride) {
+//   (*fnptr)(index, size, type, normalized, stride);
 // }
 // static void  glowVertexAttribI1i(GPVERTEXATTRIBI1I fnptr, GLuint  index, GLint  x) {
 //   (*fnptr)(index, x);
@@ -2832,6 +4972,9 @@ package gl
 // static void  glowVertexAttribIFormat(GPVERTEXATTRIBIFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexAttribIFormatNV(GPVERTEXATTRIBIFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
+// }
 // static void  glowVertexAttribIPointer(GPVERTEXATTRIBIPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
 // }
@@ -2841,10 +4984,22 @@ package gl
 // static void  glowVertexAttribL1dv(GPVERTEXATTRIBL1DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL1i64NV(GPVERTEXATTRIBL1I64NV fnptr, GLuint  index, GLint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
+// static void  glowVertexAttribL1i64vNV(GPVERTEXATTRIBL1I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL1ui64ARB(GPVERTEXATTRIBL1UI64ARB fnptr, GLuint  index, GLuint64EXT  x) {
 //   (*fnptr)(index, x);
 // }
+// static void  glowVertexAttribL1ui64NV(GPVERTEXATTRIBL1UI64NV fnptr, GLuint  index, GLuint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
 // static void  glowVertexAttribL1ui64vARB(GPVERTEXATTRIBL1UI64VARB fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL1ui64vNV(GPVERTEXATTRIBL1UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL2d(GPVERTEXATTRIBL2D fnptr, GLuint  index, GLdouble  x, GLdouble  y) {
@@ -2853,10 +5008,34 @@ package gl
 // static void  glowVertexAttribL2dv(GPVERTEXATTRIBL2DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL2i64NV(GPVERTEXATTRIBL2I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2i64vNV(GPVERTEXATTRIBL2I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL2ui64NV(GPVERTEXATTRIBL2UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2ui64vNV(GPVERTEXATTRIBL2UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL3d(GPVERTEXATTRIBL3D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z) {
 //   (*fnptr)(index, x, y, z);
 // }
 // static void  glowVertexAttribL3dv(GPVERTEXATTRIBL3DV fnptr, GLuint  index, const GLdouble * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3i64NV(GPVERTEXATTRIBL3I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3i64vNV(GPVERTEXATTRIBL3I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3ui64NV(GPVERTEXATTRIBL3UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3ui64vNV(GPVERTEXATTRIBL3UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL4d(GPVERTEXATTRIBL4D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
@@ -2865,8 +5044,23 @@ package gl
 // static void  glowVertexAttribL4dv(GPVERTEXATTRIBL4DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL4i64NV(GPVERTEXATTRIBL4I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4i64vNV(GPVERTEXATTRIBL4I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL4ui64NV(GPVERTEXATTRIBL4UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4ui64vNV(GPVERTEXATTRIBL4UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribLFormat(GPVERTEXATTRIBLFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexAttribLFormatNV(GPVERTEXATTRIBLFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
 // }
 // static void  glowVertexAttribLPointer(GPVERTEXATTRIBLPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
@@ -2901,6 +5095,9 @@ package gl
 // static void  glowVertexBindingDivisor(GPVERTEXBINDINGDIVISOR fnptr, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(bindingindex, divisor);
 // }
+// static void  glowVertexFormatNV(GPVERTEXFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
 // static void  glowViewport(GPVIEWPORT fnptr, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(x, y, width, height);
 // }
@@ -2913,8 +5110,23 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
+//   (*fnptr)(resultPath, numPaths, paths, weights);
+// }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
 // }
 import "C"
 import (
@@ -2923,10 +5135,12 @@ import (
 )
 
 const (
+	ACCUM_ADJACENT_PAIRS_NV                                    = 0x90AD
 	ACTIVE_ATOMIC_COUNTER_BUFFERS                              = 0x92D9
 	ACTIVE_ATTRIBUTES                                          = 0x8B89
 	ACTIVE_ATTRIBUTE_MAX_LENGTH                                = 0x8B8A
 	ACTIVE_PROGRAM                                             = 0x8259
+	ACTIVE_PROGRAM_EXT                                         = 0x8B8D
 	ACTIVE_RESOURCES                                           = 0x92F5
 	ACTIVE_SUBROUTINES                                         = 0x8DE5
 	ACTIVE_SUBROUTINE_MAX_LENGTH                               = 0x8E48
@@ -2939,10 +5153,15 @@ const (
 	ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH                       = 0x8A35
 	ACTIVE_UNIFORM_MAX_LENGTH                                  = 0x8B87
 	ACTIVE_VARIABLES                                           = 0x9305
+	ADJACENT_PAIRS_NV                                          = 0x90AE
+	AFFINE_2D_NV                                               = 0x9092
+	AFFINE_3D_NV                                               = 0x9094
 	ALIASED_LINE_WIDTH_RANGE                                   = 0x846E
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
+	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALPHA                                                      = 0x1906
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	AND                                                        = 0x1501
@@ -2950,6 +5169,7 @@ const (
 	AND_REVERSE                                                = 0x1502
 	ANY_SAMPLES_PASSED                                         = 0x8C2F
 	ANY_SAMPLES_PASSED_CONSERVATIVE                            = 0x8D6A
+	ARC_TO_NV                                                  = 0xFE
 	ARRAY_BUFFER                                               = 0x8892
 	ARRAY_BUFFER_BINDING                                       = 0x8894
 	ARRAY_SIZE                                                 = 0x92FB
@@ -2970,43 +5190,56 @@ const (
 	ATOMIC_COUNTER_BUFFER_SIZE                                 = 0x92C3
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	AUTO_GENERATE_MIPMAP                                       = 0x8295
 	BACK                                                       = 0x0405
 	BACK_LEFT                                                  = 0x0402
 	BACK_RIGHT                                                 = 0x0403
+	BEVEL_NV                                                   = 0x90A6
 	BGR                                                        = 0x80E0
 	BGRA                                                       = 0x80E1
 	BGRA_INTEGER                                               = 0x8D9B
 	BGR_INTEGER                                                = 0x8D9A
 	BLEND                                                      = 0x0BE2
+	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
+	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
 	BLEND_DST_RGB                                              = 0x80C8
 	BLEND_EQUATION                                             = 0x8009
 	BLEND_EQUATION_ALPHA                                       = 0x883D
 	BLEND_EQUATION_RGB                                         = 0x8009
+	BLEND_OVERLAP_NV                                           = 0x9281
+	BLEND_PREMULTIPLIED_SRC_NV                                 = 0x9280
 	BLEND_SRC                                                  = 0x0BE1
 	BLEND_SRC_ALPHA                                            = 0x80CB
 	BLEND_SRC_RGB                                              = 0x80C9
 	BLOCK_INDEX                                                = 0x92FD
 	BLUE                                                       = 0x1905
 	BLUE_INTEGER                                               = 0x8D96
+	BLUE_NV                                                    = 0x1905
+	BOLD_BIT_NV                                                = 0x01
 	BOOL                                                       = 0x8B56
 	BOOL_VEC2                                                  = 0x8B57
 	BOOL_VEC3                                                  = 0x8B58
 	BOOL_VEC4                                                  = 0x8B59
+	BOUNDING_BOX_NV                                            = 0x908D
+	BOUNDING_BOX_OF_BOUNDING_BOXES_NV                          = 0x909C
 	BUFFER                                                     = 0x82E0
 	BUFFER_ACCESS                                              = 0x88BB
 	BUFFER_ACCESS_FLAGS                                        = 0x911F
 	BUFFER_BINDING                                             = 0x9302
 	BUFFER_DATA_SIZE                                           = 0x9303
+	BUFFER_GPU_ADDRESS_NV                                      = 0x8F1D
 	BUFFER_IMMUTABLE_STORAGE                                   = 0x821F
 	BUFFER_KHR                                                 = 0x82E0
 	BUFFER_MAPPED                                              = 0x88BC
 	BUFFER_MAP_LENGTH                                          = 0x9120
 	BUFFER_MAP_OFFSET                                          = 0x9121
 	BUFFER_MAP_POINTER                                         = 0x88BD
+	BUFFER_OBJECT_EXT                                          = 0x9151
 	BUFFER_SIZE                                                = 0x8764
 	BUFFER_STORAGE_FLAGS                                       = 0x8220
 	BUFFER_UPDATE_BARRIER_BIT                                  = 0x00000200
@@ -3015,8 +5248,12 @@ const (
 	BYTE                                                       = 0x1400
 	CAVEAT_SUPPORT                                             = 0x82B8
 	CCW                                                        = 0x0901
+	CIRCULAR_CCW_ARC_TO_NV                                     = 0xF8
+	CIRCULAR_CW_ARC_TO_NV                                      = 0xFA
+	CIRCULAR_TANGENT_ARC_TO_NV                                 = 0xFC
 	CLAMP_READ_COLOR                                           = 0x891C
 	CLAMP_TO_BORDER                                            = 0x812D
+	CLAMP_TO_BORDER_ARB                                        = 0x812D
 	CLAMP_TO_EDGE                                              = 0x812F
 	CLEAR                                                      = 0x1500
 	CLEAR_BUFFER                                               = 0x82B4
@@ -3035,7 +5272,14 @@ const (
 	CLIP_DISTANCE6                                             = 0x3006
 	CLIP_DISTANCE7                                             = 0x3007
 	CLIP_ORIGIN                                                = 0x935C
+	CLOSE_PATH_NV                                              = 0x00
 	COLOR                                                      = 0x1800
+	COLORBURN_KHR                                              = 0x929A
+	COLORBURN_NV                                               = 0x929A
+	COLORDODGE_KHR                                             = 0x9299
+	COLORDODGE_NV                                              = 0x9299
+	COLOR_ARRAY_ADDRESS_NV                                     = 0x8F23
+	COLOR_ARRAY_LENGTH_NV                                      = 0x8F2D
 	COLOR_ATTACHMENT0                                          = 0x8CE0
 	COLOR_ATTACHMENT1                                          = 0x8CE1
 	COLOR_ATTACHMENT10                                         = 0x8CEA
@@ -3044,8 +5288,24 @@ const (
 	COLOR_ATTACHMENT13                                         = 0x8CED
 	COLOR_ATTACHMENT14                                         = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT5                                          = 0x8CE5
 	COLOR_ATTACHMENT6                                          = 0x8CE6
@@ -3058,11 +5318,14 @@ const (
 	COLOR_ENCODING                                             = 0x8296
 	COLOR_LOGIC_OP                                             = 0x0BF2
 	COLOR_RENDERABLE                                           = 0x8286
+	COLOR_SAMPLES_NV                                           = 0x8E20
 	COLOR_WRITEMASK                                            = 0x0C23
 	COMMAND_BARRIER_BIT                                        = 0x00000040
 	COMPARE_REF_TO_TEXTURE                                     = 0x884E
 	COMPATIBLE_SUBROUTINES                                     = 0x8E4B
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_R11_EAC                                         = 0x9270
 	COMPRESSED_RED                                             = 0x8225
 	COMPRESSED_RED_RGTC1                                       = 0x8DBB
@@ -3088,8 +5351,12 @@ const (
 	COMPRESSED_RGBA_ASTC_8x6_KHR                               = 0x93B6
 	COMPRESSED_RGBA_ASTC_8x8_KHR                               = 0x93B7
 	COMPRESSED_RGBA_BPTC_UNORM_ARB                             = 0x8E8C
+	COMPRESSED_RGBA_S3TC_DXT1_EXT                              = 0x83F1
+	COMPRESSED_RGBA_S3TC_DXT3_EXT                              = 0x83F2
+	COMPRESSED_RGBA_S3TC_DXT5_EXT                              = 0x83F3
 	COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB                       = 0x8E8E
 	COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB                     = 0x8E8F
+	COMPRESSED_RGB_S3TC_DXT1_EXT                               = 0x83F0
 	COMPRESSED_RG_RGTC2                                        = 0x8DBD
 	COMPRESSED_SIGNED_R11_EAC                                  = 0x9271
 	COMPRESSED_SIGNED_RED_RGTC1                                = 0x8DBC
@@ -3124,6 +5391,18 @@ const (
 	COMPUTE_TEXTURE                                            = 0x82A0
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
+	CONIC_CURVE_TO_NV                                          = 0x1A
+	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSTANT_ALPHA                                             = 0x8003
 	CONSTANT_COLOR                                             = 0x8001
 	CONTEXT_COMPATIBILITY_PROFILE_BIT                          = 0x00000002
@@ -3132,6 +5411,7 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
 	CONTEXT_LOST_KHR                                           = 0x0507
@@ -3142,18 +5422,28 @@ const (
 	CONTEXT_RELEASE_BEHAVIOR_KHR                               = 0x82FB
 	CONTEXT_ROBUST_ACCESS                                      = 0x90F3
 	CONTEXT_ROBUST_ACCESS_KHR                                  = 0x90F3
+	CONTRAST_NV                                                = 0x92A1
+	CONVEX_HULL_NV                                             = 0x908B
 	COPY                                                       = 0x1503
 	COPY_INVERTED                                              = 0x150C
 	COPY_READ_BUFFER                                           = 0x8F36
-	COPY_READ_BUFFER_BINDING                                   = 0x8F36
 	COPY_WRITE_BUFFER                                          = 0x8F37
-	COPY_WRITE_BUFFER_BINDING                                  = 0x8F37
+	COUNTER_RANGE_AMD                                          = 0x8BC1
+	COUNTER_TYPE_AMD                                           = 0x8BC0
+	COUNT_DOWN_NV                                              = 0x9089
+	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
+	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CULL_FACE                                                  = 0x0B44
 	CULL_FACE_MODE                                             = 0x0B45
 	CURRENT_PROGRAM                                            = 0x8B8D
 	CURRENT_QUERY                                              = 0x8865
 	CURRENT_VERTEX_ATTRIB                                      = 0x8626
 	CW                                                         = 0x0900
+	DARKEN_KHR                                                 = 0x9297
+	DARKEN_NV                                                  = 0x9297
 	DEBUG_CALLBACK_FUNCTION                                    = 0x8244
 	DEBUG_CALLBACK_FUNCTION_ARB                                = 0x8244
 	DEBUG_CALLBACK_FUNCTION_KHR                                = 0x8244
@@ -3226,6 +5516,7 @@ const (
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR                              = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_ARB                          = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_KHR                          = 0x824E
+	DECODE_EXT                                                 = 0x8A49
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DELETE_STATUS                                              = 0x8B80
@@ -3245,11 +5536,15 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
 	DEPTH_STENCIL_TEXTURE_MODE                                 = 0x90EA
 	DEPTH_TEST                                                 = 0x0B71
 	DEPTH_WRITEMASK                                            = 0x0B72
+	DIFFERENCE_KHR                                             = 0x929E
+	DIFFERENCE_NV                                              = 0x929E
+	DISJOINT_NV                                                = 0x9283
 	DISPATCH_INDIRECT_BUFFER                                   = 0x90EE
 	DISPATCH_INDIRECT_BUFFER_BINDING                           = 0x90EF
 	DITHER                                                     = 0x0BD0
@@ -3268,6 +5563,9 @@ const (
 	DOUBLE_VEC2                                                = 0x8FFC
 	DOUBLE_VEC3                                                = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER1                                               = 0x8826
@@ -3285,30 +5583,62 @@ const (
 	DRAW_BUFFER7                                               = 0x882C
 	DRAW_BUFFER8                                               = 0x882D
 	DRAW_BUFFER9                                               = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
+	DRAW_INDIRECT_ADDRESS_NV                                   = 0x8F41
 	DRAW_INDIRECT_BUFFER                                       = 0x8F3F
 	DRAW_INDIRECT_BUFFER_BINDING                               = 0x8F43
+	DRAW_INDIRECT_LENGTH_NV                                    = 0x8F42
+	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DST_ALPHA                                                  = 0x0304
+	DST_ATOP_NV                                                = 0x928F
 	DST_COLOR                                                  = 0x0306
+	DST_IN_NV                                                  = 0x928B
+	DST_NV                                                     = 0x9287
+	DST_OUT_NV                                                 = 0x928D
+	DST_OVER_NV                                                = 0x9289
+	DUP_FIRST_CUBIC_CURVE_TO_NV                                = 0xF2
+	DUP_LAST_CUBIC_CURVE_TO_NV                                 = 0xF4
 	DYNAMIC_COPY                                               = 0x88EA
 	DYNAMIC_DRAW                                               = 0x88E8
 	DYNAMIC_READ                                               = 0x88E9
 	DYNAMIC_STORAGE_BIT                                        = 0x0100
+	EDGE_FLAG_ARRAY_ADDRESS_NV                                 = 0x8F26
+	EDGE_FLAG_ARRAY_LENGTH_NV                                  = 0x8F30
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
+	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_BARRIER_BIT                                  = 0x00000002
 	ELEMENT_ARRAY_BUFFER                                       = 0x8893
 	ELEMENT_ARRAY_BUFFER_BINDING                               = 0x8895
+	ELEMENT_ARRAY_LENGTH_NV                                    = 0x8F33
+	ELEMENT_ARRAY_UNIFIED_NV                                   = 0x8F1F
 	EQUAL                                                      = 0x0202
 	EQUIV                                                      = 0x1509
+	EXCLUSION_KHR                                              = 0x92A0
+	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXTENSIONS                                                 = 0x1F03
+	FACTOR_MAX_AMD                                             = 0x901D
+	FACTOR_MIN_AMD                                             = 0x901C
 	FALSE                                                      = 0
 	FASTEST                                                    = 0x1101
+	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
+	FIRST_TO_REST_NV                                           = 0x90AF
 	FIRST_VERTEX_CONVENTION                                    = 0x8E4D
 	FIXED                                                      = 0x140C
 	FIXED_ONLY                                                 = 0x891D
 	FLOAT                                                      = 0x1406
+	FLOAT16_NV                                                 = 0x8FF8
+	FLOAT16_VEC2_NV                                            = 0x8FF9
+	FLOAT16_VEC3_NV                                            = 0x8FFA
+	FLOAT16_VEC4_NV                                            = 0x8FFB
 	FLOAT_32_UNSIGNED_INT_24_8_REV                             = 0x8DAD
 	FLOAT_MAT2                                                 = 0x8B5A
 	FLOAT_MAT2x3                                               = 0x8B65
@@ -3322,12 +5652,37 @@ const (
 	FLOAT_VEC2                                                 = 0x8B50
 	FLOAT_VEC3                                                 = 0x8B51
 	FLOAT_VEC4                                                 = 0x8B52
+	FOG_COORD_ARRAY_ADDRESS_NV                                 = 0x8F28
+	FOG_COORD_ARRAY_LENGTH_NV                                  = 0x8F32
+	FONT_ASCENDER_BIT_NV                                       = 0x00200000
+	FONT_DESCENDER_BIT_NV                                      = 0x00400000
+	FONT_GLYPHS_AVAILABLE_NV                                   = 0x9368
+	FONT_HAS_KERNING_BIT_NV                                    = 0x10000000
+	FONT_HEIGHT_BIT_NV                                         = 0x00800000
+	FONT_MAX_ADVANCE_HEIGHT_BIT_NV                             = 0x02000000
+	FONT_MAX_ADVANCE_WIDTH_BIT_NV                              = 0x01000000
+	FONT_NUM_GLYPH_INDICES_BIT_NV                              = 0x20000000
+	FONT_TARGET_UNAVAILABLE_NV                                 = 0x9369
+	FONT_UNAVAILABLE_NV                                        = 0x936A
+	FONT_UNDERLINE_POSITION_BIT_NV                             = 0x04000000
+	FONT_UNDERLINE_THICKNESS_BIT_NV                            = 0x08000000
+	FONT_UNINTELLIGIBLE_NV                                     = 0x936B
+	FONT_UNITS_PER_EM_BIT_NV                                   = 0x00100000
+	FONT_X_MAX_BOUNDS_BIT_NV                                   = 0x00040000
+	FONT_X_MIN_BOUNDS_BIT_NV                                   = 0x00010000
+	FONT_Y_MAX_BOUNDS_BIT_NV                                   = 0x00080000
+	FONT_Y_MIN_BOUNDS_BIT_NV                                   = 0x00020000
 	FRACTIONAL_EVEN                                            = 0x8E7C
 	FRACTIONAL_ODD                                             = 0x8E7B
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
+	FRAGMENT_INPUT_NV                                          = 0x936D
 	FRAGMENT_INTERPOLATION_OFFSET_BITS                         = 0x8E5D
 	FRAGMENT_SHADER                                            = 0x8B30
 	FRAGMENT_SHADER_BIT                                        = 0x00000002
+	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -3340,13 +5695,16 @@ const (
 	FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE                          = 0x8216
 	FRAMEBUFFER_ATTACHMENT_GREEN_SIZE                          = 0x8213
 	FRAMEBUFFER_ATTACHMENT_LAYERED                             = 0x8DA7
+	FRAMEBUFFER_ATTACHMENT_LAYERED_ARB                         = 0x8DA7
 	FRAMEBUFFER_ATTACHMENT_OBJECT_NAME                         = 0x8CD1
 	FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE                         = 0x8CD0
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
 	FRAMEBUFFER_BLEND                                          = 0x828B
@@ -3359,18 +5717,26 @@ const (
 	FRAMEBUFFER_DEFAULT_WIDTH                                  = 0x9310
 	FRAMEBUFFER_INCOMPLETE_ATTACHMENT                          = 0x8CD6
 	FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER                         = 0x8CDB
+	FRAMEBUFFER_INCOMPLETE_LAYER_COUNT_ARB                     = 0x8DA9
 	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS                       = 0x8DA8
+	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS_ARB                   = 0x8DA8
 	FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT                  = 0x8CD7
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE                         = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_UNDEFINED                                      = 0x8219
 	FRAMEBUFFER_UNSUPPORTED                                    = 0x8CDD
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_SUPPORT                                               = 0x82B7
@@ -3378,8 +5744,11 @@ const (
 	FUNC_REVERSE_SUBTRACT                                      = 0x800B
 	FUNC_SUBTRACT                                              = 0x800A
 	GEOMETRY_INPUT_TYPE                                        = 0x8917
+	GEOMETRY_INPUT_TYPE_ARB                                    = 0x8DDB
 	GEOMETRY_OUTPUT_TYPE                                       = 0x8918
+	GEOMETRY_OUTPUT_TYPE_ARB                                   = 0x8DDC
 	GEOMETRY_SHADER                                            = 0x8DD9
+	GEOMETRY_SHADER_ARB                                        = 0x8DD9
 	GEOMETRY_SHADER_BIT                                        = 0x00000004
 	GEOMETRY_SHADER_INVOCATIONS                                = 0x887F
 	GEOMETRY_SHADER_PRIMITIVES_EMITTED_ARB                     = 0x82F3
@@ -3387,18 +5756,42 @@ const (
 	GEOMETRY_SUBROUTINE_UNIFORM                                = 0x92F1
 	GEOMETRY_TEXTURE                                           = 0x829E
 	GEOMETRY_VERTICES_OUT                                      = 0x8916
+	GEOMETRY_VERTICES_OUT_ARB                                  = 0x8DDA
 	GEQUAL                                                     = 0x0206
 	GET_TEXTURE_IMAGE_FORMAT                                   = 0x8291
 	GET_TEXTURE_IMAGE_TYPE                                     = 0x8292
+	GLYPH_HAS_KERNING_BIT_NV                                   = 0x100
+	GLYPH_HEIGHT_BIT_NV                                        = 0x02
+	GLYPH_HORIZONTAL_BEARING_ADVANCE_BIT_NV                    = 0x10
+	GLYPH_HORIZONTAL_BEARING_X_BIT_NV                          = 0x04
+	GLYPH_HORIZONTAL_BEARING_Y_BIT_NV                          = 0x08
+	GLYPH_VERTICAL_BEARING_ADVANCE_BIT_NV                      = 0x80
+	GLYPH_VERTICAL_BEARING_X_BIT_NV                            = 0x20
+	GLYPH_VERTICAL_BEARING_Y_BIT_NV                            = 0x40
+	GLYPH_WIDTH_BIT_NV                                         = 0x01
+	GPU_ADDRESS_NV                                             = 0x8F34
 	GREATER                                                    = 0x0204
 	GREEN                                                      = 0x1904
 	GREEN_INTEGER                                              = 0x8D95
+	GREEN_NV                                                   = 0x1904
 	GUILTY_CONTEXT_RESET                                       = 0x8253
 	GUILTY_CONTEXT_RESET_ARB                                   = 0x8253
 	GUILTY_CONTEXT_RESET_KHR                                   = 0x8253
 	HALF_FLOAT                                                 = 0x140B
+	HARDLIGHT_KHR                                              = 0x929B
+	HARDLIGHT_NV                                               = 0x929B
+	HARDMIX_NV                                                 = 0x92A9
 	HIGH_FLOAT                                                 = 0x8DF2
 	HIGH_INT                                                   = 0x8DF5
+	HORIZONTAL_LINE_TO_NV                                      = 0x06
+	HSL_COLOR_KHR                                              = 0x92AF
+	HSL_COLOR_NV                                               = 0x92AF
+	HSL_HUE_KHR                                                = 0x92AD
+	HSL_HUE_NV                                                 = 0x92AD
+	HSL_LUMINOSITY_KHR                                         = 0x92B0
+	HSL_LUMINOSITY_NV                                          = 0x92B0
+	HSL_SATURATION_KHR                                         = 0x92AE
+	HSL_SATURATION_NV                                          = 0x92AE
 	IMAGE_1D                                                   = 0x904C
 	IMAGE_1D_ARRAY                                             = 0x9052
 	IMAGE_2D                                                   = 0x904D
@@ -3436,13 +5829,32 @@ const (
 	IMAGE_TEXEL_SIZE                                           = 0x82A7
 	IMPLEMENTATION_COLOR_READ_FORMAT                           = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
+	INDEX_ARRAY_ADDRESS_NV                                     = 0x8F24
+	INDEX_ARRAY_LENGTH_NV                                      = 0x8F2E
 	INFO_LOG_LENGTH                                            = 0x8B84
 	INNOCENT_CONTEXT_RESET                                     = 0x8254
 	INNOCENT_CONTEXT_RESET_ARB                                 = 0x8254
 	INNOCENT_CONTEXT_RESET_KHR                                 = 0x8254
 	INT                                                        = 0x1404
+	INT16_NV                                                   = 0x8FE4
+	INT16_VEC2_NV                                              = 0x8FE5
+	INT16_VEC3_NV                                              = 0x8FE6
+	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
+	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
+	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
+	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
+	INT64_VEC4_NV                                              = 0x8FEB
+	INT8_NV                                                    = 0x8FE0
+	INT8_VEC2_NV                                               = 0x8FE1
+	INT8_VEC3_NV                                               = 0x8FE2
+	INT8_VEC4_NV                                               = 0x8FE3
 	INTERLEAVED_ATTRIBS                                        = 0x8C8C
 	INTERNALFORMAT_ALPHA_SIZE                                  = 0x8274
 	INTERNALFORMAT_ALPHA_TYPE                                  = 0x827B
@@ -3491,27 +5903,41 @@ const (
 	INVALID_OPERATION                                          = 0x0502
 	INVALID_VALUE                                              = 0x0501
 	INVERT                                                     = 0x150A
+	INVERT_OVG_NV                                              = 0x92B4
+	INVERT_RGB_NV                                              = 0x92A3
 	ISOLINES                                                   = 0x8E7A
 	IS_PER_PATCH                                               = 0x92E7
 	IS_ROW_MAJOR                                               = 0x9300
+	ITALIC_BIT_NV                                              = 0x02
 	KEEP                                                       = 0x1E00
+	LARGE_CCW_ARC_TO_NV                                        = 0x16
+	LARGE_CW_ARC_TO_NV                                         = 0x18
 	LAST_VERTEX_CONVENTION                                     = 0x8E4E
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LESS                                                       = 0x0201
+	LIGHTEN_KHR                                                = 0x9298
+	LIGHTEN_NV                                                 = 0x9298
 	LINE                                                       = 0x1B01
 	LINEAR                                                     = 0x2601
+	LINEARBURN_NV                                              = 0x92A5
+	LINEARDODGE_NV                                             = 0x92A4
+	LINEARLIGHT_NV                                             = 0x92A7
 	LINEAR_MIPMAP_LINEAR                                       = 0x2703
 	LINEAR_MIPMAP_NEAREST                                      = 0x2701
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
+	LINES_ADJACENCY_ARB                                        = 0x000A
 	LINE_LOOP                                                  = 0x0002
 	LINE_SMOOTH                                                = 0x0B20
 	LINE_SMOOTH_HINT                                           = 0x0C52
 	LINE_STRIP                                                 = 0x0003
 	LINE_STRIP_ADJACENCY                                       = 0x000B
+	LINE_STRIP_ADJACENCY_ARB                                   = 0x000B
+	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -3611,12 +6037,17 @@ const (
 	MAX_GEOMETRY_INPUT_COMPONENTS                              = 0x9123
 	MAX_GEOMETRY_OUTPUT_COMPONENTS                             = 0x9124
 	MAX_GEOMETRY_OUTPUT_VERTICES                               = 0x8DE0
+	MAX_GEOMETRY_OUTPUT_VERTICES_ARB                           = 0x8DE0
 	MAX_GEOMETRY_SHADER_INVOCATIONS                            = 0x8E5A
 	MAX_GEOMETRY_SHADER_STORAGE_BLOCKS                         = 0x90D7
 	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS                           = 0x8C29
+	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS_ARB                       = 0x8C29
 	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS                       = 0x8DE1
+	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS_ARB                   = 0x8DE1
 	MAX_GEOMETRY_UNIFORM_BLOCKS                                = 0x8A2C
 	MAX_GEOMETRY_UNIFORM_COMPONENTS                            = 0x8DDF
+	MAX_GEOMETRY_UNIFORM_COMPONENTS_ARB                        = 0x8DDF
+	MAX_GEOMETRY_VARYING_COMPONENTS_ARB                        = 0x8DDD
 	MAX_HEIGHT                                                 = 0x827F
 	MAX_IMAGE_SAMPLES                                          = 0x906D
 	MAX_IMAGE_UNITS                                            = 0x8F38
@@ -3624,6 +6055,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_MULTISAMPLE_COVERAGE_MODES_NV                          = 0x8E11
 	MAX_NAME_LENGTH                                            = 0x92F6
 	MAX_NUM_ACTIVE_VARIABLES                                   = 0x92F7
 	MAX_NUM_COMPATIBLE_SUBROUTINES                             = 0x92F8
@@ -3631,16 +6063,21 @@ const (
 	MAX_PROGRAM_TEXEL_OFFSET                                   = 0x8905
 	MAX_PROGRAM_TEXTURE_GATHER_COMPONENTS_ARB                  = 0x8F9F
 	MAX_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5F
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RENDERBUFFER_SIZE                                      = 0x84E8
 	MAX_SAMPLES                                                = 0x8D57
 	MAX_SAMPLE_MASK_WORDS                                      = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
+	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SPARSE_3D_TEXTURE_SIZE_ARB                             = 0x9199
 	MAX_SPARSE_ARRAY_TEXTURE_LAYERS_ARB                        = 0x919A
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -3665,8 +6102,10 @@ const (
 	MAX_TESS_GEN_LEVEL                                         = 0x8E7E
 	MAX_TESS_PATCH_COMPONENTS                                  = 0x8E84
 	MAX_TEXTURE_BUFFER_SIZE                                    = 0x8C2B
+	MAX_TEXTURE_BUFFER_SIZE_ARB                                = 0x8C2B
 	MAX_TEXTURE_IMAGE_UNITS                                    = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TRANSFORM_FEEDBACK_BUFFERS                             = 0x8E70
 	MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS              = 0x8C8A
@@ -3691,23 +6130,42 @@ const (
 	MAX_VERTEX_UNIFORM_BLOCKS                                  = 0x8A2B
 	MAX_VERTEX_UNIFORM_COMPONENTS                              = 0x8B4A
 	MAX_VERTEX_UNIFORM_VECTORS                                 = 0x8DFB
+	MAX_VERTEX_VARYING_COMPONENTS_ARB                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
 	MINOR_VERSION                                              = 0x821C
+	MINUS_CLAMPED_NV                                           = 0x92B3
+	MINUS_NV                                                   = 0x929F
 	MIN_FRAGMENT_INTERPOLATION_OFFSET                          = 0x8E5B
 	MIN_MAP_BUFFER_ALIGNMENT                                   = 0x90BC
 	MIN_PROGRAM_TEXEL_OFFSET                                   = 0x8904
 	MIN_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5E
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
+	MIRRORED_REPEAT_ARB                                        = 0x8370
 	MIRROR_CLAMP_TO_EDGE                                       = 0x8743
+	MITER_REVERT_NV                                            = 0x90A7
+	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
+	MOVE_TO_CONTINUES_NV                                       = 0x90B6
+	MOVE_TO_NV                                                 = 0x02
+	MOVE_TO_RESETS_NV                                          = 0x90B5
+	MULTIPLY_KHR                                               = 0x9294
+	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
+	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	NAMED_STRING_LENGTH_ARB                                    = 0x8DE9
 	NAMED_STRING_TYPE_ARB                                      = 0x8DEA
 	NAME_LENGTH                                                = 0x92F9
@@ -3720,7 +6178,10 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
+	NORMAL_ARRAY_ADDRESS_NV                                    = 0x8F22
+	NORMAL_ARRAY_LENGTH_NV                                     = 0x8F2C
 	NOTEQUAL                                                   = 0x0205
 	NO_ERROR                                                   = 0
 	NO_RESET_NOTIFICATION                                      = 0x8261
@@ -3733,7 +6194,10 @@ const (
 	NUM_PROGRAM_BINARY_FORMATS                                 = 0x87FE
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_TYPE                                                = 0x9112
 	OFFSET                                                     = 0x92FC
 	ONE                                                        = 1
@@ -3749,6 +6213,8 @@ const (
 	OR_INVERTED                                                = 0x150D
 	OR_REVERSE                                                 = 0x150B
 	OUT_OF_MEMORY                                              = 0x0505
+	OVERLAY_KHR                                                = 0x9296
+	OVERLAY_NV                                                 = 0x9296
 	PACK_ALIGNMENT                                             = 0x0D05
 	PACK_COMPRESSED_BLOCK_DEPTH                                = 0x912D
 	PACK_COMPRESSED_BLOCK_HEIGHT                               = 0x912C
@@ -3767,11 +6233,90 @@ const (
 	PATCH_DEFAULT_INNER_LEVEL                                  = 0x8E73
 	PATCH_DEFAULT_OUTER_LEVEL                                  = 0x8E74
 	PATCH_VERTICES                                             = 0x8E72
+	PATH_CLIENT_LENGTH_NV                                      = 0x907F
+	PATH_COMMAND_COUNT_NV                                      = 0x909D
+	PATH_COMPUTED_LENGTH_NV                                    = 0x90A0
+	PATH_COORD_COUNT_NV                                        = 0x909E
+	PATH_COVER_DEPTH_FUNC_NV                                   = 0x90BF
+	PATH_DASH_ARRAY_COUNT_NV                                   = 0x909F
+	PATH_DASH_CAPS_NV                                          = 0x907B
+	PATH_DASH_OFFSET_NV                                        = 0x907E
+	PATH_DASH_OFFSET_RESET_NV                                  = 0x90B4
+	PATH_END_CAPS_NV                                           = 0x9076
+	PATH_ERROR_POSITION_NV                                     = 0x90AB
+	PATH_FILL_BOUNDING_BOX_NV                                  = 0x90A1
+	PATH_FILL_COVER_MODE_NV                                    = 0x9082
+	PATH_FILL_MASK_NV                                          = 0x9081
+	PATH_FILL_MODE_NV                                          = 0x9080
+	PATH_FORMAT_PS_NV                                          = 0x9071
+	PATH_FORMAT_SVG_NV                                         = 0x9070
+	PATH_GEN_COEFF_NV                                          = 0x90B1
+	PATH_GEN_COMPONENTS_NV                                     = 0x90B3
+	PATH_GEN_MODE_NV                                           = 0x90B0
+	PATH_INITIAL_DASH_CAP_NV                                   = 0x907C
+	PATH_INITIAL_END_CAP_NV                                    = 0x9077
+	PATH_JOIN_STYLE_NV                                         = 0x9079
+	PATH_MAX_MODELVIEW_STACK_DEPTH_NV                          = 0x0D36
+	PATH_MAX_PROJECTION_STACK_DEPTH_NV                         = 0x0D38
+	PATH_MITER_LIMIT_NV                                        = 0x907A
+	PATH_MODELVIEW_MATRIX_NV                                   = 0x0BA6
+	PATH_MODELVIEW_NV                                          = 0x1700
+	PATH_MODELVIEW_STACK_DEPTH_NV                              = 0x0BA3
+	PATH_OBJECT_BOUNDING_BOX_NV                                = 0x908A
+	PATH_PROJECTION_MATRIX_NV                                  = 0x0BA7
+	PATH_PROJECTION_NV                                         = 0x1701
+	PATH_PROJECTION_STACK_DEPTH_NV                             = 0x0BA4
+	PATH_STENCIL_DEPTH_OFFSET_FACTOR_NV                        = 0x90BD
+	PATH_STENCIL_DEPTH_OFFSET_UNITS_NV                         = 0x90BE
+	PATH_STENCIL_FUNC_NV                                       = 0x90B7
+	PATH_STENCIL_REF_NV                                        = 0x90B8
+	PATH_STENCIL_VALUE_MASK_NV                                 = 0x90B9
+	PATH_STROKE_BOUNDING_BOX_NV                                = 0x90A2
+	PATH_STROKE_COVER_MODE_NV                                  = 0x9083
+	PATH_STROKE_MASK_NV                                        = 0x9084
+	PATH_STROKE_WIDTH_NV                                       = 0x9075
+	PATH_TERMINAL_DASH_CAP_NV                                  = 0x907D
+	PATH_TERMINAL_END_CAP_NV                                   = 0x9078
+	PATH_TRANSPOSE_MODELVIEW_MATRIX_NV                         = 0x84E3
+	PATH_TRANSPOSE_PROJECTION_MATRIX_NV                        = 0x84E4
+	PERCENTAGE_AMD                                             = 0x8BC3
+	PERFMON_RESULT_AMD                                         = 0x8BC6
+	PERFMON_RESULT_AVAILABLE_AMD                               = 0x8BC4
+	PERFMON_RESULT_SIZE_AMD                                    = 0x8BC5
+	PERFQUERY_COUNTER_DATA_BOOL32_INTEL                        = 0x94FC
+	PERFQUERY_COUNTER_DATA_DOUBLE_INTEL                        = 0x94FB
+	PERFQUERY_COUNTER_DATA_FLOAT_INTEL                         = 0x94FA
+	PERFQUERY_COUNTER_DATA_UINT32_INTEL                        = 0x94F8
+	PERFQUERY_COUNTER_DATA_UINT64_INTEL                        = 0x94F9
+	PERFQUERY_COUNTER_DESC_LENGTH_MAX_INTEL                    = 0x94FF
+	PERFQUERY_COUNTER_DURATION_NORM_INTEL                      = 0x94F1
+	PERFQUERY_COUNTER_DURATION_RAW_INTEL                       = 0x94F2
+	PERFQUERY_COUNTER_EVENT_INTEL                              = 0x94F0
+	PERFQUERY_COUNTER_NAME_LENGTH_MAX_INTEL                    = 0x94FE
+	PERFQUERY_COUNTER_RAW_INTEL                                = 0x94F4
+	PERFQUERY_COUNTER_THROUGHPUT_INTEL                         = 0x94F3
+	PERFQUERY_COUNTER_TIMESTAMP_INTEL                          = 0x94F5
+	PERFQUERY_DONOT_FLUSH_INTEL                                = 0x83F9
+	PERFQUERY_FLUSH_INTEL                                      = 0x83FA
+	PERFQUERY_GLOBAL_CONTEXT_INTEL                             = 0x00000001
+	PERFQUERY_GPA_EXTENDED_COUNTERS_INTEL                      = 0x9500
+	PERFQUERY_QUERY_NAME_LENGTH_MAX_INTEL                      = 0x94FD
+	PERFQUERY_SINGLE_CONTEXT_INTEL                             = 0x00000000
+	PERFQUERY_WAIT_INTEL                                       = 0x83FB
+	PINLIGHT_NV                                                = 0x92A8
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_PACK_BUFFER                                          = 0x88EB
+	PIXEL_PACK_BUFFER_ARB                                      = 0x88EB
 	PIXEL_PACK_BUFFER_BINDING                                  = 0x88ED
+	PIXEL_PACK_BUFFER_BINDING_ARB                              = 0x88ED
 	PIXEL_UNPACK_BUFFER                                        = 0x88EC
+	PIXEL_UNPACK_BUFFER_ARB                                    = 0x88EC
 	PIXEL_UNPACK_BUFFER_BINDING                                = 0x88EF
+	PIXEL_UNPACK_BUFFER_BINDING_ARB                            = 0x88EF
+	PLUS_CLAMPED_ALPHA_NV                                      = 0x92B2
+	PLUS_CLAMPED_NV                                            = 0x92B1
+	PLUS_DARKER_NV                                             = 0x9292
+	PLUS_NV                                                    = 0x9291
 	POINT                                                      = 0x1B00
 	POINTS                                                     = 0x0000
 	POINT_FADE_THRESHOLD_SIZE                                  = 0x8128
@@ -3780,6 +6325,9 @@ const (
 	POINT_SIZE_RANGE                                           = 0x0B12
 	POINT_SPRITE_COORD_ORIGIN                                  = 0x8CA0
 	POLYGON_MODE                                               = 0x0B40
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FILL                                        = 0x8037
 	POLYGON_OFFSET_LINE                                        = 0x2A02
@@ -3789,20 +6337,33 @@ const (
 	POLYGON_SMOOTH_HINT                                        = 0x0C53
 	PRIMITIVES_GENERATED                                       = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
 	PRIMITIVE_RESTART_INDEX                                    = 0x8F9E
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_INPUT                                              = 0x92E3
 	PROGRAM_KHR                                                = 0x82E2
+	PROGRAM_MATRIX_EXT                                         = 0x8E2D
+	PROGRAM_MATRIX_STACK_DEPTH_EXT                             = 0x8E2F
+	PROGRAM_OBJECT_EXT                                         = 0x8B40
 	PROGRAM_OUTPUT                                             = 0x92E4
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
+	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
+	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
+	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
 	PROGRAM_SEPARABLE                                          = 0x8258
+	PROGRAM_SEPARABLE_EXT                                      = 0x8258
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROXY_TEXTURE_1D                                           = 0x8063
 	PROXY_TEXTURE_1D_ARRAY                                     = 0x8C19
@@ -3814,6 +6375,7 @@ const (
 	PROXY_TEXTURE_CUBE_MAP                                     = 0x851B
 	PROXY_TEXTURE_CUBE_MAP_ARRAY_ARB                           = 0x900B
 	PROXY_TEXTURE_RECTANGLE                                    = 0x84F7
+	QUADRATIC_CURVE_TO_NV                                      = 0x0A
 	QUADS                                                      = 0x0007
 	QUADS_FOLLOW_PROVOKING_VERTEX_CONVENTION                   = 0x8E4C
 	QUERY                                                      = 0x82E3
@@ -3822,18 +6384,23 @@ const (
 	QUERY_BUFFER_BINDING                                       = 0x9193
 	QUERY_BY_REGION_NO_WAIT                                    = 0x8E16
 	QUERY_BY_REGION_NO_WAIT_INVERTED                           = 0x8E1A
+	QUERY_BY_REGION_NO_WAIT_NV                                 = 0x8E16
 	QUERY_BY_REGION_WAIT                                       = 0x8E15
 	QUERY_BY_REGION_WAIT_INVERTED                              = 0x8E19
+	QUERY_BY_REGION_WAIT_NV                                    = 0x8E15
 	QUERY_COUNTER_BITS                                         = 0x8864
 	QUERY_KHR                                                  = 0x82E3
 	QUERY_NO_WAIT                                              = 0x8E14
 	QUERY_NO_WAIT_INVERTED                                     = 0x8E18
+	QUERY_NO_WAIT_NV                                           = 0x8E14
+	QUERY_OBJECT_EXT                                           = 0x9153
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
 	QUERY_RESULT_NO_WAIT                                       = 0x9194
 	QUERY_TARGET                                               = 0x82EA
 	QUERY_WAIT                                                 = 0x8E13
 	QUERY_WAIT_INVERTED                                        = 0x8E17
+	QUERY_WAIT_NV                                              = 0x8E13
 	R11F_G11F_B10F                                             = 0x8C3A
 	R16                                                        = 0x822A
 	R16F                                                       = 0x822D
@@ -3849,6 +6416,9 @@ const (
 	R8UI                                                       = 0x8232
 	R8_SNORM                                                   = 0x8F94
 	RASTERIZER_DISCARD                                         = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -3857,18 +6427,41 @@ const (
 	READ_PIXELS_FORMAT                                         = 0x828D
 	READ_PIXELS_TYPE                                           = 0x828E
 	READ_WRITE                                                 = 0x88BA
+	RECT_NV                                                    = 0xF6
 	RED                                                        = 0x1903
 	RED_INTEGER                                                = 0x8D94
+	RED_NV                                                     = 0x1903
 	REFERENCED_BY_COMPUTE_SHADER                               = 0x930B
 	REFERENCED_BY_FRAGMENT_SHADER                              = 0x930A
 	REFERENCED_BY_GEOMETRY_SHADER                              = 0x9309
 	REFERENCED_BY_TESS_CONTROL_SHADER                          = 0x9307
 	REFERENCED_BY_TESS_EVALUATION_SHADER                       = 0x9308
 	REFERENCED_BY_VERTEX_SHADER                                = 0x9306
+	RELATIVE_ARC_TO_NV                                         = 0xFF
+	RELATIVE_CONIC_CURVE_TO_NV                                 = 0x1B
+	RELATIVE_CUBIC_CURVE_TO_NV                                 = 0x0D
+	RELATIVE_HORIZONTAL_LINE_TO_NV                             = 0x07
+	RELATIVE_LARGE_CCW_ARC_TO_NV                               = 0x17
+	RELATIVE_LARGE_CW_ARC_TO_NV                                = 0x19
+	RELATIVE_LINE_TO_NV                                        = 0x05
+	RELATIVE_MOVE_TO_NV                                        = 0x03
+	RELATIVE_QUADRATIC_CURVE_TO_NV                             = 0x0B
+	RELATIVE_RECT_NV                                           = 0xF7
+	RELATIVE_ROUNDED_RECT2_NV                                  = 0xEB
+	RELATIVE_ROUNDED_RECT4_NV                                  = 0xED
+	RELATIVE_ROUNDED_RECT8_NV                                  = 0xEF
+	RELATIVE_ROUNDED_RECT_NV                                   = 0xE9
+	RELATIVE_SMALL_CCW_ARC_TO_NV                               = 0x13
+	RELATIVE_SMALL_CW_ARC_TO_NV                                = 0x15
+	RELATIVE_SMOOTH_CUBIC_CURVE_TO_NV                          = 0x11
+	RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV                      = 0x0F
+	RELATIVE_VERTICAL_LINE_TO_NV                               = 0x09
 	RENDERBUFFER                                               = 0x8D41
 	RENDERBUFFER_ALPHA_SIZE                                    = 0x8D53
 	RENDERBUFFER_BINDING                                       = 0x8CA7
 	RENDERBUFFER_BLUE_SIZE                                     = 0x8D52
+	RENDERBUFFER_COLOR_SAMPLES_NV                              = 0x8E10
+	RENDERBUFFER_COVERAGE_SAMPLES_NV                           = 0x8CAB
 	RENDERBUFFER_DEPTH_SIZE                                    = 0x8D54
 	RENDERBUFFER_GREEN_SIZE                                    = 0x8D51
 	RENDERBUFFER_HEIGHT                                        = 0x8D43
@@ -3883,6 +6476,7 @@ const (
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
 	RESET_NOTIFICATION_STRATEGY_ARB                            = 0x8256
 	RESET_NOTIFICATION_STRATEGY_KHR                            = 0x8256
+	RESTART_PATH_NV                                            = 0xF0
 	RG                                                         = 0x8227
 	RG16                                                       = 0x822C
 	RG16F                                                      = 0x822F
@@ -3935,9 +6529,16 @@ const (
 	RGBA8UI                                                    = 0x8D7C
 	RGBA8_SNORM                                                = 0x8F97
 	RGBA_INTEGER                                               = 0x8D99
+	RGB_422_APPLE                                              = 0x8A1F
 	RGB_INTEGER                                                = 0x8D98
+	RGB_RAW_422_APPLE                                          = 0x8A51
 	RG_INTEGER                                                 = 0x8228
 	RIGHT                                                      = 0x0407
+	ROUNDED_RECT2_NV                                           = 0xEA
+	ROUNDED_RECT4_NV                                           = 0xEC
+	ROUNDED_RECT8_NV                                           = 0xEE
+	ROUNDED_RECT_NV                                            = 0xE8
+	ROUND_NV                                                   = 0x90A4
 	SAMPLER                                                    = 0x82E6
 	SAMPLER_1D                                                 = 0x8B5D
 	SAMPLER_1D_ARRAY                                           = 0x8DC0
@@ -3967,23 +6568,39 @@ const (
 	SAMPLE_COVERAGE                                            = 0x80A0
 	SAMPLE_COVERAGE_INVERT                                     = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_VALUE                                          = 0x8E52
 	SAMPLE_POSITION                                            = 0x8E50
 	SAMPLE_SHADING_ARB                                         = 0x8C36
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
+	SCREEN_KHR                                                 = 0x9295
+	SCREEN_NV                                                  = 0x9295
+	SECONDARY_COLOR_ARRAY_ADDRESS_NV                           = 0x8F27
+	SECONDARY_COLOR_ARRAY_LENGTH_NV                            = 0x8F31
 	SEPARATE_ATTRIBS                                           = 0x8C8D
 	SET                                                        = 0x150F
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
+	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
 	SHADER_IMAGE_ACCESS_BARRIER_BIT                            = 0x00000020
 	SHADER_IMAGE_ATOMIC                                        = 0x82A6
 	SHADER_IMAGE_LOAD                                          = 0x82A4
 	SHADER_IMAGE_STORE                                         = 0x82A5
 	SHADER_INCLUDE_ARB                                         = 0x8DAE
 	SHADER_KHR                                                 = 0x82E1
+	SHADER_OBJECT_EXT                                          = 0x8B48
 	SHADER_SOURCE_LENGTH                                       = 0x8B88
 	SHADER_STORAGE_BARRIER_BIT                                 = 0x00002000
 	SHADER_STORAGE_BLOCK                                       = 0x92E6
@@ -3994,6 +6611,7 @@ const (
 	SHADER_STORAGE_BUFFER_START                                = 0x90D4
 	SHADER_TYPE                                                = 0x8B4F
 	SHADING_LANGUAGE_VERSION                                   = 0x8B8C
+	SHARED_EDGE_NV                                             = 0xC0
 	SHORT                                                      = 0x1402
 	SIGNALED                                                   = 0x9119
 	SIGNED_NORMALIZED                                          = 0x8F9C
@@ -4001,18 +6619,35 @@ const (
 	SIMULTANEOUS_TEXTURE_AND_DEPTH_WRITE                       = 0x82AE
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_TEST                      = 0x82AD
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_WRITE                     = 0x82AF
+	SKIP_DECODE_EXT                                            = 0x8A4A
+	SKIP_MISSING_GLYPH_NV                                      = 0x90A9
+	SMALL_CCW_ARC_TO_NV                                        = 0x12
+	SMALL_CW_ARC_TO_NV                                         = 0x14
+	SMOOTH_CUBIC_CURVE_TO_NV                                   = 0x10
 	SMOOTH_LINE_WIDTH_GRANULARITY                              = 0x0B23
 	SMOOTH_LINE_WIDTH_RANGE                                    = 0x0B22
 	SMOOTH_POINT_SIZE_GRANULARITY                              = 0x0B13
 	SMOOTH_POINT_SIZE_RANGE                                    = 0x0B12
+	SMOOTH_QUADRATIC_CURVE_TO_NV                               = 0x0E
+	SM_COUNT_NV                                                = 0x933B
+	SOFTLIGHT_KHR                                              = 0x929C
+	SOFTLIGHT_NV                                               = 0x929C
 	SPARSE_BUFFER_PAGE_SIZE_ARB                                = 0x82F8
 	SPARSE_STORAGE_BIT_ARB                                     = 0x0400
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
+	SQUARE_NV                                                  = 0x90A3
 	SRC1_ALPHA                                                 = 0x8589
 	SRC1_COLOR                                                 = 0x88F9
 	SRC_ALPHA                                                  = 0x0302
 	SRC_ALPHA_SATURATE                                         = 0x0308
+	SRC_ATOP_NV                                                = 0x928E
 	SRC_COLOR                                                  = 0x0300
+	SRC_IN_NV                                                  = 0x928A
+	SRC_NV                                                     = 0x9286
+	SRC_OUT_NV                                                 = 0x928C
+	SRC_OVER_NV                                                = 0x9288
 	SRGB                                                       = 0x8C40
 	SRGB8                                                      = 0x8C41
 	SRGB8_ALPHA8                                               = 0x8C43
@@ -4024,6 +6659,8 @@ const (
 	STACK_OVERFLOW_KHR                                         = 0x0503
 	STACK_UNDERFLOW                                            = 0x0504
 	STACK_UNDERFLOW_KHR                                        = 0x0504
+	STANDARD_FONT_FORMAT_NV                                    = 0x936C
+	STANDARD_FONT_NAME_NV                                      = 0x9072
 	STATIC_COPY                                                = 0x88E6
 	STATIC_DRAW                                                = 0x88E4
 	STATIC_READ                                                = 0x88E5
@@ -4049,7 +6686,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_VALUE_MASK                                         = 0x0B93
 	STENCIL_WRITEMASK                                          = 0x0B98
@@ -4058,6 +6697,10 @@ const (
 	STREAM_DRAW                                                = 0x88E0
 	STREAM_READ                                                = 0x88E1
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SYNC_CL_EVENT_ARB                                          = 0x8240
 	SYNC_CL_EVENT_COMPLETE_ARB                                 = 0x8241
 	SYNC_CONDITION                                             = 0x9113
@@ -4066,6 +6709,8 @@ const (
 	SYNC_FLUSH_COMMANDS_BIT                                    = 0x00000001
 	SYNC_GPU_COMMANDS_COMPLETE                                 = 0x9117
 	SYNC_STATUS                                                = 0x9114
+	SYSTEM_FONT_NAME_NV                                        = 0x9073
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
 	TESS_CONTROL_SHADER                                        = 0x8E88
 	TESS_CONTROL_SHADER_BIT                                    = 0x00000008
@@ -4126,7 +6771,6 @@ const (
 	TEXTURE_ALPHA_SIZE                                         = 0x805F
 	TEXTURE_ALPHA_TYPE                                         = 0x8C13
 	TEXTURE_BASE_LEVEL                                         = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_2D                                         = 0x8069
@@ -4135,6 +6779,7 @@ const (
 	TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY                       = 0x9105
 	TEXTURE_BINDING_3D                                         = 0x806A
 	TEXTURE_BINDING_BUFFER                                     = 0x8C2C
+	TEXTURE_BINDING_BUFFER_ARB                                 = 0x8C2C
 	TEXTURE_BINDING_CUBE_MAP                                   = 0x8514
 	TEXTURE_BINDING_CUBE_MAP_ARRAY                             = 0x900A
 	TEXTURE_BINDING_CUBE_MAP_ARRAY_ARB                         = 0x900A
@@ -4143,7 +6788,10 @@ const (
 	TEXTURE_BLUE_TYPE                                          = 0x8C12
 	TEXTURE_BORDER_COLOR                                       = 0x1004
 	TEXTURE_BUFFER                                             = 0x8C2A
+	TEXTURE_BUFFER_ARB                                         = 0x8C2A
 	TEXTURE_BUFFER_DATA_STORE_BINDING                          = 0x8C2D
+	TEXTURE_BUFFER_DATA_STORE_BINDING_ARB                      = 0x8C2D
+	TEXTURE_BUFFER_FORMAT_ARB                                  = 0x8C2E
 	TEXTURE_BUFFER_OFFSET                                      = 0x919D
 	TEXTURE_BUFFER_OFFSET_ALIGNMENT                            = 0x919F
 	TEXTURE_BUFFER_SIZE                                        = 0x919E
@@ -4155,6 +6803,8 @@ const (
 	TEXTURE_COMPRESSED_BLOCK_WIDTH                             = 0x82B1
 	TEXTURE_COMPRESSED_IMAGE_SIZE                              = 0x86A0
 	TEXTURE_COMPRESSION_HINT                                   = 0x84EF
+	TEXTURE_COORD_ARRAY_ADDRESS_NV                             = 0x8F25
+	TEXTURE_COORD_ARRAY_LENGTH_NV                              = 0x8F2F
 	TEXTURE_CUBE_MAP                                           = 0x8513
 	TEXTURE_CUBE_MAP_ARRAY                                     = 0x9009
 	TEXTURE_CUBE_MAP_ARRAY_ARB                                 = 0x9009
@@ -4182,17 +6832,21 @@ const (
 	TEXTURE_INTERNAL_FORMAT                                    = 0x1003
 	TEXTURE_LOD_BIAS                                           = 0x8501
 	TEXTURE_MAG_FILTER                                         = 0x2800
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_LEVEL                                          = 0x813D
 	TEXTURE_MAX_LOD                                            = 0x813B
 	TEXTURE_MIN_FILTER                                         = 0x2801
 	TEXTURE_MIN_LOD                                            = 0x813A
 	TEXTURE_RECTANGLE                                          = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
 	TEXTURE_SAMPLES                                            = 0x9106
 	TEXTURE_SHADOW                                             = 0x82A1
 	TEXTURE_SHARED_SIZE                                        = 0x8C3F
 	TEXTURE_SPARSE_ARB                                         = 0x91A6
+	TEXTURE_SRGB_DECODE_EXT                                    = 0x8A48
 	TEXTURE_STENCIL_SIZE                                       = 0x88F1
 	TEXTURE_SWIZZLE_A                                          = 0x8E45
 	TEXTURE_SWIZZLE_B                                          = 0x8E44
@@ -4217,7 +6871,6 @@ const (
 	TOP_LEVEL_ARRAY_SIZE                                       = 0x930C
 	TOP_LEVEL_ARRAY_STRIDE                                     = 0x930D
 	TRANSFORM_FEEDBACK                                         = 0x8E22
-	TRANSFORM_FEEDBACK_ACTIVE                                  = 0x8E24
 	TRANSFORM_FEEDBACK_BARRIER_BIT                             = 0x00000800
 	TRANSFORM_FEEDBACK_BINDING                                 = 0x8E25
 	TRANSFORM_FEEDBACK_BUFFER                                  = 0x8C8E
@@ -4230,21 +6883,32 @@ const (
 	TRANSFORM_FEEDBACK_BUFFER_START                            = 0x8C84
 	TRANSFORM_FEEDBACK_BUFFER_STRIDE                           = 0x934C
 	TRANSFORM_FEEDBACK_OVERFLOW_ARB                            = 0x82EC
-	TRANSFORM_FEEDBACK_PAUSED                                  = 0x8E23
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN                      = 0x8C88
 	TRANSFORM_FEEDBACK_STREAM_OVERFLOW_ARB                     = 0x82ED
 	TRANSFORM_FEEDBACK_VARYING                                 = 0x92F4
 	TRANSFORM_FEEDBACK_VARYINGS                                = 0x8C83
 	TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH                      = 0x8C76
+	TRANSLATE_2D_NV                                            = 0x9090
+	TRANSLATE_3D_NV                                            = 0x9091
+	TRANSLATE_X_NV                                             = 0x908E
+	TRANSLATE_Y_NV                                             = 0x908F
+	TRANSPOSE_AFFINE_2D_NV                                     = 0x9096
+	TRANSPOSE_AFFINE_3D_NV                                     = 0x9098
+	TRANSPOSE_PROGRAM_MATRIX_EXT                               = 0x8E2E
 	TRIANGLES                                                  = 0x0004
 	TRIANGLES_ADJACENCY                                        = 0x000C
+	TRIANGLES_ADJACENCY_ARB                                    = 0x000C
 	TRIANGLE_FAN                                               = 0x0006
 	TRIANGLE_STRIP                                             = 0x0005
 	TRIANGLE_STRIP_ADJACENCY                                   = 0x000D
+	TRIANGLE_STRIP_ADJACENCY_ARB                               = 0x000D
+	TRIANGULAR_NV                                              = 0x90A5
 	TRUE                                                       = 1
 	TYPE                                                       = 0x92FA
+	UNCORRELATED_NV                                            = 0x9282
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -4262,10 +6926,13 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -4292,7 +6959,23 @@ const (
 	UNSIGNED_BYTE_2_3_3_REV                                    = 0x8362
 	UNSIGNED_BYTE_3_3_2                                        = 0x8032
 	UNSIGNED_INT                                               = 0x1405
+	UNSIGNED_INT16_NV                                          = 0x8FF0
+	UNSIGNED_INT16_VEC2_NV                                     = 0x8FF1
+	UNSIGNED_INT16_VEC3_NV                                     = 0x8FF2
+	UNSIGNED_INT16_VEC4_NV                                     = 0x8FF3
+	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
+	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
+	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
+	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
+	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
+	UNSIGNED_INT8_NV                                           = 0x8FEC
+	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
+	UNSIGNED_INT8_VEC3_NV                                      = 0x8FEE
+	UNSIGNED_INT8_VEC4_NV                                      = 0x8FEF
 	UNSIGNED_INT_10F_11F_11F_REV                               = 0x8C3B
 	UNSIGNED_INT_10_10_10_2                                    = 0x8036
 	UNSIGNED_INT_24_8                                          = 0x84FA
@@ -4334,23 +7017,35 @@ const (
 	UNSIGNED_SHORT_5_5_5_1                                     = 0x8034
 	UNSIGNED_SHORT_5_6_5                                       = 0x8363
 	UNSIGNED_SHORT_5_6_5_REV                                   = 0x8364
+	UNSIGNED_SHORT_8_8_APPLE                                   = 0x85BA
+	UNSIGNED_SHORT_8_8_REV_APPLE                               = 0x85BB
 	UPPER_LEFT                                                 = 0x8CA2
+	USE_MISSING_GLYPH_NV                                       = 0x90AA
+	UTF16_NV                                                   = 0x909B
+	UTF8_NV                                                    = 0x909A
 	VALIDATE_STATUS                                            = 0x8B83
 	VENDOR                                                     = 0x1F00
 	VERSION                                                    = 0x1F02
 	VERTEX_ARRAY                                               = 0x8074
+	VERTEX_ARRAY_ADDRESS_NV                                    = 0x8F21
 	VERTEX_ARRAY_BINDING                                       = 0x85B5
 	VERTEX_ARRAY_KHR                                           = 0x8074
+	VERTEX_ARRAY_LENGTH_NV                                     = 0x8F2B
+	VERTEX_ARRAY_OBJECT_EXT                                    = 0x9154
+	VERTEX_ATTRIB_ARRAY_ADDRESS_NV                             = 0x8F20
 	VERTEX_ATTRIB_ARRAY_BARRIER_BIT                            = 0x00000001
 	VERTEX_ATTRIB_ARRAY_BUFFER_BINDING                         = 0x889F
 	VERTEX_ATTRIB_ARRAY_DIVISOR                                = 0x88FE
+	VERTEX_ATTRIB_ARRAY_DIVISOR_ARB                            = 0x88FE
 	VERTEX_ATTRIB_ARRAY_ENABLED                                = 0x8622
 	VERTEX_ATTRIB_ARRAY_INTEGER                                = 0x88FD
+	VERTEX_ATTRIB_ARRAY_LENGTH_NV                              = 0x8F2A
 	VERTEX_ATTRIB_ARRAY_NORMALIZED                             = 0x886A
 	VERTEX_ATTRIB_ARRAY_POINTER                                = 0x8645
 	VERTEX_ATTRIB_ARRAY_SIZE                                   = 0x8623
 	VERTEX_ATTRIB_ARRAY_STRIDE                                 = 0x8624
 	VERTEX_ATTRIB_ARRAY_TYPE                                   = 0x8625
+	VERTEX_ATTRIB_ARRAY_UNIFIED_NV                             = 0x8F1E
 	VERTEX_ATTRIB_BINDING                                      = 0x82D4
 	VERTEX_ATTRIB_RELATIVE_OFFSET                              = 0x82D5
 	VERTEX_BINDING_DIVISOR                                     = 0x82D6
@@ -4359,15 +7054,33 @@ const (
 	VERTEX_PROGRAM_POINT_SIZE                                  = 0x8642
 	VERTEX_SHADER                                              = 0x8B31
 	VERTEX_SHADER_BIT                                          = 0x00000001
+	VERTEX_SHADER_BIT_EXT                                      = 0x00000001
 	VERTEX_SHADER_INVOCATIONS_ARB                              = 0x82F0
 	VERTEX_SUBROUTINE                                          = 0x92E8
 	VERTEX_SUBROUTINE_UNIFORM                                  = 0x92EE
 	VERTEX_TEXTURE                                             = 0x829B
+	VERTICAL_LINE_TO_NV                                        = 0x08
 	VERTICES_SUBMITTED_ARB                                     = 0x82EE
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -4389,718 +7102,1279 @@ const (
 	VIRTUAL_PAGE_SIZE_X_ARB                                    = 0x9195
 	VIRTUAL_PAGE_SIZE_Y_ARB                                    = 0x9196
 	VIRTUAL_PAGE_SIZE_Z_ARB                                    = 0x9197
+	VIVIDLIGHT_NV                                              = 0x92A6
 	WAIT_FAILED                                                = 0x911D
+	WARPS_PER_SM_NV                                            = 0x933A
+	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRITE_ONLY                                                 = 0x88B9
 	XOR                                                        = 0x1506
+	XOR_NV                                                     = 0x1506
 	ZERO                                                       = 0
 	ZERO_TO_ONE                                                = 0x935F
 )
 
 var (
-	gpActiveShaderProgram                         C.GPACTIVESHADERPROGRAM
-	gpActiveTexture                               C.GPACTIVETEXTURE
-	gpAttachShader                                C.GPATTACHSHADER
-	gpBeginConditionalRender                      C.GPBEGINCONDITIONALRENDER
-	gpBeginQuery                                  C.GPBEGINQUERY
-	gpBeginQueryIndexed                           C.GPBEGINQUERYINDEXED
-	gpBeginTransformFeedback                      C.GPBEGINTRANSFORMFEEDBACK
-	gpBindAttribLocation                          C.GPBINDATTRIBLOCATION
-	gpBindBuffer                                  C.GPBINDBUFFER
-	gpBindBufferBase                              C.GPBINDBUFFERBASE
-	gpBindBufferRange                             C.GPBINDBUFFERRANGE
-	gpBindBuffersBase                             C.GPBINDBUFFERSBASE
-	gpBindBuffersRange                            C.GPBINDBUFFERSRANGE
-	gpBindFragDataLocation                        C.GPBINDFRAGDATALOCATION
-	gpBindFragDataLocationIndexed                 C.GPBINDFRAGDATALOCATIONINDEXED
-	gpBindFramebuffer                             C.GPBINDFRAMEBUFFER
-	gpBindImageTexture                            C.GPBINDIMAGETEXTURE
-	gpBindImageTextures                           C.GPBINDIMAGETEXTURES
-	gpBindProgramPipeline                         C.GPBINDPROGRAMPIPELINE
-	gpBindRenderbuffer                            C.GPBINDRENDERBUFFER
-	gpBindSampler                                 C.GPBINDSAMPLER
-	gpBindSamplers                                C.GPBINDSAMPLERS
-	gpBindTexture                                 C.GPBINDTEXTURE
-	gpBindTextureUnit                             C.GPBINDTEXTUREUNIT
-	gpBindTextures                                C.GPBINDTEXTURES
-	gpBindTransformFeedback                       C.GPBINDTRANSFORMFEEDBACK
-	gpBindVertexArray                             C.GPBINDVERTEXARRAY
-	gpBindVertexBuffer                            C.GPBINDVERTEXBUFFER
-	gpBindVertexBuffers                           C.GPBINDVERTEXBUFFERS
-	gpBlendColor                                  C.GPBLENDCOLOR
-	gpBlendEquation                               C.GPBLENDEQUATION
-	gpBlendEquationSeparate                       C.GPBLENDEQUATIONSEPARATE
-	gpBlendEquationSeparateiARB                   C.GPBLENDEQUATIONSEPARATEIARB
-	gpBlendEquationiARB                           C.GPBLENDEQUATIONIARB
-	gpBlendFunc                                   C.GPBLENDFUNC
-	gpBlendFuncSeparate                           C.GPBLENDFUNCSEPARATE
-	gpBlendFuncSeparateiARB                       C.GPBLENDFUNCSEPARATEIARB
-	gpBlendFunciARB                               C.GPBLENDFUNCIARB
-	gpBlitFramebuffer                             C.GPBLITFRAMEBUFFER
-	gpBlitNamedFramebuffer                        C.GPBLITNAMEDFRAMEBUFFER
-	gpBufferData                                  C.GPBUFFERDATA
-	gpBufferPageCommitmentARB                     C.GPBUFFERPAGECOMMITMENTARB
-	gpBufferStorage                               C.GPBUFFERSTORAGE
-	gpBufferSubData                               C.GPBUFFERSUBDATA
-	gpCheckFramebufferStatus                      C.GPCHECKFRAMEBUFFERSTATUS
-	gpCheckNamedFramebufferStatus                 C.GPCHECKNAMEDFRAMEBUFFERSTATUS
-	gpClampColor                                  C.GPCLAMPCOLOR
-	gpClear                                       C.GPCLEAR
-	gpClearBufferData                             C.GPCLEARBUFFERDATA
-	gpClearBufferSubData                          C.GPCLEARBUFFERSUBDATA
-	gpClearBufferfi                               C.GPCLEARBUFFERFI
-	gpClearBufferfv                               C.GPCLEARBUFFERFV
-	gpClearBufferiv                               C.GPCLEARBUFFERIV
-	gpClearBufferuiv                              C.GPCLEARBUFFERUIV
-	gpClearColor                                  C.GPCLEARCOLOR
-	gpClearDepth                                  C.GPCLEARDEPTH
-	gpClearDepthf                                 C.GPCLEARDEPTHF
-	gpClearNamedBufferData                        C.GPCLEARNAMEDBUFFERDATA
-	gpClearNamedBufferSubData                     C.GPCLEARNAMEDBUFFERSUBDATA
-	gpClearNamedFramebufferfi                     C.GPCLEARNAMEDFRAMEBUFFERFI
-	gpClearNamedFramebufferfv                     C.GPCLEARNAMEDFRAMEBUFFERFV
-	gpClearNamedFramebufferiv                     C.GPCLEARNAMEDFRAMEBUFFERIV
-	gpClearNamedFramebufferuiv                    C.GPCLEARNAMEDFRAMEBUFFERUIV
-	gpClearStencil                                C.GPCLEARSTENCIL
-	gpClearTexImage                               C.GPCLEARTEXIMAGE
-	gpClearTexSubImage                            C.GPCLEARTEXSUBIMAGE
-	gpClientWaitSync                              C.GPCLIENTWAITSYNC
-	gpClipControl                                 C.GPCLIPCONTROL
-	gpColorMask                                   C.GPCOLORMASK
-	gpColorMaski                                  C.GPCOLORMASKI
-	gpCompileShader                               C.GPCOMPILESHADER
-	gpCompileShaderIncludeARB                     C.GPCOMPILESHADERINCLUDEARB
-	gpCompressedTexImage1D                        C.GPCOMPRESSEDTEXIMAGE1D
-	gpCompressedTexImage2D                        C.GPCOMPRESSEDTEXIMAGE2D
-	gpCompressedTexImage3D                        C.GPCOMPRESSEDTEXIMAGE3D
-	gpCompressedTexSubImage1D                     C.GPCOMPRESSEDTEXSUBIMAGE1D
-	gpCompressedTexSubImage2D                     C.GPCOMPRESSEDTEXSUBIMAGE2D
-	gpCompressedTexSubImage3D                     C.GPCOMPRESSEDTEXSUBIMAGE3D
-	gpCompressedTextureSubImage1D                 C.GPCOMPRESSEDTEXTURESUBIMAGE1D
-	gpCompressedTextureSubImage2D                 C.GPCOMPRESSEDTEXTURESUBIMAGE2D
-	gpCompressedTextureSubImage3D                 C.GPCOMPRESSEDTEXTURESUBIMAGE3D
-	gpCopyBufferSubData                           C.GPCOPYBUFFERSUBDATA
-	gpCopyImageSubData                            C.GPCOPYIMAGESUBDATA
-	gpCopyNamedBufferSubData                      C.GPCOPYNAMEDBUFFERSUBDATA
-	gpCopyTexImage1D                              C.GPCOPYTEXIMAGE1D
-	gpCopyTexImage2D                              C.GPCOPYTEXIMAGE2D
-	gpCopyTexSubImage1D                           C.GPCOPYTEXSUBIMAGE1D
-	gpCopyTexSubImage2D                           C.GPCOPYTEXSUBIMAGE2D
-	gpCopyTexSubImage3D                           C.GPCOPYTEXSUBIMAGE3D
-	gpCopyTextureSubImage1D                       C.GPCOPYTEXTURESUBIMAGE1D
-	gpCopyTextureSubImage2D                       C.GPCOPYTEXTURESUBIMAGE2D
-	gpCopyTextureSubImage3D                       C.GPCOPYTEXTURESUBIMAGE3D
-	gpCreateBuffers                               C.GPCREATEBUFFERS
-	gpCreateFramebuffers                          C.GPCREATEFRAMEBUFFERS
-	gpCreateProgram                               C.GPCREATEPROGRAM
-	gpCreateProgramPipelines                      C.GPCREATEPROGRAMPIPELINES
-	gpCreateQueries                               C.GPCREATEQUERIES
-	gpCreateRenderbuffers                         C.GPCREATERENDERBUFFERS
-	gpCreateSamplers                              C.GPCREATESAMPLERS
-	gpCreateShader                                C.GPCREATESHADER
-	gpCreateShaderProgramv                        C.GPCREATESHADERPROGRAMV
-	gpCreateSyncFromCLeventARB                    C.GPCREATESYNCFROMCLEVENTARB
-	gpCreateTextures                              C.GPCREATETEXTURES
-	gpCreateTransformFeedbacks                    C.GPCREATETRANSFORMFEEDBACKS
-	gpCreateVertexArrays                          C.GPCREATEVERTEXARRAYS
-	gpCullFace                                    C.GPCULLFACE
-	gpDebugMessageCallback                        C.GPDEBUGMESSAGECALLBACK
-	gpDebugMessageCallbackARB                     C.GPDEBUGMESSAGECALLBACKARB
-	gpDebugMessageCallbackKHR                     C.GPDEBUGMESSAGECALLBACKKHR
-	gpDebugMessageControl                         C.GPDEBUGMESSAGECONTROL
-	gpDebugMessageControlARB                      C.GPDEBUGMESSAGECONTROLARB
-	gpDebugMessageControlKHR                      C.GPDEBUGMESSAGECONTROLKHR
-	gpDebugMessageInsert                          C.GPDEBUGMESSAGEINSERT
-	gpDebugMessageInsertARB                       C.GPDEBUGMESSAGEINSERTARB
-	gpDebugMessageInsertKHR                       C.GPDEBUGMESSAGEINSERTKHR
-	gpDeleteBuffers                               C.GPDELETEBUFFERS
-	gpDeleteFramebuffers                          C.GPDELETEFRAMEBUFFERS
-	gpDeleteNamedStringARB                        C.GPDELETENAMEDSTRINGARB
-	gpDeleteProgram                               C.GPDELETEPROGRAM
-	gpDeleteProgramPipelines                      C.GPDELETEPROGRAMPIPELINES
-	gpDeleteQueries                               C.GPDELETEQUERIES
-	gpDeleteRenderbuffers                         C.GPDELETERENDERBUFFERS
-	gpDeleteSamplers                              C.GPDELETESAMPLERS
-	gpDeleteShader                                C.GPDELETESHADER
-	gpDeleteSync                                  C.GPDELETESYNC
-	gpDeleteTextures                              C.GPDELETETEXTURES
-	gpDeleteTransformFeedbacks                    C.GPDELETETRANSFORMFEEDBACKS
-	gpDeleteVertexArrays                          C.GPDELETEVERTEXARRAYS
-	gpDepthFunc                                   C.GPDEPTHFUNC
-	gpDepthMask                                   C.GPDEPTHMASK
-	gpDepthRange                                  C.GPDEPTHRANGE
-	gpDepthRangeArrayv                            C.GPDEPTHRANGEARRAYV
-	gpDepthRangeIndexed                           C.GPDEPTHRANGEINDEXED
-	gpDepthRangef                                 C.GPDEPTHRANGEF
-	gpDetachShader                                C.GPDETACHSHADER
-	gpDisable                                     C.GPDISABLE
-	gpDisableVertexArrayAttrib                    C.GPDISABLEVERTEXARRAYATTRIB
-	gpDisableVertexAttribArray                    C.GPDISABLEVERTEXATTRIBARRAY
-	gpDisablei                                    C.GPDISABLEI
-	gpDispatchCompute                             C.GPDISPATCHCOMPUTE
-	gpDispatchComputeGroupSizeARB                 C.GPDISPATCHCOMPUTEGROUPSIZEARB
-	gpDispatchComputeIndirect                     C.GPDISPATCHCOMPUTEINDIRECT
-	gpDrawArrays                                  C.GPDRAWARRAYS
-	gpDrawArraysIndirect                          C.GPDRAWARRAYSINDIRECT
-	gpDrawArraysInstanced                         C.GPDRAWARRAYSINSTANCED
-	gpDrawArraysInstancedBaseInstance             C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
-	gpDrawBuffer                                  C.GPDRAWBUFFER
-	gpDrawBuffers                                 C.GPDRAWBUFFERS
-	gpDrawElements                                C.GPDRAWELEMENTS
-	gpDrawElementsBaseVertex                      C.GPDRAWELEMENTSBASEVERTEX
-	gpDrawElementsIndirect                        C.GPDRAWELEMENTSINDIRECT
-	gpDrawElementsInstanced                       C.GPDRAWELEMENTSINSTANCED
-	gpDrawElementsInstancedBaseInstance           C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
-	gpDrawElementsInstancedBaseVertex             C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
-	gpDrawElementsInstancedBaseVertexBaseInstance C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
-	gpDrawRangeElements                           C.GPDRAWRANGEELEMENTS
-	gpDrawRangeElementsBaseVertex                 C.GPDRAWRANGEELEMENTSBASEVERTEX
-	gpDrawTransformFeedback                       C.GPDRAWTRANSFORMFEEDBACK
-	gpDrawTransformFeedbackInstanced              C.GPDRAWTRANSFORMFEEDBACKINSTANCED
-	gpDrawTransformFeedbackStream                 C.GPDRAWTRANSFORMFEEDBACKSTREAM
-	gpDrawTransformFeedbackStreamInstanced        C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
-	gpEnable                                      C.GPENABLE
-	gpEnableVertexArrayAttrib                     C.GPENABLEVERTEXARRAYATTRIB
-	gpEnableVertexAttribArray                     C.GPENABLEVERTEXATTRIBARRAY
-	gpEnablei                                     C.GPENABLEI
-	gpEndConditionalRender                        C.GPENDCONDITIONALRENDER
-	gpEndQuery                                    C.GPENDQUERY
-	gpEndQueryIndexed                             C.GPENDQUERYINDEXED
-	gpEndTransformFeedback                        C.GPENDTRANSFORMFEEDBACK
-	gpFenceSync                                   C.GPFENCESYNC
-	gpFinish                                      C.GPFINISH
-	gpFlush                                       C.GPFLUSH
-	gpFlushMappedBufferRange                      C.GPFLUSHMAPPEDBUFFERRANGE
-	gpFlushMappedNamedBufferRange                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
-	gpFramebufferParameteri                       C.GPFRAMEBUFFERPARAMETERI
-	gpFramebufferRenderbuffer                     C.GPFRAMEBUFFERRENDERBUFFER
-	gpFramebufferTexture                          C.GPFRAMEBUFFERTEXTURE
-	gpFramebufferTexture1D                        C.GPFRAMEBUFFERTEXTURE1D
-	gpFramebufferTexture2D                        C.GPFRAMEBUFFERTEXTURE2D
-	gpFramebufferTexture3D                        C.GPFRAMEBUFFERTEXTURE3D
-	gpFramebufferTextureLayer                     C.GPFRAMEBUFFERTEXTURELAYER
-	gpFrontFace                                   C.GPFRONTFACE
-	gpGenBuffers                                  C.GPGENBUFFERS
-	gpGenFramebuffers                             C.GPGENFRAMEBUFFERS
-	gpGenProgramPipelines                         C.GPGENPROGRAMPIPELINES
-	gpGenQueries                                  C.GPGENQUERIES
-	gpGenRenderbuffers                            C.GPGENRENDERBUFFERS
-	gpGenSamplers                                 C.GPGENSAMPLERS
-	gpGenTextures                                 C.GPGENTEXTURES
-	gpGenTransformFeedbacks                       C.GPGENTRANSFORMFEEDBACKS
-	gpGenVertexArrays                             C.GPGENVERTEXARRAYS
-	gpGenerateMipmap                              C.GPGENERATEMIPMAP
-	gpGenerateTextureMipmap                       C.GPGENERATETEXTUREMIPMAP
-	gpGetActiveAtomicCounterBufferiv              C.GPGETACTIVEATOMICCOUNTERBUFFERIV
-	gpGetActiveAttrib                             C.GPGETACTIVEATTRIB
-	gpGetActiveSubroutineName                     C.GPGETACTIVESUBROUTINENAME
-	gpGetActiveSubroutineUniformName              C.GPGETACTIVESUBROUTINEUNIFORMNAME
-	gpGetActiveSubroutineUniformiv                C.GPGETACTIVESUBROUTINEUNIFORMIV
-	gpGetActiveUniform                            C.GPGETACTIVEUNIFORM
-	gpGetActiveUniformBlockName                   C.GPGETACTIVEUNIFORMBLOCKNAME
-	gpGetActiveUniformBlockiv                     C.GPGETACTIVEUNIFORMBLOCKIV
-	gpGetActiveUniformName                        C.GPGETACTIVEUNIFORMNAME
-	gpGetActiveUniformsiv                         C.GPGETACTIVEUNIFORMSIV
-	gpGetAttachedShaders                          C.GPGETATTACHEDSHADERS
-	gpGetAttribLocation                           C.GPGETATTRIBLOCATION
-	gpGetBooleani_v                               C.GPGETBOOLEANI_V
-	gpGetBooleanv                                 C.GPGETBOOLEANV
-	gpGetBufferParameteri64v                      C.GPGETBUFFERPARAMETERI64V
-	gpGetBufferParameteriv                        C.GPGETBUFFERPARAMETERIV
-	gpGetBufferPointerv                           C.GPGETBUFFERPOINTERV
-	gpGetBufferSubData                            C.GPGETBUFFERSUBDATA
-	gpGetCompressedTexImage                       C.GPGETCOMPRESSEDTEXIMAGE
-	gpGetCompressedTextureImage                   C.GPGETCOMPRESSEDTEXTUREIMAGE
-	gpGetCompressedTextureSubImage                C.GPGETCOMPRESSEDTEXTURESUBIMAGE
-	gpGetDebugMessageLog                          C.GPGETDEBUGMESSAGELOG
-	gpGetDebugMessageLogARB                       C.GPGETDEBUGMESSAGELOGARB
-	gpGetDebugMessageLogKHR                       C.GPGETDEBUGMESSAGELOGKHR
-	gpGetDoublei_v                                C.GPGETDOUBLEI_V
-	gpGetDoublev                                  C.GPGETDOUBLEV
-	gpGetError                                    C.GPGETERROR
-	gpGetFloati_v                                 C.GPGETFLOATI_V
-	gpGetFloatv                                   C.GPGETFLOATV
-	gpGetFragDataIndex                            C.GPGETFRAGDATAINDEX
-	gpGetFragDataLocation                         C.GPGETFRAGDATALOCATION
-	gpGetFramebufferAttachmentParameteriv         C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetFramebufferParameteriv                   C.GPGETFRAMEBUFFERPARAMETERIV
-	gpGetGraphicsResetStatus                      C.GPGETGRAPHICSRESETSTATUS
-	gpGetGraphicsResetStatusARB                   C.GPGETGRAPHICSRESETSTATUSARB
-	gpGetGraphicsResetStatusKHR                   C.GPGETGRAPHICSRESETSTATUSKHR
-	gpGetImageHandleARB                           C.GPGETIMAGEHANDLEARB
-	gpGetInteger64i_v                             C.GPGETINTEGER64I_V
-	gpGetInteger64v                               C.GPGETINTEGER64V
-	gpGetIntegeri_v                               C.GPGETINTEGERI_V
-	gpGetIntegerv                                 C.GPGETINTEGERV
-	gpGetInternalformati64v                       C.GPGETINTERNALFORMATI64V
-	gpGetInternalformativ                         C.GPGETINTERNALFORMATIV
-	gpGetMultisamplefv                            C.GPGETMULTISAMPLEFV
-	gpGetNamedBufferParameteri64v                 C.GPGETNAMEDBUFFERPARAMETERI64V
-	gpGetNamedBufferParameteriv                   C.GPGETNAMEDBUFFERPARAMETERIV
-	gpGetNamedBufferPointerv                      C.GPGETNAMEDBUFFERPOINTERV
-	gpGetNamedBufferSubData                       C.GPGETNAMEDBUFFERSUBDATA
-	gpGetNamedFramebufferAttachmentParameteriv    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetNamedFramebufferParameteriv              C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
-	gpGetNamedRenderbufferParameteriv             C.GPGETNAMEDRENDERBUFFERPARAMETERIV
-	gpGetNamedStringARB                           C.GPGETNAMEDSTRINGARB
-	gpGetNamedStringivARB                         C.GPGETNAMEDSTRINGIVARB
-	gpGetObjectLabel                              C.GPGETOBJECTLABEL
-	gpGetObjectLabelKHR                           C.GPGETOBJECTLABELKHR
-	gpGetObjectPtrLabel                           C.GPGETOBJECTPTRLABEL
-	gpGetObjectPtrLabelKHR                        C.GPGETOBJECTPTRLABELKHR
-	gpGetPointerv                                 C.GPGETPOINTERV
-	gpGetPointervKHR                              C.GPGETPOINTERVKHR
-	gpGetProgramBinary                            C.GPGETPROGRAMBINARY
-	gpGetProgramInfoLog                           C.GPGETPROGRAMINFOLOG
-	gpGetProgramInterfaceiv                       C.GPGETPROGRAMINTERFACEIV
-	gpGetProgramPipelineInfoLog                   C.GPGETPROGRAMPIPELINEINFOLOG
-	gpGetProgramPipelineiv                        C.GPGETPROGRAMPIPELINEIV
-	gpGetProgramResourceIndex                     C.GPGETPROGRAMRESOURCEINDEX
-	gpGetProgramResourceLocation                  C.GPGETPROGRAMRESOURCELOCATION
-	gpGetProgramResourceLocationIndex             C.GPGETPROGRAMRESOURCELOCATIONINDEX
-	gpGetProgramResourceName                      C.GPGETPROGRAMRESOURCENAME
-	gpGetProgramResourceiv                        C.GPGETPROGRAMRESOURCEIV
-	gpGetProgramStageiv                           C.GPGETPROGRAMSTAGEIV
-	gpGetProgramiv                                C.GPGETPROGRAMIV
-	gpGetQueryIndexediv                           C.GPGETQUERYINDEXEDIV
-	gpGetQueryObjecti64v                          C.GPGETQUERYOBJECTI64V
-	gpGetQueryObjectiv                            C.GPGETQUERYOBJECTIV
-	gpGetQueryObjectui64v                         C.GPGETQUERYOBJECTUI64V
-	gpGetQueryObjectuiv                           C.GPGETQUERYOBJECTUIV
-	gpGetQueryiv                                  C.GPGETQUERYIV
-	gpGetRenderbufferParameteriv                  C.GPGETRENDERBUFFERPARAMETERIV
-	gpGetSamplerParameterIiv                      C.GPGETSAMPLERPARAMETERIIV
-	gpGetSamplerParameterIuiv                     C.GPGETSAMPLERPARAMETERIUIV
-	gpGetSamplerParameterfv                       C.GPGETSAMPLERPARAMETERFV
-	gpGetSamplerParameteriv                       C.GPGETSAMPLERPARAMETERIV
-	gpGetShaderInfoLog                            C.GPGETSHADERINFOLOG
-	gpGetShaderPrecisionFormat                    C.GPGETSHADERPRECISIONFORMAT
-	gpGetShaderSource                             C.GPGETSHADERSOURCE
-	gpGetShaderiv                                 C.GPGETSHADERIV
-	gpGetString                                   C.GPGETSTRING
-	gpGetStringi                                  C.GPGETSTRINGI
-	gpGetSubroutineIndex                          C.GPGETSUBROUTINEINDEX
-	gpGetSubroutineUniformLocation                C.GPGETSUBROUTINEUNIFORMLOCATION
-	gpGetSynciv                                   C.GPGETSYNCIV
-	gpGetTexImage                                 C.GPGETTEXIMAGE
-	gpGetTexLevelParameterfv                      C.GPGETTEXLEVELPARAMETERFV
-	gpGetTexLevelParameteriv                      C.GPGETTEXLEVELPARAMETERIV
-	gpGetTexParameterIiv                          C.GPGETTEXPARAMETERIIV
-	gpGetTexParameterIuiv                         C.GPGETTEXPARAMETERIUIV
-	gpGetTexParameterfv                           C.GPGETTEXPARAMETERFV
-	gpGetTexParameteriv                           C.GPGETTEXPARAMETERIV
-	gpGetTextureHandleARB                         C.GPGETTEXTUREHANDLEARB
-	gpGetTextureImage                             C.GPGETTEXTUREIMAGE
-	gpGetTextureLevelParameterfv                  C.GPGETTEXTURELEVELPARAMETERFV
-	gpGetTextureLevelParameteriv                  C.GPGETTEXTURELEVELPARAMETERIV
-	gpGetTextureParameterIiv                      C.GPGETTEXTUREPARAMETERIIV
-	gpGetTextureParameterIuiv                     C.GPGETTEXTUREPARAMETERIUIV
-	gpGetTextureParameterfv                       C.GPGETTEXTUREPARAMETERFV
-	gpGetTextureParameteriv                       C.GPGETTEXTUREPARAMETERIV
-	gpGetTextureSamplerHandleARB                  C.GPGETTEXTURESAMPLERHANDLEARB
-	gpGetTextureSubImage                          C.GPGETTEXTURESUBIMAGE
-	gpGetTransformFeedbackVarying                 C.GPGETTRANSFORMFEEDBACKVARYING
-	gpGetTransformFeedbacki64_v                   C.GPGETTRANSFORMFEEDBACKI64_V
-	gpGetTransformFeedbacki_v                     C.GPGETTRANSFORMFEEDBACKI_V
-	gpGetTransformFeedbackiv                      C.GPGETTRANSFORMFEEDBACKIV
-	gpGetUniformBlockIndex                        C.GPGETUNIFORMBLOCKINDEX
-	gpGetUniformIndices                           C.GPGETUNIFORMINDICES
-	gpGetUniformLocation                          C.GPGETUNIFORMLOCATION
-	gpGetUniformSubroutineuiv                     C.GPGETUNIFORMSUBROUTINEUIV
-	gpGetUniformdv                                C.GPGETUNIFORMDV
-	gpGetUniformfv                                C.GPGETUNIFORMFV
-	gpGetUniformiv                                C.GPGETUNIFORMIV
-	gpGetUniformuiv                               C.GPGETUNIFORMUIV
-	gpGetVertexArrayIndexed64iv                   C.GPGETVERTEXARRAYINDEXED64IV
-	gpGetVertexArrayIndexediv                     C.GPGETVERTEXARRAYINDEXEDIV
-	gpGetVertexArrayiv                            C.GPGETVERTEXARRAYIV
-	gpGetVertexAttribIiv                          C.GPGETVERTEXATTRIBIIV
-	gpGetVertexAttribIuiv                         C.GPGETVERTEXATTRIBIUIV
-	gpGetVertexAttribLdv                          C.GPGETVERTEXATTRIBLDV
-	gpGetVertexAttribLui64vARB                    C.GPGETVERTEXATTRIBLUI64VARB
-	gpGetVertexAttribPointerv                     C.GPGETVERTEXATTRIBPOINTERV
-	gpGetVertexAttribdv                           C.GPGETVERTEXATTRIBDV
-	gpGetVertexAttribfv                           C.GPGETVERTEXATTRIBFV
-	gpGetVertexAttribiv                           C.GPGETVERTEXATTRIBIV
-	gpGetnCompressedTexImageARB                   C.GPGETNCOMPRESSEDTEXIMAGEARB
-	gpGetnTexImageARB                             C.GPGETNTEXIMAGEARB
-	gpGetnUniformdvARB                            C.GPGETNUNIFORMDVARB
-	gpGetnUniformfv                               C.GPGETNUNIFORMFV
-	gpGetnUniformfvARB                            C.GPGETNUNIFORMFVARB
-	gpGetnUniformfvKHR                            C.GPGETNUNIFORMFVKHR
-	gpGetnUniformiv                               C.GPGETNUNIFORMIV
-	gpGetnUniformivARB                            C.GPGETNUNIFORMIVARB
-	gpGetnUniformivKHR                            C.GPGETNUNIFORMIVKHR
-	gpGetnUniformuiv                              C.GPGETNUNIFORMUIV
-	gpGetnUniformuivARB                           C.GPGETNUNIFORMUIVARB
-	gpGetnUniformuivKHR                           C.GPGETNUNIFORMUIVKHR
-	gpHint                                        C.GPHINT
-	gpInvalidateBufferData                        C.GPINVALIDATEBUFFERDATA
-	gpInvalidateBufferSubData                     C.GPINVALIDATEBUFFERSUBDATA
-	gpInvalidateFramebuffer                       C.GPINVALIDATEFRAMEBUFFER
-	gpInvalidateNamedFramebufferData              C.GPINVALIDATENAMEDFRAMEBUFFERDATA
-	gpInvalidateNamedFramebufferSubData           C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
-	gpInvalidateSubFramebuffer                    C.GPINVALIDATESUBFRAMEBUFFER
-	gpInvalidateTexImage                          C.GPINVALIDATETEXIMAGE
-	gpInvalidateTexSubImage                       C.GPINVALIDATETEXSUBIMAGE
-	gpIsBuffer                                    C.GPISBUFFER
-	gpIsEnabled                                   C.GPISENABLED
-	gpIsEnabledi                                  C.GPISENABLEDI
-	gpIsFramebuffer                               C.GPISFRAMEBUFFER
-	gpIsImageHandleResidentARB                    C.GPISIMAGEHANDLERESIDENTARB
-	gpIsNamedStringARB                            C.GPISNAMEDSTRINGARB
-	gpIsProgram                                   C.GPISPROGRAM
-	gpIsProgramPipeline                           C.GPISPROGRAMPIPELINE
-	gpIsQuery                                     C.GPISQUERY
-	gpIsRenderbuffer                              C.GPISRENDERBUFFER
-	gpIsSampler                                   C.GPISSAMPLER
-	gpIsShader                                    C.GPISSHADER
-	gpIsSync                                      C.GPISSYNC
-	gpIsTexture                                   C.GPISTEXTURE
-	gpIsTextureHandleResidentARB                  C.GPISTEXTUREHANDLERESIDENTARB
-	gpIsTransformFeedback                         C.GPISTRANSFORMFEEDBACK
-	gpIsVertexArray                               C.GPISVERTEXARRAY
-	gpLineWidth                                   C.GPLINEWIDTH
-	gpLinkProgram                                 C.GPLINKPROGRAM
-	gpLogicOp                                     C.GPLOGICOP
-	gpMakeImageHandleNonResidentARB               C.GPMAKEIMAGEHANDLENONRESIDENTARB
-	gpMakeImageHandleResidentARB                  C.GPMAKEIMAGEHANDLERESIDENTARB
-	gpMakeTextureHandleNonResidentARB             C.GPMAKETEXTUREHANDLENONRESIDENTARB
-	gpMakeTextureHandleResidentARB                C.GPMAKETEXTUREHANDLERESIDENTARB
-	gpMapBuffer                                   C.GPMAPBUFFER
-	gpMapBufferRange                              C.GPMAPBUFFERRANGE
-	gpMapNamedBuffer                              C.GPMAPNAMEDBUFFER
-	gpMapNamedBufferRange                         C.GPMAPNAMEDBUFFERRANGE
-	gpMemoryBarrier                               C.GPMEMORYBARRIER
-	gpMemoryBarrierByRegion                       C.GPMEMORYBARRIERBYREGION
-	gpMinSampleShadingARB                         C.GPMINSAMPLESHADINGARB
-	gpMultiDrawArrays                             C.GPMULTIDRAWARRAYS
-	gpMultiDrawArraysIndirect                     C.GPMULTIDRAWARRAYSINDIRECT
-	gpMultiDrawArraysIndirectCountARB             C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
-	gpMultiDrawElements                           C.GPMULTIDRAWELEMENTS
-	gpMultiDrawElementsBaseVertex                 C.GPMULTIDRAWELEMENTSBASEVERTEX
-	gpMultiDrawElementsIndirect                   C.GPMULTIDRAWELEMENTSINDIRECT
-	gpMultiDrawElementsIndirectCountARB           C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
-	gpNamedBufferData                             C.GPNAMEDBUFFERDATA
-	gpNamedBufferPageCommitmentARB                C.GPNAMEDBUFFERPAGECOMMITMENTARB
-	gpNamedBufferPageCommitmentEXT                C.GPNAMEDBUFFERPAGECOMMITMENTEXT
-	gpNamedBufferStorage                          C.GPNAMEDBUFFERSTORAGE
-	gpNamedBufferSubData                          C.GPNAMEDBUFFERSUBDATA
-	gpNamedFramebufferDrawBuffer                  C.GPNAMEDFRAMEBUFFERDRAWBUFFER
-	gpNamedFramebufferDrawBuffers                 C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
-	gpNamedFramebufferParameteri                  C.GPNAMEDFRAMEBUFFERPARAMETERI
-	gpNamedFramebufferReadBuffer                  C.GPNAMEDFRAMEBUFFERREADBUFFER
-	gpNamedFramebufferRenderbuffer                C.GPNAMEDFRAMEBUFFERRENDERBUFFER
-	gpNamedFramebufferTexture                     C.GPNAMEDFRAMEBUFFERTEXTURE
-	gpNamedFramebufferTextureLayer                C.GPNAMEDFRAMEBUFFERTEXTURELAYER
-	gpNamedRenderbufferStorage                    C.GPNAMEDRENDERBUFFERSTORAGE
-	gpNamedRenderbufferStorageMultisample         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
-	gpNamedStringARB                              C.GPNAMEDSTRINGARB
-	gpObjectLabel                                 C.GPOBJECTLABEL
-	gpObjectLabelKHR                              C.GPOBJECTLABELKHR
-	gpObjectPtrLabel                              C.GPOBJECTPTRLABEL
-	gpObjectPtrLabelKHR                           C.GPOBJECTPTRLABELKHR
-	gpPatchParameterfv                            C.GPPATCHPARAMETERFV
-	gpPatchParameteri                             C.GPPATCHPARAMETERI
-	gpPauseTransformFeedback                      C.GPPAUSETRANSFORMFEEDBACK
-	gpPixelStoref                                 C.GPPIXELSTOREF
-	gpPixelStorei                                 C.GPPIXELSTOREI
-	gpPointParameterf                             C.GPPOINTPARAMETERF
-	gpPointParameterfv                            C.GPPOINTPARAMETERFV
-	gpPointParameteri                             C.GPPOINTPARAMETERI
-	gpPointParameteriv                            C.GPPOINTPARAMETERIV
-	gpPointSize                                   C.GPPOINTSIZE
-	gpPolygonMode                                 C.GPPOLYGONMODE
-	gpPolygonOffset                               C.GPPOLYGONOFFSET
-	gpPopDebugGroup                               C.GPPOPDEBUGGROUP
-	gpPopDebugGroupKHR                            C.GPPOPDEBUGGROUPKHR
-	gpPrimitiveRestartIndex                       C.GPPRIMITIVERESTARTINDEX
-	gpProgramBinary                               C.GPPROGRAMBINARY
-	gpProgramParameteri                           C.GPPROGRAMPARAMETERI
-	gpProgramUniform1d                            C.GPPROGRAMUNIFORM1D
-	gpProgramUniform1dv                           C.GPPROGRAMUNIFORM1DV
-	gpProgramUniform1f                            C.GPPROGRAMUNIFORM1F
-	gpProgramUniform1fv                           C.GPPROGRAMUNIFORM1FV
-	gpProgramUniform1i                            C.GPPROGRAMUNIFORM1I
-	gpProgramUniform1iv                           C.GPPROGRAMUNIFORM1IV
-	gpProgramUniform1ui                           C.GPPROGRAMUNIFORM1UI
-	gpProgramUniform1uiv                          C.GPPROGRAMUNIFORM1UIV
-	gpProgramUniform2d                            C.GPPROGRAMUNIFORM2D
-	gpProgramUniform2dv                           C.GPPROGRAMUNIFORM2DV
-	gpProgramUniform2f                            C.GPPROGRAMUNIFORM2F
-	gpProgramUniform2fv                           C.GPPROGRAMUNIFORM2FV
-	gpProgramUniform2i                            C.GPPROGRAMUNIFORM2I
-	gpProgramUniform2iv                           C.GPPROGRAMUNIFORM2IV
-	gpProgramUniform2ui                           C.GPPROGRAMUNIFORM2UI
-	gpProgramUniform2uiv                          C.GPPROGRAMUNIFORM2UIV
-	gpProgramUniform3d                            C.GPPROGRAMUNIFORM3D
-	gpProgramUniform3dv                           C.GPPROGRAMUNIFORM3DV
-	gpProgramUniform3f                            C.GPPROGRAMUNIFORM3F
-	gpProgramUniform3fv                           C.GPPROGRAMUNIFORM3FV
-	gpProgramUniform3i                            C.GPPROGRAMUNIFORM3I
-	gpProgramUniform3iv                           C.GPPROGRAMUNIFORM3IV
-	gpProgramUniform3ui                           C.GPPROGRAMUNIFORM3UI
-	gpProgramUniform3uiv                          C.GPPROGRAMUNIFORM3UIV
-	gpProgramUniform4d                            C.GPPROGRAMUNIFORM4D
-	gpProgramUniform4dv                           C.GPPROGRAMUNIFORM4DV
-	gpProgramUniform4f                            C.GPPROGRAMUNIFORM4F
-	gpProgramUniform4fv                           C.GPPROGRAMUNIFORM4FV
-	gpProgramUniform4i                            C.GPPROGRAMUNIFORM4I
-	gpProgramUniform4iv                           C.GPPROGRAMUNIFORM4IV
-	gpProgramUniform4ui                           C.GPPROGRAMUNIFORM4UI
-	gpProgramUniform4uiv                          C.GPPROGRAMUNIFORM4UIV
-	gpProgramUniformHandleui64ARB                 C.GPPROGRAMUNIFORMHANDLEUI64ARB
-	gpProgramUniformHandleui64vARB                C.GPPROGRAMUNIFORMHANDLEUI64VARB
-	gpProgramUniformMatrix2dv                     C.GPPROGRAMUNIFORMMATRIX2DV
-	gpProgramUniformMatrix2fv                     C.GPPROGRAMUNIFORMMATRIX2FV
-	gpProgramUniformMatrix2x3dv                   C.GPPROGRAMUNIFORMMATRIX2X3DV
-	gpProgramUniformMatrix2x3fv                   C.GPPROGRAMUNIFORMMATRIX2X3FV
-	gpProgramUniformMatrix2x4dv                   C.GPPROGRAMUNIFORMMATRIX2X4DV
-	gpProgramUniformMatrix2x4fv                   C.GPPROGRAMUNIFORMMATRIX2X4FV
-	gpProgramUniformMatrix3dv                     C.GPPROGRAMUNIFORMMATRIX3DV
-	gpProgramUniformMatrix3fv                     C.GPPROGRAMUNIFORMMATRIX3FV
-	gpProgramUniformMatrix3x2dv                   C.GPPROGRAMUNIFORMMATRIX3X2DV
-	gpProgramUniformMatrix3x2fv                   C.GPPROGRAMUNIFORMMATRIX3X2FV
-	gpProgramUniformMatrix3x4dv                   C.GPPROGRAMUNIFORMMATRIX3X4DV
-	gpProgramUniformMatrix3x4fv                   C.GPPROGRAMUNIFORMMATRIX3X4FV
-	gpProgramUniformMatrix4dv                     C.GPPROGRAMUNIFORMMATRIX4DV
-	gpProgramUniformMatrix4fv                     C.GPPROGRAMUNIFORMMATRIX4FV
-	gpProgramUniformMatrix4x2dv                   C.GPPROGRAMUNIFORMMATRIX4X2DV
-	gpProgramUniformMatrix4x2fv                   C.GPPROGRAMUNIFORMMATRIX4X2FV
-	gpProgramUniformMatrix4x3dv                   C.GPPROGRAMUNIFORMMATRIX4X3DV
-	gpProgramUniformMatrix4x3fv                   C.GPPROGRAMUNIFORMMATRIX4X3FV
-	gpProvokingVertex                             C.GPPROVOKINGVERTEX
-	gpPushDebugGroup                              C.GPPUSHDEBUGGROUP
-	gpPushDebugGroupKHR                           C.GPPUSHDEBUGGROUPKHR
-	gpQueryCounter                                C.GPQUERYCOUNTER
-	gpReadBuffer                                  C.GPREADBUFFER
-	gpReadPixels                                  C.GPREADPIXELS
-	gpReadnPixels                                 C.GPREADNPIXELS
-	gpReadnPixelsARB                              C.GPREADNPIXELSARB
-	gpReadnPixelsKHR                              C.GPREADNPIXELSKHR
-	gpReleaseShaderCompiler                       C.GPRELEASESHADERCOMPILER
-	gpRenderbufferStorage                         C.GPRENDERBUFFERSTORAGE
-	gpRenderbufferStorageMultisample              C.GPRENDERBUFFERSTORAGEMULTISAMPLE
-	gpResumeTransformFeedback                     C.GPRESUMETRANSFORMFEEDBACK
-	gpSampleCoverage                              C.GPSAMPLECOVERAGE
-	gpSampleMaski                                 C.GPSAMPLEMASKI
-	gpSamplerParameterIiv                         C.GPSAMPLERPARAMETERIIV
-	gpSamplerParameterIuiv                        C.GPSAMPLERPARAMETERIUIV
-	gpSamplerParameterf                           C.GPSAMPLERPARAMETERF
-	gpSamplerParameterfv                          C.GPSAMPLERPARAMETERFV
-	gpSamplerParameteri                           C.GPSAMPLERPARAMETERI
-	gpSamplerParameteriv                          C.GPSAMPLERPARAMETERIV
-	gpScissor                                     C.GPSCISSOR
-	gpScissorArrayv                               C.GPSCISSORARRAYV
-	gpScissorIndexed                              C.GPSCISSORINDEXED
-	gpScissorIndexedv                             C.GPSCISSORINDEXEDV
-	gpShaderBinary                                C.GPSHADERBINARY
-	gpShaderSource                                C.GPSHADERSOURCE
-	gpShaderStorageBlockBinding                   C.GPSHADERSTORAGEBLOCKBINDING
-	gpStencilFunc                                 C.GPSTENCILFUNC
-	gpStencilFuncSeparate                         C.GPSTENCILFUNCSEPARATE
-	gpStencilMask                                 C.GPSTENCILMASK
-	gpStencilMaskSeparate                         C.GPSTENCILMASKSEPARATE
-	gpStencilOp                                   C.GPSTENCILOP
-	gpStencilOpSeparate                           C.GPSTENCILOPSEPARATE
-	gpTexBuffer                                   C.GPTEXBUFFER
-	gpTexBufferRange                              C.GPTEXBUFFERRANGE
-	gpTexImage1D                                  C.GPTEXIMAGE1D
-	gpTexImage2D                                  C.GPTEXIMAGE2D
-	gpTexImage2DMultisample                       C.GPTEXIMAGE2DMULTISAMPLE
-	gpTexImage3D                                  C.GPTEXIMAGE3D
-	gpTexImage3DMultisample                       C.GPTEXIMAGE3DMULTISAMPLE
-	gpTexPageCommitmentARB                        C.GPTEXPAGECOMMITMENTARB
-	gpTexParameterIiv                             C.GPTEXPARAMETERIIV
-	gpTexParameterIuiv                            C.GPTEXPARAMETERIUIV
-	gpTexParameterf                               C.GPTEXPARAMETERF
-	gpTexParameterfv                              C.GPTEXPARAMETERFV
-	gpTexParameteri                               C.GPTEXPARAMETERI
-	gpTexParameteriv                              C.GPTEXPARAMETERIV
-	gpTexStorage1D                                C.GPTEXSTORAGE1D
-	gpTexStorage2D                                C.GPTEXSTORAGE2D
-	gpTexStorage2DMultisample                     C.GPTEXSTORAGE2DMULTISAMPLE
-	gpTexStorage3D                                C.GPTEXSTORAGE3D
-	gpTexStorage3DMultisample                     C.GPTEXSTORAGE3DMULTISAMPLE
-	gpTexSubImage1D                               C.GPTEXSUBIMAGE1D
-	gpTexSubImage2D                               C.GPTEXSUBIMAGE2D
-	gpTexSubImage3D                               C.GPTEXSUBIMAGE3D
-	gpTextureBarrier                              C.GPTEXTUREBARRIER
-	gpTextureBuffer                               C.GPTEXTUREBUFFER
-	gpTextureBufferRange                          C.GPTEXTUREBUFFERRANGE
-	gpTextureParameterIiv                         C.GPTEXTUREPARAMETERIIV
-	gpTextureParameterIuiv                        C.GPTEXTUREPARAMETERIUIV
-	gpTextureParameterf                           C.GPTEXTUREPARAMETERF
-	gpTextureParameterfv                          C.GPTEXTUREPARAMETERFV
-	gpTextureParameteri                           C.GPTEXTUREPARAMETERI
-	gpTextureParameteriv                          C.GPTEXTUREPARAMETERIV
-	gpTextureStorage1D                            C.GPTEXTURESTORAGE1D
-	gpTextureStorage2D                            C.GPTEXTURESTORAGE2D
-	gpTextureStorage2DMultisample                 C.GPTEXTURESTORAGE2DMULTISAMPLE
-	gpTextureStorage3D                            C.GPTEXTURESTORAGE3D
-	gpTextureStorage3DMultisample                 C.GPTEXTURESTORAGE3DMULTISAMPLE
-	gpTextureSubImage1D                           C.GPTEXTURESUBIMAGE1D
-	gpTextureSubImage2D                           C.GPTEXTURESUBIMAGE2D
-	gpTextureSubImage3D                           C.GPTEXTURESUBIMAGE3D
-	gpTextureView                                 C.GPTEXTUREVIEW
-	gpTransformFeedbackBufferBase                 C.GPTRANSFORMFEEDBACKBUFFERBASE
-	gpTransformFeedbackBufferRange                C.GPTRANSFORMFEEDBACKBUFFERRANGE
-	gpTransformFeedbackVaryings                   C.GPTRANSFORMFEEDBACKVARYINGS
-	gpUniform1d                                   C.GPUNIFORM1D
-	gpUniform1dv                                  C.GPUNIFORM1DV
-	gpUniform1f                                   C.GPUNIFORM1F
-	gpUniform1fv                                  C.GPUNIFORM1FV
-	gpUniform1i                                   C.GPUNIFORM1I
-	gpUniform1iv                                  C.GPUNIFORM1IV
-	gpUniform1ui                                  C.GPUNIFORM1UI
-	gpUniform1uiv                                 C.GPUNIFORM1UIV
-	gpUniform2d                                   C.GPUNIFORM2D
-	gpUniform2dv                                  C.GPUNIFORM2DV
-	gpUniform2f                                   C.GPUNIFORM2F
-	gpUniform2fv                                  C.GPUNIFORM2FV
-	gpUniform2i                                   C.GPUNIFORM2I
-	gpUniform2iv                                  C.GPUNIFORM2IV
-	gpUniform2ui                                  C.GPUNIFORM2UI
-	gpUniform2uiv                                 C.GPUNIFORM2UIV
-	gpUniform3d                                   C.GPUNIFORM3D
-	gpUniform3dv                                  C.GPUNIFORM3DV
-	gpUniform3f                                   C.GPUNIFORM3F
-	gpUniform3fv                                  C.GPUNIFORM3FV
-	gpUniform3i                                   C.GPUNIFORM3I
-	gpUniform3iv                                  C.GPUNIFORM3IV
-	gpUniform3ui                                  C.GPUNIFORM3UI
-	gpUniform3uiv                                 C.GPUNIFORM3UIV
-	gpUniform4d                                   C.GPUNIFORM4D
-	gpUniform4dv                                  C.GPUNIFORM4DV
-	gpUniform4f                                   C.GPUNIFORM4F
-	gpUniform4fv                                  C.GPUNIFORM4FV
-	gpUniform4i                                   C.GPUNIFORM4I
-	gpUniform4iv                                  C.GPUNIFORM4IV
-	gpUniform4ui                                  C.GPUNIFORM4UI
-	gpUniform4uiv                                 C.GPUNIFORM4UIV
-	gpUniformBlockBinding                         C.GPUNIFORMBLOCKBINDING
-	gpUniformHandleui64ARB                        C.GPUNIFORMHANDLEUI64ARB
-	gpUniformHandleui64vARB                       C.GPUNIFORMHANDLEUI64VARB
-	gpUniformMatrix2dv                            C.GPUNIFORMMATRIX2DV
-	gpUniformMatrix2fv                            C.GPUNIFORMMATRIX2FV
-	gpUniformMatrix2x3dv                          C.GPUNIFORMMATRIX2X3DV
-	gpUniformMatrix2x3fv                          C.GPUNIFORMMATRIX2X3FV
-	gpUniformMatrix2x4dv                          C.GPUNIFORMMATRIX2X4DV
-	gpUniformMatrix2x4fv                          C.GPUNIFORMMATRIX2X4FV
-	gpUniformMatrix3dv                            C.GPUNIFORMMATRIX3DV
-	gpUniformMatrix3fv                            C.GPUNIFORMMATRIX3FV
-	gpUniformMatrix3x2dv                          C.GPUNIFORMMATRIX3X2DV
-	gpUniformMatrix3x2fv                          C.GPUNIFORMMATRIX3X2FV
-	gpUniformMatrix3x4dv                          C.GPUNIFORMMATRIX3X4DV
-	gpUniformMatrix3x4fv                          C.GPUNIFORMMATRIX3X4FV
-	gpUniformMatrix4dv                            C.GPUNIFORMMATRIX4DV
-	gpUniformMatrix4fv                            C.GPUNIFORMMATRIX4FV
-	gpUniformMatrix4x2dv                          C.GPUNIFORMMATRIX4X2DV
-	gpUniformMatrix4x2fv                          C.GPUNIFORMMATRIX4X2FV
-	gpUniformMatrix4x3dv                          C.GPUNIFORMMATRIX4X3DV
-	gpUniformMatrix4x3fv                          C.GPUNIFORMMATRIX4X3FV
-	gpUniformSubroutinesuiv                       C.GPUNIFORMSUBROUTINESUIV
-	gpUnmapBuffer                                 C.GPUNMAPBUFFER
-	gpUnmapNamedBuffer                            C.GPUNMAPNAMEDBUFFER
-	gpUseProgram                                  C.GPUSEPROGRAM
-	gpUseProgramStages                            C.GPUSEPROGRAMSTAGES
-	gpValidateProgram                             C.GPVALIDATEPROGRAM
-	gpValidateProgramPipeline                     C.GPVALIDATEPROGRAMPIPELINE
-	gpVertexArrayAttribBinding                    C.GPVERTEXARRAYATTRIBBINDING
-	gpVertexArrayAttribFormat                     C.GPVERTEXARRAYATTRIBFORMAT
-	gpVertexArrayAttribIFormat                    C.GPVERTEXARRAYATTRIBIFORMAT
-	gpVertexArrayAttribLFormat                    C.GPVERTEXARRAYATTRIBLFORMAT
-	gpVertexArrayBindingDivisor                   C.GPVERTEXARRAYBINDINGDIVISOR
-	gpVertexArrayElementBuffer                    C.GPVERTEXARRAYELEMENTBUFFER
-	gpVertexArrayVertexBuffer                     C.GPVERTEXARRAYVERTEXBUFFER
-	gpVertexArrayVertexBuffers                    C.GPVERTEXARRAYVERTEXBUFFERS
-	gpVertexAttrib1d                              C.GPVERTEXATTRIB1D
-	gpVertexAttrib1dv                             C.GPVERTEXATTRIB1DV
-	gpVertexAttrib1f                              C.GPVERTEXATTRIB1F
-	gpVertexAttrib1fv                             C.GPVERTEXATTRIB1FV
-	gpVertexAttrib1s                              C.GPVERTEXATTRIB1S
-	gpVertexAttrib1sv                             C.GPVERTEXATTRIB1SV
-	gpVertexAttrib2d                              C.GPVERTEXATTRIB2D
-	gpVertexAttrib2dv                             C.GPVERTEXATTRIB2DV
-	gpVertexAttrib2f                              C.GPVERTEXATTRIB2F
-	gpVertexAttrib2fv                             C.GPVERTEXATTRIB2FV
-	gpVertexAttrib2s                              C.GPVERTEXATTRIB2S
-	gpVertexAttrib2sv                             C.GPVERTEXATTRIB2SV
-	gpVertexAttrib3d                              C.GPVERTEXATTRIB3D
-	gpVertexAttrib3dv                             C.GPVERTEXATTRIB3DV
-	gpVertexAttrib3f                              C.GPVERTEXATTRIB3F
-	gpVertexAttrib3fv                             C.GPVERTEXATTRIB3FV
-	gpVertexAttrib3s                              C.GPVERTEXATTRIB3S
-	gpVertexAttrib3sv                             C.GPVERTEXATTRIB3SV
-	gpVertexAttrib4Nbv                            C.GPVERTEXATTRIB4NBV
-	gpVertexAttrib4Niv                            C.GPVERTEXATTRIB4NIV
-	gpVertexAttrib4Nsv                            C.GPVERTEXATTRIB4NSV
-	gpVertexAttrib4Nub                            C.GPVERTEXATTRIB4NUB
-	gpVertexAttrib4Nubv                           C.GPVERTEXATTRIB4NUBV
-	gpVertexAttrib4Nuiv                           C.GPVERTEXATTRIB4NUIV
-	gpVertexAttrib4Nusv                           C.GPVERTEXATTRIB4NUSV
-	gpVertexAttrib4bv                             C.GPVERTEXATTRIB4BV
-	gpVertexAttrib4d                              C.GPVERTEXATTRIB4D
-	gpVertexAttrib4dv                             C.GPVERTEXATTRIB4DV
-	gpVertexAttrib4f                              C.GPVERTEXATTRIB4F
-	gpVertexAttrib4fv                             C.GPVERTEXATTRIB4FV
-	gpVertexAttrib4iv                             C.GPVERTEXATTRIB4IV
-	gpVertexAttrib4s                              C.GPVERTEXATTRIB4S
-	gpVertexAttrib4sv                             C.GPVERTEXATTRIB4SV
-	gpVertexAttrib4ubv                            C.GPVERTEXATTRIB4UBV
-	gpVertexAttrib4uiv                            C.GPVERTEXATTRIB4UIV
-	gpVertexAttrib4usv                            C.GPVERTEXATTRIB4USV
-	gpVertexAttribBinding                         C.GPVERTEXATTRIBBINDING
-	gpVertexAttribDivisor                         C.GPVERTEXATTRIBDIVISOR
-	gpVertexAttribFormat                          C.GPVERTEXATTRIBFORMAT
-	gpVertexAttribI1i                             C.GPVERTEXATTRIBI1I
-	gpVertexAttribI1iv                            C.GPVERTEXATTRIBI1IV
-	gpVertexAttribI1ui                            C.GPVERTEXATTRIBI1UI
-	gpVertexAttribI1uiv                           C.GPVERTEXATTRIBI1UIV
-	gpVertexAttribI2i                             C.GPVERTEXATTRIBI2I
-	gpVertexAttribI2iv                            C.GPVERTEXATTRIBI2IV
-	gpVertexAttribI2ui                            C.GPVERTEXATTRIBI2UI
-	gpVertexAttribI2uiv                           C.GPVERTEXATTRIBI2UIV
-	gpVertexAttribI3i                             C.GPVERTEXATTRIBI3I
-	gpVertexAttribI3iv                            C.GPVERTEXATTRIBI3IV
-	gpVertexAttribI3ui                            C.GPVERTEXATTRIBI3UI
-	gpVertexAttribI3uiv                           C.GPVERTEXATTRIBI3UIV
-	gpVertexAttribI4bv                            C.GPVERTEXATTRIBI4BV
-	gpVertexAttribI4i                             C.GPVERTEXATTRIBI4I
-	gpVertexAttribI4iv                            C.GPVERTEXATTRIBI4IV
-	gpVertexAttribI4sv                            C.GPVERTEXATTRIBI4SV
-	gpVertexAttribI4ubv                           C.GPVERTEXATTRIBI4UBV
-	gpVertexAttribI4ui                            C.GPVERTEXATTRIBI4UI
-	gpVertexAttribI4uiv                           C.GPVERTEXATTRIBI4UIV
-	gpVertexAttribI4usv                           C.GPVERTEXATTRIBI4USV
-	gpVertexAttribIFormat                         C.GPVERTEXATTRIBIFORMAT
-	gpVertexAttribIPointer                        C.GPVERTEXATTRIBIPOINTER
-	gpVertexAttribL1d                             C.GPVERTEXATTRIBL1D
-	gpVertexAttribL1dv                            C.GPVERTEXATTRIBL1DV
-	gpVertexAttribL1ui64ARB                       C.GPVERTEXATTRIBL1UI64ARB
-	gpVertexAttribL1ui64vARB                      C.GPVERTEXATTRIBL1UI64VARB
-	gpVertexAttribL2d                             C.GPVERTEXATTRIBL2D
-	gpVertexAttribL2dv                            C.GPVERTEXATTRIBL2DV
-	gpVertexAttribL3d                             C.GPVERTEXATTRIBL3D
-	gpVertexAttribL3dv                            C.GPVERTEXATTRIBL3DV
-	gpVertexAttribL4d                             C.GPVERTEXATTRIBL4D
-	gpVertexAttribL4dv                            C.GPVERTEXATTRIBL4DV
-	gpVertexAttribLFormat                         C.GPVERTEXATTRIBLFORMAT
-	gpVertexAttribLPointer                        C.GPVERTEXATTRIBLPOINTER
-	gpVertexAttribP1ui                            C.GPVERTEXATTRIBP1UI
-	gpVertexAttribP1uiv                           C.GPVERTEXATTRIBP1UIV
-	gpVertexAttribP2ui                            C.GPVERTEXATTRIBP2UI
-	gpVertexAttribP2uiv                           C.GPVERTEXATTRIBP2UIV
-	gpVertexAttribP3ui                            C.GPVERTEXATTRIBP3UI
-	gpVertexAttribP3uiv                           C.GPVERTEXATTRIBP3UIV
-	gpVertexAttribP4ui                            C.GPVERTEXATTRIBP4UI
-	gpVertexAttribP4uiv                           C.GPVERTEXATTRIBP4UIV
-	gpVertexAttribPointer                         C.GPVERTEXATTRIBPOINTER
-	gpVertexBindingDivisor                        C.GPVERTEXBINDINGDIVISOR
-	gpViewport                                    C.GPVIEWPORT
-	gpViewportArrayv                              C.GPVIEWPORTARRAYV
-	gpViewportIndexedf                            C.GPVIEWPORTINDEXEDF
-	gpViewportIndexedfv                           C.GPVIEWPORTINDEXEDFV
-	gpWaitSync                                    C.GPWAITSYNC
+	gpActiveProgramEXT                               C.GPACTIVEPROGRAMEXT
+	gpActiveShaderProgram                            C.GPACTIVESHADERPROGRAM
+	gpActiveShaderProgramEXT                         C.GPACTIVESHADERPROGRAMEXT
+	gpActiveTexture                                  C.GPACTIVETEXTURE
+	gpApplyFramebufferAttachmentCMAAINTEL            C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
+	gpAttachShader                                   C.GPATTACHSHADER
+	gpBeginConditionalRender                         C.GPBEGINCONDITIONALRENDER
+	gpBeginConditionalRenderNV                       C.GPBEGINCONDITIONALRENDERNV
+	gpBeginPerfMonitorAMD                            C.GPBEGINPERFMONITORAMD
+	gpBeginPerfQueryINTEL                            C.GPBEGINPERFQUERYINTEL
+	gpBeginQuery                                     C.GPBEGINQUERY
+	gpBeginQueryIndexed                              C.GPBEGINQUERYINDEXED
+	gpBeginTransformFeedback                         C.GPBEGINTRANSFORMFEEDBACK
+	gpBindAttribLocation                             C.GPBINDATTRIBLOCATION
+	gpBindBuffer                                     C.GPBINDBUFFER
+	gpBindBufferBase                                 C.GPBINDBUFFERBASE
+	gpBindBufferRange                                C.GPBINDBUFFERRANGE
+	gpBindBuffersBase                                C.GPBINDBUFFERSBASE
+	gpBindBuffersRange                               C.GPBINDBUFFERSRANGE
+	gpBindFragDataLocation                           C.GPBINDFRAGDATALOCATION
+	gpBindFragDataLocationIndexed                    C.GPBINDFRAGDATALOCATIONINDEXED
+	gpBindFramebuffer                                C.GPBINDFRAMEBUFFER
+	gpBindImageTexture                               C.GPBINDIMAGETEXTURE
+	gpBindImageTextures                              C.GPBINDIMAGETEXTURES
+	gpBindMultiTextureEXT                            C.GPBINDMULTITEXTUREEXT
+	gpBindProgramPipeline                            C.GPBINDPROGRAMPIPELINE
+	gpBindProgramPipelineEXT                         C.GPBINDPROGRAMPIPELINEEXT
+	gpBindRenderbuffer                               C.GPBINDRENDERBUFFER
+	gpBindSampler                                    C.GPBINDSAMPLER
+	gpBindSamplers                                   C.GPBINDSAMPLERS
+	gpBindTexture                                    C.GPBINDTEXTURE
+	gpBindTextureUnit                                C.GPBINDTEXTUREUNIT
+	gpBindTextures                                   C.GPBINDTEXTURES
+	gpBindTransformFeedback                          C.GPBINDTRANSFORMFEEDBACK
+	gpBindVertexArray                                C.GPBINDVERTEXARRAY
+	gpBindVertexBuffer                               C.GPBINDVERTEXBUFFER
+	gpBindVertexBuffers                              C.GPBINDVERTEXBUFFERS
+	gpBlendBarrierKHR                                C.GPBLENDBARRIERKHR
+	gpBlendBarrierNV                                 C.GPBLENDBARRIERNV
+	gpBlendColor                                     C.GPBLENDCOLOR
+	gpBlendEquation                                  C.GPBLENDEQUATION
+	gpBlendEquationSeparate                          C.GPBLENDEQUATIONSEPARATE
+	gpBlendEquationSeparateiARB                      C.GPBLENDEQUATIONSEPARATEIARB
+	gpBlendEquationiARB                              C.GPBLENDEQUATIONIARB
+	gpBlendFunc                                      C.GPBLENDFUNC
+	gpBlendFuncSeparate                              C.GPBLENDFUNCSEPARATE
+	gpBlendFuncSeparateiARB                          C.GPBLENDFUNCSEPARATEIARB
+	gpBlendFunciARB                                  C.GPBLENDFUNCIARB
+	gpBlendParameteriNV                              C.GPBLENDPARAMETERINV
+	gpBlitFramebuffer                                C.GPBLITFRAMEBUFFER
+	gpBlitNamedFramebuffer                           C.GPBLITNAMEDFRAMEBUFFER
+	gpBufferAddressRangeNV                           C.GPBUFFERADDRESSRANGENV
+	gpBufferData                                     C.GPBUFFERDATA
+	gpBufferPageCommitmentARB                        C.GPBUFFERPAGECOMMITMENTARB
+	gpBufferStorage                                  C.GPBUFFERSTORAGE
+	gpBufferSubData                                  C.GPBUFFERSUBDATA
+	gpCallCommandListNV                              C.GPCALLCOMMANDLISTNV
+	gpCheckFramebufferStatus                         C.GPCHECKFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatus                    C.GPCHECKNAMEDFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatusEXT                 C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT
+	gpClampColor                                     C.GPCLAMPCOLOR
+	gpClear                                          C.GPCLEAR
+	gpClearBufferData                                C.GPCLEARBUFFERDATA
+	gpClearBufferSubData                             C.GPCLEARBUFFERSUBDATA
+	gpClearBufferfi                                  C.GPCLEARBUFFERFI
+	gpClearBufferfv                                  C.GPCLEARBUFFERFV
+	gpClearBufferiv                                  C.GPCLEARBUFFERIV
+	gpClearBufferuiv                                 C.GPCLEARBUFFERUIV
+	gpClearColor                                     C.GPCLEARCOLOR
+	gpClearDepth                                     C.GPCLEARDEPTH
+	gpClearDepthf                                    C.GPCLEARDEPTHF
+	gpClearNamedBufferData                           C.GPCLEARNAMEDBUFFERDATA
+	gpClearNamedBufferDataEXT                        C.GPCLEARNAMEDBUFFERDATAEXT
+	gpClearNamedBufferSubData                        C.GPCLEARNAMEDBUFFERSUBDATA
+	gpClearNamedBufferSubDataEXT                     C.GPCLEARNAMEDBUFFERSUBDATAEXT
+	gpClearNamedFramebufferfi                        C.GPCLEARNAMEDFRAMEBUFFERFI
+	gpClearNamedFramebufferfv                        C.GPCLEARNAMEDFRAMEBUFFERFV
+	gpClearNamedFramebufferiv                        C.GPCLEARNAMEDFRAMEBUFFERIV
+	gpClearNamedFramebufferuiv                       C.GPCLEARNAMEDFRAMEBUFFERUIV
+	gpClearStencil                                   C.GPCLEARSTENCIL
+	gpClearTexImage                                  C.GPCLEARTEXIMAGE
+	gpClearTexSubImage                               C.GPCLEARTEXSUBIMAGE
+	gpClientAttribDefaultEXT                         C.GPCLIENTATTRIBDEFAULTEXT
+	gpClientWaitSync                                 C.GPCLIENTWAITSYNC
+	gpClipControl                                    C.GPCLIPCONTROL
+	gpColorFormatNV                                  C.GPCOLORFORMATNV
+	gpColorMask                                      C.GPCOLORMASK
+	gpColorMaski                                     C.GPCOLORMASKI
+	gpCommandListSegmentsNV                          C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                           C.GPCOMPILECOMMANDLISTNV
+	gpCompileShader                                  C.GPCOMPILESHADER
+	gpCompileShaderIncludeARB                        C.GPCOMPILESHADERINCLUDEARB
+	gpCompressedMultiTexImage1DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE1DEXT
+	gpCompressedMultiTexImage2DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE2DEXT
+	gpCompressedMultiTexImage3DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE3DEXT
+	gpCompressedMultiTexSubImage1DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT
+	gpCompressedMultiTexSubImage2DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT
+	gpCompressedMultiTexSubImage3DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT
+	gpCompressedTexImage1D                           C.GPCOMPRESSEDTEXIMAGE1D
+	gpCompressedTexImage2D                           C.GPCOMPRESSEDTEXIMAGE2D
+	gpCompressedTexImage3D                           C.GPCOMPRESSEDTEXIMAGE3D
+	gpCompressedTexSubImage1D                        C.GPCOMPRESSEDTEXSUBIMAGE1D
+	gpCompressedTexSubImage2D                        C.GPCOMPRESSEDTEXSUBIMAGE2D
+	gpCompressedTexSubImage3D                        C.GPCOMPRESSEDTEXSUBIMAGE3D
+	gpCompressedTextureImage1DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE1DEXT
+	gpCompressedTextureImage2DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE2DEXT
+	gpCompressedTextureImage3DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE3DEXT
+	gpCompressedTextureSubImage1D                    C.GPCOMPRESSEDTEXTURESUBIMAGE1D
+	gpCompressedTextureSubImage1DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT
+	gpCompressedTextureSubImage2D                    C.GPCOMPRESSEDTEXTURESUBIMAGE2D
+	gpCompressedTextureSubImage2DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
+	gpCompressedTextureSubImage3D                    C.GPCOMPRESSEDTEXTURESUBIMAGE3D
+	gpCompressedTextureSubImage3DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                 C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                 C.GPCONSERVATIVERASTERPARAMETERINV
+	gpCopyBufferSubData                              C.GPCOPYBUFFERSUBDATA
+	gpCopyImageSubData                               C.GPCOPYIMAGESUBDATA
+	gpCopyMultiTexImage1DEXT                         C.GPCOPYMULTITEXIMAGE1DEXT
+	gpCopyMultiTexImage2DEXT                         C.GPCOPYMULTITEXIMAGE2DEXT
+	gpCopyMultiTexSubImage1DEXT                      C.GPCOPYMULTITEXSUBIMAGE1DEXT
+	gpCopyMultiTexSubImage2DEXT                      C.GPCOPYMULTITEXSUBIMAGE2DEXT
+	gpCopyMultiTexSubImage3DEXT                      C.GPCOPYMULTITEXSUBIMAGE3DEXT
+	gpCopyNamedBufferSubData                         C.GPCOPYNAMEDBUFFERSUBDATA
+	gpCopyPathNV                                     C.GPCOPYPATHNV
+	gpCopyTexImage1D                                 C.GPCOPYTEXIMAGE1D
+	gpCopyTexImage2D                                 C.GPCOPYTEXIMAGE2D
+	gpCopyTexSubImage1D                              C.GPCOPYTEXSUBIMAGE1D
+	gpCopyTexSubImage2D                              C.GPCOPYTEXSUBIMAGE2D
+	gpCopyTexSubImage3D                              C.GPCOPYTEXSUBIMAGE3D
+	gpCopyTextureImage1DEXT                          C.GPCOPYTEXTUREIMAGE1DEXT
+	gpCopyTextureImage2DEXT                          C.GPCOPYTEXTUREIMAGE2DEXT
+	gpCopyTextureSubImage1D                          C.GPCOPYTEXTURESUBIMAGE1D
+	gpCopyTextureSubImage1DEXT                       C.GPCOPYTEXTURESUBIMAGE1DEXT
+	gpCopyTextureSubImage2D                          C.GPCOPYTEXTURESUBIMAGE2D
+	gpCopyTextureSubImage2DEXT                       C.GPCOPYTEXTURESUBIMAGE2DEXT
+	gpCopyTextureSubImage3D                          C.GPCOPYTEXTURESUBIMAGE3D
+	gpCopyTextureSubImage3DEXT                       C.GPCOPYTEXTURESUBIMAGE3DEXT
+	gpCoverFillPathInstancedNV                       C.GPCOVERFILLPATHINSTANCEDNV
+	gpCoverFillPathNV                                C.GPCOVERFILLPATHNV
+	gpCoverStrokePathInstancedNV                     C.GPCOVERSTROKEPATHINSTANCEDNV
+	gpCoverStrokePathNV                              C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                           C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                      C.GPCOVERAGEMODULATIONTABLENV
+	gpCreateBuffers                                  C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                           C.GPCREATECOMMANDLISTSNV
+	gpCreateFramebuffers                             C.GPCREATEFRAMEBUFFERS
+	gpCreatePerfQueryINTEL                           C.GPCREATEPERFQUERYINTEL
+	gpCreateProgram                                  C.GPCREATEPROGRAM
+	gpCreateProgramPipelines                         C.GPCREATEPROGRAMPIPELINES
+	gpCreateQueries                                  C.GPCREATEQUERIES
+	gpCreateRenderbuffers                            C.GPCREATERENDERBUFFERS
+	gpCreateSamplers                                 C.GPCREATESAMPLERS
+	gpCreateShader                                   C.GPCREATESHADER
+	gpCreateShaderProgramEXT                         C.GPCREATESHADERPROGRAMEXT
+	gpCreateShaderProgramv                           C.GPCREATESHADERPROGRAMV
+	gpCreateShaderProgramvEXT                        C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                 C.GPCREATESTATESNV
+	gpCreateSyncFromCLeventARB                       C.GPCREATESYNCFROMCLEVENTARB
+	gpCreateTextures                                 C.GPCREATETEXTURES
+	gpCreateTransformFeedbacks                       C.GPCREATETRANSFORMFEEDBACKS
+	gpCreateVertexArrays                             C.GPCREATEVERTEXARRAYS
+	gpCullFace                                       C.GPCULLFACE
+	gpDebugMessageCallback                           C.GPDEBUGMESSAGECALLBACK
+	gpDebugMessageCallbackARB                        C.GPDEBUGMESSAGECALLBACKARB
+	gpDebugMessageCallbackKHR                        C.GPDEBUGMESSAGECALLBACKKHR
+	gpDebugMessageControl                            C.GPDEBUGMESSAGECONTROL
+	gpDebugMessageControlARB                         C.GPDEBUGMESSAGECONTROLARB
+	gpDebugMessageControlKHR                         C.GPDEBUGMESSAGECONTROLKHR
+	gpDebugMessageInsert                             C.GPDEBUGMESSAGEINSERT
+	gpDebugMessageInsertARB                          C.GPDEBUGMESSAGEINSERTARB
+	gpDebugMessageInsertKHR                          C.GPDEBUGMESSAGEINSERTKHR
+	gpDeleteBuffers                                  C.GPDELETEBUFFERS
+	gpDeleteCommandListsNV                           C.GPDELETECOMMANDLISTSNV
+	gpDeleteFramebuffers                             C.GPDELETEFRAMEBUFFERS
+	gpDeleteNamedStringARB                           C.GPDELETENAMEDSTRINGARB
+	gpDeletePathsNV                                  C.GPDELETEPATHSNV
+	gpDeletePerfMonitorsAMD                          C.GPDELETEPERFMONITORSAMD
+	gpDeletePerfQueryINTEL                           C.GPDELETEPERFQUERYINTEL
+	gpDeleteProgram                                  C.GPDELETEPROGRAM
+	gpDeleteProgramPipelines                         C.GPDELETEPROGRAMPIPELINES
+	gpDeleteProgramPipelinesEXT                      C.GPDELETEPROGRAMPIPELINESEXT
+	gpDeleteQueries                                  C.GPDELETEQUERIES
+	gpDeleteRenderbuffers                            C.GPDELETERENDERBUFFERS
+	gpDeleteSamplers                                 C.GPDELETESAMPLERS
+	gpDeleteShader                                   C.GPDELETESHADER
+	gpDeleteStatesNV                                 C.GPDELETESTATESNV
+	gpDeleteSync                                     C.GPDELETESYNC
+	gpDeleteTextures                                 C.GPDELETETEXTURES
+	gpDeleteTransformFeedbacks                       C.GPDELETETRANSFORMFEEDBACKS
+	gpDeleteVertexArrays                             C.GPDELETEVERTEXARRAYS
+	gpDepthFunc                                      C.GPDEPTHFUNC
+	gpDepthMask                                      C.GPDEPTHMASK
+	gpDepthRange                                     C.GPDEPTHRANGE
+	gpDepthRangeArrayv                               C.GPDEPTHRANGEARRAYV
+	gpDepthRangeIndexed                              C.GPDEPTHRANGEINDEXED
+	gpDepthRangef                                    C.GPDEPTHRANGEF
+	gpDetachShader                                   C.GPDETACHSHADER
+	gpDisable                                        C.GPDISABLE
+	gpDisableClientStateIndexedEXT                   C.GPDISABLECLIENTSTATEINDEXEDEXT
+	gpDisableClientStateiEXT                         C.GPDISABLECLIENTSTATEIEXT
+	gpDisableIndexedEXT                              C.GPDISABLEINDEXEDEXT
+	gpDisableVertexArrayAttrib                       C.GPDISABLEVERTEXARRAYATTRIB
+	gpDisableVertexArrayAttribEXT                    C.GPDISABLEVERTEXARRAYATTRIBEXT
+	gpDisableVertexArrayEXT                          C.GPDISABLEVERTEXARRAYEXT
+	gpDisableVertexAttribArray                       C.GPDISABLEVERTEXATTRIBARRAY
+	gpDisablei                                       C.GPDISABLEI
+	gpDispatchCompute                                C.GPDISPATCHCOMPUTE
+	gpDispatchComputeGroupSizeARB                    C.GPDISPATCHCOMPUTEGROUPSIZEARB
+	gpDispatchComputeIndirect                        C.GPDISPATCHCOMPUTEINDIRECT
+	gpDrawArrays                                     C.GPDRAWARRAYS
+	gpDrawArraysIndirect                             C.GPDRAWARRAYSINDIRECT
+	gpDrawArraysInstanced                            C.GPDRAWARRAYSINSTANCED
+	gpDrawArraysInstancedARB                         C.GPDRAWARRAYSINSTANCEDARB
+	gpDrawArraysInstancedBaseInstance                C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
+	gpDrawArraysInstancedEXT                         C.GPDRAWARRAYSINSTANCEDEXT
+	gpDrawBuffer                                     C.GPDRAWBUFFER
+	gpDrawBuffers                                    C.GPDRAWBUFFERS
+	gpDrawCommandsAddressNV                          C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                 C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                    C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                           C.GPDRAWCOMMANDSSTATESNV
+	gpDrawElements                                   C.GPDRAWELEMENTS
+	gpDrawElementsBaseVertex                         C.GPDRAWELEMENTSBASEVERTEX
+	gpDrawElementsIndirect                           C.GPDRAWELEMENTSINDIRECT
+	gpDrawElementsInstanced                          C.GPDRAWELEMENTSINSTANCED
+	gpDrawElementsInstancedARB                       C.GPDRAWELEMENTSINSTANCEDARB
+	gpDrawElementsInstancedBaseInstance              C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
+	gpDrawElementsInstancedBaseVertex                C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
+	gpDrawElementsInstancedBaseVertexBaseInstance    C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
+	gpDrawElementsInstancedEXT                       C.GPDRAWELEMENTSINSTANCEDEXT
+	gpDrawRangeElements                              C.GPDRAWRANGEELEMENTS
+	gpDrawRangeElementsBaseVertex                    C.GPDRAWRANGEELEMENTSBASEVERTEX
+	gpDrawTransformFeedback                          C.GPDRAWTRANSFORMFEEDBACK
+	gpDrawTransformFeedbackInstanced                 C.GPDRAWTRANSFORMFEEDBACKINSTANCED
+	gpDrawTransformFeedbackStream                    C.GPDRAWTRANSFORMFEEDBACKSTREAM
+	gpDrawTransformFeedbackStreamInstanced           C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                  C.GPDRAWVKIMAGENV
+	gpEdgeFlagFormatNV                               C.GPEDGEFLAGFORMATNV
+	gpEnable                                         C.GPENABLE
+	gpEnableClientStateIndexedEXT                    C.GPENABLECLIENTSTATEINDEXEDEXT
+	gpEnableClientStateiEXT                          C.GPENABLECLIENTSTATEIEXT
+	gpEnableIndexedEXT                               C.GPENABLEINDEXEDEXT
+	gpEnableVertexArrayAttrib                        C.GPENABLEVERTEXARRAYATTRIB
+	gpEnableVertexArrayAttribEXT                     C.GPENABLEVERTEXARRAYATTRIBEXT
+	gpEnableVertexArrayEXT                           C.GPENABLEVERTEXARRAYEXT
+	gpEnableVertexAttribArray                        C.GPENABLEVERTEXATTRIBARRAY
+	gpEnablei                                        C.GPENABLEI
+	gpEndConditionalRender                           C.GPENDCONDITIONALRENDER
+	gpEndConditionalRenderNV                         C.GPENDCONDITIONALRENDERNV
+	gpEndPerfMonitorAMD                              C.GPENDPERFMONITORAMD
+	gpEndPerfQueryINTEL                              C.GPENDPERFQUERYINTEL
+	gpEndQuery                                       C.GPENDQUERY
+	gpEndQueryIndexed                                C.GPENDQUERYINDEXED
+	gpEndTransformFeedback                           C.GPENDTRANSFORMFEEDBACK
+	gpEvaluateDepthValuesARB                         C.GPEVALUATEDEPTHVALUESARB
+	gpFenceSync                                      C.GPFENCESYNC
+	gpFinish                                         C.GPFINISH
+	gpFlush                                          C.GPFLUSH
+	gpFlushMappedBufferRange                         C.GPFLUSHMAPPEDBUFFERRANGE
+	gpFlushMappedNamedBufferRange                    C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
+	gpFlushMappedNamedBufferRangeEXT                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT
+	gpFogCoordFormatNV                               C.GPFOGCOORDFORMATNV
+	gpFragmentCoverageColorNV                        C.GPFRAGMENTCOVERAGECOLORNV
+	gpFramebufferDrawBufferEXT                       C.GPFRAMEBUFFERDRAWBUFFEREXT
+	gpFramebufferDrawBuffersEXT                      C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                     C.GPFRAMEBUFFERFETCHBARRIEREXT
+	gpFramebufferParameteri                          C.GPFRAMEBUFFERPARAMETERI
+	gpFramebufferReadBufferEXT                       C.GPFRAMEBUFFERREADBUFFEREXT
+	gpFramebufferRenderbuffer                        C.GPFRAMEBUFFERRENDERBUFFER
+	gpFramebufferSampleLocationsfvARB                C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                 C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferTexture                             C.GPFRAMEBUFFERTEXTURE
+	gpFramebufferTexture1D                           C.GPFRAMEBUFFERTEXTURE1D
+	gpFramebufferTexture2D                           C.GPFRAMEBUFFERTEXTURE2D
+	gpFramebufferTexture3D                           C.GPFRAMEBUFFERTEXTURE3D
+	gpFramebufferTextureARB                          C.GPFRAMEBUFFERTEXTUREARB
+	gpFramebufferTextureFaceARB                      C.GPFRAMEBUFFERTEXTUREFACEARB
+	gpFramebufferTextureLayer                        C.GPFRAMEBUFFERTEXTURELAYER
+	gpFramebufferTextureLayerARB                     C.GPFRAMEBUFFERTEXTURELAYERARB
+	gpFramebufferTextureMultiviewOVR                 C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
+	gpFrontFace                                      C.GPFRONTFACE
+	gpGenBuffers                                     C.GPGENBUFFERS
+	gpGenFramebuffers                                C.GPGENFRAMEBUFFERS
+	gpGenPathsNV                                     C.GPGENPATHSNV
+	gpGenPerfMonitorsAMD                             C.GPGENPERFMONITORSAMD
+	gpGenProgramPipelines                            C.GPGENPROGRAMPIPELINES
+	gpGenProgramPipelinesEXT                         C.GPGENPROGRAMPIPELINESEXT
+	gpGenQueries                                     C.GPGENQUERIES
+	gpGenRenderbuffers                               C.GPGENRENDERBUFFERS
+	gpGenSamplers                                    C.GPGENSAMPLERS
+	gpGenTextures                                    C.GPGENTEXTURES
+	gpGenTransformFeedbacks                          C.GPGENTRANSFORMFEEDBACKS
+	gpGenVertexArrays                                C.GPGENVERTEXARRAYS
+	gpGenerateMipmap                                 C.GPGENERATEMIPMAP
+	gpGenerateMultiTexMipmapEXT                      C.GPGENERATEMULTITEXMIPMAPEXT
+	gpGenerateTextureMipmap                          C.GPGENERATETEXTUREMIPMAP
+	gpGenerateTextureMipmapEXT                       C.GPGENERATETEXTUREMIPMAPEXT
+	gpGetActiveAtomicCounterBufferiv                 C.GPGETACTIVEATOMICCOUNTERBUFFERIV
+	gpGetActiveAttrib                                C.GPGETACTIVEATTRIB
+	gpGetActiveSubroutineName                        C.GPGETACTIVESUBROUTINENAME
+	gpGetActiveSubroutineUniformName                 C.GPGETACTIVESUBROUTINEUNIFORMNAME
+	gpGetActiveSubroutineUniformiv                   C.GPGETACTIVESUBROUTINEUNIFORMIV
+	gpGetActiveUniform                               C.GPGETACTIVEUNIFORM
+	gpGetActiveUniformBlockName                      C.GPGETACTIVEUNIFORMBLOCKNAME
+	gpGetActiveUniformBlockiv                        C.GPGETACTIVEUNIFORMBLOCKIV
+	gpGetActiveUniformName                           C.GPGETACTIVEUNIFORMNAME
+	gpGetActiveUniformsiv                            C.GPGETACTIVEUNIFORMSIV
+	gpGetAttachedShaders                             C.GPGETATTACHEDSHADERS
+	gpGetAttribLocation                              C.GPGETATTRIBLOCATION
+	gpGetBooleanIndexedvEXT                          C.GPGETBOOLEANINDEXEDVEXT
+	gpGetBooleani_v                                  C.GPGETBOOLEANI_V
+	gpGetBooleanv                                    C.GPGETBOOLEANV
+	gpGetBufferParameteri64v                         C.GPGETBUFFERPARAMETERI64V
+	gpGetBufferParameteriv                           C.GPGETBUFFERPARAMETERIV
+	gpGetBufferParameterui64vNV                      C.GPGETBUFFERPARAMETERUI64VNV
+	gpGetBufferPointerv                              C.GPGETBUFFERPOINTERV
+	gpGetBufferSubData                               C.GPGETBUFFERSUBDATA
+	gpGetCommandHeaderNV                             C.GPGETCOMMANDHEADERNV
+	gpGetCompressedMultiTexImageEXT                  C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
+	gpGetCompressedTexImage                          C.GPGETCOMPRESSEDTEXIMAGE
+	gpGetCompressedTextureImage                      C.GPGETCOMPRESSEDTEXTUREIMAGE
+	gpGetCompressedTextureImageEXT                   C.GPGETCOMPRESSEDTEXTUREIMAGEEXT
+	gpGetCompressedTextureSubImage                   C.GPGETCOMPRESSEDTEXTURESUBIMAGE
+	gpGetCoverageModulationTableNV                   C.GPGETCOVERAGEMODULATIONTABLENV
+	gpGetDebugMessageLog                             C.GPGETDEBUGMESSAGELOG
+	gpGetDebugMessageLogARB                          C.GPGETDEBUGMESSAGELOGARB
+	gpGetDebugMessageLogKHR                          C.GPGETDEBUGMESSAGELOGKHR
+	gpGetDoubleIndexedvEXT                           C.GPGETDOUBLEINDEXEDVEXT
+	gpGetDoublei_v                                   C.GPGETDOUBLEI_V
+	gpGetDoublei_vEXT                                C.GPGETDOUBLEI_VEXT
+	gpGetDoublev                                     C.GPGETDOUBLEV
+	gpGetError                                       C.GPGETERROR
+	gpGetFirstPerfQueryIdINTEL                       C.GPGETFIRSTPERFQUERYIDINTEL
+	gpGetFloatIndexedvEXT                            C.GPGETFLOATINDEXEDVEXT
+	gpGetFloati_v                                    C.GPGETFLOATI_V
+	gpGetFloati_vEXT                                 C.GPGETFLOATI_VEXT
+	gpGetFloatv                                      C.GPGETFLOATV
+	gpGetFragDataIndex                               C.GPGETFRAGDATAINDEX
+	gpGetFragDataLocation                            C.GPGETFRAGDATALOCATION
+	gpGetFramebufferAttachmentParameteriv            C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetFramebufferParameteriv                      C.GPGETFRAMEBUFFERPARAMETERIV
+	gpGetFramebufferParameterivEXT                   C.GPGETFRAMEBUFFERPARAMETERIVEXT
+	gpGetGraphicsResetStatus                         C.GPGETGRAPHICSRESETSTATUS
+	gpGetGraphicsResetStatusARB                      C.GPGETGRAPHICSRESETSTATUSARB
+	gpGetGraphicsResetStatusKHR                      C.GPGETGRAPHICSRESETSTATUSKHR
+	gpGetImageHandleARB                              C.GPGETIMAGEHANDLEARB
+	gpGetImageHandleNV                               C.GPGETIMAGEHANDLENV
+	gpGetInteger64i_v                                C.GPGETINTEGER64I_V
+	gpGetInteger64v                                  C.GPGETINTEGER64V
+	gpGetIntegerIndexedvEXT                          C.GPGETINTEGERINDEXEDVEXT
+	gpGetIntegeri_v                                  C.GPGETINTEGERI_V
+	gpGetIntegerui64i_vNV                            C.GPGETINTEGERUI64I_VNV
+	gpGetIntegerui64vNV                              C.GPGETINTEGERUI64VNV
+	gpGetIntegerv                                    C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                    C.GPGETINTERNALFORMATSAMPLEIVNV
+	gpGetInternalformati64v                          C.GPGETINTERNALFORMATI64V
+	gpGetInternalformativ                            C.GPGETINTERNALFORMATIV
+	gpGetMultiTexEnvfvEXT                            C.GPGETMULTITEXENVFVEXT
+	gpGetMultiTexEnvivEXT                            C.GPGETMULTITEXENVIVEXT
+	gpGetMultiTexGendvEXT                            C.GPGETMULTITEXGENDVEXT
+	gpGetMultiTexGenfvEXT                            C.GPGETMULTITEXGENFVEXT
+	gpGetMultiTexGenivEXT                            C.GPGETMULTITEXGENIVEXT
+	gpGetMultiTexImageEXT                            C.GPGETMULTITEXIMAGEEXT
+	gpGetMultiTexLevelParameterfvEXT                 C.GPGETMULTITEXLEVELPARAMETERFVEXT
+	gpGetMultiTexLevelParameterivEXT                 C.GPGETMULTITEXLEVELPARAMETERIVEXT
+	gpGetMultiTexParameterIivEXT                     C.GPGETMULTITEXPARAMETERIIVEXT
+	gpGetMultiTexParameterIuivEXT                    C.GPGETMULTITEXPARAMETERIUIVEXT
+	gpGetMultiTexParameterfvEXT                      C.GPGETMULTITEXPARAMETERFVEXT
+	gpGetMultiTexParameterivEXT                      C.GPGETMULTITEXPARAMETERIVEXT
+	gpGetMultisamplefv                               C.GPGETMULTISAMPLEFV
+	gpGetNamedBufferParameteri64v                    C.GPGETNAMEDBUFFERPARAMETERI64V
+	gpGetNamedBufferParameteriv                      C.GPGETNAMEDBUFFERPARAMETERIV
+	gpGetNamedBufferParameterivEXT                   C.GPGETNAMEDBUFFERPARAMETERIVEXT
+	gpGetNamedBufferParameterui64vNV                 C.GPGETNAMEDBUFFERPARAMETERUI64VNV
+	gpGetNamedBufferPointerv                         C.GPGETNAMEDBUFFERPOINTERV
+	gpGetNamedBufferPointervEXT                      C.GPGETNAMEDBUFFERPOINTERVEXT
+	gpGetNamedBufferSubData                          C.GPGETNAMEDBUFFERSUBDATA
+	gpGetNamedBufferSubDataEXT                       C.GPGETNAMEDBUFFERSUBDATAEXT
+	gpGetNamedFramebufferAttachmentParameteriv       C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetNamedFramebufferAttachmentParameterivEXT    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameteriv                 C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
+	gpGetNamedFramebufferParameterivEXT              C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
+	gpGetNamedProgramLocalParameterIivEXT            C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
+	gpGetNamedProgramLocalParameterIuivEXT           C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT
+	gpGetNamedProgramLocalParameterdvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT
+	gpGetNamedProgramLocalParameterfvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT
+	gpGetNamedProgramStringEXT                       C.GPGETNAMEDPROGRAMSTRINGEXT
+	gpGetNamedProgramivEXT                           C.GPGETNAMEDPROGRAMIVEXT
+	gpGetNamedRenderbufferParameteriv                C.GPGETNAMEDRENDERBUFFERPARAMETERIV
+	gpGetNamedRenderbufferParameterivEXT             C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT
+	gpGetNamedStringARB                              C.GPGETNAMEDSTRINGARB
+	gpGetNamedStringivARB                            C.GPGETNAMEDSTRINGIVARB
+	gpGetNextPerfQueryIdINTEL                        C.GPGETNEXTPERFQUERYIDINTEL
+	gpGetObjectLabel                                 C.GPGETOBJECTLABEL
+	gpGetObjectLabelEXT                              C.GPGETOBJECTLABELEXT
+	gpGetObjectLabelKHR                              C.GPGETOBJECTLABELKHR
+	gpGetObjectPtrLabel                              C.GPGETOBJECTPTRLABEL
+	gpGetObjectPtrLabelKHR                           C.GPGETOBJECTPTRLABELKHR
+	gpGetPathCommandsNV                              C.GPGETPATHCOMMANDSNV
+	gpGetPathCoordsNV                                C.GPGETPATHCOORDSNV
+	gpGetPathDashArrayNV                             C.GPGETPATHDASHARRAYNV
+	gpGetPathLengthNV                                C.GPGETPATHLENGTHNV
+	gpGetPathMetricRangeNV                           C.GPGETPATHMETRICRANGENV
+	gpGetPathMetricsNV                               C.GPGETPATHMETRICSNV
+	gpGetPathParameterfvNV                           C.GPGETPATHPARAMETERFVNV
+	gpGetPathParameterivNV                           C.GPGETPATHPARAMETERIVNV
+	gpGetPathSpacingNV                               C.GPGETPATHSPACINGNV
+	gpGetPerfCounterInfoINTEL                        C.GPGETPERFCOUNTERINFOINTEL
+	gpGetPerfMonitorCounterDataAMD                   C.GPGETPERFMONITORCOUNTERDATAAMD
+	gpGetPerfMonitorCounterInfoAMD                   C.GPGETPERFMONITORCOUNTERINFOAMD
+	gpGetPerfMonitorCounterStringAMD                 C.GPGETPERFMONITORCOUNTERSTRINGAMD
+	gpGetPerfMonitorCountersAMD                      C.GPGETPERFMONITORCOUNTERSAMD
+	gpGetPerfMonitorGroupStringAMD                   C.GPGETPERFMONITORGROUPSTRINGAMD
+	gpGetPerfMonitorGroupsAMD                        C.GPGETPERFMONITORGROUPSAMD
+	gpGetPerfQueryDataINTEL                          C.GPGETPERFQUERYDATAINTEL
+	gpGetPerfQueryIdByNameINTEL                      C.GPGETPERFQUERYIDBYNAMEINTEL
+	gpGetPerfQueryInfoINTEL                          C.GPGETPERFQUERYINFOINTEL
+	gpGetPointerIndexedvEXT                          C.GPGETPOINTERINDEXEDVEXT
+	gpGetPointeri_vEXT                               C.GPGETPOINTERI_VEXT
+	gpGetPointerv                                    C.GPGETPOINTERV
+	gpGetPointervKHR                                 C.GPGETPOINTERVKHR
+	gpGetProgramBinary                               C.GPGETPROGRAMBINARY
+	gpGetProgramInfoLog                              C.GPGETPROGRAMINFOLOG
+	gpGetProgramInterfaceiv                          C.GPGETPROGRAMINTERFACEIV
+	gpGetProgramPipelineInfoLog                      C.GPGETPROGRAMPIPELINEINFOLOG
+	gpGetProgramPipelineInfoLogEXT                   C.GPGETPROGRAMPIPELINEINFOLOGEXT
+	gpGetProgramPipelineiv                           C.GPGETPROGRAMPIPELINEIV
+	gpGetProgramPipelineivEXT                        C.GPGETPROGRAMPIPELINEIVEXT
+	gpGetProgramResourceIndex                        C.GPGETPROGRAMRESOURCEINDEX
+	gpGetProgramResourceLocation                     C.GPGETPROGRAMRESOURCELOCATION
+	gpGetProgramResourceLocationIndex                C.GPGETPROGRAMRESOURCELOCATIONINDEX
+	gpGetProgramResourceName                         C.GPGETPROGRAMRESOURCENAME
+	gpGetProgramResourcefvNV                         C.GPGETPROGRAMRESOURCEFVNV
+	gpGetProgramResourceiv                           C.GPGETPROGRAMRESOURCEIV
+	gpGetProgramStageiv                              C.GPGETPROGRAMSTAGEIV
+	gpGetProgramiv                                   C.GPGETPROGRAMIV
+	gpGetQueryBufferObjecti64v                       C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                         C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                      C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                        C.GPGETQUERYBUFFEROBJECTUIV
+	gpGetQueryIndexediv                              C.GPGETQUERYINDEXEDIV
+	gpGetQueryObjecti64v                             C.GPGETQUERYOBJECTI64V
+	gpGetQueryObjectiv                               C.GPGETQUERYOBJECTIV
+	gpGetQueryObjectui64v                            C.GPGETQUERYOBJECTUI64V
+	gpGetQueryObjectuiv                              C.GPGETQUERYOBJECTUIV
+	gpGetQueryiv                                     C.GPGETQUERYIV
+	gpGetRenderbufferParameteriv                     C.GPGETRENDERBUFFERPARAMETERIV
+	gpGetSamplerParameterIiv                         C.GPGETSAMPLERPARAMETERIIV
+	gpGetSamplerParameterIuiv                        C.GPGETSAMPLERPARAMETERIUIV
+	gpGetSamplerParameterfv                          C.GPGETSAMPLERPARAMETERFV
+	gpGetSamplerParameteriv                          C.GPGETSAMPLERPARAMETERIV
+	gpGetShaderInfoLog                               C.GPGETSHADERINFOLOG
+	gpGetShaderPrecisionFormat                       C.GPGETSHADERPRECISIONFORMAT
+	gpGetShaderSource                                C.GPGETSHADERSOURCE
+	gpGetShaderiv                                    C.GPGETSHADERIV
+	gpGetStageIndexNV                                C.GPGETSTAGEINDEXNV
+	gpGetString                                      C.GPGETSTRING
+	gpGetStringi                                     C.GPGETSTRINGI
+	gpGetSubroutineIndex                             C.GPGETSUBROUTINEINDEX
+	gpGetSubroutineUniformLocation                   C.GPGETSUBROUTINEUNIFORMLOCATION
+	gpGetSynciv                                      C.GPGETSYNCIV
+	gpGetTexImage                                    C.GPGETTEXIMAGE
+	gpGetTexLevelParameterfv                         C.GPGETTEXLEVELPARAMETERFV
+	gpGetTexLevelParameteriv                         C.GPGETTEXLEVELPARAMETERIV
+	gpGetTexParameterIiv                             C.GPGETTEXPARAMETERIIV
+	gpGetTexParameterIuiv                            C.GPGETTEXPARAMETERIUIV
+	gpGetTexParameterfv                              C.GPGETTEXPARAMETERFV
+	gpGetTexParameteriv                              C.GPGETTEXPARAMETERIV
+	gpGetTextureHandleARB                            C.GPGETTEXTUREHANDLEARB
+	gpGetTextureHandleNV                             C.GPGETTEXTUREHANDLENV
+	gpGetTextureImage                                C.GPGETTEXTUREIMAGE
+	gpGetTextureImageEXT                             C.GPGETTEXTUREIMAGEEXT
+	gpGetTextureLevelParameterfv                     C.GPGETTEXTURELEVELPARAMETERFV
+	gpGetTextureLevelParameterfvEXT                  C.GPGETTEXTURELEVELPARAMETERFVEXT
+	gpGetTextureLevelParameteriv                     C.GPGETTEXTURELEVELPARAMETERIV
+	gpGetTextureLevelParameterivEXT                  C.GPGETTEXTURELEVELPARAMETERIVEXT
+	gpGetTextureParameterIiv                         C.GPGETTEXTUREPARAMETERIIV
+	gpGetTextureParameterIivEXT                      C.GPGETTEXTUREPARAMETERIIVEXT
+	gpGetTextureParameterIuiv                        C.GPGETTEXTUREPARAMETERIUIV
+	gpGetTextureParameterIuivEXT                     C.GPGETTEXTUREPARAMETERIUIVEXT
+	gpGetTextureParameterfv                          C.GPGETTEXTUREPARAMETERFV
+	gpGetTextureParameterfvEXT                       C.GPGETTEXTUREPARAMETERFVEXT
+	gpGetTextureParameteriv                          C.GPGETTEXTUREPARAMETERIV
+	gpGetTextureParameterivEXT                       C.GPGETTEXTUREPARAMETERIVEXT
+	gpGetTextureSamplerHandleARB                     C.GPGETTEXTURESAMPLERHANDLEARB
+	gpGetTextureSamplerHandleNV                      C.GPGETTEXTURESAMPLERHANDLENV
+	gpGetTextureSubImage                             C.GPGETTEXTURESUBIMAGE
+	gpGetTransformFeedbackVarying                    C.GPGETTRANSFORMFEEDBACKVARYING
+	gpGetTransformFeedbacki64_v                      C.GPGETTRANSFORMFEEDBACKI64_V
+	gpGetTransformFeedbacki_v                        C.GPGETTRANSFORMFEEDBACKI_V
+	gpGetTransformFeedbackiv                         C.GPGETTRANSFORMFEEDBACKIV
+	gpGetUniformBlockIndex                           C.GPGETUNIFORMBLOCKINDEX
+	gpGetUniformIndices                              C.GPGETUNIFORMINDICES
+	gpGetUniformLocation                             C.GPGETUNIFORMLOCATION
+	gpGetUniformSubroutineuiv                        C.GPGETUNIFORMSUBROUTINEUIV
+	gpGetUniformdv                                   C.GPGETUNIFORMDV
+	gpGetUniformfv                                   C.GPGETUNIFORMFV
+	gpGetUniformi64vARB                              C.GPGETUNIFORMI64VARB
+	gpGetUniformi64vNV                               C.GPGETUNIFORMI64VNV
+	gpGetUniformiv                                   C.GPGETUNIFORMIV
+	gpGetUniformui64vARB                             C.GPGETUNIFORMUI64VARB
+	gpGetUniformui64vNV                              C.GPGETUNIFORMUI64VNV
+	gpGetUniformuiv                                  C.GPGETUNIFORMUIV
+	gpGetVertexArrayIndexed64iv                      C.GPGETVERTEXARRAYINDEXED64IV
+	gpGetVertexArrayIndexediv                        C.GPGETVERTEXARRAYINDEXEDIV
+	gpGetVertexArrayIntegeri_vEXT                    C.GPGETVERTEXARRAYINTEGERI_VEXT
+	gpGetVertexArrayIntegervEXT                      C.GPGETVERTEXARRAYINTEGERVEXT
+	gpGetVertexArrayPointeri_vEXT                    C.GPGETVERTEXARRAYPOINTERI_VEXT
+	gpGetVertexArrayPointervEXT                      C.GPGETVERTEXARRAYPOINTERVEXT
+	gpGetVertexArrayiv                               C.GPGETVERTEXARRAYIV
+	gpGetVertexAttribIiv                             C.GPGETVERTEXATTRIBIIV
+	gpGetVertexAttribIuiv                            C.GPGETVERTEXATTRIBIUIV
+	gpGetVertexAttribLdv                             C.GPGETVERTEXATTRIBLDV
+	gpGetVertexAttribLi64vNV                         C.GPGETVERTEXATTRIBLI64VNV
+	gpGetVertexAttribLui64vARB                       C.GPGETVERTEXATTRIBLUI64VARB
+	gpGetVertexAttribLui64vNV                        C.GPGETVERTEXATTRIBLUI64VNV
+	gpGetVertexAttribPointerv                        C.GPGETVERTEXATTRIBPOINTERV
+	gpGetVertexAttribdv                              C.GPGETVERTEXATTRIBDV
+	gpGetVertexAttribfv                              C.GPGETVERTEXATTRIBFV
+	gpGetVertexAttribiv                              C.GPGETVERTEXATTRIBIV
+	gpGetVkProcAddrNV                                C.GPGETVKPROCADDRNV
+	gpGetnCompressedTexImageARB                      C.GPGETNCOMPRESSEDTEXIMAGEARB
+	gpGetnTexImageARB                                C.GPGETNTEXIMAGEARB
+	gpGetnUniformdvARB                               C.GPGETNUNIFORMDVARB
+	gpGetnUniformfv                                  C.GPGETNUNIFORMFV
+	gpGetnUniformfvARB                               C.GPGETNUNIFORMFVARB
+	gpGetnUniformfvKHR                               C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                             C.GPGETNUNIFORMI64VARB
+	gpGetnUniformiv                                  C.GPGETNUNIFORMIV
+	gpGetnUniformivARB                               C.GPGETNUNIFORMIVARB
+	gpGetnUniformivKHR                               C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                            C.GPGETNUNIFORMUI64VARB
+	gpGetnUniformuiv                                 C.GPGETNUNIFORMUIV
+	gpGetnUniformuivARB                              C.GPGETNUNIFORMUIVARB
+	gpGetnUniformuivKHR                              C.GPGETNUNIFORMUIVKHR
+	gpHint                                           C.GPHINT
+	gpIndexFormatNV                                  C.GPINDEXFORMATNV
+	gpInsertEventMarkerEXT                           C.GPINSERTEVENTMARKEREXT
+	gpInterpolatePathsNV                             C.GPINTERPOLATEPATHSNV
+	gpInvalidateBufferData                           C.GPINVALIDATEBUFFERDATA
+	gpInvalidateBufferSubData                        C.GPINVALIDATEBUFFERSUBDATA
+	gpInvalidateFramebuffer                          C.GPINVALIDATEFRAMEBUFFER
+	gpInvalidateNamedFramebufferData                 C.GPINVALIDATENAMEDFRAMEBUFFERDATA
+	gpInvalidateNamedFramebufferSubData              C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
+	gpInvalidateSubFramebuffer                       C.GPINVALIDATESUBFRAMEBUFFER
+	gpInvalidateTexImage                             C.GPINVALIDATETEXIMAGE
+	gpInvalidateTexSubImage                          C.GPINVALIDATETEXSUBIMAGE
+	gpIsBuffer                                       C.GPISBUFFER
+	gpIsBufferResidentNV                             C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                C.GPISCOMMANDLISTNV
+	gpIsEnabled                                      C.GPISENABLED
+	gpIsEnabledIndexedEXT                            C.GPISENABLEDINDEXEDEXT
+	gpIsEnabledi                                     C.GPISENABLEDI
+	gpIsFramebuffer                                  C.GPISFRAMEBUFFER
+	gpIsImageHandleResidentARB                       C.GPISIMAGEHANDLERESIDENTARB
+	gpIsImageHandleResidentNV                        C.GPISIMAGEHANDLERESIDENTNV
+	gpIsNamedBufferResidentNV                        C.GPISNAMEDBUFFERRESIDENTNV
+	gpIsNamedStringARB                               C.GPISNAMEDSTRINGARB
+	gpIsPathNV                                       C.GPISPATHNV
+	gpIsPointInFillPathNV                            C.GPISPOINTINFILLPATHNV
+	gpIsPointInStrokePathNV                          C.GPISPOINTINSTROKEPATHNV
+	gpIsProgram                                      C.GPISPROGRAM
+	gpIsProgramPipeline                              C.GPISPROGRAMPIPELINE
+	gpIsProgramPipelineEXT                           C.GPISPROGRAMPIPELINEEXT
+	gpIsQuery                                        C.GPISQUERY
+	gpIsRenderbuffer                                 C.GPISRENDERBUFFER
+	gpIsSampler                                      C.GPISSAMPLER
+	gpIsShader                                       C.GPISSHADER
+	gpIsStateNV                                      C.GPISSTATENV
+	gpIsSync                                         C.GPISSYNC
+	gpIsTexture                                      C.GPISTEXTURE
+	gpIsTextureHandleResidentARB                     C.GPISTEXTUREHANDLERESIDENTARB
+	gpIsTextureHandleResidentNV                      C.GPISTEXTUREHANDLERESIDENTNV
+	gpIsTransformFeedback                            C.GPISTRANSFORMFEEDBACK
+	gpIsVertexArray                                  C.GPISVERTEXARRAY
+	gpLabelObjectEXT                                 C.GPLABELOBJECTEXT
+	gpLineWidth                                      C.GPLINEWIDTH
+	gpLinkProgram                                    C.GPLINKPROGRAM
+	gpListDrawCommandsStatesClientNV                 C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
+	gpLogicOp                                        C.GPLOGICOP
+	gpMakeBufferNonResidentNV                        C.GPMAKEBUFFERNONRESIDENTNV
+	gpMakeBufferResidentNV                           C.GPMAKEBUFFERRESIDENTNV
+	gpMakeImageHandleNonResidentARB                  C.GPMAKEIMAGEHANDLENONRESIDENTARB
+	gpMakeImageHandleNonResidentNV                   C.GPMAKEIMAGEHANDLENONRESIDENTNV
+	gpMakeImageHandleResidentARB                     C.GPMAKEIMAGEHANDLERESIDENTARB
+	gpMakeImageHandleResidentNV                      C.GPMAKEIMAGEHANDLERESIDENTNV
+	gpMakeNamedBufferNonResidentNV                   C.GPMAKENAMEDBUFFERNONRESIDENTNV
+	gpMakeNamedBufferResidentNV                      C.GPMAKENAMEDBUFFERRESIDENTNV
+	gpMakeTextureHandleNonResidentARB                C.GPMAKETEXTUREHANDLENONRESIDENTARB
+	gpMakeTextureHandleNonResidentNV                 C.GPMAKETEXTUREHANDLENONRESIDENTNV
+	gpMakeTextureHandleResidentARB                   C.GPMAKETEXTUREHANDLERESIDENTARB
+	gpMakeTextureHandleResidentNV                    C.GPMAKETEXTUREHANDLERESIDENTNV
+	gpMapBuffer                                      C.GPMAPBUFFER
+	gpMapBufferRange                                 C.GPMAPBUFFERRANGE
+	gpMapNamedBuffer                                 C.GPMAPNAMEDBUFFER
+	gpMapNamedBufferEXT                              C.GPMAPNAMEDBUFFEREXT
+	gpMapNamedBufferRange                            C.GPMAPNAMEDBUFFERRANGE
+	gpMapNamedBufferRangeEXT                         C.GPMAPNAMEDBUFFERRANGEEXT
+	gpMatrixFrustumEXT                               C.GPMATRIXFRUSTUMEXT
+	gpMatrixLoad3x2fNV                               C.GPMATRIXLOAD3X2FNV
+	gpMatrixLoad3x3fNV                               C.GPMATRIXLOAD3X3FNV
+	gpMatrixLoadIdentityEXT                          C.GPMATRIXLOADIDENTITYEXT
+	gpMatrixLoadTranspose3x3fNV                      C.GPMATRIXLOADTRANSPOSE3X3FNV
+	gpMatrixLoadTransposedEXT                        C.GPMATRIXLOADTRANSPOSEDEXT
+	gpMatrixLoadTransposefEXT                        C.GPMATRIXLOADTRANSPOSEFEXT
+	gpMatrixLoaddEXT                                 C.GPMATRIXLOADDEXT
+	gpMatrixLoadfEXT                                 C.GPMATRIXLOADFEXT
+	gpMatrixMult3x2fNV                               C.GPMATRIXMULT3X2FNV
+	gpMatrixMult3x3fNV                               C.GPMATRIXMULT3X3FNV
+	gpMatrixMultTranspose3x3fNV                      C.GPMATRIXMULTTRANSPOSE3X3FNV
+	gpMatrixMultTransposedEXT                        C.GPMATRIXMULTTRANSPOSEDEXT
+	gpMatrixMultTransposefEXT                        C.GPMATRIXMULTTRANSPOSEFEXT
+	gpMatrixMultdEXT                                 C.GPMATRIXMULTDEXT
+	gpMatrixMultfEXT                                 C.GPMATRIXMULTFEXT
+	gpMatrixOrthoEXT                                 C.GPMATRIXORTHOEXT
+	gpMatrixPopEXT                                   C.GPMATRIXPOPEXT
+	gpMatrixPushEXT                                  C.GPMATRIXPUSHEXT
+	gpMatrixRotatedEXT                               C.GPMATRIXROTATEDEXT
+	gpMatrixRotatefEXT                               C.GPMATRIXROTATEFEXT
+	gpMatrixScaledEXT                                C.GPMATRIXSCALEDEXT
+	gpMatrixScalefEXT                                C.GPMATRIXSCALEFEXT
+	gpMatrixTranslatedEXT                            C.GPMATRIXTRANSLATEDEXT
+	gpMatrixTranslatefEXT                            C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                    C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                    C.GPMAXSHADERCOMPILERTHREADSKHR
+	gpMemoryBarrier                                  C.GPMEMORYBARRIER
+	gpMemoryBarrierByRegion                          C.GPMEMORYBARRIERBYREGION
+	gpMinSampleShadingARB                            C.GPMINSAMPLESHADINGARB
+	gpMultiDrawArrays                                C.GPMULTIDRAWARRAYS
+	gpMultiDrawArraysIndirect                        C.GPMULTIDRAWARRAYSINDIRECT
+	gpMultiDrawArraysIndirectBindlessCountNV         C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawArraysIndirectBindlessNV              C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV
+	gpMultiDrawArraysIndirectCountARB                C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
+	gpMultiDrawElements                              C.GPMULTIDRAWELEMENTS
+	gpMultiDrawElementsBaseVertex                    C.GPMULTIDRAWELEMENTSBASEVERTEX
+	gpMultiDrawElementsIndirect                      C.GPMULTIDRAWELEMENTSINDIRECT
+	gpMultiDrawElementsIndirectBindlessCountNV       C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawElementsIndirectBindlessNV            C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV
+	gpMultiDrawElementsIndirectCountARB              C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
+	gpMultiTexBufferEXT                              C.GPMULTITEXBUFFEREXT
+	gpMultiTexCoordPointerEXT                        C.GPMULTITEXCOORDPOINTEREXT
+	gpMultiTexEnvfEXT                                C.GPMULTITEXENVFEXT
+	gpMultiTexEnvfvEXT                               C.GPMULTITEXENVFVEXT
+	gpMultiTexEnviEXT                                C.GPMULTITEXENVIEXT
+	gpMultiTexEnvivEXT                               C.GPMULTITEXENVIVEXT
+	gpMultiTexGendEXT                                C.GPMULTITEXGENDEXT
+	gpMultiTexGendvEXT                               C.GPMULTITEXGENDVEXT
+	gpMultiTexGenfEXT                                C.GPMULTITEXGENFEXT
+	gpMultiTexGenfvEXT                               C.GPMULTITEXGENFVEXT
+	gpMultiTexGeniEXT                                C.GPMULTITEXGENIEXT
+	gpMultiTexGenivEXT                               C.GPMULTITEXGENIVEXT
+	gpMultiTexImage1DEXT                             C.GPMULTITEXIMAGE1DEXT
+	gpMultiTexImage2DEXT                             C.GPMULTITEXIMAGE2DEXT
+	gpMultiTexImage3DEXT                             C.GPMULTITEXIMAGE3DEXT
+	gpMultiTexParameterIivEXT                        C.GPMULTITEXPARAMETERIIVEXT
+	gpMultiTexParameterIuivEXT                       C.GPMULTITEXPARAMETERIUIVEXT
+	gpMultiTexParameterfEXT                          C.GPMULTITEXPARAMETERFEXT
+	gpMultiTexParameterfvEXT                         C.GPMULTITEXPARAMETERFVEXT
+	gpMultiTexParameteriEXT                          C.GPMULTITEXPARAMETERIEXT
+	gpMultiTexParameterivEXT                         C.GPMULTITEXPARAMETERIVEXT
+	gpMultiTexRenderbufferEXT                        C.GPMULTITEXRENDERBUFFEREXT
+	gpMultiTexSubImage1DEXT                          C.GPMULTITEXSUBIMAGE1DEXT
+	gpMultiTexSubImage2DEXT                          C.GPMULTITEXSUBIMAGE2DEXT
+	gpMultiTexSubImage3DEXT                          C.GPMULTITEXSUBIMAGE3DEXT
+	gpNamedBufferData                                C.GPNAMEDBUFFERDATA
+	gpNamedBufferDataEXT                             C.GPNAMEDBUFFERDATAEXT
+	gpNamedBufferPageCommitmentARB                   C.GPNAMEDBUFFERPAGECOMMITMENTARB
+	gpNamedBufferPageCommitmentEXT                   C.GPNAMEDBUFFERPAGECOMMITMENTEXT
+	gpNamedBufferStorage                             C.GPNAMEDBUFFERSTORAGE
+	gpNamedBufferStorageEXT                          C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferSubData                             C.GPNAMEDBUFFERSUBDATA
+	gpNamedBufferSubDataEXT                          C.GPNAMEDBUFFERSUBDATAEXT
+	gpNamedCopyBufferSubDataEXT                      C.GPNAMEDCOPYBUFFERSUBDATAEXT
+	gpNamedFramebufferDrawBuffer                     C.GPNAMEDFRAMEBUFFERDRAWBUFFER
+	gpNamedFramebufferDrawBuffers                    C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
+	gpNamedFramebufferParameteri                     C.GPNAMEDFRAMEBUFFERPARAMETERI
+	gpNamedFramebufferParameteriEXT                  C.GPNAMEDFRAMEBUFFERPARAMETERIEXT
+	gpNamedFramebufferReadBuffer                     C.GPNAMEDFRAMEBUFFERREADBUFFER
+	gpNamedFramebufferRenderbuffer                   C.GPNAMEDFRAMEBUFFERRENDERBUFFER
+	gpNamedFramebufferRenderbufferEXT                C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB           C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV            C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferTexture                        C.GPNAMEDFRAMEBUFFERTEXTURE
+	gpNamedFramebufferTexture1DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
+	gpNamedFramebufferTexture2DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
+	gpNamedFramebufferTexture3DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT
+	gpNamedFramebufferTextureEXT                     C.GPNAMEDFRAMEBUFFERTEXTUREEXT
+	gpNamedFramebufferTextureFaceEXT                 C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT
+	gpNamedFramebufferTextureLayer                   C.GPNAMEDFRAMEBUFFERTEXTURELAYER
+	gpNamedFramebufferTextureLayerEXT                C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT
+	gpNamedProgramLocalParameter4dEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT
+	gpNamedProgramLocalParameter4dvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT
+	gpNamedProgramLocalParameter4fEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT
+	gpNamedProgramLocalParameter4fvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT
+	gpNamedProgramLocalParameterI4iEXT               C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT
+	gpNamedProgramLocalParameterI4ivEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT
+	gpNamedProgramLocalParameterI4uiEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT
+	gpNamedProgramLocalParameterI4uivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT
+	gpNamedProgramLocalParameters4fvEXT              C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT
+	gpNamedProgramLocalParametersI4ivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT
+	gpNamedProgramLocalParametersI4uivEXT            C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT
+	gpNamedProgramStringEXT                          C.GPNAMEDPROGRAMSTRINGEXT
+	gpNamedRenderbufferStorage                       C.GPNAMEDRENDERBUFFERSTORAGE
+	gpNamedRenderbufferStorageEXT                    C.GPNAMEDRENDERBUFFERSTORAGEEXT
+	gpNamedRenderbufferStorageMultisample            C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
+	gpNamedRenderbufferStorageMultisampleCoverageEXT C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT
+	gpNamedRenderbufferStorageMultisampleEXT         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT
+	gpNamedStringARB                                 C.GPNAMEDSTRINGARB
+	gpNormalFormatNV                                 C.GPNORMALFORMATNV
+	gpObjectLabel                                    C.GPOBJECTLABEL
+	gpObjectLabelKHR                                 C.GPOBJECTLABELKHR
+	gpObjectPtrLabel                                 C.GPOBJECTPTRLABEL
+	gpObjectPtrLabelKHR                              C.GPOBJECTPTRLABELKHR
+	gpPatchParameterfv                               C.GPPATCHPARAMETERFV
+	gpPatchParameteri                                C.GPPATCHPARAMETERI
+	gpPathCommandsNV                                 C.GPPATHCOMMANDSNV
+	gpPathCoordsNV                                   C.GPPATHCOORDSNV
+	gpPathCoverDepthFuncNV                           C.GPPATHCOVERDEPTHFUNCNV
+	gpPathDashArrayNV                                C.GPPATHDASHARRAYNV
+	gpPathGlyphIndexArrayNV                          C.GPPATHGLYPHINDEXARRAYNV
+	gpPathGlyphIndexRangeNV                          C.GPPATHGLYPHINDEXRANGENV
+	gpPathGlyphRangeNV                               C.GPPATHGLYPHRANGENV
+	gpPathGlyphsNV                                   C.GPPATHGLYPHSNV
+	gpPathMemoryGlyphIndexArrayNV                    C.GPPATHMEMORYGLYPHINDEXARRAYNV
+	gpPathParameterfNV                               C.GPPATHPARAMETERFNV
+	gpPathParameterfvNV                              C.GPPATHPARAMETERFVNV
+	gpPathParameteriNV                               C.GPPATHPARAMETERINV
+	gpPathParameterivNV                              C.GPPATHPARAMETERIVNV
+	gpPathStencilDepthOffsetNV                       C.GPPATHSTENCILDEPTHOFFSETNV
+	gpPathStencilFuncNV                              C.GPPATHSTENCILFUNCNV
+	gpPathStringNV                                   C.GPPATHSTRINGNV
+	gpPathSubCommandsNV                              C.GPPATHSUBCOMMANDSNV
+	gpPathSubCoordsNV                                C.GPPATHSUBCOORDSNV
+	gpPauseTransformFeedback                         C.GPPAUSETRANSFORMFEEDBACK
+	gpPixelStoref                                    C.GPPIXELSTOREF
+	gpPixelStorei                                    C.GPPIXELSTOREI
+	gpPointAlongPathNV                               C.GPPOINTALONGPATHNV
+	gpPointParameterf                                C.GPPOINTPARAMETERF
+	gpPointParameterfv                               C.GPPOINTPARAMETERFV
+	gpPointParameteri                                C.GPPOINTPARAMETERI
+	gpPointParameteriv                               C.GPPOINTPARAMETERIV
+	gpPointSize                                      C.GPPOINTSIZE
+	gpPolygonMode                                    C.GPPOLYGONMODE
+	gpPolygonOffset                                  C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                             C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                          C.GPPOLYGONOFFSETCLAMPEXT
+	gpPopDebugGroup                                  C.GPPOPDEBUGGROUP
+	gpPopDebugGroupKHR                               C.GPPOPDEBUGGROUPKHR
+	gpPopGroupMarkerEXT                              C.GPPOPGROUPMARKEREXT
+	gpPrimitiveBoundingBoxARB                        C.GPPRIMITIVEBOUNDINGBOXARB
+	gpPrimitiveRestartIndex                          C.GPPRIMITIVERESTARTINDEX
+	gpProgramBinary                                  C.GPPROGRAMBINARY
+	gpProgramParameteri                              C.GPPROGRAMPARAMETERI
+	gpProgramParameteriARB                           C.GPPROGRAMPARAMETERIARB
+	gpProgramParameteriEXT                           C.GPPROGRAMPARAMETERIEXT
+	gpProgramPathFragmentInputGenNV                  C.GPPROGRAMPATHFRAGMENTINPUTGENNV
+	gpProgramUniform1d                               C.GPPROGRAMUNIFORM1D
+	gpProgramUniform1dEXT                            C.GPPROGRAMUNIFORM1DEXT
+	gpProgramUniform1dv                              C.GPPROGRAMUNIFORM1DV
+	gpProgramUniform1dvEXT                           C.GPPROGRAMUNIFORM1DVEXT
+	gpProgramUniform1f                               C.GPPROGRAMUNIFORM1F
+	gpProgramUniform1fEXT                            C.GPPROGRAMUNIFORM1FEXT
+	gpProgramUniform1fv                              C.GPPROGRAMUNIFORM1FV
+	gpProgramUniform1fvEXT                           C.GPPROGRAMUNIFORM1FVEXT
+	gpProgramUniform1i                               C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                          C.GPPROGRAMUNIFORM1I64ARB
+	gpProgramUniform1i64NV                           C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                         C.GPPROGRAMUNIFORM1I64VARB
+	gpProgramUniform1i64vNV                          C.GPPROGRAMUNIFORM1I64VNV
+	gpProgramUniform1iEXT                            C.GPPROGRAMUNIFORM1IEXT
+	gpProgramUniform1iv                              C.GPPROGRAMUNIFORM1IV
+	gpProgramUniform1ivEXT                           C.GPPROGRAMUNIFORM1IVEXT
+	gpProgramUniform1ui                              C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                         C.GPPROGRAMUNIFORM1UI64ARB
+	gpProgramUniform1ui64NV                          C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                        C.GPPROGRAMUNIFORM1UI64VARB
+	gpProgramUniform1ui64vNV                         C.GPPROGRAMUNIFORM1UI64VNV
+	gpProgramUniform1uiEXT                           C.GPPROGRAMUNIFORM1UIEXT
+	gpProgramUniform1uiv                             C.GPPROGRAMUNIFORM1UIV
+	gpProgramUniform1uivEXT                          C.GPPROGRAMUNIFORM1UIVEXT
+	gpProgramUniform2d                               C.GPPROGRAMUNIFORM2D
+	gpProgramUniform2dEXT                            C.GPPROGRAMUNIFORM2DEXT
+	gpProgramUniform2dv                              C.GPPROGRAMUNIFORM2DV
+	gpProgramUniform2dvEXT                           C.GPPROGRAMUNIFORM2DVEXT
+	gpProgramUniform2f                               C.GPPROGRAMUNIFORM2F
+	gpProgramUniform2fEXT                            C.GPPROGRAMUNIFORM2FEXT
+	gpProgramUniform2fv                              C.GPPROGRAMUNIFORM2FV
+	gpProgramUniform2fvEXT                           C.GPPROGRAMUNIFORM2FVEXT
+	gpProgramUniform2i                               C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                          C.GPPROGRAMUNIFORM2I64ARB
+	gpProgramUniform2i64NV                           C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                         C.GPPROGRAMUNIFORM2I64VARB
+	gpProgramUniform2i64vNV                          C.GPPROGRAMUNIFORM2I64VNV
+	gpProgramUniform2iEXT                            C.GPPROGRAMUNIFORM2IEXT
+	gpProgramUniform2iv                              C.GPPROGRAMUNIFORM2IV
+	gpProgramUniform2ivEXT                           C.GPPROGRAMUNIFORM2IVEXT
+	gpProgramUniform2ui                              C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                         C.GPPROGRAMUNIFORM2UI64ARB
+	gpProgramUniform2ui64NV                          C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                        C.GPPROGRAMUNIFORM2UI64VARB
+	gpProgramUniform2ui64vNV                         C.GPPROGRAMUNIFORM2UI64VNV
+	gpProgramUniform2uiEXT                           C.GPPROGRAMUNIFORM2UIEXT
+	gpProgramUniform2uiv                             C.GPPROGRAMUNIFORM2UIV
+	gpProgramUniform2uivEXT                          C.GPPROGRAMUNIFORM2UIVEXT
+	gpProgramUniform3d                               C.GPPROGRAMUNIFORM3D
+	gpProgramUniform3dEXT                            C.GPPROGRAMUNIFORM3DEXT
+	gpProgramUniform3dv                              C.GPPROGRAMUNIFORM3DV
+	gpProgramUniform3dvEXT                           C.GPPROGRAMUNIFORM3DVEXT
+	gpProgramUniform3f                               C.GPPROGRAMUNIFORM3F
+	gpProgramUniform3fEXT                            C.GPPROGRAMUNIFORM3FEXT
+	gpProgramUniform3fv                              C.GPPROGRAMUNIFORM3FV
+	gpProgramUniform3fvEXT                           C.GPPROGRAMUNIFORM3FVEXT
+	gpProgramUniform3i                               C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                          C.GPPROGRAMUNIFORM3I64ARB
+	gpProgramUniform3i64NV                           C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                         C.GPPROGRAMUNIFORM3I64VARB
+	gpProgramUniform3i64vNV                          C.GPPROGRAMUNIFORM3I64VNV
+	gpProgramUniform3iEXT                            C.GPPROGRAMUNIFORM3IEXT
+	gpProgramUniform3iv                              C.GPPROGRAMUNIFORM3IV
+	gpProgramUniform3ivEXT                           C.GPPROGRAMUNIFORM3IVEXT
+	gpProgramUniform3ui                              C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                         C.GPPROGRAMUNIFORM3UI64ARB
+	gpProgramUniform3ui64NV                          C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                        C.GPPROGRAMUNIFORM3UI64VARB
+	gpProgramUniform3ui64vNV                         C.GPPROGRAMUNIFORM3UI64VNV
+	gpProgramUniform3uiEXT                           C.GPPROGRAMUNIFORM3UIEXT
+	gpProgramUniform3uiv                             C.GPPROGRAMUNIFORM3UIV
+	gpProgramUniform3uivEXT                          C.GPPROGRAMUNIFORM3UIVEXT
+	gpProgramUniform4d                               C.GPPROGRAMUNIFORM4D
+	gpProgramUniform4dEXT                            C.GPPROGRAMUNIFORM4DEXT
+	gpProgramUniform4dv                              C.GPPROGRAMUNIFORM4DV
+	gpProgramUniform4dvEXT                           C.GPPROGRAMUNIFORM4DVEXT
+	gpProgramUniform4f                               C.GPPROGRAMUNIFORM4F
+	gpProgramUniform4fEXT                            C.GPPROGRAMUNIFORM4FEXT
+	gpProgramUniform4fv                              C.GPPROGRAMUNIFORM4FV
+	gpProgramUniform4fvEXT                           C.GPPROGRAMUNIFORM4FVEXT
+	gpProgramUniform4i                               C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                          C.GPPROGRAMUNIFORM4I64ARB
+	gpProgramUniform4i64NV                           C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                         C.GPPROGRAMUNIFORM4I64VARB
+	gpProgramUniform4i64vNV                          C.GPPROGRAMUNIFORM4I64VNV
+	gpProgramUniform4iEXT                            C.GPPROGRAMUNIFORM4IEXT
+	gpProgramUniform4iv                              C.GPPROGRAMUNIFORM4IV
+	gpProgramUniform4ivEXT                           C.GPPROGRAMUNIFORM4IVEXT
+	gpProgramUniform4ui                              C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                         C.GPPROGRAMUNIFORM4UI64ARB
+	gpProgramUniform4ui64NV                          C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                        C.GPPROGRAMUNIFORM4UI64VARB
+	gpProgramUniform4ui64vNV                         C.GPPROGRAMUNIFORM4UI64VNV
+	gpProgramUniform4uiEXT                           C.GPPROGRAMUNIFORM4UIEXT
+	gpProgramUniform4uiv                             C.GPPROGRAMUNIFORM4UIV
+	gpProgramUniform4uivEXT                          C.GPPROGRAMUNIFORM4UIVEXT
+	gpProgramUniformHandleui64ARB                    C.GPPROGRAMUNIFORMHANDLEUI64ARB
+	gpProgramUniformHandleui64NV                     C.GPPROGRAMUNIFORMHANDLEUI64NV
+	gpProgramUniformHandleui64vARB                   C.GPPROGRAMUNIFORMHANDLEUI64VARB
+	gpProgramUniformHandleui64vNV                    C.GPPROGRAMUNIFORMHANDLEUI64VNV
+	gpProgramUniformMatrix2dv                        C.GPPROGRAMUNIFORMMATRIX2DV
+	gpProgramUniformMatrix2dvEXT                     C.GPPROGRAMUNIFORMMATRIX2DVEXT
+	gpProgramUniformMatrix2fv                        C.GPPROGRAMUNIFORMMATRIX2FV
+	gpProgramUniformMatrix2fvEXT                     C.GPPROGRAMUNIFORMMATRIX2FVEXT
+	gpProgramUniformMatrix2x3dv                      C.GPPROGRAMUNIFORMMATRIX2X3DV
+	gpProgramUniformMatrix2x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3DVEXT
+	gpProgramUniformMatrix2x3fv                      C.GPPROGRAMUNIFORMMATRIX2X3FV
+	gpProgramUniformMatrix2x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3FVEXT
+	gpProgramUniformMatrix2x4dv                      C.GPPROGRAMUNIFORMMATRIX2X4DV
+	gpProgramUniformMatrix2x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4DVEXT
+	gpProgramUniformMatrix2x4fv                      C.GPPROGRAMUNIFORMMATRIX2X4FV
+	gpProgramUniformMatrix2x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4FVEXT
+	gpProgramUniformMatrix3dv                        C.GPPROGRAMUNIFORMMATRIX3DV
+	gpProgramUniformMatrix3dvEXT                     C.GPPROGRAMUNIFORMMATRIX3DVEXT
+	gpProgramUniformMatrix3fv                        C.GPPROGRAMUNIFORMMATRIX3FV
+	gpProgramUniformMatrix3fvEXT                     C.GPPROGRAMUNIFORMMATRIX3FVEXT
+	gpProgramUniformMatrix3x2dv                      C.GPPROGRAMUNIFORMMATRIX3X2DV
+	gpProgramUniformMatrix3x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2DVEXT
+	gpProgramUniformMatrix3x2fv                      C.GPPROGRAMUNIFORMMATRIX3X2FV
+	gpProgramUniformMatrix3x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2FVEXT
+	gpProgramUniformMatrix3x4dv                      C.GPPROGRAMUNIFORMMATRIX3X4DV
+	gpProgramUniformMatrix3x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4DVEXT
+	gpProgramUniformMatrix3x4fv                      C.GPPROGRAMUNIFORMMATRIX3X4FV
+	gpProgramUniformMatrix3x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4FVEXT
+	gpProgramUniformMatrix4dv                        C.GPPROGRAMUNIFORMMATRIX4DV
+	gpProgramUniformMatrix4dvEXT                     C.GPPROGRAMUNIFORMMATRIX4DVEXT
+	gpProgramUniformMatrix4fv                        C.GPPROGRAMUNIFORMMATRIX4FV
+	gpProgramUniformMatrix4fvEXT                     C.GPPROGRAMUNIFORMMATRIX4FVEXT
+	gpProgramUniformMatrix4x2dv                      C.GPPROGRAMUNIFORMMATRIX4X2DV
+	gpProgramUniformMatrix4x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2DVEXT
+	gpProgramUniformMatrix4x2fv                      C.GPPROGRAMUNIFORMMATRIX4X2FV
+	gpProgramUniformMatrix4x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2FVEXT
+	gpProgramUniformMatrix4x3dv                      C.GPPROGRAMUNIFORMMATRIX4X3DV
+	gpProgramUniformMatrix4x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3DVEXT
+	gpProgramUniformMatrix4x3fv                      C.GPPROGRAMUNIFORMMATRIX4X3FV
+	gpProgramUniformMatrix4x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3FVEXT
+	gpProgramUniformui64NV                           C.GPPROGRAMUNIFORMUI64NV
+	gpProgramUniformui64vNV                          C.GPPROGRAMUNIFORMUI64VNV
+	gpProvokingVertex                                C.GPPROVOKINGVERTEX
+	gpPushClientAttribDefaultEXT                     C.GPPUSHCLIENTATTRIBDEFAULTEXT
+	gpPushDebugGroup                                 C.GPPUSHDEBUGGROUP
+	gpPushDebugGroupKHR                              C.GPPUSHDEBUGGROUPKHR
+	gpPushGroupMarkerEXT                             C.GPPUSHGROUPMARKEREXT
+	gpQueryCounter                                   C.GPQUERYCOUNTER
+	gpRasterSamplesEXT                               C.GPRASTERSAMPLESEXT
+	gpReadBuffer                                     C.GPREADBUFFER
+	gpReadPixels                                     C.GPREADPIXELS
+	gpReadnPixels                                    C.GPREADNPIXELS
+	gpReadnPixelsARB                                 C.GPREADNPIXELSARB
+	gpReadnPixelsKHR                                 C.GPREADNPIXELSKHR
+	gpReleaseShaderCompiler                          C.GPRELEASESHADERCOMPILER
+	gpRenderbufferStorage                            C.GPRENDERBUFFERSTORAGE
+	gpRenderbufferStorageMultisample                 C.GPRENDERBUFFERSTORAGEMULTISAMPLE
+	gpRenderbufferStorageMultisampleCoverageNV       C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV
+	gpResolveDepthValuesNV                           C.GPRESOLVEDEPTHVALUESNV
+	gpResumeTransformFeedback                        C.GPRESUMETRANSFORMFEEDBACK
+	gpSampleCoverage                                 C.GPSAMPLECOVERAGE
+	gpSampleMaski                                    C.GPSAMPLEMASKI
+	gpSamplerParameterIiv                            C.GPSAMPLERPARAMETERIIV
+	gpSamplerParameterIuiv                           C.GPSAMPLERPARAMETERIUIV
+	gpSamplerParameterf                              C.GPSAMPLERPARAMETERF
+	gpSamplerParameterfv                             C.GPSAMPLERPARAMETERFV
+	gpSamplerParameteri                              C.GPSAMPLERPARAMETERI
+	gpSamplerParameteriv                             C.GPSAMPLERPARAMETERIV
+	gpScissor                                        C.GPSCISSOR
+	gpScissorArrayv                                  C.GPSCISSORARRAYV
+	gpScissorIndexed                                 C.GPSCISSORINDEXED
+	gpScissorIndexedv                                C.GPSCISSORINDEXEDV
+	gpSecondaryColorFormatNV                         C.GPSECONDARYCOLORFORMATNV
+	gpSelectPerfMonitorCountersAMD                   C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpShaderBinary                                   C.GPSHADERBINARY
+	gpShaderSource                                   C.GPSHADERSOURCE
+	gpShaderStorageBlockBinding                      C.GPSHADERSTORAGEBLOCKBINDING
+	gpSignalVkFenceNV                                C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                            C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                            C.GPSPECIALIZESHADERARB
+	gpStateCaptureNV                                 C.GPSTATECAPTURENV
+	gpStencilFillPathInstancedNV                     C.GPSTENCILFILLPATHINSTANCEDNV
+	gpStencilFillPathNV                              C.GPSTENCILFILLPATHNV
+	gpStencilFunc                                    C.GPSTENCILFUNC
+	gpStencilFuncSeparate                            C.GPSTENCILFUNCSEPARATE
+	gpStencilMask                                    C.GPSTENCILMASK
+	gpStencilMaskSeparate                            C.GPSTENCILMASKSEPARATE
+	gpStencilOp                                      C.GPSTENCILOP
+	gpStencilOpSeparate                              C.GPSTENCILOPSEPARATE
+	gpStencilStrokePathInstancedNV                   C.GPSTENCILSTROKEPATHINSTANCEDNV
+	gpStencilStrokePathNV                            C.GPSTENCILSTROKEPATHNV
+	gpStencilThenCoverFillPathInstancedNV            C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV
+	gpStencilThenCoverFillPathNV                     C.GPSTENCILTHENCOVERFILLPATHNV
+	gpStencilThenCoverStrokePathInstancedNV          C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV
+	gpStencilThenCoverStrokePathNV                   C.GPSTENCILTHENCOVERSTROKEPATHNV
+	gpSubpixelPrecisionBiasNV                        C.GPSUBPIXELPRECISIONBIASNV
+	gpTexBuffer                                      C.GPTEXBUFFER
+	gpTexBufferARB                                   C.GPTEXBUFFERARB
+	gpTexBufferRange                                 C.GPTEXBUFFERRANGE
+	gpTexCoordFormatNV                               C.GPTEXCOORDFORMATNV
+	gpTexImage1D                                     C.GPTEXIMAGE1D
+	gpTexImage2D                                     C.GPTEXIMAGE2D
+	gpTexImage2DMultisample                          C.GPTEXIMAGE2DMULTISAMPLE
+	gpTexImage3D                                     C.GPTEXIMAGE3D
+	gpTexImage3DMultisample                          C.GPTEXIMAGE3DMULTISAMPLE
+	gpTexPageCommitmentARB                           C.GPTEXPAGECOMMITMENTARB
+	gpTexParameterIiv                                C.GPTEXPARAMETERIIV
+	gpTexParameterIuiv                               C.GPTEXPARAMETERIUIV
+	gpTexParameterf                                  C.GPTEXPARAMETERF
+	gpTexParameterfv                                 C.GPTEXPARAMETERFV
+	gpTexParameteri                                  C.GPTEXPARAMETERI
+	gpTexParameteriv                                 C.GPTEXPARAMETERIV
+	gpTexStorage1D                                   C.GPTEXSTORAGE1D
+	gpTexStorage2D                                   C.GPTEXSTORAGE2D
+	gpTexStorage2DMultisample                        C.GPTEXSTORAGE2DMULTISAMPLE
+	gpTexStorage3D                                   C.GPTEXSTORAGE3D
+	gpTexStorage3DMultisample                        C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexSubImage1D                                  C.GPTEXSUBIMAGE1D
+	gpTexSubImage2D                                  C.GPTEXSUBIMAGE2D
+	gpTexSubImage3D                                  C.GPTEXSUBIMAGE3D
+	gpTextureBarrier                                 C.GPTEXTUREBARRIER
+	gpTextureBarrierNV                               C.GPTEXTUREBARRIERNV
+	gpTextureBuffer                                  C.GPTEXTUREBUFFER
+	gpTextureBufferEXT                               C.GPTEXTUREBUFFEREXT
+	gpTextureBufferRange                             C.GPTEXTUREBUFFERRANGE
+	gpTextureBufferRangeEXT                          C.GPTEXTUREBUFFERRANGEEXT
+	gpTextureImage1DEXT                              C.GPTEXTUREIMAGE1DEXT
+	gpTextureImage2DEXT                              C.GPTEXTUREIMAGE2DEXT
+	gpTextureImage3DEXT                              C.GPTEXTUREIMAGE3DEXT
+	gpTexturePageCommitmentEXT                       C.GPTEXTUREPAGECOMMITMENTEXT
+	gpTextureParameterIiv                            C.GPTEXTUREPARAMETERIIV
+	gpTextureParameterIivEXT                         C.GPTEXTUREPARAMETERIIVEXT
+	gpTextureParameterIuiv                           C.GPTEXTUREPARAMETERIUIV
+	gpTextureParameterIuivEXT                        C.GPTEXTUREPARAMETERIUIVEXT
+	gpTextureParameterf                              C.GPTEXTUREPARAMETERF
+	gpTextureParameterfEXT                           C.GPTEXTUREPARAMETERFEXT
+	gpTextureParameterfv                             C.GPTEXTUREPARAMETERFV
+	gpTextureParameterfvEXT                          C.GPTEXTUREPARAMETERFVEXT
+	gpTextureParameteri                              C.GPTEXTUREPARAMETERI
+	gpTextureParameteriEXT                           C.GPTEXTUREPARAMETERIEXT
+	gpTextureParameteriv                             C.GPTEXTUREPARAMETERIV
+	gpTextureParameterivEXT                          C.GPTEXTUREPARAMETERIVEXT
+	gpTextureRenderbufferEXT                         C.GPTEXTURERENDERBUFFEREXT
+	gpTextureStorage1D                               C.GPTEXTURESTORAGE1D
+	gpTextureStorage1DEXT                            C.GPTEXTURESTORAGE1DEXT
+	gpTextureStorage2D                               C.GPTEXTURESTORAGE2D
+	gpTextureStorage2DEXT                            C.GPTEXTURESTORAGE2DEXT
+	gpTextureStorage2DMultisample                    C.GPTEXTURESTORAGE2DMULTISAMPLE
+	gpTextureStorage2DMultisampleEXT                 C.GPTEXTURESTORAGE2DMULTISAMPLEEXT
+	gpTextureStorage3D                               C.GPTEXTURESTORAGE3D
+	gpTextureStorage3DEXT                            C.GPTEXTURESTORAGE3DEXT
+	gpTextureStorage3DMultisample                    C.GPTEXTURESTORAGE3DMULTISAMPLE
+	gpTextureStorage3DMultisampleEXT                 C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureSubImage1D                              C.GPTEXTURESUBIMAGE1D
+	gpTextureSubImage1DEXT                           C.GPTEXTURESUBIMAGE1DEXT
+	gpTextureSubImage2D                              C.GPTEXTURESUBIMAGE2D
+	gpTextureSubImage2DEXT                           C.GPTEXTURESUBIMAGE2DEXT
+	gpTextureSubImage3D                              C.GPTEXTURESUBIMAGE3D
+	gpTextureSubImage3DEXT                           C.GPTEXTURESUBIMAGE3DEXT
+	gpTextureView                                    C.GPTEXTUREVIEW
+	gpTransformFeedbackBufferBase                    C.GPTRANSFORMFEEDBACKBUFFERBASE
+	gpTransformFeedbackBufferRange                   C.GPTRANSFORMFEEDBACKBUFFERRANGE
+	gpTransformFeedbackVaryings                      C.GPTRANSFORMFEEDBACKVARYINGS
+	gpTransformPathNV                                C.GPTRANSFORMPATHNV
+	gpUniform1d                                      C.GPUNIFORM1D
+	gpUniform1dv                                     C.GPUNIFORM1DV
+	gpUniform1f                                      C.GPUNIFORM1F
+	gpUniform1fv                                     C.GPUNIFORM1FV
+	gpUniform1i                                      C.GPUNIFORM1I
+	gpUniform1i64ARB                                 C.GPUNIFORM1I64ARB
+	gpUniform1i64NV                                  C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                C.GPUNIFORM1I64VARB
+	gpUniform1i64vNV                                 C.GPUNIFORM1I64VNV
+	gpUniform1iv                                     C.GPUNIFORM1IV
+	gpUniform1ui                                     C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                C.GPUNIFORM1UI64ARB
+	gpUniform1ui64NV                                 C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                               C.GPUNIFORM1UI64VARB
+	gpUniform1ui64vNV                                C.GPUNIFORM1UI64VNV
+	gpUniform1uiv                                    C.GPUNIFORM1UIV
+	gpUniform2d                                      C.GPUNIFORM2D
+	gpUniform2dv                                     C.GPUNIFORM2DV
+	gpUniform2f                                      C.GPUNIFORM2F
+	gpUniform2fv                                     C.GPUNIFORM2FV
+	gpUniform2i                                      C.GPUNIFORM2I
+	gpUniform2i64ARB                                 C.GPUNIFORM2I64ARB
+	gpUniform2i64NV                                  C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                C.GPUNIFORM2I64VARB
+	gpUniform2i64vNV                                 C.GPUNIFORM2I64VNV
+	gpUniform2iv                                     C.GPUNIFORM2IV
+	gpUniform2ui                                     C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                C.GPUNIFORM2UI64ARB
+	gpUniform2ui64NV                                 C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                               C.GPUNIFORM2UI64VARB
+	gpUniform2ui64vNV                                C.GPUNIFORM2UI64VNV
+	gpUniform2uiv                                    C.GPUNIFORM2UIV
+	gpUniform3d                                      C.GPUNIFORM3D
+	gpUniform3dv                                     C.GPUNIFORM3DV
+	gpUniform3f                                      C.GPUNIFORM3F
+	gpUniform3fv                                     C.GPUNIFORM3FV
+	gpUniform3i                                      C.GPUNIFORM3I
+	gpUniform3i64ARB                                 C.GPUNIFORM3I64ARB
+	gpUniform3i64NV                                  C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                C.GPUNIFORM3I64VARB
+	gpUniform3i64vNV                                 C.GPUNIFORM3I64VNV
+	gpUniform3iv                                     C.GPUNIFORM3IV
+	gpUniform3ui                                     C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                C.GPUNIFORM3UI64ARB
+	gpUniform3ui64NV                                 C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                               C.GPUNIFORM3UI64VARB
+	gpUniform3ui64vNV                                C.GPUNIFORM3UI64VNV
+	gpUniform3uiv                                    C.GPUNIFORM3UIV
+	gpUniform4d                                      C.GPUNIFORM4D
+	gpUniform4dv                                     C.GPUNIFORM4DV
+	gpUniform4f                                      C.GPUNIFORM4F
+	gpUniform4fv                                     C.GPUNIFORM4FV
+	gpUniform4i                                      C.GPUNIFORM4I
+	gpUniform4i64ARB                                 C.GPUNIFORM4I64ARB
+	gpUniform4i64NV                                  C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                C.GPUNIFORM4I64VARB
+	gpUniform4i64vNV                                 C.GPUNIFORM4I64VNV
+	gpUniform4iv                                     C.GPUNIFORM4IV
+	gpUniform4ui                                     C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                C.GPUNIFORM4UI64ARB
+	gpUniform4ui64NV                                 C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                               C.GPUNIFORM4UI64VARB
+	gpUniform4ui64vNV                                C.GPUNIFORM4UI64VNV
+	gpUniform4uiv                                    C.GPUNIFORM4UIV
+	gpUniformBlockBinding                            C.GPUNIFORMBLOCKBINDING
+	gpUniformHandleui64ARB                           C.GPUNIFORMHANDLEUI64ARB
+	gpUniformHandleui64NV                            C.GPUNIFORMHANDLEUI64NV
+	gpUniformHandleui64vARB                          C.GPUNIFORMHANDLEUI64VARB
+	gpUniformHandleui64vNV                           C.GPUNIFORMHANDLEUI64VNV
+	gpUniformMatrix2dv                               C.GPUNIFORMMATRIX2DV
+	gpUniformMatrix2fv                               C.GPUNIFORMMATRIX2FV
+	gpUniformMatrix2x3dv                             C.GPUNIFORMMATRIX2X3DV
+	gpUniformMatrix2x3fv                             C.GPUNIFORMMATRIX2X3FV
+	gpUniformMatrix2x4dv                             C.GPUNIFORMMATRIX2X4DV
+	gpUniformMatrix2x4fv                             C.GPUNIFORMMATRIX2X4FV
+	gpUniformMatrix3dv                               C.GPUNIFORMMATRIX3DV
+	gpUniformMatrix3fv                               C.GPUNIFORMMATRIX3FV
+	gpUniformMatrix3x2dv                             C.GPUNIFORMMATRIX3X2DV
+	gpUniformMatrix3x2fv                             C.GPUNIFORMMATRIX3X2FV
+	gpUniformMatrix3x4dv                             C.GPUNIFORMMATRIX3X4DV
+	gpUniformMatrix3x4fv                             C.GPUNIFORMMATRIX3X4FV
+	gpUniformMatrix4dv                               C.GPUNIFORMMATRIX4DV
+	gpUniformMatrix4fv                               C.GPUNIFORMMATRIX4FV
+	gpUniformMatrix4x2dv                             C.GPUNIFORMMATRIX4X2DV
+	gpUniformMatrix4x2fv                             C.GPUNIFORMMATRIX4X2FV
+	gpUniformMatrix4x3dv                             C.GPUNIFORMMATRIX4X3DV
+	gpUniformMatrix4x3fv                             C.GPUNIFORMMATRIX4X3FV
+	gpUniformSubroutinesuiv                          C.GPUNIFORMSUBROUTINESUIV
+	gpUniformui64NV                                  C.GPUNIFORMUI64NV
+	gpUniformui64vNV                                 C.GPUNIFORMUI64VNV
+	gpUnmapBuffer                                    C.GPUNMAPBUFFER
+	gpUnmapNamedBuffer                               C.GPUNMAPNAMEDBUFFER
+	gpUnmapNamedBufferEXT                            C.GPUNMAPNAMEDBUFFEREXT
+	gpUseProgram                                     C.GPUSEPROGRAM
+	gpUseProgramStages                               C.GPUSEPROGRAMSTAGES
+	gpUseProgramStagesEXT                            C.GPUSEPROGRAMSTAGESEXT
+	gpUseShaderProgramEXT                            C.GPUSESHADERPROGRAMEXT
+	gpValidateProgram                                C.GPVALIDATEPROGRAM
+	gpValidateProgramPipeline                        C.GPVALIDATEPROGRAMPIPELINE
+	gpValidateProgramPipelineEXT                     C.GPVALIDATEPROGRAMPIPELINEEXT
+	gpVertexArrayAttribBinding                       C.GPVERTEXARRAYATTRIBBINDING
+	gpVertexArrayAttribFormat                        C.GPVERTEXARRAYATTRIBFORMAT
+	gpVertexArrayAttribIFormat                       C.GPVERTEXARRAYATTRIBIFORMAT
+	gpVertexArrayAttribLFormat                       C.GPVERTEXARRAYATTRIBLFORMAT
+	gpVertexArrayBindVertexBufferEXT                 C.GPVERTEXARRAYBINDVERTEXBUFFEREXT
+	gpVertexArrayBindingDivisor                      C.GPVERTEXARRAYBINDINGDIVISOR
+	gpVertexArrayColorOffsetEXT                      C.GPVERTEXARRAYCOLOROFFSETEXT
+	gpVertexArrayEdgeFlagOffsetEXT                   C.GPVERTEXARRAYEDGEFLAGOFFSETEXT
+	gpVertexArrayElementBuffer                       C.GPVERTEXARRAYELEMENTBUFFER
+	gpVertexArrayFogCoordOffsetEXT                   C.GPVERTEXARRAYFOGCOORDOFFSETEXT
+	gpVertexArrayIndexOffsetEXT                      C.GPVERTEXARRAYINDEXOFFSETEXT
+	gpVertexArrayMultiTexCoordOffsetEXT              C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT
+	gpVertexArrayNormalOffsetEXT                     C.GPVERTEXARRAYNORMALOFFSETEXT
+	gpVertexArraySecondaryColorOffsetEXT             C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT
+	gpVertexArrayTexCoordOffsetEXT                   C.GPVERTEXARRAYTEXCOORDOFFSETEXT
+	gpVertexArrayVertexAttribBindingEXT              C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT
+	gpVertexArrayVertexAttribDivisorEXT              C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT
+	gpVertexArrayVertexAttribFormatEXT               C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT
+	gpVertexArrayVertexAttribIFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT
+	gpVertexArrayVertexAttribIOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT
+	gpVertexArrayVertexAttribLFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT
+	gpVertexArrayVertexAttribLOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT
+	gpVertexArrayVertexAttribOffsetEXT               C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT
+	gpVertexArrayVertexBindingDivisorEXT             C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT
+	gpVertexArrayVertexBuffer                        C.GPVERTEXARRAYVERTEXBUFFER
+	gpVertexArrayVertexBuffers                       C.GPVERTEXARRAYVERTEXBUFFERS
+	gpVertexArrayVertexOffsetEXT                     C.GPVERTEXARRAYVERTEXOFFSETEXT
+	gpVertexAttrib1d                                 C.GPVERTEXATTRIB1D
+	gpVertexAttrib1dv                                C.GPVERTEXATTRIB1DV
+	gpVertexAttrib1f                                 C.GPVERTEXATTRIB1F
+	gpVertexAttrib1fv                                C.GPVERTEXATTRIB1FV
+	gpVertexAttrib1s                                 C.GPVERTEXATTRIB1S
+	gpVertexAttrib1sv                                C.GPVERTEXATTRIB1SV
+	gpVertexAttrib2d                                 C.GPVERTEXATTRIB2D
+	gpVertexAttrib2dv                                C.GPVERTEXATTRIB2DV
+	gpVertexAttrib2f                                 C.GPVERTEXATTRIB2F
+	gpVertexAttrib2fv                                C.GPVERTEXATTRIB2FV
+	gpVertexAttrib2s                                 C.GPVERTEXATTRIB2S
+	gpVertexAttrib2sv                                C.GPVERTEXATTRIB2SV
+	gpVertexAttrib3d                                 C.GPVERTEXATTRIB3D
+	gpVertexAttrib3dv                                C.GPVERTEXATTRIB3DV
+	gpVertexAttrib3f                                 C.GPVERTEXATTRIB3F
+	gpVertexAttrib3fv                                C.GPVERTEXATTRIB3FV
+	gpVertexAttrib3s                                 C.GPVERTEXATTRIB3S
+	gpVertexAttrib3sv                                C.GPVERTEXATTRIB3SV
+	gpVertexAttrib4Nbv                               C.GPVERTEXATTRIB4NBV
+	gpVertexAttrib4Niv                               C.GPVERTEXATTRIB4NIV
+	gpVertexAttrib4Nsv                               C.GPVERTEXATTRIB4NSV
+	gpVertexAttrib4Nub                               C.GPVERTEXATTRIB4NUB
+	gpVertexAttrib4Nubv                              C.GPVERTEXATTRIB4NUBV
+	gpVertexAttrib4Nuiv                              C.GPVERTEXATTRIB4NUIV
+	gpVertexAttrib4Nusv                              C.GPVERTEXATTRIB4NUSV
+	gpVertexAttrib4bv                                C.GPVERTEXATTRIB4BV
+	gpVertexAttrib4d                                 C.GPVERTEXATTRIB4D
+	gpVertexAttrib4dv                                C.GPVERTEXATTRIB4DV
+	gpVertexAttrib4f                                 C.GPVERTEXATTRIB4F
+	gpVertexAttrib4fv                                C.GPVERTEXATTRIB4FV
+	gpVertexAttrib4iv                                C.GPVERTEXATTRIB4IV
+	gpVertexAttrib4s                                 C.GPVERTEXATTRIB4S
+	gpVertexAttrib4sv                                C.GPVERTEXATTRIB4SV
+	gpVertexAttrib4ubv                               C.GPVERTEXATTRIB4UBV
+	gpVertexAttrib4uiv                               C.GPVERTEXATTRIB4UIV
+	gpVertexAttrib4usv                               C.GPVERTEXATTRIB4USV
+	gpVertexAttribBinding                            C.GPVERTEXATTRIBBINDING
+	gpVertexAttribDivisor                            C.GPVERTEXATTRIBDIVISOR
+	gpVertexAttribDivisorARB                         C.GPVERTEXATTRIBDIVISORARB
+	gpVertexAttribFormat                             C.GPVERTEXATTRIBFORMAT
+	gpVertexAttribFormatNV                           C.GPVERTEXATTRIBFORMATNV
+	gpVertexAttribI1i                                C.GPVERTEXATTRIBI1I
+	gpVertexAttribI1iv                               C.GPVERTEXATTRIBI1IV
+	gpVertexAttribI1ui                               C.GPVERTEXATTRIBI1UI
+	gpVertexAttribI1uiv                              C.GPVERTEXATTRIBI1UIV
+	gpVertexAttribI2i                                C.GPVERTEXATTRIBI2I
+	gpVertexAttribI2iv                               C.GPVERTEXATTRIBI2IV
+	gpVertexAttribI2ui                               C.GPVERTEXATTRIBI2UI
+	gpVertexAttribI2uiv                              C.GPVERTEXATTRIBI2UIV
+	gpVertexAttribI3i                                C.GPVERTEXATTRIBI3I
+	gpVertexAttribI3iv                               C.GPVERTEXATTRIBI3IV
+	gpVertexAttribI3ui                               C.GPVERTEXATTRIBI3UI
+	gpVertexAttribI3uiv                              C.GPVERTEXATTRIBI3UIV
+	gpVertexAttribI4bv                               C.GPVERTEXATTRIBI4BV
+	gpVertexAttribI4i                                C.GPVERTEXATTRIBI4I
+	gpVertexAttribI4iv                               C.GPVERTEXATTRIBI4IV
+	gpVertexAttribI4sv                               C.GPVERTEXATTRIBI4SV
+	gpVertexAttribI4ubv                              C.GPVERTEXATTRIBI4UBV
+	gpVertexAttribI4ui                               C.GPVERTEXATTRIBI4UI
+	gpVertexAttribI4uiv                              C.GPVERTEXATTRIBI4UIV
+	gpVertexAttribI4usv                              C.GPVERTEXATTRIBI4USV
+	gpVertexAttribIFormat                            C.GPVERTEXATTRIBIFORMAT
+	gpVertexAttribIFormatNV                          C.GPVERTEXATTRIBIFORMATNV
+	gpVertexAttribIPointer                           C.GPVERTEXATTRIBIPOINTER
+	gpVertexAttribL1d                                C.GPVERTEXATTRIBL1D
+	gpVertexAttribL1dv                               C.GPVERTEXATTRIBL1DV
+	gpVertexAttribL1i64NV                            C.GPVERTEXATTRIBL1I64NV
+	gpVertexAttribL1i64vNV                           C.GPVERTEXATTRIBL1I64VNV
+	gpVertexAttribL1ui64ARB                          C.GPVERTEXATTRIBL1UI64ARB
+	gpVertexAttribL1ui64NV                           C.GPVERTEXATTRIBL1UI64NV
+	gpVertexAttribL1ui64vARB                         C.GPVERTEXATTRIBL1UI64VARB
+	gpVertexAttribL1ui64vNV                          C.GPVERTEXATTRIBL1UI64VNV
+	gpVertexAttribL2d                                C.GPVERTEXATTRIBL2D
+	gpVertexAttribL2dv                               C.GPVERTEXATTRIBL2DV
+	gpVertexAttribL2i64NV                            C.GPVERTEXATTRIBL2I64NV
+	gpVertexAttribL2i64vNV                           C.GPVERTEXATTRIBL2I64VNV
+	gpVertexAttribL2ui64NV                           C.GPVERTEXATTRIBL2UI64NV
+	gpVertexAttribL2ui64vNV                          C.GPVERTEXATTRIBL2UI64VNV
+	gpVertexAttribL3d                                C.GPVERTEXATTRIBL3D
+	gpVertexAttribL3dv                               C.GPVERTEXATTRIBL3DV
+	gpVertexAttribL3i64NV                            C.GPVERTEXATTRIBL3I64NV
+	gpVertexAttribL3i64vNV                           C.GPVERTEXATTRIBL3I64VNV
+	gpVertexAttribL3ui64NV                           C.GPVERTEXATTRIBL3UI64NV
+	gpVertexAttribL3ui64vNV                          C.GPVERTEXATTRIBL3UI64VNV
+	gpVertexAttribL4d                                C.GPVERTEXATTRIBL4D
+	gpVertexAttribL4dv                               C.GPVERTEXATTRIBL4DV
+	gpVertexAttribL4i64NV                            C.GPVERTEXATTRIBL4I64NV
+	gpVertexAttribL4i64vNV                           C.GPVERTEXATTRIBL4I64VNV
+	gpVertexAttribL4ui64NV                           C.GPVERTEXATTRIBL4UI64NV
+	gpVertexAttribL4ui64vNV                          C.GPVERTEXATTRIBL4UI64VNV
+	gpVertexAttribLFormat                            C.GPVERTEXATTRIBLFORMAT
+	gpVertexAttribLFormatNV                          C.GPVERTEXATTRIBLFORMATNV
+	gpVertexAttribLPointer                           C.GPVERTEXATTRIBLPOINTER
+	gpVertexAttribP1ui                               C.GPVERTEXATTRIBP1UI
+	gpVertexAttribP1uiv                              C.GPVERTEXATTRIBP1UIV
+	gpVertexAttribP2ui                               C.GPVERTEXATTRIBP2UI
+	gpVertexAttribP2uiv                              C.GPVERTEXATTRIBP2UIV
+	gpVertexAttribP3ui                               C.GPVERTEXATTRIBP3UI
+	gpVertexAttribP3uiv                              C.GPVERTEXATTRIBP3UIV
+	gpVertexAttribP4ui                               C.GPVERTEXATTRIBP4UI
+	gpVertexAttribP4uiv                              C.GPVERTEXATTRIBP4UIV
+	gpVertexAttribPointer                            C.GPVERTEXATTRIBPOINTER
+	gpVertexBindingDivisor                           C.GPVERTEXBINDINGDIVISOR
+	gpVertexFormatNV                                 C.GPVERTEXFORMATNV
+	gpViewport                                       C.GPVIEWPORT
+	gpViewportArrayv                                 C.GPVIEWPORTARRAYV
+	gpViewportIndexedf                               C.GPVIEWPORTINDEXEDF
+	gpViewportIndexedfv                              C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                       C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                              C.GPVIEWPORTSWIZZLENV
+	gpWaitSync                                       C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                              C.GPWAITVKSEMAPHORENV
+	gpWeightPathsNV                                  C.GPWEIGHTPATHSNV
+	gpWindowRectanglesEXT                            C.GPWINDOWRECTANGLESEXT
 )
 
 // Helper functions
@@ -5110,15 +8384,24 @@ func boolToInt(b bool) int {
 	}
 	return 0
 }
+func ActiveProgramEXT(program uint32) {
+	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
+}
 
 // set the active program object for a program pipeline object
 func ActiveShaderProgram(pipeline uint32, program uint32) {
 	C.glowActiveShaderProgram(gpActiveShaderProgram, (C.GLuint)(pipeline), (C.GLuint)(program))
 }
+func ActiveShaderProgramEXT(pipeline uint32, program uint32) {
+	C.glowActiveShaderProgramEXT(gpActiveShaderProgramEXT, (C.GLuint)(pipeline), (C.GLuint)(program))
+}
 
 // select active texture unit
 func ActiveTexture(texture uint32) {
 	C.glowActiveTexture(gpActiveTexture, (C.GLenum)(texture))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 
 // Attaches a shader object to a program object
@@ -5129,6 +8412,15 @@ func AttachShader(program uint32, shader uint32) {
 // start conditional rendering
 func BeginConditionalRender(id uint32, mode uint32) {
 	C.glowBeginConditionalRender(gpBeginConditionalRender, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginConditionalRenderNV(id uint32, mode uint32) {
+	C.glowBeginConditionalRenderNV(gpBeginConditionalRenderNV, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginPerfMonitorAMD(monitor uint32) {
+	C.glowBeginPerfMonitorAMD(gpBeginPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func BeginPerfQueryINTEL(queryHandle uint32) {
+	C.glowBeginPerfQueryINTEL(gpBeginPerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // delimit the boundaries of a query object
@@ -5198,10 +8490,16 @@ func BindImageTexture(unit uint32, texture uint32, level int32, layered bool, la
 func BindImageTextures(first uint32, count int32, textures *uint32) {
 	C.glowBindImageTextures(gpBindImageTextures, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(textures)))
 }
+func BindMultiTextureEXT(texunit uint32, target uint32, texture uint32) {
+	C.glowBindMultiTextureEXT(gpBindMultiTextureEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(texture))
+}
 
 // bind a program pipeline to the current context
 func BindProgramPipeline(pipeline uint32) {
 	C.glowBindProgramPipeline(gpBindProgramPipeline, (C.GLuint)(pipeline))
+}
+func BindProgramPipelineEXT(pipeline uint32) {
+	C.glowBindProgramPipelineEXT(gpBindProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 
 // bind a renderbuffer to a renderbuffer target
@@ -5253,6 +8551,12 @@ func BindVertexBuffer(bindingindex uint32, buffer uint32, offset int, stride int
 func BindVertexBuffers(first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowBindVertexBuffers(gpBindVertexBuffers, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
 }
+func BlendBarrierKHR() {
+	C.glowBlendBarrierKHR(gpBlendBarrierKHR)
+}
+func BlendBarrierNV() {
+	C.glowBlendBarrierNV(gpBlendBarrierNV)
+}
 
 // set the blend color
 func BlendColor(red float32, green float32, blue float32, alpha float32) {
@@ -5290,6 +8594,9 @@ func BlendFuncSeparateiARB(buf uint32, srcRGB uint32, dstRGB uint32, srcAlpha ui
 func BlendFunciARB(buf uint32, src uint32, dst uint32) {
 	C.glowBlendFunciARB(gpBlendFunciARB, (C.GLuint)(buf), (C.GLenum)(src), (C.GLenum)(dst))
 }
+func BlendParameteriNV(pname uint32, value int32) {
+	C.glowBlendParameteriNV(gpBlendParameteriNV, (C.GLenum)(pname), (C.GLint)(value))
+}
 
 // copy a block of pixels from one framebuffer object to another
 func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
@@ -5300,13 +8607,16 @@ func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 i
 func BlitNamedFramebuffer(readFramebuffer uint32, drawFramebuffer uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
 	C.glowBlitNamedFramebuffer(gpBlitNamedFramebuffer, (C.GLuint)(readFramebuffer), (C.GLuint)(drawFramebuffer), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
 }
+func BufferAddressRangeNV(pname uint32, index uint32, address uint64, length int) {
+	C.glowBufferAddressRangeNV(gpBufferAddressRangeNV, (C.GLenum)(pname), (C.GLuint)(index), (C.GLuint64EXT)(address), (C.GLsizeiptr)(length))
+}
 
 // creates and initializes a buffer object's data     store
 func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferData(gpBufferData, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
@@ -5318,6 +8628,9 @@ func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubData(gpBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
+}
 
 // check the completeness status of a framebuffer
 func CheckFramebufferStatus(target uint32) uint32 {
@@ -5328,6 +8641,10 @@ func CheckFramebufferStatus(target uint32) uint32 {
 // check the completeness status of a framebuffer
 func CheckNamedFramebufferStatus(framebuffer uint32, target uint32) uint32 {
 	ret := C.glowCheckNamedFramebufferStatus(gpCheckNamedFramebufferStatus, (C.GLuint)(framebuffer), (C.GLenum)(target))
+	return (uint32)(ret)
+}
+func CheckNamedFramebufferStatusEXT(framebuffer uint32, target uint32) uint32 {
+	ret := C.glowCheckNamedFramebufferStatusEXT(gpCheckNamedFramebufferStatusEXT, (C.GLuint)(framebuffer), (C.GLenum)(target))
 	return (uint32)(ret)
 }
 
@@ -5372,6 +8689,8 @@ func ClearColor(red float32, green float32, blue float32, alpha float32) {
 func ClearDepth(depth float64) {
 	C.glowClearDepth(gpClearDepth, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -5380,13 +8699,19 @@ func ClearDepthf(d float32) {
 func ClearNamedBufferData(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferData(gpClearNamedBufferData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferDataEXT(gpClearNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -5412,9 +8737,12 @@ func ClearTexImage(texture uint32, level int32, format uint32, xtype uint32, dat
 func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearTexSubImage(gpClearTexSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClientAttribDefaultEXT(mask uint32) {
+	C.glowClientAttribDefaultEXT(gpClientAttribDefaultEXT, (C.GLbitfield)(mask))
+}
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -5423,11 +8751,20 @@ func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
 func ClipControl(origin uint32, depth uint32) {
 	C.glowClipControl(gpClipControl, (C.GLenum)(origin), (C.GLenum)(depth))
 }
+func ColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowColorFormatNV(gpColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func ColorMask(red bool, green bool, blue bool, alpha bool) {
 	C.glowColorMask(gpColorMask, (C.GLboolean)(boolToInt(red)), (C.GLboolean)(boolToInt(green)), (C.GLboolean)(boolToInt(blue)), (C.GLboolean)(boolToInt(alpha)))
 }
 func ColorMaski(index uint32, r bool, g bool, b bool, a bool) {
 	C.glowColorMaski(gpColorMaski, (C.GLuint)(index), (C.GLboolean)(boolToInt(r)), (C.GLboolean)(boolToInt(g)), (C.GLboolean)(boolToInt(b)), (C.GLboolean)(boolToInt(a)))
+}
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
 }
 
 // Compiles a shader object
@@ -5436,6 +8773,24 @@ func CompileShader(shader uint32) {
 }
 func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
+}
+func CompressedMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage1DEXT(gpCompressedMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage2DEXT(gpCompressedMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage3DEXT(gpCompressedMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage1DEXT(gpCompressedMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage2DEXT(gpCompressedMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage3DEXT(gpCompressedMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a one-dimensional texture image in a compressed format
@@ -5467,20 +8822,44 @@ func CompressedTexSubImage2D(target uint32, level int32, xoffset int32, yoffset 
 func CompressedTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTexSubImage3D(gpCompressedTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage1DEXT(gpCompressedTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage2DEXT(gpCompressedTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage3DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage3DEXT(gpCompressedTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a one-dimensional texture subimage in a compressed     format
 func CompressedTextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage1D(gpCompressedTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage1DEXT(gpCompressedTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a two-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage2D(gpCompressedTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage2DEXT(gpCompressedTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a three-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3D(gpCompressedTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
@@ -5492,10 +8871,28 @@ func CopyBufferSubData(readTarget uint32, writeTarget uint32, readOffset int, wr
 func CopyImageSubData(srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
 	C.glowCopyImageSubData(gpCopyImageSubData, (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
 }
+func CopyMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyMultiTexImage1DEXT(gpCopyMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyMultiTexImage2DEXT(gpCopyMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
+func CopyMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyMultiTexSubImage1DEXT(gpCopyMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage2DEXT(gpCopyMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage3DEXT(gpCopyMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func CopyPathNV(resultPath uint32, srcPath uint32) {
+	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
 }
 
 // copy pixels into a 1D texture image
@@ -5522,30 +8919,69 @@ func CopyTexSubImage2D(target uint32, level int32, xoffset int32, yoffset int32,
 func CopyTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTexSubImage3D(gpCopyTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyTextureImage1DEXT(gpCopyTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyTextureImage2DEXT(gpCopyTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
 
 // copy a one-dimensional texture subimage
 func CopyTextureSubImage1D(texture uint32, level int32, xoffset int32, x int32, y int32, width int32) {
 	C.glowCopyTextureSubImage1D(gpCopyTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyTextureSubImage1DEXT(gpCopyTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
 }
 
 // copy a two-dimensional texture subimage
 func CopyTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage2D(gpCopyTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage2DEXT(gpCopyTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy a three-dimensional texture subimage
 func CopyTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage3D(gpCopyTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage3DEXT(gpCopyTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverFillPathInstancedNV(gpCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverFillPathNV(path uint32, coverMode uint32) {
+	C.glowCoverFillPathNV(gpCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverStrokePathInstancedNV(gpCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverStrokePathNV(path uint32, coverMode uint32) {
+	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
+	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
 }
 
 // Creates a program object
@@ -5579,15 +9015,26 @@ func CreateShader(xtype uint32) uint32 {
 	ret := C.glowCreateShader(gpCreateShader, (C.GLenum)(xtype))
 	return (uint32)(ret)
 }
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
+	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
+	return (uint32)(ret)
+}
 
 // create a stand-alone program from an array of null-terminated source code strings
 func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
+	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
+	return (uint32)(ret)
+}
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -5650,6 +9097,9 @@ func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint
 func DeleteBuffers(n int32, buffers *uint32) {
 	C.glowDeleteBuffers(gpDeleteBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // delete framebuffer objects
 func DeleteFramebuffers(n int32, framebuffers *uint32) {
@@ -5657,6 +9107,15 @@ func DeleteFramebuffers(n int32, framebuffers *uint32) {
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+}
+func DeletePathsNV(path uint32, xrange int32) {
+	C.glowDeletePathsNV(gpDeletePathsNV, (C.GLuint)(path), (C.GLsizei)(xrange))
+}
+func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowDeletePerfMonitorsAMD(gpDeletePerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
+func DeletePerfQueryINTEL(queryHandle uint32) {
+	C.glowDeletePerfQueryINTEL(gpDeletePerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // Deletes a program object
@@ -5667,6 +9126,9 @@ func DeleteProgram(program uint32) {
 // delete program pipeline objects
 func DeleteProgramPipelines(n int32, pipelines *uint32) {
 	C.glowDeleteProgramPipelines(gpDeleteProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func DeleteProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowDeleteProgramPipelinesEXT(gpDeleteProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // delete named query objects
@@ -5688,9 +9150,12 @@ func DeleteSamplers(count int32, samplers *uint32) {
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -5731,6 +9196,8 @@ func DepthRangeArrayv(first uint32, count int32, v *float64) {
 func DepthRangeIndexed(index uint32, n float64, f float64) {
 	C.glowDepthRangeIndexed(gpDepthRangeIndexed, (C.GLuint)(index), (C.GLdouble)(n), (C.GLdouble)(f))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -5742,10 +9209,25 @@ func DetachShader(program uint32, shader uint32) {
 func Disable(cap uint32) {
 	C.glowDisable(gpDisable, (C.GLenum)(cap))
 }
+func DisableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowDisableClientStateIndexedEXT(gpDisableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableClientStateiEXT(array uint32, index uint32) {
+	C.glowDisableClientStateiEXT(gpDisableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableIndexedEXT(target uint32, index uint32) {
+	C.glowDisableIndexedEXT(gpDisableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func DisableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowDisableVertexArrayAttrib(gpDisableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowDisableVertexArrayAttribEXT(gpDisableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowDisableVertexArrayEXT(gpDisableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -5783,10 +9265,16 @@ func DrawArraysIndirect(mode uint32, indirect unsafe.Pointer) {
 func DrawArraysInstanced(mode uint32, first int32, count int32, instancecount int32) {
 	C.glowDrawArraysInstanced(gpDrawArraysInstanced, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount))
 }
+func DrawArraysInstancedARB(mode uint32, first int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedARB(gpDrawArraysInstancedARB, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a range of elements with offset applied to instanced attributes
 func DrawArraysInstancedBaseInstance(mode uint32, first int32, count int32, instancecount int32, baseinstance uint32) {
 	C.glowDrawArraysInstancedBaseInstance(gpDrawArraysInstancedBaseInstance, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount), (C.GLuint)(baseinstance))
+}
+func DrawArraysInstancedEXT(mode uint32, start int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedEXT(gpDrawArraysInstancedEXT, (C.GLenum)(mode), (C.GLint)(start), (C.GLsizei)(count), (C.GLsizei)(primcount))
 }
 
 // specify which color buffers are to be drawn into
@@ -5797,6 +9285,18 @@ func DrawBuffer(buf uint32) {
 // Specifies a list of color buffers to be drawn     into
 func DrawBuffers(n int32, bufs *uint32) {
 	C.glowDrawBuffers(gpDrawBuffers, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 
 // render primitives from array data
@@ -5818,6 +9318,9 @@ func DrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer) {
 func DrawElementsInstanced(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32) {
 	C.glowDrawElementsInstanced(gpDrawElementsInstanced, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount))
 }
+func DrawElementsInstancedARB(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedARB(gpDrawElementsInstancedARB, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a set of elements with offset applied to instanced attributes
 func DrawElementsInstancedBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, baseinstance uint32) {
@@ -5832,6 +9335,9 @@ func DrawElementsInstancedBaseVertex(mode uint32, count int32, xtype uint32, ind
 // render multiple instances of a set of primitives from array data with a per-element offset
 func DrawElementsInstancedBaseVertexBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, basevertex int32, baseinstance uint32) {
 	C.glowDrawElementsInstancedBaseVertexBaseInstance(gpDrawElementsInstancedBaseVertexBaseInstance, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount), (C.GLint)(basevertex), (C.GLuint)(baseinstance))
+}
+func DrawElementsInstancedEXT(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedEXT(gpDrawElementsInstancedEXT, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
 }
 
 // render primitives from array data
@@ -5863,15 +9369,36 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
 }
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
+}
+func EdgeFlagFormatNV(stride int32) {
+	C.glowEdgeFlagFormatNV(gpEdgeFlagFormatNV, (C.GLsizei)(stride))
+}
 
 // enable or disable server-side GL capabilities
 func Enable(cap uint32) {
 	C.glowEnable(gpEnable, (C.GLenum)(cap))
 }
+func EnableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowEnableClientStateIndexedEXT(gpEnableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableClientStateiEXT(array uint32, index uint32) {
+	C.glowEnableClientStateiEXT(gpEnableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableIndexedEXT(target uint32, index uint32) {
+	C.glowEnableIndexedEXT(gpEnableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func EnableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowEnableVertexArrayAttrib(gpEnableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowEnableVertexArrayAttribEXT(gpEnableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowEnableVertexArrayEXT(gpEnableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -5884,6 +9411,15 @@ func Enablei(target uint32, index uint32) {
 func EndConditionalRender() {
 	C.glowEndConditionalRender(gpEndConditionalRender)
 }
+func EndConditionalRenderNV() {
+	C.glowEndConditionalRenderNV(gpEndConditionalRenderNV)
+}
+func EndPerfMonitorAMD(monitor uint32) {
+	C.glowEndPerfMonitorAMD(gpEndPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func EndPerfQueryINTEL(queryHandle uint32) {
+	C.glowEndPerfQueryINTEL(gpEndPerfQueryINTEL, (C.GLuint)(queryHandle))
+}
 func EndQuery(target uint32) {
 	C.glowEndQuery(gpEndQuery, (C.GLenum)(target))
 }
@@ -5893,11 +9429,14 @@ func EndQueryIndexed(target uint32, index uint32) {
 func EndTransformFeedback() {
 	C.glowEndTransformFeedback(gpEndTransformFeedback)
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -5916,18 +9455,45 @@ func FlushMappedBufferRange(target uint32, offset int, length int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FogCoordFormatNV(xtype uint32, stride int32) {
+	C.glowFogCoordFormatNV(gpFogCoordFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
+func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferDrawBufferEXT(gpFramebufferDrawBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
+func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
+	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
 }
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
 	C.glowFramebufferParameteri(gpFramebufferParameteri, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
 }
+func FramebufferReadBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferReadBufferEXT(gpFramebufferReadBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
 
 // attach a renderbuffer as a logical buffer of a framebuffer object
 func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbuffer(gpFramebufferRenderbuffer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
@@ -5937,16 +9503,30 @@ func FramebufferTexture(target uint32, attachment uint32, texture uint32, level 
 func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1D(gpFramebufferTexture1D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
 func FramebufferTexture3D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
 	C.glowFramebufferTexture3D(gpFramebufferTexture3D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
 }
+func FramebufferTextureARB(target uint32, attachment uint32, texture uint32, level int32) {
+	C.glowFramebufferTextureARB(gpFramebufferTextureARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func FramebufferTextureFaceARB(target uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowFramebufferTextureFaceARB(gpFramebufferTextureFaceARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
+}
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func FramebufferTextureLayer(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayer(gpFramebufferTextureLayer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowFramebufferTextureLayerARB(gpFramebufferTextureLayerARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 
 // define front- and back-facing polygons
@@ -5963,10 +9543,20 @@ func GenBuffers(n int32, buffers *uint32) {
 func GenFramebuffers(n int32, framebuffers *uint32) {
 	C.glowGenFramebuffers(gpGenFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
 }
+func GenPathsNV(xrange int32) uint32 {
+	ret := C.glowGenPathsNV(gpGenPathsNV, (C.GLsizei)(xrange))
+	return (uint32)(ret)
+}
+func GenPerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowGenPerfMonitorsAMD(gpGenPerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
 
 // reserve program pipeline object names
 func GenProgramPipelines(n int32, pipelines *uint32) {
 	C.glowGenProgramPipelines(gpGenProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func GenProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowGenProgramPipelinesEXT(gpGenProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // generate query object names
@@ -6003,10 +9593,16 @@ func GenVertexArrays(n int32, arrays *uint32) {
 func GenerateMipmap(target uint32) {
 	C.glowGenerateMipmap(gpGenerateMipmap, (C.GLenum)(target))
 }
+func GenerateMultiTexMipmapEXT(texunit uint32, target uint32) {
+	C.glowGenerateMultiTexMipmapEXT(gpGenerateMultiTexMipmapEXT, (C.GLenum)(texunit), (C.GLenum)(target))
+}
 
 // generate mipmaps for a specified texture object
 func GenerateTextureMipmap(texture uint32) {
 	C.glowGenerateTextureMipmap(gpGenerateTextureMipmap, (C.GLuint)(texture))
+}
+func GenerateTextureMipmapEXT(texture uint32, target uint32) {
+	C.glowGenerateTextureMipmapEXT(gpGenerateTextureMipmapEXT, (C.GLuint)(texture), (C.GLenum)(target))
 }
 
 // retrieve information about the set of active atomic counter buffers for a program
@@ -6041,6 +9637,8 @@ func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6065,6 +9663,9 @@ func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
+func GetBooleanIndexedvEXT(target uint32, index uint32, data *bool) {
+	C.glowGetBooleanIndexedvEXT(gpGetBooleanIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
+}
 func GetBooleani_v(target uint32, index uint32, data *bool) {
 	C.glowGetBooleani_v(gpGetBooleani_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
 }
@@ -6081,6 +9682,9 @@ func GetBufferParameteri64v(target uint32, pname uint32, params *int64) {
 func GetBufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetBufferParameteriv(gpGetBufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetBufferParameterui64vNV(target uint32, pname uint32, params *uint64) {
+	C.glowGetBufferParameterui64vNV(gpGetBufferParameterui64vNV, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
@@ -6090,6 +9694,13 @@ func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
 // returns a subset of a buffer object's data store
 func GetBufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetBufferSubData(gpGetBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
+func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
 
 // return a compressed texture image
@@ -6101,10 +9712,16 @@ func GetCompressedTexImage(target uint32, level int32, img unsafe.Pointer) {
 func GetCompressedTextureImage(texture uint32, level int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureImage(gpGetCompressedTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLsizei)(bufSize), pixels)
 }
+func GetCompressedTextureImageEXT(texture uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedTextureImageEXT(gpGetCompressedTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(lod), img)
+}
 
 // retrieve a sub-region of a compressed texture image from a     compressed texture object
 func GetCompressedTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureSubImage(gpGetCompressedTextureSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(bufSize), pixels)
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -6120,8 +9737,14 @@ func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
+func GetDoubleIndexedvEXT(target uint32, index uint32, data *float64) {
+	C.glowGetDoubleIndexedvEXT(gpGetDoubleIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
 func GetDoublei_v(target uint32, index uint32, data *float64) {
 	C.glowGetDoublei_v(gpGetDoublei_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
+func GetDoublei_vEXT(pname uint32, index uint32, params *float64) {
+	C.glowGetDoublei_vEXT(gpGetDoublei_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
 }
 func GetDoublev(pname uint32, data *float64) {
 	C.glowGetDoublev(gpGetDoublev, (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(data)))
@@ -6132,8 +9755,17 @@ func GetError() uint32 {
 	ret := C.glowGetError(gpGetError)
 	return (uint32)(ret)
 }
+func GetFirstPerfQueryIdINTEL(queryId *uint32) {
+	C.glowGetFirstPerfQueryIdINTEL(gpGetFirstPerfQueryIdINTEL, (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetFloatIndexedvEXT(target uint32, index uint32, data *float32) {
+	C.glowGetFloatIndexedvEXT(gpGetFloatIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
 func GetFloati_v(target uint32, index uint32, data *float32) {
 	C.glowGetFloati_v(gpGetFloati_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
+func GetFloati_vEXT(pname uint32, index uint32, params *float32) {
+	C.glowGetFloati_vEXT(gpGetFloati_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetFloatv(pname uint32, data *float32) {
 	C.glowGetFloatv(gpGetFloatv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(data)))
@@ -6151,14 +9783,17 @@ func GetFragDataLocation(program uint32, name *uint8) int32 {
 	return (int32)(ret)
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetFramebufferParameterivEXT(gpGetFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // check if the rendering context has not been lost due to software or hardware issues
@@ -6178,23 +9813,77 @@ func GetImageHandleARB(texture uint32, level int32, layered bool, layer int32, f
 	ret := C.glowGetImageHandleARB(gpGetImageHandleARB, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
 	return (uint64)(ret)
 }
+func GetImageHandleNV(texture uint32, level int32, layered bool, layer int32, format uint32) uint64 {
+	ret := C.glowGetImageHandleNV(gpGetImageHandleNV, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
+	return (uint64)(ret)
+}
 func GetInteger64i_v(target uint32, index uint32, data *int64) {
 	C.glowGetInteger64i_v(gpGetInteger64i_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint64)(unsafe.Pointer(data)))
 }
 func GetInteger64v(pname uint32, data *int64) {
 	C.glowGetInteger64v(gpGetInteger64v, (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(data)))
 }
+func GetIntegerIndexedvEXT(target uint32, index uint32, data *int32) {
+	C.glowGetIntegerIndexedvEXT(gpGetIntegerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
 func GetIntegeri_v(target uint32, index uint32, data *int32) {
 	C.glowGetIntegeri_v(gpGetIntegeri_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
+func GetIntegerui64i_vNV(value uint32, index uint32, result *uint64) {
+	C.glowGetIntegerui64i_vNV(gpGetIntegerui64i_vNV, (C.GLenum)(value), (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(result)))
+}
+func GetIntegerui64vNV(value uint32, result *uint64) {
+	C.glowGetIntegerui64vNV(gpGetIntegerui64vNV, (C.GLenum)(value), (*C.GLuint64EXT)(unsafe.Pointer(result)))
 }
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexEnvfvEXT(gpGetMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexEnvivEXT(gpGetMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowGetMultiTexGendvEXT(gpGetMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexGenfvEXT(gpGetMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexGenivEXT(gpGetMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexImageEXT(texunit uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetMultiTexImageEXT(gpGetMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func GetMultiTexLevelParameterfvEXT(texunit uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetMultiTexLevelParameterfvEXT(gpGetMultiTexLevelParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexLevelParameterivEXT(texunit uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetMultiTexLevelParameterivEXT(gpGetMultiTexLevelParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterIivEXT(gpGetMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetMultiTexParameterIuivEXT(gpGetMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexParameterfvEXT(gpGetMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterivEXT(gpGetMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // retrieve the location of a sample
@@ -6211,30 +9900,69 @@ func GetNamedBufferParameteri64v(buffer uint32, pname uint32, params *int64) {
 func GetNamedBufferParameteriv(buffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedBufferParameteriv(gpGetNamedBufferParameteriv, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedBufferParameterivEXT(buffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedBufferParameterivEXT(gpGetNamedBufferParameterivEXT, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedBufferParameterui64vNV(buffer uint32, pname uint32, params *uint64) {
+	C.glowGetNamedBufferParameterui64vNV(gpGetNamedBufferParameterui64vNV, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetNamedBufferPointerv(buffer uint32, pname uint32, params *unsafe.Pointer) {
 	C.glowGetNamedBufferPointerv(gpGetNamedBufferPointerv, (C.GLuint)(buffer), (C.GLenum)(pname), params)
 }
+func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Pointer) {
+	C.glowGetNamedBufferPointervEXT(gpGetNamedBufferPointervEXT, (C.GLuint)(buffer), (C.GLenum)(pname), params)
+}
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 
 // retrieve information about attachments of a framebuffer object
 func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameteriv(gpGetNamedFramebufferAttachmentParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a framebuffer object
 func GetNamedFramebufferParameteriv(framebuffer uint32, pname uint32, param *int32) {
 	C.glowGetNamedFramebufferParameteriv(gpGetNamedFramebufferParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
 }
+func GetNamedFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferParameterivEXT(gpGetNamedFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowGetNamedProgramLocalParameterIivEXT(gpGetNamedProgramLocalParameterIivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIuivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowGetNamedProgramLocalParameterIuivEXT(gpGetNamedProgramLocalParameterIuivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterdvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowGetNamedProgramLocalParameterdvEXT(gpGetNamedProgramLocalParameterdvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterfvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowGetNamedProgramLocalParameterfvEXT(gpGetNamedProgramLocalParameterfvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetNamedProgramStringEXT(program uint32, target uint32, pname uint32, xstring unsafe.Pointer) {
+	C.glowGetNamedProgramStringEXT(gpGetNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), xstring)
+}
+func GetNamedProgramivEXT(program uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetNamedProgramivEXT(gpGetNamedProgramivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a renderbuffer object
 func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameteriv(gpGetNamedRenderbufferParameteriv, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedRenderbufferParameterivEXT(renderbuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedRenderbufferParameterivEXT(gpGetNamedRenderbufferParameterivEXT, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
@@ -6242,10 +9970,16 @@ func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int
 func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
+	C.glowGetNextPerfQueryIdINTEL(gpGetNextPerfQueryIdINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(nextQueryId)))
+}
 
 // retrieve the label of a named object identified within a namespace
 func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
+	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
@@ -6257,6 +9991,70 @@ func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *
 }
 func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetPathCommandsNV(path uint32, commands *uint8) {
+	C.glowGetPathCommandsNV(gpGetPathCommandsNV, (C.GLuint)(path), (*C.GLubyte)(unsafe.Pointer(commands)))
+}
+func GetPathCoordsNV(path uint32, coords *float32) {
+	C.glowGetPathCoordsNV(gpGetPathCoordsNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(coords)))
+}
+func GetPathDashArrayNV(path uint32, dashArray *float32) {
+	C.glowGetPathDashArrayNV(gpGetPathDashArrayNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func GetPathLengthNV(path uint32, startSegment int32, numSegments int32) float32 {
+	ret := C.glowGetPathLengthNV(gpGetPathLengthNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments))
+	return (float32)(ret)
+}
+func GetPathMetricRangeNV(metricQueryMask uint32, firstPathName uint32, numPaths int32, stride int32, metrics *float32) {
+	C.glowGetPathMetricRangeNV(gpGetPathMetricRangeNV, (C.GLbitfield)(metricQueryMask), (C.GLuint)(firstPathName), (C.GLsizei)(numPaths), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathMetricsNV(metricQueryMask uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, stride int32, metrics *float32) {
+	C.glowGetPathMetricsNV(gpGetPathMetricsNV, (C.GLbitfield)(metricQueryMask), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowGetPathParameterfvNV(gpGetPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func GetPathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowGetPathParameterivNV(gpGetPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func GetPathSpacingNV(pathListMode uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, advanceScale float32, kerningScale float32, transformType uint32, returnedSpacing *float32) {
+	C.glowGetPathSpacingNV(gpGetPathSpacingNV, (C.GLenum)(pathListMode), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLfloat)(advanceScale), (C.GLfloat)(kerningScale), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(returnedSpacing)))
+}
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
+}
+func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
+	C.glowGetPerfMonitorCounterDataAMD(gpGetPerfMonitorCounterDataAMD, (C.GLuint)(monitor), (C.GLenum)(pname), (C.GLsizei)(dataSize), (*C.GLuint)(unsafe.Pointer(data)), (*C.GLint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
+	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
+}
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
+	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
+}
+func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
+	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
+}
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
+	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
+}
+func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
+	C.glowGetPerfMonitorGroupsAMD(gpGetPerfMonitorGroupsAMD, (*C.GLint)(unsafe.Pointer(numGroups)), (C.GLsizei)(groupsSize), (*C.GLuint)(unsafe.Pointer(groups)))
+}
+func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
+	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
+	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
+}
+func GetPointerIndexedvEXT(target uint32, index uint32, data *unsafe.Pointer) {
+	C.glowGetPointerIndexedvEXT(gpGetPointerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), data)
+}
+func GetPointeri_vEXT(pname uint32, index uint32, params *unsafe.Pointer) {
+	C.glowGetPointeri_vEXT(gpGetPointeri_vEXT, (C.GLenum)(pname), (C.GLuint)(index), params)
 }
 
 // return the address of the specified pointer
@@ -6284,8 +10082,14 @@ func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32
 func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
+	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
+}
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
 	C.glowGetProgramPipelineiv(gpGetProgramPipelineiv, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
+	C.glowGetProgramPipelineivEXT(gpGetProgramPipelineivEXT, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // query the index of a named resource within a program
@@ -6310,6 +10114,9 @@ func GetProgramResourceLocationIndex(program uint32, programInterface uint32, na
 func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
+func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
+	C.glowGetProgramResourcefvNV(gpGetProgramResourcefvNV, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLfloat)(unsafe.Pointer(params)))
+}
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
 	C.glowGetProgramResourceiv(gpGetProgramResourceiv, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6320,6 +10127,18 @@ func GetProgramStageiv(program uint32, shadertype uint32, pname uint32, values *
 // Returns a parameter from a program object
 func GetProgramiv(program uint32, pname uint32, params *int32) {
 	C.glowGetProgramiv(gpGetProgramiv, (C.GLuint)(program), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
 }
 
 // return parameters of an indexed query object target
@@ -6335,6 +10154,8 @@ func GetQueryObjectiv(id uint32, pname uint32, params *int32) {
 func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64v(gpGetQueryObjectui64v, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -6344,7 +10165,7 @@ func GetQueryiv(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryiv(gpGetQueryiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6380,6 +10201,10 @@ func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8)
 func GetShaderiv(shader uint32, pname uint32, params *int32) {
 	C.glowGetShaderiv(gpGetShaderiv, (C.GLuint)(shader), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -6404,7 +10229,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 
@@ -6434,31 +10259,60 @@ func GetTextureHandleARB(texture uint32) uint64 {
 	ret := C.glowGetTextureHandleARB(gpGetTextureHandleARB, (C.GLuint)(texture))
 	return (uint64)(ret)
 }
+func GetTextureHandleNV(texture uint32) uint64 {
+	ret := C.glowGetTextureHandleNV(gpGetTextureHandleNV, (C.GLuint)(texture))
+	return (uint64)(ret)
+}
 
 // return a texture image
 func GetTextureImage(texture uint32, level int32, format uint32, xtype uint32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetTextureImage(gpGetTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), pixels)
 }
+func GetTextureImageEXT(texture uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetTextureImageEXT(gpGetTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 func GetTextureLevelParameterfv(texture uint32, level int32, pname uint32, params *float32) {
 	C.glowGetTextureLevelParameterfv(gpGetTextureLevelParameterfv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureLevelParameterfvEXT(texture uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetTextureLevelParameterfvEXT(gpGetTextureLevelParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureLevelParameteriv(texture uint32, level int32, pname uint32, params *int32) {
 	C.glowGetTextureLevelParameteriv(gpGetTextureLevelParameteriv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureLevelParameterivEXT(texture uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetTextureLevelParameterivEXT(gpGetTextureLevelParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameterIiv(gpGetTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetTextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterIivEXT(gpGetTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetTextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowGetTextureParameterIuiv(gpGetTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetTextureParameterIuivEXT(gpGetTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterfv(texture uint32, pname uint32, params *float32) {
 	C.glowGetTextureParameterfv(gpGetTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetTextureParameterfvEXT(gpGetTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureParameteriv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameteriv(gpGetTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterivEXT(gpGetTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureSamplerHandleARB(texture uint32, sampler uint32) uint64 {
 	ret := C.glowGetTextureSamplerHandleARB(gpGetTextureSamplerHandleARB, (C.GLuint)(texture), (C.GLuint)(sampler))
+	return (uint64)(ret)
+}
+func GetTextureSamplerHandleNV(texture uint32, sampler uint32) uint64 {
+	ret := C.glowGetTextureSamplerHandleNV(gpGetTextureSamplerHandleNV, (C.GLuint)(texture), (C.GLuint)(sampler))
 	return (uint64)(ret)
 }
 
@@ -6510,10 +10364,22 @@ func GetUniformdv(program uint32, location int32, params *float64) {
 func GetUniformfv(program uint32, location int32, params *float32) {
 	C.glowGetUniformfv(gpGetUniformfv, (C.GLuint)(program), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func GetUniformi64vNV(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 
 // Returns the value of a uniform variable
 func GetUniformiv(program uint32, location int32, params *int32) {
 	C.glowGetUniformiv(gpGetUniformiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func GetUniformui64vNV(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 func GetUniformuiv(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuiv(gpGetUniformuiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
@@ -6523,6 +10389,18 @@ func GetVertexArrayIndexed64iv(vaobj uint32, index uint32, pname uint32, param *
 }
 func GetVertexArrayIndexediv(vaobj uint32, index uint32, pname uint32, param *int32) {
 	C.glowGetVertexArrayIndexediv(gpGetVertexArrayIndexediv, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegeri_vEXT(vaobj uint32, index uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegeri_vEXT(gpGetVertexArrayIntegeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegervEXT(vaobj uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegervEXT(gpGetVertexArrayIntegervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayPointeri_vEXT(vaobj uint32, index uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointeri_vEXT(gpGetVertexArrayPointeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), param)
+}
+func GetVertexArrayPointervEXT(vaobj uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointervEXT(gpGetVertexArrayPointervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), param)
 }
 
 // retrieve parameters of a vertex array object
@@ -6544,8 +10422,14 @@ func GetVertexAttribIuiv(index uint32, pname uint32, params *uint32) {
 func GetVertexAttribLdv(index uint32, pname uint32, params *float64) {
 	C.glowGetVertexAttribLdv(gpGetVertexAttribLdv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
 }
+func GetVertexAttribLi64vNV(index uint32, pname uint32, params *int64) {
+	C.glowGetVertexAttribLi64vNV(gpGetVertexAttribLi64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 func GetVertexAttribLui64vARB(index uint32, pname uint32, params *uint64) {
 	C.glowGetVertexAttribLui64vARB(gpGetVertexAttribLui64vARB, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
+func GetVertexAttribLui64vNV(index uint32, pname uint32, params *uint64) {
+	C.glowGetVertexAttribLui64vNV(gpGetVertexAttribLui64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 
 // return the address of the specified generic vertex attribute pointer
@@ -6567,6 +10451,10 @@ func GetVertexAttribfv(index uint32, pname uint32, params *float32) {
 func GetVertexAttribiv(index uint32, pname uint32, params *int32) {
 	C.glowGetVertexAttribiv(gpGetVertexAttribiv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
+}
 func GetnCompressedTexImageARB(target uint32, lod int32, bufSize int32, img unsafe.Pointer) {
 	C.glowGetnCompressedTexImageARB(gpGetnCompressedTexImageARB, (C.GLenum)(target), (C.GLint)(lod), (C.GLsizei)(bufSize), img)
 }
@@ -6585,6 +10473,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6593,6 +10484,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -6607,6 +10501,15 @@ func GetnUniformuivKHR(program uint32, location int32, bufSize int32, params *ui
 // specify implementation-specific hints
 func Hint(target uint32, mode uint32) {
 	C.glowHint(gpHint, (C.GLenum)(target), (C.GLenum)(mode))
+}
+func IndexFormatNV(xtype uint32, stride int32) {
+	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func InsertEventMarkerEXT(length int32, marker *uint8) {
+	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
+func InterpolatePathsNV(resultPath uint32, pathA uint32, pathB uint32, weight float32) {
+	C.glowInterpolatePathsNV(gpInterpolatePathsNV, (C.GLuint)(resultPath), (C.GLuint)(pathA), (C.GLuint)(pathB), (C.GLfloat)(weight))
 }
 
 // invalidate the content of a buffer object's data store
@@ -6654,8 +10557,20 @@ func IsBuffer(buffer uint32) bool {
 	ret := C.glowIsBuffer(gpIsBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func IsBufferResidentNV(target uint32) bool {
+	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
+	return ret == TRUE
+}
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
+	return ret == TRUE
+}
+func IsEnabledIndexedEXT(target uint32, index uint32) bool {
+	ret := C.glowIsEnabledIndexedEXT(gpIsEnabledIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
 	return ret == TRUE
 }
 func IsEnabledi(target uint32, index uint32) bool {
@@ -6672,8 +10587,28 @@ func IsImageHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsImageHandleResidentARB(gpIsImageHandleResidentARB, (C.GLuint64)(handle))
 	return ret == TRUE
 }
+func IsImageHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsImageHandleResidentNV(gpIsImageHandleResidentNV, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsNamedBufferResidentNV(buffer uint32) bool {
+	ret := C.glowIsNamedBufferResidentNV(gpIsNamedBufferResidentNV, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+	return ret == TRUE
+}
+func IsPathNV(path uint32) bool {
+	ret := C.glowIsPathNV(gpIsPathNV, (C.GLuint)(path))
+	return ret == TRUE
+}
+func IsPointInFillPathNV(path uint32, mask uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInFillPathNV(gpIsPointInFillPathNV, (C.GLuint)(path), (C.GLuint)(mask), (C.GLfloat)(x), (C.GLfloat)(y))
+	return ret == TRUE
+}
+func IsPointInStrokePathNV(path uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInStrokePathNV(gpIsPointInStrokePathNV, (C.GLuint)(path), (C.GLfloat)(x), (C.GLfloat)(y))
 	return ret == TRUE
 }
 
@@ -6686,6 +10621,10 @@ func IsProgram(program uint32) bool {
 // determine if a name corresponds to a program pipeline object
 func IsProgramPipeline(pipeline uint32) bool {
 	ret := C.glowIsProgramPipeline(gpIsProgramPipeline, (C.GLuint)(pipeline))
+	return ret == TRUE
+}
+func IsProgramPipelineEXT(pipeline uint32) bool {
+	ret := C.glowIsProgramPipelineEXT(gpIsProgramPipelineEXT, (C.GLuint)(pipeline))
 	return ret == TRUE
 }
 
@@ -6712,9 +10651,13 @@ func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -6726,6 +10669,10 @@ func IsTexture(texture uint32) bool {
 }
 func IsTextureHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsTextureHandleResidentARB(gpIsTextureHandleResidentARB, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsTextureHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsTextureHandleResidentNV(gpIsTextureHandleResidentNV, (C.GLuint64)(handle))
 	return ret == TRUE
 }
 
@@ -6740,6 +10687,9 @@ func IsVertexArray(array uint32) bool {
 	ret := C.glowIsVertexArray(gpIsVertexArray, (C.GLuint)(array))
 	return ret == TRUE
 }
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
+	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
+}
 
 // specify the width of rasterized lines
 func LineWidth(width float32) {
@@ -6750,22 +10700,49 @@ func LineWidth(width float32) {
 func LinkProgram(program uint32) {
 	C.glowLinkProgram(gpLinkProgram, (C.GLuint)(program))
 }
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 
 // specify a logical pixel operation for rendering
 func LogicOp(opcode uint32) {
 	C.glowLogicOp(gpLogicOp, (C.GLenum)(opcode))
 }
+func MakeBufferNonResidentNV(target uint32) {
+	C.glowMakeBufferNonResidentNV(gpMakeBufferNonResidentNV, (C.GLenum)(target))
+}
+func MakeBufferResidentNV(target uint32, access uint32) {
+	C.glowMakeBufferResidentNV(gpMakeBufferResidentNV, (C.GLenum)(target), (C.GLenum)(access))
+}
 func MakeImageHandleNonResidentARB(handle uint64) {
 	C.glowMakeImageHandleNonResidentARB(gpMakeImageHandleNonResidentARB, (C.GLuint64)(handle))
+}
+func MakeImageHandleNonResidentNV(handle uint64) {
+	C.glowMakeImageHandleNonResidentNV(gpMakeImageHandleNonResidentNV, (C.GLuint64)(handle))
 }
 func MakeImageHandleResidentARB(handle uint64, access uint32) {
 	C.glowMakeImageHandleResidentARB(gpMakeImageHandleResidentARB, (C.GLuint64)(handle), (C.GLenum)(access))
 }
+func MakeImageHandleResidentNV(handle uint64, access uint32) {
+	C.glowMakeImageHandleResidentNV(gpMakeImageHandleResidentNV, (C.GLuint64)(handle), (C.GLenum)(access))
+}
+func MakeNamedBufferNonResidentNV(buffer uint32) {
+	C.glowMakeNamedBufferNonResidentNV(gpMakeNamedBufferNonResidentNV, (C.GLuint)(buffer))
+}
+func MakeNamedBufferResidentNV(buffer uint32, access uint32) {
+	C.glowMakeNamedBufferResidentNV(gpMakeNamedBufferResidentNV, (C.GLuint)(buffer), (C.GLenum)(access))
+}
 func MakeTextureHandleNonResidentARB(handle uint64) {
 	C.glowMakeTextureHandleNonResidentARB(gpMakeTextureHandleNonResidentARB, (C.GLuint64)(handle))
 }
+func MakeTextureHandleNonResidentNV(handle uint64) {
+	C.glowMakeTextureHandleNonResidentNV(gpMakeTextureHandleNonResidentNV, (C.GLuint64)(handle))
+}
 func MakeTextureHandleResidentARB(handle uint64) {
 	C.glowMakeTextureHandleResidentARB(gpMakeTextureHandleResidentARB, (C.GLuint64)(handle))
+}
+func MakeTextureHandleResidentNV(handle uint64) {
+	C.glowMakeTextureHandleResidentNV(gpMakeTextureHandleResidentNV, (C.GLuint64)(handle))
 }
 
 // map all of a buffer object's data store into the client's address space
@@ -6785,11 +10762,100 @@ func MapNamedBuffer(buffer uint32, access uint32) unsafe.Pointer {
 	ret := C.glowMapNamedBuffer(gpMapNamedBuffer, (C.GLuint)(buffer), (C.GLenum)(access))
 	return (unsafe.Pointer)(ret)
 }
+func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferEXT(gpMapNamedBufferEXT, (C.GLuint)(buffer), (C.GLenum)(access))
+	return (unsafe.Pointer)(ret)
+}
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
+}
+func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRangeEXT(gpMapNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
+	return (unsafe.Pointer)(ret)
+}
+func MatrixFrustumEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixFrustumEXT(gpMatrixFrustumEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixLoad3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x2fNV(gpMatrixLoad3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoad3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x3fNV(gpMatrixLoad3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadIdentityEXT(mode uint32) {
+	C.glowMatrixLoadIdentityEXT(gpMatrixLoadIdentityEXT, (C.GLenum)(mode))
+}
+func MatrixLoadTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoadTranspose3x3fNV(gpMatrixLoadTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixLoadTransposedEXT(gpMatrixLoadTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadTransposefEXT(gpMatrixLoadTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoaddEXT(mode uint32, m *float64) {
+	C.glowMatrixLoaddEXT(gpMatrixLoaddEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadfEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadfEXT(gpMatrixLoadfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x2fNV(gpMatrixMult3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x3fNV(gpMatrixMult3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMultTranspose3x3fNV(gpMatrixMultTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixMultTransposedEXT(gpMatrixMultTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixMultTransposefEXT(gpMatrixMultTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultdEXT(mode uint32, m *float64) {
+	C.glowMatrixMultdEXT(gpMatrixMultdEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultfEXT(mode uint32, m *float32) {
+	C.glowMatrixMultfEXT(gpMatrixMultfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixOrthoEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixOrthoEXT(gpMatrixOrthoEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixPopEXT(mode uint32) {
+	C.glowMatrixPopEXT(gpMatrixPopEXT, (C.GLenum)(mode))
+}
+func MatrixPushEXT(mode uint32) {
+	C.glowMatrixPushEXT(gpMatrixPushEXT, (C.GLenum)(mode))
+}
+func MatrixRotatedEXT(mode uint32, angle float64, x float64, y float64, z float64) {
+	C.glowMatrixRotatedEXT(gpMatrixRotatedEXT, (C.GLenum)(mode), (C.GLdouble)(angle), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixRotatefEXT(mode uint32, angle float32, x float32, y float32, z float32) {
+	C.glowMatrixRotatefEXT(gpMatrixRotatefEXT, (C.GLenum)(mode), (C.GLfloat)(angle), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixScaledEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixScaledEXT(gpMatrixScaledEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixScalefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixScalefEXT(gpMatrixScalefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixTranslatedEXT(gpMatrixTranslatedEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
 }
 
 // defines a barrier ordering memory transactions
@@ -6812,8 +10878,14 @@ func MultiDrawArrays(mode uint32, first *int32, count *int32, drawcount int32) {
 func MultiDrawArraysIndirect(mode uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawArraysIndirect(gpMultiDrawArraysIndirect, (C.GLenum)(mode), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessCountNV(gpMultiDrawArraysIndirectBindlessCountNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 
 // render multiple sets of primitives by specifying indices of array data elements
@@ -6830,29 +10902,122 @@ func MultiDrawElementsBaseVertex(mode uint32, count *int32, xtype uint32, indice
 func MultiDrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawElementsIndirect(gpMultiDrawElementsIndirect, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessCountNV(gpMultiDrawElementsIndirectBindlessCountNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+}
+func MultiTexBufferEXT(texunit uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowMultiTexBufferEXT(gpMultiTexBufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
+func MultiTexCoordPointerEXT(texunit uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
+	C.glowMultiTexCoordPointerEXT(gpMultiTexCoordPointerEXT, (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
+}
+func MultiTexEnvfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexEnvfEXT(gpMultiTexEnvfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexEnvfvEXT(gpMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexEnviEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexEnviEXT(gpMultiTexEnviEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexEnvivEXT(gpMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexGendEXT(texunit uint32, coord uint32, pname uint32, param float64) {
+	C.glowMultiTexGendEXT(gpMultiTexGendEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLdouble)(param))
+}
+func MultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowMultiTexGendvEXT(gpMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func MultiTexGenfEXT(texunit uint32, coord uint32, pname uint32, param float32) {
+	C.glowMultiTexGenfEXT(gpMultiTexGenfEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowMultiTexGenfvEXT(gpMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexGeniEXT(texunit uint32, coord uint32, pname uint32, param int32) {
+	C.glowMultiTexGeniEXT(gpMultiTexGeniEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowMultiTexGenivEXT(gpMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage1DEXT(gpMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage2DEXT(gpMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage3DEXT(gpMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterIivEXT(gpMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowMultiTexParameterIuivEXT(gpMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexParameterfEXT(gpMultiTexParameterfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexParameterfvEXT(gpMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexParameteriEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexParameteriEXT(gpMultiTexParameteriEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterivEXT(gpMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexRenderbufferEXT(texunit uint32, target uint32, renderbuffer uint32) {
+	C.glowMultiTexRenderbufferEXT(gpMultiTexRenderbufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(renderbuffer))
+}
+func MultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage1DEXT(gpMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage2DEXT(gpMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
+}
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
+}
+func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedCopyBufferSubDataEXT(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowNamedCopyBufferSubDataEXT(gpNamedCopyBufferSubDataEXT, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 
 // specify which color buffers are to be drawn into
@@ -6869,6 +11034,9 @@ func NamedFramebufferDrawBuffers(framebuffer uint32, n int32, bufs *uint32) {
 func NamedFramebufferParameteri(framebuffer uint32, pname uint32, param int32) {
 	C.glowNamedFramebufferParameteri(gpNamedFramebufferParameteri, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
 }
+func NamedFramebufferParameteriEXT(framebuffer uint32, pname uint32, param int32) {
+	C.glowNamedFramebufferParameteriEXT(gpNamedFramebufferParameteriEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // select a color buffer source for pixels
 func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
@@ -6879,26 +11047,101 @@ func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
 func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbuffer(gpNamedFramebufferRenderbuffer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
+	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture1DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture1DEXT(gpNamedFramebufferTexture1DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture2DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture2DEXT(gpNamedFramebufferTexture2DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture3DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
+	C.glowNamedFramebufferTexture3DEXT(gpNamedFramebufferTexture3DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
+}
+func NamedFramebufferTextureEXT(framebuffer uint32, attachment uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTextureEXT(gpNamedFramebufferTextureEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTextureFaceEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowNamedFramebufferTextureFaceEXT(gpNamedFramebufferTextureFaceEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
 }
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func NamedFramebufferTextureLayer(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowNamedFramebufferTextureLayer(gpNamedFramebufferTextureLayer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
 }
+func NamedFramebufferTextureLayerEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowNamedFramebufferTextureLayerEXT(gpNamedFramebufferTextureLayerEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func NamedProgramLocalParameter4dEXT(program uint32, target uint32, index uint32, x float64, y float64, z float64, w float64) {
+	C.glowNamedProgramLocalParameter4dEXT(gpNamedProgramLocalParameter4dEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
+func NamedProgramLocalParameter4dvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowNamedProgramLocalParameter4dvEXT(gpNamedProgramLocalParameter4dvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameter4fEXT(program uint32, target uint32, index uint32, x float32, y float32, z float32, w float32) {
+	C.glowNamedProgramLocalParameter4fEXT(gpNamedProgramLocalParameter4fEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z), (C.GLfloat)(w))
+}
+func NamedProgramLocalParameter4fvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowNamedProgramLocalParameter4fvEXT(gpNamedProgramLocalParameter4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4iEXT(program uint32, target uint32, index uint32, x int32, y int32, z int32, w int32) {
+	C.glowNamedProgramLocalParameterI4iEXT(gpNamedProgramLocalParameterI4iEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLint)(x), (C.GLint)(y), (C.GLint)(z), (C.GLint)(w))
+}
+func NamedProgramLocalParameterI4ivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowNamedProgramLocalParameterI4ivEXT(gpNamedProgramLocalParameterI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4uiEXT(program uint32, target uint32, index uint32, x uint32, y uint32, z uint32, w uint32) {
+	C.glowNamedProgramLocalParameterI4uiEXT(gpNamedProgramLocalParameterI4uiEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(x), (C.GLuint)(y), (C.GLuint)(z), (C.GLuint)(w))
+}
+func NamedProgramLocalParameterI4uivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowNamedProgramLocalParameterI4uivEXT(gpNamedProgramLocalParameterI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameters4fvEXT(program uint32, target uint32, index uint32, count int32, params *float32) {
+	C.glowNamedProgramLocalParameters4fvEXT(gpNamedProgramLocalParameters4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4ivEXT(program uint32, target uint32, index uint32, count int32, params *int32) {
+	C.glowNamedProgramLocalParametersI4ivEXT(gpNamedProgramLocalParametersI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4uivEXT(program uint32, target uint32, index uint32, count int32, params *uint32) {
+	C.glowNamedProgramLocalParametersI4uivEXT(gpNamedProgramLocalParametersI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramStringEXT(program uint32, target uint32, format uint32, len int32, xstring unsafe.Pointer) {
+	C.glowNamedProgramStringEXT(gpNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(format), (C.GLsizei)(len), xstring)
+}
 
 // establish data storage, format and dimensions of a     renderbuffer object's image
 func NamedRenderbufferStorage(renderbuffer uint32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorage(gpNamedRenderbufferStorage, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageEXT(renderbuffer uint32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageEXT(gpNamedRenderbufferStorageEXT, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func NamedRenderbufferStorageMultisample(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisample(gpNamedRenderbufferStorageMultisample, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func NamedRenderbufferStorageMultisampleCoverageEXT(renderbuffer uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleCoverageEXT(gpNamedRenderbufferStorageMultisampleCoverageEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageMultisampleEXT(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleEXT(gpNamedRenderbufferStorageMultisampleEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
+}
+func NormalFormatNV(xtype uint32, stride int32) {
+	C.glowNormalFormatNV(gpNormalFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // label a named object identified within a namespace
@@ -6919,8 +11162,67 @@ func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathCommandsNV(path uint32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCommandsNV(gpPathCommandsNV, (C.GLuint)(path), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoordsNV(path uint32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCoordsNV(gpPathCoordsNV, (C.GLuint)(path), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoverDepthFuncNV(xfunc uint32) {
+	C.glowPathCoverDepthFuncNV(gpPathCoverDepthFuncNV, (C.GLenum)(xfunc))
+}
+func PathDashArrayNV(path uint32, dashCount int32, dashArray *float32) {
+	C.glowPathDashArrayNV(gpPathDashArrayNV, (C.GLuint)(path), (C.GLsizei)(dashCount), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func PathGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathGlyphIndexArrayNV(gpPathGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathGlyphIndexRangeNV(fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, pathParameterTemplate uint32, emScale float32, baseAndCount *uint32) uint32 {
+	ret := C.glowPathGlyphIndexRangeNV(gpPathGlyphIndexRangeNV, (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale), (*C.GLuint)(unsafe.Pointer(baseAndCount)))
+	return (uint32)(ret)
+}
+func PathGlyphRangeNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyph uint32, numGlyphs int32, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphRangeNV(gpPathGlyphRangeNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyph), (C.GLsizei)(numGlyphs), (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathGlyphsNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, numGlyphs int32, xtype uint32, charcodes unsafe.Pointer, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphsNV(gpPathGlyphsNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLsizei)(numGlyphs), (C.GLenum)(xtype), charcodes, (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathMemoryGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontSize int, fontData unsafe.Pointer, faceIndex int32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathMemoryGlyphIndexArrayNV(gpPathMemoryGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), (C.GLsizeiptr)(fontSize), fontData, (C.GLsizei)(faceIndex), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathParameterfNV(path uint32, pname uint32, value float32) {
+	C.glowPathParameterfNV(gpPathParameterfNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func PathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowPathParameterfvNV(gpPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func PathParameteriNV(path uint32, pname uint32, value int32) {
+	C.glowPathParameteriNV(gpPathParameteriNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowPathParameterivNV(gpPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func PathStencilDepthOffsetNV(factor float32, units float32) {
+	C.glowPathStencilDepthOffsetNV(gpPathStencilDepthOffsetNV, (C.GLfloat)(factor), (C.GLfloat)(units))
+}
+func PathStencilFuncNV(xfunc uint32, ref int32, mask uint32) {
+	C.glowPathStencilFuncNV(gpPathStencilFuncNV, (C.GLenum)(xfunc), (C.GLint)(ref), (C.GLuint)(mask))
+}
+func PathStringNV(path uint32, format uint32, length int32, pathString unsafe.Pointer) {
+	C.glowPathStringNV(gpPathStringNV, (C.GLuint)(path), (C.GLenum)(format), (C.GLsizei)(length), pathString)
+}
+func PathSubCommandsNV(path uint32, commandStart int32, commandsToDelete int32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCommandsNV(gpPathSubCommandsNV, (C.GLuint)(path), (C.GLsizei)(commandStart), (C.GLsizei)(commandsToDelete), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathSubCoordsNV(path uint32, coordStart int32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCoordsNV(gpPathSubCoordsNV, (C.GLuint)(path), (C.GLsizei)(coordStart), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
 }
 
 // pause transform feedback operations
@@ -6930,8 +11232,14 @@ func PauseTransformFeedback() {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
+}
+func PointAlongPathNV(path uint32, startSegment int32, numSegments int32, distance float32, x *float32, y *float32, tangentX *float32, tangentY *float32) bool {
+	ret := C.glowPointAlongPathNV(gpPointAlongPathNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments), (C.GLfloat)(distance), (*C.GLfloat)(unsafe.Pointer(x)), (*C.GLfloat)(unsafe.Pointer(y)), (*C.GLfloat)(unsafe.Pointer(tangentX)), (*C.GLfloat)(unsafe.Pointer(tangentY)))
+	return ret == TRUE
 }
 func PointParameterf(pname uint32, param float32) {
 	C.glowPointParameterf(gpPointParameterf, (C.GLenum)(pname), (C.GLfloat)(param))
@@ -6960,6 +11268,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 
 // pop the active debug group
 func PopDebugGroup() {
@@ -6967,6 +11281,12 @@ func PopDebugGroup() {
 }
 func PopDebugGroupKHR() {
 	C.glowPopDebugGroupKHR(gpPopDebugGroupKHR)
+}
+func PopGroupMarkerEXT() {
+	C.glowPopGroupMarkerEXT(gpPopGroupMarkerEXT)
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -6978,235 +11298,507 @@ func PrimitiveRestartIndex(index uint32) {
 func ProgramBinary(program uint32, binaryFormat uint32, binary unsafe.Pointer, length int32) {
 	C.glowProgramBinary(gpProgramBinary, (C.GLuint)(program), (C.GLenum)(binaryFormat), binary, (C.GLsizei)(length))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriARB(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriARB(gpProgramParameteriARB, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriEXT(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriEXT(gpProgramParameteriEXT, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramPathFragmentInputGenNV(program uint32, location int32, genMode uint32, components int32, coeffs *float32) {
+	C.glowProgramPathFragmentInputGenNV(gpProgramPathFragmentInputGenNV, (C.GLuint)(program), (C.GLint)(location), (C.GLenum)(genMode), (C.GLint)(components), (*C.GLfloat)(unsafe.Pointer(coeffs)))
 }
 func ProgramUniform1d(program uint32, location int32, v0 float64) {
 	C.glowProgramUniform1d(gpProgramUniform1d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0))
 }
+func ProgramUniform1dEXT(program uint32, location int32, x float64) {
+	C.glowProgramUniform1dEXT(gpProgramUniform1dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x))
+}
 func ProgramUniform1dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform1dv(gpProgramUniform1dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform1dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform1dvEXT(gpProgramUniform1dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1f(program uint32, location int32, v0 float32) {
 	C.glowProgramUniform1f(gpProgramUniform1f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
 }
+func ProgramUniform1fEXT(program uint32, location int32, v0 float32) {
+	C.glowProgramUniform1fEXT(gpProgramUniform1fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform1fv(gpProgramUniform1fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform1fvEXT(gpProgramUniform1fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
+func ProgramUniform1i64NV(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1iEXT(program uint32, location int32, v0 int32) {
+	C.glowProgramUniform1iEXT(gpProgramUniform1iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform1iv(gpProgramUniform1iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform1ivEXT(gpProgramUniform1ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
+func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1uiEXT(program uint32, location int32, v0 uint32) {
+	C.glowProgramUniform1uiEXT(gpProgramUniform1uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform1uiv(gpProgramUniform1uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform1uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform1uivEXT(gpProgramUniform1uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform2d(program uint32, location int32, v0 float64, v1 float64) {
 	C.glowProgramUniform2d(gpProgramUniform2d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1))
 }
+func ProgramUniform2dEXT(program uint32, location int32, x float64, y float64) {
+	C.glowProgramUniform2dEXT(gpProgramUniform2dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y))
+}
 func ProgramUniform2dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform2dv(gpProgramUniform2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform2dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform2dvEXT(gpProgramUniform2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2f(program uint32, location int32, v0 float32, v1 float32) {
 	C.glowProgramUniform2f(gpProgramUniform2f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
 }
+func ProgramUniform2fEXT(program uint32, location int32, v0 float32, v1 float32) {
+	C.glowProgramUniform2fEXT(gpProgramUniform2fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform2fv(gpProgramUniform2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform2fvEXT(gpProgramUniform2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2iEXT(program uint32, location int32, v0 int32, v1 int32) {
+	C.glowProgramUniform2iEXT(gpProgramUniform2iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform2iv(gpProgramUniform2iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform2ivEXT(gpProgramUniform2ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2uiEXT(program uint32, location int32, v0 uint32, v1 uint32) {
+	C.glowProgramUniform2uiEXT(gpProgramUniform2uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform2uiv(gpProgramUniform2uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform2uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform2uivEXT(gpProgramUniform2uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform3d(program uint32, location int32, v0 float64, v1 float64, v2 float64) {
 	C.glowProgramUniform3d(gpProgramUniform3d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2))
 }
+func ProgramUniform3dEXT(program uint32, location int32, x float64, y float64, z float64) {
+	C.glowProgramUniform3dEXT(gpProgramUniform3dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
 func ProgramUniform3dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform3dv(gpProgramUniform3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform3dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform3dvEXT(gpProgramUniform3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3f(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
 	C.glowProgramUniform3f(gpProgramUniform3f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
 }
+func ProgramUniform3fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
+	C.glowProgramUniform3fEXT(gpProgramUniform3fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform3fv(gpProgramUniform3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform3fvEXT(gpProgramUniform3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
+	C.glowProgramUniform3iEXT(gpProgramUniform3iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform3iv(gpProgramUniform3iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform3ivEXT(gpProgramUniform3ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
+	C.glowProgramUniform3uiEXT(gpProgramUniform3uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform3uiv(gpProgramUniform3uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform3uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform3uivEXT(gpProgramUniform3uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform4d(program uint32, location int32, v0 float64, v1 float64, v2 float64, v3 float64) {
 	C.glowProgramUniform4d(gpProgramUniform4d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2), (C.GLdouble)(v3))
 }
+func ProgramUniform4dEXT(program uint32, location int32, x float64, y float64, z float64, w float64) {
+	C.glowProgramUniform4dEXT(gpProgramUniform4dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
 func ProgramUniform4dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform4dv(gpProgramUniform4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform4dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform4dvEXT(gpProgramUniform4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4f(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
 	C.glowProgramUniform4f(gpProgramUniform4f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
 }
+func ProgramUniform4fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
+	C.glowProgramUniform4fEXT(gpProgramUniform4fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform4fv(gpProgramUniform4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform4fvEXT(gpProgramUniform4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
+	C.glowProgramUniform4iEXT(gpProgramUniform4iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform4iv(gpProgramUniform4iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform4ivEXT(gpProgramUniform4ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
+	C.glowProgramUniform4uiEXT(gpProgramUniform4uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform4uiv(gpProgramUniform4uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform4uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform4uivEXT(gpProgramUniform4uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniformHandleui64ARB(program uint32, location int32, value uint64) {
 	C.glowProgramUniformHandleui64ARB(gpProgramUniformHandleui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
+}
+func ProgramUniformHandleui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformHandleui64NV(gpProgramUniformHandleui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
 }
 func ProgramUniformHandleui64vARB(program uint32, location int32, count int32, values *uint64) {
 	C.glowProgramUniformHandleui64vARB(gpProgramUniformHandleui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
 }
+func ProgramUniformHandleui64vNV(program uint32, location int32, count int32, values *uint64) {
+	C.glowProgramUniformHandleui64vNV(gpProgramUniformHandleui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
+}
 func ProgramUniformMatrix2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2dv(gpProgramUniformMatrix2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2dvEXT(gpProgramUniformMatrix2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2fv(gpProgramUniformMatrix2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2fvEXT(gpProgramUniformMatrix2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x3dv(gpProgramUniformMatrix2x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x3dvEXT(gpProgramUniformMatrix2x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x3fv(gpProgramUniformMatrix2x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x3fvEXT(gpProgramUniformMatrix2x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x4dv(gpProgramUniformMatrix2x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x4dvEXT(gpProgramUniformMatrix2x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x4fv(gpProgramUniformMatrix2x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x4fvEXT(gpProgramUniformMatrix2x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3dv(gpProgramUniformMatrix3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3dvEXT(gpProgramUniformMatrix3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3fv(gpProgramUniformMatrix3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3fvEXT(gpProgramUniformMatrix3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x2dv(gpProgramUniformMatrix3x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x2dvEXT(gpProgramUniformMatrix3x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x2fv(gpProgramUniformMatrix3x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x2fvEXT(gpProgramUniformMatrix3x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x4dv(gpProgramUniformMatrix3x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x4dvEXT(gpProgramUniformMatrix3x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x4fv(gpProgramUniformMatrix3x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x4fvEXT(gpProgramUniformMatrix3x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4dv(gpProgramUniformMatrix4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4dvEXT(gpProgramUniformMatrix4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4fv(gpProgramUniformMatrix4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4fvEXT(gpProgramUniformMatrix4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x2dv(gpProgramUniformMatrix4x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x2dvEXT(gpProgramUniformMatrix4x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x2fv(gpProgramUniformMatrix4x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x2fvEXT(gpProgramUniformMatrix4x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x3dv(gpProgramUniformMatrix4x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x3dvEXT(gpProgramUniformMatrix4x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x3fv(gpProgramUniformMatrix4x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x3fvEXT(gpProgramUniformMatrix4x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniformui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformui64NV(gpProgramUniformui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func ProgramUniformui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniformui64vNV(gpProgramUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // specifiy the vertex to be used as the source of data for flat shaded varyings
 func ProvokingVertex(mode uint32) {
 	C.glowProvokingVertex(gpProvokingVertex, (C.GLenum)(mode))
+}
+func PushClientAttribDefaultEXT(mask uint32) {
+	C.glowPushClientAttribDefaultEXT(gpPushClientAttribDefaultEXT, (C.GLbitfield)(mask))
 }
 
 // push a named debug group into the command stream
@@ -7216,10 +11808,16 @@ func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
+func PushGroupMarkerEXT(length int32, marker *uint8) {
+	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
 
 // record the GL time into a query object after all previous commands have reached the GL server but have not yet necessarily executed.
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
+}
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
 
 // select a color buffer source for pixels
@@ -7256,6 +11854,12 @@ func RenderbufferStorage(target uint32, internalformat uint32, width int32, heig
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func RenderbufferStorageMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowRenderbufferStorageMultisample(gpRenderbufferStorageMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func RenderbufferStorageMultisampleCoverageNV(target uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowRenderbufferStorageMultisampleCoverageNV(gpRenderbufferStorageMultisampleCoverageNV, (C.GLenum)(target), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
 }
 
 // resume transform feedback operations
@@ -7306,6 +11910,12 @@ func ScissorIndexed(index uint32, left int32, bottom int32, width int32, height 
 func ScissorIndexedv(index uint32, v *int32) {
 	C.glowScissorIndexedv(gpScissorIndexedv, (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(v)))
 }
+func SecondaryColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowSecondaryColorFormatNV(gpSecondaryColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
+	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
+}
 
 // load pre-compiled shader binaries
 func ShaderBinary(count int32, shaders *uint32, binaryformat uint32, binary unsafe.Pointer, length int32) {
@@ -7320,6 +11930,24 @@ func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 // change an active shader storage block binding
 func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storageBlockBinding uint32) {
 	C.glowShaderStorageBlockBinding(gpShaderStorageBlockBinding, (C.GLuint)(program), (C.GLuint)(storageBlockIndex), (C.GLuint)(storageBlockBinding))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
+}
+func StencilFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilFillPathInstancedNV(gpStencilFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilFillPathNV(path uint32, fillMode uint32, mask uint32) {
+	C.glowStencilFillPathNV(gpStencilFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask))
 }
 
 // set front and back function and reference value for stencil testing
@@ -7351,15 +11979,42 @@ func StencilOp(fail uint32, zfail uint32, zpass uint32) {
 func StencilOpSeparate(face uint32, sfail uint32, dpfail uint32, dppass uint32) {
 	C.glowStencilOpSeparate(gpStencilOpSeparate, (C.GLenum)(face), (C.GLenum)(sfail), (C.GLenum)(dpfail), (C.GLenum)(dppass))
 }
+func StencilStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilStrokePathInstancedNV(gpStencilStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilStrokePathNV(path uint32, reference int32, mask uint32) {
+	C.glowStencilStrokePathNV(gpStencilStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask))
+}
+func StencilThenCoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverFillPathInstancedNV(gpStencilThenCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverFillPathNV(path uint32, fillMode uint32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverFillPathNV(gpStencilThenCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func StencilThenCoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverStrokePathInstancedNV(gpStencilThenCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverStrokePathNV(path uint32, reference int32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverStrokePathNV(gpStencilThenCoverStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TexBuffer(target uint32, internalformat uint32, buffer uint32) {
 	C.glowTexBuffer(gpTexBuffer, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TexBufferARB(target uint32, internalformat uint32, buffer uint32) {
+	C.glowTexBufferARB(gpTexBufferARB, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
 func TexBufferRange(target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTexBufferRange(gpTexBufferRange, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TexCoordFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowTexCoordFormatNV(gpTexCoordFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // specify a one-dimensional texture image
@@ -7386,8 +12041,8 @@ func TexImage3D(target uint32, level int32, internalformat int32, width int32, h
 func TexImage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexImage3DMultisample(gpTexImage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -7452,73 +12107,139 @@ func TexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zof
 func TextureBarrier() {
 	C.glowTextureBarrier(gpTextureBarrier)
 }
+func TextureBarrierNV() {
+	C.glowTextureBarrierNV(gpTextureBarrierNV)
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TextureBuffer(texture uint32, internalformat uint32, buffer uint32) {
 	C.glowTextureBuffer(gpTextureBuffer, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowTextureBufferEXT(gpTextureBufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureImage1DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage1DEXT(gpTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage2DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage2DEXT(gpTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage3DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage3DEXT(gpTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func TextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterIivEXT(gpTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func TextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowTextureParameterIuiv(gpTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func TextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowTextureParameterIuivEXT(gpTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
 func TextureParameterf(texture uint32, pname uint32, param float32) {
 	C.glowTextureParameterf(gpTextureParameterf, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLfloat)(param))
 }
+func TextureParameterfEXT(texture uint32, target uint32, pname uint32, param float32) {
+	C.glowTextureParameterfEXT(gpTextureParameterfEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
 func TextureParameterfv(texture uint32, pname uint32, param *float32) {
 	C.glowTextureParameterfv(gpTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(param)))
+}
+func TextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowTextureParameterfvEXT(gpTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func TextureParameteri(texture uint32, pname uint32, param int32) {
 	C.glowTextureParameteri(gpTextureParameteri, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLint)(param))
 }
+func TextureParameteriEXT(texture uint32, target uint32, pname uint32, param int32) {
+	C.glowTextureParameteriEXT(gpTextureParameteriEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
 func TextureParameteriv(texture uint32, pname uint32, param *int32) {
 	C.glowTextureParameteriv(gpTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func TextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterivEXT(gpTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func TextureRenderbufferEXT(texture uint32, target uint32, renderbuffer uint32) {
+	C.glowTextureRenderbufferEXT(gpTextureRenderbufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLuint)(renderbuffer))
 }
 
 // simultaneously specify storage for all levels of a one-dimensional texture
 func TextureStorage1D(texture uint32, levels int32, internalformat uint32, width int32) {
 	C.glowTextureStorage1D(gpTextureStorage1D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
 }
+func TextureStorage1DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32) {
+	C.glowTextureStorage1DEXT(gpTextureStorage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
+}
 
 // simultaneously specify storage for all levels of a two-dimensional or one-dimensional array texture
 func TextureStorage2D(texture uint32, levels int32, internalformat uint32, width int32, height int32) {
 	C.glowTextureStorage2D(gpTextureStorage2D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func TextureStorage2DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32) {
+	C.glowTextureStorage2DEXT(gpTextureStorage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // specify storage for a two-dimensional multisample texture
 func TextureStorage2DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
 	C.glowTextureStorage2DMultisample(gpTextureStorage2DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage2DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
+	C.glowTextureStorage2DMultisampleEXT(gpTextureStorage2DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // simultaneously specify storage for all levels of a three-dimensional, two-dimensional array or cube-map array texture
 func TextureStorage3D(texture uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
 	C.glowTextureStorage3D(gpTextureStorage3D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func TextureStorage3DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
+	C.glowTextureStorage3DEXT(gpTextureStorage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
 }
 
 // specify storage for a two-dimensional multisample array texture
 func TextureStorage3DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisample(gpTextureStorage3DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
+	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // specify a one-dimensional texture subimage
 func TextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage1D(gpTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage1DEXT(gpTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // specify a two-dimensional texture subimage
 func TextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage2D(gpTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func TextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage2DEXT(gpTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 
 // specify a three-dimensional texture subimage
 func TextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage3D(gpTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage3DEXT(gpTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // initialize a texture as a data alias of another texture's data store
@@ -7532,13 +12253,16 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 
 // specify values to record in transform feedback buffers
 func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
+}
+func TransformPathNV(resultPath uint32, srcPath uint32, transformType uint32, transformValues *float32) {
+	C.glowTransformPathNV(gpTransformPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
 }
 func Uniform1d(location int32, x float64) {
 	C.glowUniform1d(gpUniform1d, (C.GLint)(location), (C.GLdouble)(x))
@@ -7561,6 +12285,18 @@ func Uniform1fv(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
+func Uniform1i64NV(location int32, x int64) {
+	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform1i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform1iv(location int32, count int32, value *int32) {
@@ -7570,6 +12306,18 @@ func Uniform1iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
+}
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
+func Uniform1ui64NV(location int32, x uint64) {
+	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform1ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7597,6 +12345,18 @@ func Uniform2fv(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func Uniform2i64NV(location int32, x int64, y int64) {
+	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform2i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform2iv(location int32, count int32, value *int32) {
@@ -7606,6 +12366,18 @@ func Uniform2iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func Uniform2ui64NV(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform2ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7633,6 +12405,18 @@ func Uniform3fv(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func Uniform3i64NV(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform3i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform3iv(location int32, count int32, value *int32) {
@@ -7642,6 +12426,18 @@ func Uniform3iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform3ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7669,6 +12465,18 @@ func Uniform4fv(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform4i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform4iv(location int32, count int32, value *int32) {
@@ -7678,6 +12486,18 @@ func Uniform4iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform4ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7692,8 +12512,14 @@ func UniformBlockBinding(program uint32, uniformBlockIndex uint32, uniformBlockB
 func UniformHandleui64ARB(location int32, value uint64) {
 	C.glowUniformHandleui64ARB(gpUniformHandleui64ARB, (C.GLint)(location), (C.GLuint64)(value))
 }
+func UniformHandleui64NV(location int32, value uint64) {
+	C.glowUniformHandleui64NV(gpUniformHandleui64NV, (C.GLint)(location), (C.GLuint64)(value))
+}
 func UniformHandleui64vARB(location int32, count int32, value *uint64) {
 	C.glowUniformHandleui64vARB(gpUniformHandleui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func UniformHandleui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformHandleui64vNV(gpUniformHandleui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func UniformMatrix2dv(location int32, count int32, transpose bool, value *float64) {
 	C.glowUniformMatrix2dv(gpUniformMatrix2dv, (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
@@ -7770,6 +12596,12 @@ func UniformMatrix4x3fv(location int32, count int32, transpose bool, value *floa
 func UniformSubroutinesuiv(shadertype uint32, count int32, indices *uint32) {
 	C.glowUniformSubroutinesuiv(gpUniformSubroutinesuiv, (C.GLenum)(shadertype), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(indices)))
 }
+func Uniformui64NV(location int32, value uint64) {
+	C.glowUniformui64NV(gpUniformui64NV, (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func Uniformui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformui64vNV(gpUniformui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // release the mapping of a buffer object's data store into the client's address space
 func UnmapBuffer(target uint32) bool {
@@ -7782,6 +12614,10 @@ func UnmapNamedBuffer(buffer uint32) bool {
 	ret := C.glowUnmapNamedBuffer(gpUnmapNamedBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func UnmapNamedBufferEXT(buffer uint32) bool {
+	ret := C.glowUnmapNamedBufferEXT(gpUnmapNamedBufferEXT, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 
 // Installs a program object as part of current rendering state
 func UseProgram(program uint32) {
@@ -7792,6 +12628,12 @@ func UseProgram(program uint32) {
 func UseProgramStages(pipeline uint32, stages uint32, program uint32) {
 	C.glowUseProgramStages(gpUseProgramStages, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
 }
+func UseProgramStagesEXT(pipeline uint32, stages uint32, program uint32) {
+	C.glowUseProgramStagesEXT(gpUseProgramStagesEXT, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
+}
+func UseShaderProgramEXT(xtype uint32, program uint32) {
+	C.glowUseShaderProgramEXT(gpUseShaderProgramEXT, (C.GLenum)(xtype), (C.GLuint)(program))
+}
 
 // Validates a program object
 func ValidateProgram(program uint32) {
@@ -7801,6 +12643,9 @@ func ValidateProgram(program uint32) {
 // validate a program pipeline object against current GL state
 func ValidateProgramPipeline(pipeline uint32) {
 	C.glowValidateProgramPipeline(gpValidateProgramPipeline, (C.GLuint)(pipeline))
+}
+func ValidateProgramPipelineEXT(pipeline uint32) {
+	C.glowValidateProgramPipelineEXT(gpValidateProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 func VertexArrayAttribBinding(vaobj uint32, attribindex uint32, bindingindex uint32) {
 	C.glowVertexArrayAttribBinding(gpVertexArrayAttribBinding, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
@@ -7816,15 +12661,69 @@ func VertexArrayAttribIFormat(vaobj uint32, attribindex uint32, size int32, xtyp
 func VertexArrayAttribLFormat(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexArrayAttribLFormat(gpVertexArrayAttribLFormat, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexArrayBindVertexBufferEXT(vaobj uint32, bindingindex uint32, buffer uint32, offset int, stride int32) {
+	C.glowVertexArrayBindVertexBufferEXT(gpVertexArrayBindVertexBufferEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(stride))
+}
 
 // modify the rate at which generic vertex attributes     advance
 func VertexArrayBindingDivisor(vaobj uint32, bindingindex uint32, divisor uint32) {
 	C.glowVertexArrayBindingDivisor(gpVertexArrayBindingDivisor, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexArrayColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayColorOffsetEXT(gpVertexArrayColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayEdgeFlagOffsetEXT(vaobj uint32, buffer uint32, stride int32, offset int) {
+	C.glowVertexArrayEdgeFlagOffsetEXT(gpVertexArrayEdgeFlagOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
 
 // configures element array buffer binding of a vertex array object
 func VertexArrayElementBuffer(vaobj uint32, buffer uint32) {
 	C.glowVertexArrayElementBuffer(gpVertexArrayElementBuffer, (C.GLuint)(vaobj), (C.GLuint)(buffer))
+}
+func VertexArrayFogCoordOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayFogCoordOffsetEXT(gpVertexArrayFogCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayIndexOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayIndexOffsetEXT(gpVertexArrayIndexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayMultiTexCoordOffsetEXT(vaobj uint32, buffer uint32, texunit uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayMultiTexCoordOffsetEXT(gpVertexArrayMultiTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayNormalOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayNormalOffsetEXT(gpVertexArrayNormalOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArraySecondaryColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArraySecondaryColorOffsetEXT(gpVertexArraySecondaryColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayTexCoordOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayTexCoordOffsetEXT(gpVertexArrayTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribBindingEXT(vaobj uint32, attribindex uint32, bindingindex uint32) {
+	C.glowVertexArrayVertexAttribBindingEXT(gpVertexArrayVertexAttribBindingEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
+}
+func VertexArrayVertexAttribDivisorEXT(vaobj uint32, index uint32, divisor uint32) {
+	C.glowVertexArrayVertexAttribDivisorEXT(gpVertexArrayVertexAttribDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLuint)(divisor))
+}
+func VertexArrayVertexAttribFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribFormatEXT(gpVertexArrayVertexAttribFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribIFormatEXT(gpVertexArrayVertexAttribIFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribIOffsetEXT(gpVertexArrayVertexAttribIOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribLFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribLFormatEXT(gpVertexArrayVertexAttribLFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribLOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribLOffsetEXT(gpVertexArrayVertexAttribLOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, normalized bool, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribOffsetEXT(gpVertexArrayVertexAttribOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexBindingDivisorEXT(vaobj uint32, bindingindex uint32, divisor uint32) {
+	C.glowVertexArrayVertexBindingDivisorEXT(gpVertexArrayVertexBindingDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
 
 // bind a buffer to a vertex buffer bind point
@@ -7835,6 +12734,9 @@ func VertexArrayVertexBuffer(vaobj uint32, bindingindex uint32, buffer uint32, o
 // attach multiple buffer objects to a vertex array object
 func VertexArrayVertexBuffers(vaobj uint32, first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowVertexArrayVertexBuffers(gpVertexArrayVertexBuffers, (C.GLuint)(vaobj), (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
+}
+func VertexArrayVertexOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexOffsetEXT(gpVertexArrayVertexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
 }
 func VertexAttrib1d(index uint32, x float64) {
 	C.glowVertexAttrib1d(gpVertexAttrib1d, (C.GLuint)(index), (C.GLdouble)(x))
@@ -7954,10 +12856,16 @@ func VertexAttribBinding(attribindex uint32, bindingindex uint32) {
 func VertexAttribDivisor(index uint32, divisor uint32) {
 	C.glowVertexAttribDivisor(gpVertexAttribDivisor, (C.GLuint)(index), (C.GLuint)(divisor))
 }
+func VertexAttribDivisorARB(index uint32, divisor uint32) {
+	C.glowVertexAttribDivisorARB(gpVertexAttribDivisorARB, (C.GLuint)(index), (C.GLuint)(divisor))
+}
 
 // specify the organization of vertex arrays
 func VertexAttribFormat(attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
 	C.glowVertexAttribFormat(gpVertexAttribFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexAttribFormatNV(index uint32, size int32, xtype uint32, normalized bool, stride int32) {
+	C.glowVertexAttribFormatNV(gpVertexAttribFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride))
 }
 func VertexAttribI1i(index uint32, x int32) {
 	C.glowVertexAttribI1i(gpVertexAttribI1i, (C.GLuint)(index), (C.GLint)(x))
@@ -8022,6 +12930,9 @@ func VertexAttribI4usv(index uint32, v *uint16) {
 func VertexAttribIFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribIFormat(gpVertexAttribIFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexAttribIFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribIFormatNV(gpVertexAttribIFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func VertexAttribIPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribIPointer(gpVertexAttribIPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
 }
@@ -8031,11 +12942,23 @@ func VertexAttribL1d(index uint32, x float64) {
 func VertexAttribL1dv(index uint32, v *float64) {
 	C.glowVertexAttribL1dv(gpVertexAttribL1dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL1i64NV(index uint32, x int64) {
+	C.glowVertexAttribL1i64NV(gpVertexAttribL1i64NV, (C.GLuint)(index), (C.GLint64EXT)(x))
+}
+func VertexAttribL1i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL1i64vNV(gpVertexAttribL1i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL1ui64ARB(index uint32, x uint64) {
 	C.glowVertexAttribL1ui64ARB(gpVertexAttribL1ui64ARB, (C.GLuint)(index), (C.GLuint64EXT)(x))
 }
+func VertexAttribL1ui64NV(index uint32, x uint64) {
+	C.glowVertexAttribL1ui64NV(gpVertexAttribL1ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x))
+}
 func VertexAttribL1ui64vARB(index uint32, v *uint64) {
 	C.glowVertexAttribL1ui64vARB(gpVertexAttribL1ui64vARB, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL1ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL1ui64vNV(gpVertexAttribL1ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL2d(index uint32, x float64, y float64) {
 	C.glowVertexAttribL2d(gpVertexAttribL2d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y))
@@ -8043,11 +12966,35 @@ func VertexAttribL2d(index uint32, x float64, y float64) {
 func VertexAttribL2dv(index uint32, v *float64) {
 	C.glowVertexAttribL2dv(gpVertexAttribL2dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL2i64NV(index uint32, x int64, y int64) {
+	C.glowVertexAttribL2i64NV(gpVertexAttribL2i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func VertexAttribL2i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL2i64vNV(gpVertexAttribL2i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL2ui64NV(index uint32, x uint64, y uint64) {
+	C.glowVertexAttribL2ui64NV(gpVertexAttribL2ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func VertexAttribL2ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL2ui64vNV(gpVertexAttribL2ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL3d(index uint32, x float64, y float64, z float64) {
 	C.glowVertexAttribL3d(gpVertexAttribL3d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
 }
 func VertexAttribL3dv(index uint32, v *float64) {
 	C.glowVertexAttribL3dv(gpVertexAttribL3dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
+}
+func VertexAttribL3i64NV(index uint32, x int64, y int64, z int64) {
+	C.glowVertexAttribL3i64NV(gpVertexAttribL3i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func VertexAttribL3i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL3i64vNV(gpVertexAttribL3i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL3ui64NV(index uint32, x uint64, y uint64, z uint64) {
+	C.glowVertexAttribL3ui64NV(gpVertexAttribL3ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func VertexAttribL3ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL3ui64vNV(gpVertexAttribL3ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 	C.glowVertexAttribL4d(gpVertexAttribL4d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
@@ -8055,8 +13002,23 @@ func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 func VertexAttribL4dv(index uint32, v *float64) {
 	C.glowVertexAttribL4dv(gpVertexAttribL4dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL4i64NV(index uint32, x int64, y int64, z int64, w int64) {
+	C.glowVertexAttribL4i64NV(gpVertexAttribL4i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func VertexAttribL4i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL4i64vNV(gpVertexAttribL4i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL4ui64NV(index uint32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowVertexAttribL4ui64NV(gpVertexAttribL4ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func VertexAttribL4ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL4ui64vNV(gpVertexAttribL4ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribLFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribLFormat(gpVertexAttribLFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexAttribLFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribLFormatNV(gpVertexAttribLFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 func VertexAttribLPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribLPointer(gpVertexAttribLPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
@@ -8095,6 +13057,9 @@ func VertexAttribPointer(index uint32, size int32, xtype uint32, normalized bool
 func VertexBindingDivisor(bindingindex uint32, divisor uint32) {
 	C.glowVertexBindingDivisor(gpVertexBindingDivisor, (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowVertexFormatNV(gpVertexFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 
 // set the viewport
 func Viewport(x int32, y int32, width int32, height int32) {
@@ -8109,10 +13074,25 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
+	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
+}
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
 }
 
 // Init initializes the OpenGL bindings by loading the function pointers (for
@@ -8142,11 +13122,14 @@ func Init() error {
 // function pointer loading function. For more cases Init should be used
 // instead.
 func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
+	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
+	gpActiveShaderProgramEXT = (C.GPACTIVESHADERPROGRAMEXT)(getProcAddr("glActiveShaderProgramEXT"))
 	gpActiveTexture = (C.GPACTIVETEXTURE)(getProcAddr("glActiveTexture"))
 	if gpActiveTexture == nil {
 		return errors.New("glActiveTexture")
 	}
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpAttachShader = (C.GPATTACHSHADER)(getProcAddr("glAttachShader"))
 	if gpAttachShader == nil {
 		return errors.New("glAttachShader")
@@ -8155,6 +13138,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBeginConditionalRender == nil {
 		return errors.New("glBeginConditionalRender")
 	}
+	gpBeginConditionalRenderNV = (C.GPBEGINCONDITIONALRENDERNV)(getProcAddr("glBeginConditionalRenderNV"))
+	gpBeginPerfMonitorAMD = (C.GPBEGINPERFMONITORAMD)(getProcAddr("glBeginPerfMonitorAMD"))
+	gpBeginPerfQueryINTEL = (C.GPBEGINPERFQUERYINTEL)(getProcAddr("glBeginPerfQueryINTEL"))
 	gpBeginQuery = (C.GPBEGINQUERY)(getProcAddr("glBeginQuery"))
 	if gpBeginQuery == nil {
 		return errors.New("glBeginQuery")
@@ -8196,7 +13182,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpBindImageTexture = (C.GPBINDIMAGETEXTURE)(getProcAddr("glBindImageTexture"))
 	gpBindImageTextures = (C.GPBINDIMAGETEXTURES)(getProcAddr("glBindImageTextures"))
+	gpBindMultiTextureEXT = (C.GPBINDMULTITEXTUREEXT)(getProcAddr("glBindMultiTextureEXT"))
 	gpBindProgramPipeline = (C.GPBINDPROGRAMPIPELINE)(getProcAddr("glBindProgramPipeline"))
+	gpBindProgramPipelineEXT = (C.GPBINDPROGRAMPIPELINEEXT)(getProcAddr("glBindProgramPipelineEXT"))
 	gpBindRenderbuffer = (C.GPBINDRENDERBUFFER)(getProcAddr("glBindRenderbuffer"))
 	if gpBindRenderbuffer == nil {
 		return errors.New("glBindRenderbuffer")
@@ -8219,6 +13207,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpBindVertexBuffer = (C.GPBINDVERTEXBUFFER)(getProcAddr("glBindVertexBuffer"))
 	gpBindVertexBuffers = (C.GPBINDVERTEXBUFFERS)(getProcAddr("glBindVertexBuffers"))
+	gpBlendBarrierKHR = (C.GPBLENDBARRIERKHR)(getProcAddr("glBlendBarrierKHR"))
+	gpBlendBarrierNV = (C.GPBLENDBARRIERNV)(getProcAddr("glBlendBarrierNV"))
 	gpBlendColor = (C.GPBLENDCOLOR)(getProcAddr("glBlendColor"))
 	if gpBlendColor == nil {
 		return errors.New("glBlendColor")
@@ -8243,11 +13233,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpBlendFuncSeparateiARB = (C.GPBLENDFUNCSEPARATEIARB)(getProcAddr("glBlendFuncSeparateiARB"))
 	gpBlendFunciARB = (C.GPBLENDFUNCIARB)(getProcAddr("glBlendFunciARB"))
+	gpBlendParameteriNV = (C.GPBLENDPARAMETERINV)(getProcAddr("glBlendParameteriNV"))
 	gpBlitFramebuffer = (C.GPBLITFRAMEBUFFER)(getProcAddr("glBlitFramebuffer"))
 	if gpBlitFramebuffer == nil {
 		return errors.New("glBlitFramebuffer")
 	}
 	gpBlitNamedFramebuffer = (C.GPBLITNAMEDFRAMEBUFFER)(getProcAddr("glBlitNamedFramebuffer"))
+	gpBufferAddressRangeNV = (C.GPBUFFERADDRESSRANGENV)(getProcAddr("glBufferAddressRangeNV"))
 	gpBufferData = (C.GPBUFFERDATA)(getProcAddr("glBufferData"))
 	if gpBufferData == nil {
 		return errors.New("glBufferData")
@@ -8258,11 +13250,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCheckFramebufferStatus = (C.GPCHECKFRAMEBUFFERSTATUS)(getProcAddr("glCheckFramebufferStatus"))
 	if gpCheckFramebufferStatus == nil {
 		return errors.New("glCheckFramebufferStatus")
 	}
 	gpCheckNamedFramebufferStatus = (C.GPCHECKNAMEDFRAMEBUFFERSTATUS)(getProcAddr("glCheckNamedFramebufferStatus"))
+	gpCheckNamedFramebufferStatusEXT = (C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(getProcAddr("glCheckNamedFramebufferStatusEXT"))
 	gpClampColor = (C.GPCLAMPCOLOR)(getProcAddr("glClampColor"))
 	if gpClampColor == nil {
 		return errors.New("glClampColor")
@@ -8299,7 +13293,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpClearDepthf = (C.GPCLEARDEPTHF)(getProcAddr("glClearDepthf"))
 	gpClearNamedBufferData = (C.GPCLEARNAMEDBUFFERDATA)(getProcAddr("glClearNamedBufferData"))
+	gpClearNamedBufferDataEXT = (C.GPCLEARNAMEDBUFFERDATAEXT)(getProcAddr("glClearNamedBufferDataEXT"))
 	gpClearNamedBufferSubData = (C.GPCLEARNAMEDBUFFERSUBDATA)(getProcAddr("glClearNamedBufferSubData"))
+	gpClearNamedBufferSubDataEXT = (C.GPCLEARNAMEDBUFFERSUBDATAEXT)(getProcAddr("glClearNamedBufferSubDataEXT"))
 	gpClearNamedFramebufferfi = (C.GPCLEARNAMEDFRAMEBUFFERFI)(getProcAddr("glClearNamedFramebufferfi"))
 	gpClearNamedFramebufferfv = (C.GPCLEARNAMEDFRAMEBUFFERFV)(getProcAddr("glClearNamedFramebufferfv"))
 	gpClearNamedFramebufferiv = (C.GPCLEARNAMEDFRAMEBUFFERIV)(getProcAddr("glClearNamedFramebufferiv"))
@@ -8310,11 +13306,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpClearTexImage = (C.GPCLEARTEXIMAGE)(getProcAddr("glClearTexImage"))
 	gpClearTexSubImage = (C.GPCLEARTEXSUBIMAGE)(getProcAddr("glClearTexSubImage"))
+	gpClientAttribDefaultEXT = (C.GPCLIENTATTRIBDEFAULTEXT)(getProcAddr("glClientAttribDefaultEXT"))
 	gpClientWaitSync = (C.GPCLIENTWAITSYNC)(getProcAddr("glClientWaitSync"))
 	if gpClientWaitSync == nil {
 		return errors.New("glClientWaitSync")
 	}
 	gpClipControl = (C.GPCLIPCONTROL)(getProcAddr("glClipControl"))
+	gpColorFormatNV = (C.GPCOLORFORMATNV)(getProcAddr("glColorFormatNV"))
 	gpColorMask = (C.GPCOLORMASK)(getProcAddr("glColorMask"))
 	if gpColorMask == nil {
 		return errors.New("glColorMask")
@@ -8323,11 +13321,19 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpColorMaski == nil {
 		return errors.New("glColorMaski")
 	}
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
 	}
 	gpCompileShaderIncludeARB = (C.GPCOMPILESHADERINCLUDEARB)(getProcAddr("glCompileShaderIncludeARB"))
+	gpCompressedMultiTexImage1DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE1DEXT)(getProcAddr("glCompressedMultiTexImage1DEXT"))
+	gpCompressedMultiTexImage2DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE2DEXT)(getProcAddr("glCompressedMultiTexImage2DEXT"))
+	gpCompressedMultiTexImage3DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE3DEXT)(getProcAddr("glCompressedMultiTexImage3DEXT"))
+	gpCompressedMultiTexSubImage1DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCompressedMultiTexSubImage1DEXT"))
+	gpCompressedMultiTexSubImage2DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCompressedMultiTexSubImage2DEXT"))
+	gpCompressedMultiTexSubImage3DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCompressedMultiTexSubImage3DEXT"))
 	gpCompressedTexImage1D = (C.GPCOMPRESSEDTEXIMAGE1D)(getProcAddr("glCompressedTexImage1D"))
 	if gpCompressedTexImage1D == nil {
 		return errors.New("glCompressedTexImage1D")
@@ -8352,15 +13358,29 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCompressedTexSubImage3D == nil {
 		return errors.New("glCompressedTexSubImage3D")
 	}
+	gpCompressedTextureImage1DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE1DEXT)(getProcAddr("glCompressedTextureImage1DEXT"))
+	gpCompressedTextureImage2DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE2DEXT)(getProcAddr("glCompressedTextureImage2DEXT"))
+	gpCompressedTextureImage3DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE3DEXT)(getProcAddr("glCompressedTextureImage3DEXT"))
 	gpCompressedTextureSubImage1D = (C.GPCOMPRESSEDTEXTURESUBIMAGE1D)(getProcAddr("glCompressedTextureSubImage1D"))
+	gpCompressedTextureSubImage1DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(getProcAddr("glCompressedTextureSubImage1DEXT"))
 	gpCompressedTextureSubImage2D = (C.GPCOMPRESSEDTEXTURESUBIMAGE2D)(getProcAddr("glCompressedTextureSubImage2D"))
+	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
+	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpCopyBufferSubData = (C.GPCOPYBUFFERSUBDATA)(getProcAddr("glCopyBufferSubData"))
 	if gpCopyBufferSubData == nil {
 		return errors.New("glCopyBufferSubData")
 	}
 	gpCopyImageSubData = (C.GPCOPYIMAGESUBDATA)(getProcAddr("glCopyImageSubData"))
+	gpCopyMultiTexImage1DEXT = (C.GPCOPYMULTITEXIMAGE1DEXT)(getProcAddr("glCopyMultiTexImage1DEXT"))
+	gpCopyMultiTexImage2DEXT = (C.GPCOPYMULTITEXIMAGE2DEXT)(getProcAddr("glCopyMultiTexImage2DEXT"))
+	gpCopyMultiTexSubImage1DEXT = (C.GPCOPYMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCopyMultiTexSubImage1DEXT"))
+	gpCopyMultiTexSubImage2DEXT = (C.GPCOPYMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCopyMultiTexSubImage2DEXT"))
+	gpCopyMultiTexSubImage3DEXT = (C.GPCOPYMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCopyMultiTexSubImage3DEXT"))
 	gpCopyNamedBufferSubData = (C.GPCOPYNAMEDBUFFERSUBDATA)(getProcAddr("glCopyNamedBufferSubData"))
+	gpCopyPathNV = (C.GPCOPYPATHNV)(getProcAddr("glCopyPathNV"))
 	gpCopyTexImage1D = (C.GPCOPYTEXIMAGE1D)(getProcAddr("glCopyTexImage1D"))
 	if gpCopyTexImage1D == nil {
 		return errors.New("glCopyTexImage1D")
@@ -8381,11 +13401,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCopyTexSubImage3D == nil {
 		return errors.New("glCopyTexSubImage3D")
 	}
+	gpCopyTextureImage1DEXT = (C.GPCOPYTEXTUREIMAGE1DEXT)(getProcAddr("glCopyTextureImage1DEXT"))
+	gpCopyTextureImage2DEXT = (C.GPCOPYTEXTUREIMAGE2DEXT)(getProcAddr("glCopyTextureImage2DEXT"))
 	gpCopyTextureSubImage1D = (C.GPCOPYTEXTURESUBIMAGE1D)(getProcAddr("glCopyTextureSubImage1D"))
+	gpCopyTextureSubImage1DEXT = (C.GPCOPYTEXTURESUBIMAGE1DEXT)(getProcAddr("glCopyTextureSubImage1DEXT"))
 	gpCopyTextureSubImage2D = (C.GPCOPYTEXTURESUBIMAGE2D)(getProcAddr("glCopyTextureSubImage2D"))
+	gpCopyTextureSubImage2DEXT = (C.GPCOPYTEXTURESUBIMAGE2DEXT)(getProcAddr("glCopyTextureSubImage2DEXT"))
 	gpCopyTextureSubImage3D = (C.GPCOPYTEXTURESUBIMAGE3D)(getProcAddr("glCopyTextureSubImage3D"))
+	gpCopyTextureSubImage3DEXT = (C.GPCOPYTEXTURESUBIMAGE3DEXT)(getProcAddr("glCopyTextureSubImage3DEXT"))
+	gpCoverFillPathInstancedNV = (C.GPCOVERFILLPATHINSTANCEDNV)(getProcAddr("glCoverFillPathInstancedNV"))
+	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
+	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
+	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
+	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
 		return errors.New("glCreateProgram")
@@ -8398,7 +13431,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCreateShader == nil {
 		return errors.New("glCreateShader")
 	}
+	gpCreateShaderProgramEXT = (C.GPCREATESHADERPROGRAMEXT)(getProcAddr("glCreateShaderProgramEXT"))
 	gpCreateShaderProgramv = (C.GPCREATESHADERPROGRAMV)(getProcAddr("glCreateShaderProgramv"))
+	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	gpCreateTransformFeedbacks = (C.GPCREATETRANSFORMFEEDBACKS)(getProcAddr("glCreateTransformFeedbacks"))
@@ -8420,16 +13456,21 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteBuffers == nil {
 		return errors.New("glDeleteBuffers")
 	}
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFramebuffers = (C.GPDELETEFRAMEBUFFERS)(getProcAddr("glDeleteFramebuffers"))
 	if gpDeleteFramebuffers == nil {
 		return errors.New("glDeleteFramebuffers")
 	}
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
+	gpDeletePathsNV = (C.GPDELETEPATHSNV)(getProcAddr("glDeletePathsNV"))
+	gpDeletePerfMonitorsAMD = (C.GPDELETEPERFMONITORSAMD)(getProcAddr("glDeletePerfMonitorsAMD"))
+	gpDeletePerfQueryINTEL = (C.GPDELETEPERFQUERYINTEL)(getProcAddr("glDeletePerfQueryINTEL"))
 	gpDeleteProgram = (C.GPDELETEPROGRAM)(getProcAddr("glDeleteProgram"))
 	if gpDeleteProgram == nil {
 		return errors.New("glDeleteProgram")
 	}
 	gpDeleteProgramPipelines = (C.GPDELETEPROGRAMPIPELINES)(getProcAddr("glDeleteProgramPipelines"))
+	gpDeleteProgramPipelinesEXT = (C.GPDELETEPROGRAMPIPELINESEXT)(getProcAddr("glDeleteProgramPipelinesEXT"))
 	gpDeleteQueries = (C.GPDELETEQUERIES)(getProcAddr("glDeleteQueries"))
 	if gpDeleteQueries == nil {
 		return errors.New("glDeleteQueries")
@@ -8446,6 +13487,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	if gpDeleteSync == nil {
 		return errors.New("glDeleteSync")
@@ -8482,7 +13524,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDisable == nil {
 		return errors.New("glDisable")
 	}
+	gpDisableClientStateIndexedEXT = (C.GPDISABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glDisableClientStateIndexedEXT"))
+	gpDisableClientStateiEXT = (C.GPDISABLECLIENTSTATEIEXT)(getProcAddr("glDisableClientStateiEXT"))
+	gpDisableIndexedEXT = (C.GPDISABLEINDEXEDEXT)(getProcAddr("glDisableIndexedEXT"))
 	gpDisableVertexArrayAttrib = (C.GPDISABLEVERTEXARRAYATTRIB)(getProcAddr("glDisableVertexArrayAttrib"))
+	gpDisableVertexArrayAttribEXT = (C.GPDISABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glDisableVertexArrayAttribEXT"))
+	gpDisableVertexArrayEXT = (C.GPDISABLEVERTEXARRAYEXT)(getProcAddr("glDisableVertexArrayEXT"))
 	gpDisableVertexAttribArray = (C.GPDISABLEVERTEXATTRIBARRAY)(getProcAddr("glDisableVertexAttribArray"))
 	if gpDisableVertexAttribArray == nil {
 		return errors.New("glDisableVertexAttribArray")
@@ -8503,7 +13550,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawArraysInstanced == nil {
 		return errors.New("glDrawArraysInstanced")
 	}
+	gpDrawArraysInstancedARB = (C.GPDRAWARRAYSINSTANCEDARB)(getProcAddr("glDrawArraysInstancedARB"))
 	gpDrawArraysInstancedBaseInstance = (C.GPDRAWARRAYSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawArraysInstancedBaseInstance"))
+	gpDrawArraysInstancedEXT = (C.GPDRAWARRAYSINSTANCEDEXT)(getProcAddr("glDrawArraysInstancedEXT"))
 	gpDrawBuffer = (C.GPDRAWBUFFER)(getProcAddr("glDrawBuffer"))
 	if gpDrawBuffer == nil {
 		return errors.New("glDrawBuffer")
@@ -8512,6 +13561,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawBuffers == nil {
 		return errors.New("glDrawBuffers")
 	}
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
 	if gpDrawElements == nil {
 		return errors.New("glDrawElements")
@@ -8525,12 +13578,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawElementsInstanced == nil {
 		return errors.New("glDrawElementsInstanced")
 	}
+	gpDrawElementsInstancedARB = (C.GPDRAWELEMENTSINSTANCEDARB)(getProcAddr("glDrawElementsInstancedARB"))
 	gpDrawElementsInstancedBaseInstance = (C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawElementsInstancedBaseInstance"))
 	gpDrawElementsInstancedBaseVertex = (C.GPDRAWELEMENTSINSTANCEDBASEVERTEX)(getProcAddr("glDrawElementsInstancedBaseVertex"))
 	if gpDrawElementsInstancedBaseVertex == nil {
 		return errors.New("glDrawElementsInstancedBaseVertex")
 	}
 	gpDrawElementsInstancedBaseVertexBaseInstance = (C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE)(getProcAddr("glDrawElementsInstancedBaseVertexBaseInstance"))
+	gpDrawElementsInstancedEXT = (C.GPDRAWELEMENTSINSTANCEDEXT)(getProcAddr("glDrawElementsInstancedEXT"))
 	gpDrawRangeElements = (C.GPDRAWRANGEELEMENTS)(getProcAddr("glDrawRangeElements"))
 	if gpDrawRangeElements == nil {
 		return errors.New("glDrawRangeElements")
@@ -8543,11 +13598,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpDrawTransformFeedbackInstanced = (C.GPDRAWTRANSFORMFEEDBACKINSTANCED)(getProcAddr("glDrawTransformFeedbackInstanced"))
 	gpDrawTransformFeedbackStream = (C.GPDRAWTRANSFORMFEEDBACKSTREAM)(getProcAddr("glDrawTransformFeedbackStream"))
 	gpDrawTransformFeedbackStreamInstanced = (C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(getProcAddr("glDrawTransformFeedbackStreamInstanced"))
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
+	gpEdgeFlagFormatNV = (C.GPEDGEFLAGFORMATNV)(getProcAddr("glEdgeFlagFormatNV"))
 	gpEnable = (C.GPENABLE)(getProcAddr("glEnable"))
 	if gpEnable == nil {
 		return errors.New("glEnable")
 	}
+	gpEnableClientStateIndexedEXT = (C.GPENABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glEnableClientStateIndexedEXT"))
+	gpEnableClientStateiEXT = (C.GPENABLECLIENTSTATEIEXT)(getProcAddr("glEnableClientStateiEXT"))
+	gpEnableIndexedEXT = (C.GPENABLEINDEXEDEXT)(getProcAddr("glEnableIndexedEXT"))
 	gpEnableVertexArrayAttrib = (C.GPENABLEVERTEXARRAYATTRIB)(getProcAddr("glEnableVertexArrayAttrib"))
+	gpEnableVertexArrayAttribEXT = (C.GPENABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glEnableVertexArrayAttribEXT"))
+	gpEnableVertexArrayEXT = (C.GPENABLEVERTEXARRAYEXT)(getProcAddr("glEnableVertexArrayEXT"))
 	gpEnableVertexAttribArray = (C.GPENABLEVERTEXATTRIBARRAY)(getProcAddr("glEnableVertexAttribArray"))
 	if gpEnableVertexAttribArray == nil {
 		return errors.New("glEnableVertexAttribArray")
@@ -8560,6 +13622,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEndConditionalRender == nil {
 		return errors.New("glEndConditionalRender")
 	}
+	gpEndConditionalRenderNV = (C.GPENDCONDITIONALRENDERNV)(getProcAddr("glEndConditionalRenderNV"))
+	gpEndPerfMonitorAMD = (C.GPENDPERFMONITORAMD)(getProcAddr("glEndPerfMonitorAMD"))
+	gpEndPerfQueryINTEL = (C.GPENDPERFQUERYINTEL)(getProcAddr("glEndPerfQueryINTEL"))
 	gpEndQuery = (C.GPENDQUERY)(getProcAddr("glEndQuery"))
 	if gpEndQuery == nil {
 		return errors.New("glEndQuery")
@@ -8569,6 +13634,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEndTransformFeedback == nil {
 		return errors.New("glEndTransformFeedback")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpFenceSync = (C.GPFENCESYNC)(getProcAddr("glFenceSync"))
 	if gpFenceSync == nil {
 		return errors.New("glFenceSync")
@@ -8586,11 +13652,20 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glFlushMappedBufferRange")
 	}
 	gpFlushMappedNamedBufferRange = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGE)(getProcAddr("glFlushMappedNamedBufferRange"))
+	gpFlushMappedNamedBufferRangeEXT = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(getProcAddr("glFlushMappedNamedBufferRangeEXT"))
+	gpFogCoordFormatNV = (C.GPFOGCOORDFORMATNV)(getProcAddr("glFogCoordFormatNV"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
+	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
+	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
+	gpFramebufferReadBufferEXT = (C.GPFRAMEBUFFERREADBUFFEREXT)(getProcAddr("glFramebufferReadBufferEXT"))
 	gpFramebufferRenderbuffer = (C.GPFRAMEBUFFERRENDERBUFFER)(getProcAddr("glFramebufferRenderbuffer"))
 	if gpFramebufferRenderbuffer == nil {
 		return errors.New("glFramebufferRenderbuffer")
 	}
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	if gpFramebufferTexture == nil {
 		return errors.New("glFramebufferTexture")
@@ -8607,10 +13682,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpFramebufferTexture3D == nil {
 		return errors.New("glFramebufferTexture3D")
 	}
+	gpFramebufferTextureARB = (C.GPFRAMEBUFFERTEXTUREARB)(getProcAddr("glFramebufferTextureARB"))
+	gpFramebufferTextureFaceARB = (C.GPFRAMEBUFFERTEXTUREFACEARB)(getProcAddr("glFramebufferTextureFaceARB"))
 	gpFramebufferTextureLayer = (C.GPFRAMEBUFFERTEXTURELAYER)(getProcAddr("glFramebufferTextureLayer"))
 	if gpFramebufferTextureLayer == nil {
 		return errors.New("glFramebufferTextureLayer")
 	}
+	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
 		return errors.New("glFrontFace")
@@ -8623,7 +13702,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenFramebuffers == nil {
 		return errors.New("glGenFramebuffers")
 	}
+	gpGenPathsNV = (C.GPGENPATHSNV)(getProcAddr("glGenPathsNV"))
+	gpGenPerfMonitorsAMD = (C.GPGENPERFMONITORSAMD)(getProcAddr("glGenPerfMonitorsAMD"))
 	gpGenProgramPipelines = (C.GPGENPROGRAMPIPELINES)(getProcAddr("glGenProgramPipelines"))
+	gpGenProgramPipelinesEXT = (C.GPGENPROGRAMPIPELINESEXT)(getProcAddr("glGenProgramPipelinesEXT"))
 	gpGenQueries = (C.GPGENQUERIES)(getProcAddr("glGenQueries"))
 	if gpGenQueries == nil {
 		return errors.New("glGenQueries")
@@ -8649,7 +13731,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenerateMipmap == nil {
 		return errors.New("glGenerateMipmap")
 	}
+	gpGenerateMultiTexMipmapEXT = (C.GPGENERATEMULTITEXMIPMAPEXT)(getProcAddr("glGenerateMultiTexMipmapEXT"))
 	gpGenerateTextureMipmap = (C.GPGENERATETEXTUREMIPMAP)(getProcAddr("glGenerateTextureMipmap"))
+	gpGenerateTextureMipmapEXT = (C.GPGENERATETEXTUREMIPMAPEXT)(getProcAddr("glGenerateTextureMipmapEXT"))
 	gpGetActiveAtomicCounterBufferiv = (C.GPGETACTIVEATOMICCOUNTERBUFFERIV)(getProcAddr("glGetActiveAtomicCounterBufferiv"))
 	gpGetActiveAttrib = (C.GPGETACTIVEATTRIB)(getProcAddr("glGetActiveAttrib"))
 	if gpGetActiveAttrib == nil {
@@ -8686,6 +13770,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetAttribLocation == nil {
 		return errors.New("glGetAttribLocation")
 	}
+	gpGetBooleanIndexedvEXT = (C.GPGETBOOLEANINDEXEDVEXT)(getProcAddr("glGetBooleanIndexedvEXT"))
 	gpGetBooleani_v = (C.GPGETBOOLEANI_V)(getProcAddr("glGetBooleani_v"))
 	if gpGetBooleani_v == nil {
 		return errors.New("glGetBooleani_v")
@@ -8702,6 +13787,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetBufferParameteriv == nil {
 		return errors.New("glGetBufferParameteriv")
 	}
+	gpGetBufferParameterui64vNV = (C.GPGETBUFFERPARAMETERUI64VNV)(getProcAddr("glGetBufferParameterui64vNV"))
 	gpGetBufferPointerv = (C.GPGETBUFFERPOINTERV)(getProcAddr("glGetBufferPointerv"))
 	if gpGetBufferPointerv == nil {
 		return errors.New("glGetBufferPointerv")
@@ -8710,16 +13796,22 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetBufferSubData == nil {
 		return errors.New("glGetBufferSubData")
 	}
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
+	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
 		return errors.New("glGetCompressedTexImage")
 	}
 	gpGetCompressedTextureImage = (C.GPGETCOMPRESSEDTEXTUREIMAGE)(getProcAddr("glGetCompressedTextureImage"))
+	gpGetCompressedTextureImageEXT = (C.GPGETCOMPRESSEDTEXTUREIMAGEEXT)(getProcAddr("glGetCompressedTextureImageEXT"))
 	gpGetCompressedTextureSubImage = (C.GPGETCOMPRESSEDTEXTURESUBIMAGE)(getProcAddr("glGetCompressedTextureSubImage"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	gpGetDebugMessageLogARB = (C.GPGETDEBUGMESSAGELOGARB)(getProcAddr("glGetDebugMessageLogARB"))
 	gpGetDebugMessageLogKHR = (C.GPGETDEBUGMESSAGELOGKHR)(getProcAddr("glGetDebugMessageLogKHR"))
+	gpGetDoubleIndexedvEXT = (C.GPGETDOUBLEINDEXEDVEXT)(getProcAddr("glGetDoubleIndexedvEXT"))
 	gpGetDoublei_v = (C.GPGETDOUBLEI_V)(getProcAddr("glGetDoublei_v"))
+	gpGetDoublei_vEXT = (C.GPGETDOUBLEI_VEXT)(getProcAddr("glGetDoublei_vEXT"))
 	gpGetDoublev = (C.GPGETDOUBLEV)(getProcAddr("glGetDoublev"))
 	if gpGetDoublev == nil {
 		return errors.New("glGetDoublev")
@@ -8728,7 +13820,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetError == nil {
 		return errors.New("glGetError")
 	}
+	gpGetFirstPerfQueryIdINTEL = (C.GPGETFIRSTPERFQUERYIDINTEL)(getProcAddr("glGetFirstPerfQueryIdINTEL"))
+	gpGetFloatIndexedvEXT = (C.GPGETFLOATINDEXEDVEXT)(getProcAddr("glGetFloatIndexedvEXT"))
 	gpGetFloati_v = (C.GPGETFLOATI_V)(getProcAddr("glGetFloati_v"))
+	gpGetFloati_vEXT = (C.GPGETFLOATI_VEXT)(getProcAddr("glGetFloati_vEXT"))
 	gpGetFloatv = (C.GPGETFLOATV)(getProcAddr("glGetFloatv"))
 	if gpGetFloatv == nil {
 		return errors.New("glGetFloatv")
@@ -8746,10 +13841,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetFramebufferAttachmentParameteriv")
 	}
 	gpGetFramebufferParameteriv = (C.GPGETFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetFramebufferParameteriv"))
+	gpGetFramebufferParameterivEXT = (C.GPGETFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetFramebufferParameterivEXT"))
 	gpGetGraphicsResetStatus = (C.GPGETGRAPHICSRESETSTATUS)(getProcAddr("glGetGraphicsResetStatus"))
 	gpGetGraphicsResetStatusARB = (C.GPGETGRAPHICSRESETSTATUSARB)(getProcAddr("glGetGraphicsResetStatusARB"))
 	gpGetGraphicsResetStatusKHR = (C.GPGETGRAPHICSRESETSTATUSKHR)(getProcAddr("glGetGraphicsResetStatusKHR"))
 	gpGetImageHandleARB = (C.GPGETIMAGEHANDLEARB)(getProcAddr("glGetImageHandleARB"))
+	gpGetImageHandleNV = (C.GPGETIMAGEHANDLENV)(getProcAddr("glGetImageHandleNV"))
 	gpGetInteger64i_v = (C.GPGETINTEGER64I_V)(getProcAddr("glGetInteger64i_v"))
 	if gpGetInteger64i_v == nil {
 		return errors.New("glGetInteger64i_v")
@@ -8758,33 +13855,85 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetInteger64v == nil {
 		return errors.New("glGetInteger64v")
 	}
+	gpGetIntegerIndexedvEXT = (C.GPGETINTEGERINDEXEDVEXT)(getProcAddr("glGetIntegerIndexedvEXT"))
 	gpGetIntegeri_v = (C.GPGETINTEGERI_V)(getProcAddr("glGetIntegeri_v"))
 	if gpGetIntegeri_v == nil {
 		return errors.New("glGetIntegeri_v")
 	}
+	gpGetIntegerui64i_vNV = (C.GPGETINTEGERUI64I_VNV)(getProcAddr("glGetIntegerui64i_vNV"))
+	gpGetIntegerui64vNV = (C.GPGETINTEGERUI64VNV)(getProcAddr("glGetIntegerui64vNV"))
 	gpGetIntegerv = (C.GPGETINTEGERV)(getProcAddr("glGetIntegerv"))
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	gpGetInternalformativ = (C.GPGETINTERNALFORMATIV)(getProcAddr("glGetInternalformativ"))
+	gpGetMultiTexEnvfvEXT = (C.GPGETMULTITEXENVFVEXT)(getProcAddr("glGetMultiTexEnvfvEXT"))
+	gpGetMultiTexEnvivEXT = (C.GPGETMULTITEXENVIVEXT)(getProcAddr("glGetMultiTexEnvivEXT"))
+	gpGetMultiTexGendvEXT = (C.GPGETMULTITEXGENDVEXT)(getProcAddr("glGetMultiTexGendvEXT"))
+	gpGetMultiTexGenfvEXT = (C.GPGETMULTITEXGENFVEXT)(getProcAddr("glGetMultiTexGenfvEXT"))
+	gpGetMultiTexGenivEXT = (C.GPGETMULTITEXGENIVEXT)(getProcAddr("glGetMultiTexGenivEXT"))
+	gpGetMultiTexImageEXT = (C.GPGETMULTITEXIMAGEEXT)(getProcAddr("glGetMultiTexImageEXT"))
+	gpGetMultiTexLevelParameterfvEXT = (C.GPGETMULTITEXLEVELPARAMETERFVEXT)(getProcAddr("glGetMultiTexLevelParameterfvEXT"))
+	gpGetMultiTexLevelParameterivEXT = (C.GPGETMULTITEXLEVELPARAMETERIVEXT)(getProcAddr("glGetMultiTexLevelParameterivEXT"))
+	gpGetMultiTexParameterIivEXT = (C.GPGETMULTITEXPARAMETERIIVEXT)(getProcAddr("glGetMultiTexParameterIivEXT"))
+	gpGetMultiTexParameterIuivEXT = (C.GPGETMULTITEXPARAMETERIUIVEXT)(getProcAddr("glGetMultiTexParameterIuivEXT"))
+	gpGetMultiTexParameterfvEXT = (C.GPGETMULTITEXPARAMETERFVEXT)(getProcAddr("glGetMultiTexParameterfvEXT"))
+	gpGetMultiTexParameterivEXT = (C.GPGETMULTITEXPARAMETERIVEXT)(getProcAddr("glGetMultiTexParameterivEXT"))
 	gpGetMultisamplefv = (C.GPGETMULTISAMPLEFV)(getProcAddr("glGetMultisamplefv"))
 	if gpGetMultisamplefv == nil {
 		return errors.New("glGetMultisamplefv")
 	}
 	gpGetNamedBufferParameteri64v = (C.GPGETNAMEDBUFFERPARAMETERI64V)(getProcAddr("glGetNamedBufferParameteri64v"))
 	gpGetNamedBufferParameteriv = (C.GPGETNAMEDBUFFERPARAMETERIV)(getProcAddr("glGetNamedBufferParameteriv"))
+	gpGetNamedBufferParameterivEXT = (C.GPGETNAMEDBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedBufferParameterivEXT"))
+	gpGetNamedBufferParameterui64vNV = (C.GPGETNAMEDBUFFERPARAMETERUI64VNV)(getProcAddr("glGetNamedBufferParameterui64vNV"))
 	gpGetNamedBufferPointerv = (C.GPGETNAMEDBUFFERPOINTERV)(getProcAddr("glGetNamedBufferPointerv"))
+	gpGetNamedBufferPointervEXT = (C.GPGETNAMEDBUFFERPOINTERVEXT)(getProcAddr("glGetNamedBufferPointervEXT"))
 	gpGetNamedBufferSubData = (C.GPGETNAMEDBUFFERSUBDATA)(getProcAddr("glGetNamedBufferSubData"))
+	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
+	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
+	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
+	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
+	gpGetNamedProgramLocalParameterIuivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIuivEXT"))
+	gpGetNamedProgramLocalParameterdvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(getProcAddr("glGetNamedProgramLocalParameterdvEXT"))
+	gpGetNamedProgramLocalParameterfvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(getProcAddr("glGetNamedProgramLocalParameterfvEXT"))
+	gpGetNamedProgramStringEXT = (C.GPGETNAMEDPROGRAMSTRINGEXT)(getProcAddr("glGetNamedProgramStringEXT"))
+	gpGetNamedProgramivEXT = (C.GPGETNAMEDPROGRAMIVEXT)(getProcAddr("glGetNamedProgramivEXT"))
 	gpGetNamedRenderbufferParameteriv = (C.GPGETNAMEDRENDERBUFFERPARAMETERIV)(getProcAddr("glGetNamedRenderbufferParameteriv"))
+	gpGetNamedRenderbufferParameterivEXT = (C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedRenderbufferParameterivEXT"))
 	gpGetNamedStringARB = (C.GPGETNAMEDSTRINGARB)(getProcAddr("glGetNamedStringARB"))
 	gpGetNamedStringivARB = (C.GPGETNAMEDSTRINGIVARB)(getProcAddr("glGetNamedStringivARB"))
+	gpGetNextPerfQueryIdINTEL = (C.GPGETNEXTPERFQUERYIDINTEL)(getProcAddr("glGetNextPerfQueryIdINTEL"))
 	gpGetObjectLabel = (C.GPGETOBJECTLABEL)(getProcAddr("glGetObjectLabel"))
+	gpGetObjectLabelEXT = (C.GPGETOBJECTLABELEXT)(getProcAddr("glGetObjectLabelEXT"))
 	gpGetObjectLabelKHR = (C.GPGETOBJECTLABELKHR)(getProcAddr("glGetObjectLabelKHR"))
 	gpGetObjectPtrLabel = (C.GPGETOBJECTPTRLABEL)(getProcAddr("glGetObjectPtrLabel"))
 	gpGetObjectPtrLabelKHR = (C.GPGETOBJECTPTRLABELKHR)(getProcAddr("glGetObjectPtrLabelKHR"))
+	gpGetPathCommandsNV = (C.GPGETPATHCOMMANDSNV)(getProcAddr("glGetPathCommandsNV"))
+	gpGetPathCoordsNV = (C.GPGETPATHCOORDSNV)(getProcAddr("glGetPathCoordsNV"))
+	gpGetPathDashArrayNV = (C.GPGETPATHDASHARRAYNV)(getProcAddr("glGetPathDashArrayNV"))
+	gpGetPathLengthNV = (C.GPGETPATHLENGTHNV)(getProcAddr("glGetPathLengthNV"))
+	gpGetPathMetricRangeNV = (C.GPGETPATHMETRICRANGENV)(getProcAddr("glGetPathMetricRangeNV"))
+	gpGetPathMetricsNV = (C.GPGETPATHMETRICSNV)(getProcAddr("glGetPathMetricsNV"))
+	gpGetPathParameterfvNV = (C.GPGETPATHPARAMETERFVNV)(getProcAddr("glGetPathParameterfvNV"))
+	gpGetPathParameterivNV = (C.GPGETPATHPARAMETERIVNV)(getProcAddr("glGetPathParameterivNV"))
+	gpGetPathSpacingNV = (C.GPGETPATHSPACINGNV)(getProcAddr("glGetPathSpacingNV"))
+	gpGetPerfCounterInfoINTEL = (C.GPGETPERFCOUNTERINFOINTEL)(getProcAddr("glGetPerfCounterInfoINTEL"))
+	gpGetPerfMonitorCounterDataAMD = (C.GPGETPERFMONITORCOUNTERDATAAMD)(getProcAddr("glGetPerfMonitorCounterDataAMD"))
+	gpGetPerfMonitorCounterInfoAMD = (C.GPGETPERFMONITORCOUNTERINFOAMD)(getProcAddr("glGetPerfMonitorCounterInfoAMD"))
+	gpGetPerfMonitorCounterStringAMD = (C.GPGETPERFMONITORCOUNTERSTRINGAMD)(getProcAddr("glGetPerfMonitorCounterStringAMD"))
+	gpGetPerfMonitorCountersAMD = (C.GPGETPERFMONITORCOUNTERSAMD)(getProcAddr("glGetPerfMonitorCountersAMD"))
+	gpGetPerfMonitorGroupStringAMD = (C.GPGETPERFMONITORGROUPSTRINGAMD)(getProcAddr("glGetPerfMonitorGroupStringAMD"))
+	gpGetPerfMonitorGroupsAMD = (C.GPGETPERFMONITORGROUPSAMD)(getProcAddr("glGetPerfMonitorGroupsAMD"))
+	gpGetPerfQueryDataINTEL = (C.GPGETPERFQUERYDATAINTEL)(getProcAddr("glGetPerfQueryDataINTEL"))
+	gpGetPerfQueryIdByNameINTEL = (C.GPGETPERFQUERYIDBYNAMEINTEL)(getProcAddr("glGetPerfQueryIdByNameINTEL"))
+	gpGetPerfQueryInfoINTEL = (C.GPGETPERFQUERYINFOINTEL)(getProcAddr("glGetPerfQueryInfoINTEL"))
+	gpGetPointerIndexedvEXT = (C.GPGETPOINTERINDEXEDVEXT)(getProcAddr("glGetPointerIndexedvEXT"))
+	gpGetPointeri_vEXT = (C.GPGETPOINTERI_VEXT)(getProcAddr("glGetPointeri_vEXT"))
 	gpGetPointerv = (C.GPGETPOINTERV)(getProcAddr("glGetPointerv"))
 	gpGetPointervKHR = (C.GPGETPOINTERVKHR)(getProcAddr("glGetPointervKHR"))
 	gpGetProgramBinary = (C.GPGETPROGRAMBINARY)(getProcAddr("glGetProgramBinary"))
@@ -8794,17 +13943,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetProgramInterfaceiv = (C.GPGETPROGRAMINTERFACEIV)(getProcAddr("glGetProgramInterfaceiv"))
 	gpGetProgramPipelineInfoLog = (C.GPGETPROGRAMPIPELINEINFOLOG)(getProcAddr("glGetProgramPipelineInfoLog"))
+	gpGetProgramPipelineInfoLogEXT = (C.GPGETPROGRAMPIPELINEINFOLOGEXT)(getProcAddr("glGetProgramPipelineInfoLogEXT"))
 	gpGetProgramPipelineiv = (C.GPGETPROGRAMPIPELINEIV)(getProcAddr("glGetProgramPipelineiv"))
+	gpGetProgramPipelineivEXT = (C.GPGETPROGRAMPIPELINEIVEXT)(getProcAddr("glGetProgramPipelineivEXT"))
 	gpGetProgramResourceIndex = (C.GPGETPROGRAMRESOURCEINDEX)(getProcAddr("glGetProgramResourceIndex"))
 	gpGetProgramResourceLocation = (C.GPGETPROGRAMRESOURCELOCATION)(getProcAddr("glGetProgramResourceLocation"))
 	gpGetProgramResourceLocationIndex = (C.GPGETPROGRAMRESOURCELOCATIONINDEX)(getProcAddr("glGetProgramResourceLocationIndex"))
 	gpGetProgramResourceName = (C.GPGETPROGRAMRESOURCENAME)(getProcAddr("glGetProgramResourceName"))
+	gpGetProgramResourcefvNV = (C.GPGETPROGRAMRESOURCEFVNV)(getProcAddr("glGetProgramResourcefvNV"))
 	gpGetProgramResourceiv = (C.GPGETPROGRAMRESOURCEIV)(getProcAddr("glGetProgramResourceiv"))
 	gpGetProgramStageiv = (C.GPGETPROGRAMSTAGEIV)(getProcAddr("glGetProgramStageiv"))
 	gpGetProgramiv = (C.GPGETPROGRAMIV)(getProcAddr("glGetProgramiv"))
 	if gpGetProgramiv == nil {
 		return errors.New("glGetProgramiv")
 	}
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	gpGetQueryObjecti64v = (C.GPGETQUERYOBJECTI64V)(getProcAddr("glGetQueryObjecti64v"))
 	if gpGetQueryObjecti64v == nil {
@@ -8859,6 +14015,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetShaderiv == nil {
 		return errors.New("glGetShaderiv")
 	}
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -8902,14 +14059,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetTexParameteriv")
 	}
 	gpGetTextureHandleARB = (C.GPGETTEXTUREHANDLEARB)(getProcAddr("glGetTextureHandleARB"))
+	gpGetTextureHandleNV = (C.GPGETTEXTUREHANDLENV)(getProcAddr("glGetTextureHandleNV"))
 	gpGetTextureImage = (C.GPGETTEXTUREIMAGE)(getProcAddr("glGetTextureImage"))
+	gpGetTextureImageEXT = (C.GPGETTEXTUREIMAGEEXT)(getProcAddr("glGetTextureImageEXT"))
 	gpGetTextureLevelParameterfv = (C.GPGETTEXTURELEVELPARAMETERFV)(getProcAddr("glGetTextureLevelParameterfv"))
+	gpGetTextureLevelParameterfvEXT = (C.GPGETTEXTURELEVELPARAMETERFVEXT)(getProcAddr("glGetTextureLevelParameterfvEXT"))
 	gpGetTextureLevelParameteriv = (C.GPGETTEXTURELEVELPARAMETERIV)(getProcAddr("glGetTextureLevelParameteriv"))
+	gpGetTextureLevelParameterivEXT = (C.GPGETTEXTURELEVELPARAMETERIVEXT)(getProcAddr("glGetTextureLevelParameterivEXT"))
 	gpGetTextureParameterIiv = (C.GPGETTEXTUREPARAMETERIIV)(getProcAddr("glGetTextureParameterIiv"))
+	gpGetTextureParameterIivEXT = (C.GPGETTEXTUREPARAMETERIIVEXT)(getProcAddr("glGetTextureParameterIivEXT"))
 	gpGetTextureParameterIuiv = (C.GPGETTEXTUREPARAMETERIUIV)(getProcAddr("glGetTextureParameterIuiv"))
+	gpGetTextureParameterIuivEXT = (C.GPGETTEXTUREPARAMETERIUIVEXT)(getProcAddr("glGetTextureParameterIuivEXT"))
 	gpGetTextureParameterfv = (C.GPGETTEXTUREPARAMETERFV)(getProcAddr("glGetTextureParameterfv"))
+	gpGetTextureParameterfvEXT = (C.GPGETTEXTUREPARAMETERFVEXT)(getProcAddr("glGetTextureParameterfvEXT"))
 	gpGetTextureParameteriv = (C.GPGETTEXTUREPARAMETERIV)(getProcAddr("glGetTextureParameteriv"))
+	gpGetTextureParameterivEXT = (C.GPGETTEXTUREPARAMETERIVEXT)(getProcAddr("glGetTextureParameterivEXT"))
 	gpGetTextureSamplerHandleARB = (C.GPGETTEXTURESAMPLERHANDLEARB)(getProcAddr("glGetTextureSamplerHandleARB"))
+	gpGetTextureSamplerHandleNV = (C.GPGETTEXTURESAMPLERHANDLENV)(getProcAddr("glGetTextureSamplerHandleNV"))
 	gpGetTextureSubImage = (C.GPGETTEXTURESUBIMAGE)(getProcAddr("glGetTextureSubImage"))
 	gpGetTransformFeedbackVarying = (C.GPGETTRANSFORMFEEDBACKVARYING)(getProcAddr("glGetTransformFeedbackVarying"))
 	if gpGetTransformFeedbackVarying == nil {
@@ -8936,16 +14102,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetUniformfv == nil {
 		return errors.New("glGetUniformfv")
 	}
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
+	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
+	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
 	}
 	gpGetVertexArrayIndexed64iv = (C.GPGETVERTEXARRAYINDEXED64IV)(getProcAddr("glGetVertexArrayIndexed64iv"))
 	gpGetVertexArrayIndexediv = (C.GPGETVERTEXARRAYINDEXEDIV)(getProcAddr("glGetVertexArrayIndexediv"))
+	gpGetVertexArrayIntegeri_vEXT = (C.GPGETVERTEXARRAYINTEGERI_VEXT)(getProcAddr("glGetVertexArrayIntegeri_vEXT"))
+	gpGetVertexArrayIntegervEXT = (C.GPGETVERTEXARRAYINTEGERVEXT)(getProcAddr("glGetVertexArrayIntegervEXT"))
+	gpGetVertexArrayPointeri_vEXT = (C.GPGETVERTEXARRAYPOINTERI_VEXT)(getProcAddr("glGetVertexArrayPointeri_vEXT"))
+	gpGetVertexArrayPointervEXT = (C.GPGETVERTEXARRAYPOINTERVEXT)(getProcAddr("glGetVertexArrayPointervEXT"))
 	gpGetVertexArrayiv = (C.GPGETVERTEXARRAYIV)(getProcAddr("glGetVertexArrayiv"))
 	gpGetVertexAttribIiv = (C.GPGETVERTEXATTRIBIIV)(getProcAddr("glGetVertexAttribIiv"))
 	if gpGetVertexAttribIiv == nil {
@@ -8956,7 +14130,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetVertexAttribIuiv")
 	}
 	gpGetVertexAttribLdv = (C.GPGETVERTEXATTRIBLDV)(getProcAddr("glGetVertexAttribLdv"))
+	gpGetVertexAttribLi64vNV = (C.GPGETVERTEXATTRIBLI64VNV)(getProcAddr("glGetVertexAttribLi64vNV"))
 	gpGetVertexAttribLui64vARB = (C.GPGETVERTEXATTRIBLUI64VARB)(getProcAddr("glGetVertexAttribLui64vARB"))
+	gpGetVertexAttribLui64vNV = (C.GPGETVERTEXATTRIBLUI64VNV)(getProcAddr("glGetVertexAttribLui64vNV"))
 	gpGetVertexAttribPointerv = (C.GPGETVERTEXATTRIBPOINTERV)(getProcAddr("glGetVertexAttribPointerv"))
 	if gpGetVertexAttribPointerv == nil {
 		return errors.New("glGetVertexAttribPointerv")
@@ -8973,15 +14149,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetVertexAttribiv == nil {
 		return errors.New("glGetVertexAttribiv")
 	}
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnCompressedTexImageARB = (C.GPGETNCOMPRESSEDTEXIMAGEARB)(getProcAddr("glGetnCompressedTexImageARB"))
 	gpGetnTexImageARB = (C.GPGETNTEXIMAGEARB)(getProcAddr("glGetnTexImageARB"))
 	gpGetnUniformdvARB = (C.GPGETNUNIFORMDVARB)(getProcAddr("glGetnUniformdvARB"))
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	gpGetnUniformuivARB = (C.GPGETNUNIFORMUIVARB)(getProcAddr("glGetnUniformuivARB"))
 	gpGetnUniformuivKHR = (C.GPGETNUNIFORMUIVKHR)(getProcAddr("glGetnUniformuivKHR"))
@@ -8989,6 +14168,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpHint == nil {
 		return errors.New("glHint")
 	}
+	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
+	gpInsertEventMarkerEXT = (C.GPINSERTEVENTMARKEREXT)(getProcAddr("glInsertEventMarkerEXT"))
+	gpInterpolatePathsNV = (C.GPINTERPOLATEPATHSNV)(getProcAddr("glInterpolatePathsNV"))
 	gpInvalidateBufferData = (C.GPINVALIDATEBUFFERDATA)(getProcAddr("glInvalidateBufferData"))
 	gpInvalidateBufferSubData = (C.GPINVALIDATEBUFFERSUBDATA)(getProcAddr("glInvalidateBufferSubData"))
 	gpInvalidateFramebuffer = (C.GPINVALIDATEFRAMEBUFFER)(getProcAddr("glInvalidateFramebuffer"))
@@ -9001,10 +14183,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsBuffer == nil {
 		return errors.New("glIsBuffer")
 	}
+	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
 	}
+	gpIsEnabledIndexedEXT = (C.GPISENABLEDINDEXEDEXT)(getProcAddr("glIsEnabledIndexedEXT"))
 	gpIsEnabledi = (C.GPISENABLEDI)(getProcAddr("glIsEnabledi"))
 	if gpIsEnabledi == nil {
 		return errors.New("glIsEnabledi")
@@ -9014,12 +14199,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsFramebuffer")
 	}
 	gpIsImageHandleResidentARB = (C.GPISIMAGEHANDLERESIDENTARB)(getProcAddr("glIsImageHandleResidentARB"))
+	gpIsImageHandleResidentNV = (C.GPISIMAGEHANDLERESIDENTNV)(getProcAddr("glIsImageHandleResidentNV"))
+	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
+	gpIsPathNV = (C.GPISPATHNV)(getProcAddr("glIsPathNV"))
+	gpIsPointInFillPathNV = (C.GPISPOINTINFILLPATHNV)(getProcAddr("glIsPointInFillPathNV"))
+	gpIsPointInStrokePathNV = (C.GPISPOINTINSTROKEPATHNV)(getProcAddr("glIsPointInStrokePathNV"))
 	gpIsProgram = (C.GPISPROGRAM)(getProcAddr("glIsProgram"))
 	if gpIsProgram == nil {
 		return errors.New("glIsProgram")
 	}
 	gpIsProgramPipeline = (C.GPISPROGRAMPIPELINE)(getProcAddr("glIsProgramPipeline"))
+	gpIsProgramPipelineEXT = (C.GPISPROGRAMPIPELINEEXT)(getProcAddr("glIsProgramPipelineEXT"))
 	gpIsQuery = (C.GPISQUERY)(getProcAddr("glIsQuery"))
 	if gpIsQuery == nil {
 		return errors.New("glIsQuery")
@@ -9036,6 +14227,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	if gpIsSync == nil {
 		return errors.New("glIsSync")
@@ -9045,11 +14237,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsTexture")
 	}
 	gpIsTextureHandleResidentARB = (C.GPISTEXTUREHANDLERESIDENTARB)(getProcAddr("glIsTextureHandleResidentARB"))
+	gpIsTextureHandleResidentNV = (C.GPISTEXTUREHANDLERESIDENTNV)(getProcAddr("glIsTextureHandleResidentNV"))
 	gpIsTransformFeedback = (C.GPISTRANSFORMFEEDBACK)(getProcAddr("glIsTransformFeedback"))
 	gpIsVertexArray = (C.GPISVERTEXARRAY)(getProcAddr("glIsVertexArray"))
 	if gpIsVertexArray == nil {
 		return errors.New("glIsVertexArray")
 	}
+	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLineWidth = (C.GPLINEWIDTH)(getProcAddr("glLineWidth"))
 	if gpLineWidth == nil {
 		return errors.New("glLineWidth")
@@ -9058,14 +14252,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpLinkProgram == nil {
 		return errors.New("glLinkProgram")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpLogicOp = (C.GPLOGICOP)(getProcAddr("glLogicOp"))
 	if gpLogicOp == nil {
 		return errors.New("glLogicOp")
 	}
+	gpMakeBufferNonResidentNV = (C.GPMAKEBUFFERNONRESIDENTNV)(getProcAddr("glMakeBufferNonResidentNV"))
+	gpMakeBufferResidentNV = (C.GPMAKEBUFFERRESIDENTNV)(getProcAddr("glMakeBufferResidentNV"))
 	gpMakeImageHandleNonResidentARB = (C.GPMAKEIMAGEHANDLENONRESIDENTARB)(getProcAddr("glMakeImageHandleNonResidentARB"))
+	gpMakeImageHandleNonResidentNV = (C.GPMAKEIMAGEHANDLENONRESIDENTNV)(getProcAddr("glMakeImageHandleNonResidentNV"))
 	gpMakeImageHandleResidentARB = (C.GPMAKEIMAGEHANDLERESIDENTARB)(getProcAddr("glMakeImageHandleResidentARB"))
+	gpMakeImageHandleResidentNV = (C.GPMAKEIMAGEHANDLERESIDENTNV)(getProcAddr("glMakeImageHandleResidentNV"))
+	gpMakeNamedBufferNonResidentNV = (C.GPMAKENAMEDBUFFERNONRESIDENTNV)(getProcAddr("glMakeNamedBufferNonResidentNV"))
+	gpMakeNamedBufferResidentNV = (C.GPMAKENAMEDBUFFERRESIDENTNV)(getProcAddr("glMakeNamedBufferResidentNV"))
 	gpMakeTextureHandleNonResidentARB = (C.GPMAKETEXTUREHANDLENONRESIDENTARB)(getProcAddr("glMakeTextureHandleNonResidentARB"))
+	gpMakeTextureHandleNonResidentNV = (C.GPMAKETEXTUREHANDLENONRESIDENTNV)(getProcAddr("glMakeTextureHandleNonResidentNV"))
 	gpMakeTextureHandleResidentARB = (C.GPMAKETEXTUREHANDLERESIDENTARB)(getProcAddr("glMakeTextureHandleResidentARB"))
+	gpMakeTextureHandleResidentNV = (C.GPMAKETEXTUREHANDLERESIDENTNV)(getProcAddr("glMakeTextureHandleResidentNV"))
 	gpMapBuffer = (C.GPMAPBUFFER)(getProcAddr("glMapBuffer"))
 	if gpMapBuffer == nil {
 		return errors.New("glMapBuffer")
@@ -9075,7 +14278,36 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMapBufferRange")
 	}
 	gpMapNamedBuffer = (C.GPMAPNAMEDBUFFER)(getProcAddr("glMapNamedBuffer"))
+	gpMapNamedBufferEXT = (C.GPMAPNAMEDBUFFEREXT)(getProcAddr("glMapNamedBufferEXT"))
 	gpMapNamedBufferRange = (C.GPMAPNAMEDBUFFERRANGE)(getProcAddr("glMapNamedBufferRange"))
+	gpMapNamedBufferRangeEXT = (C.GPMAPNAMEDBUFFERRANGEEXT)(getProcAddr("glMapNamedBufferRangeEXT"))
+	gpMatrixFrustumEXT = (C.GPMATRIXFRUSTUMEXT)(getProcAddr("glMatrixFrustumEXT"))
+	gpMatrixLoad3x2fNV = (C.GPMATRIXLOAD3X2FNV)(getProcAddr("glMatrixLoad3x2fNV"))
+	gpMatrixLoad3x3fNV = (C.GPMATRIXLOAD3X3FNV)(getProcAddr("glMatrixLoad3x3fNV"))
+	gpMatrixLoadIdentityEXT = (C.GPMATRIXLOADIDENTITYEXT)(getProcAddr("glMatrixLoadIdentityEXT"))
+	gpMatrixLoadTranspose3x3fNV = (C.GPMATRIXLOADTRANSPOSE3X3FNV)(getProcAddr("glMatrixLoadTranspose3x3fNV"))
+	gpMatrixLoadTransposedEXT = (C.GPMATRIXLOADTRANSPOSEDEXT)(getProcAddr("glMatrixLoadTransposedEXT"))
+	gpMatrixLoadTransposefEXT = (C.GPMATRIXLOADTRANSPOSEFEXT)(getProcAddr("glMatrixLoadTransposefEXT"))
+	gpMatrixLoaddEXT = (C.GPMATRIXLOADDEXT)(getProcAddr("glMatrixLoaddEXT"))
+	gpMatrixLoadfEXT = (C.GPMATRIXLOADFEXT)(getProcAddr("glMatrixLoadfEXT"))
+	gpMatrixMult3x2fNV = (C.GPMATRIXMULT3X2FNV)(getProcAddr("glMatrixMult3x2fNV"))
+	gpMatrixMult3x3fNV = (C.GPMATRIXMULT3X3FNV)(getProcAddr("glMatrixMult3x3fNV"))
+	gpMatrixMultTranspose3x3fNV = (C.GPMATRIXMULTTRANSPOSE3X3FNV)(getProcAddr("glMatrixMultTranspose3x3fNV"))
+	gpMatrixMultTransposedEXT = (C.GPMATRIXMULTTRANSPOSEDEXT)(getProcAddr("glMatrixMultTransposedEXT"))
+	gpMatrixMultTransposefEXT = (C.GPMATRIXMULTTRANSPOSEFEXT)(getProcAddr("glMatrixMultTransposefEXT"))
+	gpMatrixMultdEXT = (C.GPMATRIXMULTDEXT)(getProcAddr("glMatrixMultdEXT"))
+	gpMatrixMultfEXT = (C.GPMATRIXMULTFEXT)(getProcAddr("glMatrixMultfEXT"))
+	gpMatrixOrthoEXT = (C.GPMATRIXORTHOEXT)(getProcAddr("glMatrixOrthoEXT"))
+	gpMatrixPopEXT = (C.GPMATRIXPOPEXT)(getProcAddr("glMatrixPopEXT"))
+	gpMatrixPushEXT = (C.GPMATRIXPUSHEXT)(getProcAddr("glMatrixPushEXT"))
+	gpMatrixRotatedEXT = (C.GPMATRIXROTATEDEXT)(getProcAddr("glMatrixRotatedEXT"))
+	gpMatrixRotatefEXT = (C.GPMATRIXROTATEFEXT)(getProcAddr("glMatrixRotatefEXT"))
+	gpMatrixScaledEXT = (C.GPMATRIXSCALEDEXT)(getProcAddr("glMatrixScaledEXT"))
+	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
+	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
+	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	gpMemoryBarrierByRegion = (C.GPMEMORYBARRIERBYREGION)(getProcAddr("glMemoryBarrierByRegion"))
 	gpMinSampleShadingARB = (C.GPMINSAMPLESHADINGARB)(getProcAddr("glMinSampleShadingARB"))
@@ -9084,6 +14316,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMultiDrawArrays")
 	}
 	gpMultiDrawArraysIndirect = (C.GPMULTIDRAWARRAYSINDIRECT)(getProcAddr("glMultiDrawArraysIndirect"))
+	gpMultiDrawArraysIndirectBindlessCountNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawArraysIndirectBindlessCountNV"))
+	gpMultiDrawArraysIndirectBindlessNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawArraysIndirectBindlessNV"))
 	gpMultiDrawArraysIndirectCountARB = (C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawArraysIndirectCountARB"))
 	gpMultiDrawElements = (C.GPMULTIDRAWELEMENTS)(getProcAddr("glMultiDrawElements"))
 	if gpMultiDrawElements == nil {
@@ -9094,28 +14328,103 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMultiDrawElementsBaseVertex")
 	}
 	gpMultiDrawElementsIndirect = (C.GPMULTIDRAWELEMENTSINDIRECT)(getProcAddr("glMultiDrawElementsIndirect"))
+	gpMultiDrawElementsIndirectBindlessCountNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawElementsIndirectBindlessCountNV"))
+	gpMultiDrawElementsIndirectBindlessNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawElementsIndirectBindlessNV"))
 	gpMultiDrawElementsIndirectCountARB = (C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawElementsIndirectCountARB"))
+	gpMultiTexBufferEXT = (C.GPMULTITEXBUFFEREXT)(getProcAddr("glMultiTexBufferEXT"))
+	gpMultiTexCoordPointerEXT = (C.GPMULTITEXCOORDPOINTEREXT)(getProcAddr("glMultiTexCoordPointerEXT"))
+	gpMultiTexEnvfEXT = (C.GPMULTITEXENVFEXT)(getProcAddr("glMultiTexEnvfEXT"))
+	gpMultiTexEnvfvEXT = (C.GPMULTITEXENVFVEXT)(getProcAddr("glMultiTexEnvfvEXT"))
+	gpMultiTexEnviEXT = (C.GPMULTITEXENVIEXT)(getProcAddr("glMultiTexEnviEXT"))
+	gpMultiTexEnvivEXT = (C.GPMULTITEXENVIVEXT)(getProcAddr("glMultiTexEnvivEXT"))
+	gpMultiTexGendEXT = (C.GPMULTITEXGENDEXT)(getProcAddr("glMultiTexGendEXT"))
+	gpMultiTexGendvEXT = (C.GPMULTITEXGENDVEXT)(getProcAddr("glMultiTexGendvEXT"))
+	gpMultiTexGenfEXT = (C.GPMULTITEXGENFEXT)(getProcAddr("glMultiTexGenfEXT"))
+	gpMultiTexGenfvEXT = (C.GPMULTITEXGENFVEXT)(getProcAddr("glMultiTexGenfvEXT"))
+	gpMultiTexGeniEXT = (C.GPMULTITEXGENIEXT)(getProcAddr("glMultiTexGeniEXT"))
+	gpMultiTexGenivEXT = (C.GPMULTITEXGENIVEXT)(getProcAddr("glMultiTexGenivEXT"))
+	gpMultiTexImage1DEXT = (C.GPMULTITEXIMAGE1DEXT)(getProcAddr("glMultiTexImage1DEXT"))
+	gpMultiTexImage2DEXT = (C.GPMULTITEXIMAGE2DEXT)(getProcAddr("glMultiTexImage2DEXT"))
+	gpMultiTexImage3DEXT = (C.GPMULTITEXIMAGE3DEXT)(getProcAddr("glMultiTexImage3DEXT"))
+	gpMultiTexParameterIivEXT = (C.GPMULTITEXPARAMETERIIVEXT)(getProcAddr("glMultiTexParameterIivEXT"))
+	gpMultiTexParameterIuivEXT = (C.GPMULTITEXPARAMETERIUIVEXT)(getProcAddr("glMultiTexParameterIuivEXT"))
+	gpMultiTexParameterfEXT = (C.GPMULTITEXPARAMETERFEXT)(getProcAddr("glMultiTexParameterfEXT"))
+	gpMultiTexParameterfvEXT = (C.GPMULTITEXPARAMETERFVEXT)(getProcAddr("glMultiTexParameterfvEXT"))
+	gpMultiTexParameteriEXT = (C.GPMULTITEXPARAMETERIEXT)(getProcAddr("glMultiTexParameteriEXT"))
+	gpMultiTexParameterivEXT = (C.GPMULTITEXPARAMETERIVEXT)(getProcAddr("glMultiTexParameterivEXT"))
+	gpMultiTexRenderbufferEXT = (C.GPMULTITEXRENDERBUFFEREXT)(getProcAddr("glMultiTexRenderbufferEXT"))
+	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
+	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
+	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
+	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
+	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
+	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
+	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
 	gpNamedFramebufferDrawBuffer = (C.GPNAMEDFRAMEBUFFERDRAWBUFFER)(getProcAddr("glNamedFramebufferDrawBuffer"))
 	gpNamedFramebufferDrawBuffers = (C.GPNAMEDFRAMEBUFFERDRAWBUFFERS)(getProcAddr("glNamedFramebufferDrawBuffers"))
 	gpNamedFramebufferParameteri = (C.GPNAMEDFRAMEBUFFERPARAMETERI)(getProcAddr("glNamedFramebufferParameteri"))
+	gpNamedFramebufferParameteriEXT = (C.GPNAMEDFRAMEBUFFERPARAMETERIEXT)(getProcAddr("glNamedFramebufferParameteriEXT"))
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	gpNamedFramebufferRenderbuffer = (C.GPNAMEDFRAMEBUFFERRENDERBUFFER)(getProcAddr("glNamedFramebufferRenderbuffer"))
+	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
+	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
+	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
+	gpNamedFramebufferTexture3DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(getProcAddr("glNamedFramebufferTexture3DEXT"))
+	gpNamedFramebufferTextureEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREEXT)(getProcAddr("glNamedFramebufferTextureEXT"))
+	gpNamedFramebufferTextureFaceEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(getProcAddr("glNamedFramebufferTextureFaceEXT"))
 	gpNamedFramebufferTextureLayer = (C.GPNAMEDFRAMEBUFFERTEXTURELAYER)(getProcAddr("glNamedFramebufferTextureLayer"))
+	gpNamedFramebufferTextureLayerEXT = (C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glNamedFramebufferTextureLayerEXT"))
+	gpNamedProgramLocalParameter4dEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(getProcAddr("glNamedProgramLocalParameter4dEXT"))
+	gpNamedProgramLocalParameter4dvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(getProcAddr("glNamedProgramLocalParameter4dvEXT"))
+	gpNamedProgramLocalParameter4fEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(getProcAddr("glNamedProgramLocalParameter4fEXT"))
+	gpNamedProgramLocalParameter4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(getProcAddr("glNamedProgramLocalParameter4fvEXT"))
+	gpNamedProgramLocalParameterI4iEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(getProcAddr("glNamedProgramLocalParameterI4iEXT"))
+	gpNamedProgramLocalParameterI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(getProcAddr("glNamedProgramLocalParameterI4ivEXT"))
+	gpNamedProgramLocalParameterI4uiEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(getProcAddr("glNamedProgramLocalParameterI4uiEXT"))
+	gpNamedProgramLocalParameterI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(getProcAddr("glNamedProgramLocalParameterI4uivEXT"))
+	gpNamedProgramLocalParameters4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(getProcAddr("glNamedProgramLocalParameters4fvEXT"))
+	gpNamedProgramLocalParametersI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(getProcAddr("glNamedProgramLocalParametersI4ivEXT"))
+	gpNamedProgramLocalParametersI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(getProcAddr("glNamedProgramLocalParametersI4uivEXT"))
+	gpNamedProgramStringEXT = (C.GPNAMEDPROGRAMSTRINGEXT)(getProcAddr("glNamedProgramStringEXT"))
 	gpNamedRenderbufferStorage = (C.GPNAMEDRENDERBUFFERSTORAGE)(getProcAddr("glNamedRenderbufferStorage"))
+	gpNamedRenderbufferStorageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEEXT)(getProcAddr("glNamedRenderbufferStorageEXT"))
 	gpNamedRenderbufferStorageMultisample = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(getProcAddr("glNamedRenderbufferStorageMultisample"))
+	gpNamedRenderbufferStorageMultisampleCoverageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleCoverageEXT"))
+	gpNamedRenderbufferStorageMultisampleEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleEXT"))
 	gpNamedStringARB = (C.GPNAMEDSTRINGARB)(getProcAddr("glNamedStringARB"))
+	gpNormalFormatNV = (C.GPNORMALFORMATNV)(getProcAddr("glNormalFormatNV"))
 	gpObjectLabel = (C.GPOBJECTLABEL)(getProcAddr("glObjectLabel"))
 	gpObjectLabelKHR = (C.GPOBJECTLABELKHR)(getProcAddr("glObjectLabelKHR"))
 	gpObjectPtrLabel = (C.GPOBJECTPTRLABEL)(getProcAddr("glObjectPtrLabel"))
 	gpObjectPtrLabelKHR = (C.GPOBJECTPTRLABELKHR)(getProcAddr("glObjectPtrLabelKHR"))
 	gpPatchParameterfv = (C.GPPATCHPARAMETERFV)(getProcAddr("glPatchParameterfv"))
 	gpPatchParameteri = (C.GPPATCHPARAMETERI)(getProcAddr("glPatchParameteri"))
+	gpPathCommandsNV = (C.GPPATHCOMMANDSNV)(getProcAddr("glPathCommandsNV"))
+	gpPathCoordsNV = (C.GPPATHCOORDSNV)(getProcAddr("glPathCoordsNV"))
+	gpPathCoverDepthFuncNV = (C.GPPATHCOVERDEPTHFUNCNV)(getProcAddr("glPathCoverDepthFuncNV"))
+	gpPathDashArrayNV = (C.GPPATHDASHARRAYNV)(getProcAddr("glPathDashArrayNV"))
+	gpPathGlyphIndexArrayNV = (C.GPPATHGLYPHINDEXARRAYNV)(getProcAddr("glPathGlyphIndexArrayNV"))
+	gpPathGlyphIndexRangeNV = (C.GPPATHGLYPHINDEXRANGENV)(getProcAddr("glPathGlyphIndexRangeNV"))
+	gpPathGlyphRangeNV = (C.GPPATHGLYPHRANGENV)(getProcAddr("glPathGlyphRangeNV"))
+	gpPathGlyphsNV = (C.GPPATHGLYPHSNV)(getProcAddr("glPathGlyphsNV"))
+	gpPathMemoryGlyphIndexArrayNV = (C.GPPATHMEMORYGLYPHINDEXARRAYNV)(getProcAddr("glPathMemoryGlyphIndexArrayNV"))
+	gpPathParameterfNV = (C.GPPATHPARAMETERFNV)(getProcAddr("glPathParameterfNV"))
+	gpPathParameterfvNV = (C.GPPATHPARAMETERFVNV)(getProcAddr("glPathParameterfvNV"))
+	gpPathParameteriNV = (C.GPPATHPARAMETERINV)(getProcAddr("glPathParameteriNV"))
+	gpPathParameterivNV = (C.GPPATHPARAMETERIVNV)(getProcAddr("glPathParameterivNV"))
+	gpPathStencilDepthOffsetNV = (C.GPPATHSTENCILDEPTHOFFSETNV)(getProcAddr("glPathStencilDepthOffsetNV"))
+	gpPathStencilFuncNV = (C.GPPATHSTENCILFUNCNV)(getProcAddr("glPathStencilFuncNV"))
+	gpPathStringNV = (C.GPPATHSTRINGNV)(getProcAddr("glPathStringNV"))
+	gpPathSubCommandsNV = (C.GPPATHSUBCOMMANDSNV)(getProcAddr("glPathSubCommandsNV"))
+	gpPathSubCoordsNV = (C.GPPATHSUBCOORDSNV)(getProcAddr("glPathSubCoordsNV"))
 	gpPauseTransformFeedback = (C.GPPAUSETRANSFORMFEEDBACK)(getProcAddr("glPauseTransformFeedback"))
 	gpPixelStoref = (C.GPPIXELSTOREF)(getProcAddr("glPixelStoref"))
 	if gpPixelStoref == nil {
@@ -9125,6 +14434,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPixelStorei == nil {
 		return errors.New("glPixelStorei")
 	}
+	gpPointAlongPathNV = (C.GPPOINTALONGPATHNV)(getProcAddr("glPointAlongPathNV"))
 	gpPointParameterf = (C.GPPOINTPARAMETERF)(getProcAddr("glPointParameterf"))
 	if gpPointParameterf == nil {
 		return errors.New("glPointParameterf")
@@ -9153,76 +14463,172 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPopDebugGroup = (C.GPPOPDEBUGGROUP)(getProcAddr("glPopDebugGroup"))
 	gpPopDebugGroupKHR = (C.GPPOPDEBUGGROUPKHR)(getProcAddr("glPopDebugGroupKHR"))
+	gpPopGroupMarkerEXT = (C.GPPOPGROUPMARKEREXT)(getProcAddr("glPopGroupMarkerEXT"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	if gpPrimitiveRestartIndex == nil {
 		return errors.New("glPrimitiveRestartIndex")
 	}
 	gpProgramBinary = (C.GPPROGRAMBINARY)(getProcAddr("glProgramBinary"))
 	gpProgramParameteri = (C.GPPROGRAMPARAMETERI)(getProcAddr("glProgramParameteri"))
+	gpProgramParameteriARB = (C.GPPROGRAMPARAMETERIARB)(getProcAddr("glProgramParameteriARB"))
+	gpProgramParameteriEXT = (C.GPPROGRAMPARAMETERIEXT)(getProcAddr("glProgramParameteriEXT"))
+	gpProgramPathFragmentInputGenNV = (C.GPPROGRAMPATHFRAGMENTINPUTGENNV)(getProcAddr("glProgramPathFragmentInputGenNV"))
 	gpProgramUniform1d = (C.GPPROGRAMUNIFORM1D)(getProcAddr("glProgramUniform1d"))
+	gpProgramUniform1dEXT = (C.GPPROGRAMUNIFORM1DEXT)(getProcAddr("glProgramUniform1dEXT"))
 	gpProgramUniform1dv = (C.GPPROGRAMUNIFORM1DV)(getProcAddr("glProgramUniform1dv"))
+	gpProgramUniform1dvEXT = (C.GPPROGRAMUNIFORM1DVEXT)(getProcAddr("glProgramUniform1dvEXT"))
 	gpProgramUniform1f = (C.GPPROGRAMUNIFORM1F)(getProcAddr("glProgramUniform1f"))
+	gpProgramUniform1fEXT = (C.GPPROGRAMUNIFORM1FEXT)(getProcAddr("glProgramUniform1fEXT"))
 	gpProgramUniform1fv = (C.GPPROGRAMUNIFORM1FV)(getProcAddr("glProgramUniform1fv"))
+	gpProgramUniform1fvEXT = (C.GPPROGRAMUNIFORM1FVEXT)(getProcAddr("glProgramUniform1fvEXT"))
 	gpProgramUniform1i = (C.GPPROGRAMUNIFORM1I)(getProcAddr("glProgramUniform1i"))
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
+	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
+	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
+	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
+	gpProgramUniform1ivEXT = (C.GPPROGRAMUNIFORM1IVEXT)(getProcAddr("glProgramUniform1ivEXT"))
 	gpProgramUniform1ui = (C.GPPROGRAMUNIFORM1UI)(getProcAddr("glProgramUniform1ui"))
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
+	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
+	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
+	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
+	gpProgramUniform1uivEXT = (C.GPPROGRAMUNIFORM1UIVEXT)(getProcAddr("glProgramUniform1uivEXT"))
 	gpProgramUniform2d = (C.GPPROGRAMUNIFORM2D)(getProcAddr("glProgramUniform2d"))
+	gpProgramUniform2dEXT = (C.GPPROGRAMUNIFORM2DEXT)(getProcAddr("glProgramUniform2dEXT"))
 	gpProgramUniform2dv = (C.GPPROGRAMUNIFORM2DV)(getProcAddr("glProgramUniform2dv"))
+	gpProgramUniform2dvEXT = (C.GPPROGRAMUNIFORM2DVEXT)(getProcAddr("glProgramUniform2dvEXT"))
 	gpProgramUniform2f = (C.GPPROGRAMUNIFORM2F)(getProcAddr("glProgramUniform2f"))
+	gpProgramUniform2fEXT = (C.GPPROGRAMUNIFORM2FEXT)(getProcAddr("glProgramUniform2fEXT"))
 	gpProgramUniform2fv = (C.GPPROGRAMUNIFORM2FV)(getProcAddr("glProgramUniform2fv"))
+	gpProgramUniform2fvEXT = (C.GPPROGRAMUNIFORM2FVEXT)(getProcAddr("glProgramUniform2fvEXT"))
 	gpProgramUniform2i = (C.GPPROGRAMUNIFORM2I)(getProcAddr("glProgramUniform2i"))
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
+	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
+	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
+	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
+	gpProgramUniform2ivEXT = (C.GPPROGRAMUNIFORM2IVEXT)(getProcAddr("glProgramUniform2ivEXT"))
 	gpProgramUniform2ui = (C.GPPROGRAMUNIFORM2UI)(getProcAddr("glProgramUniform2ui"))
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
+	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
+	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
+	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
+	gpProgramUniform2uivEXT = (C.GPPROGRAMUNIFORM2UIVEXT)(getProcAddr("glProgramUniform2uivEXT"))
 	gpProgramUniform3d = (C.GPPROGRAMUNIFORM3D)(getProcAddr("glProgramUniform3d"))
+	gpProgramUniform3dEXT = (C.GPPROGRAMUNIFORM3DEXT)(getProcAddr("glProgramUniform3dEXT"))
 	gpProgramUniform3dv = (C.GPPROGRAMUNIFORM3DV)(getProcAddr("glProgramUniform3dv"))
+	gpProgramUniform3dvEXT = (C.GPPROGRAMUNIFORM3DVEXT)(getProcAddr("glProgramUniform3dvEXT"))
 	gpProgramUniform3f = (C.GPPROGRAMUNIFORM3F)(getProcAddr("glProgramUniform3f"))
+	gpProgramUniform3fEXT = (C.GPPROGRAMUNIFORM3FEXT)(getProcAddr("glProgramUniform3fEXT"))
 	gpProgramUniform3fv = (C.GPPROGRAMUNIFORM3FV)(getProcAddr("glProgramUniform3fv"))
+	gpProgramUniform3fvEXT = (C.GPPROGRAMUNIFORM3FVEXT)(getProcAddr("glProgramUniform3fvEXT"))
 	gpProgramUniform3i = (C.GPPROGRAMUNIFORM3I)(getProcAddr("glProgramUniform3i"))
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
+	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
+	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
+	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
+	gpProgramUniform3ivEXT = (C.GPPROGRAMUNIFORM3IVEXT)(getProcAddr("glProgramUniform3ivEXT"))
 	gpProgramUniform3ui = (C.GPPROGRAMUNIFORM3UI)(getProcAddr("glProgramUniform3ui"))
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
+	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
+	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
+	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
+	gpProgramUniform3uivEXT = (C.GPPROGRAMUNIFORM3UIVEXT)(getProcAddr("glProgramUniform3uivEXT"))
 	gpProgramUniform4d = (C.GPPROGRAMUNIFORM4D)(getProcAddr("glProgramUniform4d"))
+	gpProgramUniform4dEXT = (C.GPPROGRAMUNIFORM4DEXT)(getProcAddr("glProgramUniform4dEXT"))
 	gpProgramUniform4dv = (C.GPPROGRAMUNIFORM4DV)(getProcAddr("glProgramUniform4dv"))
+	gpProgramUniform4dvEXT = (C.GPPROGRAMUNIFORM4DVEXT)(getProcAddr("glProgramUniform4dvEXT"))
 	gpProgramUniform4f = (C.GPPROGRAMUNIFORM4F)(getProcAddr("glProgramUniform4f"))
+	gpProgramUniform4fEXT = (C.GPPROGRAMUNIFORM4FEXT)(getProcAddr("glProgramUniform4fEXT"))
 	gpProgramUniform4fv = (C.GPPROGRAMUNIFORM4FV)(getProcAddr("glProgramUniform4fv"))
+	gpProgramUniform4fvEXT = (C.GPPROGRAMUNIFORM4FVEXT)(getProcAddr("glProgramUniform4fvEXT"))
 	gpProgramUniform4i = (C.GPPROGRAMUNIFORM4I)(getProcAddr("glProgramUniform4i"))
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
+	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
+	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
+	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
+	gpProgramUniform4ivEXT = (C.GPPROGRAMUNIFORM4IVEXT)(getProcAddr("glProgramUniform4ivEXT"))
 	gpProgramUniform4ui = (C.GPPROGRAMUNIFORM4UI)(getProcAddr("glProgramUniform4ui"))
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
+	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
+	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
+	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
+	gpProgramUniform4uivEXT = (C.GPPROGRAMUNIFORM4UIVEXT)(getProcAddr("glProgramUniform4uivEXT"))
 	gpProgramUniformHandleui64ARB = (C.GPPROGRAMUNIFORMHANDLEUI64ARB)(getProcAddr("glProgramUniformHandleui64ARB"))
+	gpProgramUniformHandleui64NV = (C.GPPROGRAMUNIFORMHANDLEUI64NV)(getProcAddr("glProgramUniformHandleui64NV"))
 	gpProgramUniformHandleui64vARB = (C.GPPROGRAMUNIFORMHANDLEUI64VARB)(getProcAddr("glProgramUniformHandleui64vARB"))
+	gpProgramUniformHandleui64vNV = (C.GPPROGRAMUNIFORMHANDLEUI64VNV)(getProcAddr("glProgramUniformHandleui64vNV"))
 	gpProgramUniformMatrix2dv = (C.GPPROGRAMUNIFORMMATRIX2DV)(getProcAddr("glProgramUniformMatrix2dv"))
+	gpProgramUniformMatrix2dvEXT = (C.GPPROGRAMUNIFORMMATRIX2DVEXT)(getProcAddr("glProgramUniformMatrix2dvEXT"))
 	gpProgramUniformMatrix2fv = (C.GPPROGRAMUNIFORMMATRIX2FV)(getProcAddr("glProgramUniformMatrix2fv"))
+	gpProgramUniformMatrix2fvEXT = (C.GPPROGRAMUNIFORMMATRIX2FVEXT)(getProcAddr("glProgramUniformMatrix2fvEXT"))
 	gpProgramUniformMatrix2x3dv = (C.GPPROGRAMUNIFORMMATRIX2X3DV)(getProcAddr("glProgramUniformMatrix2x3dv"))
+	gpProgramUniformMatrix2x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3DVEXT)(getProcAddr("glProgramUniformMatrix2x3dvEXT"))
 	gpProgramUniformMatrix2x3fv = (C.GPPROGRAMUNIFORMMATRIX2X3FV)(getProcAddr("glProgramUniformMatrix2x3fv"))
+	gpProgramUniformMatrix2x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3FVEXT)(getProcAddr("glProgramUniformMatrix2x3fvEXT"))
 	gpProgramUniformMatrix2x4dv = (C.GPPROGRAMUNIFORMMATRIX2X4DV)(getProcAddr("glProgramUniformMatrix2x4dv"))
+	gpProgramUniformMatrix2x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4DVEXT)(getProcAddr("glProgramUniformMatrix2x4dvEXT"))
 	gpProgramUniformMatrix2x4fv = (C.GPPROGRAMUNIFORMMATRIX2X4FV)(getProcAddr("glProgramUniformMatrix2x4fv"))
+	gpProgramUniformMatrix2x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4FVEXT)(getProcAddr("glProgramUniformMatrix2x4fvEXT"))
 	gpProgramUniformMatrix3dv = (C.GPPROGRAMUNIFORMMATRIX3DV)(getProcAddr("glProgramUniformMatrix3dv"))
+	gpProgramUniformMatrix3dvEXT = (C.GPPROGRAMUNIFORMMATRIX3DVEXT)(getProcAddr("glProgramUniformMatrix3dvEXT"))
 	gpProgramUniformMatrix3fv = (C.GPPROGRAMUNIFORMMATRIX3FV)(getProcAddr("glProgramUniformMatrix3fv"))
+	gpProgramUniformMatrix3fvEXT = (C.GPPROGRAMUNIFORMMATRIX3FVEXT)(getProcAddr("glProgramUniformMatrix3fvEXT"))
 	gpProgramUniformMatrix3x2dv = (C.GPPROGRAMUNIFORMMATRIX3X2DV)(getProcAddr("glProgramUniformMatrix3x2dv"))
+	gpProgramUniformMatrix3x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2DVEXT)(getProcAddr("glProgramUniformMatrix3x2dvEXT"))
 	gpProgramUniformMatrix3x2fv = (C.GPPROGRAMUNIFORMMATRIX3X2FV)(getProcAddr("glProgramUniformMatrix3x2fv"))
+	gpProgramUniformMatrix3x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2FVEXT)(getProcAddr("glProgramUniformMatrix3x2fvEXT"))
 	gpProgramUniformMatrix3x4dv = (C.GPPROGRAMUNIFORMMATRIX3X4DV)(getProcAddr("glProgramUniformMatrix3x4dv"))
+	gpProgramUniformMatrix3x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4DVEXT)(getProcAddr("glProgramUniformMatrix3x4dvEXT"))
 	gpProgramUniformMatrix3x4fv = (C.GPPROGRAMUNIFORMMATRIX3X4FV)(getProcAddr("glProgramUniformMatrix3x4fv"))
+	gpProgramUniformMatrix3x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4FVEXT)(getProcAddr("glProgramUniformMatrix3x4fvEXT"))
 	gpProgramUniformMatrix4dv = (C.GPPROGRAMUNIFORMMATRIX4DV)(getProcAddr("glProgramUniformMatrix4dv"))
+	gpProgramUniformMatrix4dvEXT = (C.GPPROGRAMUNIFORMMATRIX4DVEXT)(getProcAddr("glProgramUniformMatrix4dvEXT"))
 	gpProgramUniformMatrix4fv = (C.GPPROGRAMUNIFORMMATRIX4FV)(getProcAddr("glProgramUniformMatrix4fv"))
+	gpProgramUniformMatrix4fvEXT = (C.GPPROGRAMUNIFORMMATRIX4FVEXT)(getProcAddr("glProgramUniformMatrix4fvEXT"))
 	gpProgramUniformMatrix4x2dv = (C.GPPROGRAMUNIFORMMATRIX4X2DV)(getProcAddr("glProgramUniformMatrix4x2dv"))
+	gpProgramUniformMatrix4x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2DVEXT)(getProcAddr("glProgramUniformMatrix4x2dvEXT"))
 	gpProgramUniformMatrix4x2fv = (C.GPPROGRAMUNIFORMMATRIX4X2FV)(getProcAddr("glProgramUniformMatrix4x2fv"))
+	gpProgramUniformMatrix4x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2FVEXT)(getProcAddr("glProgramUniformMatrix4x2fvEXT"))
 	gpProgramUniformMatrix4x3dv = (C.GPPROGRAMUNIFORMMATRIX4X3DV)(getProcAddr("glProgramUniformMatrix4x3dv"))
+	gpProgramUniformMatrix4x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3DVEXT)(getProcAddr("glProgramUniformMatrix4x3dvEXT"))
 	gpProgramUniformMatrix4x3fv = (C.GPPROGRAMUNIFORMMATRIX4X3FV)(getProcAddr("glProgramUniformMatrix4x3fv"))
+	gpProgramUniformMatrix4x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3FVEXT)(getProcAddr("glProgramUniformMatrix4x3fvEXT"))
+	gpProgramUniformui64NV = (C.GPPROGRAMUNIFORMUI64NV)(getProcAddr("glProgramUniformui64NV"))
+	gpProgramUniformui64vNV = (C.GPPROGRAMUNIFORMUI64VNV)(getProcAddr("glProgramUniformui64vNV"))
 	gpProvokingVertex = (C.GPPROVOKINGVERTEX)(getProcAddr("glProvokingVertex"))
 	if gpProvokingVertex == nil {
 		return errors.New("glProvokingVertex")
 	}
+	gpPushClientAttribDefaultEXT = (C.GPPUSHCLIENTATTRIBDEFAULTEXT)(getProcAddr("glPushClientAttribDefaultEXT"))
 	gpPushDebugGroup = (C.GPPUSHDEBUGGROUP)(getProcAddr("glPushDebugGroup"))
 	gpPushDebugGroupKHR = (C.GPPUSHDEBUGGROUPKHR)(getProcAddr("glPushDebugGroupKHR"))
+	gpPushGroupMarkerEXT = (C.GPPUSHGROUPMARKEREXT)(getProcAddr("glPushGroupMarkerEXT"))
 	gpQueryCounter = (C.GPQUERYCOUNTER)(getProcAddr("glQueryCounter"))
 	if gpQueryCounter == nil {
 		return errors.New("glQueryCounter")
 	}
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -9243,6 +14649,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpRenderbufferStorageMultisample == nil {
 		return errors.New("glRenderbufferStorageMultisample")
 	}
+	gpRenderbufferStorageMultisampleCoverageNV = (C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(getProcAddr("glRenderbufferStorageMultisampleCoverageNV"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	gpSampleCoverage = (C.GPSAMPLECOVERAGE)(getProcAddr("glSampleCoverage"))
 	if gpSampleCoverage == nil {
@@ -9283,12 +14691,20 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpScissorArrayv = (C.GPSCISSORARRAYV)(getProcAddr("glScissorArrayv"))
 	gpScissorIndexed = (C.GPSCISSORINDEXED)(getProcAddr("glScissorIndexed"))
 	gpScissorIndexedv = (C.GPSCISSORINDEXEDV)(getProcAddr("glScissorIndexedv"))
+	gpSecondaryColorFormatNV = (C.GPSECONDARYCOLORFORMATNV)(getProcAddr("glSecondaryColorFormatNV"))
+	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
 	gpShaderBinary = (C.GPSHADERBINARY)(getProcAddr("glShaderBinary"))
 	gpShaderSource = (C.GPSHADERSOURCE)(getProcAddr("glShaderSource"))
 	if gpShaderSource == nil {
 		return errors.New("glShaderSource")
 	}
 	gpShaderStorageBlockBinding = (C.GPSHADERSTORAGEBLOCKBINDING)(getProcAddr("glShaderStorageBlockBinding"))
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
+	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
+	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
 	gpStencilFunc = (C.GPSTENCILFUNC)(getProcAddr("glStencilFunc"))
 	if gpStencilFunc == nil {
 		return errors.New("glStencilFunc")
@@ -9313,11 +14729,20 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpStencilOpSeparate == nil {
 		return errors.New("glStencilOpSeparate")
 	}
+	gpStencilStrokePathInstancedNV = (C.GPSTENCILSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilStrokePathInstancedNV"))
+	gpStencilStrokePathNV = (C.GPSTENCILSTROKEPATHNV)(getProcAddr("glStencilStrokePathNV"))
+	gpStencilThenCoverFillPathInstancedNV = (C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverFillPathInstancedNV"))
+	gpStencilThenCoverFillPathNV = (C.GPSTENCILTHENCOVERFILLPATHNV)(getProcAddr("glStencilThenCoverFillPathNV"))
+	gpStencilThenCoverStrokePathInstancedNV = (C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverStrokePathInstancedNV"))
+	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpTexBuffer = (C.GPTEXBUFFER)(getProcAddr("glTexBuffer"))
 	if gpTexBuffer == nil {
 		return errors.New("glTexBuffer")
 	}
+	gpTexBufferARB = (C.GPTEXBUFFERARB)(getProcAddr("glTexBufferARB"))
 	gpTexBufferRange = (C.GPTEXBUFFERRANGE)(getProcAddr("glTexBufferRange"))
+	gpTexCoordFormatNV = (C.GPTEXCOORDFORMATNV)(getProcAddr("glTexCoordFormatNV"))
 	gpTexImage1D = (C.GPTEXIMAGE1D)(getProcAddr("glTexImage1D"))
 	if gpTexImage1D == nil {
 		return errors.New("glTexImage1D")
@@ -9381,22 +14806,44 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glTexSubImage3D")
 	}
 	gpTextureBarrier = (C.GPTEXTUREBARRIER)(getProcAddr("glTextureBarrier"))
+	gpTextureBarrierNV = (C.GPTEXTUREBARRIERNV)(getProcAddr("glTextureBarrierNV"))
 	gpTextureBuffer = (C.GPTEXTUREBUFFER)(getProcAddr("glTextureBuffer"))
+	gpTextureBufferEXT = (C.GPTEXTUREBUFFEREXT)(getProcAddr("glTextureBufferEXT"))
 	gpTextureBufferRange = (C.GPTEXTUREBUFFERRANGE)(getProcAddr("glTextureBufferRange"))
+	gpTextureBufferRangeEXT = (C.GPTEXTUREBUFFERRANGEEXT)(getProcAddr("glTextureBufferRangeEXT"))
+	gpTextureImage1DEXT = (C.GPTEXTUREIMAGE1DEXT)(getProcAddr("glTextureImage1DEXT"))
+	gpTextureImage2DEXT = (C.GPTEXTUREIMAGE2DEXT)(getProcAddr("glTextureImage2DEXT"))
+	gpTextureImage3DEXT = (C.GPTEXTUREIMAGE3DEXT)(getProcAddr("glTextureImage3DEXT"))
+	gpTexturePageCommitmentEXT = (C.GPTEXTUREPAGECOMMITMENTEXT)(getProcAddr("glTexturePageCommitmentEXT"))
 	gpTextureParameterIiv = (C.GPTEXTUREPARAMETERIIV)(getProcAddr("glTextureParameterIiv"))
+	gpTextureParameterIivEXT = (C.GPTEXTUREPARAMETERIIVEXT)(getProcAddr("glTextureParameterIivEXT"))
 	gpTextureParameterIuiv = (C.GPTEXTUREPARAMETERIUIV)(getProcAddr("glTextureParameterIuiv"))
+	gpTextureParameterIuivEXT = (C.GPTEXTUREPARAMETERIUIVEXT)(getProcAddr("glTextureParameterIuivEXT"))
 	gpTextureParameterf = (C.GPTEXTUREPARAMETERF)(getProcAddr("glTextureParameterf"))
+	gpTextureParameterfEXT = (C.GPTEXTUREPARAMETERFEXT)(getProcAddr("glTextureParameterfEXT"))
 	gpTextureParameterfv = (C.GPTEXTUREPARAMETERFV)(getProcAddr("glTextureParameterfv"))
+	gpTextureParameterfvEXT = (C.GPTEXTUREPARAMETERFVEXT)(getProcAddr("glTextureParameterfvEXT"))
 	gpTextureParameteri = (C.GPTEXTUREPARAMETERI)(getProcAddr("glTextureParameteri"))
+	gpTextureParameteriEXT = (C.GPTEXTUREPARAMETERIEXT)(getProcAddr("glTextureParameteriEXT"))
 	gpTextureParameteriv = (C.GPTEXTUREPARAMETERIV)(getProcAddr("glTextureParameteriv"))
+	gpTextureParameterivEXT = (C.GPTEXTUREPARAMETERIVEXT)(getProcAddr("glTextureParameterivEXT"))
+	gpTextureRenderbufferEXT = (C.GPTEXTURERENDERBUFFEREXT)(getProcAddr("glTextureRenderbufferEXT"))
 	gpTextureStorage1D = (C.GPTEXTURESTORAGE1D)(getProcAddr("glTextureStorage1D"))
+	gpTextureStorage1DEXT = (C.GPTEXTURESTORAGE1DEXT)(getProcAddr("glTextureStorage1DEXT"))
 	gpTextureStorage2D = (C.GPTEXTURESTORAGE2D)(getProcAddr("glTextureStorage2D"))
+	gpTextureStorage2DEXT = (C.GPTEXTURESTORAGE2DEXT)(getProcAddr("glTextureStorage2DEXT"))
 	gpTextureStorage2DMultisample = (C.GPTEXTURESTORAGE2DMULTISAMPLE)(getProcAddr("glTextureStorage2DMultisample"))
+	gpTextureStorage2DMultisampleEXT = (C.GPTEXTURESTORAGE2DMULTISAMPLEEXT)(getProcAddr("glTextureStorage2DMultisampleEXT"))
 	gpTextureStorage3D = (C.GPTEXTURESTORAGE3D)(getProcAddr("glTextureStorage3D"))
+	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
+	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
+	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
 	gpTextureSubImage2D = (C.GPTEXTURESUBIMAGE2D)(getProcAddr("glTextureSubImage2D"))
+	gpTextureSubImage2DEXT = (C.GPTEXTURESUBIMAGE2DEXT)(getProcAddr("glTextureSubImage2DEXT"))
 	gpTextureSubImage3D = (C.GPTEXTURESUBIMAGE3D)(getProcAddr("glTextureSubImage3D"))
+	gpTextureSubImage3DEXT = (C.GPTEXTURESUBIMAGE3DEXT)(getProcAddr("glTextureSubImage3DEXT"))
 	gpTextureView = (C.GPTEXTUREVIEW)(getProcAddr("glTextureView"))
 	gpTransformFeedbackBufferBase = (C.GPTRANSFORMFEEDBACKBUFFERBASE)(getProcAddr("glTransformFeedbackBufferBase"))
 	gpTransformFeedbackBufferRange = (C.GPTRANSFORMFEEDBACKBUFFERRANGE)(getProcAddr("glTransformFeedbackBufferRange"))
@@ -9404,6 +14851,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpTransformFeedbackVaryings == nil {
 		return errors.New("glTransformFeedbackVaryings")
 	}
+	gpTransformPathNV = (C.GPTRANSFORMPATHNV)(getProcAddr("glTransformPathNV"))
 	gpUniform1d = (C.GPUNIFORM1D)(getProcAddr("glUniform1d"))
 	gpUniform1dv = (C.GPUNIFORM1DV)(getProcAddr("glUniform1dv"))
 	gpUniform1f = (C.GPUNIFORM1F)(getProcAddr("glUniform1f"))
@@ -9418,6 +14866,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
+	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
+	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
 	if gpUniform1iv == nil {
 		return errors.New("glUniform1iv")
@@ -9426,6 +14878,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
+	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
+	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
 	if gpUniform1uiv == nil {
 		return errors.New("glUniform1uiv")
@@ -9444,6 +14900,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
+	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
+	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
 	if gpUniform2iv == nil {
 		return errors.New("glUniform2iv")
@@ -9452,6 +14912,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
+	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
+	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
 	if gpUniform2uiv == nil {
 		return errors.New("glUniform2uiv")
@@ -9470,6 +14934,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
+	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
+	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
 	if gpUniform3iv == nil {
 		return errors.New("glUniform3iv")
@@ -9478,6 +14946,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
+	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
+	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
 	if gpUniform3uiv == nil {
 		return errors.New("glUniform3uiv")
@@ -9496,6 +14968,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
+	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
+	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
 	if gpUniform4iv == nil {
 		return errors.New("glUniform4iv")
@@ -9504,6 +14980,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
+	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
+	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
 	if gpUniform4uiv == nil {
 		return errors.New("glUniform4uiv")
@@ -9513,7 +14993,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glUniformBlockBinding")
 	}
 	gpUniformHandleui64ARB = (C.GPUNIFORMHANDLEUI64ARB)(getProcAddr("glUniformHandleui64ARB"))
+	gpUniformHandleui64NV = (C.GPUNIFORMHANDLEUI64NV)(getProcAddr("glUniformHandleui64NV"))
 	gpUniformHandleui64vARB = (C.GPUNIFORMHANDLEUI64VARB)(getProcAddr("glUniformHandleui64vARB"))
+	gpUniformHandleui64vNV = (C.GPUNIFORMHANDLEUI64VNV)(getProcAddr("glUniformHandleui64vNV"))
 	gpUniformMatrix2dv = (C.GPUNIFORMMATRIX2DV)(getProcAddr("glUniformMatrix2dv"))
 	gpUniformMatrix2fv = (C.GPUNIFORMMATRIX2FV)(getProcAddr("glUniformMatrix2fv"))
 	if gpUniformMatrix2fv == nil {
@@ -9560,29 +15042,54 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glUniformMatrix4x3fv")
 	}
 	gpUniformSubroutinesuiv = (C.GPUNIFORMSUBROUTINESUIV)(getProcAddr("glUniformSubroutinesuiv"))
+	gpUniformui64NV = (C.GPUNIFORMUI64NV)(getProcAddr("glUniformui64NV"))
+	gpUniformui64vNV = (C.GPUNIFORMUI64VNV)(getProcAddr("glUniformui64vNV"))
 	gpUnmapBuffer = (C.GPUNMAPBUFFER)(getProcAddr("glUnmapBuffer"))
 	if gpUnmapBuffer == nil {
 		return errors.New("glUnmapBuffer")
 	}
 	gpUnmapNamedBuffer = (C.GPUNMAPNAMEDBUFFER)(getProcAddr("glUnmapNamedBuffer"))
+	gpUnmapNamedBufferEXT = (C.GPUNMAPNAMEDBUFFEREXT)(getProcAddr("glUnmapNamedBufferEXT"))
 	gpUseProgram = (C.GPUSEPROGRAM)(getProcAddr("glUseProgram"))
 	if gpUseProgram == nil {
 		return errors.New("glUseProgram")
 	}
 	gpUseProgramStages = (C.GPUSEPROGRAMSTAGES)(getProcAddr("glUseProgramStages"))
+	gpUseProgramStagesEXT = (C.GPUSEPROGRAMSTAGESEXT)(getProcAddr("glUseProgramStagesEXT"))
+	gpUseShaderProgramEXT = (C.GPUSESHADERPROGRAMEXT)(getProcAddr("glUseShaderProgramEXT"))
 	gpValidateProgram = (C.GPVALIDATEPROGRAM)(getProcAddr("glValidateProgram"))
 	if gpValidateProgram == nil {
 		return errors.New("glValidateProgram")
 	}
 	gpValidateProgramPipeline = (C.GPVALIDATEPROGRAMPIPELINE)(getProcAddr("glValidateProgramPipeline"))
+	gpValidateProgramPipelineEXT = (C.GPVALIDATEPROGRAMPIPELINEEXT)(getProcAddr("glValidateProgramPipelineEXT"))
 	gpVertexArrayAttribBinding = (C.GPVERTEXARRAYATTRIBBINDING)(getProcAddr("glVertexArrayAttribBinding"))
 	gpVertexArrayAttribFormat = (C.GPVERTEXARRAYATTRIBFORMAT)(getProcAddr("glVertexArrayAttribFormat"))
 	gpVertexArrayAttribIFormat = (C.GPVERTEXARRAYATTRIBIFORMAT)(getProcAddr("glVertexArrayAttribIFormat"))
 	gpVertexArrayAttribLFormat = (C.GPVERTEXARRAYATTRIBLFORMAT)(getProcAddr("glVertexArrayAttribLFormat"))
+	gpVertexArrayBindVertexBufferEXT = (C.GPVERTEXARRAYBINDVERTEXBUFFEREXT)(getProcAddr("glVertexArrayBindVertexBufferEXT"))
 	gpVertexArrayBindingDivisor = (C.GPVERTEXARRAYBINDINGDIVISOR)(getProcAddr("glVertexArrayBindingDivisor"))
+	gpVertexArrayColorOffsetEXT = (C.GPVERTEXARRAYCOLOROFFSETEXT)(getProcAddr("glVertexArrayColorOffsetEXT"))
+	gpVertexArrayEdgeFlagOffsetEXT = (C.GPVERTEXARRAYEDGEFLAGOFFSETEXT)(getProcAddr("glVertexArrayEdgeFlagOffsetEXT"))
 	gpVertexArrayElementBuffer = (C.GPVERTEXARRAYELEMENTBUFFER)(getProcAddr("glVertexArrayElementBuffer"))
+	gpVertexArrayFogCoordOffsetEXT = (C.GPVERTEXARRAYFOGCOORDOFFSETEXT)(getProcAddr("glVertexArrayFogCoordOffsetEXT"))
+	gpVertexArrayIndexOffsetEXT = (C.GPVERTEXARRAYINDEXOFFSETEXT)(getProcAddr("glVertexArrayIndexOffsetEXT"))
+	gpVertexArrayMultiTexCoordOffsetEXT = (C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayMultiTexCoordOffsetEXT"))
+	gpVertexArrayNormalOffsetEXT = (C.GPVERTEXARRAYNORMALOFFSETEXT)(getProcAddr("glVertexArrayNormalOffsetEXT"))
+	gpVertexArraySecondaryColorOffsetEXT = (C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(getProcAddr("glVertexArraySecondaryColorOffsetEXT"))
+	gpVertexArrayTexCoordOffsetEXT = (C.GPVERTEXARRAYTEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayTexCoordOffsetEXT"))
+	gpVertexArrayVertexAttribBindingEXT = (C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(getProcAddr("glVertexArrayVertexAttribBindingEXT"))
+	gpVertexArrayVertexAttribDivisorEXT = (C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(getProcAddr("glVertexArrayVertexAttribDivisorEXT"))
+	gpVertexArrayVertexAttribFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(getProcAddr("glVertexArrayVertexAttribFormatEXT"))
+	gpVertexArrayVertexAttribIFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(getProcAddr("glVertexArrayVertexAttribIFormatEXT"))
+	gpVertexArrayVertexAttribIOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribIOffsetEXT"))
+	gpVertexArrayVertexAttribLFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(getProcAddr("glVertexArrayVertexAttribLFormatEXT"))
+	gpVertexArrayVertexAttribLOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribLOffsetEXT"))
+	gpVertexArrayVertexAttribOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribOffsetEXT"))
+	gpVertexArrayVertexBindingDivisorEXT = (C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(getProcAddr("glVertexArrayVertexBindingDivisorEXT"))
 	gpVertexArrayVertexBuffer = (C.GPVERTEXARRAYVERTEXBUFFER)(getProcAddr("glVertexArrayVertexBuffer"))
 	gpVertexArrayVertexBuffers = (C.GPVERTEXARRAYVERTEXBUFFERS)(getProcAddr("glVertexArrayVertexBuffers"))
+	gpVertexArrayVertexOffsetEXT = (C.GPVERTEXARRAYVERTEXOFFSETEXT)(getProcAddr("glVertexArrayVertexOffsetEXT"))
 	gpVertexAttrib1d = (C.GPVERTEXATTRIB1D)(getProcAddr("glVertexAttrib1d"))
 	if gpVertexAttrib1d == nil {
 		return errors.New("glVertexAttrib1d")
@@ -9732,7 +15239,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribDivisor == nil {
 		return errors.New("glVertexAttribDivisor")
 	}
+	gpVertexAttribDivisorARB = (C.GPVERTEXATTRIBDIVISORARB)(getProcAddr("glVertexAttribDivisorARB"))
 	gpVertexAttribFormat = (C.GPVERTEXATTRIBFORMAT)(getProcAddr("glVertexAttribFormat"))
+	gpVertexAttribFormatNV = (C.GPVERTEXATTRIBFORMATNV)(getProcAddr("glVertexAttribFormatNV"))
 	gpVertexAttribI1i = (C.GPVERTEXATTRIBI1I)(getProcAddr("glVertexAttribI1i"))
 	if gpVertexAttribI1i == nil {
 		return errors.New("glVertexAttribI1i")
@@ -9814,21 +15323,39 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glVertexAttribI4usv")
 	}
 	gpVertexAttribIFormat = (C.GPVERTEXATTRIBIFORMAT)(getProcAddr("glVertexAttribIFormat"))
+	gpVertexAttribIFormatNV = (C.GPVERTEXATTRIBIFORMATNV)(getProcAddr("glVertexAttribIFormatNV"))
 	gpVertexAttribIPointer = (C.GPVERTEXATTRIBIPOINTER)(getProcAddr("glVertexAttribIPointer"))
 	if gpVertexAttribIPointer == nil {
 		return errors.New("glVertexAttribIPointer")
 	}
 	gpVertexAttribL1d = (C.GPVERTEXATTRIBL1D)(getProcAddr("glVertexAttribL1d"))
 	gpVertexAttribL1dv = (C.GPVERTEXATTRIBL1DV)(getProcAddr("glVertexAttribL1dv"))
+	gpVertexAttribL1i64NV = (C.GPVERTEXATTRIBL1I64NV)(getProcAddr("glVertexAttribL1i64NV"))
+	gpVertexAttribL1i64vNV = (C.GPVERTEXATTRIBL1I64VNV)(getProcAddr("glVertexAttribL1i64vNV"))
 	gpVertexAttribL1ui64ARB = (C.GPVERTEXATTRIBL1UI64ARB)(getProcAddr("glVertexAttribL1ui64ARB"))
+	gpVertexAttribL1ui64NV = (C.GPVERTEXATTRIBL1UI64NV)(getProcAddr("glVertexAttribL1ui64NV"))
 	gpVertexAttribL1ui64vARB = (C.GPVERTEXATTRIBL1UI64VARB)(getProcAddr("glVertexAttribL1ui64vARB"))
+	gpVertexAttribL1ui64vNV = (C.GPVERTEXATTRIBL1UI64VNV)(getProcAddr("glVertexAttribL1ui64vNV"))
 	gpVertexAttribL2d = (C.GPVERTEXATTRIBL2D)(getProcAddr("glVertexAttribL2d"))
 	gpVertexAttribL2dv = (C.GPVERTEXATTRIBL2DV)(getProcAddr("glVertexAttribL2dv"))
+	gpVertexAttribL2i64NV = (C.GPVERTEXATTRIBL2I64NV)(getProcAddr("glVertexAttribL2i64NV"))
+	gpVertexAttribL2i64vNV = (C.GPVERTEXATTRIBL2I64VNV)(getProcAddr("glVertexAttribL2i64vNV"))
+	gpVertexAttribL2ui64NV = (C.GPVERTEXATTRIBL2UI64NV)(getProcAddr("glVertexAttribL2ui64NV"))
+	gpVertexAttribL2ui64vNV = (C.GPVERTEXATTRIBL2UI64VNV)(getProcAddr("glVertexAttribL2ui64vNV"))
 	gpVertexAttribL3d = (C.GPVERTEXATTRIBL3D)(getProcAddr("glVertexAttribL3d"))
 	gpVertexAttribL3dv = (C.GPVERTEXATTRIBL3DV)(getProcAddr("glVertexAttribL3dv"))
+	gpVertexAttribL3i64NV = (C.GPVERTEXATTRIBL3I64NV)(getProcAddr("glVertexAttribL3i64NV"))
+	gpVertexAttribL3i64vNV = (C.GPVERTEXATTRIBL3I64VNV)(getProcAddr("glVertexAttribL3i64vNV"))
+	gpVertexAttribL3ui64NV = (C.GPVERTEXATTRIBL3UI64NV)(getProcAddr("glVertexAttribL3ui64NV"))
+	gpVertexAttribL3ui64vNV = (C.GPVERTEXATTRIBL3UI64VNV)(getProcAddr("glVertexAttribL3ui64vNV"))
 	gpVertexAttribL4d = (C.GPVERTEXATTRIBL4D)(getProcAddr("glVertexAttribL4d"))
 	gpVertexAttribL4dv = (C.GPVERTEXATTRIBL4DV)(getProcAddr("glVertexAttribL4dv"))
+	gpVertexAttribL4i64NV = (C.GPVERTEXATTRIBL4I64NV)(getProcAddr("glVertexAttribL4i64NV"))
+	gpVertexAttribL4i64vNV = (C.GPVERTEXATTRIBL4I64VNV)(getProcAddr("glVertexAttribL4i64vNV"))
+	gpVertexAttribL4ui64NV = (C.GPVERTEXATTRIBL4UI64NV)(getProcAddr("glVertexAttribL4ui64NV"))
+	gpVertexAttribL4ui64vNV = (C.GPVERTEXATTRIBL4UI64VNV)(getProcAddr("glVertexAttribL4ui64vNV"))
 	gpVertexAttribLFormat = (C.GPVERTEXATTRIBLFORMAT)(getProcAddr("glVertexAttribLFormat"))
+	gpVertexAttribLFormatNV = (C.GPVERTEXATTRIBLFORMATNV)(getProcAddr("glVertexAttribLFormatNV"))
 	gpVertexAttribLPointer = (C.GPVERTEXATTRIBLPOINTER)(getProcAddr("glVertexAttribLPointer"))
 	gpVertexAttribP1ui = (C.GPVERTEXATTRIBP1UI)(getProcAddr("glVertexAttribP1ui"))
 	if gpVertexAttribP1ui == nil {
@@ -9867,6 +15394,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glVertexAttribPointer")
 	}
 	gpVertexBindingDivisor = (C.GPVERTEXBINDINGDIVISOR)(getProcAddr("glVertexBindingDivisor"))
+	gpVertexFormatNV = (C.GPVERTEXFORMATNV)(getProcAddr("glVertexFormatNV"))
 	gpViewport = (C.GPVIEWPORT)(getProcAddr("glViewport"))
 	if gpViewport == nil {
 		return errors.New("glViewport")
@@ -9874,9 +15402,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpViewportArrayv = (C.GPVIEWPORTARRAYV)(getProcAddr("glViewportArrayv"))
 	gpViewportIndexedf = (C.GPVIEWPORTINDEXEDF)(getProcAddr("glViewportIndexedf"))
 	gpViewportIndexedfv = (C.GPVIEWPORTINDEXEDFV)(getProcAddr("glViewportIndexedfv"))
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
+	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	return nil
 }

--- a/v3.3-core/gl/procaddr.go
+++ b/v3.3-core/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcore33(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v4.1-compatibility/gl/package.go
+++ b/v4.1-compatibility/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -75,7 +73,6 @@ package gl
 // typedef unsigned int GLenum;
 // typedef unsigned char GLboolean;
 // typedef unsigned int GLbitfield;
-// typedef void GLvoid;
 // typedef signed char GLbyte;
 // typedef short GLshort;
 // typedef int GLint;
@@ -88,6 +85,7 @@ package gl
 // typedef float GLclampf;
 // typedef double GLdouble;
 // typedef double GLclampd;
+// typedef void *GLeglClientBufferEXT;
 // typedef char GLchar;
 // typedef char GLcharARB;
 // #ifdef __APPLE__
@@ -104,7 +102,7 @@ package gl
 // typedef ptrdiff_t GLsizeiptrARB;
 // typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
@@ -113,12 +111,14 @@ package gl
 // typedef void (APIENTRY *GLDEBUGPROCAMD)(GLuint id,GLenum category,GLenum severity,GLsizei length,const GLchar *message,void *userParam);
 // typedef unsigned short GLhalfNV;
 // typedef GLintptr GLvdpauSurfaceNV;
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcompatibility41(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcompatibility41(source, type, id, severity, length, message, userParam);
 // }
 // typedef void  (APIENTRYP GPACCUM)(GLenum  op, GLfloat  value);
 // typedef void  (APIENTRYP GPACCUMXOES)(GLenum  op, GLfixed  value);
+// typedef GLboolean  (APIENTRYP GPACQUIREKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key, GLuint  timeout);
 // typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
@@ -131,6 +131,8 @@ package gl
 // typedef void  (APIENTRYP GPALPHAFRAGMENTOP3ATI)(GLenum  op, GLuint  dst, GLuint  dstMod, GLuint  arg1, GLuint  arg1Rep, GLuint  arg1Mod, GLuint  arg2, GLuint  arg2Rep, GLuint  arg2Mod, GLuint  arg3, GLuint  arg3Rep, GLuint  arg3Mod);
 // typedef void  (APIENTRYP GPALPHAFUNC)(GLenum  func, GLfloat  ref);
 // typedef void  (APIENTRYP GPALPHAFUNCXOES)(GLenum  func, GLfixed  ref);
+// typedef void  (APIENTRYP GPALPHATOCOVERAGEDITHERCONTROLNV)(GLenum  mode);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPAPPLYTEXTUREEXT)(GLenum  mode);
 // typedef GLboolean  (APIENTRYP GPAREPROGRAMSRESIDENTNV)(GLsizei  n, const GLuint * programs, GLboolean * residences);
 // typedef GLboolean  (APIENTRYP GPARETEXTURESRESIDENT)(GLsizei  n, const GLuint * textures, GLboolean * residences);
@@ -252,11 +254,14 @@ package gl
 // typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPBUFFERDATAARB)(GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERPARAMETERIAPPLE)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEEXTERNALEXT)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEMEMEXT)(GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPBUFFERSUBDATAARB)(GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLIST)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLISTS)(GLsizei  n, GLenum  type, const void * lists);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
@@ -286,9 +291,9 @@ package gl
 // typedef void  (APIENTRYP GPCLEARINDEX)(GLfloat  c);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
@@ -384,6 +389,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERIVNV)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERARB)(GLhandleARB  shaderObj);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
@@ -414,6 +421,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER2D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * image);
@@ -444,7 +453,7 @@ package gl
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  type);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
@@ -469,8 +478,12 @@ package gl
 // typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEMEMORYOBJECTSEXT)(GLsizei  n, GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef GLhandleARB  (APIENTRYP GPCREATEPROGRAMOBJECTARB)();
@@ -483,6 +496,7 @@ package gl
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -509,12 +523,14 @@ package gl
 // typedef void  (APIENTRYP GPDELETEASYNCMARKERSSGIX)(GLuint  marker, GLsizei  range);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
 // typedef void  (APIENTRYP GPDELETEBUFFERSARB)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFENCESAPPLE)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFENCESNV)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFRAGMENTSHADERATI)(GLuint  id);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERSEXT)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETELISTS)(GLuint  list, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEMEMORYOBJECTSEXT)(GLsizei  n, const GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
 // typedef void  (APIENTRYP GPDELETENAMESAMD)(GLenum  identifier, GLuint  num, const GLuint * names);
 // typedef void  (APIENTRYP GPDELETEOBJECTARB)(GLhandleARB  obj);
@@ -529,10 +545,13 @@ package gl
 // typedef void  (APIENTRYP GPDELETEPROGRAMSNV)(GLsizei  n, const GLuint * programs);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETEQUERIESARB)(GLsizei  n, const GLuint * ids);
+// typedef void  (APIENTRYP GPDELETEQUERYRESOURCETAGNV)(GLsizei  n, const GLint * tagIds);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERSEXT)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
+// typedef void  (APIENTRYP GPDELETESEMAPHORESEXT)(GLsizei  n, const GLuint * semaphores);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETEXTURESEXT)(GLsizei  n, const GLuint * textures);
@@ -582,6 +601,10 @@ package gl
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSARB)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSATI)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYAPPLE)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYATI)(GLenum  mode, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
@@ -606,6 +629,7 @@ package gl
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKNV)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
 // typedef void  (APIENTRYP GPEDGEFLAG)(GLboolean  flag);
 // typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPEDGEFLAGPOINTER)(GLsizei  stride, const void * pointer);
@@ -661,6 +685,7 @@ package gl
 // typedef void  (APIENTRYP GPEVALMESH2)(GLenum  mode, GLint  i1, GLint  i2, GLint  j1, GLint  j2);
 // typedef void  (APIENTRYP GPEVALPOINT1)(GLint  i);
 // typedef void  (APIENTRYP GPEVALPOINT2)(GLint  i, GLint  j);
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef void  (APIENTRYP GPEXECUTEPROGRAMNV)(GLenum  target, GLuint  id, const GLfloat * params);
 // typedef void  (APIENTRYP GPEXTRACTCOMPONENTEXT)(GLuint  res, GLuint  src, GLuint  num);
 // typedef void  (APIENTRYP GPFEEDBACKBUFFER)(GLsizei  size, GLenum  type, GLfloat * buffer);
@@ -676,7 +701,7 @@ package gl
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGEAPPLE)(GLenum  target, GLintptr  offset, GLsizeiptr  size);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHPIXELDATARANGENV)(GLenum  target);
 // typedef void  (APIENTRYP GPFLUSHRASTERSGIX)();
@@ -705,6 +730,7 @@ package gl
 // typedef void  (APIENTRYP GPFOGXOES)(GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPFOGXVOES)(GLenum  pname, const GLfixed * param);
 // typedef void  (APIENTRYP GPFRAGMENTCOLORMATERIALSGIX)(GLenum  face, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELISGIX)(GLenum  pname, GLint  param);
@@ -721,10 +747,14 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEZOOMSGIX)(GLint  factor);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFEREXT)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1DEXT)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -739,6 +769,7 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYEREXT)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFREEOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPFRUSTUM)(GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
@@ -763,9 +794,11 @@ package gl
 // typedef void  (APIENTRYP GPGENPROGRAMSNV)(GLsizei  n, GLuint * programs);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENQUERIESARB)(GLsizei  n, GLuint * ids);
+// typedef void  (APIENTRYP GPGENQUERYRESOURCETAGNV)(GLsizei  n, GLint * tagIds);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERSEXT)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
+// typedef void  (APIENTRYP GPGENSEMAPHORESEXT)(GLsizei  n, GLuint * semaphores);
 // typedef GLuint  (APIENTRYP GPGENSYMBOLSEXT)(GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components);
 // typedef void  (APIENTRYP GPGENTEXTURES)(GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPGENTEXTURESEXT)(GLsizei  n, GLuint * textures);
@@ -826,6 +859,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERFVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERIVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, GLfloat * params);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  level, void * img);
@@ -839,6 +873,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIVEXT)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERXVOES)(GLenum  target, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGAMD)(GLuint  count, GLsizei  bufsize, GLenum * categories, GLuint * severities, GLuint * ids, GLsizei * lengths, GLchar * message);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
@@ -868,6 +903,7 @@ package gl
 // typedef void  (APIENTRYP GPGETFRAGMENTMATERIALIVSGIX)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERFVAMD)(GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
@@ -894,6 +930,7 @@ package gl
 // typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -921,6 +958,7 @@ package gl
 // typedef void  (APIENTRYP GPGETMATERIALIV)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMATERIALXOES)(GLenum  face, GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPGETMATERIALXVOES)(GLenum  face, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMINMAX)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXEXT)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
@@ -947,10 +985,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
@@ -996,7 +1035,7 @@ package gl
 // typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
-// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
 // typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
 // typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
 // typedef void  (APIENTRYP GPGETPIXELMAPFV)(GLenum  map, GLfloat * values);
@@ -1045,6 +1084,10 @@ package gl
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVARB)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVNV)(GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64VEXT)(GLuint  id, GLenum  pname, GLint64 * params);
@@ -1062,6 +1105,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIUIV)(GLuint  sampler, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERFV)(GLuint  sampler, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIV)(GLuint  sampler, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTER)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTEREXT)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSHADERINFOLOG)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
@@ -1070,6 +1114,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERSOURCEARB)(GLhandleARB  obj, GLsizei  maxLength, GLsizei * length, GLcharARB * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETSHARPENTEXFUNCSGIS)(GLenum  target, GLfloat * points);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -1133,12 +1178,16 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFVARB)(GLhandleARB  programObj, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIVARB)(GLhandleARB  programObj, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIVEXT)(GLuint  program, GLint  location, GLuint * params);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEI_VEXT)(GLenum  target, GLuint  index, GLubyte * data);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEVEXT)(GLenum  pname, GLubyte * data);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTFVATI)(GLuint  id, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTIVATI)(GLuint  id, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -1184,6 +1233,7 @@ package gl
 // typedef void  (APIENTRYP GPGETVIDEOIVNV)(GLuint  video_slot, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVIDEOUI64VNV)(GLuint  video_slot, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVIDEOUIVNV)(GLuint  video_slot, GLenum  pname, GLuint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOLORTABLEARB)(GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNCONVOLUTIONFILTERARB)(GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * image);
@@ -1202,9 +1252,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
@@ -1225,6 +1277,12 @@ package gl
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERFVHP)(GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIHP)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIVHP)(GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPIMPORTMEMORYFDEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32HANDLEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32NAMEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, const void * name);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREFDEXT)(GLuint  semaphore, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32HANDLEEXT)(GLuint  semaphore, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32NAMEEXT)(GLuint  semaphore, GLenum  handleType, const void * name);
 // typedef GLsync  (APIENTRYP GPIMPORTSYNCEXT)(GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags);
 // typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPINDEXFUNCEXT)(GLenum  func, GLclampf  ref);
@@ -1263,6 +1321,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERARB)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
 // typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
@@ -1273,6 +1332,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISLIST)(GLuint  list);
+// typedef GLboolean  (APIENTRYP GPISMEMORYOBJECTEXT)(GLuint  memoryObject);
 // typedef GLboolean  (APIENTRYP GPISNAMEAMD)(GLenum  identifier, GLuint  name);
 // typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
@@ -1291,7 +1351,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFEREXT)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
+// typedef GLboolean  (APIENTRYP GPISSEMAPHOREEXT)(GLuint  semaphore);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREEXT)(GLuint  texture);
@@ -1303,6 +1365,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAYAPPLE)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXATTRIBENABLEDAPPLE)(GLuint  index, GLenum  pname);
+// typedef void  (APIENTRYP GPLGPUCOPYIMAGESUBDATANVX)(GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPLGPUINTERLOCKNVX)();
+// typedef void  (APIENTRYP GPLGPUNAMEDBUFFERSUBDATANVX)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLIGHTENVISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPLIGHTMODELF)(GLenum  pname, GLfloat  param);
@@ -1323,6 +1388,7 @@ package gl
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPLINKPROGRAMARB)(GLhandleARB  programObj);
 // typedef void  (APIENTRYP GPLISTBASE)(GLuint  base);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLISTPARAMETERFSGIX)(GLuint  list, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPLISTPARAMETERFVSGIX)(GLuint  list, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPLISTPARAMETERISGIX)(GLuint  list, GLenum  pname, GLint  param);
@@ -1371,7 +1437,7 @@ package gl
 // typedef void  (APIENTRYP GPMAPGRID2XOES)(GLint  n, GLfixed  u1, GLfixed  u2, GLfixed  v1, GLfixed  v2);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPMAPPARAMETERFVNV)(GLenum  target, GLenum  pname, const GLfloat * params);
@@ -1417,9 +1483,12 @@ package gl
 // typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIEREXT)(GLbitfield  barriers);
+// typedef void  (APIENTRYP GPMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPMINSAMPLESHADING)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINMAX)(GLenum  target, GLenum  internalformat, GLboolean  sink);
@@ -1438,7 +1507,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTAMD)(GLenum  mode, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTARRAYAPPLE)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
@@ -1447,7 +1516,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTAMD)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWRANGEELEMENTARRAYAPPLE)(GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWARRAYSIBM)(const GLenum * mode, const GLint * first, const GLsizei * count, GLsizei  primcount, GLint  modestride);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWELEMENTSIBM)(const GLenum * mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  primcount, GLint  modestride);
@@ -1572,13 +1641,26 @@ package gl
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPMULTICASTBARRIERNV)();
+// typedef void  (APIENTRYP GPMULTICASTBLITFRAMEBUFFERNV)(GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPMULTICASTBUFFERSUBDATANV)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPMULTICASTCOPYBUFFERSUBDATANV)(GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPMULTICASTCOPYIMAGESUBDATANV)(GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
+// typedef void  (APIENTRYP GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPMULTICASTWAITSYNCNV)(GLuint  signalGpu, GLbitfield  waitGpuMask);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXTERNALEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEMEMEXT)(GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
@@ -1588,6 +1670,9 @@ package gl
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -1731,6 +1816,8 @@ package gl
 // typedef GLint  (APIENTRYP GPPOLLINSTRUMENTSSGIX)(GLint * marker_p);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETEXT)(GLfloat  factor, GLfloat  bias);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETXOES)(GLfixed  factor, GLfixed  units);
 // typedef void  (APIENTRYP GPPOLYGONSTIPPLE)(const GLubyte * mask);
@@ -1743,6 +1830,7 @@ package gl
 // typedef void  (APIENTRYP GPPOPNAME)();
 // typedef void  (APIENTRYP GPPRESENTFRAMEDUALFILLNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLenum  target1, GLuint  fill1, GLenum  target2, GLuint  fill2, GLenum  target3, GLuint  fill3);
 // typedef void  (APIENTRYP GPPRESENTFRAMEKEYEDNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1);
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEXNV)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTNV)();
@@ -1800,13 +1888,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1820,13 +1912,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1840,13 +1936,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1860,13 +1960,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1927,6 +2031,8 @@ package gl
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
 // typedef GLbitfield  (APIENTRYP GPQUERYMATRIXXOES)(GLfixed * mantissa, GLint * exponent);
 // typedef void  (APIENTRYP GPQUERYOBJECTPARAMETERUIAMD)(GLenum  target, GLuint  id, GLenum  pname, GLuint  param);
+// typedef GLint  (APIENTRYP GPQUERYRESOURCENV)(GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer);
+// typedef void  (APIENTRYP GPQUERYRESOURCETAGNV)(GLint  tagId, const GLchar * tagString);
 // typedef void  (APIENTRYP GPRASTERPOS2D)(GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPRASTERPOS2DV)(const GLdouble * v);
 // typedef void  (APIENTRYP GPRASTERPOS2F)(GLfloat  x, GLfloat  y);
@@ -1957,6 +2063,7 @@ package gl
 // typedef void  (APIENTRYP GPRASTERPOS4SV)(const GLshort * v);
 // typedef void  (APIENTRYP GPRASTERPOS4XOES)(GLfixed  x, GLfixed  y, GLfixed  z, GLfixed  w);
 // typedef void  (APIENTRYP GPRASTERPOS4XVOES)(const GLfixed * coords);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
@@ -1974,7 +2081,9 @@ package gl
 // typedef void  (APIENTRYP GPRECTXOES)(GLfixed  x1, GLfixed  y1, GLfixed  x2, GLfixed  y2);
 // typedef void  (APIENTRYP GPRECTXVOES)(const GLfixed * v1, const GLfixed * v2);
 // typedef void  (APIENTRYP GPREFERENCEPLANESGIX)(const GLdouble * equation);
+// typedef GLboolean  (APIENTRYP GPRELEASEKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key);
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
+// typedef void  (APIENTRYP GPRENDERGPUMASKNV)(GLbitfield  mask);
 // typedef GLint  (APIENTRYP GPRENDERMODE)(GLenum  mode);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
@@ -2010,6 +2119,7 @@ package gl
 // typedef void  (APIENTRYP GPRESETMINMAX)(GLenum  target);
 // typedef void  (APIENTRYP GPRESETMINMAXEXT)(GLenum  target);
 // typedef void  (APIENTRYP GPRESIZEBUFFERSMESA)();
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACKNV)();
 // typedef void  (APIENTRYP GPROTATED)(GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
@@ -2017,7 +2127,6 @@ package gl
 // typedef void  (APIENTRYP GPROTATEXOES)(GLfixed  angle, GLfixed  x, GLfixed  y, GLfixed  z);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEARB)(GLfloat  value, GLboolean  invert);
-// typedef void  (APIENTRYP GPSAMPLECOVERAGEOES)(GLfixed  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEXOES)(GLclampx  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMAPATI)(GLuint  dst, GLuint  interp, GLenum  swizzle);
 // typedef void  (APIENTRYP GPSAMPLEMASKEXT)(GLclampf  value, GLboolean  invert);
@@ -2081,6 +2190,7 @@ package gl
 // typedef void  (APIENTRYP GPSECONDARYCOLORPOINTERLISTIBM)(GLint  size, GLenum  type, GLint  stride, const void ** pointer, GLint  ptrstride);
 // typedef void  (APIENTRYP GPSELECTBUFFER)(GLsizei  size, GLuint * buffer);
 // typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
+// typedef void  (APIENTRYP GPSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, const GLuint64 * params);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSETFENCEAPPLE)(GLuint  fence);
@@ -2098,11 +2208,16 @@ package gl
 // typedef void  (APIENTRYP GPSHADERSOURCEARB)(GLhandleARB  shaderObj, GLsizei  count, const GLcharARB ** string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
 // typedef void  (APIENTRYP GPSHARPENTEXFUNCSGIS)(GLenum  target, GLsizei  n, const GLfloat * points);
+// typedef void  (APIENTRYP GPSIGNALSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERIVSGIX)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPSTARTINSTRUMENTSSGIX)();
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
 // typedef void  (APIENTRYP GPSTENCILCLEARTAGEXT)(GLsizei  stencilTagBits, GLuint  stencilClearTag);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
@@ -2123,6 +2238,7 @@ package gl
 // typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
 // typedef void  (APIENTRYP GPSTOPINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPSTRINGMARKERGREMEDY)(GLsizei  len, const void * string);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPSWIZZLEEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // typedef void  (APIENTRYP GPSYNCTEXTUREINTEL)(GLuint  texture);
 // typedef void  (APIENTRYP GPTAGSAMPLEBUFFERSGIX)();
@@ -2256,7 +2372,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLint  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations);
 // typedef void  (APIENTRYP GPTEXIMAGE4DSGIS)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIVEXT)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
@@ -2273,6 +2389,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXSTORAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXSTORAGE3D)(GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXSTORAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM1DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXSTORAGESPARSEAMD)(GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1DEXT)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2285,7 +2406,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTURECOLORMASKSGIS)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
@@ -2298,7 +2419,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURELIGHTEXT)(GLenum  pname);
 // typedef void  (APIENTRYP GPTEXTUREMATERIALEXT)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPTEXTURENORMALEXT)(GLenum  mode);
-// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
@@ -2323,6 +2444,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM1DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXTURESTORAGESPARSEAMD)(GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2334,7 +2460,7 @@ package gl
 // typedef void  (APIENTRYP GPTRACKMATRIXNV)(GLenum  target, GLuint  address, GLenum  matrix, GLenum  transform);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKATTRIBSNV)(GLsizei  count, const GLint * attribs, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKSTREAMATTRIBSNV)(GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGSEXT)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
@@ -2350,13 +2476,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IARB)(GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIEXT)(GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2368,13 +2498,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IARB)(GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIEXT)(GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2386,13 +2520,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2404,13 +2542,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2837,7 +2979,11 @@ package gl
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
+// typedef void  (APIENTRYP GPWAITSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
 // typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
 // typedef void  (APIENTRYP GPWEIGHTPOINTERARB)(GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPWEIGHTBVARB)(GLint  size, const GLbyte * weights);
@@ -2904,12 +3050,16 @@ package gl
 // typedef void  (APIENTRYP GPWINDOWPOS4IVMESA)(const GLint * v);
 // typedef void  (APIENTRYP GPWINDOWPOS4SMESA)(GLshort  x, GLshort  y, GLshort  z, GLshort  w);
 // typedef void  (APIENTRYP GPWINDOWPOS4SVMESA)(const GLshort * v);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
 // typedef void  (APIENTRYP GPWRITEMASKEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // static void  glowAccum(GPACCUM fnptr, GLenum  op, GLfloat  value) {
 //   (*fnptr)(op, value);
 // }
 // static void  glowAccumxOES(GPACCUMXOES fnptr, GLenum  op, GLfixed  value) {
 //   (*fnptr)(op, value);
+// }
+// static GLboolean  glowAcquireKeyedMutexWin32EXT(GPACQUIREKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key, GLuint  timeout) {
+//   return (*fnptr)(memory, key, timeout);
 // }
 // static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
 //   (*fnptr)(program);
@@ -2946,6 +3096,12 @@ package gl
 // }
 // static void  glowAlphaFuncxOES(GPALPHAFUNCXOES fnptr, GLenum  func, GLfixed  ref) {
 //   (*fnptr)(func, ref);
+// }
+// static void  glowAlphaToCoverageDitherControlNV(GPALPHATOCOVERAGEDITHERCONTROLNV fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowApplyTextureEXT(GPAPPLYTEXTUREEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -3310,7 +3466,7 @@ package gl
 // static void  glowBufferDataARB(GPBUFFERDATAARB fnptr, GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferParameteriAPPLE(GPBUFFERPARAMETERIAPPLE fnptr, GLenum  target, GLenum  pname, GLint  param) {
@@ -3319,11 +3475,20 @@ package gl
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(target, size, data, flags);
 // }
+// static void  glowBufferStorageExternalEXT(GPBUFFERSTORAGEEXTERNALEXT fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(target, offset, size, clientBuffer, flags);
+// }
+// static void  glowBufferStorageMemEXT(GPBUFFERSTORAGEMEMEXT fnptr, GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, size, memory, offset);
+// }
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
 // static void  glowBufferSubDataARB(GPBUFFERSUBDATAARB fnptr, GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
 // }
 // static void  glowCallList(GPCALLLIST fnptr, GLuint  list) {
 //   (*fnptr)(list);
@@ -3412,14 +3577,14 @@ package gl
 // static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
 // static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -3706,6 +3871,12 @@ package gl
 // static void  glowCombinerStageParameterfvNV(GPCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, const GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
@@ -3795,6 +3966,12 @@ package gl
 // }
 // static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
 //   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowConvolutionFilter1D(GPCONVOLUTIONFILTER1D fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image) {
 //   (*fnptr)(target, internalformat, width, format, type, image);
@@ -3886,7 +4063,7 @@ package gl
 // static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
@@ -3961,11 +4138,23 @@ package gl
 // static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
 //   (*fnptr)(path, coverMode);
 // }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
+// }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreateMemoryObjectsEXT(GPCREATEMEMORYOBJECTSEXT fnptr, GLsizei  n, GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
 //   (*fnptr)(queryId, queryHandle);
@@ -4002,6 +4191,9 @@ package gl
 // }
 // static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -4081,6 +4273,9 @@ package gl
 // static void  glowDeleteBuffersARB(GPDELETEBUFFERSARB fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFencesAPPLE(GPDELETEFENCESAPPLE fnptr, GLsizei  n, const GLuint * fences) {
 //   (*fnptr)(n, fences);
 // }
@@ -4098,6 +4293,9 @@ package gl
 // }
 // static void  glowDeleteLists(GPDELETELISTS fnptr, GLuint  list, GLsizei  range) {
 //   (*fnptr)(list, range);
+// }
+// static void  glowDeleteMemoryObjectsEXT(GPDELETEMEMORYOBJECTSEXT fnptr, GLsizei  n, const GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
@@ -4141,6 +4339,9 @@ package gl
 // static void  glowDeleteQueriesARB(GPDELETEQUERIESARB fnptr, GLsizei  n, const GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowDeleteQueryResourceTagNV(GPDELETEQUERYRESOURCETAGNV fnptr, GLsizei  n, const GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowDeleteRenderbuffers(GPDELETERENDERBUFFERS fnptr, GLsizei  n, const GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4150,8 +4351,14 @@ package gl
 // static void  glowDeleteSamplers(GPDELETESAMPLERS fnptr, GLsizei  count, const GLuint * samplers) {
 //   (*fnptr)(count, samplers);
 // }
+// static void  glowDeleteSemaphoresEXT(GPDELETESEMAPHORESEXT fnptr, GLsizei  n, const GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
+// }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -4300,6 +4507,18 @@ package gl
 // static void  glowDrawBuffersATI(GPDRAWBUFFERSATI fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
 // }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
+// }
 // static void  glowDrawElementArrayAPPLE(GPDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, GLint  first, GLsizei  count) {
 //   (*fnptr)(mode, first, count);
 // }
@@ -4371,6 +4590,9 @@ package gl
 // }
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
+// }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
 // }
 // static void  glowEdgeFlag(GPEDGEFLAG fnptr, GLboolean  flag) {
 //   (*fnptr)(flag);
@@ -4537,6 +4759,9 @@ package gl
 // static void  glowEvalPoint2(GPEVALPOINT2 fnptr, GLint  i, GLint  j) {
 //   (*fnptr)(i, j);
 // }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowExecuteProgramNV(GPEXECUTEPROGRAMNV fnptr, GLenum  target, GLuint  id, const GLfloat * params) {
 //   (*fnptr)(target, id, params);
 // }
@@ -4582,7 +4807,7 @@ package gl
 // static void  glowFlushMappedBufferRangeAPPLE(GPFLUSHMAPPEDBUFFERRANGEAPPLE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, offset, size);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
 // }
 // static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
@@ -4669,6 +4894,9 @@ package gl
 // static void  glowFragmentColorMaterialSGIX(GPFRAGMENTCOLORMATERIALSGIX fnptr, GLenum  face, GLenum  mode) {
 //   (*fnptr)(face, mode);
 // }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
 // static void  glowFragmentLightModelfSGIX(GPFRAGMENTLIGHTMODELFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -4717,6 +4945,9 @@ package gl
 // static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(framebuffer, n, bufs);
 // }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
@@ -4728,6 +4959,15 @@ package gl
 // }
 // static void  glowFramebufferRenderbufferEXT(GPFRAMEBUFFERRENDERBUFFEREXT fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSamplePositionsfvAMD(GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(target, numsamples, pixelindex, values);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -4770,6 +5010,9 @@ package gl
 // }
 // static void  glowFramebufferTextureLayerEXT(GPFRAMEBUFFERTEXTURELAYEREXT fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFreeObjectBufferATI(GPFREEOBJECTBUFFERATI fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -4843,6 +5086,9 @@ package gl
 // static void  glowGenQueriesARB(GPGENQUERIESARB fnptr, GLsizei  n, GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowGenQueryResourceTagNV(GPGENQUERYRESOURCETAGNV fnptr, GLsizei  n, GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowGenRenderbuffers(GPGENRENDERBUFFERS fnptr, GLsizei  n, GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4851,6 +5097,9 @@ package gl
 // }
 // static void  glowGenSamplers(GPGENSAMPLERS fnptr, GLsizei  count, GLuint * samplers) {
 //   (*fnptr)(count, samplers);
+// }
+// static void  glowGenSemaphoresEXT(GPGENSEMAPHORESEXT fnptr, GLsizei  n, GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
 // }
 // static GLuint  glowGenSymbolsEXT(GPGENSYMBOLSEXT fnptr, GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components) {
 //   return (*fnptr)(datatype, storagetype, range, components);
@@ -5032,6 +5281,9 @@ package gl
 // static void  glowGetCombinerStageParameterfvNV(GPGETCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
 // static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
 //   (*fnptr)(texunit, target, lod, img);
 // }
@@ -5070,6 +5322,9 @@ package gl
 // }
 // static void  glowGetConvolutionParameterxvOES(GPGETCONVOLUTIONPARAMETERXVOES fnptr, GLenum  target, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -5158,6 +5413,9 @@ package gl
 // static void  glowGetFramebufferAttachmentParameterivEXT(GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLenum  target, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, attachment, pname, params);
 // }
+// static void  glowGetFramebufferParameterfvAMD(GPGETFRAMEBUFFERPARAMETERFVAMD fnptr, GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(target, pname, numsamples, pixelindex, size, values);
+// }
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
@@ -5235,6 +5493,9 @@ package gl
 // }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
@@ -5317,6 +5578,9 @@ package gl
 // static void  glowGetMaterialxvOES(GPGETMATERIALXVOES fnptr, GLenum  face, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(face, pname, params);
 // }
+// static void  glowGetMemoryObjectParameterivEXT(GPGETMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
+// }
 // static void  glowGetMinmax(GPGETMINMAX fnptr, GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values) {
 //   (*fnptr)(target, reset, format, type, values);
 // }
@@ -5395,7 +5659,7 @@ package gl
 // static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
@@ -5406,6 +5670,9 @@ package gl
 // }
 // static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
+// }
+// static void  glowGetNamedFramebufferParameterfvAMD(GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD fnptr, GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(framebuffer, pname, numsamples, pixelindex, size, values);
 // }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
@@ -5542,7 +5809,7 @@ package gl
 // static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
 //   (*fnptr)(numGroups, groupsSize, groups);
 // }
-// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten) {
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
 //   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
 // }
 // static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
@@ -5689,6 +5956,18 @@ package gl
 // static void  glowGetProgramivNV(GPGETPROGRAMIVNV fnptr, GLuint  id, GLenum  pname, GLint * params) {
 //   (*fnptr)(id, pname, params);
 // }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
 // }
@@ -5740,6 +6019,9 @@ package gl
 // static void  glowGetSamplerParameteriv(GPGETSAMPLERPARAMETERIV fnptr, GLuint  sampler, GLenum  pname, GLint * params) {
 //   (*fnptr)(sampler, pname, params);
 // }
+// static void  glowGetSemaphoreParameterui64vEXT(GPGETSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowGetSeparableFilter(GPGETSEPARABLEFILTER fnptr, GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span) {
 //   (*fnptr)(target, format, type, row, column, span);
 // }
@@ -5763,6 +6045,9 @@ package gl
 // }
 // static void  glowGetSharpenTexFuncSGIS(GPGETSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLfloat * points) {
 //   (*fnptr)(target, points);
+// }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
 // }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
@@ -5953,6 +6238,9 @@ package gl
 // static void  glowGetUniformfvARB(GPGETUNIFORMFVARB fnptr, GLhandleARB  programObj, GLint  location, GLfloat * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5962,6 +6250,9 @@ package gl
 // static void  glowGetUniformivARB(GPGETUNIFORMIVARB fnptr, GLhandleARB  programObj, GLint  location, GLint * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5970,6 +6261,12 @@ package gl
 // }
 // static void  glowGetUniformuivEXT(GPGETUNIFORMUIVEXT fnptr, GLuint  program, GLint  location, GLuint * params) {
 //   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUnsignedBytei_vEXT(GPGETUNSIGNEDBYTEI_VEXT fnptr, GLenum  target, GLuint  index, GLubyte * data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetUnsignedBytevEXT(GPGETUNSIGNEDBYTEVEXT fnptr, GLenum  pname, GLubyte * data) {
+//   (*fnptr)(pname, data);
 // }
 // static void  glowGetVariantArrayObjectfvATI(GPGETVARIANTARRAYOBJECTFVATI fnptr, GLuint  id, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(id, pname, params);
@@ -6106,6 +6403,9 @@ package gl
 // static void  glowGetVideouivNV(GPGETVIDEOUIVNV fnptr, GLuint  video_slot, GLenum  pname, GLuint * params) {
 //   (*fnptr)(video_slot, pname, params);
 // }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
+// }
 // static void  glowGetnColorTableARB(GPGETNCOLORTABLEARB fnptr, GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table) {
 //   (*fnptr)(target, format, type, bufSize, table);
 // }
@@ -6160,6 +6460,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -6167,6 +6470,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -6228,6 +6534,24 @@ package gl
 // }
 // static void  glowImageTransformParameterivHP(GPIMAGETRANSFORMPARAMETERIVHP fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowImportMemoryFdEXT(GPIMPORTMEMORYFDEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(memory, size, handleType, fd);
+// }
+// static void  glowImportMemoryWin32HandleEXT(GPIMPORTMEMORYWIN32HANDLEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, void * handle) {
+//   (*fnptr)(memory, size, handleType, handle);
+// }
+// static void  glowImportMemoryWin32NameEXT(GPIMPORTMEMORYWIN32NAMEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, const void * name) {
+//   (*fnptr)(memory, size, handleType, name);
+// }
+// static void  glowImportSemaphoreFdEXT(GPIMPORTSEMAPHOREFDEXT fnptr, GLuint  semaphore, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(semaphore, handleType, fd);
+// }
+// static void  glowImportSemaphoreWin32HandleEXT(GPIMPORTSEMAPHOREWIN32HANDLEEXT fnptr, GLuint  semaphore, GLenum  handleType, void * handle) {
+//   (*fnptr)(semaphore, handleType, handle);
+// }
+// static void  glowImportSemaphoreWin32NameEXT(GPIMPORTSEMAPHOREWIN32NAMEEXT fnptr, GLuint  semaphore, GLenum  handleType, const void * name) {
+//   (*fnptr)(semaphore, handleType, name);
 // }
 // static GLsync  glowImportSyncEXT(GPIMPORTSYNCEXT fnptr, GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags) {
 //   return (*fnptr)(external_sync_type, external_sync, flags);
@@ -6343,6 +6667,9 @@ package gl
 // static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
 // }
@@ -6372,6 +6699,9 @@ package gl
 // }
 // static GLboolean  glowIsList(GPISLIST fnptr, GLuint  list) {
 //   return (*fnptr)(list);
+// }
+// static GLboolean  glowIsMemoryObjectEXT(GPISMEMORYOBJECTEXT fnptr, GLuint  memoryObject) {
+//   return (*fnptr)(memoryObject);
 // }
 // static GLboolean  glowIsNameAMD(GPISNAMEAMD fnptr, GLenum  identifier, GLuint  name) {
 //   return (*fnptr)(identifier, name);
@@ -6427,8 +6757,14 @@ package gl
 // static GLboolean  glowIsSampler(GPISSAMPLER fnptr, GLuint  sampler) {
 //   return (*fnptr)(sampler);
 // }
+// static GLboolean  glowIsSemaphoreEXT(GPISSEMAPHOREEXT fnptr, GLuint  semaphore) {
+//   return (*fnptr)(semaphore);
+// }
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
+// }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
 // }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
@@ -6462,6 +6798,15 @@ package gl
 // }
 // static GLboolean  glowIsVertexAttribEnabledAPPLE(GPISVERTEXATTRIBENABLEDAPPLE fnptr, GLuint  index, GLenum  pname) {
 //   return (*fnptr)(index, pname);
+// }
+// static void  glowLGPUCopyImageSubDataNVX(GPLGPUCOPYIMAGESUBDATANVX fnptr, GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(sourceGpu, destinationGpuMask, srcName, srcTarget, srcLevel, srcX, srxY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, width, height, depth);
+// }
+// static void  glowLGPUInterlockNVX(GPLGPUINTERLOCKNVX fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowLGPUNamedBufferSubDataNVX(GPLGPUNAMEDBUFFERSUBDATANVX fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
 // }
 // static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(type, object, length, label);
@@ -6522,6 +6867,9 @@ package gl
 // }
 // static void  glowListBase(GPLISTBASE fnptr, GLuint  base) {
 //   (*fnptr)(base);
+// }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
 // }
 // static void  glowListParameterfSGIX(GPLISTPARAMETERFSGIX fnptr, GLuint  list, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(list, pname, param);
@@ -6667,7 +7015,7 @@ package gl
 // static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
 // }
 // static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
@@ -6805,6 +7153,12 @@ package gl
 // static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
 //   (*fnptr)(mode, x, y, z);
 // }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
 // }
@@ -6813,6 +7167,9 @@ package gl
 // }
 // static void  glowMemoryBarrierEXT(GPMEMORYBARRIEREXT fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
+// }
+// static void  glowMemoryObjectParameterivEXT(GPMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, const GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
 // }
 // static void  glowMinSampleShading(GPMINSAMPLESHADING fnptr, GLfloat  value) {
 //   (*fnptr)(value);
@@ -6868,7 +7225,7 @@ package gl
 // static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElementArrayAPPLE(GPMULTIDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -6895,7 +7252,7 @@ package gl
 // static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawRangeElementArrayAPPLE(GPMULTIDRAWRANGEELEMENTARRAYAPPLE fnptr, GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -7270,25 +7627,64 @@ package gl
 // static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMulticastBarrierNV(GPMULTICASTBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowMulticastBlitFramebufferNV(GPMULTICASTBLITFRAMEBUFFERNV fnptr, GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
+//   (*fnptr)(srcGpu, dstGpu, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+// }
+// static void  glowMulticastBufferSubDataNV(GPMULTICASTBUFFERSUBDATANV fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
+// }
+// static void  glowMulticastCopyBufferSubDataNV(GPMULTICASTCOPYBUFFERSUBDATANV fnptr, GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readGpu, writeGpuMask, readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowMulticastCopyImageSubDataNV(GPMULTICASTCOPYIMAGESUBDATANV fnptr, GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
+//   (*fnptr)(srcGpu, dstGpuMask, srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
+// }
+// static void  glowMulticastFramebufferSampleLocationsfvNV(GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(gpu, framebuffer, start, count, v);
+// }
+// static void  glowMulticastGetQueryObjecti64vNV(GPMULTICASTGETQUERYOBJECTI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectivNV(GPMULTICASTGETQUERYOBJECTIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectui64vNV(GPMULTICASTGETQUERYOBJECTUI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectuivNV(GPMULTICASTGETQUERYOBJECTUIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastWaitSyncNV(GPMULTICASTWAITSYNCNV fnptr, GLuint  signalGpu, GLbitfield  waitGpuMask) {
+//   (*fnptr)(signalGpu, waitGpuMask);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
 // static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
 // static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageExternalEXT(GPNAMEDBUFFERSTORAGEEXTERNALEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(buffer, offset, size, clientBuffer, flags);
+// }
+// static void  glowNamedBufferStorageMemEXT(GPNAMEDBUFFERSTORAGEMEMEXT fnptr, GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(buffer, size, memory, offset);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
@@ -7317,6 +7713,15 @@ package gl
 // }
 // static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSamplePositionsfvAMD(GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(framebuffer, numsamples, pixelindex, values);
 // }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
@@ -7747,6 +8152,12 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPolygonOffsetEXT(GPPOLYGONOFFSETEXT fnptr, GLfloat  factor, GLfloat  bias) {
 //   (*fnptr)(factor, bias);
 // }
@@ -7782,6 +8193,9 @@ package gl
 // }
 // static void  glowPresentFrameKeyedNV(GPPRESENTFRAMEKEYEDNV fnptr, GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1) {
 //   (*fnptr)(video_slot, minPresentTime, beginPresentTimeId, presentDurationId, type, target0, fill0, key0, target1, fill1, key1);
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -7954,8 +8368,14 @@ package gl
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7972,8 +8392,14 @@ package gl
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8014,8 +8440,14 @@ package gl
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8032,8 +8464,14 @@ package gl
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8074,8 +8512,14 @@ package gl
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8092,8 +8536,14 @@ package gl
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8134,8 +8584,14 @@ package gl
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8152,8 +8608,14 @@ package gl
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8335,6 +8797,12 @@ package gl
 // static void  glowQueryObjectParameteruiAMD(GPQUERYOBJECTPARAMETERUIAMD fnptr, GLenum  target, GLuint  id, GLenum  pname, GLuint  param) {
 //   (*fnptr)(target, id, pname, param);
 // }
+// static GLint  glowQueryResourceNV(GPQUERYRESOURCENV fnptr, GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer) {
+//   return (*fnptr)(queryType, tagId, bufSize, buffer);
+// }
+// static void  glowQueryResourceTagNV(GPQUERYRESOURCETAGNV fnptr, GLint  tagId, const GLchar * tagString) {
+//   (*fnptr)(tagId, tagString);
+// }
 // static void  glowRasterPos2d(GPRASTERPOS2D fnptr, GLdouble  x, GLdouble  y) {
 //   (*fnptr)(x, y);
 // }
@@ -8425,6 +8893,9 @@ package gl
 // static void  glowRasterPos4xvOES(GPRASTERPOS4XVOES fnptr, const GLfixed * coords) {
 //   (*fnptr)(coords);
 // }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
+// }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
 // }
@@ -8476,8 +8947,14 @@ package gl
 // static void  glowReferencePlaneSGIX(GPREFERENCEPLANESGIX fnptr, const GLdouble * equation) {
 //   (*fnptr)(equation);
 // }
+// static GLboolean  glowReleaseKeyedMutexWin32EXT(GPRELEASEKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key) {
+//   return (*fnptr)(memory, key);
+// }
 // static void  glowReleaseShaderCompiler(GPRELEASESHADERCOMPILER fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowRenderGpuMaskNV(GPRENDERGPUMASKNV fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static GLint  glowRenderMode(GPRENDERMODE fnptr, GLenum  mode) {
 //   return (*fnptr)(mode);
@@ -8584,6 +9061,9 @@ package gl
 // static void  glowResizeBuffersMESA(GPRESIZEBUFFERSMESA fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -8603,9 +9083,6 @@ package gl
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoverageARB(GPSAMPLECOVERAGEARB fnptr, GLfloat  value, GLboolean  invert) {
-//   (*fnptr)(value, invert);
-// }
-// static void  glowSampleCoverageOES(GPSAMPLECOVERAGEOES fnptr, GLfixed  value, GLboolean  invert) {
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoveragexOES(GPSAMPLECOVERAGEXOES fnptr, GLclampx  value, GLboolean  invert) {
@@ -8797,6 +9274,9 @@ package gl
 // static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
 //   (*fnptr)(monitor, enable, group, numCounters, counterList);
 // }
+// static void  glowSemaphoreParameterui64vEXT(GPSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, const GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowSeparableFilter2D(GPSEPARABLEFILTER2D fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column) {
 //   (*fnptr)(target, internalformat, width, height, format, type, row, column);
 // }
@@ -8848,6 +9328,18 @@ package gl
 // static void  glowSharpenTexFuncSGIS(GPSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLsizei  n, const GLfloat * points) {
 //   (*fnptr)(target, n, points);
 // }
+// static void  glowSignalSemaphoreEXT(GPSIGNALSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, dstLayouts);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
 // static void  glowSpriteParameterfSGIX(GPSPRITEPARAMETERFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -8862,6 +9354,9 @@ package gl
 // }
 // static void  glowStartInstrumentsSGIX(GPSTARTINSTRUMENTSSGIX fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
 // }
 // static void  glowStencilClearTagEXT(GPSTENCILCLEARTAGEXT fnptr, GLsizei  stencilTagBits, GLuint  stencilClearTag) {
 //   (*fnptr)(stencilTagBits, stencilClearTag);
@@ -8922,6 +9417,9 @@ package gl
 // }
 // static void  glowStringMarkerGREMEDY(GPSTRINGMARKERGREMEDY fnptr, GLsizei  len, const void * string) {
 //   (*fnptr)(len, string);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
 // }
 // static void  glowSwizzleEXT(GPSWIZZLEEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
@@ -9322,8 +9820,8 @@ package gl
 // static void  glowTexImage4DSGIS(GPTEXIMAGE4DSGIS fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, height, depth, size4d, border, format, type, pixels);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -9373,6 +9871,21 @@ package gl
 // static void  glowTexStorage3DMultisample(GPTEXSTORAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTexStorageMem1DEXT(GPTEXSTORAGEMEM1DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTexStorageMem2DEXT(GPTEXSTORAGEMEM2DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTexStorageMem2DMultisampleEXT(GPTEXSTORAGEMEM2DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTexStorageMem3DEXT(GPTEXSTORAGEMEM3DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTexStorageMem3DMultisampleEXT(GPTEXSTORAGEMEM3DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTexStorageSparseAMD(GPTEXSTORAGESPARSEAMD fnptr, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9409,7 +9922,7 @@ package gl
 // static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, target, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
 // }
 // static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
@@ -9448,8 +9961,8 @@ package gl
 // static void  glowTextureNormalEXT(GPTEXTURENORMALEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
 // }
-// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
@@ -9523,6 +10036,21 @@ package gl
 // static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorageMem1DEXT(GPTEXTURESTORAGEMEM1DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTextureStorageMem2DEXT(GPTEXTURESTORAGEMEM2DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTextureStorageMem2DMultisampleEXT(GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTextureStorageMem3DEXT(GPTEXTURESTORAGEMEM3DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTextureStorageMem3DMultisampleEXT(GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTextureStorageSparseAMD(GPTEXTURESTORAGESPARSEAMD fnptr, GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(texture, target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9556,7 +10084,7 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackStreamAttribsNV(GPTRANSFORMFEEDBACKSTREAMATTRIBSNV fnptr, GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode) {
@@ -9604,8 +10132,14 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9622,8 +10156,14 @@ package gl
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9658,8 +10198,14 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9676,8 +10222,14 @@ package gl
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9712,8 +10264,14 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9730,8 +10288,14 @@ package gl
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9766,8 +10330,14 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9784,8 +10354,14 @@ package gl
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -11065,8 +11641,20 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
+// static void  glowWaitSemaphoreEXT(GPWAITSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, srcLayouts);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
 // }
 // static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
 //   (*fnptr)(resultPath, numPaths, paths, weights);
@@ -11266,6 +11854,9 @@ package gl
 // static void  glowWindowPos4svMESA(GPWINDOWPOS4SVMESA fnptr, const GLshort * v) {
 //   (*fnptr)(v);
 // }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
+// }
 // static void  glowWriteMaskEXT(GPWRITEMASKEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
 // }
@@ -11357,6 +11948,7 @@ const (
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_BARRIER_BITS_EXT                                       = 0xFFFFFFFF
 	ALL_COMPLETED_NV                                           = 0x84F2
+	ALL_PIXELS_AMD                                             = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
 	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALL_STATIC_DATA_IBM                                        = 103060
@@ -11391,11 +11983,16 @@ const (
 	ALPHA_MAX_SGIX                                             = 0x8321
 	ALPHA_MIN_CLAMP_INGR                                       = 0x8563
 	ALPHA_MIN_SGIX                                             = 0x8320
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALPHA_SCALE                                                = 0x0D1C
 	ALPHA_SNORM                                                = 0x9010
 	ALPHA_TEST                                                 = 0x0BC0
 	ALPHA_TEST_FUNC                                            = 0x0BC1
 	ALPHA_TEST_REF                                             = 0x0BC2
+	ALPHA_TO_COVERAGE_DITHER_DEFAULT_NV                        = 0x934D
+	ALPHA_TO_COVERAGE_DITHER_DISABLE_NV                        = 0x934F
+	ALPHA_TO_COVERAGE_DITHER_ENABLE_NV                         = 0x934E
+	ALPHA_TO_COVERAGE_DITHER_MODE_NV                           = 0x92BF
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	ALWAYS_FAST_HINT_PGI                                       = 0x1A20C
@@ -11441,6 +12038,7 @@ const (
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
 	ATTENUATION_EXT                                            = 0x834D
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	ATTRIB_ARRAY_POINTER_NV                                    = 0x8645
 	ATTRIB_ARRAY_SIZE_NV                                       = 0x8623
 	ATTRIB_ARRAY_STRIDE_NV                                     = 0x8624
@@ -11483,6 +12081,7 @@ const (
 	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
 	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_COLOR_EXT                                            = 0x8005
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
@@ -11660,10 +12259,26 @@ const (
 	COLOR_ATTACHMENT14_EXT                                     = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
 	COLOR_ATTACHMENT15_EXT                                     = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT1_EXT                                      = 0x8CE1
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT2_EXT                                      = 0x8CE2
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT3_EXT                                      = 0x8CE3
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT4_EXT                                      = 0x8CE4
@@ -11767,6 +12382,8 @@ const (
 	COMPILE                                                    = 0x1300
 	COMPILE_AND_EXECUTE                                        = 0x1301
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_ALPHA                                           = 0x84E9
 	COMPRESSED_ALPHA_ARB                                       = 0x84E9
 	COMPRESSED_INTENSITY                                       = 0x84EC
@@ -11866,8 +12483,18 @@ const (
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	COMP_BIT_ATI                                               = 0x00000002
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
 	CONIC_CURVE_TO_NV                                          = 0x1A
 	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSERVE_MEMORY_HINT_PGI                                   = 0x1A1FD
 	CONSTANT                                                   = 0x8576
 	CONSTANT_ALPHA                                             = 0x8003
@@ -11889,6 +12516,7 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
 	CONTEXT_LOST_KHR                                           = 0x0507
@@ -11960,13 +12588,14 @@ const (
 	COPY_INVERTED                                              = 0x150C
 	COPY_PIXEL_TOKEN                                           = 0x0706
 	COPY_READ_BUFFER                                           = 0x8F36
-	COPY_READ_BUFFER_BINDING                                   = 0x8F36
 	COPY_WRITE_BUFFER                                          = 0x8F37
-	COPY_WRITE_BUFFER_BINDING                                  = 0x8F37
 	COUNTER_RANGE_AMD                                          = 0x8BC1
 	COUNTER_TYPE_AMD                                           = 0x8BC0
 	COUNT_DOWN_NV                                              = 0x9089
 	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
 	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CUBIC_EXT                                                  = 0x8334
 	CUBIC_HP                                                   = 0x815F
@@ -12016,6 +12645,7 @@ const (
 	CURRENT_VERTEX_WEIGHT_EXT                                  = 0x850B
 	CURRENT_WEIGHT_ARB                                         = 0x86A8
 	CW                                                         = 0x0900
+	D3D12_FENCE_VALUE_EXT                                      = 0x9595
 	DARKEN_KHR                                                 = 0x9297
 	DARKEN_NV                                                  = 0x9297
 	DATA_BUFFER_AMD                                            = 0x9151
@@ -12108,6 +12738,7 @@ const (
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DECR_WRAP_EXT                                              = 0x8508
+	DEDICATED_MEMORY_OBJECT_EXT                                = 0x9581
 	DEFORMATIONS_MASK_SGIX                                     = 0x8196
 	DELETE_STATUS                                              = 0x8B80
 	DEPENDENT_AR_TEXTURE_2D_NV                                 = 0x86E9
@@ -12149,6 +12780,7 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_SCALE                                                = 0x0D1E
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
@@ -12166,6 +12798,9 @@ const (
 	DETAIL_TEXTURE_FUNC_POINTS_SGIS                            = 0x809C
 	DETAIL_TEXTURE_LEVEL_SGIS                                  = 0x809A
 	DETAIL_TEXTURE_MODE_SGIS                                   = 0x809B
+	DEVICE_LUID_EXT                                            = 0x9599
+	DEVICE_NODE_MASK_EXT                                       = 0x959A
+	DEVICE_UUID_EXT                                            = 0x9597
 	DIFFERENCE_KHR                                             = 0x929E
 	DIFFERENCE_NV                                              = 0x929E
 	DIFFUSE                                                    = 0x1201
@@ -12228,6 +12863,9 @@ const (
 	DOUBLE_VEC3_EXT                                            = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
 	DOUBLE_VEC4_EXT                                            = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER0_ARB                                           = 0x8825
@@ -12277,6 +12915,9 @@ const (
 	DRAW_BUFFER9                                               = 0x882E
 	DRAW_BUFFER9_ARB                                           = 0x882E
 	DRAW_BUFFER9_ATI                                           = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
 	DRAW_FRAMEBUFFER_BINDING_EXT                               = 0x8CA6
@@ -12288,6 +12929,7 @@ const (
 	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DRAW_PIXELS_APPLE                                          = 0x8A0A
 	DRAW_PIXEL_TOKEN                                           = 0x0705
+	DRIVER_UUID_EXT                                            = 0x9598
 	DSDT8_MAG8_INTENSITY8_NV                                   = 0x870B
 	DSDT8_MAG8_NV                                              = 0x870A
 	DSDT8_NV                                                   = 0x8709
@@ -12348,7 +12990,9 @@ const (
 	EDGE_FLAG_ARRAY_POINTER_EXT                                = 0x8093
 	EDGE_FLAG_ARRAY_STRIDE                                     = 0x808C
 	EDGE_FLAG_ARRAY_STRIDE_EXT                                 = 0x808C
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
 	EIGHTH_BIT_ATI                                             = 0x00000020
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
 	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_APPLE                                        = 0x8A0C
 	ELEMENT_ARRAY_ATI                                          = 0x8768
@@ -12393,6 +13037,7 @@ const (
 	EVAL_VERTEX_ATTRIB9_NV                                     = 0x86CF
 	EXCLUSION_KHR                                              = 0x92A0
 	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXP                                                        = 0x0800
 	EXP2                                                       = 0x0801
 	EXPAND_NEGATE_NV                                           = 0x8539
@@ -12426,6 +13071,7 @@ const (
 	FIELD_UPPER_NV                                             = 0x9022
 	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
 	FILTER4_SGIS                                               = 0x8146
 	FIRST_TO_REST_NV                                           = 0x90AF
@@ -12437,6 +13083,15 @@ const (
 	FIXED_ONLY_ARB                                             = 0x891D
 	FLAT                                                       = 0x1D00
 	FLOAT                                                      = 0x1406
+	FLOAT16_MAT2_AMD                                           = 0x91C5
+	FLOAT16_MAT2x3_AMD                                         = 0x91C8
+	FLOAT16_MAT2x4_AMD                                         = 0x91C9
+	FLOAT16_MAT3_AMD                                           = 0x91C6
+	FLOAT16_MAT3x2_AMD                                         = 0x91CA
+	FLOAT16_MAT3x4_AMD                                         = 0x91CB
+	FLOAT16_MAT4_AMD                                           = 0x91C7
+	FLOAT16_MAT4x2_AMD                                         = 0x91CC
+	FLOAT16_MAT4x3_AMD                                         = 0x91CD
 	FLOAT16_NV                                                 = 0x8FF8
 	FLOAT16_VEC2_NV                                            = 0x8FF9
 	FLOAT16_VEC3_NV                                            = 0x8FFA
@@ -12542,6 +13197,8 @@ const (
 	FRAGMENT_COLOR_MATERIAL_FACE_SGIX                          = 0x8402
 	FRAGMENT_COLOR_MATERIAL_PARAMETER_SGIX                     = 0x8403
 	FRAGMENT_COLOR_MATERIAL_SGIX                               = 0x8401
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
 	FRAGMENT_DEPTH                                             = 0x8452
 	FRAGMENT_DEPTH_EXT                                         = 0x8452
 	FRAGMENT_INPUT_NV                                          = 0x936D
@@ -12573,6 +13230,7 @@ const (
 	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
 	FRAGMENT_SHADER_DERIVATIVE_HINT_ARB                        = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -12594,12 +13252,14 @@ const (
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_3D_ZOFFSET_EXT              = 0x8CD4
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE_EXT           = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER_EXT                   = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL_EXT                   = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BARRIER_BIT_EXT                                = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
@@ -12631,8 +13291,13 @@ const (
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_EXT                     = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER_EXT                     = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_SRGB_CAPABLE_EXT                               = 0x8DBA
 	FRAMEBUFFER_SRGB_EXT                                       = 0x8DB9
@@ -12645,6 +13310,7 @@ const (
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_RANGE_EXT                                             = 0x87E1
@@ -12724,6 +13390,14 @@ const (
 	HALF_FLOAT                                                 = 0x140B
 	HALF_FLOAT_ARB                                             = 0x140B
 	HALF_FLOAT_NV                                              = 0x140B
+	HANDLE_TYPE_D3D11_IMAGE_EXT                                = 0x958B
+	HANDLE_TYPE_D3D11_IMAGE_KMT_EXT                            = 0x958C
+	HANDLE_TYPE_D3D12_FENCE_EXT                                = 0x9594
+	HANDLE_TYPE_D3D12_RESOURCE_EXT                             = 0x958A
+	HANDLE_TYPE_D3D12_TILEPOOL_EXT                             = 0x9589
+	HANDLE_TYPE_OPAQUE_FD_EXT                                  = 0x9586
+	HANDLE_TYPE_OPAQUE_WIN32_EXT                               = 0x9587
+	HANDLE_TYPE_OPAQUE_WIN32_KMT_EXT                           = 0x9588
 	HARDLIGHT_KHR                                              = 0x929B
 	HARDLIGHT_NV                                               = 0x929B
 	HARDMIX_NV                                                 = 0x92A9
@@ -12831,6 +13505,7 @@ const (
 	IMPLEMENTATION_COLOR_READ_FORMAT_OES                       = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
 	IMPLEMENTATION_COLOR_READ_TYPE_OES                         = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
 	INCR_WRAP_EXT                                              = 0x8507
@@ -12875,9 +13550,13 @@ const (
 	INT16_VEC2_NV                                              = 0x8FE5
 	INT16_VEC3_NV                                              = 0x8FE6
 	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
 	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
 	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
 	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
 	INT64_VEC4_NV                                              = 0x8FEB
 	INT8_NV                                                    = 0x8FE0
 	INT8_VEC2_NV                                               = 0x8FE1
@@ -13016,13 +13695,23 @@ const (
 	LAST_VIDEO_CAPTURE_STATUS_NV                               = 0x9027
 	LAYER_NV                                                   = 0x8DAA
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
+	LAYOUT_COLOR_ATTACHMENT_EXT                                = 0x958E
 	LAYOUT_DEFAULT_INTEL                                       = 0
+	LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT              = 0x9531
+	LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT              = 0x9530
+	LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT                        = 0x958F
+	LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT                         = 0x9590
+	LAYOUT_GENERAL_EXT                                         = 0x958D
 	LAYOUT_LINEAR_CPU_CACHED_INTEL                             = 2
 	LAYOUT_LINEAR_INTEL                                        = 1
+	LAYOUT_SHADER_READ_ONLY_EXT                                = 0x9591
+	LAYOUT_TRANSFER_DST_EXT                                    = 0x9593
+	LAYOUT_TRANSFER_SRC_EXT                                    = 0x9592
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LERP_ATI                                                   = 0x8969
 	LESS                                                       = 0x0201
+	LGPU_SEPARATE_STORAGE_BIT_NVX                              = 0x0800
 	LIGHT0                                                     = 0x4000
 	LIGHT1                                                     = 0x4001
 	LIGHT2                                                     = 0x4002
@@ -13058,6 +13747,7 @@ const (
 	LINEAR_SHARPEN_ALPHA_SGIS                                  = 0x80AE
 	LINEAR_SHARPEN_COLOR_SGIS                                  = 0x80AF
 	LINEAR_SHARPEN_SGIS                                        = 0x80AD
+	LINEAR_TILING_EXT                                          = 0x9585
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
 	LINES_ADJACENCY_ARB                                        = 0x000A
@@ -13077,6 +13767,7 @@ const (
 	LINE_TOKEN                                                 = 0x0702
 	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -13103,6 +13794,7 @@ const (
 	LOW_INT                                                    = 0x8DF3
 	LO_BIAS_NV                                                 = 0x8715
 	LO_SCALE_NV                                                = 0x870F
+	LUID_SIZE_EXT                                              = 8
 	LUMINANCE                                                  = 0x1909
 	LUMINANCE12                                                = 0x8041
 	LUMINANCE12_ALPHA12                                        = 0x8047
@@ -13436,6 +14128,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_LGPU_GPUS_NVX                                          = 0x92BA
 	MAX_LIGHTS                                                 = 0x0D31
 	MAX_LIST_NESTING                                           = 0x0B31
 	MAX_MAP_TESSELLATION_NV                                    = 0x86D6
@@ -13500,6 +14193,7 @@ const (
 	MAX_PROGRAM_TEX_INSTRUCTIONS_ARB                           = 0x880C
 	MAX_PROGRAM_TOTAL_OUTPUT_COMPONENTS_NV                     = 0x8C28
 	MAX_PROJECTION_STACK_DEPTH                                 = 0x0D38
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RATIONAL_EVAL_ORDER_NV                                 = 0x86D7
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RECTANGLE_TEXTURE_SIZE_ARB                             = 0x84F8
@@ -13512,6 +14206,8 @@ const (
 	MAX_SAMPLE_MASK_WORDS_NV                                   = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
 	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SHININESS_NV                                           = 0x8504
@@ -13522,6 +14218,7 @@ const (
 	MAX_SPARSE_TEXTURE_SIZE_AMD                                = 0x9198
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
 	MAX_SPOT_EXPONENT_NV                                       = 0x8505
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -13556,6 +14253,7 @@ const (
 	MAX_TEXTURE_IMAGE_UNITS_NV                                 = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
 	MAX_TEXTURE_LOD_BIAS_EXT                                   = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_MAX_ANISOTROPY_EXT                             = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TEXTURE_STACK_DEPTH                                    = 0x0D39
@@ -13611,7 +14309,9 @@ const (
 	MAX_VERTEX_VARYING_COMPONENTS_EXT                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
@@ -13638,7 +14338,6 @@ const (
 	MIN_SAMPLE_SHADING_VALUE                                   = 0x8C37
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
 	MIN_SPARSE_LEVEL_AMD                                       = 0x919B
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
 	MIRRORED_REPEAT_ARB                                        = 0x8370
@@ -13651,6 +14350,8 @@ const (
 	MIRROR_CLAMP_TO_EDGE_EXT                                   = 0x8743
 	MITER_REVERT_NV                                            = 0x90A7
 	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
 	MODELVIEW                                                  = 0x1700
 	MODELVIEW0_ARB                                             = 0x1700
 	MODELVIEW0_EXT                                             = 0x1700
@@ -13702,9 +14403,12 @@ const (
 	MOVE_TO_RESETS_NV                                          = 0x90B5
 	MOV_ATI                                                    = 0x8961
 	MULT                                                       = 0x0103
+	MULTICAST_GPUS_NV                                          = 0x92BA
+	MULTICAST_PROGRAMMABLE_SAMPLE_LOCATION_NV                  = 0x9549
 	MULTIPLY_KHR                                               = 0x9294
 	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
 	MULTISAMPLE_3DFX                                           = 0x86B2
 	MULTISAMPLE_ARB                                            = 0x809D
 	MULTISAMPLE_BIT                                            = 0x20000000
@@ -13714,6 +14418,9 @@ const (
 	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
 	MULTISAMPLE_EXT                                            = 0x809D
 	MULTISAMPLE_FILTER_HINT_NV                                 = 0x8534
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	MULTISAMPLE_SGIS                                           = 0x809D
 	MUL_ATI                                                    = 0x8964
 	MVP_MATRIX_EXT                                             = 0x87E3
@@ -13744,6 +14451,7 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
 	NORMALIZE                                                  = 0x0BA1
 	NORMALIZED_RANGE_EXT                                       = 0x87E0
@@ -13777,6 +14485,7 @@ const (
 	NUM_COMPATIBLE_SUBROUTINES                                 = 0x8E4A
 	NUM_COMPRESSED_TEXTURE_FORMATS                             = 0x86A2
 	NUM_COMPRESSED_TEXTURE_FORMATS_ARB                         = 0x86A2
+	NUM_DEVICE_UUIDS_EXT                                       = 0x9596
 	NUM_EXTENSIONS                                             = 0x821D
 	NUM_FILL_STREAMS_NV                                        = 0x8E29
 	NUM_FRAGMENT_CONSTANTS_ATI                                 = 0x896F
@@ -13790,8 +14499,12 @@ const (
 	NUM_PROGRAM_BINARY_FORMATS                                 = 0x87FE
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
+	NUM_TILING_TYPES_EXT                                       = 0x9582
 	NUM_VIDEO_CAPTURE_STREAMS_NV                               = 0x9024
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_ACTIVE_ATTRIBUTES_ARB                               = 0x8B89
 	OBJECT_ACTIVE_ATTRIBUTE_MAX_LENGTH_ARB                     = 0x8B8A
 	OBJECT_ACTIVE_UNIFORMS_ARB                                 = 0x8B86
@@ -13868,6 +14581,7 @@ const (
 	OPERAND2_RGB_EXT                                           = 0x8592
 	OPERAND3_ALPHA_NV                                          = 0x859B
 	OPERAND3_RGB_NV                                            = 0x8593
+	OPTIMAL_TILING_EXT                                         = 0x9584
 	OP_ADD_EXT                                                 = 0x8787
 	OP_CLAMP_EXT                                               = 0x878E
 	OP_CROSS_PRODUCT_EXT                                       = 0x8797
@@ -13947,7 +14661,7 @@ const (
 	PACK_INVERT_MESA                                           = 0x8758
 	PACK_LSB_FIRST                                             = 0x0D01
 	PACK_RESAMPLE_OML                                          = 0x8984
-	PACK_RESAMPLE_SGIX                                         = 0x842C
+	PACK_RESAMPLE_SGIX                                         = 0x842E
 	PACK_ROW_BYTES_APPLE                                       = 0x8A15
 	PACK_ROW_LENGTH                                            = 0x0D02
 	PACK_SKIP_IMAGES                                           = 0x806B
@@ -14052,10 +14766,14 @@ const (
 	PERFQUERY_WAIT_INTEL                                       = 0x83FB
 	PERSPECTIVE_CORRECTION_HINT                                = 0x0C50
 	PERTURB_EXT                                                = 0x85AE
+	PER_GPU_STORAGE_BIT_NV                                     = 0x0800
+	PER_GPU_STORAGE_NV                                         = 0x9548
 	PER_STAGE_CONSTANTS_NV                                     = 0x8535
 	PHONG_HINT_WIN                                             = 0x80EB
 	PHONG_WIN                                                  = 0x80EA
 	PINLIGHT_NV                                                = 0x92A8
+	PIXELS_PER_SAMPLE_PATTERN_X_AMD                            = 0x91AE
+	PIXELS_PER_SAMPLE_PATTERN_Y_AMD                            = 0x91AF
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_BUFFER_BARRIER_BIT_EXT                               = 0x00000080
 	PIXEL_COUNTER_BITS_NV                                      = 0x8864
@@ -14161,6 +14879,9 @@ const (
 	POLYGON_BIT                                                = 0x00000008
 	POLYGON_MODE                                               = 0x0B40
 	POLYGON_OFFSET_BIAS_EXT                                    = 0x8039
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_EXT                                         = 0x8037
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FACTOR_EXT                                  = 0x8038
@@ -14231,6 +14952,7 @@ const (
 	PRIMITIVES_GENERATED_EXT                                   = 0x8C87
 	PRIMITIVES_GENERATED_NV                                    = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_ID_NV                                            = 0x8C7C
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
@@ -14238,11 +14960,16 @@ const (
 	PRIMITIVE_RESTART_INDEX_NV                                 = 0x8559
 	PRIMITIVE_RESTART_NV                                       = 0x8558
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_ADDRESS_REGISTERS_ARB                              = 0x88B0
 	PROGRAM_ALU_INSTRUCTIONS_ARB                               = 0x8805
 	PROGRAM_ATTRIBS_ARB                                        = 0x88AC
 	PROGRAM_ATTRIB_COMPONENTS_NV                               = 0x8906
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
+	PROGRAM_BINARY_FORMAT_MESA                                 = 0x875F
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_BINDING_ARB                                        = 0x8677
@@ -14275,6 +15002,7 @@ const (
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
 	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
 	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
 	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
@@ -14293,6 +15021,7 @@ const (
 	PROJECTION                                                 = 0x1701
 	PROJECTION_MATRIX                                          = 0x0BA7
 	PROJECTION_STACK_DEPTH                                     = 0x0BA4
+	PROTECTED_MEMORY_OBJECT_EXT                                = 0x959B
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROVOKING_VERTEX_EXT                                       = 0x8E4F
 	PROXY_COLOR_TABLE                                          = 0x80D3
@@ -14329,6 +15058,7 @@ const (
 	PROXY_TEXTURE_RECTANGLE_ARB                                = 0x84F7
 	PROXY_TEXTURE_RECTANGLE_NV                                 = 0x84F7
 	PURGEABLE_APPLE                                            = 0x8A1D
+	PURGED_CONTEXT_RESET_NV                                    = 0x92BB
 	Q                                                          = 0x2003
 	QUADRATIC_ATTENUATION                                      = 0x1209
 	QUADRATIC_CURVE_TO_NV                                      = 0x0A
@@ -14369,6 +15099,12 @@ const (
 	QUERY_NO_WAIT_NV                                           = 0x8E14
 	QUERY_OBJECT_AMD                                           = 0x9153
 	QUERY_OBJECT_EXT                                           = 0x9153
+	QUERY_RESOURCE_BUFFEROBJECT_NV                             = 0x9547
+	QUERY_RESOURCE_MEMTYPE_VIDMEM_NV                           = 0x9542
+	QUERY_RESOURCE_RENDERBUFFER_NV                             = 0x9546
+	QUERY_RESOURCE_SYS_RESERVED_NV                             = 0x9544
+	QUERY_RESOURCE_TEXTURE_NV                                  = 0x9545
+	QUERY_RESOURCE_TYPE_VIDMEM_ALLOC_NV                        = 0x9540
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_ARB                                           = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
@@ -14407,7 +15143,10 @@ const (
 	RASTERIZER_DISCARD                                         = 0x8C89
 	RASTERIZER_DISCARD_EXT                                     = 0x8C89
 	RASTERIZER_DISCARD_NV                                      = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
 	RASTER_POSITION_UNCLIPPED_IBM                              = 0x19262
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -14532,6 +15271,7 @@ const (
 	RENDERBUFFER_WIDTH                                         = 0x8D42
 	RENDERBUFFER_WIDTH_EXT                                     = 0x8D42
 	RENDERER                                                   = 0x1F01
+	RENDER_GPU_MASK_NV                                         = 0x9558
 	RENDER_MODE                                                = 0x0C40
 	REPEAT                                                     = 0x2901
 	REPLACE                                                    = 0x1E01
@@ -14550,9 +15290,9 @@ const (
 	RESAMPLE_DECIMATE_OML                                      = 0x8989
 	RESAMPLE_DECIMATE_SGIX                                     = 0x8430
 	RESAMPLE_REPLICATE_OML                                     = 0x8986
-	RESAMPLE_REPLICATE_SGIX                                    = 0x842E
+	RESAMPLE_REPLICATE_SGIX                                    = 0x8433
 	RESAMPLE_ZERO_FILL_OML                                     = 0x8987
-	RESAMPLE_ZERO_FILL_SGIX                                    = 0x842F
+	RESAMPLE_ZERO_FILL_SGIX                                    = 0x8434
 	RESCALE_NORMAL                                             = 0x803A
 	RESCALE_NORMAL_EXT                                         = 0x803A
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
@@ -14750,6 +15490,14 @@ const (
 	SAMPLE_COVERAGE_INVERT_ARB                                 = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
 	SAMPLE_COVERAGE_VALUE_ARB                                  = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_EXT                                            = 0x80A0
 	SAMPLE_MASK_INVERT_EXT                                     = 0x80AB
@@ -14776,6 +15524,7 @@ const (
 	SCALE_BY_TWO_NV                                            = 0x853E
 	SCISSOR_BIT                                                = 0x00080000
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
 	SCREEN_COORDINATES_REND                                    = 0x8490
 	SCREEN_KHR                                                 = 0x9295
@@ -14812,6 +15561,7 @@ const (
 	SET_AMD                                                    = 0x874A
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
 	SHADER_CONSISTENT_NV                                       = 0x86DD
 	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
@@ -14839,6 +15589,7 @@ const (
 	SHADING_LANGUAGE_VERSION_ARB                               = 0x8B8C
 	SHADOW_AMBIENT_SGIX                                        = 0x80BF
 	SHADOW_ATTENUATION_EXT                                     = 0x834E
+	SHARED_EDGE_NV                                             = 0xC0
 	SHARED_TEXTURE_PALETTE_EXT                                 = 0x81FB
 	SHARPEN_TEXTURE_FUNC_POINTS_SGIS                           = 0x80B0
 	SHININESS                                                  = 0x1601
@@ -14925,6 +15676,8 @@ const (
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
 	SPECULAR                                                   = 0x1202
 	SPHERE_MAP                                                 = 0x2402
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
 	SPOT_CUTOFF                                                = 0x1206
 	SPOT_DIRECTION                                             = 0x1204
 	SPOT_EXPONENT                                              = 0x1205
@@ -15011,7 +15764,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TAG_BITS_EXT                                       = 0x88F2
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_TEST_TWO_SIDE_EXT                                  = 0x8910
@@ -15033,11 +15788,15 @@ const (
 	STRICT_LIGHTING_HINT_PGI                                   = 0x1A217
 	STRICT_SCISSOR_HINT_PGI                                    = 0x1A218
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
 	SUBSAMPLE_DISTANCE_AMD                                     = 0x883F
 	SUBTRACT                                                   = 0x84E7
 	SUBTRACT_ARB                                               = 0x84E7
 	SUB_ATI                                                    = 0x8965
 	SUCCESS_NV                                                 = 0x902F
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SURFACE_MAPPED_NV                                          = 0x8700
 	SURFACE_REGISTERED_NV                                      = 0x86FD
 	SURFACE_STATE_NV                                           = 0x86EB
@@ -15075,6 +15834,7 @@ const (
 	TANGENT_ARRAY_POINTER_EXT                                  = 0x8442
 	TANGENT_ARRAY_STRIDE_EXT                                   = 0x843F
 	TANGENT_ARRAY_TYPE_EXT                                     = 0x843E
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESSELLATION_FACTOR_AMD                                    = 0x9005
 	TESSELLATION_MODE_AMD                                      = 0x9004
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
@@ -15194,7 +15954,6 @@ const (
 	TEXTURE_APPLICATION_MODE_EXT                               = 0x834F
 	TEXTURE_BASE_LEVEL                                         = 0x813C
 	TEXTURE_BASE_LEVEL_SGIS                                    = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_1D_ARRAY_EXT                               = 0x8C1C
@@ -15370,6 +16129,7 @@ const (
 	TEXTURE_MATERIAL_FACE_EXT                                  = 0x8351
 	TEXTURE_MATERIAL_PARAMETER_EXT                             = 0x8352
 	TEXTURE_MATRIX                                             = 0x0BA8
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_ANISOTROPY_EXT                                 = 0x84FE
 	TEXTURE_MAX_CLAMP_R_SGIX                                   = 0x836B
 	TEXTURE_MAX_CLAMP_S_SGIX                                   = 0x8369
@@ -15393,6 +16153,8 @@ const (
 	TEXTURE_RECTANGLE                                          = 0x84F5
 	TEXTURE_RECTANGLE_ARB                                      = 0x84F5
 	TEXTURE_RECTANGLE_NV                                       = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_SIZE_EXT                                       = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
@@ -15424,6 +16186,7 @@ const (
 	TEXTURE_SWIZZLE_RGBA_EXT                                   = 0x8E46
 	TEXTURE_SWIZZLE_R_EXT                                      = 0x8E42
 	TEXTURE_TARGET                                             = 0x1006
+	TEXTURE_TILING_EXT                                         = 0x9580
 	TEXTURE_TOO_LARGE_EXT                                      = 0x8065
 	TEXTURE_UNSIGNED_REMAP_MODE_NV                             = 0x888F
 	TEXTURE_UPDATE_BARRIER_BIT                                 = 0x00000100
@@ -15440,6 +16203,10 @@ const (
 	TEXTURE_WRAP_S                                             = 0x2802
 	TEXTURE_WRAP_T                                             = 0x2803
 	TEXT_FRAGMENT_SHADER_ATI                                   = 0x8200
+	TILE_RASTER_ORDER_FIXED_MESA                               = 0x8BB8
+	TILE_RASTER_ORDER_INCREASING_X_MESA                        = 0x8BB9
+	TILE_RASTER_ORDER_INCREASING_Y_MESA                        = 0x8BBA
+	TILING_TYPES_EXT                                           = 0x9583
 	TIMEOUT_EXPIRED                                            = 0x911B
 	TIMEOUT_IGNORED                                            = 0xFFFFFFFFFFFFFFFF
 	TIMESTAMP                                                  = 0x8E28
@@ -15451,7 +16218,6 @@ const (
 	TRACK_MATRIX_TRANSFORM_NV                                  = 0x8649
 	TRANSFORM_BIT                                              = 0x00001000
 	TRANSFORM_FEEDBACK                                         = 0x8E22
-	TRANSFORM_FEEDBACK_ACTIVE                                  = 0x8E24
 	TRANSFORM_FEEDBACK_ATTRIBS_NV                              = 0x8C7E
 	TRANSFORM_FEEDBACK_BARRIER_BIT                             = 0x00000800
 	TRANSFORM_FEEDBACK_BARRIER_BIT_EXT                         = 0x00000800
@@ -15480,7 +16246,6 @@ const (
 	TRANSFORM_FEEDBACK_BUFFER_STRIDE                           = 0x934C
 	TRANSFORM_FEEDBACK_NV                                      = 0x8E22
 	TRANSFORM_FEEDBACK_OVERFLOW_ARB                            = 0x82EC
-	TRANSFORM_FEEDBACK_PAUSED                                  = 0x8E23
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN                      = 0x8C88
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN_EXT                  = 0x8C88
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN_NV                   = 0x8C88
@@ -15528,6 +16293,7 @@ const (
 	UNDEFINED_APPLE                                            = 0x8A1C
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -15546,12 +16312,15 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
 	UNIFORM_BUFFER_BINDING_EXT                                 = 0x8DEF
 	UNIFORM_BUFFER_EXT                                         = 0x8DEE
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -15574,7 +16343,7 @@ const (
 	UNPACK_IMAGE_HEIGHT_EXT                                    = 0x806E
 	UNPACK_LSB_FIRST                                           = 0x0CF1
 	UNPACK_RESAMPLE_OML                                        = 0x8985
-	UNPACK_RESAMPLE_SGIX                                       = 0x842D
+	UNPACK_RESAMPLE_SGIX                                       = 0x842F
 	UNPACK_ROW_BYTES_APPLE                                     = 0x8A16
 	UNPACK_ROW_LENGTH                                          = 0x0CF2
 	UNPACK_SKIP_IMAGES                                         = 0x806D
@@ -15598,8 +16367,11 @@ const (
 	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
 	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
 	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
 	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
 	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
 	UNSIGNED_INT8_NV                                           = 0x8FEC
 	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
@@ -15691,6 +16463,7 @@ const (
 	USE_MISSING_GLYPH_NV                                       = 0x90AA
 	UTF16_NV                                                   = 0x909B
 	UTF8_NV                                                    = 0x909A
+	UUID_SIZE_EXT                                              = 16
 	V2F                                                        = 0x2A20
 	V3F                                                        = 0x2A21
 	VALIDATE_STATUS                                            = 0x8B83
@@ -15872,8 +16645,24 @@ const (
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BIT                                               = 0x00000800
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -15903,6 +16692,8 @@ const (
 	WAIT_FAILED                                                = 0x911D
 	WARPS_PER_SM_NV                                            = 0x933A
 	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
 	WEIGHT_ARRAY_ARB                                           = 0x86AD
 	WEIGHT_ARRAY_BUFFER_BINDING                                = 0x889E
 	WEIGHT_ARRAY_BUFFER_BINDING_ARB                            = 0x889E
@@ -15912,6 +16703,8 @@ const (
 	WEIGHT_ARRAY_TYPE_ARB                                      = 0x86A9
 	WEIGHT_SUM_UNITY_ARB                                       = 0x86A6
 	WIDE_LINE_HINT_PGI                                         = 0x1A222
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRAP_BORDER_SUN                                            = 0x81D4
 	WRITE_DISCARD_NV                                           = 0x88BE
 	WRITE_ONLY                                                 = 0x88B9
@@ -15948,6 +16741,7 @@ const (
 var (
 	gpAccum                                                  C.GPACCUM
 	gpAccumxOES                                              C.GPACCUMXOES
+	gpAcquireKeyedMutexWin32EXT                              C.GPACQUIREKEYEDMUTEXWIN32EXT
 	gpActiveProgramEXT                                       C.GPACTIVEPROGRAMEXT
 	gpActiveShaderProgram                                    C.GPACTIVESHADERPROGRAM
 	gpActiveShaderProgramEXT                                 C.GPACTIVESHADERPROGRAMEXT
@@ -15960,6 +16754,8 @@ var (
 	gpAlphaFragmentOp3ATI                                    C.GPALPHAFRAGMENTOP3ATI
 	gpAlphaFunc                                              C.GPALPHAFUNC
 	gpAlphaFuncxOES                                          C.GPALPHAFUNCXOES
+	gpAlphaToCoverageDitherControlNV                         C.GPALPHATOCOVERAGEDITHERCONTROLNV
+	gpApplyFramebufferAttachmentCMAAINTEL                    C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
 	gpApplyTextureEXT                                        C.GPAPPLYTEXTUREEXT
 	gpAreProgramsResidentNV                                  C.GPAREPROGRAMSRESIDENTNV
 	gpAreTexturesResident                                    C.GPARETEXTURESRESIDENT
@@ -16084,8 +16880,11 @@ var (
 	gpBufferPageCommitmentARB                                C.GPBUFFERPAGECOMMITMENTARB
 	gpBufferParameteriAPPLE                                  C.GPBUFFERPARAMETERIAPPLE
 	gpBufferStorage                                          C.GPBUFFERSTORAGE
+	gpBufferStorageExternalEXT                               C.GPBUFFERSTORAGEEXTERNALEXT
+	gpBufferStorageMemEXT                                    C.GPBUFFERSTORAGEMEMEXT
 	gpBufferSubData                                          C.GPBUFFERSUBDATA
 	gpBufferSubDataARB                                       C.GPBUFFERSUBDATAARB
+	gpCallCommandListNV                                      C.GPCALLCOMMANDLISTNV
 	gpCallList                                               C.GPCALLLIST
 	gpCallLists                                              C.GPCALLLISTS
 	gpCheckFramebufferStatus                                 C.GPCHECKFRAMEBUFFERSTATUS
@@ -16213,6 +17012,8 @@ var (
 	gpCombinerParameteriNV                                   C.GPCOMBINERPARAMETERINV
 	gpCombinerParameterivNV                                  C.GPCOMBINERPARAMETERIVNV
 	gpCombinerStageParameterfvNV                             C.GPCOMBINERSTAGEPARAMETERFVNV
+	gpCommandListSegmentsNV                                  C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                                   C.GPCOMPILECOMMANDLISTNV
 	gpCompileShader                                          C.GPCOMPILESHADER
 	gpCompileShaderARB                                       C.GPCOMPILESHADERARB
 	gpCompileShaderIncludeARB                                C.GPCOMPILESHADERINCLUDEARB
@@ -16243,6 +17044,8 @@ var (
 	gpCompressedTextureSubImage2DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
 	gpCompressedTextureSubImage3D                            C.GPCOMPRESSEDTEXTURESUBIMAGE3D
 	gpCompressedTextureSubImage3DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                         C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                         C.GPCONSERVATIVERASTERPARAMETERINV
 	gpConvolutionFilter1D                                    C.GPCONVOLUTIONFILTER1D
 	gpConvolutionFilter1DEXT                                 C.GPCONVOLUTIONFILTER1DEXT
 	gpConvolutionFilter2D                                    C.GPCONVOLUTIONFILTER2D
@@ -16298,8 +17101,12 @@ var (
 	gpCoverFillPathNV                                        C.GPCOVERFILLPATHNV
 	gpCoverStrokePathInstancedNV                             C.GPCOVERSTROKEPATHINSTANCEDNV
 	gpCoverStrokePathNV                                      C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                                   C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                              C.GPCOVERAGEMODULATIONTABLENV
 	gpCreateBuffers                                          C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                                   C.GPCREATECOMMANDLISTSNV
 	gpCreateFramebuffers                                     C.GPCREATEFRAMEBUFFERS
+	gpCreateMemoryObjectsEXT                                 C.GPCREATEMEMORYOBJECTSEXT
 	gpCreatePerfQueryINTEL                                   C.GPCREATEPERFQUERYINTEL
 	gpCreateProgram                                          C.GPCREATEPROGRAM
 	gpCreateProgramObjectARB                                 C.GPCREATEPROGRAMOBJECTARB
@@ -16312,6 +17119,7 @@ var (
 	gpCreateShaderProgramEXT                                 C.GPCREATESHADERPROGRAMEXT
 	gpCreateShaderProgramv                                   C.GPCREATESHADERPROGRAMV
 	gpCreateShaderProgramvEXT                                C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                         C.GPCREATESTATESNV
 	gpCreateSyncFromCLeventARB                               C.GPCREATESYNCFROMCLEVENTARB
 	gpCreateTextures                                         C.GPCREATETEXTURES
 	gpCreateTransformFeedbacks                               C.GPCREATETRANSFORMFEEDBACKS
@@ -16338,12 +17146,14 @@ var (
 	gpDeleteAsyncMarkersSGIX                                 C.GPDELETEASYNCMARKERSSGIX
 	gpDeleteBuffers                                          C.GPDELETEBUFFERS
 	gpDeleteBuffersARB                                       C.GPDELETEBUFFERSARB
+	gpDeleteCommandListsNV                                   C.GPDELETECOMMANDLISTSNV
 	gpDeleteFencesAPPLE                                      C.GPDELETEFENCESAPPLE
 	gpDeleteFencesNV                                         C.GPDELETEFENCESNV
 	gpDeleteFragmentShaderATI                                C.GPDELETEFRAGMENTSHADERATI
 	gpDeleteFramebuffers                                     C.GPDELETEFRAMEBUFFERS
 	gpDeleteFramebuffersEXT                                  C.GPDELETEFRAMEBUFFERSEXT
 	gpDeleteLists                                            C.GPDELETELISTS
+	gpDeleteMemoryObjectsEXT                                 C.GPDELETEMEMORYOBJECTSEXT
 	gpDeleteNamedStringARB                                   C.GPDELETENAMEDSTRINGARB
 	gpDeleteNamesAMD                                         C.GPDELETENAMESAMD
 	gpDeleteObjectARB                                        C.GPDELETEOBJECTARB
@@ -16358,10 +17168,13 @@ var (
 	gpDeleteProgramsNV                                       C.GPDELETEPROGRAMSNV
 	gpDeleteQueries                                          C.GPDELETEQUERIES
 	gpDeleteQueriesARB                                       C.GPDELETEQUERIESARB
+	gpDeleteQueryResourceTagNV                               C.GPDELETEQUERYRESOURCETAGNV
 	gpDeleteRenderbuffers                                    C.GPDELETERENDERBUFFERS
 	gpDeleteRenderbuffersEXT                                 C.GPDELETERENDERBUFFERSEXT
 	gpDeleteSamplers                                         C.GPDELETESAMPLERS
+	gpDeleteSemaphoresEXT                                    C.GPDELETESEMAPHORESEXT
 	gpDeleteShader                                           C.GPDELETESHADER
+	gpDeleteStatesNV                                         C.GPDELETESTATESNV
 	gpDeleteSync                                             C.GPDELETESYNC
 	gpDeleteTextures                                         C.GPDELETETEXTURES
 	gpDeleteTexturesEXT                                      C.GPDELETETEXTURESEXT
@@ -16411,6 +17224,10 @@ var (
 	gpDrawBuffers                                            C.GPDRAWBUFFERS
 	gpDrawBuffersARB                                         C.GPDRAWBUFFERSARB
 	gpDrawBuffersATI                                         C.GPDRAWBUFFERSATI
+	gpDrawCommandsAddressNV                                  C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                         C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                            C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                                   C.GPDRAWCOMMANDSSTATESNV
 	gpDrawElementArrayAPPLE                                  C.GPDRAWELEMENTARRAYAPPLE
 	gpDrawElementArrayATI                                    C.GPDRAWELEMENTARRAYATI
 	gpDrawElements                                           C.GPDRAWELEMENTS
@@ -16435,6 +17252,7 @@ var (
 	gpDrawTransformFeedbackNV                                C.GPDRAWTRANSFORMFEEDBACKNV
 	gpDrawTransformFeedbackStream                            C.GPDRAWTRANSFORMFEEDBACKSTREAM
 	gpDrawTransformFeedbackStreamInstanced                   C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                          C.GPDRAWVKIMAGENV
 	gpEdgeFlag                                               C.GPEDGEFLAG
 	gpEdgeFlagFormatNV                                       C.GPEDGEFLAGFORMATNV
 	gpEdgeFlagPointer                                        C.GPEDGEFLAGPOINTER
@@ -16490,6 +17308,7 @@ var (
 	gpEvalMesh2                                              C.GPEVALMESH2
 	gpEvalPoint1                                             C.GPEVALPOINT1
 	gpEvalPoint2                                             C.GPEVALPOINT2
+	gpEvaluateDepthValuesARB                                 C.GPEVALUATEDEPTHVALUESARB
 	gpExecuteProgramNV                                       C.GPEXECUTEPROGRAMNV
 	gpExtractComponentEXT                                    C.GPEXTRACTCOMPONENTEXT
 	gpFeedbackBuffer                                         C.GPFEEDBACKBUFFER
@@ -16534,6 +17353,7 @@ var (
 	gpFogxOES                                                C.GPFOGXOES
 	gpFogxvOES                                               C.GPFOGXVOES
 	gpFragmentColorMaterialSGIX                              C.GPFRAGMENTCOLORMATERIALSGIX
+	gpFragmentCoverageColorNV                                C.GPFRAGMENTCOVERAGECOLORNV
 	gpFragmentLightModelfSGIX                                C.GPFRAGMENTLIGHTMODELFSGIX
 	gpFragmentLightModelfvSGIX                               C.GPFRAGMENTLIGHTMODELFVSGIX
 	gpFragmentLightModeliSGIX                                C.GPFRAGMENTLIGHTMODELISGIX
@@ -16550,10 +17370,14 @@ var (
 	gpFrameZoomSGIX                                          C.GPFRAMEZOOMSGIX
 	gpFramebufferDrawBufferEXT                               C.GPFRAMEBUFFERDRAWBUFFEREXT
 	gpFramebufferDrawBuffersEXT                              C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                             C.GPFRAMEBUFFERFETCHBARRIEREXT
 	gpFramebufferParameteri                                  C.GPFRAMEBUFFERPARAMETERI
 	gpFramebufferReadBufferEXT                               C.GPFRAMEBUFFERREADBUFFEREXT
 	gpFramebufferRenderbuffer                                C.GPFRAMEBUFFERRENDERBUFFER
 	gpFramebufferRenderbufferEXT                             C.GPFRAMEBUFFERRENDERBUFFEREXT
+	gpFramebufferSampleLocationsfvARB                        C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                         C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferSamplePositionsfvAMD                        C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpFramebufferTexture                                     C.GPFRAMEBUFFERTEXTURE
 	gpFramebufferTexture1D                                   C.GPFRAMEBUFFERTEXTURE1D
 	gpFramebufferTexture1DEXT                                C.GPFRAMEBUFFERTEXTURE1DEXT
@@ -16568,6 +17392,7 @@ var (
 	gpFramebufferTextureLayer                                C.GPFRAMEBUFFERTEXTURELAYER
 	gpFramebufferTextureLayerARB                             C.GPFRAMEBUFFERTEXTURELAYERARB
 	gpFramebufferTextureLayerEXT                             C.GPFRAMEBUFFERTEXTURELAYEREXT
+	gpFramebufferTextureMultiviewOVR                         C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
 	gpFreeObjectBufferATI                                    C.GPFREEOBJECTBUFFERATI
 	gpFrontFace                                              C.GPFRONTFACE
 	gpFrustum                                                C.GPFRUSTUM
@@ -16592,9 +17417,11 @@ var (
 	gpGenProgramsNV                                          C.GPGENPROGRAMSNV
 	gpGenQueries                                             C.GPGENQUERIES
 	gpGenQueriesARB                                          C.GPGENQUERIESARB
+	gpGenQueryResourceTagNV                                  C.GPGENQUERYRESOURCETAGNV
 	gpGenRenderbuffers                                       C.GPGENRENDERBUFFERS
 	gpGenRenderbuffersEXT                                    C.GPGENRENDERBUFFERSEXT
 	gpGenSamplers                                            C.GPGENSAMPLERS
+	gpGenSemaphoresEXT                                       C.GPGENSEMAPHORESEXT
 	gpGenSymbolsEXT                                          C.GPGENSYMBOLSEXT
 	gpGenTextures                                            C.GPGENTEXTURES
 	gpGenTexturesEXT                                         C.GPGENTEXTURESEXT
@@ -16655,6 +17482,7 @@ var (
 	gpGetCombinerOutputParameterfvNV                         C.GPGETCOMBINEROUTPUTPARAMETERFVNV
 	gpGetCombinerOutputParameterivNV                         C.GPGETCOMBINEROUTPUTPARAMETERIVNV
 	gpGetCombinerStageParameterfvNV                          C.GPGETCOMBINERSTAGEPARAMETERFVNV
+	gpGetCommandHeaderNV                                     C.GPGETCOMMANDHEADERNV
 	gpGetCompressedMultiTexImageEXT                          C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
 	gpGetCompressedTexImage                                  C.GPGETCOMPRESSEDTEXIMAGE
 	gpGetCompressedTexImageARB                               C.GPGETCOMPRESSEDTEXIMAGEARB
@@ -16668,6 +17496,7 @@ var (
 	gpGetConvolutionParameteriv                              C.GPGETCONVOLUTIONPARAMETERIV
 	gpGetConvolutionParameterivEXT                           C.GPGETCONVOLUTIONPARAMETERIVEXT
 	gpGetConvolutionParameterxvOES                           C.GPGETCONVOLUTIONPARAMETERXVOES
+	gpGetCoverageModulationTableNV                           C.GPGETCOVERAGEMODULATIONTABLENV
 	gpGetDebugMessageLog                                     C.GPGETDEBUGMESSAGELOG
 	gpGetDebugMessageLogAMD                                  C.GPGETDEBUGMESSAGELOGAMD
 	gpGetDebugMessageLogARB                                  C.GPGETDEBUGMESSAGELOGARB
@@ -16697,6 +17526,7 @@ var (
 	gpGetFragmentMaterialivSGIX                              C.GPGETFRAGMENTMATERIALIVSGIX
 	gpGetFramebufferAttachmentParameteriv                    C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetFramebufferAttachmentParameterivEXT                 C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetFramebufferParameterfvAMD                           C.GPGETFRAMEBUFFERPARAMETERFVAMD
 	gpGetFramebufferParameteriv                              C.GPGETFRAMEBUFFERPARAMETERIV
 	gpGetFramebufferParameterivEXT                           C.GPGETFRAMEBUFFERPARAMETERIVEXT
 	gpGetGraphicsResetStatus                                 C.GPGETGRAPHICSRESETSTATUS
@@ -16723,6 +17553,7 @@ var (
 	gpGetIntegerui64i_vNV                                    C.GPGETINTEGERUI64I_VNV
 	gpGetIntegerui64vNV                                      C.GPGETINTEGERUI64VNV
 	gpGetIntegerv                                            C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                            C.GPGETINTERNALFORMATSAMPLEIVNV
 	gpGetInternalformati64v                                  C.GPGETINTERNALFORMATI64V
 	gpGetInternalformativ                                    C.GPGETINTERNALFORMATIV
 	gpGetInvariantBooleanvEXT                                C.GPGETINVARIANTBOOLEANVEXT
@@ -16750,6 +17581,7 @@ var (
 	gpGetMaterialiv                                          C.GPGETMATERIALIV
 	gpGetMaterialxOES                                        C.GPGETMATERIALXOES
 	gpGetMaterialxvOES                                       C.GPGETMATERIALXVOES
+	gpGetMemoryObjectParameterivEXT                          C.GPGETMEMORYOBJECTPARAMETERIVEXT
 	gpGetMinmax                                              C.GPGETMINMAX
 	gpGetMinmaxEXT                                           C.GPGETMINMAXEXT
 	gpGetMinmaxParameterfv                                   C.GPGETMINMAXPARAMETERFV
@@ -16780,6 +17612,7 @@ var (
 	gpGetNamedBufferSubDataEXT                               C.GPGETNAMEDBUFFERSUBDATAEXT
 	gpGetNamedFramebufferAttachmentParameteriv               C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetNamedFramebufferAttachmentParameterivEXT            C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameterfvAMD                      C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD
 	gpGetNamedFramebufferParameteriv                         C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
 	gpGetNamedFramebufferParameterivEXT                      C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
 	gpGetNamedProgramLocalParameterIivEXT                    C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
@@ -16874,6 +17707,10 @@ var (
 	gpGetProgramiv                                           C.GPGETPROGRAMIV
 	gpGetProgramivARB                                        C.GPGETPROGRAMIVARB
 	gpGetProgramivNV                                         C.GPGETPROGRAMIVNV
+	gpGetQueryBufferObjecti64v                               C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                                 C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                              C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                                C.GPGETQUERYBUFFEROBJECTUIV
 	gpGetQueryIndexediv                                      C.GPGETQUERYINDEXEDIV
 	gpGetQueryObjecti64v                                     C.GPGETQUERYOBJECTI64V
 	gpGetQueryObjecti64vEXT                                  C.GPGETQUERYOBJECTI64VEXT
@@ -16891,6 +17728,7 @@ var (
 	gpGetSamplerParameterIuiv                                C.GPGETSAMPLERPARAMETERIUIV
 	gpGetSamplerParameterfv                                  C.GPGETSAMPLERPARAMETERFV
 	gpGetSamplerParameteriv                                  C.GPGETSAMPLERPARAMETERIV
+	gpGetSemaphoreParameterui64vEXT                          C.GPGETSEMAPHOREPARAMETERUI64VEXT
 	gpGetSeparableFilter                                     C.GPGETSEPARABLEFILTER
 	gpGetSeparableFilterEXT                                  C.GPGETSEPARABLEFILTEREXT
 	gpGetShaderInfoLog                                       C.GPGETSHADERINFOLOG
@@ -16899,6 +17737,7 @@ var (
 	gpGetShaderSourceARB                                     C.GPGETSHADERSOURCEARB
 	gpGetShaderiv                                            C.GPGETSHADERIV
 	gpGetSharpenTexFuncSGIS                                  C.GPGETSHARPENTEXFUNCSGIS
+	gpGetStageIndexNV                                        C.GPGETSTAGEINDEXNV
 	gpGetString                                              C.GPGETSTRING
 	gpGetStringi                                             C.GPGETSTRINGI
 	gpGetSubroutineIndex                                     C.GPGETSUBROUTINEINDEX
@@ -16962,12 +17801,16 @@ var (
 	gpGetUniformdv                                           C.GPGETUNIFORMDV
 	gpGetUniformfv                                           C.GPGETUNIFORMFV
 	gpGetUniformfvARB                                        C.GPGETUNIFORMFVARB
+	gpGetUniformi64vARB                                      C.GPGETUNIFORMI64VARB
 	gpGetUniformi64vNV                                       C.GPGETUNIFORMI64VNV
 	gpGetUniformiv                                           C.GPGETUNIFORMIV
 	gpGetUniformivARB                                        C.GPGETUNIFORMIVARB
+	gpGetUniformui64vARB                                     C.GPGETUNIFORMUI64VARB
 	gpGetUniformui64vNV                                      C.GPGETUNIFORMUI64VNV
 	gpGetUniformuiv                                          C.GPGETUNIFORMUIV
 	gpGetUniformuivEXT                                       C.GPGETUNIFORMUIVEXT
+	gpGetUnsignedBytei_vEXT                                  C.GPGETUNSIGNEDBYTEI_VEXT
+	gpGetUnsignedBytevEXT                                    C.GPGETUNSIGNEDBYTEVEXT
 	gpGetVariantArrayObjectfvATI                             C.GPGETVARIANTARRAYOBJECTFVATI
 	gpGetVariantArrayObjectivATI                             C.GPGETVARIANTARRAYOBJECTIVATI
 	gpGetVariantBooleanvEXT                                  C.GPGETVARIANTBOOLEANVEXT
@@ -17013,6 +17856,7 @@ var (
 	gpGetVideoivNV                                           C.GPGETVIDEOIVNV
 	gpGetVideoui64vNV                                        C.GPGETVIDEOUI64VNV
 	gpGetVideouivNV                                          C.GPGETVIDEOUIVNV
+	gpGetVkProcAddrNV                                        C.GPGETVKPROCADDRNV
 	gpGetnColorTableARB                                      C.GPGETNCOLORTABLEARB
 	gpGetnCompressedTexImageARB                              C.GPGETNCOMPRESSEDTEXIMAGEARB
 	gpGetnConvolutionFilterARB                               C.GPGETNCONVOLUTIONFILTERARB
@@ -17031,9 +17875,11 @@ var (
 	gpGetnUniformfv                                          C.GPGETNUNIFORMFV
 	gpGetnUniformfvARB                                       C.GPGETNUNIFORMFVARB
 	gpGetnUniformfvKHR                                       C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                                     C.GPGETNUNIFORMI64VARB
 	gpGetnUniformiv                                          C.GPGETNUNIFORMIV
 	gpGetnUniformivARB                                       C.GPGETNUNIFORMIVARB
 	gpGetnUniformivKHR                                       C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                                    C.GPGETNUNIFORMUI64VARB
 	gpGetnUniformuiv                                         C.GPGETNUNIFORMUIV
 	gpGetnUniformuivARB                                      C.GPGETNUNIFORMUIVARB
 	gpGetnUniformuivKHR                                      C.GPGETNUNIFORMUIVKHR
@@ -17054,6 +17900,12 @@ var (
 	gpImageTransformParameterfvHP                            C.GPIMAGETRANSFORMPARAMETERFVHP
 	gpImageTransformParameteriHP                             C.GPIMAGETRANSFORMPARAMETERIHP
 	gpImageTransformParameterivHP                            C.GPIMAGETRANSFORMPARAMETERIVHP
+	gpImportMemoryFdEXT                                      C.GPIMPORTMEMORYFDEXT
+	gpImportMemoryWin32HandleEXT                             C.GPIMPORTMEMORYWIN32HANDLEEXT
+	gpImportMemoryWin32NameEXT                               C.GPIMPORTMEMORYWIN32NAMEEXT
+	gpImportSemaphoreFdEXT                                   C.GPIMPORTSEMAPHOREFDEXT
+	gpImportSemaphoreWin32HandleEXT                          C.GPIMPORTSEMAPHOREWIN32HANDLEEXT
+	gpImportSemaphoreWin32NameEXT                            C.GPIMPORTSEMAPHOREWIN32NAMEEXT
 	gpImportSyncEXT                                          C.GPIMPORTSYNCEXT
 	gpIndexFormatNV                                          C.GPINDEXFORMATNV
 	gpIndexFuncEXT                                           C.GPINDEXFUNCEXT
@@ -17092,6 +17944,7 @@ var (
 	gpIsBuffer                                               C.GPISBUFFER
 	gpIsBufferARB                                            C.GPISBUFFERARB
 	gpIsBufferResidentNV                                     C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                        C.GPISCOMMANDLISTNV
 	gpIsEnabled                                              C.GPISENABLED
 	gpIsEnabledIndexedEXT                                    C.GPISENABLEDINDEXEDEXT
 	gpIsEnabledi                                             C.GPISENABLEDI
@@ -17102,6 +17955,7 @@ var (
 	gpIsImageHandleResidentARB                               C.GPISIMAGEHANDLERESIDENTARB
 	gpIsImageHandleResidentNV                                C.GPISIMAGEHANDLERESIDENTNV
 	gpIsList                                                 C.GPISLIST
+	gpIsMemoryObjectEXT                                      C.GPISMEMORYOBJECTEXT
 	gpIsNameAMD                                              C.GPISNAMEAMD
 	gpIsNamedBufferResidentNV                                C.GPISNAMEDBUFFERRESIDENTNV
 	gpIsNamedStringARB                                       C.GPISNAMEDSTRINGARB
@@ -17120,7 +17974,9 @@ var (
 	gpIsRenderbuffer                                         C.GPISRENDERBUFFER
 	gpIsRenderbufferEXT                                      C.GPISRENDERBUFFEREXT
 	gpIsSampler                                              C.GPISSAMPLER
+	gpIsSemaphoreEXT                                         C.GPISSEMAPHOREEXT
 	gpIsShader                                               C.GPISSHADER
+	gpIsStateNV                                              C.GPISSTATENV
 	gpIsSync                                                 C.GPISSYNC
 	gpIsTexture                                              C.GPISTEXTURE
 	gpIsTextureEXT                                           C.GPISTEXTUREEXT
@@ -17132,6 +17988,9 @@ var (
 	gpIsVertexArray                                          C.GPISVERTEXARRAY
 	gpIsVertexArrayAPPLE                                     C.GPISVERTEXARRAYAPPLE
 	gpIsVertexAttribEnabledAPPLE                             C.GPISVERTEXATTRIBENABLEDAPPLE
+	gpLGPUCopyImageSubDataNVX                                C.GPLGPUCOPYIMAGESUBDATANVX
+	gpLGPUInterlockNVX                                       C.GPLGPUINTERLOCKNVX
+	gpLGPUNamedBufferSubDataNVX                              C.GPLGPUNAMEDBUFFERSUBDATANVX
 	gpLabelObjectEXT                                         C.GPLABELOBJECTEXT
 	gpLightEnviSGIX                                          C.GPLIGHTENVISGIX
 	gpLightModelf                                            C.GPLIGHTMODELF
@@ -17152,6 +18011,7 @@ var (
 	gpLinkProgram                                            C.GPLINKPROGRAM
 	gpLinkProgramARB                                         C.GPLINKPROGRAMARB
 	gpListBase                                               C.GPLISTBASE
+	gpListDrawCommandsStatesClientNV                         C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
 	gpListParameterfSGIX                                     C.GPLISTPARAMETERFSGIX
 	gpListParameterfvSGIX                                    C.GPLISTPARAMETERFVSGIX
 	gpListParameteriSGIX                                     C.GPLISTPARAMETERISGIX
@@ -17246,9 +18106,12 @@ var (
 	gpMatrixScalefEXT                                        C.GPMATRIXSCALEFEXT
 	gpMatrixTranslatedEXT                                    C.GPMATRIXTRANSLATEDEXT
 	gpMatrixTranslatefEXT                                    C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                            C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                            C.GPMAXSHADERCOMPILERTHREADSKHR
 	gpMemoryBarrier                                          C.GPMEMORYBARRIER
 	gpMemoryBarrierByRegion                                  C.GPMEMORYBARRIERBYREGION
 	gpMemoryBarrierEXT                                       C.GPMEMORYBARRIEREXT
+	gpMemoryObjectParameterivEXT                             C.GPMEMORYOBJECTPARAMETERIVEXT
 	gpMinSampleShading                                       C.GPMINSAMPLESHADING
 	gpMinSampleShadingARB                                    C.GPMINSAMPLESHADINGARB
 	gpMinmax                                                 C.GPMINMAX
@@ -17401,12 +18264,25 @@ var (
 	gpMultiTexSubImage1DEXT                                  C.GPMULTITEXSUBIMAGE1DEXT
 	gpMultiTexSubImage2DEXT                                  C.GPMULTITEXSUBIMAGE2DEXT
 	gpMultiTexSubImage3DEXT                                  C.GPMULTITEXSUBIMAGE3DEXT
+	gpMulticastBarrierNV                                     C.GPMULTICASTBARRIERNV
+	gpMulticastBlitFramebufferNV                             C.GPMULTICASTBLITFRAMEBUFFERNV
+	gpMulticastBufferSubDataNV                               C.GPMULTICASTBUFFERSUBDATANV
+	gpMulticastCopyBufferSubDataNV                           C.GPMULTICASTCOPYBUFFERSUBDATANV
+	gpMulticastCopyImageSubDataNV                            C.GPMULTICASTCOPYIMAGESUBDATANV
+	gpMulticastFramebufferSampleLocationsfvNV                C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpMulticastGetQueryObjecti64vNV                          C.GPMULTICASTGETQUERYOBJECTI64VNV
+	gpMulticastGetQueryObjectivNV                            C.GPMULTICASTGETQUERYOBJECTIVNV
+	gpMulticastGetQueryObjectui64vNV                         C.GPMULTICASTGETQUERYOBJECTUI64VNV
+	gpMulticastGetQueryObjectuivNV                           C.GPMULTICASTGETQUERYOBJECTUIVNV
+	gpMulticastWaitSyncNV                                    C.GPMULTICASTWAITSYNCNV
 	gpNamedBufferData                                        C.GPNAMEDBUFFERDATA
 	gpNamedBufferDataEXT                                     C.GPNAMEDBUFFERDATAEXT
 	gpNamedBufferPageCommitmentARB                           C.GPNAMEDBUFFERPAGECOMMITMENTARB
 	gpNamedBufferPageCommitmentEXT                           C.GPNAMEDBUFFERPAGECOMMITMENTEXT
 	gpNamedBufferStorage                                     C.GPNAMEDBUFFERSTORAGE
 	gpNamedBufferStorageEXT                                  C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferStorageExternalEXT                          C.GPNAMEDBUFFERSTORAGEEXTERNALEXT
+	gpNamedBufferStorageMemEXT                               C.GPNAMEDBUFFERSTORAGEMEMEXT
 	gpNamedBufferSubData                                     C.GPNAMEDBUFFERSUBDATA
 	gpNamedBufferSubDataEXT                                  C.GPNAMEDBUFFERSUBDATAEXT
 	gpNamedCopyBufferSubDataEXT                              C.GPNAMEDCOPYBUFFERSUBDATAEXT
@@ -17417,6 +18293,9 @@ var (
 	gpNamedFramebufferReadBuffer                             C.GPNAMEDFRAMEBUFFERREADBUFFER
 	gpNamedFramebufferRenderbuffer                           C.GPNAMEDFRAMEBUFFERRENDERBUFFER
 	gpNamedFramebufferRenderbufferEXT                        C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB                   C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV                    C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferSamplePositionsfvAMD                   C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpNamedFramebufferTexture                                C.GPNAMEDFRAMEBUFFERTEXTURE
 	gpNamedFramebufferTexture1DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
 	gpNamedFramebufferTexture2DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
@@ -17560,6 +18439,8 @@ var (
 	gpPollInstrumentsSGIX                                    C.GPPOLLINSTRUMENTSSGIX
 	gpPolygonMode                                            C.GPPOLYGONMODE
 	gpPolygonOffset                                          C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                                     C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                                  C.GPPOLYGONOFFSETCLAMPEXT
 	gpPolygonOffsetEXT                                       C.GPPOLYGONOFFSETEXT
 	gpPolygonOffsetxOES                                      C.GPPOLYGONOFFSETXOES
 	gpPolygonStipple                                         C.GPPOLYGONSTIPPLE
@@ -17572,6 +18453,7 @@ var (
 	gpPopName                                                C.GPPOPNAME
 	gpPresentFrameDualFillNV                                 C.GPPRESENTFRAMEDUALFILLNV
 	gpPresentFrameKeyedNV                                    C.GPPRESENTFRAMEKEYEDNV
+	gpPrimitiveBoundingBoxARB                                C.GPPRIMITIVEBOUNDINGBOXARB
 	gpPrimitiveRestartIndex                                  C.GPPRIMITIVERESTARTINDEX
 	gpPrimitiveRestartIndexNV                                C.GPPRIMITIVERESTARTINDEXNV
 	gpPrimitiveRestartNV                                     C.GPPRIMITIVERESTARTNV
@@ -17629,13 +18511,17 @@ var (
 	gpProgramUniform1fv                                      C.GPPROGRAMUNIFORM1FV
 	gpProgramUniform1fvEXT                                   C.GPPROGRAMUNIFORM1FVEXT
 	gpProgramUniform1i                                       C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                                  C.GPPROGRAMUNIFORM1I64ARB
 	gpProgramUniform1i64NV                                   C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                                 C.GPPROGRAMUNIFORM1I64VARB
 	gpProgramUniform1i64vNV                                  C.GPPROGRAMUNIFORM1I64VNV
 	gpProgramUniform1iEXT                                    C.GPPROGRAMUNIFORM1IEXT
 	gpProgramUniform1iv                                      C.GPPROGRAMUNIFORM1IV
 	gpProgramUniform1ivEXT                                   C.GPPROGRAMUNIFORM1IVEXT
 	gpProgramUniform1ui                                      C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                                 C.GPPROGRAMUNIFORM1UI64ARB
 	gpProgramUniform1ui64NV                                  C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                                C.GPPROGRAMUNIFORM1UI64VARB
 	gpProgramUniform1ui64vNV                                 C.GPPROGRAMUNIFORM1UI64VNV
 	gpProgramUniform1uiEXT                                   C.GPPROGRAMUNIFORM1UIEXT
 	gpProgramUniform1uiv                                     C.GPPROGRAMUNIFORM1UIV
@@ -17649,13 +18535,17 @@ var (
 	gpProgramUniform2fv                                      C.GPPROGRAMUNIFORM2FV
 	gpProgramUniform2fvEXT                                   C.GPPROGRAMUNIFORM2FVEXT
 	gpProgramUniform2i                                       C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                                  C.GPPROGRAMUNIFORM2I64ARB
 	gpProgramUniform2i64NV                                   C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                                 C.GPPROGRAMUNIFORM2I64VARB
 	gpProgramUniform2i64vNV                                  C.GPPROGRAMUNIFORM2I64VNV
 	gpProgramUniform2iEXT                                    C.GPPROGRAMUNIFORM2IEXT
 	gpProgramUniform2iv                                      C.GPPROGRAMUNIFORM2IV
 	gpProgramUniform2ivEXT                                   C.GPPROGRAMUNIFORM2IVEXT
 	gpProgramUniform2ui                                      C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                                 C.GPPROGRAMUNIFORM2UI64ARB
 	gpProgramUniform2ui64NV                                  C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                                C.GPPROGRAMUNIFORM2UI64VARB
 	gpProgramUniform2ui64vNV                                 C.GPPROGRAMUNIFORM2UI64VNV
 	gpProgramUniform2uiEXT                                   C.GPPROGRAMUNIFORM2UIEXT
 	gpProgramUniform2uiv                                     C.GPPROGRAMUNIFORM2UIV
@@ -17669,13 +18559,17 @@ var (
 	gpProgramUniform3fv                                      C.GPPROGRAMUNIFORM3FV
 	gpProgramUniform3fvEXT                                   C.GPPROGRAMUNIFORM3FVEXT
 	gpProgramUniform3i                                       C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                                  C.GPPROGRAMUNIFORM3I64ARB
 	gpProgramUniform3i64NV                                   C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                                 C.GPPROGRAMUNIFORM3I64VARB
 	gpProgramUniform3i64vNV                                  C.GPPROGRAMUNIFORM3I64VNV
 	gpProgramUniform3iEXT                                    C.GPPROGRAMUNIFORM3IEXT
 	gpProgramUniform3iv                                      C.GPPROGRAMUNIFORM3IV
 	gpProgramUniform3ivEXT                                   C.GPPROGRAMUNIFORM3IVEXT
 	gpProgramUniform3ui                                      C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                                 C.GPPROGRAMUNIFORM3UI64ARB
 	gpProgramUniform3ui64NV                                  C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                                C.GPPROGRAMUNIFORM3UI64VARB
 	gpProgramUniform3ui64vNV                                 C.GPPROGRAMUNIFORM3UI64VNV
 	gpProgramUniform3uiEXT                                   C.GPPROGRAMUNIFORM3UIEXT
 	gpProgramUniform3uiv                                     C.GPPROGRAMUNIFORM3UIV
@@ -17689,13 +18583,17 @@ var (
 	gpProgramUniform4fv                                      C.GPPROGRAMUNIFORM4FV
 	gpProgramUniform4fvEXT                                   C.GPPROGRAMUNIFORM4FVEXT
 	gpProgramUniform4i                                       C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                                  C.GPPROGRAMUNIFORM4I64ARB
 	gpProgramUniform4i64NV                                   C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                                 C.GPPROGRAMUNIFORM4I64VARB
 	gpProgramUniform4i64vNV                                  C.GPPROGRAMUNIFORM4I64VNV
 	gpProgramUniform4iEXT                                    C.GPPROGRAMUNIFORM4IEXT
 	gpProgramUniform4iv                                      C.GPPROGRAMUNIFORM4IV
 	gpProgramUniform4ivEXT                                   C.GPPROGRAMUNIFORM4IVEXT
 	gpProgramUniform4ui                                      C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                                 C.GPPROGRAMUNIFORM4UI64ARB
 	gpProgramUniform4ui64NV                                  C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                                C.GPPROGRAMUNIFORM4UI64VARB
 	gpProgramUniform4ui64vNV                                 C.GPPROGRAMUNIFORM4UI64VNV
 	gpProgramUniform4uiEXT                                   C.GPPROGRAMUNIFORM4UIEXT
 	gpProgramUniform4uiv                                     C.GPPROGRAMUNIFORM4UIV
@@ -17756,6 +18654,8 @@ var (
 	gpQueryCounter                                           C.GPQUERYCOUNTER
 	gpQueryMatrixxOES                                        C.GPQUERYMATRIXXOES
 	gpQueryObjectParameteruiAMD                              C.GPQUERYOBJECTPARAMETERUIAMD
+	gpQueryResourceNV                                        C.GPQUERYRESOURCENV
+	gpQueryResourceTagNV                                     C.GPQUERYRESOURCETAGNV
 	gpRasterPos2d                                            C.GPRASTERPOS2D
 	gpRasterPos2dv                                           C.GPRASTERPOS2DV
 	gpRasterPos2f                                            C.GPRASTERPOS2F
@@ -17786,6 +18686,7 @@ var (
 	gpRasterPos4sv                                           C.GPRASTERPOS4SV
 	gpRasterPos4xOES                                         C.GPRASTERPOS4XOES
 	gpRasterPos4xvOES                                        C.GPRASTERPOS4XVOES
+	gpRasterSamplesEXT                                       C.GPRASTERSAMPLESEXT
 	gpReadBuffer                                             C.GPREADBUFFER
 	gpReadInstrumentsSGIX                                    C.GPREADINSTRUMENTSSGIX
 	gpReadPixels                                             C.GPREADPIXELS
@@ -17803,7 +18704,9 @@ var (
 	gpRectxOES                                               C.GPRECTXOES
 	gpRectxvOES                                              C.GPRECTXVOES
 	gpReferencePlaneSGIX                                     C.GPREFERENCEPLANESGIX
+	gpReleaseKeyedMutexWin32EXT                              C.GPRELEASEKEYEDMUTEXWIN32EXT
 	gpReleaseShaderCompiler                                  C.GPRELEASESHADERCOMPILER
+	gpRenderGpuMaskNV                                        C.GPRENDERGPUMASKNV
 	gpRenderMode                                             C.GPRENDERMODE
 	gpRenderbufferStorage                                    C.GPRENDERBUFFERSTORAGE
 	gpRenderbufferStorageEXT                                 C.GPRENDERBUFFERSTORAGEEXT
@@ -17839,6 +18742,7 @@ var (
 	gpResetMinmax                                            C.GPRESETMINMAX
 	gpResetMinmaxEXT                                         C.GPRESETMINMAXEXT
 	gpResizeBuffersMESA                                      C.GPRESIZEBUFFERSMESA
+	gpResolveDepthValuesNV                                   C.GPRESOLVEDEPTHVALUESNV
 	gpResumeTransformFeedback                                C.GPRESUMETRANSFORMFEEDBACK
 	gpResumeTransformFeedbackNV                              C.GPRESUMETRANSFORMFEEDBACKNV
 	gpRotated                                                C.GPROTATED
@@ -17846,7 +18750,6 @@ var (
 	gpRotatexOES                                             C.GPROTATEXOES
 	gpSampleCoverage                                         C.GPSAMPLECOVERAGE
 	gpSampleCoverageARB                                      C.GPSAMPLECOVERAGEARB
-	gpSampleCoverageOES                                      C.GPSAMPLECOVERAGEOES
 	gpSampleCoveragexOES                                     C.GPSAMPLECOVERAGEXOES
 	gpSampleMapATI                                           C.GPSAMPLEMAPATI
 	gpSampleMaskEXT                                          C.GPSAMPLEMASKEXT
@@ -17910,6 +18813,7 @@ var (
 	gpSecondaryColorPointerListIBM                           C.GPSECONDARYCOLORPOINTERLISTIBM
 	gpSelectBuffer                                           C.GPSELECTBUFFER
 	gpSelectPerfMonitorCountersAMD                           C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpSemaphoreParameterui64vEXT                             C.GPSEMAPHOREPARAMETERUI64VEXT
 	gpSeparableFilter2D                                      C.GPSEPARABLEFILTER2D
 	gpSeparableFilter2DEXT                                   C.GPSEPARABLEFILTER2DEXT
 	gpSetFenceAPPLE                                          C.GPSETFENCEAPPLE
@@ -17927,11 +18831,16 @@ var (
 	gpShaderSourceARB                                        C.GPSHADERSOURCEARB
 	gpShaderStorageBlockBinding                              C.GPSHADERSTORAGEBLOCKBINDING
 	gpSharpenTexFuncSGIS                                     C.GPSHARPENTEXFUNCSGIS
+	gpSignalSemaphoreEXT                                     C.GPSIGNALSEMAPHOREEXT
+	gpSignalVkFenceNV                                        C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                                    C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                                    C.GPSPECIALIZESHADERARB
 	gpSpriteParameterfSGIX                                   C.GPSPRITEPARAMETERFSGIX
 	gpSpriteParameterfvSGIX                                  C.GPSPRITEPARAMETERFVSGIX
 	gpSpriteParameteriSGIX                                   C.GPSPRITEPARAMETERISGIX
 	gpSpriteParameterivSGIX                                  C.GPSPRITEPARAMETERIVSGIX
 	gpStartInstrumentsSGIX                                   C.GPSTARTINSTRUMENTSSGIX
+	gpStateCaptureNV                                         C.GPSTATECAPTURENV
 	gpStencilClearTagEXT                                     C.GPSTENCILCLEARTAGEXT
 	gpStencilFillPathInstancedNV                             C.GPSTENCILFILLPATHINSTANCEDNV
 	gpStencilFillPathNV                                      C.GPSTENCILFILLPATHNV
@@ -17952,6 +18861,7 @@ var (
 	gpStencilThenCoverStrokePathNV                           C.GPSTENCILTHENCOVERSTROKEPATHNV
 	gpStopInstrumentsSGIX                                    C.GPSTOPINSTRUMENTSSGIX
 	gpStringMarkerGREMEDY                                    C.GPSTRINGMARKERGREMEDY
+	gpSubpixelPrecisionBiasNV                                C.GPSUBPIXELPRECISIONBIASNV
 	gpSwizzleEXT                                             C.GPSWIZZLEEXT
 	gpSyncTextureINTEL                                       C.GPSYNCTEXTUREINTEL
 	gpTagSampleBufferSGIX                                    C.GPTAGSAMPLEBUFFERSGIX
@@ -18102,6 +19012,11 @@ var (
 	gpTexStorage2DMultisample                                C.GPTEXSTORAGE2DMULTISAMPLE
 	gpTexStorage3D                                           C.GPTEXSTORAGE3D
 	gpTexStorage3DMultisample                                C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexStorageMem1DEXT                                     C.GPTEXSTORAGEMEM1DEXT
+	gpTexStorageMem2DEXT                                     C.GPTEXSTORAGEMEM2DEXT
+	gpTexStorageMem2DMultisampleEXT                          C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT
+	gpTexStorageMem3DEXT                                     C.GPTEXSTORAGEMEM3DEXT
+	gpTexStorageMem3DMultisampleEXT                          C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT
 	gpTexStorageSparseAMD                                    C.GPTEXSTORAGESPARSEAMD
 	gpTexSubImage1D                                          C.GPTEXSUBIMAGE1D
 	gpTexSubImage1DEXT                                       C.GPTEXSUBIMAGE1DEXT
@@ -18152,6 +19067,11 @@ var (
 	gpTextureStorage3DEXT                                    C.GPTEXTURESTORAGE3DEXT
 	gpTextureStorage3DMultisample                            C.GPTEXTURESTORAGE3DMULTISAMPLE
 	gpTextureStorage3DMultisampleEXT                         C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureStorageMem1DEXT                                 C.GPTEXTURESTORAGEMEM1DEXT
+	gpTextureStorageMem2DEXT                                 C.GPTEXTURESTORAGEMEM2DEXT
+	gpTextureStorageMem2DMultisampleEXT                      C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT
+	gpTextureStorageMem3DEXT                                 C.GPTEXTURESTORAGEMEM3DEXT
+	gpTextureStorageMem3DMultisampleEXT                      C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT
 	gpTextureStorageSparseAMD                                C.GPTEXTURESTORAGESPARSEAMD
 	gpTextureSubImage1D                                      C.GPTEXTURESUBIMAGE1D
 	gpTextureSubImage1DEXT                                   C.GPTEXTURESUBIMAGE1DEXT
@@ -18179,13 +19099,17 @@ var (
 	gpUniform1fv                                             C.GPUNIFORM1FV
 	gpUniform1fvARB                                          C.GPUNIFORM1FVARB
 	gpUniform1i                                              C.GPUNIFORM1I
+	gpUniform1i64ARB                                         C.GPUNIFORM1I64ARB
 	gpUniform1i64NV                                          C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                        C.GPUNIFORM1I64VARB
 	gpUniform1i64vNV                                         C.GPUNIFORM1I64VNV
 	gpUniform1iARB                                           C.GPUNIFORM1IARB
 	gpUniform1iv                                             C.GPUNIFORM1IV
 	gpUniform1ivARB                                          C.GPUNIFORM1IVARB
 	gpUniform1ui                                             C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                        C.GPUNIFORM1UI64ARB
 	gpUniform1ui64NV                                         C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                                       C.GPUNIFORM1UI64VARB
 	gpUniform1ui64vNV                                        C.GPUNIFORM1UI64VNV
 	gpUniform1uiEXT                                          C.GPUNIFORM1UIEXT
 	gpUniform1uiv                                            C.GPUNIFORM1UIV
@@ -18197,13 +19121,17 @@ var (
 	gpUniform2fv                                             C.GPUNIFORM2FV
 	gpUniform2fvARB                                          C.GPUNIFORM2FVARB
 	gpUniform2i                                              C.GPUNIFORM2I
+	gpUniform2i64ARB                                         C.GPUNIFORM2I64ARB
 	gpUniform2i64NV                                          C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                        C.GPUNIFORM2I64VARB
 	gpUniform2i64vNV                                         C.GPUNIFORM2I64VNV
 	gpUniform2iARB                                           C.GPUNIFORM2IARB
 	gpUniform2iv                                             C.GPUNIFORM2IV
 	gpUniform2ivARB                                          C.GPUNIFORM2IVARB
 	gpUniform2ui                                             C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                        C.GPUNIFORM2UI64ARB
 	gpUniform2ui64NV                                         C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                                       C.GPUNIFORM2UI64VARB
 	gpUniform2ui64vNV                                        C.GPUNIFORM2UI64VNV
 	gpUniform2uiEXT                                          C.GPUNIFORM2UIEXT
 	gpUniform2uiv                                            C.GPUNIFORM2UIV
@@ -18215,13 +19143,17 @@ var (
 	gpUniform3fv                                             C.GPUNIFORM3FV
 	gpUniform3fvARB                                          C.GPUNIFORM3FVARB
 	gpUniform3i                                              C.GPUNIFORM3I
+	gpUniform3i64ARB                                         C.GPUNIFORM3I64ARB
 	gpUniform3i64NV                                          C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                        C.GPUNIFORM3I64VARB
 	gpUniform3i64vNV                                         C.GPUNIFORM3I64VNV
 	gpUniform3iARB                                           C.GPUNIFORM3IARB
 	gpUniform3iv                                             C.GPUNIFORM3IV
 	gpUniform3ivARB                                          C.GPUNIFORM3IVARB
 	gpUniform3ui                                             C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                        C.GPUNIFORM3UI64ARB
 	gpUniform3ui64NV                                         C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                                       C.GPUNIFORM3UI64VARB
 	gpUniform3ui64vNV                                        C.GPUNIFORM3UI64VNV
 	gpUniform3uiEXT                                          C.GPUNIFORM3UIEXT
 	gpUniform3uiv                                            C.GPUNIFORM3UIV
@@ -18233,13 +19165,17 @@ var (
 	gpUniform4fv                                             C.GPUNIFORM4FV
 	gpUniform4fvARB                                          C.GPUNIFORM4FVARB
 	gpUniform4i                                              C.GPUNIFORM4I
+	gpUniform4i64ARB                                         C.GPUNIFORM4I64ARB
 	gpUniform4i64NV                                          C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                        C.GPUNIFORM4I64VARB
 	gpUniform4i64vNV                                         C.GPUNIFORM4I64VNV
 	gpUniform4iARB                                           C.GPUNIFORM4IARB
 	gpUniform4iv                                             C.GPUNIFORM4IV
 	gpUniform4ivARB                                          C.GPUNIFORM4IVARB
 	gpUniform4ui                                             C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                        C.GPUNIFORM4UI64ARB
 	gpUniform4ui64NV                                         C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                                       C.GPUNIFORM4UI64VARB
 	gpUniform4ui64vNV                                        C.GPUNIFORM4UI64VNV
 	gpUniform4uiEXT                                          C.GPUNIFORM4UIEXT
 	gpUniform4uiv                                            C.GPUNIFORM4UIV
@@ -18666,7 +19602,11 @@ var (
 	gpViewportArrayv                                         C.GPVIEWPORTARRAYV
 	gpViewportIndexedf                                       C.GPVIEWPORTINDEXEDF
 	gpViewportIndexedfv                                      C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                               C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                                      C.GPVIEWPORTSWIZZLENV
+	gpWaitSemaphoreEXT                                       C.GPWAITSEMAPHOREEXT
 	gpWaitSync                                               C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                                      C.GPWAITVKSEMAPHORENV
 	gpWeightPathsNV                                          C.GPWEIGHTPATHSNV
 	gpWeightPointerARB                                       C.GPWEIGHTPOINTERARB
 	gpWeightbvARB                                            C.GPWEIGHTBVARB
@@ -18733,6 +19673,7 @@ var (
 	gpWindowPos4ivMESA                                       C.GPWINDOWPOS4IVMESA
 	gpWindowPos4sMESA                                        C.GPWINDOWPOS4SMESA
 	gpWindowPos4svMESA                                       C.GPWINDOWPOS4SVMESA
+	gpWindowRectanglesEXT                                    C.GPWINDOWRECTANGLESEXT
 	gpWriteMaskEXT                                           C.GPWRITEMASKEXT
 )
 
@@ -18750,6 +19691,10 @@ func Accum(op uint32, value float32) {
 }
 func AccumxOES(op uint32, value int32) {
 	C.glowAccumxOES(gpAccumxOES, (C.GLenum)(op), (C.GLfixed)(value))
+}
+func AcquireKeyedMutexWin32EXT(memory uint32, key uint64, timeout uint32) bool {
+	ret := C.glowAcquireKeyedMutexWin32EXT(gpAcquireKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key), (C.GLuint)(timeout))
+	return ret == TRUE
 }
 func ActiveProgramEXT(program uint32) {
 	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
@@ -18792,6 +19737,12 @@ func AlphaFunc(xfunc uint32, ref float32) {
 }
 func AlphaFuncxOES(xfunc uint32, ref int32) {
 	C.glowAlphaFuncxOES(gpAlphaFuncxOES, (C.GLenum)(xfunc), (C.GLfixed)(ref))
+}
+func AlphaToCoverageDitherControlNV(mode uint32) {
+	C.glowAlphaToCoverageDitherControlNV(gpAlphaToCoverageDitherControlNV, (C.GLenum)(mode))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 func ApplyTextureEXT(mode uint32) {
 	C.glowApplyTextureEXT(gpApplyTextureEXT, (C.GLenum)(mode))
@@ -19240,8 +20191,8 @@ func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 func BufferDataARB(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferDataARB(gpBufferDataARB, (C.GLenum)(target), (C.GLsizeiptrARB)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 	C.glowBufferParameteriAPPLE(gpBufferParameteriAPPLE, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
@@ -19251,6 +20202,12 @@ func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowBufferStorage(gpBufferStorage, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func BufferStorageExternalEXT(target uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowBufferStorageExternalEXT(gpBufferStorageExternalEXT, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func BufferStorageMemEXT(target uint32, size int, memory uint32, offset uint64) {
+	C.glowBufferStorageMemEXT(gpBufferStorageMemEXT, (C.GLenum)(target), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
@@ -19258,6 +20215,9 @@ func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 }
 func BufferSubDataARB(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubDataARB(gpBufferSubDataARB, (C.GLenum)(target), (C.GLintptrARB)(offset), (C.GLsizeiptrARB)(size), data)
+}
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
 }
 
 // execute a display list
@@ -19354,6 +20314,8 @@ func ClearDepth(depth float64) {
 func ClearDepthdNV(depth float64) {
 	C.glowClearDepthdNV(gpClearDepthdNV, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -19378,14 +20340,14 @@ func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32
 }
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
 func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -19427,7 +20389,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -19695,6 +20657,12 @@ func CombinerParameterivNV(pname uint32, params *int32) {
 func CombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowCombinerStageParameterfvNV(gpCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
+}
 
 // Compiles a shader object
 func CompileShader(shader uint32) {
@@ -19805,6 +20773,12 @@ func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yof
 func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // define a one-dimensional convolution filter
 func ConvolutionFilter1D(target uint32, internalformat uint32, width int32, format uint32, xtype uint32, image unsafe.Pointer) {
@@ -19913,8 +20887,8 @@ func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffs
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 func CopyPathNV(resultPath uint32, srcPath uint32) {
 	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
@@ -20006,15 +20980,27 @@ func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsaf
 func CoverStrokePathNV(path uint32, coverMode uint32) {
 	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
 }
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreateMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowCreateMemoryObjectsEXT(gpCreateMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
 	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
@@ -20073,9 +21059,12 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -20171,6 +21160,9 @@ func DeleteBuffers(n int32, buffers *uint32) {
 func DeleteBuffersARB(n int32, buffers *uint32) {
 	C.glowDeleteBuffersARB(gpDeleteBuffersARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 func DeleteFencesAPPLE(n int32, fences *uint32) {
 	C.glowDeleteFencesAPPLE(gpDeleteFencesAPPLE, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(fences)))
 }
@@ -20192,6 +21184,9 @@ func DeleteFramebuffersEXT(n int32, framebuffers *uint32) {
 // delete a contiguous group of display lists
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
+}
+func DeleteMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowDeleteMemoryObjectsEXT(gpDeleteMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
@@ -20241,6 +21236,9 @@ func DeleteQueries(n int32, ids *uint32) {
 func DeleteQueriesARB(n int32, ids *uint32) {
 	C.glowDeleteQueriesARB(gpDeleteQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func DeleteQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowDeleteQueryResourceTagNV(gpDeleteQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // delete renderbuffer objects
 func DeleteRenderbuffers(n int32, renderbuffers *uint32) {
@@ -20254,14 +21252,20 @@ func DeleteRenderbuffersEXT(n int32, renderbuffers *uint32) {
 func DeleteSamplers(count int32, samplers *uint32) {
 	C.glowDeleteSamplers(gpDeleteSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
 }
+func DeleteSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowDeleteSemaphoresEXT(gpDeleteSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
+}
 
 // Deletes a shader object
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -20323,6 +21327,8 @@ func DepthRangeIndexed(index uint32, n float64, f float64) {
 func DepthRangedNV(zNear float64, zFar float64) {
 	C.glowDepthRangedNV(gpDepthRangedNV, (C.GLdouble)(zNear), (C.GLdouble)(zFar))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -20444,6 +21450,18 @@ func DrawBuffersARB(n int32, bufs *uint32) {
 func DrawBuffersATI(n int32, bufs *uint32) {
 	C.glowDrawBuffersATI(gpDrawBuffersATI, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 func DrawElementArrayAPPLE(mode uint32, first int32, count int32) {
 	C.glowDrawElementArrayAPPLE(gpDrawElementArrayAPPLE, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count))
 }
@@ -20543,6 +21561,9 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 // render multiple instances of primitives using a count derived from a specifed stream of a transform feedback object
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
+}
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
 }
 
 // flag edges as either boundary or nonboundary
@@ -20721,6 +21742,9 @@ func EvalPoint1(i int32) {
 func EvalPoint2(i int32, j int32) {
 	C.glowEvalPoint2(gpEvalPoint2, (C.GLint)(i), (C.GLint)(j))
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 func ExecuteProgramNV(target uint32, id uint32, params *float32) {
 	C.glowExecuteProgramNV(gpExecuteProgramNV, (C.GLenum)(target), (C.GLuint)(id), (*C.GLfloat)(unsafe.Pointer(params)))
 }
@@ -20737,9 +21761,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -20780,8 +21804,8 @@ func FlushMappedBufferRangeAPPLE(target uint32, offset int, size int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
 }
 func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
 	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
@@ -20869,6 +21893,9 @@ func FogxvOES(pname uint32, param *int32) {
 func FragmentColorMaterialSGIX(face uint32, mode uint32) {
 	C.glowFragmentColorMaterialSGIX(gpFragmentColorMaterialSGIX, (C.GLenum)(face), (C.GLenum)(mode))
 }
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
 func FragmentLightModelfSGIX(pname uint32, param float32) {
 	C.glowFragmentLightModelfSGIX(gpFragmentLightModelfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -20917,6 +21944,9 @@ func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
 func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
 	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
+}
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
@@ -20933,6 +21963,15 @@ func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarge
 func FramebufferRenderbufferEXT(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbufferEXT(gpFramebufferRenderbufferEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSamplePositionsfvAMD(target uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowFramebufferSamplePositionsfvAMD(gpFramebufferSamplePositionsfvAMD, (C.GLenum)(target), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
 func FramebufferTexture(target uint32, attachment uint32, texture uint32, level int32) {
@@ -20944,6 +21983,8 @@ func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, te
 func FramebufferTexture1DEXT(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1DEXT(gpFramebufferTexture1DEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
@@ -20978,6 +22019,9 @@ func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32
 }
 func FramebufferTextureLayerEXT(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayerEXT(gpFramebufferTextureLayerEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 func FreeObjectBufferATI(buffer uint32) {
 	C.glowFreeObjectBufferATI(gpFreeObjectBufferATI, (C.GLuint)(buffer))
@@ -21069,6 +22113,9 @@ func GenQueries(n int32, ids *uint32) {
 func GenQueriesARB(n int32, ids *uint32) {
 	C.glowGenQueriesARB(gpGenQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func GenQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowGenQueryResourceTagNV(gpGenQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // generate renderbuffer object names
 func GenRenderbuffers(n int32, renderbuffers *uint32) {
@@ -21081,6 +22128,9 @@ func GenRenderbuffersEXT(n int32, renderbuffers *uint32) {
 // generate sampler object names
 func GenSamplers(count int32, samplers *uint32) {
 	C.glowGenSamplers(gpGenSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
+}
+func GenSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowGenSemaphoresEXT(gpGenSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
 }
 func GenSymbolsEXT(datatype uint32, storagetype uint32, xrange uint32, components uint32) uint32 {
 	ret := C.glowGenSymbolsEXT(gpGenSymbolsEXT, (C.GLenum)(datatype), (C.GLenum)(storagetype), (C.GLenum)(xrange), (C.GLuint)(components))
@@ -21172,6 +22222,8 @@ func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, leng
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21308,6 +22360,10 @@ func GetCombinerOutputParameterivNV(stage uint32, portion uint32, pname uint32, 
 func GetCombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowGetCombinerStageParameterfvNV(gpGetCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
 func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
 	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
@@ -21354,6 +22410,9 @@ func GetConvolutionParameterivEXT(target uint32, pname uint32, params *int32) {
 }
 func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 	C.glowGetConvolutionParameterxvOES(gpGetConvolutionParameterxvOES, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -21453,15 +22512,18 @@ func GetFragmentMaterialivSGIX(face uint32, pname uint32, params *int32) {
 	C.glowGetFragmentMaterialivSGIX(gpGetFragmentMaterialivSGIX, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetFramebufferAttachmentParameterivEXT(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameterivEXT(gpGetFramebufferAttachmentParameterivEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetFramebufferParameterfvAMD(target uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetFramebufferParameterfvAMD(gpGetFramebufferParameterfvAMD, (C.GLenum)(target), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21551,9 +22613,14 @@ func GetIntegerui64vNV(value uint32, result *uint64) {
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21631,6 +22698,9 @@ func GetMaterialxOES(face uint32, pname uint32, param int32) {
 }
 func GetMaterialxvOES(face uint32, pname uint32, params *int32) {
 	C.glowGetMaterialxvOES(gpGetMaterialxvOES, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetMemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowGetMemoryObjectParameterivEXT(gpGetMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // get minimum and maximum pixel values
@@ -21722,8 +22792,8 @@ func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Point
 }
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -21735,6 +22805,9 @@ func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uin
 }
 func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedFramebufferParameterfvAMD(framebuffer uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetNamedFramebufferParameterfvAMD(gpGetNamedFramebufferParameterfvAMD, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 
 // query a named parameter of a framebuffer object
@@ -22050,6 +23123,18 @@ func GetProgramivARB(target uint32, pname uint32, params *int32) {
 func GetProgramivNV(id uint32, pname uint32, params *int32) {
 	C.glowGetProgramivNV(gpGetProgramivNV, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
 
 // return parameters of an indexed query object target
 func GetQueryIndexediv(target uint32, index uint32, pname uint32, params *int32) {
@@ -22073,6 +23158,8 @@ func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 func GetQueryObjectui64vEXT(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64vEXT(gpGetQueryObjectui64vEXT, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -22088,7 +23175,7 @@ func GetQueryivARB(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryivARB(gpGetQueryivARB, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -22106,6 +23193,9 @@ func GetSamplerParameterfv(sampler uint32, pname uint32, params *float32) {
 }
 func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 	C.glowGetSamplerParameteriv(gpGetSamplerParameteriv, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetSemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowGetSemaphoreParameterui64vEXT(gpGetSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 
 // get separable convolution filter kernel images
@@ -22141,6 +23231,10 @@ func GetShaderiv(shader uint32, pname uint32, params *int32) {
 func GetSharpenTexFuncSGIS(target uint32, points *float32) {
 	C.glowGetSharpenTexFuncSGIS(gpGetSharpenTexFuncSGIS, (C.GLenum)(target), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -22165,7 +23259,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -22369,6 +23463,9 @@ func GetUniformfv(program uint32, location int32, params *float32) {
 func GetUniformfvARB(programObj uintptr, location int32, params *float32) {
 	C.glowGetUniformfvARB(gpGetUniformfvARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetUniformi64vNV(program uint32, location int32, params *int64) {
 	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
 }
@@ -22380,6 +23477,9 @@ func GetUniformiv(program uint32, location int32, params *int32) {
 func GetUniformivARB(programObj uintptr, location int32, params *int32) {
 	C.glowGetUniformivARB(gpGetUniformivARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 func GetUniformui64vNV(program uint32, location int32, params *uint64) {
 	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
@@ -22388,6 +23488,12 @@ func GetUniformuiv(program uint32, location int32, params *uint32) {
 }
 func GetUniformuivEXT(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuivEXT(gpGetUniformuivEXT, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetUnsignedBytei_vEXT(target uint32, index uint32, data *uint8) {
+	C.glowGetUnsignedBytei_vEXT(gpGetUnsignedBytei_vEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLubyte)(unsafe.Pointer(data)))
+}
+func GetUnsignedBytevEXT(pname uint32, data *uint8) {
+	C.glowGetUnsignedBytevEXT(gpGetUnsignedBytevEXT, (C.GLenum)(pname), (*C.GLubyte)(unsafe.Pointer(data)))
 }
 func GetVariantArrayObjectfvATI(id uint32, pname uint32, params *float32) {
 	C.glowGetVariantArrayObjectfvATI(gpGetVariantArrayObjectfvATI, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
@@ -22541,6 +23647,10 @@ func GetVideoui64vNV(video_slot uint32, pname uint32, params *uint64) {
 func GetVideouivNV(video_slot uint32, pname uint32, params *uint32) {
 	C.glowGetVideouivNV(gpGetVideouivNV, (C.GLuint)(video_slot), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
+}
 func GetnColorTableARB(target uint32, format uint32, xtype uint32, bufSize int32, table unsafe.Pointer) {
 	C.glowGetnColorTableARB(gpGetnColorTableARB, (C.GLenum)(target), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), table)
 }
@@ -22595,6 +23705,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -22603,6 +23716,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -22668,9 +23784,27 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportMemoryFdEXT(memory uint32, size uint64, handleType uint32, fd int32) {
+	C.glowImportMemoryFdEXT(gpImportMemoryFdEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportMemoryWin32HandleEXT(memory uint32, size uint64, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportMemoryWin32HandleEXT(gpImportMemoryWin32HandleEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), handle)
+}
+func ImportMemoryWin32NameEXT(memory uint32, size uint64, handleType uint32, name unsafe.Pointer) {
+	C.glowImportMemoryWin32NameEXT(gpImportMemoryWin32NameEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), name)
+}
+func ImportSemaphoreFdEXT(semaphore uint32, handleType uint32, fd int32) {
+	C.glowImportSemaphoreFdEXT(gpImportSemaphoreFdEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportSemaphoreWin32HandleEXT(semaphore uint32, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportSemaphoreWin32HandleEXT(gpImportSemaphoreWin32HandleEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), handle)
+}
+func ImportSemaphoreWin32NameEXT(semaphore uint32, handleType uint32, name unsafe.Pointer) {
+	C.glowImportSemaphoreWin32NameEXT(gpImportSemaphoreWin32NameEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), name)
+}
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -22813,6 +23947,10 @@ func IsBufferResidentNV(target uint32) bool {
 	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
 	return ret == TRUE
 }
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
 	return ret == TRUE
@@ -22855,6 +23993,10 @@ func IsImageHandleResidentNV(handle uint64) bool {
 // determine if a name corresponds to a display list
 func IsList(list uint32) bool {
 	ret := C.glowIsList(gpIsList, (C.GLuint)(list))
+	return ret == TRUE
+}
+func IsMemoryObjectEXT(memoryObject uint32) bool {
+	ret := C.glowIsMemoryObjectEXT(gpIsMemoryObjectEXT, (C.GLuint)(memoryObject))
 	return ret == TRUE
 }
 func IsNameAMD(identifier uint32, name uint32) bool {
@@ -22939,15 +24081,23 @@ func IsSampler(sampler uint32) bool {
 	ret := C.glowIsSampler(gpIsSampler, (C.GLuint)(sampler))
 	return ret == TRUE
 }
+func IsSemaphoreEXT(semaphore uint32) bool {
+	ret := C.glowIsSemaphoreEXT(gpIsSemaphoreEXT, (C.GLuint)(semaphore))
+	return ret == TRUE
+}
 
 // Determines if a name corresponds to a shader object
 func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -22996,6 +24146,15 @@ func IsVertexArrayAPPLE(array uint32) bool {
 func IsVertexAttribEnabledAPPLE(index uint32, pname uint32) bool {
 	ret := C.glowIsVertexAttribEnabledAPPLE(gpIsVertexAttribEnabledAPPLE, (C.GLuint)(index), (C.GLenum)(pname))
 	return ret == TRUE
+}
+func LGPUCopyImageSubDataNVX(sourceGpu uint32, destinationGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srxY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, width int32, height int32, depth int32) {
+	C.glowLGPUCopyImageSubDataNVX(gpLGPUCopyImageSubDataNVX, (C.GLuint)(sourceGpu), (C.GLbitfield)(destinationGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srxY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func LGPUInterlockNVX() {
+	C.glowLGPUInterlockNVX(gpLGPUInterlockNVX)
+}
+func LGPUNamedBufferSubDataNVX(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowLGPUNamedBufferSubDataNVX(gpLGPUNamedBufferSubDataNVX, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
@@ -23064,6 +24223,9 @@ func LinkProgramARB(programObj uintptr) {
 // set the display-list base for
 func ListBase(base uint32) {
 	C.glowListBase(gpListBase, (C.GLuint)(base))
+}
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 func ListParameterfSGIX(list uint32, pname uint32, param float32) {
 	C.glowListParameterfSGIX(gpListParameterfSGIX, (C.GLuint)(list), (C.GLenum)(pname), (C.GLfloat)(param))
@@ -23228,8 +24390,8 @@ func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
 }
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
 }
 func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
@@ -23372,6 +24534,12 @@ func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
 func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
 	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
 }
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
+}
 
 // defines a barrier ordering memory transactions
 func MemoryBarrier(barriers uint32) {
@@ -23382,6 +24550,9 @@ func MemoryBarrierByRegion(barriers uint32) {
 }
 func MemoryBarrierEXT(barriers uint32) {
 	C.glowMemoryBarrierEXT(gpMemoryBarrierEXT, (C.GLbitfield)(barriers))
+}
+func MemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowMemoryObjectParameterivEXT(gpMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // specifies minimum rate at which sample shaing takes place
@@ -23445,8 +24616,8 @@ func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer
 func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawElementArrayAPPLE(mode uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawElementArrayAPPLE(gpMultiDrawElementArrayAPPLE, (C.GLenum)(mode), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -23478,8 +24649,8 @@ func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirec
 func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawRangeElementArrayAPPLE(mode uint32, start uint32, end uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawRangeElementArrayAPPLE(gpMultiDrawRangeElementArrayAPPLE, (C.GLenum)(mode), (C.GLuint)(start), (C.GLuint)(end), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -23853,32 +25024,71 @@ func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset i
 func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func MulticastBarrierNV() {
+	C.glowMulticastBarrierNV(gpMulticastBarrierNV)
+}
+func MulticastBlitFramebufferNV(srcGpu uint32, dstGpu uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
+	C.glowMulticastBlitFramebufferNV(gpMulticastBlitFramebufferNV, (C.GLuint)(srcGpu), (C.GLuint)(dstGpu), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
+}
+func MulticastBufferSubDataNV(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowMulticastBufferSubDataNV(gpMulticastBufferSubDataNV, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func MulticastCopyBufferSubDataNV(readGpu uint32, writeGpuMask uint32, readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowMulticastCopyBufferSubDataNV(gpMulticastCopyBufferSubDataNV, (C.GLuint)(readGpu), (C.GLbitfield)(writeGpuMask), (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func MulticastCopyImageSubDataNV(srcGpu uint32, dstGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
+	C.glowMulticastCopyImageSubDataNV(gpMulticastCopyImageSubDataNV, (C.GLuint)(srcGpu), (C.GLbitfield)(dstGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
+}
+func MulticastFramebufferSampleLocationsfvNV(gpu uint32, framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowMulticastFramebufferSampleLocationsfvNV(gpMulticastFramebufferSampleLocationsfvNV, (C.GLuint)(gpu), (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func MulticastGetQueryObjecti64vNV(gpu uint32, id uint32, pname uint32, params *int64) {
+	C.glowMulticastGetQueryObjecti64vNV(gpMulticastGetQueryObjecti64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectivNV(gpu uint32, id uint32, pname uint32, params *int32) {
+	C.glowMulticastGetQueryObjectivNV(gpMulticastGetQueryObjectivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectui64vNV(gpu uint32, id uint32, pname uint32, params *uint64) {
+	C.glowMulticastGetQueryObjectui64vNV(gpMulticastGetQueryObjectui64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectuivNV(gpu uint32, id uint32, pname uint32, params *uint32) {
+	C.glowMulticastGetQueryObjectuivNV(gpMulticastGetQueryObjectuivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MulticastWaitSyncNV(signalGpu uint32, waitGpuMask uint32) {
+	C.glowMulticastWaitSyncNV(gpMulticastWaitSyncNV, (C.GLuint)(signalGpu), (C.GLbitfield)(waitGpuMask))
+}
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
 func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func NamedBufferStorageExternalEXT(buffer uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowNamedBufferStorageExternalEXT(gpNamedBufferStorageExternalEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func NamedBufferStorageMemEXT(buffer uint32, size int, memory uint32, offset uint64) {
+	C.glowNamedBufferStorageMemEXT(gpNamedBufferStorageMemEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -23916,6 +25126,15 @@ func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderb
 }
 func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSamplePositionsfvAMD(framebuffer uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowNamedFramebufferSamplePositionsfvAMD(gpNamedFramebufferSamplePositionsfvAMD, (C.GLuint)(framebuffer), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
@@ -24166,6 +25385,8 @@ func PassThroughxOES(token int32) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -24261,6 +25482,8 @@ func PixelMapx(xmap uint32, size int32, values *int32) {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
 }
@@ -24383,6 +25606,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 func PolygonOffsetEXT(factor float32, bias float32) {
 	C.glowPolygonOffsetEXT(gpPolygonOffsetEXT, (C.GLfloat)(factor), (C.GLfloat)(bias))
 }
@@ -24422,6 +25651,9 @@ func PresentFrameDualFillNV(video_slot uint32, minPresentTime uint64, beginPrese
 }
 func PresentFrameKeyedNV(video_slot uint32, minPresentTime uint64, beginPresentTimeId uint32, presentDurationId uint32, xtype uint32, target0 uint32, fill0 uint32, key0 uint32, target1 uint32, fill1 uint32, key1 uint32) {
 	C.glowPresentFrameKeyedNV(gpPresentFrameKeyedNV, (C.GLuint)(video_slot), (C.GLuint64EXT)(minPresentTime), (C.GLuint)(beginPresentTimeId), (C.GLuint)(presentDurationId), (C.GLenum)(xtype), (C.GLenum)(target0), (C.GLuint)(fill0), (C.GLuint)(key0), (C.GLenum)(target1), (C.GLuint)(fill1), (C.GLuint)(key1))
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -24549,6 +25781,8 @@ func ProgramParameter4fNV(target uint32, index uint32, x float32, y float32, z f
 func ProgramParameter4fvNV(target uint32, index uint32, v *float32) {
 	C.glowProgramParameter4fvNV(gpProgramParameter4fvNV, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -24606,8 +25840,14 @@ func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
 func ProgramUniform1i64NV(program uint32, location int32, x int64) {
 	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24628,8 +25868,14 @@ func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
 func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
 	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24678,8 +25924,14 @@ func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
 	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24700,8 +25952,14 @@ func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
 	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24750,8 +26008,14 @@ func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
 	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24772,8 +26036,14 @@ func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
 	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24822,8 +26092,14 @@ func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
 	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24844,8 +26120,14 @@ func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -25055,12 +26337,21 @@ func PushName(name uint32) {
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
 }
+
+// return the values of the current matrix
 func QueryMatrixxOES(mantissa *int32, exponent *int32) uint32 {
 	ret := C.glowQueryMatrixxOES(gpQueryMatrixxOES, (*C.GLfixed)(unsafe.Pointer(mantissa)), (*C.GLint)(unsafe.Pointer(exponent)))
 	return (uint32)(ret)
 }
 func QueryObjectParameteruiAMD(target uint32, id uint32, pname uint32, param uint32) {
 	C.glowQueryObjectParameteruiAMD(gpQueryObjectParameteruiAMD, (C.GLenum)(target), (C.GLuint)(id), (C.GLenum)(pname), (C.GLuint)(param))
+}
+func QueryResourceNV(queryType uint32, tagId int32, bufSize uint32, buffer *int32) int32 {
+	ret := C.glowQueryResourceNV(gpQueryResourceNV, (C.GLenum)(queryType), (C.GLint)(tagId), (C.GLuint)(bufSize), (*C.GLint)(unsafe.Pointer(buffer)))
+	return (int32)(ret)
+}
+func QueryResourceTagNV(tagId int32, tagString *uint8) {
+	C.glowQueryResourceTagNV(gpQueryResourceTagNV, (C.GLint)(tagId), (*C.GLchar)(unsafe.Pointer(tagString)))
 }
 func RasterPos2d(x float64, y float64) {
 	C.glowRasterPos2d(gpRasterPos2d, (C.GLdouble)(x), (C.GLdouble)(y))
@@ -25152,6 +26443,9 @@ func RasterPos4xOES(x int32, y int32, z int32, w int32) {
 func RasterPos4xvOES(coords *int32) {
 	C.glowRasterPos4xvOES(gpRasterPos4xvOES, (*C.GLfixed)(unsafe.Pointer(coords)))
 }
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // select a color buffer source for pixels
 func ReadBuffer(src uint32) {
@@ -25209,10 +26503,17 @@ func RectxvOES(v1 *int32, v2 *int32) {
 func ReferencePlaneSGIX(equation *float64) {
 	C.glowReferencePlaneSGIX(gpReferencePlaneSGIX, (*C.GLdouble)(unsafe.Pointer(equation)))
 }
+func ReleaseKeyedMutexWin32EXT(memory uint32, key uint64) bool {
+	ret := C.glowReleaseKeyedMutexWin32EXT(gpReleaseKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key))
+	return ret == TRUE
+}
 
 // release resources consumed by the implementation's shader compiler
 func ReleaseShaderCompiler() {
 	C.glowReleaseShaderCompiler(gpReleaseShaderCompiler)
+}
+func RenderGpuMaskNV(mask uint32) {
+	C.glowRenderGpuMaskNV(gpRenderGpuMaskNV, (C.GLbitfield)(mask))
 }
 
 // set rasterization mode
@@ -25330,6 +26631,9 @@ func ResetMinmaxEXT(target uint32) {
 func ResizeBuffersMESA() {
 	C.glowResizeBuffersMESA(gpResizeBuffersMESA)
 }
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
+}
 
 // resume transform feedback operations
 func ResumeTransformFeedback() {
@@ -25354,9 +26658,6 @@ func SampleCoverage(value float32, invert bool) {
 }
 func SampleCoverageARB(value float32, invert bool) {
 	C.glowSampleCoverageARB(gpSampleCoverageARB, (C.GLfloat)(value), (C.GLboolean)(boolToInt(invert)))
-}
-func SampleCoverageOES(value int32, invert bool) {
-	C.glowSampleCoverageOES(gpSampleCoverageOES, (C.GLfixed)(value), (C.GLboolean)(boolToInt(invert)))
 }
 func SampleCoveragexOES(value int32, invert bool) {
 	C.glowSampleCoveragexOES(gpSampleCoveragexOES, (C.GLclampx)(value), (C.GLboolean)(boolToInt(invert)))
@@ -25557,6 +26858,9 @@ func SelectBuffer(size int32, buffer *uint32) {
 func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
 	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
 }
+func SemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowSemaphoreParameterui64vEXT(gpSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 
 // define a separable two-dimensional convolution filter
 func SeparableFilter2D(target uint32, internalformat uint32, width int32, height int32, format uint32, xtype uint32, row unsafe.Pointer, column unsafe.Pointer) {
@@ -25618,6 +26922,18 @@ func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storage
 func SharpenTexFuncSGIS(target uint32, n int32, points *float32) {
 	C.glowSharpenTexFuncSGIS(gpSharpenTexFuncSGIS, (C.GLenum)(target), (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func SignalSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, dstLayouts *uint32) {
+	C.glowSignalSemaphoreEXT(gpSignalSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(dstLayouts)))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
 func SpriteParameterfSGIX(pname uint32, param float32) {
 	C.glowSpriteParameterfSGIX(gpSpriteParameterfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -25632,6 +26948,9 @@ func SpriteParameterivSGIX(pname uint32, params *int32) {
 }
 func StartInstrumentsSGIX() {
 	C.glowStartInstrumentsSGIX(gpStartInstrumentsSGIX)
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
 }
 func StencilClearTagEXT(stencilTagBits int32, stencilClearTag uint32) {
 	C.glowStencilClearTagEXT(gpStencilClearTagEXT, (C.GLsizei)(stencilTagBits), (C.GLuint)(stencilClearTag))
@@ -25704,6 +27023,9 @@ func StopInstrumentsSGIX(marker int32) {
 }
 func StringMarkerGREMEDY(len int32, xstring unsafe.Pointer) {
 	C.glowStringMarkerGREMEDY(gpStringMarkerGREMEDY, (C.GLsizei)(len), xstring)
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
 }
 func SwizzleEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowSwizzleEXT(gpSwizzleEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
@@ -26123,8 +27445,8 @@ func TexImage3DMultisampleCoverageNV(target uint32, coverageSamples int32, color
 func TexImage4DSGIS(target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, size4d int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTexImage4DSGIS(gpTexImage4DSGIS, (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(size4d), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -26184,6 +27506,21 @@ func TexStorage3D(target uint32, levels int32, internalformat uint32, width int3
 func TexStorage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexStorage3DMultisample(gpTexStorage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TexStorageMem1DEXT(target uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem1DEXT(gpTexStorageMem1DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DEXT(gpTexStorageMem2DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DMultisampleEXT(gpTexStorageMem2DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DEXT(gpTexStorageMem3DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DMultisampleEXT(gpTexStorageMem3DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TexStorageSparseAMD(target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTexStorageSparseAMD(gpTexStorageSparseAMD, (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -26232,8 +27569,8 @@ func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buff
 }
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
@@ -26271,8 +27608,8 @@ func TextureMaterialEXT(face uint32, mode uint32) {
 func TextureNormalEXT(mode uint32) {
 	C.glowTextureNormalEXT(gpTextureNormalEXT, (C.GLenum)(mode))
 }
-func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -26356,6 +27693,21 @@ func TextureStorage3DMultisample(texture uint32, samples int32, internalformat u
 func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorageMem1DEXT(texture uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem1DEXT(gpTextureStorageMem1DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DEXT(gpTextureStorageMem2DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DMultisampleEXT(gpTextureStorageMem2DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DEXT(gpTextureStorageMem3DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DMultisampleEXT(gpTextureStorageMem3DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TextureStorageSparseAMD(texture uint32, target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTextureStorageSparseAMD(gpTextureStorageSparseAMD, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -26401,8 +27753,8 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TransformFeedbackStreamAttribsNV(count int32, attribs *int32, nbuffers int32, bufstreams *int32, bufferMode uint32) {
 	C.glowTransformFeedbackStreamAttribsNV(gpTransformFeedbackStreamAttribsNV, (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(attribs)), (C.GLsizei)(nbuffers), (*C.GLint)(unsafe.Pointer(bufstreams)), (C.GLenum)(bufferMode))
@@ -26457,8 +27809,14 @@ func Uniform1fvARB(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
 func Uniform1i64NV(location int32, x int64) {
 	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform1i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26479,8 +27837,14 @@ func Uniform1ivARB(location int32, count int32, value *int32) {
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
 }
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
 func Uniform1ui64NV(location int32, x uint64) {
 	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform1ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26523,8 +27887,14 @@ func Uniform2fvARB(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func Uniform2i64NV(location int32, x int64, y int64) {
 	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform2i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26545,8 +27915,14 @@ func Uniform2ivARB(location int32, count int32, value *int32) {
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func Uniform2ui64NV(location int32, x uint64, y uint64) {
 	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform2ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26589,8 +27965,14 @@ func Uniform3fvARB(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func Uniform3i64NV(location int32, x int64, y int64, z int64) {
 	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform3i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26611,8 +27993,14 @@ func Uniform3ivARB(location int32, count int32, value *int32) {
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
 	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform3ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26655,8 +28043,14 @@ func Uniform4fvARB(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
 	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform4i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26677,8 +28071,14 @@ func Uniform4ivARB(location int32, count int32, value *int32) {
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform4ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -28024,10 +29424,22 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
+func WaitSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, srcLayouts *uint32) {
+	C.glowWaitSemaphoreEXT(gpWaitSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(srcLayouts)))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
 	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
@@ -28227,6 +29639,9 @@ func WindowPos4sMESA(x int16, y int16, z int16, w int16) {
 func WindowPos4svMESA(v *int16) {
 	C.glowWindowPos4svMESA(gpWindowPos4svMESA, (*C.GLshort)(unsafe.Pointer(v)))
 }
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
+}
 func WriteMaskEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowWriteMaskEXT(gpWriteMaskEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
 }
@@ -28263,6 +29678,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAccum")
 	}
 	gpAccumxOES = (C.GPACCUMXOES)(getProcAddr("glAccumxOES"))
+	gpAcquireKeyedMutexWin32EXT = (C.GPACQUIREKEYEDMUTEXWIN32EXT)(getProcAddr("glAcquireKeyedMutexWin32EXT"))
 	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
 	if gpActiveShaderProgram == nil {
@@ -28284,6 +29700,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAlphaFunc")
 	}
 	gpAlphaFuncxOES = (C.GPALPHAFUNCXOES)(getProcAddr("glAlphaFuncxOES"))
+	gpAlphaToCoverageDitherControlNV = (C.GPALPHATOCOVERAGEDITHERCONTROLNV)(getProcAddr("glAlphaToCoverageDitherControlNV"))
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpApplyTextureEXT = (C.GPAPPLYTEXTUREEXT)(getProcAddr("glApplyTextureEXT"))
 	gpAreProgramsResidentNV = (C.GPAREPROGRAMSRESIDENTNV)(getProcAddr("glAreProgramsResidentNV"))
 	gpAreTexturesResident = (C.GPARETEXTURESRESIDENT)(getProcAddr("glAreTexturesResident"))
@@ -28507,11 +29925,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpBufferPageCommitmentARB = (C.GPBUFFERPAGECOMMITMENTARB)(getProcAddr("glBufferPageCommitmentARB"))
 	gpBufferParameteriAPPLE = (C.GPBUFFERPARAMETERIAPPLE)(getProcAddr("glBufferParameteriAPPLE"))
 	gpBufferStorage = (C.GPBUFFERSTORAGE)(getProcAddr("glBufferStorage"))
+	gpBufferStorageExternalEXT = (C.GPBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glBufferStorageExternalEXT"))
+	gpBufferStorageMemEXT = (C.GPBUFFERSTORAGEMEMEXT)(getProcAddr("glBufferStorageMemEXT"))
 	gpBufferSubData = (C.GPBUFFERSUBDATA)(getProcAddr("glBufferSubData"))
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
 	gpBufferSubDataARB = (C.GPBUFFERSUBDATAARB)(getProcAddr("glBufferSubDataARB"))
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCallList = (C.GPCALLLIST)(getProcAddr("glCallList"))
 	if gpCallList == nil {
 		return errors.New("glCallList")
@@ -28813,6 +30234,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCombinerParameteriNV = (C.GPCOMBINERPARAMETERINV)(getProcAddr("glCombinerParameteriNV"))
 	gpCombinerParameterivNV = (C.GPCOMBINERPARAMETERIVNV)(getProcAddr("glCombinerParameterivNV"))
 	gpCombinerStageParameterfvNV = (C.GPCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glCombinerStageParameterfvNV"))
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
@@ -28864,6 +30287,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
 	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpConvolutionFilter1D = (C.GPCONVOLUTIONFILTER1D)(getProcAddr("glConvolutionFilter1D"))
 	gpConvolutionFilter1DEXT = (C.GPCONVOLUTIONFILTER1DEXT)(getProcAddr("glConvolutionFilter1DEXT"))
 	gpConvolutionFilter2D = (C.GPCONVOLUTIONFILTER2D)(getProcAddr("glConvolutionFilter2D"))
@@ -28940,8 +30365,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
 	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
 	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
+	gpCreateMemoryObjectsEXT = (C.GPCREATEMEMORYOBJECTSEXT)(getProcAddr("glCreateMemoryObjectsEXT"))
 	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
@@ -28963,6 +30392,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glCreateShaderProgramv")
 	}
 	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	gpCreateTransformFeedbacks = (C.GPCREATETRANSFORMFEEDBACKS)(getProcAddr("glCreateTransformFeedbacks"))
@@ -28995,6 +30425,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteBuffers")
 	}
 	gpDeleteBuffersARB = (C.GPDELETEBUFFERSARB)(getProcAddr("glDeleteBuffersARB"))
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFencesAPPLE = (C.GPDELETEFENCESAPPLE)(getProcAddr("glDeleteFencesAPPLE"))
 	gpDeleteFencesNV = (C.GPDELETEFENCESNV)(getProcAddr("glDeleteFencesNV"))
 	gpDeleteFragmentShaderATI = (C.GPDELETEFRAGMENTSHADERATI)(getProcAddr("glDeleteFragmentShaderATI"))
@@ -29007,6 +30438,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteLists == nil {
 		return errors.New("glDeleteLists")
 	}
+	gpDeleteMemoryObjectsEXT = (C.GPDELETEMEMORYOBJECTSEXT)(getProcAddr("glDeleteMemoryObjectsEXT"))
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
 	gpDeleteNamesAMD = (C.GPDELETENAMESAMD)(getProcAddr("glDeleteNamesAMD"))
 	gpDeleteObjectARB = (C.GPDELETEOBJECTARB)(getProcAddr("glDeleteObjectARB"))
@@ -29030,6 +30462,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteQueries")
 	}
 	gpDeleteQueriesARB = (C.GPDELETEQUERIESARB)(getProcAddr("glDeleteQueriesARB"))
+	gpDeleteQueryResourceTagNV = (C.GPDELETEQUERYRESOURCETAGNV)(getProcAddr("glDeleteQueryResourceTagNV"))
 	gpDeleteRenderbuffers = (C.GPDELETERENDERBUFFERS)(getProcAddr("glDeleteRenderbuffers"))
 	if gpDeleteRenderbuffers == nil {
 		return errors.New("glDeleteRenderbuffers")
@@ -29039,10 +30472,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteSamplers == nil {
 		return errors.New("glDeleteSamplers")
 	}
+	gpDeleteSemaphoresEXT = (C.GPDELETESEMAPHORESEXT)(getProcAddr("glDeleteSemaphoresEXT"))
 	gpDeleteShader = (C.GPDELETESHADER)(getProcAddr("glDeleteShader"))
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	if gpDeleteSync == nil {
 		return errors.New("glDeleteSync")
@@ -29152,6 +30587,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpDrawBuffersARB = (C.GPDRAWBUFFERSARB)(getProcAddr("glDrawBuffersARB"))
 	gpDrawBuffersATI = (C.GPDRAWBUFFERSATI)(getProcAddr("glDrawBuffersATI"))
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElementArrayAPPLE = (C.GPDRAWELEMENTARRAYAPPLE)(getProcAddr("glDrawElementArrayAPPLE"))
 	gpDrawElementArrayATI = (C.GPDRAWELEMENTARRAYATI)(getProcAddr("glDrawElementArrayATI"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
@@ -29206,6 +30645,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDrawTransformFeedbackStream")
 	}
 	gpDrawTransformFeedbackStreamInstanced = (C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(getProcAddr("glDrawTransformFeedbackStreamInstanced"))
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
 	gpEdgeFlag = (C.GPEDGEFLAG)(getProcAddr("glEdgeFlag"))
 	if gpEdgeFlag == nil {
 		return errors.New("glEdgeFlag")
@@ -29336,6 +30776,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEvalPoint2 == nil {
 		return errors.New("glEvalPoint2")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpExecuteProgramNV = (C.GPEXECUTEPROGRAMNV)(getProcAddr("glExecuteProgramNV"))
 	gpExtractComponentEXT = (C.GPEXTRACTCOMPONENTEXT)(getProcAddr("glExtractComponentEXT"))
 	gpFeedbackBuffer = (C.GPFEEDBACKBUFFER)(getProcAddr("glFeedbackBuffer"))
@@ -29422,6 +30863,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFogxOES = (C.GPFOGXOES)(getProcAddr("glFogxOES"))
 	gpFogxvOES = (C.GPFOGXVOES)(getProcAddr("glFogxvOES"))
 	gpFragmentColorMaterialSGIX = (C.GPFRAGMENTCOLORMATERIALSGIX)(getProcAddr("glFragmentColorMaterialSGIX"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
 	gpFragmentLightModelfSGIX = (C.GPFRAGMENTLIGHTMODELFSGIX)(getProcAddr("glFragmentLightModelfSGIX"))
 	gpFragmentLightModelfvSGIX = (C.GPFRAGMENTLIGHTMODELFVSGIX)(getProcAddr("glFragmentLightModelfvSGIX"))
 	gpFragmentLightModeliSGIX = (C.GPFRAGMENTLIGHTMODELISGIX)(getProcAddr("glFragmentLightModeliSGIX"))
@@ -29438,6 +30880,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFrameZoomSGIX = (C.GPFRAMEZOOMSGIX)(getProcAddr("glFrameZoomSGIX"))
 	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
 	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
 	gpFramebufferReadBufferEXT = (C.GPFRAMEBUFFERREADBUFFEREXT)(getProcAddr("glFramebufferReadBufferEXT"))
 	gpFramebufferRenderbuffer = (C.GPFRAMEBUFFERRENDERBUFFER)(getProcAddr("glFramebufferRenderbuffer"))
@@ -29445,6 +30888,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glFramebufferRenderbuffer")
 	}
 	gpFramebufferRenderbufferEXT = (C.GPFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glFramebufferRenderbufferEXT"))
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
+	gpFramebufferSamplePositionsfvAMD = (C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glFramebufferSamplePositionsfvAMD"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	if gpFramebufferTexture == nil {
 		return errors.New("glFramebufferTexture")
@@ -29474,6 +30920,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
 	gpFramebufferTextureLayerEXT = (C.GPFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glFramebufferTextureLayerEXT"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFreeObjectBufferATI = (C.GPFREEOBJECTBUFFERATI)(getProcAddr("glFreeObjectBufferATI"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
@@ -29519,6 +30966,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGenQueries")
 	}
 	gpGenQueriesARB = (C.GPGENQUERIESARB)(getProcAddr("glGenQueriesARB"))
+	gpGenQueryResourceTagNV = (C.GPGENQUERYRESOURCETAGNV)(getProcAddr("glGenQueryResourceTagNV"))
 	gpGenRenderbuffers = (C.GPGENRENDERBUFFERS)(getProcAddr("glGenRenderbuffers"))
 	if gpGenRenderbuffers == nil {
 		return errors.New("glGenRenderbuffers")
@@ -29528,6 +30976,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenSamplers == nil {
 		return errors.New("glGenSamplers")
 	}
+	gpGenSemaphoresEXT = (C.GPGENSEMAPHORESEXT)(getProcAddr("glGenSemaphoresEXT"))
 	gpGenSymbolsEXT = (C.GPGENSYMBOLSEXT)(getProcAddr("glGenSymbolsEXT"))
 	gpGenTextures = (C.GPGENTEXTURES)(getProcAddr("glGenTextures"))
 	if gpGenTextures == nil {
@@ -29654,6 +31103,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetCombinerOutputParameterfvNV = (C.GPGETCOMBINEROUTPUTPARAMETERFVNV)(getProcAddr("glGetCombinerOutputParameterfvNV"))
 	gpGetCombinerOutputParameterivNV = (C.GPGETCOMBINEROUTPUTPARAMETERIVNV)(getProcAddr("glGetCombinerOutputParameterivNV"))
 	gpGetCombinerStageParameterfvNV = (C.GPGETCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glGetCombinerStageParameterfvNV"))
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
 	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
@@ -29670,6 +31120,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetConvolutionParameteriv = (C.GPGETCONVOLUTIONPARAMETERIV)(getProcAddr("glGetConvolutionParameteriv"))
 	gpGetConvolutionParameterivEXT = (C.GPGETCONVOLUTIONPARAMETERIVEXT)(getProcAddr("glGetConvolutionParameterivEXT"))
 	gpGetConvolutionParameterxvOES = (C.GPGETCONVOLUTIONPARAMETERXVOES)(getProcAddr("glGetConvolutionParameterxvOES"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	gpGetDebugMessageLogAMD = (C.GPGETDEBUGMESSAGELOGAMD)(getProcAddr("glGetDebugMessageLogAMD"))
 	gpGetDebugMessageLogARB = (C.GPGETDEBUGMESSAGELOGARB)(getProcAddr("glGetDebugMessageLogARB"))
@@ -29723,6 +31174,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetFramebufferAttachmentParameteriv")
 	}
 	gpGetFramebufferAttachmentParameterivEXT = (C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetFramebufferAttachmentParameterivEXT"))
+	gpGetFramebufferParameterfvAMD = (C.GPGETFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetFramebufferParameterfvAMD"))
 	gpGetFramebufferParameteriv = (C.GPGETFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetFramebufferParameteriv"))
 	gpGetFramebufferParameterivEXT = (C.GPGETFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetFramebufferParameterivEXT"))
 	gpGetGraphicsResetStatus = (C.GPGETGRAPHICSRESETSTATUS)(getProcAddr("glGetGraphicsResetStatus"))
@@ -29761,6 +31213,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	gpGetInternalformativ = (C.GPGETINTERNALFORMATIV)(getProcAddr("glGetInternalformativ"))
 	gpGetInvariantBooleanvEXT = (C.GPGETINVARIANTBOOLEANVEXT)(getProcAddr("glGetInvariantBooleanvEXT"))
@@ -29809,6 +31262,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetMaterialxOES = (C.GPGETMATERIALXOES)(getProcAddr("glGetMaterialxOES"))
 	gpGetMaterialxvOES = (C.GPGETMATERIALXVOES)(getProcAddr("glGetMaterialxvOES"))
+	gpGetMemoryObjectParameterivEXT = (C.GPGETMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glGetMemoryObjectParameterivEXT"))
 	gpGetMinmax = (C.GPGETMINMAX)(getProcAddr("glGetMinmax"))
 	gpGetMinmaxEXT = (C.GPGETMINMAXEXT)(getProcAddr("glGetMinmaxEXT"))
 	gpGetMinmaxParameterfv = (C.GPGETMINMAXPARAMETERFV)(getProcAddr("glGetMinmaxParameterfv"))
@@ -29842,6 +31296,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
 	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
+	gpGetNamedFramebufferParameterfvAMD = (C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetNamedFramebufferParameterfvAMD"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
 	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
 	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
@@ -29969,6 +31424,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetProgramivARB = (C.GPGETPROGRAMIVARB)(getProcAddr("glGetProgramivARB"))
 	gpGetProgramivNV = (C.GPGETPROGRAMIVNV)(getProcAddr("glGetProgramivNV"))
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	if gpGetQueryIndexediv == nil {
 		return errors.New("glGetQueryIndexediv")
@@ -30019,6 +31478,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetSamplerParameteriv == nil {
 		return errors.New("glGetSamplerParameteriv")
 	}
+	gpGetSemaphoreParameterui64vEXT = (C.GPGETSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glGetSemaphoreParameterui64vEXT"))
 	gpGetSeparableFilter = (C.GPGETSEPARABLEFILTER)(getProcAddr("glGetSeparableFilter"))
 	gpGetSeparableFilterEXT = (C.GPGETSEPARABLEFILTEREXT)(getProcAddr("glGetSeparableFilterEXT"))
 	gpGetShaderInfoLog = (C.GPGETSHADERINFOLOG)(getProcAddr("glGetShaderInfoLog"))
@@ -30039,6 +31499,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetShaderiv")
 	}
 	gpGetSharpenTexFuncSGIS = (C.GPGETSHARPENTEXFUNCSGIS)(getProcAddr("glGetSharpenTexFuncSGIS"))
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -30174,18 +31635,22 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetUniformfv")
 	}
 	gpGetUniformfvARB = (C.GPGETUNIFORMFVARB)(getProcAddr("glGetUniformfvARB"))
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
 	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
 	gpGetUniformivARB = (C.GPGETUNIFORMIVARB)(getProcAddr("glGetUniformivARB"))
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
 	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
 	}
 	gpGetUniformuivEXT = (C.GPGETUNIFORMUIVEXT)(getProcAddr("glGetUniformuivEXT"))
+	gpGetUnsignedBytei_vEXT = (C.GPGETUNSIGNEDBYTEI_VEXT)(getProcAddr("glGetUnsignedBytei_vEXT"))
+	gpGetUnsignedBytevEXT = (C.GPGETUNSIGNEDBYTEVEXT)(getProcAddr("glGetUnsignedBytevEXT"))
 	gpGetVariantArrayObjectfvATI = (C.GPGETVARIANTARRAYOBJECTFVATI)(getProcAddr("glGetVariantArrayObjectfvATI"))
 	gpGetVariantArrayObjectivATI = (C.GPGETVARIANTARRAYOBJECTIVATI)(getProcAddr("glGetVariantArrayObjectivATI"))
 	gpGetVariantBooleanvEXT = (C.GPGETVARIANTBOOLEANVEXT)(getProcAddr("glGetVariantBooleanvEXT"))
@@ -30252,6 +31717,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetVideoivNV = (C.GPGETVIDEOIVNV)(getProcAddr("glGetVideoivNV"))
 	gpGetVideoui64vNV = (C.GPGETVIDEOUI64VNV)(getProcAddr("glGetVideoui64vNV"))
 	gpGetVideouivNV = (C.GPGETVIDEOUIVNV)(getProcAddr("glGetVideouivNV"))
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnColorTableARB = (C.GPGETNCOLORTABLEARB)(getProcAddr("glGetnColorTableARB"))
 	gpGetnCompressedTexImageARB = (C.GPGETNCOMPRESSEDTEXIMAGEARB)(getProcAddr("glGetnCompressedTexImageARB"))
 	gpGetnConvolutionFilterARB = (C.GPGETNCONVOLUTIONFILTERARB)(getProcAddr("glGetnConvolutionFilterARB"))
@@ -30270,9 +31736,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	gpGetnUniformuivARB = (C.GPGETNUNIFORMUIVARB)(getProcAddr("glGetnUniformuivARB"))
 	gpGetnUniformuivKHR = (C.GPGETNUNIFORMUIVKHR)(getProcAddr("glGetnUniformuivKHR"))
@@ -30296,6 +31764,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpImageTransformParameterfvHP = (C.GPIMAGETRANSFORMPARAMETERFVHP)(getProcAddr("glImageTransformParameterfvHP"))
 	gpImageTransformParameteriHP = (C.GPIMAGETRANSFORMPARAMETERIHP)(getProcAddr("glImageTransformParameteriHP"))
 	gpImageTransformParameterivHP = (C.GPIMAGETRANSFORMPARAMETERIVHP)(getProcAddr("glImageTransformParameterivHP"))
+	gpImportMemoryFdEXT = (C.GPIMPORTMEMORYFDEXT)(getProcAddr("glImportMemoryFdEXT"))
+	gpImportMemoryWin32HandleEXT = (C.GPIMPORTMEMORYWIN32HANDLEEXT)(getProcAddr("glImportMemoryWin32HandleEXT"))
+	gpImportMemoryWin32NameEXT = (C.GPIMPORTMEMORYWIN32NAMEEXT)(getProcAddr("glImportMemoryWin32NameEXT"))
+	gpImportSemaphoreFdEXT = (C.GPIMPORTSEMAPHOREFDEXT)(getProcAddr("glImportSemaphoreFdEXT"))
+	gpImportSemaphoreWin32HandleEXT = (C.GPIMPORTSEMAPHOREWIN32HANDLEEXT)(getProcAddr("glImportSemaphoreWin32HandleEXT"))
+	gpImportSemaphoreWin32NameEXT = (C.GPIMPORTSEMAPHOREWIN32NAMEEXT)(getProcAddr("glImportSemaphoreWin32NameEXT"))
 	gpImportSyncEXT = (C.GPIMPORTSYNCEXT)(getProcAddr("glImportSyncEXT"))
 	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
 	gpIndexFuncEXT = (C.GPINDEXFUNCEXT)(getProcAddr("glIndexFuncEXT"))
@@ -30379,6 +31853,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsBufferARB = (C.GPISBUFFERARB)(getProcAddr("glIsBufferARB"))
 	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
@@ -30401,6 +31876,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsList == nil {
 		return errors.New("glIsList")
 	}
+	gpIsMemoryObjectEXT = (C.GPISMEMORYOBJECTEXT)(getProcAddr("glIsMemoryObjectEXT"))
 	gpIsNameAMD = (C.GPISNAMEAMD)(getProcAddr("glIsNameAMD"))
 	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
@@ -30434,10 +31910,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsSampler == nil {
 		return errors.New("glIsSampler")
 	}
+	gpIsSemaphoreEXT = (C.GPISSEMAPHOREEXT)(getProcAddr("glIsSemaphoreEXT"))
 	gpIsShader = (C.GPISSHADER)(getProcAddr("glIsShader"))
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	if gpIsSync == nil {
 		return errors.New("glIsSync")
@@ -30461,6 +31939,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsVertexArrayAPPLE = (C.GPISVERTEXARRAYAPPLE)(getProcAddr("glIsVertexArrayAPPLE"))
 	gpIsVertexAttribEnabledAPPLE = (C.GPISVERTEXATTRIBENABLEDAPPLE)(getProcAddr("glIsVertexAttribEnabledAPPLE"))
+	gpLGPUCopyImageSubDataNVX = (C.GPLGPUCOPYIMAGESUBDATANVX)(getProcAddr("glLGPUCopyImageSubDataNVX"))
+	gpLGPUInterlockNVX = (C.GPLGPUINTERLOCKNVX)(getProcAddr("glLGPUInterlockNVX"))
+	gpLGPUNamedBufferSubDataNVX = (C.GPLGPUNAMEDBUFFERSUBDATANVX)(getProcAddr("glLGPUNamedBufferSubDataNVX"))
 	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLightEnviSGIX = (C.GPLIGHTENVISGIX)(getProcAddr("glLightEnviSGIX"))
 	gpLightModelf = (C.GPLIGHTMODELF)(getProcAddr("glLightModelf"))
@@ -30517,6 +31998,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpListBase == nil {
 		return errors.New("glListBase")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpListParameterfSGIX = (C.GPLISTPARAMETERFSGIX)(getProcAddr("glListParameterfSGIX"))
 	gpListParameterfvSGIX = (C.GPLISTPARAMETERFVSGIX)(getProcAddr("glListParameterfvSGIX"))
 	gpListParameteriSGIX = (C.GPLISTPARAMETERISGIX)(getProcAddr("glListParameteriSGIX"))
@@ -30677,9 +32159,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
 	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
 	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	gpMemoryBarrierByRegion = (C.GPMEMORYBARRIERBYREGION)(getProcAddr("glMemoryBarrierByRegion"))
 	gpMemoryBarrierEXT = (C.GPMEMORYBARRIEREXT)(getProcAddr("glMemoryBarrierEXT"))
+	gpMemoryObjectParameterivEXT = (C.GPMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glMemoryObjectParameterivEXT"))
 	gpMinSampleShading = (C.GPMINSAMPLESHADING)(getProcAddr("glMinSampleShading"))
 	if gpMinSampleShading == nil {
 		return errors.New("glMinSampleShading")
@@ -30976,12 +32461,25 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
 	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
 	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
+	gpMulticastBarrierNV = (C.GPMULTICASTBARRIERNV)(getProcAddr("glMulticastBarrierNV"))
+	gpMulticastBlitFramebufferNV = (C.GPMULTICASTBLITFRAMEBUFFERNV)(getProcAddr("glMulticastBlitFramebufferNV"))
+	gpMulticastBufferSubDataNV = (C.GPMULTICASTBUFFERSUBDATANV)(getProcAddr("glMulticastBufferSubDataNV"))
+	gpMulticastCopyBufferSubDataNV = (C.GPMULTICASTCOPYBUFFERSUBDATANV)(getProcAddr("glMulticastCopyBufferSubDataNV"))
+	gpMulticastCopyImageSubDataNV = (C.GPMULTICASTCOPYIMAGESUBDATANV)(getProcAddr("glMulticastCopyImageSubDataNV"))
+	gpMulticastFramebufferSampleLocationsfvNV = (C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glMulticastFramebufferSampleLocationsfvNV"))
+	gpMulticastGetQueryObjecti64vNV = (C.GPMULTICASTGETQUERYOBJECTI64VNV)(getProcAddr("glMulticastGetQueryObjecti64vNV"))
+	gpMulticastGetQueryObjectivNV = (C.GPMULTICASTGETQUERYOBJECTIVNV)(getProcAddr("glMulticastGetQueryObjectivNV"))
+	gpMulticastGetQueryObjectui64vNV = (C.GPMULTICASTGETQUERYOBJECTUI64VNV)(getProcAddr("glMulticastGetQueryObjectui64vNV"))
+	gpMulticastGetQueryObjectuivNV = (C.GPMULTICASTGETQUERYOBJECTUIVNV)(getProcAddr("glMulticastGetQueryObjectuivNV"))
+	gpMulticastWaitSyncNV = (C.GPMULTICASTWAITSYNCNV)(getProcAddr("glMulticastWaitSyncNV"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
 	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
 	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
+	gpNamedBufferStorageExternalEXT = (C.GPNAMEDBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glNamedBufferStorageExternalEXT"))
+	gpNamedBufferStorageMemEXT = (C.GPNAMEDBUFFERSTORAGEMEMEXT)(getProcAddr("glNamedBufferStorageMemEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
 	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
 	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
@@ -30992,6 +32490,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	gpNamedFramebufferRenderbuffer = (C.GPNAMEDFRAMEBUFFERRENDERBUFFER)(getProcAddr("glNamedFramebufferRenderbuffer"))
 	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
+	gpNamedFramebufferSamplePositionsfvAMD = (C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glNamedFramebufferSamplePositionsfvAMD"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
 	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
 	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
@@ -31237,6 +32738,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPolygonOffsetEXT = (C.GPPOLYGONOFFSETEXT)(getProcAddr("glPolygonOffsetEXT"))
 	gpPolygonOffsetxOES = (C.GPPOLYGONOFFSETXOES)(getProcAddr("glPolygonOffsetxOES"))
 	gpPolygonStipple = (C.GPPOLYGONSTIPPLE)(getProcAddr("glPolygonStipple"))
@@ -31264,6 +32767,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpPresentFrameDualFillNV = (C.GPPRESENTFRAMEDUALFILLNV)(getProcAddr("glPresentFrameDualFillNV"))
 	gpPresentFrameKeyedNV = (C.GPPRESENTFRAMEKEYEDNV)(getProcAddr("glPresentFrameKeyedNV"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	if gpPrimitiveRestartIndex == nil {
 		return errors.New("glPrimitiveRestartIndex")
@@ -31348,7 +32852,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform1i == nil {
 		return errors.New("glProgramUniform1i")
 	}
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
 	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
 	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
 	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
@@ -31360,7 +32866,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform1ui == nil {
 		return errors.New("glProgramUniform1ui")
 	}
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
 	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
 	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
 	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
@@ -31392,7 +32900,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform2i == nil {
 		return errors.New("glProgramUniform2i")
 	}
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
 	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
 	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
 	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
@@ -31404,7 +32914,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform2ui == nil {
 		return errors.New("glProgramUniform2ui")
 	}
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
 	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
 	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
 	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
@@ -31436,7 +32948,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform3i == nil {
 		return errors.New("glProgramUniform3i")
 	}
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
 	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
 	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
 	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
@@ -31448,7 +32962,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform3ui == nil {
 		return errors.New("glProgramUniform3ui")
 	}
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
 	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
 	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
 	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
@@ -31480,7 +32996,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform4i == nil {
 		return errors.New("glProgramUniform4i")
 	}
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
 	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
 	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
 	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
@@ -31492,7 +33010,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform4ui == nil {
 		return errors.New("glProgramUniform4ui")
 	}
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
 	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
 	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
 	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
@@ -31628,6 +33148,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpQueryMatrixxOES = (C.GPQUERYMATRIXXOES)(getProcAddr("glQueryMatrixxOES"))
 	gpQueryObjectParameteruiAMD = (C.GPQUERYOBJECTPARAMETERUIAMD)(getProcAddr("glQueryObjectParameteruiAMD"))
+	gpQueryResourceNV = (C.GPQUERYRESOURCENV)(getProcAddr("glQueryResourceNV"))
+	gpQueryResourceTagNV = (C.GPQUERYRESOURCETAGNV)(getProcAddr("glQueryResourceTagNV"))
 	gpRasterPos2d = (C.GPRASTERPOS2D)(getProcAddr("glRasterPos2d"))
 	if gpRasterPos2d == nil {
 		return errors.New("glRasterPos2d")
@@ -31730,6 +33252,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpRasterPos4xOES = (C.GPRASTERPOS4XOES)(getProcAddr("glRasterPos4xOES"))
 	gpRasterPos4xvOES = (C.GPRASTERPOS4XVOES)(getProcAddr("glRasterPos4xvOES"))
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -31777,10 +33300,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpRectxOES = (C.GPRECTXOES)(getProcAddr("glRectxOES"))
 	gpRectxvOES = (C.GPRECTXVOES)(getProcAddr("glRectxvOES"))
 	gpReferencePlaneSGIX = (C.GPREFERENCEPLANESGIX)(getProcAddr("glReferencePlaneSGIX"))
+	gpReleaseKeyedMutexWin32EXT = (C.GPRELEASEKEYEDMUTEXWIN32EXT)(getProcAddr("glReleaseKeyedMutexWin32EXT"))
 	gpReleaseShaderCompiler = (C.GPRELEASESHADERCOMPILER)(getProcAddr("glReleaseShaderCompiler"))
 	if gpReleaseShaderCompiler == nil {
 		return errors.New("glReleaseShaderCompiler")
 	}
+	gpRenderGpuMaskNV = (C.GPRENDERGPUMASKNV)(getProcAddr("glRenderGpuMaskNV"))
 	gpRenderMode = (C.GPRENDERMODE)(getProcAddr("glRenderMode"))
 	if gpRenderMode == nil {
 		return errors.New("glRenderMode")
@@ -31825,6 +33350,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpResetMinmax = (C.GPRESETMINMAX)(getProcAddr("glResetMinmax"))
 	gpResetMinmaxEXT = (C.GPRESETMINMAXEXT)(getProcAddr("glResetMinmaxEXT"))
 	gpResizeBuffersMESA = (C.GPRESIZEBUFFERSMESA)(getProcAddr("glResizeBuffersMESA"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	if gpResumeTransformFeedback == nil {
 		return errors.New("glResumeTransformFeedback")
@@ -31844,7 +33370,6 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSampleCoverage")
 	}
 	gpSampleCoverageARB = (C.GPSAMPLECOVERAGEARB)(getProcAddr("glSampleCoverageARB"))
-	gpSampleCoverageOES = (C.GPSAMPLECOVERAGEOES)(getProcAddr("glSampleCoverageOES"))
 	gpSampleCoveragexOES = (C.GPSAMPLECOVERAGEXOES)(getProcAddr("glSampleCoveragexOES"))
 	gpSampleMapATI = (C.GPSAMPLEMAPATI)(getProcAddr("glSampleMapATI"))
 	gpSampleMaskEXT = (C.GPSAMPLEMASKEXT)(getProcAddr("glSampleMaskEXT"))
@@ -32007,6 +33532,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSelectBuffer")
 	}
 	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
+	gpSemaphoreParameterui64vEXT = (C.GPSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glSemaphoreParameterui64vEXT"))
 	gpSeparableFilter2D = (C.GPSEPARABLEFILTER2D)(getProcAddr("glSeparableFilter2D"))
 	gpSeparableFilter2DEXT = (C.GPSEPARABLEFILTER2DEXT)(getProcAddr("glSeparableFilter2DEXT"))
 	gpSetFenceAPPLE = (C.GPSETFENCEAPPLE)(getProcAddr("glSetFenceAPPLE"))
@@ -32033,11 +33559,16 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpShaderSourceARB = (C.GPSHADERSOURCEARB)(getProcAddr("glShaderSourceARB"))
 	gpShaderStorageBlockBinding = (C.GPSHADERSTORAGEBLOCKBINDING)(getProcAddr("glShaderStorageBlockBinding"))
 	gpSharpenTexFuncSGIS = (C.GPSHARPENTEXFUNCSGIS)(getProcAddr("glSharpenTexFuncSGIS"))
+	gpSignalSemaphoreEXT = (C.GPSIGNALSEMAPHOREEXT)(getProcAddr("glSignalSemaphoreEXT"))
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
 	gpSpriteParameterfSGIX = (C.GPSPRITEPARAMETERFSGIX)(getProcAddr("glSpriteParameterfSGIX"))
 	gpSpriteParameterfvSGIX = (C.GPSPRITEPARAMETERFVSGIX)(getProcAddr("glSpriteParameterfvSGIX"))
 	gpSpriteParameteriSGIX = (C.GPSPRITEPARAMETERISGIX)(getProcAddr("glSpriteParameteriSGIX"))
 	gpSpriteParameterivSGIX = (C.GPSPRITEPARAMETERIVSGIX)(getProcAddr("glSpriteParameterivSGIX"))
 	gpStartInstrumentsSGIX = (C.GPSTARTINSTRUMENTSSGIX)(getProcAddr("glStartInstrumentsSGIX"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
 	gpStencilClearTagEXT = (C.GPSTENCILCLEARTAGEXT)(getProcAddr("glStencilClearTagEXT"))
 	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
 	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
@@ -32076,6 +33607,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
 	gpStopInstrumentsSGIX = (C.GPSTOPINSTRUMENTSSGIX)(getProcAddr("glStopInstrumentsSGIX"))
 	gpStringMarkerGREMEDY = (C.GPSTRINGMARKERGREMEDY)(getProcAddr("glStringMarkerGREMEDY"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpSwizzleEXT = (C.GPSWIZZLEEXT)(getProcAddr("glSwizzleEXT"))
 	gpSyncTextureINTEL = (C.GPSYNCTEXTUREINTEL)(getProcAddr("glSyncTextureINTEL"))
 	gpTagSampleBufferSGIX = (C.GPTAGSAMPLEBUFFERSGIX)(getProcAddr("glTagSampleBufferSGIX"))
@@ -32415,6 +33947,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpTexStorage2DMultisample = (C.GPTEXSTORAGE2DMULTISAMPLE)(getProcAddr("glTexStorage2DMultisample"))
 	gpTexStorage3D = (C.GPTEXSTORAGE3D)(getProcAddr("glTexStorage3D"))
 	gpTexStorage3DMultisample = (C.GPTEXSTORAGE3DMULTISAMPLE)(getProcAddr("glTexStorage3DMultisample"))
+	gpTexStorageMem1DEXT = (C.GPTEXSTORAGEMEM1DEXT)(getProcAddr("glTexStorageMem1DEXT"))
+	gpTexStorageMem2DEXT = (C.GPTEXSTORAGEMEM2DEXT)(getProcAddr("glTexStorageMem2DEXT"))
+	gpTexStorageMem2DMultisampleEXT = (C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem2DMultisampleEXT"))
+	gpTexStorageMem3DEXT = (C.GPTEXSTORAGEMEM3DEXT)(getProcAddr("glTexStorageMem3DEXT"))
+	gpTexStorageMem3DMultisampleEXT = (C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem3DMultisampleEXT"))
 	gpTexStorageSparseAMD = (C.GPTEXSTORAGESPARSEAMD)(getProcAddr("glTexStorageSparseAMD"))
 	gpTexSubImage1D = (C.GPTEXSUBIMAGE1D)(getProcAddr("glTexSubImage1D"))
 	if gpTexSubImage1D == nil {
@@ -32474,6 +34011,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
 	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
+	gpTextureStorageMem1DEXT = (C.GPTEXTURESTORAGEMEM1DEXT)(getProcAddr("glTextureStorageMem1DEXT"))
+	gpTextureStorageMem2DEXT = (C.GPTEXTURESTORAGEMEM2DEXT)(getProcAddr("glTextureStorageMem2DEXT"))
+	gpTextureStorageMem2DMultisampleEXT = (C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem2DMultisampleEXT"))
+	gpTextureStorageMem3DEXT = (C.GPTEXTURESTORAGEMEM3DEXT)(getProcAddr("glTextureStorageMem3DEXT"))
+	gpTextureStorageMem3DMultisampleEXT = (C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem3DMultisampleEXT"))
 	gpTextureStorageSparseAMD = (C.GPTEXTURESTORAGESPARSEAMD)(getProcAddr("glTextureStorageSparseAMD"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
 	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
@@ -32525,7 +34067,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
 	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
 	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iARB = (C.GPUNIFORM1IARB)(getProcAddr("glUniform1iARB"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
@@ -32537,7 +34081,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
 	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
 	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiEXT = (C.GPUNIFORM1UIEXT)(getProcAddr("glUniform1uiEXT"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
@@ -32567,7 +34113,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
 	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
 	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iARB = (C.GPUNIFORM2IARB)(getProcAddr("glUniform2iARB"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
@@ -32579,7 +34127,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
 	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
 	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiEXT = (C.GPUNIFORM2UIEXT)(getProcAddr("glUniform2uiEXT"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
@@ -32609,7 +34159,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
 	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
 	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iARB = (C.GPUNIFORM3IARB)(getProcAddr("glUniform3iARB"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
@@ -32621,7 +34173,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
 	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
 	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiEXT = (C.GPUNIFORM3UIEXT)(getProcAddr("glUniform3uiEXT"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
@@ -32651,7 +34205,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
 	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
 	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iARB = (C.GPUNIFORM4IARB)(getProcAddr("glUniform4iARB"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
@@ -32663,7 +34219,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
 	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
 	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiEXT = (C.GPUNIFORM4UIEXT)(getProcAddr("glUniform4uiEXT"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
@@ -33501,10 +35059,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpViewportIndexedfv == nil {
 		return errors.New("glViewportIndexedfv")
 	}
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
+	gpWaitSemaphoreEXT = (C.GPWAITSEMAPHOREEXT)(getProcAddr("glWaitSemaphoreEXT"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
 	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
 	gpWeightPointerARB = (C.GPWEIGHTPOINTERARB)(getProcAddr("glWeightPointerARB"))
 	gpWeightbvARB = (C.GPWEIGHTBVARB)(getProcAddr("glWeightbvARB"))
@@ -33619,6 +35181,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpWindowPos4ivMESA = (C.GPWINDOWPOS4IVMESA)(getProcAddr("glWindowPos4ivMESA"))
 	gpWindowPos4sMESA = (C.GPWINDOWPOS4SMESA)(getProcAddr("glWindowPos4sMESA"))
 	gpWindowPos4svMESA = (C.GPWINDOWPOS4SVMESA)(getProcAddr("glWindowPos4svMESA"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	gpWriteMaskEXT = (C.GPWRITEMASKEXT)(getProcAddr("glWriteMaskEXT"))
 	return nil
 }

--- a/v4.1-compatibility/gl/procaddr.go
+++ b/v4.1-compatibility/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcompatibility41(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v4.1-core/gl/package.go
+++ b/v4.1-core/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -89,21 +87,29 @@ package gl
 // typedef ptrdiff_t GLsizeiptr;
 // typedef int64_t GLint64;
 // typedef uint64_t GLuint64;
+// typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCARB)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCKHR)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcore41(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcore41(source, type, id, severity, length, message, userParam);
 // }
+// typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
+// typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVETEXTURE)(GLenum  texture);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPATTACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPBEGINCONDITIONALRENDER)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINCONDITIONALRENDERNV)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPBEGINPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPBEGINQUERY)(GLenum  target, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINQUERYINDEXED)(GLenum  target, GLuint  index, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINTRANSFORMFEEDBACK)(GLenum  primitiveMode);
@@ -118,7 +124,9 @@ package gl
 // typedef void  (APIENTRYP GPBINDFRAMEBUFFER)(GLenum  target, GLuint  framebuffer);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURE)(GLuint  unit, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  access, GLenum  format);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURES)(GLuint  first, GLsizei  count, const GLuint * textures);
+// typedef void  (APIENTRYP GPBINDMULTITEXTUREEXT)(GLenum  texunit, GLenum  target, GLuint  texture);
 // typedef void  (APIENTRYP GPBINDPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPBINDPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPBINDRENDERBUFFER)(GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPBINDSAMPLER)(GLuint  unit, GLuint  sampler);
 // typedef void  (APIENTRYP GPBINDSAMPLERS)(GLuint  first, GLsizei  count, const GLuint * samplers);
@@ -129,6 +137,8 @@ package gl
 // typedef void  (APIENTRYP GPBINDVERTEXARRAY)(GLuint  array);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFER)(GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFERS)(GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPBLENDBARRIERKHR)();
+// typedef void  (APIENTRYP GPBLENDBARRIERNV)();
 // typedef void  (APIENTRYP GPBLENDCOLOR)(GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha);
 // typedef void  (APIENTRYP GPBLENDEQUATION)(GLenum  mode);
 // typedef void  (APIENTRYP GPBLENDEQUATIONSEPARATE)(GLenum  modeRGB, GLenum  modeAlpha);
@@ -142,14 +152,18 @@ package gl
 // typedef void  (APIENTRYP GPBLENDFUNCSEPARATEIARB)(GLuint  buf, GLenum  srcRGB, GLenum  dstRGB, GLenum  srcAlpha, GLenum  dstAlpha);
 // typedef void  (APIENTRYP GPBLENDFUNCI)(GLuint  buf, GLenum  src, GLenum  dst);
 // typedef void  (APIENTRYP GPBLENDFUNCIARB)(GLuint  buf, GLenum  src, GLenum  dst);
+// typedef void  (APIENTRYP GPBLENDPARAMETERINV)(GLenum  pname, GLint  value);
 // typedef void  (APIENTRYP GPBLITFRAMEBUFFER)(GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
 // typedef void  (APIENTRYP GPBLITNAMEDFRAMEBUFFER)(GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
 // typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUS)(GLuint  framebuffer, GLenum  target);
+// typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(GLuint  framebuffer, GLenum  target);
 // typedef void  (APIENTRYP GPCLAMPCOLOR)(GLenum  target, GLenum  clamp);
 // typedef void  (APIENTRYP GPCLEAR)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPCLEARBUFFERDATA)(GLenum  target, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
@@ -162,49 +176,91 @@ package gl
 // typedef void  (APIENTRYP GPCLEARDEPTH)(GLdouble  depth);
 // typedef void  (APIENTRYP GPCLEARDEPTHF)(GLfloat  d);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
 // typedef void  (APIENTRYP GPCLEARSTENCIL)(GLint  s);
 // typedef void  (APIENTRYP GPCLEARTEXIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARTEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef GLenum  (APIENTRYP GPCLIENTWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
 // typedef void  (APIENTRYP GPCLIPCONTROL)(GLenum  origin, GLenum  depth);
+// typedef void  (APIENTRYP GPCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPCOLORMASK)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPCOLORMASKI)(GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE3D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOPYBUFFERSUBDATA)(GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYIMAGESUBDATA)(GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef void  (APIENTRYP GPCREATEPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPCREATEQUERIES)(GLenum  target, GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPCREATERENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPCREATESAMPLERS)(GLsizei  n, GLuint * samplers);
 // typedef GLuint  (APIENTRYP GPCREATESHADER)(GLenum  type);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -220,14 +276,20 @@ package gl
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTARB)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTKHR)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef void  (APIENTRYP GPDELETEPATHSNV)(GLuint  path, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
+// typedef void  (APIENTRYP GPDELETEPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPDELETEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINES)(GLsizei  n, const GLuint * pipelines);
+// typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINESEXT)(GLsizei  n, const GLuint * pipelines);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETRANSFORMFEEDBACKS)(GLsizei  n, const GLuint * ids);
@@ -240,7 +302,12 @@ package gl
 // typedef void  (APIENTRYP GPDEPTHRANGEF)(GLfloat  n, GLfloat  f);
 // typedef void  (APIENTRYP GPDETACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPDISABLE)(GLenum  cap);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPDISABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISPATCHCOMPUTE)(GLuint  num_groups_x, GLuint  num_groups_y, GLuint  num_groups_z);
@@ -249,46 +316,81 @@ package gl
 // typedef void  (APIENTRYP GPDRAWARRAYS)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCED)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDARB)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDBASEINSTANCE)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDEXT)(GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWBUFFER)(GLenum  buf);
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWELEMENTSBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCED)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDARB)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDEXT)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTS)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTSBASEVERTEX)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACK)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKINSTANCED)(GLenum  mode, GLuint  id, GLsizei  instancecount);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
+// typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPENABLE)(GLenum  cap);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPENABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPENABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDCONDITIONALRENDER)();
+// typedef void  (APIENTRYP GPENDCONDITIONALRENDERNV)();
+// typedef void  (APIENTRYP GPENDPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPENDPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPENDQUERY)(GLenum  target);
 // typedef void  (APIENTRYP GPENDQUERYINDEXED)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDTRANSFORMFEEDBACK)();
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef GLsync  (APIENTRYP GPFENCESYNC)(GLenum  condition, GLbitfield  flags);
 // typedef void  (APIENTRYP GPFINISH)();
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFOGCOORDFORMATNV)(GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE2D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE3D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREFACEARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPGENBUFFERS)(GLsizei  n, GLuint * buffers);
 // typedef void  (APIENTRYP GPGENFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef GLuint  (APIENTRYP GPGENPATHSNV)(GLsizei  range);
+// typedef void  (APIENTRYP GPGENPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
 // typedef void  (APIENTRYP GPGENPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
+// typedef void  (APIENTRYP GPGENPROGRAMPIPELINESEXT)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
@@ -296,7 +398,9 @@ package gl
 // typedef void  (APIENTRYP GPGENTRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENVERTEXARRAYS)(GLsizei  n, GLuint * arrays);
 // typedef void  (APIENTRYP GPGENERATEMIPMAP)(GLenum  target);
+// typedef void  (APIENTRYP GPGENERATEMULTITEXMIPMAPEXT)(GLenum  texunit, GLenum  target);
 // typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAP)(GLuint  texture);
+// typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAPEXT)(GLuint  texture, GLenum  target);
 // typedef void  (APIENTRYP GPGETACTIVEATOMICCOUNTERBUFFERIV)(GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETACTIVEATTRIB)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLint * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETACTIVESUBROUTINENAME)(GLuint  program, GLenum  shadertype, GLuint  index, GLsizei  bufsize, GLsizei * length, GLchar * name);
@@ -309,65 +413,137 @@ package gl
 // typedef void  (APIENTRYP GPGETACTIVEUNIFORMSIV)(GLuint  program, GLsizei  uniformCount, const GLuint * uniformIndices, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETATTACHEDSHADERS)(GLuint  program, GLsizei  maxCount, GLsizei * count, GLuint * shaders);
 // typedef GLint  (APIENTRYP GPGETATTRIBLOCATION)(GLuint  program, const GLchar * name);
+// typedef void  (APIENTRYP GPGETBOOLEANINDEXEDVEXT)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANI_V)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANV)(GLenum  pname, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERI64V)(GLenum  target, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETBUFFERPARAMETERUI64VNV)(GLenum  target, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETBUFFERPOINTERV)(GLenum  target, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGE)(GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGKHR)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
+// typedef void  (APIENTRYP GPGETDOUBLEINDEXEDVEXT)(GLenum  target, GLuint  index, GLdouble * data);
 // typedef void  (APIENTRYP GPGETDOUBLEI_V)(GLenum  target, GLuint  index, GLdouble * data);
+// typedef void  (APIENTRYP GPGETDOUBLEI_VEXT)(GLenum  pname, GLuint  index, GLdouble * params);
 // typedef void  (APIENTRYP GPGETDOUBLEV)(GLenum  pname, GLdouble * data);
 // typedef GLenum  (APIENTRYP GPGETERROR)();
+// typedef void  (APIENTRYP GPGETFIRSTPERFQUERYIDINTEL)(GLuint * queryId);
+// typedef void  (APIENTRYP GPGETFLOATINDEXEDVEXT)(GLenum  target, GLuint  index, GLfloat * data);
 // typedef void  (APIENTRYP GPGETFLOATI_V)(GLenum  target, GLuint  index, GLfloat * data);
+// typedef void  (APIENTRYP GPGETFLOATI_VEXT)(GLenum  pname, GLuint  index, GLfloat * params);
 // typedef void  (APIENTRYP GPGETFLOATV)(GLenum  pname, GLfloat * data);
 // typedef GLint  (APIENTRYP GPGETFRAGDATAINDEX)(GLuint  program, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETFRAGDATALOCATION)(GLuint  program, const GLchar * name);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSARB)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSKHR)();
 // typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLEARB)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
+// typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLENV)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
 // typedef void  (APIENTRYP GPGETINTEGER64I_V)(GLenum  target, GLuint  index, GLint64 * data);
 // typedef void  (APIENTRYP GPGETINTEGER64V)(GLenum  pname, GLint64 * data);
+// typedef void  (APIENTRYP GPGETINTEGERINDEXEDVEXT)(GLenum  target, GLuint  index, GLint * data);
 // typedef void  (APIENTRYP GPGETINTEGERI_V)(GLenum  target, GLuint  index, GLint * data);
+// typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
+// typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMULTISAMPLEFV)(GLenum  pname, GLuint  index, GLfloat * val);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERI64V)(GLuint  buffer, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIV)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIVEXT)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  pname, void * string);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMIVEXT)(GLuint  program, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIV)(GLuint  renderbuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(GLuint  renderbuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGARB)(GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGIVARB)(GLint  namelen, const GLchar * name, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNEXTPERFQUERYIDINTEL)(GLuint  queryId, GLuint * nextQueryId);
 // typedef void  (APIENTRYP GPGETOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETOBJECTLABELEXT)(GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABEL)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABELKHR)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETPATHCOMMANDSNV)(GLuint  path, GLubyte * commands);
+// typedef void  (APIENTRYP GPGETPATHCOORDSNV)(GLuint  path, GLfloat * coords);
+// typedef void  (APIENTRYP GPGETPATHDASHARRAYNV)(GLuint  path, GLfloat * dashArray);
+// typedef GLfloat  (APIENTRYP GPGETPATHLENGTHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments);
+// typedef void  (APIENTRYP GPGETPATHMETRICRANGENV)(GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHMETRICSNV)(GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, GLfloat * value);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, GLint * value);
+// typedef void  (APIENTRYP GPGETPATHSPACINGNV)(GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing);
+// typedef void  (APIENTRYP GPGETPERFCOUNTERINFOINTEL)(GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERDATAAMD)(GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERINFOAMD)(GLuint  group, GLuint  counter, GLenum  pname, void * data);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSTRINGAMD)(GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
+// typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
+// typedef void  (APIENTRYP GPGETPOINTERINDEXEDVEXT)(GLenum  target, GLuint  index, void ** data);
+// typedef void  (APIENTRYP GPGETPOINTERI_VEXT)(GLenum  pname, GLuint  index, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERV)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERVKHR)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPROGRAMBINARY)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLenum * binaryFormat, void * binary);
 // typedef void  (APIENTRYP GPGETPROGRAMINFOLOG)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMINTERFACEIV)(GLuint  program, GLenum  programInterface, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOG)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOGEXT)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIV)(GLuint  pipeline, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIVEXT)(GLuint  pipeline, GLenum  pname, GLint * params);
 // typedef GLuint  (APIENTRYP GPGETPROGRAMRESOURCEINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATION)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATIONINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCENAME)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name);
+// typedef void  (APIENTRYP GPGETPROGRAMRESOURCEFVNV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCEIV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMSTAGEIV)(GLuint  program, GLenum  shadertype, GLenum  pname, GLint * values);
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTIV)(GLuint  id, GLenum  pname, GLint * params);
@@ -383,6 +559,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERPRECISIONFORMAT)(GLenum  shadertype, GLenum  precisiontype, GLint * range, GLint * precision);
 // typedef void  (APIENTRYP GPGETSHADERSOURCE)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -396,14 +573,23 @@ package gl
 // typedef void  (APIENTRYP GPGETTEXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLEARB)(GLuint  texture);
+// typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLENV)(GLuint  texture);
 // typedef void  (APIENTRYP GPGETTEXTUREIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFV)(GLuint  texture, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIV)(GLuint  texture, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLEARB)(GLuint  texture, GLuint  sampler);
+// typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLENV)(GLuint  texture, GLuint  sampler);
 // typedef void  (APIENTRYP GPGETTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKVARYING)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLsizei * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKI64_V)(GLuint  xfb, GLenum  pname, GLuint  index, GLint64 * param);
@@ -415,32 +601,48 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMSUBROUTINEUIV)(GLenum  shadertype, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXED64IV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint64 * param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXEDIV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERVEXT)(GLuint  vaobj, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, void ** param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERVEXT)(GLuint  vaobj, GLenum  pname, void ** param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYIV)(GLuint  vaobj, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIIV)(GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIUIV)(GLuint  index, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLDV)(GLuint  index, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLI64VNV)(GLuint  index, GLenum  pname, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VARB)(GLuint  index, GLenum  pname, GLuint64EXT * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VNV)(GLuint  index, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBPOINTERV)(GLuint  index, GLenum  pname, void ** pointer);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBDV)(GLuint  index, GLenum  pname, GLdouble * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBFV)(GLuint  index, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIV)(GLuint  index, GLenum  pname, GLint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNTEXIMAGEARB)(GLenum  target, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNUNIFORMDVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLdouble * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPHINT)(GLenum  target, GLenum  mode);
+// typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPINSERTEVENTMARKEREXT)(GLsizei  length, const GLchar * marker);
+// typedef void  (APIENTRYP GPINTERPOLATEPATHSNV)(GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERDATA)(GLuint  buffer);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPINVALIDATEFRAMEBUFFER)(GLenum  target, GLsizei  numAttachments, const GLenum * attachments);
@@ -450,68 +652,196 @@ package gl
 // typedef void  (APIENTRYP GPINVALIDATETEXIMAGE)(GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPINVALIDATETEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
+// typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISFRAMEBUFFER)(GLuint  framebuffer);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef GLboolean  (APIENTRYP GPISPATHNV)(GLuint  path);
+// typedef GLboolean  (APIENTRYP GPISPOINTINFILLPATHNV)(GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y);
+// typedef GLboolean  (APIENTRYP GPISPOINTINSTROKEPATHNV)(GLuint  path, GLfloat  x, GLfloat  y);
 // typedef GLboolean  (APIENTRYP GPISPROGRAM)(GLuint  program);
 // typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef GLboolean  (APIENTRYP GPISQUERY)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISTRANSFORMFEEDBACK)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
+// typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLINEWIDTH)(GLfloat  width);
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLOGICOP)(GLenum  opcode);
+// typedef void  (APIENTRYP GPMAKEBUFFERNONRESIDENTNV)(GLenum  target);
+// typedef void  (APIENTRYP GPMAKEBUFFERRESIDENTNV)(GLenum  target, GLenum  access);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTARB)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTNV)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERNONRESIDENTNV)(GLuint  buffer);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERRESIDENTNV)(GLuint  buffer, GLenum  access);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef void * (APIENTRYP GPMAPBUFFER)(GLenum  target, GLenum  access);
 // typedef void * (APIENTRYP GPMAPBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void  (APIENTRYP GPMATRIXFRUSTUMEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADIDENTITYEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXORTHOEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXPOPEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXPUSHEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXROTATEDEXT)(GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXROTATEFEXT)(GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMINSAMPLESHADING)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYS)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTITEXBUFFEREXT)(GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPMULTITEXCOORDPOINTEREXT)(GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
+// typedef void  (APIENTRYP GPMULTITEXENVFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXENVIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXGENDEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param);
+// typedef void  (APIENTRYP GPMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params);
+// typedef void  (APIENTRYP GPMULTITEXGENFEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXGENIEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXRENDERBUFFEREXT)(GLenum  texunit, GLenum  target, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFERS)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERI)(GLuint  framebuffer, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERIEXT)(GLuint  framebuffer, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYER)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLdouble * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGE)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEEXT)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDSTRINGARB)(GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string);
+// typedef void  (APIENTRYP GPNORMALFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABEL)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABELKHR)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPPATCHPARAMETERFV)(GLenum  pname, const GLfloat * values);
 // typedef void  (APIENTRYP GPPATCHPARAMETERI)(GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHCOMMANDSNV)(GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOORDSNV)(GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOVERDEPTHFUNCNV)(GLenum  func);
+// typedef void  (APIENTRYP GPPATHDASHARRAYNV)(GLuint  path, GLsizei  dashCount, const GLfloat * dashArray);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXRANGENV)(GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount);
+// typedef void  (APIENTRYP GPPATHGLYPHRANGENV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHGLYPHSNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHMEMORYGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHPARAMETERFNV)(GLuint  path, GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, const GLfloat * value);
+// typedef void  (APIENTRYP GPPATHPARAMETERINV)(GLuint  path, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, const GLint * value);
+// typedef void  (APIENTRYP GPPATHSTENCILDEPTHOFFSETNV)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPATHSTENCILFUNCNV)(GLenum  func, GLint  ref, GLuint  mask);
+// typedef void  (APIENTRYP GPPATHSTRINGNV)(GLuint  path, GLenum  format, GLsizei  length, const void * pathString);
+// typedef void  (APIENTRYP GPPATHSUBCOMMANDSNV)(GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHSUBCOORDSNV)(GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords);
 // typedef void  (APIENTRYP GPPAUSETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPPIXELSTOREF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPIXELSTOREI)(GLenum  pname, GLint  param);
+// typedef GLboolean  (APIENTRYP GPPOINTALONGPATHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY);
 // typedef void  (APIENTRYP GPPOINTPARAMETERF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPOINTPARAMETERFV)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPPOINTPARAMETERI)(GLenum  pname, GLint  param);
@@ -519,67 +849,163 @@ package gl
 // typedef void  (APIENTRYP GPPOINTSIZE)(GLfloat  size);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOPDEBUGGROUP)();
 // typedef void  (APIENTRYP GPPOPDEBUGGROUPKHR)();
+// typedef void  (APIENTRYP GPPOPGROUPMARKEREXT)();
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPROGRAMBINARY)(GLuint  program, GLenum  binaryFormat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPPROGRAMPARAMETERI)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIARB)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIEXT)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPATHFRAGMENTINPUTGENNV)(GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1D)(GLuint  program, GLint  location, GLdouble  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DEXT)(GLuint  program, GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1F)(GLuint  program, GLint  location, GLfloat  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FEXT)(GLuint  program, GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64ARB)(GLuint  program, GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64NV)(GLuint  program, GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64NV)(GLuint  program, GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROVOKINGVERTEX)(GLenum  mode);
+// typedef void  (APIENTRYP GPPUSHCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUP)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUPKHR)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
+// typedef void  (APIENTRYP GPPUSHGROUPMARKEREXT)(GLsizei  length, const GLchar * marker);
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPREADNPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, GLsizei  bufSize, void * data);
@@ -588,6 +1014,8 @@ package gl
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMASKI)(GLuint  maskNumber, GLbitfield  mask);
@@ -601,23 +1029,40 @@ package gl
 // typedef void  (APIENTRYP GPSCISSORARRAYV)(GLuint  first, GLsizei  count, const GLint * v);
 // typedef void  (APIENTRYP GPSCISSORINDEXED)(GLuint  index, GLint  left, GLint  bottom, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPSCISSORINDEXEDV)(GLuint  index, const GLint * v);
+// typedef void  (APIENTRYP GPSECONDARYCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
 // typedef void  (APIENTRYP GPSHADERBINARY)(GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPSHADERSOURCE)(GLuint  shader, GLsizei  count, const GLchar *const* string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNC)(GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNCSEPARATE)(GLenum  face, GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASK)(GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASKSEPARATE)(GLenum  face, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILOP)(GLenum  fail, GLenum  zfail, GLenum  zpass);
 // typedef void  (APIENTRYP GPSTENCILOPSEPARATE)(GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPTEXBUFFER)(GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXBUFFERARB)(GLenum  target, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXBUFFERRANGE)(GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXCOORDFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPTEXIMAGE1D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE2D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERF)(GLenum  target, GLenum  pname, GLfloat  param);
@@ -633,61 +1078,118 @@ package gl
 // typedef void  (APIENTRYP GPTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREBARRIER)();
+// typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERF)(GLuint  texture, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, const GLfloat * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERI)(GLuint  texture, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, const GLint * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTURERENDERBUFFEREXT)(GLuint  texture, GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE1D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE1DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREVIEW)(GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
+// typedef void  (APIENTRYP GPTRANSFORMPATHNV)(GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPUNIFORM1D)(GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPUNIFORM1DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM1F)(GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM2D)(GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPUNIFORM2DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM2F)(GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM3D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPUNIFORM3DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM3F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM4D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPUNIFORM4DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM4F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORMBLOCKBINDING)(GLuint  program, GLuint  uniformBlockIndex, GLuint  uniformBlockBinding);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64ARB)(GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64NV)(GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VNV)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
@@ -707,20 +1209,45 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMSUBROUTINESUIV)(GLenum  shadertype, GLsizei  count, const GLuint * indices);
+// typedef void  (APIENTRYP GPUNIFORMUI64NV)(GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPUNIFORMUI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef GLboolean  (APIENTRYP GPUNMAPBUFFER)(GLenum  target);
 // typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFEREXT)(GLuint  buffer);
 // typedef void  (APIENTRYP GPUSEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPUSEPROGRAMSTAGES)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSEPROGRAMSTAGESEXT)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSESHADERPROGRAMEXT)(GLenum  type, GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBBINDING)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBIFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBLFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYBINDVERTEXBUFFEREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYBINDINGDIVISOR)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYEDGEFLAGOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXARRAYELEMENTBUFFER)(GLuint  vaobj, GLuint  buffer);
+// typedef void  (APIENTRYP GPVERTEXARRAYFOGCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYINDEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYNORMALOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYTEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(GLuint  vaobj, GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFER)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFERS)(GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1DV)(GLuint  index, const GLdouble * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1F)(GLuint  index, GLfloat  x);
@@ -759,7 +1286,9 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIB4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBBINDING)(GLuint  attribindex, GLuint  bindingindex);
 // typedef void  (APIENTRYP GPVERTEXATTRIBDIVISOR)(GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXATTRIBDIVISORARB)(GLuint  index, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXATTRIBFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1I)(GLuint  index, GLint  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1IV)(GLuint  index, const GLint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1UI)(GLuint  index, GLuint  x);
@@ -781,18 +1310,36 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4UIV)(GLuint  index, const GLuint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBIFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64NV)(GLuint  index, GLint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64VNV)(GLuint  index, const GLint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64ARB)(GLuint  index, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64NV)(GLuint  index, GLuint64EXT  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VARB)(GLuint  index, const GLuint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2D)(GLuint  index, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBLFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UI)(GLuint  index, GLenum  type, GLboolean  normalized, GLuint  value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
@@ -804,22 +1351,46 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBP4UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBPOINTER)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXBINDINGDIVISOR)(GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVIEWPORT)(GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
+// static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
+//   (*fnptr)(program);
+// }
 // static void  glowActiveShaderProgram(GPACTIVESHADERPROGRAM fnptr, GLuint  pipeline, GLuint  program) {
+//   (*fnptr)(pipeline, program);
+// }
+// static void  glowActiveShaderProgramEXT(GPACTIVESHADERPROGRAMEXT fnptr, GLuint  pipeline, GLuint  program) {
 //   (*fnptr)(pipeline, program);
 // }
 // static void  glowActiveTexture(GPACTIVETEXTURE fnptr, GLenum  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowAttachShader(GPATTACHSHADER fnptr, GLuint  program, GLuint  shader) {
 //   (*fnptr)(program, shader);
 // }
 // static void  glowBeginConditionalRender(GPBEGINCONDITIONALRENDER fnptr, GLuint  id, GLenum  mode) {
 //   (*fnptr)(id, mode);
+// }
+// static void  glowBeginConditionalRenderNV(GPBEGINCONDITIONALRENDERNV fnptr, GLuint  id, GLenum  mode) {
+//   (*fnptr)(id, mode);
+// }
+// static void  glowBeginPerfMonitorAMD(GPBEGINPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowBeginPerfQueryINTEL(GPBEGINPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
 // }
 // static void  glowBeginQuery(GPBEGINQUERY fnptr, GLenum  target, GLuint  id) {
 //   (*fnptr)(target, id);
@@ -863,7 +1434,13 @@ package gl
 // static void  glowBindImageTextures(GPBINDIMAGETEXTURES fnptr, GLuint  first, GLsizei  count, const GLuint * textures) {
 //   (*fnptr)(first, count, textures);
 // }
+// static void  glowBindMultiTextureEXT(GPBINDMULTITEXTUREEXT fnptr, GLenum  texunit, GLenum  target, GLuint  texture) {
+//   (*fnptr)(texunit, target, texture);
+// }
 // static void  glowBindProgramPipeline(GPBINDPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowBindProgramPipelineEXT(GPBINDPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowBindRenderbuffer(GPBINDRENDERBUFFER fnptr, GLenum  target, GLuint  renderbuffer) {
@@ -895,6 +1472,12 @@ package gl
 // }
 // static void  glowBindVertexBuffers(GPBINDVERTEXBUFFERS fnptr, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(first, count, buffers, offsets, strides);
+// }
+// static void  glowBlendBarrierKHR(GPBLENDBARRIERKHR fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowBlendBarrierNV(GPBLENDBARRIERNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowBlendColor(GPBLENDCOLOR fnptr, GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
@@ -935,16 +1518,22 @@ package gl
 // static void  glowBlendFunciARB(GPBLENDFUNCIARB fnptr, GLuint  buf, GLenum  src, GLenum  dst) {
 //   (*fnptr)(buf, src, dst);
 // }
+// static void  glowBlendParameteriNV(GPBLENDPARAMETERINV fnptr, GLenum  pname, GLint  value) {
+//   (*fnptr)(pname, value);
+// }
 // static void  glowBlitFramebuffer(GPBLITFRAMEBUFFER fnptr, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
 // static void  glowBlitNamedFramebuffer(GPBLITNAMEDFRAMEBUFFER fnptr, GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
+// static void  glowBufferAddressRangeNV(GPBUFFERADDRESSRANGENV fnptr, GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length) {
+//   (*fnptr)(pname, index, address, length);
+// }
 // static void  glowBufferData(GPBUFFERDATA fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
@@ -953,10 +1542,16 @@ package gl
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static GLenum  glowCheckFramebufferStatus(GPCHECKFRAMEBUFFERSTATUS fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLenum  glowCheckNamedFramebufferStatus(GPCHECKNAMEDFRAMEBUFFERSTATUS fnptr, GLuint  framebuffer, GLenum  target) {
+//   return (*fnptr)(framebuffer, target);
+// }
+// static GLenum  glowCheckNamedFramebufferStatusEXT(GPCHECKNAMEDFRAMEBUFFERSTATUSEXT fnptr, GLuint  framebuffer, GLenum  target) {
 //   return (*fnptr)(framebuffer, target);
 // }
 // static void  glowClampColor(GPCLAMPCOLOR fnptr, GLenum  target, GLenum  clamp) {
@@ -995,11 +1590,17 @@ package gl
 // static void  glowClearNamedBufferData(GPCLEARNAMEDBUFFERDATA fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, format, type, data);
+// }
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
+// }
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -1019,11 +1620,17 @@ package gl
 // static void  glowClearTexSubImage(GPCLEARTEXSUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data);
 // }
+// static void  glowClientAttribDefaultEXT(GPCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
+// }
 // static GLenum  glowClientWaitSync(GPCLIENTWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   return (*fnptr)(sync, flags, timeout);
 // }
 // static void  glowClipControl(GPCLIPCONTROL fnptr, GLenum  origin, GLenum  depth) {
 //   (*fnptr)(origin, depth);
+// }
+// static void  glowColorFormatNV(GPCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
 // }
 // static void  glowColorMask(GPCOLORMASK fnptr, GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
@@ -1031,11 +1638,35 @@ package gl
 // static void  glowColorMaski(GPCOLORMASKI fnptr, GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a) {
 //   (*fnptr)(index, r, g, b, a);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
 // static void  glowCompileShaderIncludeARB(GPCOMPILESHADERINCLUDEARB fnptr, GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length) {
 //   (*fnptr)(shader, count, path, length);
+// }
+// static void  glowCompressedMultiTexImage1DEXT(GPCOMPRESSEDMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage2DEXT(GPCOMPRESSEDMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage3DEXT(GPCOMPRESSEDMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage1DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage2DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage3DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
 // }
 // static void  glowCompressedTexImage1D(GPCOMPRESSEDTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, internalformat, width, border, imageSize, data);
@@ -1055,14 +1686,38 @@ package gl
 // static void  glowCompressedTexSubImage3D(GPCOMPRESSEDTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
 // }
+// static void  glowCompressedTextureImage1DEXT(GPCOMPRESSEDTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage2DEXT(GPCOMPRESSEDTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage3DEXT(GPCOMPRESSEDTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage1D(GPCOMPRESSEDTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, width, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage1DEXT(GPCOMPRESSEDTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, imageSize, bits);
 // }
 // static void  glowCompressedTextureSubImage2D(GPCOMPRESSEDTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, imageSize, data);
 // }
+// static void  glowCompressedTextureSubImage2DEXT(GPCOMPRESSEDTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage3D(GPCOMPRESSEDTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowCopyBufferSubData(GPCOPYBUFFERSUBDATA fnptr, GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readTarget, writeTarget, readOffset, writeOffset, size);
@@ -1070,8 +1725,26 @@ package gl
 // static void  glowCopyImageSubData(GPCOPYIMAGESUBDATA fnptr, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
 //   (*fnptr)(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyMultiTexImage1DEXT(GPCOPYMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyMultiTexImage2DEXT(GPCOPYMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, height, border);
+// }
+// static void  glowCopyMultiTexSubImage1DEXT(GPCOPYMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texunit, target, level, xoffset, x, y, width);
+// }
+// static void  glowCopyMultiTexSubImage2DEXT(GPCOPYMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, x, y, width, height);
+// }
+// static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
+//   (*fnptr)(resultPath, srcPath);
 // }
 // static void  glowCopyTexImage1D(GPCOPYTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
 //   (*fnptr)(target, level, internalformat, x, y, width, border);
@@ -1088,20 +1761,59 @@ package gl
 // static void  glowCopyTexSubImage3D(GPCOPYTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureImage1DEXT(GPCOPYTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyTextureImage2DEXT(GPCOPYTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, height, border);
+// }
 // static void  glowCopyTextureSubImage1D(GPCOPYTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
 //   (*fnptr)(texture, level, xoffset, x, y, width);
+// }
+// static void  glowCopyTextureSubImage1DEXT(GPCOPYTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texture, target, level, xoffset, x, y, width);
 // }
 // static void  glowCopyTextureSubImage2D(GPCOPYTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureSubImage2DEXT(GPCOPYTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, x, y, width, height);
+// }
 // static void  glowCopyTextureSubImage3D(GPCOPYTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyTextureSubImage3DEXT(GPCOPYTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCoverFillPathInstancedNV(GPCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverFillPathNV(GPCOVERFILLPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverStrokePathInstancedNV(GPCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
 // }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
+//   (*fnptr)(queryId, queryHandle);
 // }
 // static GLuint  glowCreateProgram(GPCREATEPROGRAM fnptr) {
 //   return (*fnptr)();
@@ -1121,8 +1833,17 @@ package gl
 // static GLuint  glowCreateShader(GPCREATESHADER fnptr, GLenum  type) {
 //   return (*fnptr)(type);
 // }
+// static GLuint  glowCreateShaderProgramEXT(GPCREATESHADERPROGRAMEXT fnptr, GLenum  type, const GLchar * string) {
+//   return (*fnptr)(type, string);
+// }
 // static GLuint  glowCreateShaderProgramv(GPCREATESHADERPROGRAMV fnptr, GLenum  type, GLsizei  count, const GLchar *const* strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
+//   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -1169,16 +1890,31 @@ package gl
 // static void  glowDeleteBuffers(GPDELETEBUFFERS fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFramebuffers(GPDELETEFRAMEBUFFERS fnptr, GLsizei  n, const GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
 // }
+// static void  glowDeletePathsNV(GPDELETEPATHSNV fnptr, GLuint  path, GLsizei  range) {
+//   (*fnptr)(path, range);
+// }
+// static void  glowDeletePerfMonitorsAMD(GPDELETEPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
+// static void  glowDeletePerfQueryINTEL(GPDELETEPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowDeleteProgram(GPDELETEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowDeleteProgramPipelines(GPDELETEPROGRAMPIPELINES fnptr, GLsizei  n, const GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowDeleteProgramPipelinesEXT(GPDELETEPROGRAMPIPELINESEXT fnptr, GLsizei  n, const GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowDeleteQueries(GPDELETEQUERIES fnptr, GLsizei  n, const GLuint * ids) {
@@ -1192,6 +1928,9 @@ package gl
 // }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -1229,8 +1968,23 @@ package gl
 // static void  glowDisable(GPDISABLE fnptr, GLenum  cap) {
 //   (*fnptr)(cap);
 // }
+// static void  glowDisableClientStateIndexedEXT(GPDISABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableClientStateiEXT(GPDISABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableIndexedEXT(GPDISABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowDisableVertexArrayAttrib(GPDISABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayAttribEXT(GPDISABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayEXT(GPDISABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowDisableVertexAttribArray(GPDISABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1256,14 +2010,32 @@ package gl
 // static void  glowDrawArraysInstanced(GPDRAWARRAYSINSTANCED fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount) {
 //   (*fnptr)(mode, first, count, instancecount);
 // }
+// static void  glowDrawArraysInstancedARB(GPDRAWARRAYSINSTANCEDARB fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, first, count, primcount);
+// }
 // static void  glowDrawArraysInstancedBaseInstance(GPDRAWARRAYSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, first, count, instancecount, baseinstance);
+// }
+// static void  glowDrawArraysInstancedEXT(GPDRAWARRAYSINSTANCEDEXT fnptr, GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, start, count, primcount);
 // }
 // static void  glowDrawBuffer(GPDRAWBUFFER fnptr, GLenum  buf) {
 //   (*fnptr)(buf);
 // }
 // static void  glowDrawBuffers(GPDRAWBUFFERS fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
+// }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
 // }
 // static void  glowDrawElements(GPDRAWELEMENTS fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, count, type, indices);
@@ -1277,6 +2049,9 @@ package gl
 // static void  glowDrawElementsInstanced(GPDRAWELEMENTSINSTANCED fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount) {
 //   (*fnptr)(mode, count, type, indices, instancecount);
 // }
+// static void  glowDrawElementsInstancedARB(GPDRAWELEMENTSINSTANCEDARB fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
+// }
 // static void  glowDrawElementsInstancedBaseInstance(GPDRAWELEMENTSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, baseinstance);
 // }
@@ -1285,6 +2060,9 @@ package gl
 // }
 // static void  glowDrawElementsInstancedBaseVertexBaseInstance(GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, basevertex, baseinstance);
+// }
+// static void  glowDrawElementsInstancedEXT(GPDRAWELEMENTSINSTANCEDEXT fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
 // }
 // static void  glowDrawRangeElements(GPDRAWRANGEELEMENTS fnptr, GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, start, end, count, type, indices);
@@ -1304,11 +2082,32 @@ package gl
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
 // }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
+// }
+// static void  glowEdgeFlagFormatNV(GPEDGEFLAGFORMATNV fnptr, GLsizei  stride) {
+//   (*fnptr)(stride);
+// }
 // static void  glowEnable(GPENABLE fnptr, GLenum  cap) {
 //   (*fnptr)(cap);
 // }
+// static void  glowEnableClientStateIndexedEXT(GPENABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableClientStateiEXT(GPENABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableIndexedEXT(GPENABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowEnableVertexArrayAttrib(GPENABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayAttribEXT(GPENABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayEXT(GPENABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowEnableVertexAttribArray(GPENABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1319,6 +2118,15 @@ package gl
 // static void  glowEndConditionalRender(GPENDCONDITIONALRENDER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowEndConditionalRenderNV(GPENDCONDITIONALRENDERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowEndPerfMonitorAMD(GPENDPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowEndPerfQueryINTEL(GPENDPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowEndQuery(GPENDQUERY fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
@@ -1326,6 +2134,9 @@ package gl
 //   (*fnptr)(target, index);
 // }
 // static void  glowEndTransformFeedback(GPENDTRANSFORMFEEDBACK fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
 //   (*fnptr)();
 // }
 // static GLsync  glowFenceSync(GPFENCESYNC fnptr, GLenum  condition, GLbitfield  flags) {
@@ -1340,14 +2151,41 @@ package gl
 // static void  glowFlushMappedBufferRange(GPFLUSHMAPPEDBUFFERRANGE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(target, offset, length);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
+//   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFogCoordFormatNV(GPFOGCOORDFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
+// static void  glowFramebufferDrawBufferEXT(GPFRAMEBUFFERDRAWBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
+// static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
+//   (*fnptr)(framebuffer, n, bufs);
+// }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
+// static void  glowFramebufferReadBufferEXT(GPFRAMEBUFFERREADBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
 // static void  glowFramebufferRenderbuffer(GPFRAMEBUFFERRENDERBUFFER fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -1361,8 +2199,20 @@ package gl
 // static void  glowFramebufferTexture3D(GPFRAMEBUFFERTEXTURE3D fnptr, GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
 //   (*fnptr)(target, attachment, textarget, texture, level, zoffset);
 // }
+// static void  glowFramebufferTextureARB(GPFRAMEBUFFERTEXTUREARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(target, attachment, texture, level);
+// }
+// static void  glowFramebufferTextureFaceARB(GPFRAMEBUFFERTEXTUREFACEARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(target, attachment, texture, level, face);
+// }
 // static void  glowFramebufferTextureLayer(GPFRAMEBUFFERTEXTURELAYER fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureLayerARB(GPFRAMEBUFFERTEXTURELAYERARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFrontFace(GPFRONTFACE fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -1373,7 +2223,16 @@ package gl
 // static void  glowGenFramebuffers(GPGENFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
+// static GLuint  glowGenPathsNV(GPGENPATHSNV fnptr, GLsizei  range) {
+//   return (*fnptr)(range);
+// }
+// static void  glowGenPerfMonitorsAMD(GPGENPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
 // static void  glowGenProgramPipelines(GPGENPROGRAMPIPELINES fnptr, GLsizei  n, GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowGenProgramPipelinesEXT(GPGENPROGRAMPIPELINESEXT fnptr, GLsizei  n, GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowGenQueries(GPGENQUERIES fnptr, GLsizei  n, GLuint * ids) {
@@ -1397,8 +2256,14 @@ package gl
 // static void  glowGenerateMipmap(GPGENERATEMIPMAP fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
+// static void  glowGenerateMultiTexMipmapEXT(GPGENERATEMULTITEXMIPMAPEXT fnptr, GLenum  texunit, GLenum  target) {
+//   (*fnptr)(texunit, target);
+// }
 // static void  glowGenerateTextureMipmap(GPGENERATETEXTUREMIPMAP fnptr, GLuint  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowGenerateTextureMipmapEXT(GPGENERATETEXTUREMIPMAPEXT fnptr, GLuint  texture, GLenum  target) {
+//   (*fnptr)(texture, target);
 // }
 // static void  glowGetActiveAtomicCounterBufferiv(GPGETACTIVEATOMICCOUNTERBUFFERIV fnptr, GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, bufferIndex, pname, params);
@@ -1436,6 +2301,9 @@ package gl
 // static GLint  glowGetAttribLocation(GPGETATTRIBLOCATION fnptr, GLuint  program, const GLchar * name) {
 //   return (*fnptr)(program, name);
 // }
+// static void  glowGetBooleanIndexedvEXT(GPGETBOOLEANINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLboolean * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetBooleani_v(GPGETBOOLEANI_V fnptr, GLenum  target, GLuint  index, GLboolean * data) {
 //   (*fnptr)(target, index, data);
 // }
@@ -1448,11 +2316,20 @@ package gl
 // static void  glowGetBufferParameteriv(GPGETBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetBufferParameterui64vNV(GPGETBUFFERPARAMETERUI64VNV fnptr, GLenum  target, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(target, pname, params);
+// }
 // static void  glowGetBufferPointerv(GPGETBUFFERPOINTERV fnptr, GLenum  target, GLenum  pname, void ** params) {
 //   (*fnptr)(target, pname, params);
 // }
 // static void  glowGetBufferSubData(GPGETBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
+// static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texunit, target, lod, img);
 // }
 // static void  glowGetCompressedTexImage(GPGETCOMPRESSEDTEXIMAGE fnptr, GLenum  target, GLint  level, void * img) {
 //   (*fnptr)(target, level, img);
@@ -1460,8 +2337,14 @@ package gl
 // static void  glowGetCompressedTextureImage(GPGETCOMPRESSEDTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, bufSize, pixels);
 // }
+// static void  glowGetCompressedTextureImageEXT(GPGETCOMPRESSEDTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texture, target, lod, img);
+// }
 // static void  glowGetCompressedTextureSubImage(GPGETCOMPRESSEDTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -1472,8 +2355,14 @@ package gl
 // static GLuint  glowGetDebugMessageLogKHR(GPGETDEBUGMESSAGELOGKHR fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
 // }
+// static void  glowGetDoubleIndexedvEXT(GPGETDOUBLEINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLdouble * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetDoublei_v(GPGETDOUBLEI_V fnptr, GLenum  target, GLuint  index, GLdouble * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetDoublei_vEXT(GPGETDOUBLEI_VEXT fnptr, GLenum  pname, GLuint  index, GLdouble * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetDoublev(GPGETDOUBLEV fnptr, GLenum  pname, GLdouble * data) {
 //   (*fnptr)(pname, data);
@@ -1481,8 +2370,17 @@ package gl
 // static GLenum  glowGetError(GPGETERROR fnptr) {
 //   return (*fnptr)();
 // }
+// static void  glowGetFirstPerfQueryIdINTEL(GPGETFIRSTPERFQUERYIDINTEL fnptr, GLuint * queryId) {
+//   (*fnptr)(queryId);
+// }
+// static void  glowGetFloatIndexedvEXT(GPGETFLOATINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLfloat * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetFloati_v(GPGETFLOATI_V fnptr, GLenum  target, GLuint  index, GLfloat * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetFloati_vEXT(GPGETFLOATI_VEXT fnptr, GLenum  pname, GLuint  index, GLfloat * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetFloatv(GPGETFLOATV fnptr, GLenum  pname, GLfloat * data) {
 //   (*fnptr)(pname, data);
@@ -1499,6 +2397,9 @@ package gl
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetFramebufferParameterivEXT(GPGETFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
 // static GLenum  glowGetGraphicsResetStatus(GPGETGRAPHICSRESETSTATUS fnptr) {
 //   return (*fnptr)();
 // }
@@ -1511,23 +2412,74 @@ package gl
 // static GLuint64  glowGetImageHandleARB(GPGETIMAGEHANDLEARB fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
 //   return (*fnptr)(texture, level, layered, layer, format);
 // }
+// static GLuint64  glowGetImageHandleNV(GPGETIMAGEHANDLENV fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
+//   return (*fnptr)(texture, level, layered, layer, format);
+// }
 // static void  glowGetInteger64i_v(GPGETINTEGER64I_V fnptr, GLenum  target, GLuint  index, GLint64 * data) {
 //   (*fnptr)(target, index, data);
 // }
 // static void  glowGetInteger64v(GPGETINTEGER64V fnptr, GLenum  pname, GLint64 * data) {
 //   (*fnptr)(pname, data);
 // }
+// static void  glowGetIntegerIndexedvEXT(GPGETINTEGERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLint * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetIntegeri_v(GPGETINTEGERI_V fnptr, GLenum  target, GLuint  index, GLint * data) {
 //   (*fnptr)(target, index, data);
 // }
+// static void  glowGetIntegerui64i_vNV(GPGETINTEGERUI64I_VNV fnptr, GLenum  value, GLuint  index, GLuint64EXT * result) {
+//   (*fnptr)(value, index, result);
+// }
+// static void  glowGetIntegerui64vNV(GPGETINTEGERUI64VNV fnptr, GLenum  value, GLuint64EXT * result) {
+//   (*fnptr)(value, result);
+// }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
 // }
 // static void  glowGetInternalformativ(GPGETINTERNALFORMATIV fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
+// }
+// static void  glowGetMultiTexEnvfvEXT(GPGETMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexEnvivEXT(GPGETMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexGendvEXT(GPGETMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenfvEXT(GPGETMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenivEXT(GPGETMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexImageEXT(GPGETMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texunit, target, level, format, type, pixels);
+// }
+// static void  glowGetMultiTexLevelParameterfvEXT(GPGETMULTITEXLEVELPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexLevelParameterivEXT(GPGETMULTITEXLEVELPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexParameterIivEXT(GPGETMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterIuivEXT(GPGETMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterfvEXT(GPGETMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterivEXT(GPGETMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
 // }
 // static void  glowGetMultisamplefv(GPGETMULTISAMPLEFV fnptr, GLenum  pname, GLuint  index, GLfloat * val) {
 //   (*fnptr)(pname, index, val);
@@ -1538,19 +2490,58 @@ package gl
 // static void  glowGetNamedBufferParameteriv(GPGETNAMEDBUFFERPARAMETERIV fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(buffer, pname, params);
 // }
+// static void  glowGetNamedBufferParameterivEXT(GPGETNAMEDBUFFERPARAMETERIVEXT fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferParameterui64vNV(GPGETNAMEDBUFFERPARAMETERUI64VNV fnptr, GLuint  buffer, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
 // static void  glowGetNamedBufferPointerv(GPGETNAMEDBUFFERPOINTERV fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedFramebufferAttachmentParameteriv(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
 // }
+// static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, attachment, pname, params);
+// }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowGetNamedFramebufferParameterivEXT(GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIuivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterdvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterfvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramStringEXT(GPGETNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, void * string) {
+//   (*fnptr)(program, target, pname, string);
+// }
+// static void  glowGetNamedProgramivEXT(GPGETNAMEDPROGRAMIVEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(program, target, pname, params);
+// }
 // static void  glowGetNamedRenderbufferParameteriv(GPGETNAMEDRENDERBUFFERPARAMETERIV fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(renderbuffer, pname, params);
+// }
+// static void  glowGetNamedRenderbufferParameterivEXT(GPGETNAMEDRENDERBUFFERPARAMETERIVEXT fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(renderbuffer, pname, params);
 // }
 // static void  glowGetNamedStringARB(GPGETNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string) {
@@ -1559,8 +2550,14 @@ package gl
 // static void  glowGetNamedStringivARB(GPGETNAMEDSTRINGIVARB fnptr, GLint  namelen, const GLchar * name, GLenum  pname, GLint * params) {
 //   (*fnptr)(namelen, name, pname, params);
 // }
+// static void  glowGetNextPerfQueryIdINTEL(GPGETNEXTPERFQUERYIDINTEL fnptr, GLuint  queryId, GLuint * nextQueryId) {
+//   (*fnptr)(queryId, nextQueryId);
+// }
 // static void  glowGetObjectLabel(GPGETOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
+// }
+// static void  glowGetObjectLabelEXT(GPGETOBJECTLABELEXT fnptr, GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label) {
+//   (*fnptr)(type, object, bufSize, length, label);
 // }
 // static void  glowGetObjectLabelKHR(GPGETOBJECTLABELKHR fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
@@ -1570,6 +2567,69 @@ package gl
 // }
 // static void  glowGetObjectPtrLabelKHR(GPGETOBJECTPTRLABELKHR fnptr, const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(ptr, bufSize, length, label);
+// }
+// static void  glowGetPathCommandsNV(GPGETPATHCOMMANDSNV fnptr, GLuint  path, GLubyte * commands) {
+//   (*fnptr)(path, commands);
+// }
+// static void  glowGetPathCoordsNV(GPGETPATHCOORDSNV fnptr, GLuint  path, GLfloat * coords) {
+//   (*fnptr)(path, coords);
+// }
+// static void  glowGetPathDashArrayNV(GPGETPATHDASHARRAYNV fnptr, GLuint  path, GLfloat * dashArray) {
+//   (*fnptr)(path, dashArray);
+// }
+// static GLfloat  glowGetPathLengthNV(GPGETPATHLENGTHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments) {
+//   return (*fnptr)(path, startSegment, numSegments);
+// }
+// static void  glowGetPathMetricRangeNV(GPGETPATHMETRICRANGENV fnptr, GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, firstPathName, numPaths, stride, metrics);
+// }
+// static void  glowGetPathMetricsNV(GPGETPATHMETRICSNV fnptr, GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, numPaths, pathNameType, paths, pathBase, stride, metrics);
+// }
+// static void  glowGetPathParameterfvNV(GPGETPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathParameterivNV(GPGETPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathSpacingNV(GPGETPATHSPACINGNV fnptr, GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing) {
+//   (*fnptr)(pathListMode, numPaths, pathNameType, paths, pathBase, advanceScale, kerningScale, transformType, returnedSpacing);
+// }
+// static void  glowGetPerfCounterInfoINTEL(GPGETPERFCOUNTERINFOINTEL fnptr, GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue) {
+//   (*fnptr)(queryId, counterId, counterNameLength, counterName, counterDescLength, counterDesc, counterOffset, counterDataSize, counterTypeEnum, counterDataTypeEnum, rawCounterMaxValue);
+// }
+// static void  glowGetPerfMonitorCounterDataAMD(GPGETPERFMONITORCOUNTERDATAAMD fnptr, GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten) {
+//   (*fnptr)(monitor, pname, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfMonitorCounterInfoAMD(GPGETPERFMONITORCOUNTERINFOAMD fnptr, GLuint  group, GLuint  counter, GLenum  pname, void * data) {
+//   (*fnptr)(group, counter, pname, data);
+// }
+// static void  glowGetPerfMonitorCounterStringAMD(GPGETPERFMONITORCOUNTERSTRINGAMD fnptr, GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString) {
+//   (*fnptr)(group, counter, bufSize, length, counterString);
+// }
+// static void  glowGetPerfMonitorCountersAMD(GPGETPERFMONITORCOUNTERSAMD fnptr, GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters) {
+//   (*fnptr)(group, numCounters, maxActiveCounters, counterSize, counters);
+// }
+// static void  glowGetPerfMonitorGroupStringAMD(GPGETPERFMONITORGROUPSTRINGAMD fnptr, GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString) {
+//   (*fnptr)(group, bufSize, length, groupString);
+// }
+// static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
+//   (*fnptr)(numGroups, groupsSize, groups);
+// }
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
+//   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
+//   (*fnptr)(queryName, queryId);
+// }
+// static void  glowGetPerfQueryInfoINTEL(GPGETPERFQUERYINFOINTEL fnptr, GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask) {
+//   (*fnptr)(queryId, queryNameLength, queryName, dataSize, noCounters, noInstances, capsMask);
+// }
+// static void  glowGetPointerIndexedvEXT(GPGETPOINTERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, void ** data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetPointeri_vEXT(GPGETPOINTERI_VEXT fnptr, GLenum  pname, GLuint  index, void ** params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetPointerv(GPGETPOINTERV fnptr, GLenum  pname, void ** params) {
 //   (*fnptr)(pname, params);
@@ -1589,7 +2649,13 @@ package gl
 // static void  glowGetProgramPipelineInfoLog(GPGETPROGRAMPIPELINEINFOLOG fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
 //   (*fnptr)(pipeline, bufSize, length, infoLog);
 // }
+// static void  glowGetProgramPipelineInfoLogEXT(GPGETPROGRAMPIPELINEINFOLOGEXT fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
+//   (*fnptr)(pipeline, bufSize, length, infoLog);
+// }
 // static void  glowGetProgramPipelineiv(GPGETPROGRAMPIPELINEIV fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
+//   (*fnptr)(pipeline, pname, params);
+// }
+// static void  glowGetProgramPipelineivEXT(GPGETPROGRAMPIPELINEIVEXT fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
 //   (*fnptr)(pipeline, pname, params);
 // }
 // static GLuint  glowGetProgramResourceIndex(GPGETPROGRAMRESOURCEINDEX fnptr, GLuint  program, GLenum  programInterface, const GLchar * name) {
@@ -1604,6 +2670,9 @@ package gl
 // static void  glowGetProgramResourceName(GPGETPROGRAMRESOURCENAME fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name) {
 //   (*fnptr)(program, programInterface, index, bufSize, length, name);
 // }
+// static void  glowGetProgramResourcefvNV(GPGETPROGRAMRESOURCEFVNV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params) {
+//   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
+// }
 // static void  glowGetProgramResourceiv(GPGETPROGRAMRESOURCEIV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params) {
 //   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
 // }
@@ -1612,6 +2681,18 @@ package gl
 // }
 // static void  glowGetProgramiv(GPGETPROGRAMIV fnptr, GLuint  program, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, pname, params);
+// }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
 // }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
@@ -1658,6 +2739,9 @@ package gl
 // static void  glowGetShaderiv(GPGETSHADERIV fnptr, GLuint  shader, GLenum  pname, GLint * params) {
 //   (*fnptr)(shader, pname, params);
 // }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
+// }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
 // }
@@ -1697,28 +2781,55 @@ package gl
 // static GLuint64  glowGetTextureHandleARB(GPGETTEXTUREHANDLEARB fnptr, GLuint  texture) {
 //   return (*fnptr)(texture);
 // }
+// static GLuint64  glowGetTextureHandleNV(GPGETTEXTUREHANDLENV fnptr, GLuint  texture) {
+//   return (*fnptr)(texture);
+// }
 // static void  glowGetTextureImage(GPGETTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, format, type, bufSize, pixels);
+// }
+// static void  glowGetTextureImageEXT(GPGETTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texture, target, level, format, type, pixels);
 // }
 // static void  glowGetTextureLevelParameterfv(GPGETTEXTURELEVELPARAMETERFV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, level, pname, params);
 // }
+// static void  glowGetTextureLevelParameterfvEXT(GPGETTEXTURELEVELPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, level, pname, params);
+// }
 // static void  glowGetTextureLevelParameteriv(GPGETTEXTURELEVELPARAMETERIV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, level, pname, params);
+// }
+// static void  glowGetTextureLevelParameterivEXT(GPGETTEXTURELEVELPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, level, pname, params);
 // }
 // static void  glowGetTextureParameterIiv(GPGETTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterIivEXT(GPGETTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameterIuiv(GPGETTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowGetTextureParameterIuivEXT(GPGETTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowGetTextureParameterfv(GPGETTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterfvEXT(GPGETTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameteriv(GPGETTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterivEXT(GPGETTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static GLuint64  glowGetTextureSamplerHandleARB(GPGETTEXTURESAMPLERHANDLEARB fnptr, GLuint  texture, GLuint  sampler) {
+//   return (*fnptr)(texture, sampler);
+// }
+// static GLuint64  glowGetTextureSamplerHandleNV(GPGETTEXTURESAMPLERHANDLENV fnptr, GLuint  texture, GLuint  sampler) {
 //   return (*fnptr)(texture, sampler);
 // }
 // static void  glowGetTextureSubImage(GPGETTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
@@ -1754,7 +2865,19 @@ package gl
 // static void  glowGetUniformfv(GPGETUNIFORMFV fnptr, GLuint  program, GLint  location, GLfloat * params) {
 //   (*fnptr)(program, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformiv(GPGETUNIFORMIV fnptr, GLuint  program, GLint  location, GLint * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
 // static void  glowGetUniformuiv(GPGETUNIFORMUIV fnptr, GLuint  program, GLint  location, GLuint * params) {
@@ -1765,6 +2888,18 @@ package gl
 // }
 // static void  glowGetVertexArrayIndexediv(GPGETVERTEXARRAYINDEXEDIV fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegeri_vEXT(GPGETVERTEXARRAYINTEGERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegervEXT(GPGETVERTEXARRAYINTEGERVEXT fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, pname, param);
+// }
+// static void  glowGetVertexArrayPointeri_vEXT(GPGETVERTEXARRAYPOINTERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayPointervEXT(GPGETVERTEXARRAYPOINTERVEXT fnptr, GLuint  vaobj, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, pname, param);
 // }
 // static void  glowGetVertexArrayiv(GPGETVERTEXARRAYIV fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, pname, param);
@@ -1778,7 +2913,13 @@ package gl
 // static void  glowGetVertexAttribLdv(GPGETVERTEXATTRIBLDV fnptr, GLuint  index, GLenum  pname, GLdouble * params) {
 //   (*fnptr)(index, pname, params);
 // }
+// static void  glowGetVertexAttribLi64vNV(GPGETVERTEXATTRIBLI64VNV fnptr, GLuint  index, GLenum  pname, GLint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
 // static void  glowGetVertexAttribLui64vARB(GPGETVERTEXATTRIBLUI64VARB fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
+// static void  glowGetVertexAttribLui64vNV(GPGETVERTEXATTRIBLUI64VNV fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
 //   (*fnptr)(index, pname, params);
 // }
 // static void  glowGetVertexAttribPointerv(GPGETVERTEXATTRIBPOINTERV fnptr, GLuint  index, GLenum  pname, void ** pointer) {
@@ -1792,6 +2933,9 @@ package gl
 // }
 // static void  glowGetVertexAttribiv(GPGETVERTEXATTRIBIV fnptr, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(index, pname, params);
+// }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
 // }
 // static void  glowGetnCompressedTexImageARB(GPGETNCOMPRESSEDTEXIMAGEARB fnptr, GLenum  target, GLint  lod, GLsizei  bufSize, void * img) {
 //   (*fnptr)(target, lod, bufSize, img);
@@ -1811,6 +2955,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -1818,6 +2965,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -1831,6 +2981,15 @@ package gl
 // }
 // static void  glowHint(GPHINT fnptr, GLenum  target, GLenum  mode) {
 //   (*fnptr)(target, mode);
+// }
+// static void  glowIndexFormatNV(GPINDEXFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
+// static void  glowInsertEventMarkerEXT(GPINSERTEVENTMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
+// static void  glowInterpolatePathsNV(GPINTERPOLATEPATHSNV fnptr, GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight) {
+//   (*fnptr)(resultPath, pathA, pathB, weight);
 // }
 // static void  glowInvalidateBufferData(GPINVALIDATEBUFFERDATA fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -1859,8 +3018,17 @@ package gl
 // static GLboolean  glowIsBuffer(GPISBUFFER fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
+// static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
+//   return (*fnptr)(target);
+// }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
+// }
+// static GLboolean  glowIsEnabledIndexedEXT(GPISENABLEDINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   return (*fnptr)(target, index);
 // }
 // static GLboolean  glowIsEnabledi(GPISENABLEDI fnptr, GLenum  target, GLuint  index) {
 //   return (*fnptr)(target, index);
@@ -1871,13 +3039,31 @@ package gl
 // static GLboolean  glowIsImageHandleResidentARB(GPISIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsImageHandleResidentNV(GPISIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
+// static GLboolean  glowIsNamedBufferResidentNV(GPISNAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
 // static GLboolean  glowIsNamedStringARB(GPISNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   return (*fnptr)(namelen, name);
+// }
+// static GLboolean  glowIsPathNV(GPISPATHNV fnptr, GLuint  path) {
+//   return (*fnptr)(path);
+// }
+// static GLboolean  glowIsPointInFillPathNV(GPISPOINTINFILLPATHNV fnptr, GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, mask, x, y);
+// }
+// static GLboolean  glowIsPointInStrokePathNV(GPISPOINTINSTROKEPATHNV fnptr, GLuint  path, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, x, y);
 // }
 // static GLboolean  glowIsProgram(GPISPROGRAM fnptr, GLuint  program) {
 //   return (*fnptr)(program);
 // }
 // static GLboolean  glowIsProgramPipeline(GPISPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   return (*fnptr)(pipeline);
+// }
+// static GLboolean  glowIsProgramPipelineEXT(GPISPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   return (*fnptr)(pipeline);
 // }
 // static GLboolean  glowIsQuery(GPISQUERY fnptr, GLuint  id) {
@@ -1892,6 +3078,9 @@ package gl
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
 // }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
+// }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
 // }
@@ -1901,11 +3090,17 @@ package gl
 // static GLboolean  glowIsTextureHandleResidentARB(GPISTEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsTextureHandleResidentNV(GPISTEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
 // static GLboolean  glowIsTransformFeedback(GPISTRANSFORMFEEDBACK fnptr, GLuint  id) {
 //   return (*fnptr)(id);
 // }
 // static GLboolean  glowIsVertexArray(GPISVERTEXARRAY fnptr, GLuint  array) {
 //   return (*fnptr)(array);
+// }
+// static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
+//   (*fnptr)(type, object, length, label);
 // }
 // static void  glowLineWidth(GPLINEWIDTH fnptr, GLfloat  width) {
 //   (*fnptr)(width);
@@ -1913,19 +3108,46 @@ package gl
 // static void  glowLinkProgram(GPLINKPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
+// }
 // static void  glowLogicOp(GPLOGICOP fnptr, GLenum  opcode) {
 //   (*fnptr)(opcode);
 // }
+// static void  glowMakeBufferNonResidentNV(GPMAKEBUFFERNONRESIDENTNV fnptr, GLenum  target) {
+//   (*fnptr)(target);
+// }
+// static void  glowMakeBufferResidentNV(GPMAKEBUFFERRESIDENTNV fnptr, GLenum  target, GLenum  access) {
+//   (*fnptr)(target, access);
+// }
 // static void  glowMakeImageHandleNonResidentARB(GPMAKEIMAGEHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeImageHandleNonResidentNV(GPMAKEIMAGEHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void  glowMakeImageHandleResidentARB(GPMAKEIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle, GLenum  access) {
 //   (*fnptr)(handle, access);
 // }
+// static void  glowMakeImageHandleResidentNV(GPMAKEIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle, GLenum  access) {
+//   (*fnptr)(handle, access);
+// }
+// static void  glowMakeNamedBufferNonResidentNV(GPMAKENAMEDBUFFERNONRESIDENTNV fnptr, GLuint  buffer) {
+//   (*fnptr)(buffer);
+// }
+// static void  glowMakeNamedBufferResidentNV(GPMAKENAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer, GLenum  access) {
+//   (*fnptr)(buffer, access);
+// }
 // static void  glowMakeTextureHandleNonResidentARB(GPMAKETEXTUREHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
+// static void  glowMakeTextureHandleNonResidentNV(GPMAKETEXTUREHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
 // static void  glowMakeTextureHandleResidentARB(GPMAKETEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeTextureHandleResidentNV(GPMAKETEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void * glowMapBuffer(GPMAPBUFFER fnptr, GLenum  target, GLenum  access) {
@@ -1937,8 +3159,95 @@ package gl
 // static void * glowMapNamedBuffer(GPMAPNAMEDBUFFER fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
+//   return (*fnptr)(buffer, access);
+// }
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
+//   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void  glowMatrixFrustumEXT(GPMATRIXFRUSTUMEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixLoad3x2fNV(GPMATRIXLOAD3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoad3x3fNV(GPMATRIXLOAD3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadIdentityEXT(GPMATRIXLOADIDENTITYEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixLoadTranspose3x3fNV(GPMATRIXLOADTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadTransposedEXT(GPMATRIXLOADTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadTransposefEXT(GPMATRIXLOADTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoaddEXT(GPMATRIXLOADDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadfEXT(GPMATRIXLOADFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMult3x2fNV(GPMATRIXMULT3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMult3x3fNV(GPMATRIXMULT3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTranspose3x3fNV(GPMATRIXMULTTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTransposedEXT(GPMATRIXMULTTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultTransposefEXT(GPMATRIXMULTTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultdEXT(GPMATRIXMULTDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultfEXT(GPMATRIXMULTFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixOrthoEXT(GPMATRIXORTHOEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixPopEXT(GPMATRIXPOPEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixPushEXT(GPMATRIXPUSHEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixRotatedEXT(GPMATRIXROTATEDEXT fnptr, GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixRotatefEXT(GPMATRIXROTATEFEXT fnptr, GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixScaledEXT(GPMATRIXSCALEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixScalefEXT(GPMATRIXSCALEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatedEXT(GPMATRIXTRANSLATEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
 // }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
@@ -1958,7 +3267,13 @@ package gl
 // static void  glowMultiDrawArraysIndirect(GPMULTIDRAWARRAYSINDIRECT fnptr, GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectBindlessCountNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElements(GPMULTIDRAWELEMENTS fnptr, GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount) {
@@ -1970,23 +3285,116 @@ package gl
 // static void  glowMultiDrawElementsIndirect(GPMULTIDRAWELEMENTSINDIRECT fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectBindlessCountNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMultiTexBufferEXT(GPMULTITEXBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texunit, target, internalformat, buffer);
+// }
+// static void  glowMultiTexCoordPointerEXT(GPMULTITEXCOORDPOINTEREXT fnptr, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
+//   (*fnptr)(texunit, size, type, stride, pointer);
+// }
+// static void  glowMultiTexEnvfEXT(GPMULTITEXENVFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvfvEXT(GPMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexEnviEXT(GPMULTITEXENVIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvivEXT(GPMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexGendEXT(GPMULTITEXGENDEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGendvEXT(GPMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGenfEXT(GPMULTITEXGENFEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenfvEXT(GPMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGeniEXT(GPMULTITEXGENIEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenivEXT(GPMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexImage1DEXT(GPMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage2DEXT(GPMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage3DEXT(GPMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowMultiTexParameterIivEXT(GPMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterIuivEXT(GPMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterfEXT(GPMULTITEXPARAMETERFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterfvEXT(GPMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameteriEXT(GPMULTITEXPARAMETERIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterivEXT(GPMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexRenderbufferEXT(GPMULTITEXRENDERBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texunit, target, renderbuffer);
+// }
+// static void  glowMultiTexSubImage1DEXT(GPMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage2DEXT(GPMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
+//   (*fnptr)(buffer, size, data, usage);
+// }
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
+//   (*fnptr)(buffer, size, data, flags);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedCopyBufferSubDataEXT(GPNAMEDCOPYBUFFERSUBDATAEXT fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowNamedFramebufferDrawBuffer(GPNAMEDFRAMEBUFFERDRAWBUFFER fnptr, GLuint  framebuffer, GLenum  buf) {
 //   (*fnptr)(framebuffer, buf);
@@ -1997,26 +3405,104 @@ package gl
 // static void  glowNamedFramebufferParameteri(GPNAMEDFRAMEBUFFERPARAMETERI fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowNamedFramebufferParameteriEXT(GPNAMEDFRAMEBUFFERPARAMETERIEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
+//   (*fnptr)(framebuffer, pname, param);
+// }
 // static void  glowNamedFramebufferReadBuffer(GPNAMEDFRAMEBUFFERREADBUFFER fnptr, GLuint  framebuffer, GLenum  src) {
 //   (*fnptr)(framebuffer, src);
 // }
 // static void  glowNamedFramebufferRenderbuffer(GPNAMEDFRAMEBUFFERRENDERBUFFER fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
 // }
+// static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
+//   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTexture1DEXT(GPNAMEDFRAMEBUFFERTEXTURE1DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture2DEXT(GPNAMEDFRAMEBUFFERTEXTURE2DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture3DEXT(GPNAMEDFRAMEBUFFERTEXTURE3DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level, zoffset);
+// }
+// static void  glowNamedFramebufferTextureEXT(GPNAMEDFRAMEBUFFERTEXTUREEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTextureFaceEXT(GPNAMEDFRAMEBUFFERTEXTUREFACEEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(framebuffer, attachment, texture, level, face);
 // }
 // static void  glowNamedFramebufferTextureLayer(GPNAMEDFRAMEBUFFERTEXTURELAYER fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(framebuffer, attachment, texture, level, layer);
 // }
+// static void  glowNamedFramebufferTextureLayerEXT(GPNAMEDFRAMEBUFFERTEXTURELAYEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(framebuffer, attachment, texture, level, layer);
+// }
+// static void  glowNamedProgramLocalParameter4dEXT(GPNAMEDPROGRAMLOCALPARAMETER4DEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4dvEXT(GPNAMEDPROGRAMLOCALPARAMETER4DVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameter4fEXT(GPNAMEDPROGRAMLOCALPARAMETER4FEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4fvEXT(GPNAMEDPROGRAMLOCALPARAMETER4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4iEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4uiEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameters4fvEXT(GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramStringEXT(GPNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string) {
+//   (*fnptr)(program, target, format, len, string);
+// }
 // static void  glowNamedRenderbufferStorage(GPNAMEDRENDERBUFFERSTORAGE fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageEXT(GPNAMEDRENDERBUFFERSTORAGEEXT fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, internalformat, width, height);
 // }
 // static void  glowNamedRenderbufferStorageMultisample(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, samples, internalformat, width, height);
 // }
+// static void  glowNamedRenderbufferStorageMultisampleCoverageEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT fnptr, GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageMultisampleEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, samples, internalformat, width, height);
+// }
 // static void  glowNamedStringARB(GPNAMEDSTRINGARB fnptr, GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string) {
 //   (*fnptr)(type, namelen, name, stringlen, string);
+// }
+// static void  glowNormalFormatNV(GPNORMALFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
 // }
 // static void  glowObjectLabel(GPOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(identifier, name, length, label);
@@ -2036,6 +3522,60 @@ package gl
 // static void  glowPatchParameteri(GPPATCHPARAMETERI fnptr, GLenum  pname, GLint  value) {
 //   (*fnptr)(pname, value);
 // }
+// static void  glowPathCommandsNV(GPPATHCOMMANDSNV fnptr, GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathCoordsNV(GPPATHCOORDSNV fnptr, GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCoords, coordType, coords);
+// }
+// static void  glowPathCoverDepthFuncNV(GPPATHCOVERDEPTHFUNCNV fnptr, GLenum  func) {
+//   (*fnptr)(func);
+// }
+// static void  glowPathDashArrayNV(GPPATHDASHARRAYNV fnptr, GLuint  path, GLsizei  dashCount, const GLfloat * dashArray) {
+//   (*fnptr)(path, dashCount, dashArray);
+// }
+// static GLenum  glowPathGlyphIndexArrayNV(GPPATHGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathGlyphIndexRangeNV(GPPATHGLYPHINDEXRANGENV fnptr, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount) {
+//   return (*fnptr)(fontTarget, fontName, fontStyle, pathParameterTemplate, emScale, baseAndCount);
+// }
+// static void  glowPathGlyphRangeNV(GPPATHGLYPHRANGENV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyph, numGlyphs, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathGlyphsNV(GPPATHGLYPHSNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, numGlyphs, type, charcodes, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathMemoryGlyphIndexArrayNV(GPPATHMEMORYGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontSize, fontData, faceIndex, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathParameterfNV(GPPATHPARAMETERFNV fnptr, GLuint  path, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterfvNV(GPPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, const GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameteriNV(GPPATHPARAMETERINV fnptr, GLuint  path, GLenum  pname, GLint  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterivNV(GPPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, const GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathStencilDepthOffsetNV(GPPATHSTENCILDEPTHOFFSETNV fnptr, GLfloat  factor, GLfloat  units) {
+//   (*fnptr)(factor, units);
+// }
+// static void  glowPathStencilFuncNV(GPPATHSTENCILFUNCNV fnptr, GLenum  func, GLint  ref, GLuint  mask) {
+//   (*fnptr)(func, ref, mask);
+// }
+// static void  glowPathStringNV(GPPATHSTRINGNV fnptr, GLuint  path, GLenum  format, GLsizei  length, const void * pathString) {
+//   (*fnptr)(path, format, length, pathString);
+// }
+// static void  glowPathSubCommandsNV(GPPATHSUBCOMMANDSNV fnptr, GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, commandStart, commandsToDelete, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathSubCoordsNV(GPPATHSUBCOORDSNV fnptr, GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, coordStart, numCoords, coordType, coords);
+// }
 // static void  glowPauseTransformFeedback(GPPAUSETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -2044,6 +3584,9 @@ package gl
 // }
 // static void  glowPixelStorei(GPPIXELSTOREI fnptr, GLenum  pname, GLint  param) {
 //   (*fnptr)(pname, param);
+// }
+// static GLboolean  glowPointAlongPathNV(GPPOINTALONGPATHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY) {
+//   return (*fnptr)(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
 // }
 // static void  glowPointParameterf(GPPOINTPARAMETERF fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
@@ -2066,11 +3609,23 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPopDebugGroup(GPPOPDEBUGGROUP fnptr) {
 //   (*fnptr)();
 // }
 // static void  glowPopDebugGroupKHR(GPPOPDEBUGGROUPKHR fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowPopGroupMarkerEXT(GPPOPGROUPMARKEREXT fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -2081,164 +3636,434 @@ package gl
 // static void  glowProgramParameteri(GPPROGRAMPARAMETERI fnptr, GLuint  program, GLenum  pname, GLint  value) {
 //   (*fnptr)(program, pname, value);
 // }
+// static void  glowProgramParameteriARB(GPPROGRAMPARAMETERIARB fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramParameteriEXT(GPPROGRAMPARAMETERIEXT fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramPathFragmentInputGenNV(GPPROGRAMPATHFRAGMENTINPUTGENNV fnptr, GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs) {
+//   (*fnptr)(program, location, genMode, components, coeffs);
+// }
 // static void  glowProgramUniform1d(GPPROGRAMUNIFORM1D fnptr, GLuint  program, GLint  location, GLdouble  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1dEXT(GPPROGRAMUNIFORM1DEXT fnptr, GLuint  program, GLint  location, GLdouble  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1dv(GPPROGRAMUNIFORM1DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1dvEXT(GPPROGRAMUNIFORM1DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1f(GPPROGRAMUNIFORM1F fnptr, GLuint  program, GLint  location, GLfloat  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1fEXT(GPPROGRAMUNIFORM1FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1fv(GPPROGRAMUNIFORM1FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1fvEXT(GPPROGRAMUNIFORM1FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1iEXT(GPPROGRAMUNIFORM1IEXT fnptr, GLuint  program, GLint  location, GLint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1iv(GPPROGRAMUNIFORM1IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ivEXT(GPPROGRAMUNIFORM1IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uiEXT(GPPROGRAMUNIFORM1UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1uiv(GPPROGRAMUNIFORM1UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uivEXT(GPPROGRAMUNIFORM1UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2d(GPPROGRAMUNIFORM2D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2dEXT(GPPROGRAMUNIFORM2DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2dv(GPPROGRAMUNIFORM2DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2dvEXT(GPPROGRAMUNIFORM2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2f(GPPROGRAMUNIFORM2F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2fEXT(GPPROGRAMUNIFORM2FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2fv(GPPROGRAMUNIFORM2FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2fvEXT(GPPROGRAMUNIFORM2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2iEXT(GPPROGRAMUNIFORM2IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2iv(GPPROGRAMUNIFORM2IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ivEXT(GPPROGRAMUNIFORM2IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uiEXT(GPPROGRAMUNIFORM2UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2uiv(GPPROGRAMUNIFORM2UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uivEXT(GPPROGRAMUNIFORM2UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3d(GPPROGRAMUNIFORM3D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3dEXT(GPPROGRAMUNIFORM3DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3dv(GPPROGRAMUNIFORM3DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3dvEXT(GPPROGRAMUNIFORM3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3f(GPPROGRAMUNIFORM3F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3fEXT(GPPROGRAMUNIFORM3FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3fv(GPPROGRAMUNIFORM3FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3fvEXT(GPPROGRAMUNIFORM3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3iEXT(GPPROGRAMUNIFORM3IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3iv(GPPROGRAMUNIFORM3IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ivEXT(GPPROGRAMUNIFORM3IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uiEXT(GPPROGRAMUNIFORM3UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3uiv(GPPROGRAMUNIFORM3UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uivEXT(GPPROGRAMUNIFORM3UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4d(GPPROGRAMUNIFORM4D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4dEXT(GPPROGRAMUNIFORM4DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4dv(GPPROGRAMUNIFORM4DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4dvEXT(GPPROGRAMUNIFORM4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4f(GPPROGRAMUNIFORM4F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4fEXT(GPPROGRAMUNIFORM4FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4fv(GPPROGRAMUNIFORM4FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4fvEXT(GPPROGRAMUNIFORM4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4iEXT(GPPROGRAMUNIFORM4IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4iv(GPPROGRAMUNIFORM4IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ivEXT(GPPROGRAMUNIFORM4IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uiEXT(GPPROGRAMUNIFORM4UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4uiv(GPPROGRAMUNIFORM4UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uivEXT(GPPROGRAMUNIFORM4UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniformHandleui64ARB(GPPROGRAMUNIFORMHANDLEUI64ARB fnptr, GLuint  program, GLint  location, GLuint64  value) {
 //   (*fnptr)(program, location, value);
 // }
+// static void  glowProgramUniformHandleui64NV(GPPROGRAMUNIFORMHANDLEUI64NV fnptr, GLuint  program, GLint  location, GLuint64  value) {
+//   (*fnptr)(program, location, value);
+// }
 // static void  glowProgramUniformHandleui64vARB(GPPROGRAMUNIFORMHANDLEUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
+//   (*fnptr)(program, location, count, values);
+// }
+// static void  glowProgramUniformHandleui64vNV(GPPROGRAMUNIFORMHANDLEUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
 //   (*fnptr)(program, location, count, values);
 // }
 // static void  glowProgramUniformMatrix2dv(GPPROGRAMUNIFORMMATRIX2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2dvEXT(GPPROGRAMUNIFORMMATRIX2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2fv(GPPROGRAMUNIFORMMATRIX2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2fvEXT(GPPROGRAMUNIFORMMATRIX2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x3dv(GPPROGRAMUNIFORMMATRIX2X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x3dvEXT(GPPROGRAMUNIFORMMATRIX2X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x3fv(GPPROGRAMUNIFORMMATRIX2X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x3fvEXT(GPPROGRAMUNIFORMMATRIX2X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x4dv(GPPROGRAMUNIFORMMATRIX2X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x4dvEXT(GPPROGRAMUNIFORMMATRIX2X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x4fv(GPPROGRAMUNIFORMMATRIX2X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x4fvEXT(GPPROGRAMUNIFORMMATRIX2X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3dv(GPPROGRAMUNIFORMMATRIX3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3dvEXT(GPPROGRAMUNIFORMMATRIX3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3fv(GPPROGRAMUNIFORMMATRIX3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3fvEXT(GPPROGRAMUNIFORMMATRIX3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x2dv(GPPROGRAMUNIFORMMATRIX3X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x2dvEXT(GPPROGRAMUNIFORMMATRIX3X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x2fv(GPPROGRAMUNIFORMMATRIX3X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x2fvEXT(GPPROGRAMUNIFORMMATRIX3X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x4dv(GPPROGRAMUNIFORMMATRIX3X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x4dvEXT(GPPROGRAMUNIFORMMATRIX3X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x4fv(GPPROGRAMUNIFORMMATRIX3X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x4fvEXT(GPPROGRAMUNIFORMMATRIX3X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4dv(GPPROGRAMUNIFORMMATRIX4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4dvEXT(GPPROGRAMUNIFORMMATRIX4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4fv(GPPROGRAMUNIFORMMATRIX4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4fvEXT(GPPROGRAMUNIFORMMATRIX4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x2dv(GPPROGRAMUNIFORMMATRIX4X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x2dvEXT(GPPROGRAMUNIFORMMATRIX4X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x2fv(GPPROGRAMUNIFORMMATRIX4X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4x2fvEXT(GPPROGRAMUNIFORMMATRIX4X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x3dv(GPPROGRAMUNIFORMMATRIX4X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3dvEXT(GPPROGRAMUNIFORMMATRIX4X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x3fv(GPPROGRAMUNIFORMMATRIX4X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3fvEXT(GPPROGRAMUNIFORMMATRIX4X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformui64NV(GPPROGRAMUNIFORMUI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(program, location, value);
+// }
+// static void  glowProgramUniformui64vNV(GPPROGRAMUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
 // static void  glowProvokingVertex(GPPROVOKINGVERTEX fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
+// }
+// static void  glowPushClientAttribDefaultEXT(GPPUSHCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static void  glowPushDebugGroup(GPPUSHDEBUGGROUP fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
@@ -2246,8 +4071,14 @@ package gl
 // static void  glowPushDebugGroupKHR(GPPUSHDEBUGGROUPKHR fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
 // }
+// static void  glowPushGroupMarkerEXT(GPPUSHGROUPMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
 // static void  glowQueryCounter(GPQUERYCOUNTER fnptr, GLuint  id, GLenum  target) {
 //   (*fnptr)(id, target);
+// }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
 // }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
@@ -2272,6 +4103,12 @@ package gl
 // }
 // static void  glowRenderbufferStorageMultisample(GPRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, samples, internalformat, width, height);
+// }
+// static void  glowRenderbufferStorageMultisampleCoverageNV(GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV fnptr, GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(target, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
@@ -2312,6 +4149,12 @@ package gl
 // static void  glowScissorIndexedv(GPSCISSORINDEXEDV fnptr, GLuint  index, const GLint * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowSecondaryColorFormatNV(GPSECONDARYCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
+// static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
+//   (*fnptr)(monitor, enable, group, numCounters, counterList);
+// }
 // static void  glowShaderBinary(GPSHADERBINARY fnptr, GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length) {
 //   (*fnptr)(count, shaders, binaryformat, binary, length);
 // }
@@ -2320,6 +4163,24 @@ package gl
 // }
 // static void  glowShaderStorageBlockBinding(GPSHADERSTORAGEBLOCKBINDING fnptr, GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding) {
 //   (*fnptr)(program, storageBlockIndex, storageBlockBinding);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
+// }
+// static void  glowStencilFillPathInstancedNV(GPSTENCILFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, transformType, transformValues);
+// }
+// static void  glowStencilFillPathNV(GPSTENCILFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask) {
+//   (*fnptr)(path, fillMode, mask);
 // }
 // static void  glowStencilFunc(GPSTENCILFUNC fnptr, GLenum  func, GLint  ref, GLuint  mask) {
 //   (*fnptr)(func, ref, mask);
@@ -2339,11 +4200,38 @@ package gl
 // static void  glowStencilOpSeparate(GPSTENCILOPSEPARATE fnptr, GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass) {
 //   (*fnptr)(face, sfail, dpfail, dppass);
 // }
+// static void  glowStencilStrokePathInstancedNV(GPSTENCILSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, transformType, transformValues);
+// }
+// static void  glowStencilStrokePathNV(GPSTENCILSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask) {
+//   (*fnptr)(path, reference, mask);
+// }
+// static void  glowStencilThenCoverFillPathInstancedNV(GPSTENCILTHENCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverFillPathNV(GPSTENCILTHENCOVERFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, fillMode, mask, coverMode);
+// }
+// static void  glowStencilThenCoverStrokePathInstancedNV(GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverStrokePathNV(GPSTENCILTHENCOVERSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, reference, mask, coverMode);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
+// }
 // static void  glowTexBuffer(GPTEXBUFFER fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(target, internalformat, buffer);
+// }
+// static void  glowTexBufferARB(GPTEXBUFFERARB fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(target, internalformat, buffer);
 // }
 // static void  glowTexBufferRange(GPTEXBUFFERRANGE fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, internalformat, buffer, offset, size);
+// }
+// static void  glowTexCoordFormatNV(GPTEXCOORDFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
 // }
 // static void  glowTexImage1D(GPTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, border, format, type, pixels);
@@ -2360,8 +4248,8 @@ package gl
 // static void  glowTexImage3DMultisample(GPTEXIMAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -2408,53 +4296,119 @@ package gl
 // static void  glowTextureBarrier(GPTEXTUREBARRIER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowTextureBarrierNV(GPTEXTUREBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowTextureBuffer(GPTEXTUREBUFFER fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texture, target, internalformat, buffer);
+// }
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
+//   (*fnptr)(texture, target, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureImage1DEXT(GPTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowTextureImage2DEXT(GPTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowTextureImage3DEXT(GPTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowTextureParameterIivEXT(GPTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowTextureParameterIuiv(GPTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, const GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowTextureParameterIuivEXT(GPTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameterf(GPTEXTUREPARAMETERF fnptr, GLuint  texture, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameterfEXT(GPTEXTUREPARAMETERFEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameterfv(GPTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, const GLfloat * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterfvEXT(GPTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameteri(GPTEXTUREPARAMETERI fnptr, GLuint  texture, GLenum  pname, GLint  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameteriEXT(GPTEXTUREPARAMETERIEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameteriv(GPTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, const GLint * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterivEXT(GPTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
+// static void  glowTextureRenderbufferEXT(GPTEXTURERENDERBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texture, target, renderbuffer);
 // }
 // static void  glowTextureStorage1D(GPTEXTURESTORAGE1D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
 //   (*fnptr)(texture, levels, internalformat, width);
 // }
+// static void  glowTextureStorage1DEXT(GPTEXTURESTORAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
+//   (*fnptr)(texture, target, levels, internalformat, width);
+// }
 // static void  glowTextureStorage2D(GPTEXTURESTORAGE2D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, levels, internalformat, width, height);
+// }
+// static void  glowTextureStorage2DEXT(GPTEXTURESTORAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height);
 // }
 // static void  glowTextureStorage2DMultisample(GPTEXTURESTORAGE2DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, fixedsamplelocations);
 // }
+// static void  glowTextureStorage2DMultisampleEXT(GPTEXTURESTORAGE2DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, fixedsamplelocations);
+// }
 // static void  glowTextureStorage3D(GPTEXTURESTORAGE3D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
 //   (*fnptr)(texture, levels, internalformat, width, height, depth);
+// }
+// static void  glowTextureStorage3DEXT(GPTEXTURESTORAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height, depth);
 // }
 // static void  glowTextureStorage3DMultisample(GPTEXTURESTORAGE3DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
+// }
 // static void  glowTextureSubImage1D(GPTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowTextureSubImage1DEXT(GPTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, type, pixels);
 // }
 // static void  glowTextureSubImage2D(GPTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, type, pixels);
 // }
+// static void  glowTextureSubImage2DEXT(GPTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
 // static void  glowTextureSubImage3D(GPTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowTextureSubImage3DEXT(GPTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
 // static void  glowTextureView(GPTEXTUREVIEW fnptr, GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers) {
 //   (*fnptr)(texture, target, origtexture, internalformat, minlevel, numlevels, minlayer, numlayers);
@@ -2462,11 +4416,14 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackVaryings(GPTRANSFORMFEEDBACKVARYINGS fnptr, GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode) {
 //   (*fnptr)(program, count, varyings, bufferMode);
+// }
+// static void  glowTransformPathNV(GPTRANSFORMPATHNV fnptr, GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(resultPath, srcPath, transformType, transformValues);
 // }
 // static void  glowUniform1d(GPUNIFORM1D fnptr, GLint  location, GLdouble  x) {
 //   (*fnptr)(location, x);
@@ -2483,11 +4440,35 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform1iv(GPUNIFORM1IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
+// }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1uiv(GPUNIFORM1UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2507,11 +4488,35 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform2iv(GPUNIFORM2IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
+// }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2uiv(GPUNIFORM2UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2531,11 +4536,35 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform3iv(GPUNIFORM3IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
+// }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3uiv(GPUNIFORM3UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2555,11 +4584,35 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform4iv(GPUNIFORM4IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
+// }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4uiv(GPUNIFORM4UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2570,7 +4623,13 @@ package gl
 // static void  glowUniformHandleui64ARB(GPUNIFORMHANDLEUI64ARB fnptr, GLint  location, GLuint64  value) {
 //   (*fnptr)(location, value);
 // }
+// static void  glowUniformHandleui64NV(GPUNIFORMHANDLEUI64NV fnptr, GLint  location, GLuint64  value) {
+//   (*fnptr)(location, value);
+// }
 // static void  glowUniformHandleui64vARB(GPUNIFORMHANDLEUI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniformHandleui64vNV(GPUNIFORMHANDLEUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniformMatrix2dv(GPUNIFORMMATRIX2DV fnptr, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
@@ -2630,10 +4689,19 @@ package gl
 // static void  glowUniformSubroutinesuiv(GPUNIFORMSUBROUTINESUIV fnptr, GLenum  shadertype, GLsizei  count, const GLuint * indices) {
 //   (*fnptr)(shadertype, count, indices);
 // }
+// static void  glowUniformui64NV(GPUNIFORMUI64NV fnptr, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(location, value);
+// }
+// static void  glowUniformui64vNV(GPUNIFORMUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static GLboolean  glowUnmapBuffer(GPUNMAPBUFFER fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLboolean  glowUnmapNamedBuffer(GPUNMAPNAMEDBUFFER fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
+// static GLboolean  glowUnmapNamedBufferEXT(GPUNMAPNAMEDBUFFEREXT fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
 // static void  glowUseProgram(GPUSEPROGRAM fnptr, GLuint  program) {
@@ -2642,10 +4710,19 @@ package gl
 // static void  glowUseProgramStages(GPUSEPROGRAMSTAGES fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
 //   (*fnptr)(pipeline, stages, program);
 // }
+// static void  glowUseProgramStagesEXT(GPUSEPROGRAMSTAGESEXT fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
+//   (*fnptr)(pipeline, stages, program);
+// }
+// static void  glowUseShaderProgramEXT(GPUSESHADERPROGRAMEXT fnptr, GLenum  type, GLuint  program) {
+//   (*fnptr)(type, program);
+// }
 // static void  glowValidateProgram(GPVALIDATEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowValidateProgramPipeline(GPVALIDATEPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowValidateProgramPipelineEXT(GPVALIDATEPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowVertexArrayAttribBinding(GPVERTEXARRAYATTRIBBINDING fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
@@ -2660,17 +4737,74 @@ package gl
 // static void  glowVertexArrayAttribLFormat(GPVERTEXARRAYATTRIBLFORMAT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexArrayBindVertexBufferEXT(GPVERTEXARRAYBINDVERTEXBUFFEREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
+//   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
+// }
 // static void  glowVertexArrayBindingDivisor(GPVERTEXARRAYBINDINGDIVISOR fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(vaobj, bindingindex, divisor);
 // }
+// static void  glowVertexArrayColorOffsetEXT(GPVERTEXARRAYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayEdgeFlagOffsetEXT(GPVERTEXARRAYEDGEFLAGOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, stride, offset);
+// }
 // static void  glowVertexArrayElementBuffer(GPVERTEXARRAYELEMENTBUFFER fnptr, GLuint  vaobj, GLuint  buffer) {
 //   (*fnptr)(vaobj, buffer);
+// }
+// static void  glowVertexArrayFogCoordOffsetEXT(GPVERTEXARRAYFOGCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayIndexOffsetEXT(GPVERTEXARRAYINDEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayMultiTexCoordOffsetEXT(GPVERTEXARRAYMULTITEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, texunit, size, type, stride, offset);
+// }
+// static void  glowVertexArrayNormalOffsetEXT(GPVERTEXARRAYNORMALOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArraySecondaryColorOffsetEXT(GPVERTEXARRAYSECONDARYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayTexCoordOffsetEXT(GPVERTEXARRAYTEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribBindingEXT(GPVERTEXARRAYVERTEXATTRIBBINDINGEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
+//   (*fnptr)(vaobj, attribindex, bindingindex);
+// }
+// static void  glowVertexArrayVertexAttribDivisorEXT(GPVERTEXARRAYVERTEXATTRIBDIVISOREXT fnptr, GLuint  vaobj, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(vaobj, index, divisor);
+// }
+// static void  glowVertexArrayVertexAttribFormatEXT(GPVERTEXARRAYVERTEXATTRIBFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIFormatEXT(GPVERTEXARRAYVERTEXATTRIBIFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIOffsetEXT(GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribLFormatEXT(GPVERTEXARRAYVERTEXATTRIBLFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribLOffsetEXT(GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribOffsetEXT(GPVERTEXARRAYVERTEXATTRIBOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, normalized, stride, offset);
+// }
+// static void  glowVertexArrayVertexBindingDivisorEXT(GPVERTEXARRAYVERTEXBINDINGDIVISOREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
+//   (*fnptr)(vaobj, bindingindex, divisor);
 // }
 // static void  glowVertexArrayVertexBuffer(GPVERTEXARRAYVERTEXBUFFER fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
 //   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
 // }
 // static void  glowVertexArrayVertexBuffers(GPVERTEXARRAYVERTEXBUFFERS fnptr, GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(vaobj, first, count, buffers, offsets, strides);
+// }
+// static void  glowVertexArrayVertexOffsetEXT(GPVERTEXARRAYVERTEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
 // }
 // static void  glowVertexAttrib1d(GPVERTEXATTRIB1D fnptr, GLuint  index, GLdouble  x) {
 //   (*fnptr)(index, x);
@@ -2786,8 +4920,14 @@ package gl
 // static void  glowVertexAttribDivisor(GPVERTEXATTRIBDIVISOR fnptr, GLuint  index, GLuint  divisor) {
 //   (*fnptr)(index, divisor);
 // }
+// static void  glowVertexAttribDivisorARB(GPVERTEXATTRIBDIVISORARB fnptr, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(index, divisor);
+// }
 // static void  glowVertexAttribFormat(GPVERTEXATTRIBFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexAttribFormatNV(GPVERTEXATTRIBFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride) {
+//   (*fnptr)(index, size, type, normalized, stride);
 // }
 // static void  glowVertexAttribI1i(GPVERTEXATTRIBI1I fnptr, GLuint  index, GLint  x) {
 //   (*fnptr)(index, x);
@@ -2852,6 +4992,9 @@ package gl
 // static void  glowVertexAttribIFormat(GPVERTEXATTRIBIFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexAttribIFormatNV(GPVERTEXATTRIBIFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
+// }
 // static void  glowVertexAttribIPointer(GPVERTEXATTRIBIPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
 // }
@@ -2861,10 +5004,22 @@ package gl
 // static void  glowVertexAttribL1dv(GPVERTEXATTRIBL1DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL1i64NV(GPVERTEXATTRIBL1I64NV fnptr, GLuint  index, GLint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
+// static void  glowVertexAttribL1i64vNV(GPVERTEXATTRIBL1I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL1ui64ARB(GPVERTEXATTRIBL1UI64ARB fnptr, GLuint  index, GLuint64EXT  x) {
 //   (*fnptr)(index, x);
 // }
+// static void  glowVertexAttribL1ui64NV(GPVERTEXATTRIBL1UI64NV fnptr, GLuint  index, GLuint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
 // static void  glowVertexAttribL1ui64vARB(GPVERTEXATTRIBL1UI64VARB fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL1ui64vNV(GPVERTEXATTRIBL1UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL2d(GPVERTEXATTRIBL2D fnptr, GLuint  index, GLdouble  x, GLdouble  y) {
@@ -2873,10 +5028,34 @@ package gl
 // static void  glowVertexAttribL2dv(GPVERTEXATTRIBL2DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL2i64NV(GPVERTEXATTRIBL2I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2i64vNV(GPVERTEXATTRIBL2I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL2ui64NV(GPVERTEXATTRIBL2UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2ui64vNV(GPVERTEXATTRIBL2UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL3d(GPVERTEXATTRIBL3D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z) {
 //   (*fnptr)(index, x, y, z);
 // }
 // static void  glowVertexAttribL3dv(GPVERTEXATTRIBL3DV fnptr, GLuint  index, const GLdouble * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3i64NV(GPVERTEXATTRIBL3I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3i64vNV(GPVERTEXATTRIBL3I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3ui64NV(GPVERTEXATTRIBL3UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3ui64vNV(GPVERTEXATTRIBL3UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL4d(GPVERTEXATTRIBL4D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
@@ -2885,8 +5064,23 @@ package gl
 // static void  glowVertexAttribL4dv(GPVERTEXATTRIBL4DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL4i64NV(GPVERTEXATTRIBL4I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4i64vNV(GPVERTEXATTRIBL4I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL4ui64NV(GPVERTEXATTRIBL4UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4ui64vNV(GPVERTEXATTRIBL4UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribLFormat(GPVERTEXATTRIBLFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexAttribLFormatNV(GPVERTEXATTRIBLFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
 // }
 // static void  glowVertexAttribLPointer(GPVERTEXATTRIBLPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
@@ -2921,6 +5115,9 @@ package gl
 // static void  glowVertexBindingDivisor(GPVERTEXBINDINGDIVISOR fnptr, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(bindingindex, divisor);
 // }
+// static void  glowVertexFormatNV(GPVERTEXFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
 // static void  glowViewport(GPVIEWPORT fnptr, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(x, y, width, height);
 // }
@@ -2933,8 +5130,23 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
+//   (*fnptr)(resultPath, numPaths, paths, weights);
+// }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
 // }
 import "C"
 import (
@@ -2943,10 +5155,12 @@ import (
 )
 
 const (
+	ACCUM_ADJACENT_PAIRS_NV                                    = 0x90AD
 	ACTIVE_ATOMIC_COUNTER_BUFFERS                              = 0x92D9
 	ACTIVE_ATTRIBUTES                                          = 0x8B89
 	ACTIVE_ATTRIBUTE_MAX_LENGTH                                = 0x8B8A
 	ACTIVE_PROGRAM                                             = 0x8259
+	ACTIVE_PROGRAM_EXT                                         = 0x8B8D
 	ACTIVE_RESOURCES                                           = 0x92F5
 	ACTIVE_SUBROUTINES                                         = 0x8DE5
 	ACTIVE_SUBROUTINE_MAX_LENGTH                               = 0x8E48
@@ -2959,10 +5173,15 @@ const (
 	ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH                       = 0x8A35
 	ACTIVE_UNIFORM_MAX_LENGTH                                  = 0x8B87
 	ACTIVE_VARIABLES                                           = 0x9305
+	ADJACENT_PAIRS_NV                                          = 0x90AE
+	AFFINE_2D_NV                                               = 0x9092
+	AFFINE_3D_NV                                               = 0x9094
 	ALIASED_LINE_WIDTH_RANGE                                   = 0x846E
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
+	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALPHA                                                      = 0x1906
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	AND                                                        = 0x1501
@@ -2970,6 +5189,7 @@ const (
 	AND_REVERSE                                                = 0x1502
 	ANY_SAMPLES_PASSED                                         = 0x8C2F
 	ANY_SAMPLES_PASSED_CONSERVATIVE                            = 0x8D6A
+	ARC_TO_NV                                                  = 0xFE
 	ARRAY_BUFFER                                               = 0x8892
 	ARRAY_BUFFER_BINDING                                       = 0x8894
 	ARRAY_SIZE                                                 = 0x92FB
@@ -2990,43 +5210,56 @@ const (
 	ATOMIC_COUNTER_BUFFER_SIZE                                 = 0x92C3
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	AUTO_GENERATE_MIPMAP                                       = 0x8295
 	BACK                                                       = 0x0405
 	BACK_LEFT                                                  = 0x0402
 	BACK_RIGHT                                                 = 0x0403
+	BEVEL_NV                                                   = 0x90A6
 	BGR                                                        = 0x80E0
 	BGRA                                                       = 0x80E1
 	BGRA_INTEGER                                               = 0x8D9B
 	BGR_INTEGER                                                = 0x8D9A
 	BLEND                                                      = 0x0BE2
+	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
+	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
 	BLEND_DST_RGB                                              = 0x80C8
 	BLEND_EQUATION                                             = 0x8009
 	BLEND_EQUATION_ALPHA                                       = 0x883D
 	BLEND_EQUATION_RGB                                         = 0x8009
+	BLEND_OVERLAP_NV                                           = 0x9281
+	BLEND_PREMULTIPLIED_SRC_NV                                 = 0x9280
 	BLEND_SRC                                                  = 0x0BE1
 	BLEND_SRC_ALPHA                                            = 0x80CB
 	BLEND_SRC_RGB                                              = 0x80C9
 	BLOCK_INDEX                                                = 0x92FD
 	BLUE                                                       = 0x1905
 	BLUE_INTEGER                                               = 0x8D96
+	BLUE_NV                                                    = 0x1905
+	BOLD_BIT_NV                                                = 0x01
 	BOOL                                                       = 0x8B56
 	BOOL_VEC2                                                  = 0x8B57
 	BOOL_VEC3                                                  = 0x8B58
 	BOOL_VEC4                                                  = 0x8B59
+	BOUNDING_BOX_NV                                            = 0x908D
+	BOUNDING_BOX_OF_BOUNDING_BOXES_NV                          = 0x909C
 	BUFFER                                                     = 0x82E0
 	BUFFER_ACCESS                                              = 0x88BB
 	BUFFER_ACCESS_FLAGS                                        = 0x911F
 	BUFFER_BINDING                                             = 0x9302
 	BUFFER_DATA_SIZE                                           = 0x9303
+	BUFFER_GPU_ADDRESS_NV                                      = 0x8F1D
 	BUFFER_IMMUTABLE_STORAGE                                   = 0x821F
 	BUFFER_KHR                                                 = 0x82E0
 	BUFFER_MAPPED                                              = 0x88BC
 	BUFFER_MAP_LENGTH                                          = 0x9120
 	BUFFER_MAP_OFFSET                                          = 0x9121
 	BUFFER_MAP_POINTER                                         = 0x88BD
+	BUFFER_OBJECT_EXT                                          = 0x9151
 	BUFFER_SIZE                                                = 0x8764
 	BUFFER_STORAGE_FLAGS                                       = 0x8220
 	BUFFER_UPDATE_BARRIER_BIT                                  = 0x00000200
@@ -3035,8 +5268,12 @@ const (
 	BYTE                                                       = 0x1400
 	CAVEAT_SUPPORT                                             = 0x82B8
 	CCW                                                        = 0x0901
+	CIRCULAR_CCW_ARC_TO_NV                                     = 0xF8
+	CIRCULAR_CW_ARC_TO_NV                                      = 0xFA
+	CIRCULAR_TANGENT_ARC_TO_NV                                 = 0xFC
 	CLAMP_READ_COLOR                                           = 0x891C
 	CLAMP_TO_BORDER                                            = 0x812D
+	CLAMP_TO_BORDER_ARB                                        = 0x812D
 	CLAMP_TO_EDGE                                              = 0x812F
 	CLEAR                                                      = 0x1500
 	CLEAR_BUFFER                                               = 0x82B4
@@ -3055,7 +5292,14 @@ const (
 	CLIP_DISTANCE6                                             = 0x3006
 	CLIP_DISTANCE7                                             = 0x3007
 	CLIP_ORIGIN                                                = 0x935C
+	CLOSE_PATH_NV                                              = 0x00
 	COLOR                                                      = 0x1800
+	COLORBURN_KHR                                              = 0x929A
+	COLORBURN_NV                                               = 0x929A
+	COLORDODGE_KHR                                             = 0x9299
+	COLORDODGE_NV                                              = 0x9299
+	COLOR_ARRAY_ADDRESS_NV                                     = 0x8F23
+	COLOR_ARRAY_LENGTH_NV                                      = 0x8F2D
 	COLOR_ATTACHMENT0                                          = 0x8CE0
 	COLOR_ATTACHMENT1                                          = 0x8CE1
 	COLOR_ATTACHMENT10                                         = 0x8CEA
@@ -3064,8 +5308,24 @@ const (
 	COLOR_ATTACHMENT13                                         = 0x8CED
 	COLOR_ATTACHMENT14                                         = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT5                                          = 0x8CE5
 	COLOR_ATTACHMENT6                                          = 0x8CE6
@@ -3078,11 +5338,14 @@ const (
 	COLOR_ENCODING                                             = 0x8296
 	COLOR_LOGIC_OP                                             = 0x0BF2
 	COLOR_RENDERABLE                                           = 0x8286
+	COLOR_SAMPLES_NV                                           = 0x8E20
 	COLOR_WRITEMASK                                            = 0x0C23
 	COMMAND_BARRIER_BIT                                        = 0x00000040
 	COMPARE_REF_TO_TEXTURE                                     = 0x884E
 	COMPATIBLE_SUBROUTINES                                     = 0x8E4B
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_R11_EAC                                         = 0x9270
 	COMPRESSED_RED                                             = 0x8225
 	COMPRESSED_RED_RGTC1                                       = 0x8DBB
@@ -3108,8 +5371,12 @@ const (
 	COMPRESSED_RGBA_ASTC_8x6_KHR                               = 0x93B6
 	COMPRESSED_RGBA_ASTC_8x8_KHR                               = 0x93B7
 	COMPRESSED_RGBA_BPTC_UNORM_ARB                             = 0x8E8C
+	COMPRESSED_RGBA_S3TC_DXT1_EXT                              = 0x83F1
+	COMPRESSED_RGBA_S3TC_DXT3_EXT                              = 0x83F2
+	COMPRESSED_RGBA_S3TC_DXT5_EXT                              = 0x83F3
 	COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB                       = 0x8E8E
 	COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB                     = 0x8E8F
+	COMPRESSED_RGB_S3TC_DXT1_EXT                               = 0x83F0
 	COMPRESSED_RG_RGTC2                                        = 0x8DBD
 	COMPRESSED_SIGNED_R11_EAC                                  = 0x9271
 	COMPRESSED_SIGNED_RED_RGTC1                                = 0x8DBC
@@ -3144,6 +5411,18 @@ const (
 	COMPUTE_TEXTURE                                            = 0x82A0
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
+	CONIC_CURVE_TO_NV                                          = 0x1A
+	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSTANT_ALPHA                                             = 0x8003
 	CONSTANT_COLOR                                             = 0x8001
 	CONTEXT_COMPATIBILITY_PROFILE_BIT                          = 0x00000002
@@ -3152,6 +5431,7 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
 	CONTEXT_LOST_KHR                                           = 0x0507
@@ -3162,18 +5442,28 @@ const (
 	CONTEXT_RELEASE_BEHAVIOR_KHR                               = 0x82FB
 	CONTEXT_ROBUST_ACCESS                                      = 0x90F3
 	CONTEXT_ROBUST_ACCESS_KHR                                  = 0x90F3
+	CONTRAST_NV                                                = 0x92A1
+	CONVEX_HULL_NV                                             = 0x908B
 	COPY                                                       = 0x1503
 	COPY_INVERTED                                              = 0x150C
 	COPY_READ_BUFFER                                           = 0x8F36
-	COPY_READ_BUFFER_BINDING                                   = 0x8F36
 	COPY_WRITE_BUFFER                                          = 0x8F37
-	COPY_WRITE_BUFFER_BINDING                                  = 0x8F37
+	COUNTER_RANGE_AMD                                          = 0x8BC1
+	COUNTER_TYPE_AMD                                           = 0x8BC0
+	COUNT_DOWN_NV                                              = 0x9089
+	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
+	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CULL_FACE                                                  = 0x0B44
 	CULL_FACE_MODE                                             = 0x0B45
 	CURRENT_PROGRAM                                            = 0x8B8D
 	CURRENT_QUERY                                              = 0x8865
 	CURRENT_VERTEX_ATTRIB                                      = 0x8626
 	CW                                                         = 0x0900
+	DARKEN_KHR                                                 = 0x9297
+	DARKEN_NV                                                  = 0x9297
 	DEBUG_CALLBACK_FUNCTION                                    = 0x8244
 	DEBUG_CALLBACK_FUNCTION_ARB                                = 0x8244
 	DEBUG_CALLBACK_FUNCTION_KHR                                = 0x8244
@@ -3246,6 +5536,7 @@ const (
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR                              = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_ARB                          = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_KHR                          = 0x824E
+	DECODE_EXT                                                 = 0x8A49
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DELETE_STATUS                                              = 0x8B80
@@ -3265,11 +5556,15 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
 	DEPTH_STENCIL_TEXTURE_MODE                                 = 0x90EA
 	DEPTH_TEST                                                 = 0x0B71
 	DEPTH_WRITEMASK                                            = 0x0B72
+	DIFFERENCE_KHR                                             = 0x929E
+	DIFFERENCE_NV                                              = 0x929E
+	DISJOINT_NV                                                = 0x9283
 	DISPATCH_INDIRECT_BUFFER                                   = 0x90EE
 	DISPATCH_INDIRECT_BUFFER_BINDING                           = 0x90EF
 	DITHER                                                     = 0x0BD0
@@ -3288,6 +5583,9 @@ const (
 	DOUBLE_VEC2                                                = 0x8FFC
 	DOUBLE_VEC3                                                = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER1                                               = 0x8826
@@ -3305,30 +5603,62 @@ const (
 	DRAW_BUFFER7                                               = 0x882C
 	DRAW_BUFFER8                                               = 0x882D
 	DRAW_BUFFER9                                               = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
+	DRAW_INDIRECT_ADDRESS_NV                                   = 0x8F41
 	DRAW_INDIRECT_BUFFER                                       = 0x8F3F
 	DRAW_INDIRECT_BUFFER_BINDING                               = 0x8F43
+	DRAW_INDIRECT_LENGTH_NV                                    = 0x8F42
+	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DST_ALPHA                                                  = 0x0304
+	DST_ATOP_NV                                                = 0x928F
 	DST_COLOR                                                  = 0x0306
+	DST_IN_NV                                                  = 0x928B
+	DST_NV                                                     = 0x9287
+	DST_OUT_NV                                                 = 0x928D
+	DST_OVER_NV                                                = 0x9289
+	DUP_FIRST_CUBIC_CURVE_TO_NV                                = 0xF2
+	DUP_LAST_CUBIC_CURVE_TO_NV                                 = 0xF4
 	DYNAMIC_COPY                                               = 0x88EA
 	DYNAMIC_DRAW                                               = 0x88E8
 	DYNAMIC_READ                                               = 0x88E9
 	DYNAMIC_STORAGE_BIT                                        = 0x0100
+	EDGE_FLAG_ARRAY_ADDRESS_NV                                 = 0x8F26
+	EDGE_FLAG_ARRAY_LENGTH_NV                                  = 0x8F30
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
+	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_BARRIER_BIT                                  = 0x00000002
 	ELEMENT_ARRAY_BUFFER                                       = 0x8893
 	ELEMENT_ARRAY_BUFFER_BINDING                               = 0x8895
+	ELEMENT_ARRAY_LENGTH_NV                                    = 0x8F33
+	ELEMENT_ARRAY_UNIFIED_NV                                   = 0x8F1F
 	EQUAL                                                      = 0x0202
 	EQUIV                                                      = 0x1509
+	EXCLUSION_KHR                                              = 0x92A0
+	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXTENSIONS                                                 = 0x1F03
+	FACTOR_MAX_AMD                                             = 0x901D
+	FACTOR_MIN_AMD                                             = 0x901C
 	FALSE                                                      = 0
 	FASTEST                                                    = 0x1101
+	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
+	FIRST_TO_REST_NV                                           = 0x90AF
 	FIRST_VERTEX_CONVENTION                                    = 0x8E4D
 	FIXED                                                      = 0x140C
 	FIXED_ONLY                                                 = 0x891D
 	FLOAT                                                      = 0x1406
+	FLOAT16_NV                                                 = 0x8FF8
+	FLOAT16_VEC2_NV                                            = 0x8FF9
+	FLOAT16_VEC3_NV                                            = 0x8FFA
+	FLOAT16_VEC4_NV                                            = 0x8FFB
 	FLOAT_32_UNSIGNED_INT_24_8_REV                             = 0x8DAD
 	FLOAT_MAT2                                                 = 0x8B5A
 	FLOAT_MAT2x3                                               = 0x8B65
@@ -3342,12 +5672,37 @@ const (
 	FLOAT_VEC2                                                 = 0x8B50
 	FLOAT_VEC3                                                 = 0x8B51
 	FLOAT_VEC4                                                 = 0x8B52
+	FOG_COORD_ARRAY_ADDRESS_NV                                 = 0x8F28
+	FOG_COORD_ARRAY_LENGTH_NV                                  = 0x8F32
+	FONT_ASCENDER_BIT_NV                                       = 0x00200000
+	FONT_DESCENDER_BIT_NV                                      = 0x00400000
+	FONT_GLYPHS_AVAILABLE_NV                                   = 0x9368
+	FONT_HAS_KERNING_BIT_NV                                    = 0x10000000
+	FONT_HEIGHT_BIT_NV                                         = 0x00800000
+	FONT_MAX_ADVANCE_HEIGHT_BIT_NV                             = 0x02000000
+	FONT_MAX_ADVANCE_WIDTH_BIT_NV                              = 0x01000000
+	FONT_NUM_GLYPH_INDICES_BIT_NV                              = 0x20000000
+	FONT_TARGET_UNAVAILABLE_NV                                 = 0x9369
+	FONT_UNAVAILABLE_NV                                        = 0x936A
+	FONT_UNDERLINE_POSITION_BIT_NV                             = 0x04000000
+	FONT_UNDERLINE_THICKNESS_BIT_NV                            = 0x08000000
+	FONT_UNINTELLIGIBLE_NV                                     = 0x936B
+	FONT_UNITS_PER_EM_BIT_NV                                   = 0x00100000
+	FONT_X_MAX_BOUNDS_BIT_NV                                   = 0x00040000
+	FONT_X_MIN_BOUNDS_BIT_NV                                   = 0x00010000
+	FONT_Y_MAX_BOUNDS_BIT_NV                                   = 0x00080000
+	FONT_Y_MIN_BOUNDS_BIT_NV                                   = 0x00020000
 	FRACTIONAL_EVEN                                            = 0x8E7C
 	FRACTIONAL_ODD                                             = 0x8E7B
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
+	FRAGMENT_INPUT_NV                                          = 0x936D
 	FRAGMENT_INTERPOLATION_OFFSET_BITS                         = 0x8E5D
 	FRAGMENT_SHADER                                            = 0x8B30
 	FRAGMENT_SHADER_BIT                                        = 0x00000002
+	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -3360,13 +5715,16 @@ const (
 	FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE                          = 0x8216
 	FRAMEBUFFER_ATTACHMENT_GREEN_SIZE                          = 0x8213
 	FRAMEBUFFER_ATTACHMENT_LAYERED                             = 0x8DA7
+	FRAMEBUFFER_ATTACHMENT_LAYERED_ARB                         = 0x8DA7
 	FRAMEBUFFER_ATTACHMENT_OBJECT_NAME                         = 0x8CD1
 	FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE                         = 0x8CD0
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
 	FRAMEBUFFER_BLEND                                          = 0x828B
@@ -3379,18 +5737,26 @@ const (
 	FRAMEBUFFER_DEFAULT_WIDTH                                  = 0x9310
 	FRAMEBUFFER_INCOMPLETE_ATTACHMENT                          = 0x8CD6
 	FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER                         = 0x8CDB
+	FRAMEBUFFER_INCOMPLETE_LAYER_COUNT_ARB                     = 0x8DA9
 	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS                       = 0x8DA8
+	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS_ARB                   = 0x8DA8
 	FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT                  = 0x8CD7
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE                         = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_UNDEFINED                                      = 0x8219
 	FRAMEBUFFER_UNSUPPORTED                                    = 0x8CDD
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_SUPPORT                                               = 0x82B7
@@ -3398,8 +5764,11 @@ const (
 	FUNC_REVERSE_SUBTRACT                                      = 0x800B
 	FUNC_SUBTRACT                                              = 0x800A
 	GEOMETRY_INPUT_TYPE                                        = 0x8917
+	GEOMETRY_INPUT_TYPE_ARB                                    = 0x8DDB
 	GEOMETRY_OUTPUT_TYPE                                       = 0x8918
+	GEOMETRY_OUTPUT_TYPE_ARB                                   = 0x8DDC
 	GEOMETRY_SHADER                                            = 0x8DD9
+	GEOMETRY_SHADER_ARB                                        = 0x8DD9
 	GEOMETRY_SHADER_BIT                                        = 0x00000004
 	GEOMETRY_SHADER_INVOCATIONS                                = 0x887F
 	GEOMETRY_SHADER_PRIMITIVES_EMITTED_ARB                     = 0x82F3
@@ -3407,18 +5776,42 @@ const (
 	GEOMETRY_SUBROUTINE_UNIFORM                                = 0x92F1
 	GEOMETRY_TEXTURE                                           = 0x829E
 	GEOMETRY_VERTICES_OUT                                      = 0x8916
+	GEOMETRY_VERTICES_OUT_ARB                                  = 0x8DDA
 	GEQUAL                                                     = 0x0206
 	GET_TEXTURE_IMAGE_FORMAT                                   = 0x8291
 	GET_TEXTURE_IMAGE_TYPE                                     = 0x8292
+	GLYPH_HAS_KERNING_BIT_NV                                   = 0x100
+	GLYPH_HEIGHT_BIT_NV                                        = 0x02
+	GLYPH_HORIZONTAL_BEARING_ADVANCE_BIT_NV                    = 0x10
+	GLYPH_HORIZONTAL_BEARING_X_BIT_NV                          = 0x04
+	GLYPH_HORIZONTAL_BEARING_Y_BIT_NV                          = 0x08
+	GLYPH_VERTICAL_BEARING_ADVANCE_BIT_NV                      = 0x80
+	GLYPH_VERTICAL_BEARING_X_BIT_NV                            = 0x20
+	GLYPH_VERTICAL_BEARING_Y_BIT_NV                            = 0x40
+	GLYPH_WIDTH_BIT_NV                                         = 0x01
+	GPU_ADDRESS_NV                                             = 0x8F34
 	GREATER                                                    = 0x0204
 	GREEN                                                      = 0x1904
 	GREEN_INTEGER                                              = 0x8D95
+	GREEN_NV                                                   = 0x1904
 	GUILTY_CONTEXT_RESET                                       = 0x8253
 	GUILTY_CONTEXT_RESET_ARB                                   = 0x8253
 	GUILTY_CONTEXT_RESET_KHR                                   = 0x8253
 	HALF_FLOAT                                                 = 0x140B
+	HARDLIGHT_KHR                                              = 0x929B
+	HARDLIGHT_NV                                               = 0x929B
+	HARDMIX_NV                                                 = 0x92A9
 	HIGH_FLOAT                                                 = 0x8DF2
 	HIGH_INT                                                   = 0x8DF5
+	HORIZONTAL_LINE_TO_NV                                      = 0x06
+	HSL_COLOR_KHR                                              = 0x92AF
+	HSL_COLOR_NV                                               = 0x92AF
+	HSL_HUE_KHR                                                = 0x92AD
+	HSL_HUE_NV                                                 = 0x92AD
+	HSL_LUMINOSITY_KHR                                         = 0x92B0
+	HSL_LUMINOSITY_NV                                          = 0x92B0
+	HSL_SATURATION_KHR                                         = 0x92AE
+	HSL_SATURATION_NV                                          = 0x92AE
 	IMAGE_1D                                                   = 0x904C
 	IMAGE_1D_ARRAY                                             = 0x9052
 	IMAGE_2D                                                   = 0x904D
@@ -3456,13 +5849,32 @@ const (
 	IMAGE_TEXEL_SIZE                                           = 0x82A7
 	IMPLEMENTATION_COLOR_READ_FORMAT                           = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
+	INDEX_ARRAY_ADDRESS_NV                                     = 0x8F24
+	INDEX_ARRAY_LENGTH_NV                                      = 0x8F2E
 	INFO_LOG_LENGTH                                            = 0x8B84
 	INNOCENT_CONTEXT_RESET                                     = 0x8254
 	INNOCENT_CONTEXT_RESET_ARB                                 = 0x8254
 	INNOCENT_CONTEXT_RESET_KHR                                 = 0x8254
 	INT                                                        = 0x1404
+	INT16_NV                                                   = 0x8FE4
+	INT16_VEC2_NV                                              = 0x8FE5
+	INT16_VEC3_NV                                              = 0x8FE6
+	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
+	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
+	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
+	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
+	INT64_VEC4_NV                                              = 0x8FEB
+	INT8_NV                                                    = 0x8FE0
+	INT8_VEC2_NV                                               = 0x8FE1
+	INT8_VEC3_NV                                               = 0x8FE2
+	INT8_VEC4_NV                                               = 0x8FE3
 	INTERLEAVED_ATTRIBS                                        = 0x8C8C
 	INTERNALFORMAT_ALPHA_SIZE                                  = 0x8274
 	INTERNALFORMAT_ALPHA_TYPE                                  = 0x827B
@@ -3512,27 +5924,41 @@ const (
 	INVALID_OPERATION                                          = 0x0502
 	INVALID_VALUE                                              = 0x0501
 	INVERT                                                     = 0x150A
+	INVERT_OVG_NV                                              = 0x92B4
+	INVERT_RGB_NV                                              = 0x92A3
 	ISOLINES                                                   = 0x8E7A
 	IS_PER_PATCH                                               = 0x92E7
 	IS_ROW_MAJOR                                               = 0x9300
+	ITALIC_BIT_NV                                              = 0x02
 	KEEP                                                       = 0x1E00
+	LARGE_CCW_ARC_TO_NV                                        = 0x16
+	LARGE_CW_ARC_TO_NV                                         = 0x18
 	LAST_VERTEX_CONVENTION                                     = 0x8E4E
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LESS                                                       = 0x0201
+	LIGHTEN_KHR                                                = 0x9298
+	LIGHTEN_NV                                                 = 0x9298
 	LINE                                                       = 0x1B01
 	LINEAR                                                     = 0x2601
+	LINEARBURN_NV                                              = 0x92A5
+	LINEARDODGE_NV                                             = 0x92A4
+	LINEARLIGHT_NV                                             = 0x92A7
 	LINEAR_MIPMAP_LINEAR                                       = 0x2703
 	LINEAR_MIPMAP_NEAREST                                      = 0x2701
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
+	LINES_ADJACENCY_ARB                                        = 0x000A
 	LINE_LOOP                                                  = 0x0002
 	LINE_SMOOTH                                                = 0x0B20
 	LINE_SMOOTH_HINT                                           = 0x0C52
 	LINE_STRIP                                                 = 0x0003
 	LINE_STRIP_ADJACENCY                                       = 0x000B
+	LINE_STRIP_ADJACENCY_ARB                                   = 0x000B
+	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -3632,12 +6058,17 @@ const (
 	MAX_GEOMETRY_INPUT_COMPONENTS                              = 0x9123
 	MAX_GEOMETRY_OUTPUT_COMPONENTS                             = 0x9124
 	MAX_GEOMETRY_OUTPUT_VERTICES                               = 0x8DE0
+	MAX_GEOMETRY_OUTPUT_VERTICES_ARB                           = 0x8DE0
 	MAX_GEOMETRY_SHADER_INVOCATIONS                            = 0x8E5A
 	MAX_GEOMETRY_SHADER_STORAGE_BLOCKS                         = 0x90D7
 	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS                           = 0x8C29
+	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS_ARB                       = 0x8C29
 	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS                       = 0x8DE1
+	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS_ARB                   = 0x8DE1
 	MAX_GEOMETRY_UNIFORM_BLOCKS                                = 0x8A2C
 	MAX_GEOMETRY_UNIFORM_COMPONENTS                            = 0x8DDF
+	MAX_GEOMETRY_UNIFORM_COMPONENTS_ARB                        = 0x8DDF
+	MAX_GEOMETRY_VARYING_COMPONENTS_ARB                        = 0x8DDD
 	MAX_HEIGHT                                                 = 0x827F
 	MAX_IMAGE_SAMPLES                                          = 0x906D
 	MAX_IMAGE_UNITS                                            = 0x8F38
@@ -3645,6 +6076,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_MULTISAMPLE_COVERAGE_MODES_NV                          = 0x8E11
 	MAX_NAME_LENGTH                                            = 0x92F6
 	MAX_NUM_ACTIVE_VARIABLES                                   = 0x92F7
 	MAX_NUM_COMPATIBLE_SUBROUTINES                             = 0x92F8
@@ -3653,16 +6085,21 @@ const (
 	MAX_PROGRAM_TEXTURE_GATHER_COMPONENTS_ARB                  = 0x8F9F
 	MAX_PROGRAM_TEXTURE_GATHER_OFFSET                          = 0x8E5F
 	MAX_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5F
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RENDERBUFFER_SIZE                                      = 0x84E8
 	MAX_SAMPLES                                                = 0x8D57
 	MAX_SAMPLE_MASK_WORDS                                      = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
+	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SPARSE_3D_TEXTURE_SIZE_ARB                             = 0x9199
 	MAX_SPARSE_ARRAY_TEXTURE_LAYERS_ARB                        = 0x919A
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -3687,8 +6124,10 @@ const (
 	MAX_TESS_GEN_LEVEL                                         = 0x8E7E
 	MAX_TESS_PATCH_COMPONENTS                                  = 0x8E84
 	MAX_TEXTURE_BUFFER_SIZE                                    = 0x8C2B
+	MAX_TEXTURE_BUFFER_SIZE_ARB                                = 0x8C2B
 	MAX_TEXTURE_IMAGE_UNITS                                    = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TRANSFORM_FEEDBACK_BUFFERS                             = 0x8E70
 	MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS              = 0x8C8A
@@ -3713,13 +6152,18 @@ const (
 	MAX_VERTEX_UNIFORM_BLOCKS                                  = 0x8A2B
 	MAX_VERTEX_UNIFORM_COMPONENTS                              = 0x8B4A
 	MAX_VERTEX_UNIFORM_VECTORS                                 = 0x8DFB
+	MAX_VERTEX_VARYING_COMPONENTS_ARB                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
 	MINOR_VERSION                                              = 0x821C
+	MINUS_CLAMPED_NV                                           = 0x92B3
+	MINUS_NV                                                   = 0x929F
 	MIN_FRAGMENT_INTERPOLATION_OFFSET                          = 0x8E5B
 	MIN_MAP_BUFFER_ALIGNMENT                                   = 0x90BC
 	MIN_PROGRAM_TEXEL_OFFSET                                   = 0x8904
@@ -3727,11 +6171,25 @@ const (
 	MIN_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5E
 	MIN_SAMPLE_SHADING_VALUE                                   = 0x8C37
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
+	MIRRORED_REPEAT_ARB                                        = 0x8370
 	MIRROR_CLAMP_TO_EDGE                                       = 0x8743
+	MITER_REVERT_NV                                            = 0x90A7
+	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
+	MOVE_TO_CONTINUES_NV                                       = 0x90B6
+	MOVE_TO_NV                                                 = 0x02
+	MOVE_TO_RESETS_NV                                          = 0x90B5
+	MULTIPLY_KHR                                               = 0x9294
+	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
+	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	NAMED_STRING_LENGTH_ARB                                    = 0x8DE9
 	NAMED_STRING_TYPE_ARB                                      = 0x8DEA
 	NAME_LENGTH                                                = 0x92F9
@@ -3744,7 +6202,10 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
+	NORMAL_ARRAY_ADDRESS_NV                                    = 0x8F22
+	NORMAL_ARRAY_LENGTH_NV                                     = 0x8F2C
 	NOTEQUAL                                                   = 0x0205
 	NO_ERROR                                                   = 0
 	NO_RESET_NOTIFICATION                                      = 0x8261
@@ -3757,7 +6218,10 @@ const (
 	NUM_PROGRAM_BINARY_FORMATS                                 = 0x87FE
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_TYPE                                                = 0x9112
 	OFFSET                                                     = 0x92FC
 	ONE                                                        = 1
@@ -3773,6 +6237,8 @@ const (
 	OR_INVERTED                                                = 0x150D
 	OR_REVERSE                                                 = 0x150B
 	OUT_OF_MEMORY                                              = 0x0505
+	OVERLAY_KHR                                                = 0x9296
+	OVERLAY_NV                                                 = 0x9296
 	PACK_ALIGNMENT                                             = 0x0D05
 	PACK_COMPRESSED_BLOCK_DEPTH                                = 0x912D
 	PACK_COMPRESSED_BLOCK_HEIGHT                               = 0x912C
@@ -3791,11 +6257,90 @@ const (
 	PATCH_DEFAULT_INNER_LEVEL                                  = 0x8E73
 	PATCH_DEFAULT_OUTER_LEVEL                                  = 0x8E74
 	PATCH_VERTICES                                             = 0x8E72
+	PATH_CLIENT_LENGTH_NV                                      = 0x907F
+	PATH_COMMAND_COUNT_NV                                      = 0x909D
+	PATH_COMPUTED_LENGTH_NV                                    = 0x90A0
+	PATH_COORD_COUNT_NV                                        = 0x909E
+	PATH_COVER_DEPTH_FUNC_NV                                   = 0x90BF
+	PATH_DASH_ARRAY_COUNT_NV                                   = 0x909F
+	PATH_DASH_CAPS_NV                                          = 0x907B
+	PATH_DASH_OFFSET_NV                                        = 0x907E
+	PATH_DASH_OFFSET_RESET_NV                                  = 0x90B4
+	PATH_END_CAPS_NV                                           = 0x9076
+	PATH_ERROR_POSITION_NV                                     = 0x90AB
+	PATH_FILL_BOUNDING_BOX_NV                                  = 0x90A1
+	PATH_FILL_COVER_MODE_NV                                    = 0x9082
+	PATH_FILL_MASK_NV                                          = 0x9081
+	PATH_FILL_MODE_NV                                          = 0x9080
+	PATH_FORMAT_PS_NV                                          = 0x9071
+	PATH_FORMAT_SVG_NV                                         = 0x9070
+	PATH_GEN_COEFF_NV                                          = 0x90B1
+	PATH_GEN_COMPONENTS_NV                                     = 0x90B3
+	PATH_GEN_MODE_NV                                           = 0x90B0
+	PATH_INITIAL_DASH_CAP_NV                                   = 0x907C
+	PATH_INITIAL_END_CAP_NV                                    = 0x9077
+	PATH_JOIN_STYLE_NV                                         = 0x9079
+	PATH_MAX_MODELVIEW_STACK_DEPTH_NV                          = 0x0D36
+	PATH_MAX_PROJECTION_STACK_DEPTH_NV                         = 0x0D38
+	PATH_MITER_LIMIT_NV                                        = 0x907A
+	PATH_MODELVIEW_MATRIX_NV                                   = 0x0BA6
+	PATH_MODELVIEW_NV                                          = 0x1700
+	PATH_MODELVIEW_STACK_DEPTH_NV                              = 0x0BA3
+	PATH_OBJECT_BOUNDING_BOX_NV                                = 0x908A
+	PATH_PROJECTION_MATRIX_NV                                  = 0x0BA7
+	PATH_PROJECTION_NV                                         = 0x1701
+	PATH_PROJECTION_STACK_DEPTH_NV                             = 0x0BA4
+	PATH_STENCIL_DEPTH_OFFSET_FACTOR_NV                        = 0x90BD
+	PATH_STENCIL_DEPTH_OFFSET_UNITS_NV                         = 0x90BE
+	PATH_STENCIL_FUNC_NV                                       = 0x90B7
+	PATH_STENCIL_REF_NV                                        = 0x90B8
+	PATH_STENCIL_VALUE_MASK_NV                                 = 0x90B9
+	PATH_STROKE_BOUNDING_BOX_NV                                = 0x90A2
+	PATH_STROKE_COVER_MODE_NV                                  = 0x9083
+	PATH_STROKE_MASK_NV                                        = 0x9084
+	PATH_STROKE_WIDTH_NV                                       = 0x9075
+	PATH_TERMINAL_DASH_CAP_NV                                  = 0x907D
+	PATH_TERMINAL_END_CAP_NV                                   = 0x9078
+	PATH_TRANSPOSE_MODELVIEW_MATRIX_NV                         = 0x84E3
+	PATH_TRANSPOSE_PROJECTION_MATRIX_NV                        = 0x84E4
+	PERCENTAGE_AMD                                             = 0x8BC3
+	PERFMON_RESULT_AMD                                         = 0x8BC6
+	PERFMON_RESULT_AVAILABLE_AMD                               = 0x8BC4
+	PERFMON_RESULT_SIZE_AMD                                    = 0x8BC5
+	PERFQUERY_COUNTER_DATA_BOOL32_INTEL                        = 0x94FC
+	PERFQUERY_COUNTER_DATA_DOUBLE_INTEL                        = 0x94FB
+	PERFQUERY_COUNTER_DATA_FLOAT_INTEL                         = 0x94FA
+	PERFQUERY_COUNTER_DATA_UINT32_INTEL                        = 0x94F8
+	PERFQUERY_COUNTER_DATA_UINT64_INTEL                        = 0x94F9
+	PERFQUERY_COUNTER_DESC_LENGTH_MAX_INTEL                    = 0x94FF
+	PERFQUERY_COUNTER_DURATION_NORM_INTEL                      = 0x94F1
+	PERFQUERY_COUNTER_DURATION_RAW_INTEL                       = 0x94F2
+	PERFQUERY_COUNTER_EVENT_INTEL                              = 0x94F0
+	PERFQUERY_COUNTER_NAME_LENGTH_MAX_INTEL                    = 0x94FE
+	PERFQUERY_COUNTER_RAW_INTEL                                = 0x94F4
+	PERFQUERY_COUNTER_THROUGHPUT_INTEL                         = 0x94F3
+	PERFQUERY_COUNTER_TIMESTAMP_INTEL                          = 0x94F5
+	PERFQUERY_DONOT_FLUSH_INTEL                                = 0x83F9
+	PERFQUERY_FLUSH_INTEL                                      = 0x83FA
+	PERFQUERY_GLOBAL_CONTEXT_INTEL                             = 0x00000001
+	PERFQUERY_GPA_EXTENDED_COUNTERS_INTEL                      = 0x9500
+	PERFQUERY_QUERY_NAME_LENGTH_MAX_INTEL                      = 0x94FD
+	PERFQUERY_SINGLE_CONTEXT_INTEL                             = 0x00000000
+	PERFQUERY_WAIT_INTEL                                       = 0x83FB
+	PINLIGHT_NV                                                = 0x92A8
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_PACK_BUFFER                                          = 0x88EB
+	PIXEL_PACK_BUFFER_ARB                                      = 0x88EB
 	PIXEL_PACK_BUFFER_BINDING                                  = 0x88ED
+	PIXEL_PACK_BUFFER_BINDING_ARB                              = 0x88ED
 	PIXEL_UNPACK_BUFFER                                        = 0x88EC
+	PIXEL_UNPACK_BUFFER_ARB                                    = 0x88EC
 	PIXEL_UNPACK_BUFFER_BINDING                                = 0x88EF
+	PIXEL_UNPACK_BUFFER_BINDING_ARB                            = 0x88EF
+	PLUS_CLAMPED_ALPHA_NV                                      = 0x92B2
+	PLUS_CLAMPED_NV                                            = 0x92B1
+	PLUS_DARKER_NV                                             = 0x9292
+	PLUS_NV                                                    = 0x9291
 	POINT                                                      = 0x1B00
 	POINTS                                                     = 0x0000
 	POINT_FADE_THRESHOLD_SIZE                                  = 0x8128
@@ -3804,6 +6349,9 @@ const (
 	POINT_SIZE_RANGE                                           = 0x0B12
 	POINT_SPRITE_COORD_ORIGIN                                  = 0x8CA0
 	POLYGON_MODE                                               = 0x0B40
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FILL                                        = 0x8037
 	POLYGON_OFFSET_LINE                                        = 0x2A02
@@ -3813,20 +6361,33 @@ const (
 	POLYGON_SMOOTH_HINT                                        = 0x0C53
 	PRIMITIVES_GENERATED                                       = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
 	PRIMITIVE_RESTART_INDEX                                    = 0x8F9E
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_INPUT                                              = 0x92E3
 	PROGRAM_KHR                                                = 0x82E2
+	PROGRAM_MATRIX_EXT                                         = 0x8E2D
+	PROGRAM_MATRIX_STACK_DEPTH_EXT                             = 0x8E2F
+	PROGRAM_OBJECT_EXT                                         = 0x8B40
 	PROGRAM_OUTPUT                                             = 0x92E4
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
+	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
+	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
+	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
 	PROGRAM_SEPARABLE                                          = 0x8258
+	PROGRAM_SEPARABLE_EXT                                      = 0x8258
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROXY_TEXTURE_1D                                           = 0x8063
 	PROXY_TEXTURE_1D_ARRAY                                     = 0x8C19
@@ -3839,6 +6400,7 @@ const (
 	PROXY_TEXTURE_CUBE_MAP_ARRAY                               = 0x900B
 	PROXY_TEXTURE_CUBE_MAP_ARRAY_ARB                           = 0x900B
 	PROXY_TEXTURE_RECTANGLE                                    = 0x84F7
+	QUADRATIC_CURVE_TO_NV                                      = 0x0A
 	QUADS                                                      = 0x0007
 	QUADS_FOLLOW_PROVOKING_VERTEX_CONVENTION                   = 0x8E4C
 	QUERY                                                      = 0x82E3
@@ -3847,18 +6409,23 @@ const (
 	QUERY_BUFFER_BINDING                                       = 0x9193
 	QUERY_BY_REGION_NO_WAIT                                    = 0x8E16
 	QUERY_BY_REGION_NO_WAIT_INVERTED                           = 0x8E1A
+	QUERY_BY_REGION_NO_WAIT_NV                                 = 0x8E16
 	QUERY_BY_REGION_WAIT                                       = 0x8E15
 	QUERY_BY_REGION_WAIT_INVERTED                              = 0x8E19
+	QUERY_BY_REGION_WAIT_NV                                    = 0x8E15
 	QUERY_COUNTER_BITS                                         = 0x8864
 	QUERY_KHR                                                  = 0x82E3
 	QUERY_NO_WAIT                                              = 0x8E14
 	QUERY_NO_WAIT_INVERTED                                     = 0x8E18
+	QUERY_NO_WAIT_NV                                           = 0x8E14
+	QUERY_OBJECT_EXT                                           = 0x9153
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
 	QUERY_RESULT_NO_WAIT                                       = 0x9194
 	QUERY_TARGET                                               = 0x82EA
 	QUERY_WAIT                                                 = 0x8E13
 	QUERY_WAIT_INVERTED                                        = 0x8E17
+	QUERY_WAIT_NV                                              = 0x8E13
 	R11F_G11F_B10F                                             = 0x8C3A
 	R16                                                        = 0x822A
 	R16F                                                       = 0x822D
@@ -3874,6 +6441,9 @@ const (
 	R8UI                                                       = 0x8232
 	R8_SNORM                                                   = 0x8F94
 	RASTERIZER_DISCARD                                         = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -3882,18 +6452,41 @@ const (
 	READ_PIXELS_FORMAT                                         = 0x828D
 	READ_PIXELS_TYPE                                           = 0x828E
 	READ_WRITE                                                 = 0x88BA
+	RECT_NV                                                    = 0xF6
 	RED                                                        = 0x1903
 	RED_INTEGER                                                = 0x8D94
+	RED_NV                                                     = 0x1903
 	REFERENCED_BY_COMPUTE_SHADER                               = 0x930B
 	REFERENCED_BY_FRAGMENT_SHADER                              = 0x930A
 	REFERENCED_BY_GEOMETRY_SHADER                              = 0x9309
 	REFERENCED_BY_TESS_CONTROL_SHADER                          = 0x9307
 	REFERENCED_BY_TESS_EVALUATION_SHADER                       = 0x9308
 	REFERENCED_BY_VERTEX_SHADER                                = 0x9306
+	RELATIVE_ARC_TO_NV                                         = 0xFF
+	RELATIVE_CONIC_CURVE_TO_NV                                 = 0x1B
+	RELATIVE_CUBIC_CURVE_TO_NV                                 = 0x0D
+	RELATIVE_HORIZONTAL_LINE_TO_NV                             = 0x07
+	RELATIVE_LARGE_CCW_ARC_TO_NV                               = 0x17
+	RELATIVE_LARGE_CW_ARC_TO_NV                                = 0x19
+	RELATIVE_LINE_TO_NV                                        = 0x05
+	RELATIVE_MOVE_TO_NV                                        = 0x03
+	RELATIVE_QUADRATIC_CURVE_TO_NV                             = 0x0B
+	RELATIVE_RECT_NV                                           = 0xF7
+	RELATIVE_ROUNDED_RECT2_NV                                  = 0xEB
+	RELATIVE_ROUNDED_RECT4_NV                                  = 0xED
+	RELATIVE_ROUNDED_RECT8_NV                                  = 0xEF
+	RELATIVE_ROUNDED_RECT_NV                                   = 0xE9
+	RELATIVE_SMALL_CCW_ARC_TO_NV                               = 0x13
+	RELATIVE_SMALL_CW_ARC_TO_NV                                = 0x15
+	RELATIVE_SMOOTH_CUBIC_CURVE_TO_NV                          = 0x11
+	RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV                      = 0x0F
+	RELATIVE_VERTICAL_LINE_TO_NV                               = 0x09
 	RENDERBUFFER                                               = 0x8D41
 	RENDERBUFFER_ALPHA_SIZE                                    = 0x8D53
 	RENDERBUFFER_BINDING                                       = 0x8CA7
 	RENDERBUFFER_BLUE_SIZE                                     = 0x8D52
+	RENDERBUFFER_COLOR_SAMPLES_NV                              = 0x8E10
+	RENDERBUFFER_COVERAGE_SAMPLES_NV                           = 0x8CAB
 	RENDERBUFFER_DEPTH_SIZE                                    = 0x8D54
 	RENDERBUFFER_GREEN_SIZE                                    = 0x8D51
 	RENDERBUFFER_HEIGHT                                        = 0x8D43
@@ -3908,6 +6501,7 @@ const (
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
 	RESET_NOTIFICATION_STRATEGY_ARB                            = 0x8256
 	RESET_NOTIFICATION_STRATEGY_KHR                            = 0x8256
+	RESTART_PATH_NV                                            = 0xF0
 	RG                                                         = 0x8227
 	RG16                                                       = 0x822C
 	RG16F                                                      = 0x822F
@@ -3960,9 +6554,16 @@ const (
 	RGBA8UI                                                    = 0x8D7C
 	RGBA8_SNORM                                                = 0x8F97
 	RGBA_INTEGER                                               = 0x8D99
+	RGB_422_APPLE                                              = 0x8A1F
 	RGB_INTEGER                                                = 0x8D98
+	RGB_RAW_422_APPLE                                          = 0x8A51
 	RG_INTEGER                                                 = 0x8228
 	RIGHT                                                      = 0x0407
+	ROUNDED_RECT2_NV                                           = 0xEA
+	ROUNDED_RECT4_NV                                           = 0xEC
+	ROUNDED_RECT8_NV                                           = 0xEE
+	ROUNDED_RECT_NV                                            = 0xE8
+	ROUND_NV                                                   = 0x90A4
 	SAMPLER                                                    = 0x82E6
 	SAMPLER_1D                                                 = 0x8B5D
 	SAMPLER_1D_ARRAY                                           = 0x8DC0
@@ -3994,24 +6595,40 @@ const (
 	SAMPLE_COVERAGE                                            = 0x80A0
 	SAMPLE_COVERAGE_INVERT                                     = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_VALUE                                          = 0x8E52
 	SAMPLE_POSITION                                            = 0x8E50
 	SAMPLE_SHADING                                             = 0x8C36
 	SAMPLE_SHADING_ARB                                         = 0x8C36
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
+	SCREEN_KHR                                                 = 0x9295
+	SCREEN_NV                                                  = 0x9295
+	SECONDARY_COLOR_ARRAY_ADDRESS_NV                           = 0x8F27
+	SECONDARY_COLOR_ARRAY_LENGTH_NV                            = 0x8F31
 	SEPARATE_ATTRIBS                                           = 0x8C8D
 	SET                                                        = 0x150F
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
+	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
 	SHADER_IMAGE_ACCESS_BARRIER_BIT                            = 0x00000020
 	SHADER_IMAGE_ATOMIC                                        = 0x82A6
 	SHADER_IMAGE_LOAD                                          = 0x82A4
 	SHADER_IMAGE_STORE                                         = 0x82A5
 	SHADER_INCLUDE_ARB                                         = 0x8DAE
 	SHADER_KHR                                                 = 0x82E1
+	SHADER_OBJECT_EXT                                          = 0x8B48
 	SHADER_SOURCE_LENGTH                                       = 0x8B88
 	SHADER_STORAGE_BARRIER_BIT                                 = 0x00002000
 	SHADER_STORAGE_BLOCK                                       = 0x92E6
@@ -4022,6 +6639,7 @@ const (
 	SHADER_STORAGE_BUFFER_START                                = 0x90D4
 	SHADER_TYPE                                                = 0x8B4F
 	SHADING_LANGUAGE_VERSION                                   = 0x8B8C
+	SHARED_EDGE_NV                                             = 0xC0
 	SHORT                                                      = 0x1402
 	SIGNALED                                                   = 0x9119
 	SIGNED_NORMALIZED                                          = 0x8F9C
@@ -4029,18 +6647,35 @@ const (
 	SIMULTANEOUS_TEXTURE_AND_DEPTH_WRITE                       = 0x82AE
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_TEST                      = 0x82AD
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_WRITE                     = 0x82AF
+	SKIP_DECODE_EXT                                            = 0x8A4A
+	SKIP_MISSING_GLYPH_NV                                      = 0x90A9
+	SMALL_CCW_ARC_TO_NV                                        = 0x12
+	SMALL_CW_ARC_TO_NV                                         = 0x14
+	SMOOTH_CUBIC_CURVE_TO_NV                                   = 0x10
 	SMOOTH_LINE_WIDTH_GRANULARITY                              = 0x0B23
 	SMOOTH_LINE_WIDTH_RANGE                                    = 0x0B22
 	SMOOTH_POINT_SIZE_GRANULARITY                              = 0x0B13
 	SMOOTH_POINT_SIZE_RANGE                                    = 0x0B12
+	SMOOTH_QUADRATIC_CURVE_TO_NV                               = 0x0E
+	SM_COUNT_NV                                                = 0x933B
+	SOFTLIGHT_KHR                                              = 0x929C
+	SOFTLIGHT_NV                                               = 0x929C
 	SPARSE_BUFFER_PAGE_SIZE_ARB                                = 0x82F8
 	SPARSE_STORAGE_BIT_ARB                                     = 0x0400
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
+	SQUARE_NV                                                  = 0x90A3
 	SRC1_ALPHA                                                 = 0x8589
 	SRC1_COLOR                                                 = 0x88F9
 	SRC_ALPHA                                                  = 0x0302
 	SRC_ALPHA_SATURATE                                         = 0x0308
+	SRC_ATOP_NV                                                = 0x928E
 	SRC_COLOR                                                  = 0x0300
+	SRC_IN_NV                                                  = 0x928A
+	SRC_NV                                                     = 0x9286
+	SRC_OUT_NV                                                 = 0x928C
+	SRC_OVER_NV                                                = 0x9288
 	SRGB                                                       = 0x8C40
 	SRGB8                                                      = 0x8C41
 	SRGB8_ALPHA8                                               = 0x8C43
@@ -4052,6 +6687,8 @@ const (
 	STACK_OVERFLOW_KHR                                         = 0x0503
 	STACK_UNDERFLOW                                            = 0x0504
 	STACK_UNDERFLOW_KHR                                        = 0x0504
+	STANDARD_FONT_FORMAT_NV                                    = 0x936C
+	STANDARD_FONT_NAME_NV                                      = 0x9072
 	STATIC_COPY                                                = 0x88E6
 	STATIC_DRAW                                                = 0x88E4
 	STATIC_READ                                                = 0x88E5
@@ -4077,7 +6714,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_VALUE_MASK                                         = 0x0B93
 	STENCIL_WRITEMASK                                          = 0x0B98
@@ -4086,6 +6725,10 @@ const (
 	STREAM_DRAW                                                = 0x88E0
 	STREAM_READ                                                = 0x88E1
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SYNC_CL_EVENT_ARB                                          = 0x8240
 	SYNC_CL_EVENT_COMPLETE_ARB                                 = 0x8241
 	SYNC_CONDITION                                             = 0x9113
@@ -4094,6 +6737,8 @@ const (
 	SYNC_FLUSH_COMMANDS_BIT                                    = 0x00000001
 	SYNC_GPU_COMMANDS_COMPLETE                                 = 0x9117
 	SYNC_STATUS                                                = 0x9114
+	SYSTEM_FONT_NAME_NV                                        = 0x9073
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
 	TESS_CONTROL_SHADER                                        = 0x8E88
 	TESS_CONTROL_SHADER_BIT                                    = 0x00000008
@@ -4154,7 +6799,6 @@ const (
 	TEXTURE_ALPHA_SIZE                                         = 0x805F
 	TEXTURE_ALPHA_TYPE                                         = 0x8C13
 	TEXTURE_BASE_LEVEL                                         = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_2D                                         = 0x8069
@@ -4163,6 +6807,7 @@ const (
 	TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY                       = 0x9105
 	TEXTURE_BINDING_3D                                         = 0x806A
 	TEXTURE_BINDING_BUFFER                                     = 0x8C2C
+	TEXTURE_BINDING_BUFFER_ARB                                 = 0x8C2C
 	TEXTURE_BINDING_CUBE_MAP                                   = 0x8514
 	TEXTURE_BINDING_CUBE_MAP_ARRAY                             = 0x900A
 	TEXTURE_BINDING_CUBE_MAP_ARRAY_ARB                         = 0x900A
@@ -4171,7 +6816,10 @@ const (
 	TEXTURE_BLUE_TYPE                                          = 0x8C12
 	TEXTURE_BORDER_COLOR                                       = 0x1004
 	TEXTURE_BUFFER                                             = 0x8C2A
+	TEXTURE_BUFFER_ARB                                         = 0x8C2A
 	TEXTURE_BUFFER_DATA_STORE_BINDING                          = 0x8C2D
+	TEXTURE_BUFFER_DATA_STORE_BINDING_ARB                      = 0x8C2D
+	TEXTURE_BUFFER_FORMAT_ARB                                  = 0x8C2E
 	TEXTURE_BUFFER_OFFSET                                      = 0x919D
 	TEXTURE_BUFFER_OFFSET_ALIGNMENT                            = 0x919F
 	TEXTURE_BUFFER_SIZE                                        = 0x919E
@@ -4183,6 +6831,8 @@ const (
 	TEXTURE_COMPRESSED_BLOCK_WIDTH                             = 0x82B1
 	TEXTURE_COMPRESSED_IMAGE_SIZE                              = 0x86A0
 	TEXTURE_COMPRESSION_HINT                                   = 0x84EF
+	TEXTURE_COORD_ARRAY_ADDRESS_NV                             = 0x8F25
+	TEXTURE_COORD_ARRAY_LENGTH_NV                              = 0x8F2F
 	TEXTURE_CUBE_MAP                                           = 0x8513
 	TEXTURE_CUBE_MAP_ARRAY                                     = 0x9009
 	TEXTURE_CUBE_MAP_ARRAY_ARB                                 = 0x9009
@@ -4210,17 +6860,21 @@ const (
 	TEXTURE_INTERNAL_FORMAT                                    = 0x1003
 	TEXTURE_LOD_BIAS                                           = 0x8501
 	TEXTURE_MAG_FILTER                                         = 0x2800
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_LEVEL                                          = 0x813D
 	TEXTURE_MAX_LOD                                            = 0x813B
 	TEXTURE_MIN_FILTER                                         = 0x2801
 	TEXTURE_MIN_LOD                                            = 0x813A
 	TEXTURE_RECTANGLE                                          = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
 	TEXTURE_SAMPLES                                            = 0x9106
 	TEXTURE_SHADOW                                             = 0x82A1
 	TEXTURE_SHARED_SIZE                                        = 0x8C3F
 	TEXTURE_SPARSE_ARB                                         = 0x91A6
+	TEXTURE_SRGB_DECODE_EXT                                    = 0x8A48
 	TEXTURE_STENCIL_SIZE                                       = 0x88F1
 	TEXTURE_SWIZZLE_A                                          = 0x8E45
 	TEXTURE_SWIZZLE_B                                          = 0x8E44
@@ -4245,7 +6899,6 @@ const (
 	TOP_LEVEL_ARRAY_SIZE                                       = 0x930C
 	TOP_LEVEL_ARRAY_STRIDE                                     = 0x930D
 	TRANSFORM_FEEDBACK                                         = 0x8E22
-	TRANSFORM_FEEDBACK_ACTIVE                                  = 0x8E24
 	TRANSFORM_FEEDBACK_BARRIER_BIT                             = 0x00000800
 	TRANSFORM_FEEDBACK_BINDING                                 = 0x8E25
 	TRANSFORM_FEEDBACK_BUFFER                                  = 0x8C8E
@@ -4258,21 +6911,32 @@ const (
 	TRANSFORM_FEEDBACK_BUFFER_START                            = 0x8C84
 	TRANSFORM_FEEDBACK_BUFFER_STRIDE                           = 0x934C
 	TRANSFORM_FEEDBACK_OVERFLOW_ARB                            = 0x82EC
-	TRANSFORM_FEEDBACK_PAUSED                                  = 0x8E23
 	TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN                      = 0x8C88
 	TRANSFORM_FEEDBACK_STREAM_OVERFLOW_ARB                     = 0x82ED
 	TRANSFORM_FEEDBACK_VARYING                                 = 0x92F4
 	TRANSFORM_FEEDBACK_VARYINGS                                = 0x8C83
 	TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH                      = 0x8C76
+	TRANSLATE_2D_NV                                            = 0x9090
+	TRANSLATE_3D_NV                                            = 0x9091
+	TRANSLATE_X_NV                                             = 0x908E
+	TRANSLATE_Y_NV                                             = 0x908F
+	TRANSPOSE_AFFINE_2D_NV                                     = 0x9096
+	TRANSPOSE_AFFINE_3D_NV                                     = 0x9098
+	TRANSPOSE_PROGRAM_MATRIX_EXT                               = 0x8E2E
 	TRIANGLES                                                  = 0x0004
 	TRIANGLES_ADJACENCY                                        = 0x000C
+	TRIANGLES_ADJACENCY_ARB                                    = 0x000C
 	TRIANGLE_FAN                                               = 0x0006
 	TRIANGLE_STRIP                                             = 0x0005
 	TRIANGLE_STRIP_ADJACENCY                                   = 0x000D
+	TRIANGLE_STRIP_ADJACENCY_ARB                               = 0x000D
+	TRIANGULAR_NV                                              = 0x90A5
 	TRUE                                                       = 1
 	TYPE                                                       = 0x92FA
+	UNCORRELATED_NV                                            = 0x9282
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -4290,10 +6954,13 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -4320,7 +6987,23 @@ const (
 	UNSIGNED_BYTE_2_3_3_REV                                    = 0x8362
 	UNSIGNED_BYTE_3_3_2                                        = 0x8032
 	UNSIGNED_INT                                               = 0x1405
+	UNSIGNED_INT16_NV                                          = 0x8FF0
+	UNSIGNED_INT16_VEC2_NV                                     = 0x8FF1
+	UNSIGNED_INT16_VEC3_NV                                     = 0x8FF2
+	UNSIGNED_INT16_VEC4_NV                                     = 0x8FF3
+	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
+	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
+	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
+	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
+	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
+	UNSIGNED_INT8_NV                                           = 0x8FEC
+	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
+	UNSIGNED_INT8_VEC3_NV                                      = 0x8FEE
+	UNSIGNED_INT8_VEC4_NV                                      = 0x8FEF
 	UNSIGNED_INT_10F_11F_11F_REV                               = 0x8C3B
 	UNSIGNED_INT_10_10_10_2                                    = 0x8036
 	UNSIGNED_INT_24_8                                          = 0x84FA
@@ -4363,23 +7046,35 @@ const (
 	UNSIGNED_SHORT_5_5_5_1                                     = 0x8034
 	UNSIGNED_SHORT_5_6_5                                       = 0x8363
 	UNSIGNED_SHORT_5_6_5_REV                                   = 0x8364
+	UNSIGNED_SHORT_8_8_APPLE                                   = 0x85BA
+	UNSIGNED_SHORT_8_8_REV_APPLE                               = 0x85BB
 	UPPER_LEFT                                                 = 0x8CA2
+	USE_MISSING_GLYPH_NV                                       = 0x90AA
+	UTF16_NV                                                   = 0x909B
+	UTF8_NV                                                    = 0x909A
 	VALIDATE_STATUS                                            = 0x8B83
 	VENDOR                                                     = 0x1F00
 	VERSION                                                    = 0x1F02
 	VERTEX_ARRAY                                               = 0x8074
+	VERTEX_ARRAY_ADDRESS_NV                                    = 0x8F21
 	VERTEX_ARRAY_BINDING                                       = 0x85B5
 	VERTEX_ARRAY_KHR                                           = 0x8074
+	VERTEX_ARRAY_LENGTH_NV                                     = 0x8F2B
+	VERTEX_ARRAY_OBJECT_EXT                                    = 0x9154
+	VERTEX_ATTRIB_ARRAY_ADDRESS_NV                             = 0x8F20
 	VERTEX_ATTRIB_ARRAY_BARRIER_BIT                            = 0x00000001
 	VERTEX_ATTRIB_ARRAY_BUFFER_BINDING                         = 0x889F
 	VERTEX_ATTRIB_ARRAY_DIVISOR                                = 0x88FE
+	VERTEX_ATTRIB_ARRAY_DIVISOR_ARB                            = 0x88FE
 	VERTEX_ATTRIB_ARRAY_ENABLED                                = 0x8622
 	VERTEX_ATTRIB_ARRAY_INTEGER                                = 0x88FD
+	VERTEX_ATTRIB_ARRAY_LENGTH_NV                              = 0x8F2A
 	VERTEX_ATTRIB_ARRAY_NORMALIZED                             = 0x886A
 	VERTEX_ATTRIB_ARRAY_POINTER                                = 0x8645
 	VERTEX_ATTRIB_ARRAY_SIZE                                   = 0x8623
 	VERTEX_ATTRIB_ARRAY_STRIDE                                 = 0x8624
 	VERTEX_ATTRIB_ARRAY_TYPE                                   = 0x8625
+	VERTEX_ATTRIB_ARRAY_UNIFIED_NV                             = 0x8F1E
 	VERTEX_ATTRIB_BINDING                                      = 0x82D4
 	VERTEX_ATTRIB_RELATIVE_OFFSET                              = 0x82D5
 	VERTEX_BINDING_DIVISOR                                     = 0x82D6
@@ -4388,15 +7083,33 @@ const (
 	VERTEX_PROGRAM_POINT_SIZE                                  = 0x8642
 	VERTEX_SHADER                                              = 0x8B31
 	VERTEX_SHADER_BIT                                          = 0x00000001
+	VERTEX_SHADER_BIT_EXT                                      = 0x00000001
 	VERTEX_SHADER_INVOCATIONS_ARB                              = 0x82F0
 	VERTEX_SUBROUTINE                                          = 0x92E8
 	VERTEX_SUBROUTINE_UNIFORM                                  = 0x92EE
 	VERTEX_TEXTURE                                             = 0x829B
+	VERTICAL_LINE_TO_NV                                        = 0x08
 	VERTICES_SUBMITTED_ARB                                     = 0x82EE
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -4418,723 +7131,1284 @@ const (
 	VIRTUAL_PAGE_SIZE_X_ARB                                    = 0x9195
 	VIRTUAL_PAGE_SIZE_Y_ARB                                    = 0x9196
 	VIRTUAL_PAGE_SIZE_Z_ARB                                    = 0x9197
+	VIVIDLIGHT_NV                                              = 0x92A6
 	WAIT_FAILED                                                = 0x911D
+	WARPS_PER_SM_NV                                            = 0x933A
+	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRITE_ONLY                                                 = 0x88B9
 	XOR                                                        = 0x1506
+	XOR_NV                                                     = 0x1506
 	ZERO                                                       = 0
 	ZERO_TO_ONE                                                = 0x935F
 )
 
 var (
-	gpActiveShaderProgram                         C.GPACTIVESHADERPROGRAM
-	gpActiveTexture                               C.GPACTIVETEXTURE
-	gpAttachShader                                C.GPATTACHSHADER
-	gpBeginConditionalRender                      C.GPBEGINCONDITIONALRENDER
-	gpBeginQuery                                  C.GPBEGINQUERY
-	gpBeginQueryIndexed                           C.GPBEGINQUERYINDEXED
-	gpBeginTransformFeedback                      C.GPBEGINTRANSFORMFEEDBACK
-	gpBindAttribLocation                          C.GPBINDATTRIBLOCATION
-	gpBindBuffer                                  C.GPBINDBUFFER
-	gpBindBufferBase                              C.GPBINDBUFFERBASE
-	gpBindBufferRange                             C.GPBINDBUFFERRANGE
-	gpBindBuffersBase                             C.GPBINDBUFFERSBASE
-	gpBindBuffersRange                            C.GPBINDBUFFERSRANGE
-	gpBindFragDataLocation                        C.GPBINDFRAGDATALOCATION
-	gpBindFragDataLocationIndexed                 C.GPBINDFRAGDATALOCATIONINDEXED
-	gpBindFramebuffer                             C.GPBINDFRAMEBUFFER
-	gpBindImageTexture                            C.GPBINDIMAGETEXTURE
-	gpBindImageTextures                           C.GPBINDIMAGETEXTURES
-	gpBindProgramPipeline                         C.GPBINDPROGRAMPIPELINE
-	gpBindRenderbuffer                            C.GPBINDRENDERBUFFER
-	gpBindSampler                                 C.GPBINDSAMPLER
-	gpBindSamplers                                C.GPBINDSAMPLERS
-	gpBindTexture                                 C.GPBINDTEXTURE
-	gpBindTextureUnit                             C.GPBINDTEXTUREUNIT
-	gpBindTextures                                C.GPBINDTEXTURES
-	gpBindTransformFeedback                       C.GPBINDTRANSFORMFEEDBACK
-	gpBindVertexArray                             C.GPBINDVERTEXARRAY
-	gpBindVertexBuffer                            C.GPBINDVERTEXBUFFER
-	gpBindVertexBuffers                           C.GPBINDVERTEXBUFFERS
-	gpBlendColor                                  C.GPBLENDCOLOR
-	gpBlendEquation                               C.GPBLENDEQUATION
-	gpBlendEquationSeparate                       C.GPBLENDEQUATIONSEPARATE
-	gpBlendEquationSeparatei                      C.GPBLENDEQUATIONSEPARATEI
-	gpBlendEquationSeparateiARB                   C.GPBLENDEQUATIONSEPARATEIARB
-	gpBlendEquationi                              C.GPBLENDEQUATIONI
-	gpBlendEquationiARB                           C.GPBLENDEQUATIONIARB
-	gpBlendFunc                                   C.GPBLENDFUNC
-	gpBlendFuncSeparate                           C.GPBLENDFUNCSEPARATE
-	gpBlendFuncSeparatei                          C.GPBLENDFUNCSEPARATEI
-	gpBlendFuncSeparateiARB                       C.GPBLENDFUNCSEPARATEIARB
-	gpBlendFunci                                  C.GPBLENDFUNCI
-	gpBlendFunciARB                               C.GPBLENDFUNCIARB
-	gpBlitFramebuffer                             C.GPBLITFRAMEBUFFER
-	gpBlitNamedFramebuffer                        C.GPBLITNAMEDFRAMEBUFFER
-	gpBufferData                                  C.GPBUFFERDATA
-	gpBufferPageCommitmentARB                     C.GPBUFFERPAGECOMMITMENTARB
-	gpBufferStorage                               C.GPBUFFERSTORAGE
-	gpBufferSubData                               C.GPBUFFERSUBDATA
-	gpCheckFramebufferStatus                      C.GPCHECKFRAMEBUFFERSTATUS
-	gpCheckNamedFramebufferStatus                 C.GPCHECKNAMEDFRAMEBUFFERSTATUS
-	gpClampColor                                  C.GPCLAMPCOLOR
-	gpClear                                       C.GPCLEAR
-	gpClearBufferData                             C.GPCLEARBUFFERDATA
-	gpClearBufferSubData                          C.GPCLEARBUFFERSUBDATA
-	gpClearBufferfi                               C.GPCLEARBUFFERFI
-	gpClearBufferfv                               C.GPCLEARBUFFERFV
-	gpClearBufferiv                               C.GPCLEARBUFFERIV
-	gpClearBufferuiv                              C.GPCLEARBUFFERUIV
-	gpClearColor                                  C.GPCLEARCOLOR
-	gpClearDepth                                  C.GPCLEARDEPTH
-	gpClearDepthf                                 C.GPCLEARDEPTHF
-	gpClearNamedBufferData                        C.GPCLEARNAMEDBUFFERDATA
-	gpClearNamedBufferSubData                     C.GPCLEARNAMEDBUFFERSUBDATA
-	gpClearNamedFramebufferfi                     C.GPCLEARNAMEDFRAMEBUFFERFI
-	gpClearNamedFramebufferfv                     C.GPCLEARNAMEDFRAMEBUFFERFV
-	gpClearNamedFramebufferiv                     C.GPCLEARNAMEDFRAMEBUFFERIV
-	gpClearNamedFramebufferuiv                    C.GPCLEARNAMEDFRAMEBUFFERUIV
-	gpClearStencil                                C.GPCLEARSTENCIL
-	gpClearTexImage                               C.GPCLEARTEXIMAGE
-	gpClearTexSubImage                            C.GPCLEARTEXSUBIMAGE
-	gpClientWaitSync                              C.GPCLIENTWAITSYNC
-	gpClipControl                                 C.GPCLIPCONTROL
-	gpColorMask                                   C.GPCOLORMASK
-	gpColorMaski                                  C.GPCOLORMASKI
-	gpCompileShader                               C.GPCOMPILESHADER
-	gpCompileShaderIncludeARB                     C.GPCOMPILESHADERINCLUDEARB
-	gpCompressedTexImage1D                        C.GPCOMPRESSEDTEXIMAGE1D
-	gpCompressedTexImage2D                        C.GPCOMPRESSEDTEXIMAGE2D
-	gpCompressedTexImage3D                        C.GPCOMPRESSEDTEXIMAGE3D
-	gpCompressedTexSubImage1D                     C.GPCOMPRESSEDTEXSUBIMAGE1D
-	gpCompressedTexSubImage2D                     C.GPCOMPRESSEDTEXSUBIMAGE2D
-	gpCompressedTexSubImage3D                     C.GPCOMPRESSEDTEXSUBIMAGE3D
-	gpCompressedTextureSubImage1D                 C.GPCOMPRESSEDTEXTURESUBIMAGE1D
-	gpCompressedTextureSubImage2D                 C.GPCOMPRESSEDTEXTURESUBIMAGE2D
-	gpCompressedTextureSubImage3D                 C.GPCOMPRESSEDTEXTURESUBIMAGE3D
-	gpCopyBufferSubData                           C.GPCOPYBUFFERSUBDATA
-	gpCopyImageSubData                            C.GPCOPYIMAGESUBDATA
-	gpCopyNamedBufferSubData                      C.GPCOPYNAMEDBUFFERSUBDATA
-	gpCopyTexImage1D                              C.GPCOPYTEXIMAGE1D
-	gpCopyTexImage2D                              C.GPCOPYTEXIMAGE2D
-	gpCopyTexSubImage1D                           C.GPCOPYTEXSUBIMAGE1D
-	gpCopyTexSubImage2D                           C.GPCOPYTEXSUBIMAGE2D
-	gpCopyTexSubImage3D                           C.GPCOPYTEXSUBIMAGE3D
-	gpCopyTextureSubImage1D                       C.GPCOPYTEXTURESUBIMAGE1D
-	gpCopyTextureSubImage2D                       C.GPCOPYTEXTURESUBIMAGE2D
-	gpCopyTextureSubImage3D                       C.GPCOPYTEXTURESUBIMAGE3D
-	gpCreateBuffers                               C.GPCREATEBUFFERS
-	gpCreateFramebuffers                          C.GPCREATEFRAMEBUFFERS
-	gpCreateProgram                               C.GPCREATEPROGRAM
-	gpCreateProgramPipelines                      C.GPCREATEPROGRAMPIPELINES
-	gpCreateQueries                               C.GPCREATEQUERIES
-	gpCreateRenderbuffers                         C.GPCREATERENDERBUFFERS
-	gpCreateSamplers                              C.GPCREATESAMPLERS
-	gpCreateShader                                C.GPCREATESHADER
-	gpCreateShaderProgramv                        C.GPCREATESHADERPROGRAMV
-	gpCreateSyncFromCLeventARB                    C.GPCREATESYNCFROMCLEVENTARB
-	gpCreateTextures                              C.GPCREATETEXTURES
-	gpCreateTransformFeedbacks                    C.GPCREATETRANSFORMFEEDBACKS
-	gpCreateVertexArrays                          C.GPCREATEVERTEXARRAYS
-	gpCullFace                                    C.GPCULLFACE
-	gpDebugMessageCallback                        C.GPDEBUGMESSAGECALLBACK
-	gpDebugMessageCallbackARB                     C.GPDEBUGMESSAGECALLBACKARB
-	gpDebugMessageCallbackKHR                     C.GPDEBUGMESSAGECALLBACKKHR
-	gpDebugMessageControl                         C.GPDEBUGMESSAGECONTROL
-	gpDebugMessageControlARB                      C.GPDEBUGMESSAGECONTROLARB
-	gpDebugMessageControlKHR                      C.GPDEBUGMESSAGECONTROLKHR
-	gpDebugMessageInsert                          C.GPDEBUGMESSAGEINSERT
-	gpDebugMessageInsertARB                       C.GPDEBUGMESSAGEINSERTARB
-	gpDebugMessageInsertKHR                       C.GPDEBUGMESSAGEINSERTKHR
-	gpDeleteBuffers                               C.GPDELETEBUFFERS
-	gpDeleteFramebuffers                          C.GPDELETEFRAMEBUFFERS
-	gpDeleteNamedStringARB                        C.GPDELETENAMEDSTRINGARB
-	gpDeleteProgram                               C.GPDELETEPROGRAM
-	gpDeleteProgramPipelines                      C.GPDELETEPROGRAMPIPELINES
-	gpDeleteQueries                               C.GPDELETEQUERIES
-	gpDeleteRenderbuffers                         C.GPDELETERENDERBUFFERS
-	gpDeleteSamplers                              C.GPDELETESAMPLERS
-	gpDeleteShader                                C.GPDELETESHADER
-	gpDeleteSync                                  C.GPDELETESYNC
-	gpDeleteTextures                              C.GPDELETETEXTURES
-	gpDeleteTransformFeedbacks                    C.GPDELETETRANSFORMFEEDBACKS
-	gpDeleteVertexArrays                          C.GPDELETEVERTEXARRAYS
-	gpDepthFunc                                   C.GPDEPTHFUNC
-	gpDepthMask                                   C.GPDEPTHMASK
-	gpDepthRange                                  C.GPDEPTHRANGE
-	gpDepthRangeArrayv                            C.GPDEPTHRANGEARRAYV
-	gpDepthRangeIndexed                           C.GPDEPTHRANGEINDEXED
-	gpDepthRangef                                 C.GPDEPTHRANGEF
-	gpDetachShader                                C.GPDETACHSHADER
-	gpDisable                                     C.GPDISABLE
-	gpDisableVertexArrayAttrib                    C.GPDISABLEVERTEXARRAYATTRIB
-	gpDisableVertexAttribArray                    C.GPDISABLEVERTEXATTRIBARRAY
-	gpDisablei                                    C.GPDISABLEI
-	gpDispatchCompute                             C.GPDISPATCHCOMPUTE
-	gpDispatchComputeGroupSizeARB                 C.GPDISPATCHCOMPUTEGROUPSIZEARB
-	gpDispatchComputeIndirect                     C.GPDISPATCHCOMPUTEINDIRECT
-	gpDrawArrays                                  C.GPDRAWARRAYS
-	gpDrawArraysIndirect                          C.GPDRAWARRAYSINDIRECT
-	gpDrawArraysInstanced                         C.GPDRAWARRAYSINSTANCED
-	gpDrawArraysInstancedBaseInstance             C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
-	gpDrawBuffer                                  C.GPDRAWBUFFER
-	gpDrawBuffers                                 C.GPDRAWBUFFERS
-	gpDrawElements                                C.GPDRAWELEMENTS
-	gpDrawElementsBaseVertex                      C.GPDRAWELEMENTSBASEVERTEX
-	gpDrawElementsIndirect                        C.GPDRAWELEMENTSINDIRECT
-	gpDrawElementsInstanced                       C.GPDRAWELEMENTSINSTANCED
-	gpDrawElementsInstancedBaseInstance           C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
-	gpDrawElementsInstancedBaseVertex             C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
-	gpDrawElementsInstancedBaseVertexBaseInstance C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
-	gpDrawRangeElements                           C.GPDRAWRANGEELEMENTS
-	gpDrawRangeElementsBaseVertex                 C.GPDRAWRANGEELEMENTSBASEVERTEX
-	gpDrawTransformFeedback                       C.GPDRAWTRANSFORMFEEDBACK
-	gpDrawTransformFeedbackInstanced              C.GPDRAWTRANSFORMFEEDBACKINSTANCED
-	gpDrawTransformFeedbackStream                 C.GPDRAWTRANSFORMFEEDBACKSTREAM
-	gpDrawTransformFeedbackStreamInstanced        C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
-	gpEnable                                      C.GPENABLE
-	gpEnableVertexArrayAttrib                     C.GPENABLEVERTEXARRAYATTRIB
-	gpEnableVertexAttribArray                     C.GPENABLEVERTEXATTRIBARRAY
-	gpEnablei                                     C.GPENABLEI
-	gpEndConditionalRender                        C.GPENDCONDITIONALRENDER
-	gpEndQuery                                    C.GPENDQUERY
-	gpEndQueryIndexed                             C.GPENDQUERYINDEXED
-	gpEndTransformFeedback                        C.GPENDTRANSFORMFEEDBACK
-	gpFenceSync                                   C.GPFENCESYNC
-	gpFinish                                      C.GPFINISH
-	gpFlush                                       C.GPFLUSH
-	gpFlushMappedBufferRange                      C.GPFLUSHMAPPEDBUFFERRANGE
-	gpFlushMappedNamedBufferRange                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
-	gpFramebufferParameteri                       C.GPFRAMEBUFFERPARAMETERI
-	gpFramebufferRenderbuffer                     C.GPFRAMEBUFFERRENDERBUFFER
-	gpFramebufferTexture                          C.GPFRAMEBUFFERTEXTURE
-	gpFramebufferTexture1D                        C.GPFRAMEBUFFERTEXTURE1D
-	gpFramebufferTexture2D                        C.GPFRAMEBUFFERTEXTURE2D
-	gpFramebufferTexture3D                        C.GPFRAMEBUFFERTEXTURE3D
-	gpFramebufferTextureLayer                     C.GPFRAMEBUFFERTEXTURELAYER
-	gpFrontFace                                   C.GPFRONTFACE
-	gpGenBuffers                                  C.GPGENBUFFERS
-	gpGenFramebuffers                             C.GPGENFRAMEBUFFERS
-	gpGenProgramPipelines                         C.GPGENPROGRAMPIPELINES
-	gpGenQueries                                  C.GPGENQUERIES
-	gpGenRenderbuffers                            C.GPGENRENDERBUFFERS
-	gpGenSamplers                                 C.GPGENSAMPLERS
-	gpGenTextures                                 C.GPGENTEXTURES
-	gpGenTransformFeedbacks                       C.GPGENTRANSFORMFEEDBACKS
-	gpGenVertexArrays                             C.GPGENVERTEXARRAYS
-	gpGenerateMipmap                              C.GPGENERATEMIPMAP
-	gpGenerateTextureMipmap                       C.GPGENERATETEXTUREMIPMAP
-	gpGetActiveAtomicCounterBufferiv              C.GPGETACTIVEATOMICCOUNTERBUFFERIV
-	gpGetActiveAttrib                             C.GPGETACTIVEATTRIB
-	gpGetActiveSubroutineName                     C.GPGETACTIVESUBROUTINENAME
-	gpGetActiveSubroutineUniformName              C.GPGETACTIVESUBROUTINEUNIFORMNAME
-	gpGetActiveSubroutineUniformiv                C.GPGETACTIVESUBROUTINEUNIFORMIV
-	gpGetActiveUniform                            C.GPGETACTIVEUNIFORM
-	gpGetActiveUniformBlockName                   C.GPGETACTIVEUNIFORMBLOCKNAME
-	gpGetActiveUniformBlockiv                     C.GPGETACTIVEUNIFORMBLOCKIV
-	gpGetActiveUniformName                        C.GPGETACTIVEUNIFORMNAME
-	gpGetActiveUniformsiv                         C.GPGETACTIVEUNIFORMSIV
-	gpGetAttachedShaders                          C.GPGETATTACHEDSHADERS
-	gpGetAttribLocation                           C.GPGETATTRIBLOCATION
-	gpGetBooleani_v                               C.GPGETBOOLEANI_V
-	gpGetBooleanv                                 C.GPGETBOOLEANV
-	gpGetBufferParameteri64v                      C.GPGETBUFFERPARAMETERI64V
-	gpGetBufferParameteriv                        C.GPGETBUFFERPARAMETERIV
-	gpGetBufferPointerv                           C.GPGETBUFFERPOINTERV
-	gpGetBufferSubData                            C.GPGETBUFFERSUBDATA
-	gpGetCompressedTexImage                       C.GPGETCOMPRESSEDTEXIMAGE
-	gpGetCompressedTextureImage                   C.GPGETCOMPRESSEDTEXTUREIMAGE
-	gpGetCompressedTextureSubImage                C.GPGETCOMPRESSEDTEXTURESUBIMAGE
-	gpGetDebugMessageLog                          C.GPGETDEBUGMESSAGELOG
-	gpGetDebugMessageLogARB                       C.GPGETDEBUGMESSAGELOGARB
-	gpGetDebugMessageLogKHR                       C.GPGETDEBUGMESSAGELOGKHR
-	gpGetDoublei_v                                C.GPGETDOUBLEI_V
-	gpGetDoublev                                  C.GPGETDOUBLEV
-	gpGetError                                    C.GPGETERROR
-	gpGetFloati_v                                 C.GPGETFLOATI_V
-	gpGetFloatv                                   C.GPGETFLOATV
-	gpGetFragDataIndex                            C.GPGETFRAGDATAINDEX
-	gpGetFragDataLocation                         C.GPGETFRAGDATALOCATION
-	gpGetFramebufferAttachmentParameteriv         C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetFramebufferParameteriv                   C.GPGETFRAMEBUFFERPARAMETERIV
-	gpGetGraphicsResetStatus                      C.GPGETGRAPHICSRESETSTATUS
-	gpGetGraphicsResetStatusARB                   C.GPGETGRAPHICSRESETSTATUSARB
-	gpGetGraphicsResetStatusKHR                   C.GPGETGRAPHICSRESETSTATUSKHR
-	gpGetImageHandleARB                           C.GPGETIMAGEHANDLEARB
-	gpGetInteger64i_v                             C.GPGETINTEGER64I_V
-	gpGetInteger64v                               C.GPGETINTEGER64V
-	gpGetIntegeri_v                               C.GPGETINTEGERI_V
-	gpGetIntegerv                                 C.GPGETINTEGERV
-	gpGetInternalformati64v                       C.GPGETINTERNALFORMATI64V
-	gpGetInternalformativ                         C.GPGETINTERNALFORMATIV
-	gpGetMultisamplefv                            C.GPGETMULTISAMPLEFV
-	gpGetNamedBufferParameteri64v                 C.GPGETNAMEDBUFFERPARAMETERI64V
-	gpGetNamedBufferParameteriv                   C.GPGETNAMEDBUFFERPARAMETERIV
-	gpGetNamedBufferPointerv                      C.GPGETNAMEDBUFFERPOINTERV
-	gpGetNamedBufferSubData                       C.GPGETNAMEDBUFFERSUBDATA
-	gpGetNamedFramebufferAttachmentParameteriv    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetNamedFramebufferParameteriv              C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
-	gpGetNamedRenderbufferParameteriv             C.GPGETNAMEDRENDERBUFFERPARAMETERIV
-	gpGetNamedStringARB                           C.GPGETNAMEDSTRINGARB
-	gpGetNamedStringivARB                         C.GPGETNAMEDSTRINGIVARB
-	gpGetObjectLabel                              C.GPGETOBJECTLABEL
-	gpGetObjectLabelKHR                           C.GPGETOBJECTLABELKHR
-	gpGetObjectPtrLabel                           C.GPGETOBJECTPTRLABEL
-	gpGetObjectPtrLabelKHR                        C.GPGETOBJECTPTRLABELKHR
-	gpGetPointerv                                 C.GPGETPOINTERV
-	gpGetPointervKHR                              C.GPGETPOINTERVKHR
-	gpGetProgramBinary                            C.GPGETPROGRAMBINARY
-	gpGetProgramInfoLog                           C.GPGETPROGRAMINFOLOG
-	gpGetProgramInterfaceiv                       C.GPGETPROGRAMINTERFACEIV
-	gpGetProgramPipelineInfoLog                   C.GPGETPROGRAMPIPELINEINFOLOG
-	gpGetProgramPipelineiv                        C.GPGETPROGRAMPIPELINEIV
-	gpGetProgramResourceIndex                     C.GPGETPROGRAMRESOURCEINDEX
-	gpGetProgramResourceLocation                  C.GPGETPROGRAMRESOURCELOCATION
-	gpGetProgramResourceLocationIndex             C.GPGETPROGRAMRESOURCELOCATIONINDEX
-	gpGetProgramResourceName                      C.GPGETPROGRAMRESOURCENAME
-	gpGetProgramResourceiv                        C.GPGETPROGRAMRESOURCEIV
-	gpGetProgramStageiv                           C.GPGETPROGRAMSTAGEIV
-	gpGetProgramiv                                C.GPGETPROGRAMIV
-	gpGetQueryIndexediv                           C.GPGETQUERYINDEXEDIV
-	gpGetQueryObjecti64v                          C.GPGETQUERYOBJECTI64V
-	gpGetQueryObjectiv                            C.GPGETQUERYOBJECTIV
-	gpGetQueryObjectui64v                         C.GPGETQUERYOBJECTUI64V
-	gpGetQueryObjectuiv                           C.GPGETQUERYOBJECTUIV
-	gpGetQueryiv                                  C.GPGETQUERYIV
-	gpGetRenderbufferParameteriv                  C.GPGETRENDERBUFFERPARAMETERIV
-	gpGetSamplerParameterIiv                      C.GPGETSAMPLERPARAMETERIIV
-	gpGetSamplerParameterIuiv                     C.GPGETSAMPLERPARAMETERIUIV
-	gpGetSamplerParameterfv                       C.GPGETSAMPLERPARAMETERFV
-	gpGetSamplerParameteriv                       C.GPGETSAMPLERPARAMETERIV
-	gpGetShaderInfoLog                            C.GPGETSHADERINFOLOG
-	gpGetShaderPrecisionFormat                    C.GPGETSHADERPRECISIONFORMAT
-	gpGetShaderSource                             C.GPGETSHADERSOURCE
-	gpGetShaderiv                                 C.GPGETSHADERIV
-	gpGetString                                   C.GPGETSTRING
-	gpGetStringi                                  C.GPGETSTRINGI
-	gpGetSubroutineIndex                          C.GPGETSUBROUTINEINDEX
-	gpGetSubroutineUniformLocation                C.GPGETSUBROUTINEUNIFORMLOCATION
-	gpGetSynciv                                   C.GPGETSYNCIV
-	gpGetTexImage                                 C.GPGETTEXIMAGE
-	gpGetTexLevelParameterfv                      C.GPGETTEXLEVELPARAMETERFV
-	gpGetTexLevelParameteriv                      C.GPGETTEXLEVELPARAMETERIV
-	gpGetTexParameterIiv                          C.GPGETTEXPARAMETERIIV
-	gpGetTexParameterIuiv                         C.GPGETTEXPARAMETERIUIV
-	gpGetTexParameterfv                           C.GPGETTEXPARAMETERFV
-	gpGetTexParameteriv                           C.GPGETTEXPARAMETERIV
-	gpGetTextureHandleARB                         C.GPGETTEXTUREHANDLEARB
-	gpGetTextureImage                             C.GPGETTEXTUREIMAGE
-	gpGetTextureLevelParameterfv                  C.GPGETTEXTURELEVELPARAMETERFV
-	gpGetTextureLevelParameteriv                  C.GPGETTEXTURELEVELPARAMETERIV
-	gpGetTextureParameterIiv                      C.GPGETTEXTUREPARAMETERIIV
-	gpGetTextureParameterIuiv                     C.GPGETTEXTUREPARAMETERIUIV
-	gpGetTextureParameterfv                       C.GPGETTEXTUREPARAMETERFV
-	gpGetTextureParameteriv                       C.GPGETTEXTUREPARAMETERIV
-	gpGetTextureSamplerHandleARB                  C.GPGETTEXTURESAMPLERHANDLEARB
-	gpGetTextureSubImage                          C.GPGETTEXTURESUBIMAGE
-	gpGetTransformFeedbackVarying                 C.GPGETTRANSFORMFEEDBACKVARYING
-	gpGetTransformFeedbacki64_v                   C.GPGETTRANSFORMFEEDBACKI64_V
-	gpGetTransformFeedbacki_v                     C.GPGETTRANSFORMFEEDBACKI_V
-	gpGetTransformFeedbackiv                      C.GPGETTRANSFORMFEEDBACKIV
-	gpGetUniformBlockIndex                        C.GPGETUNIFORMBLOCKINDEX
-	gpGetUniformIndices                           C.GPGETUNIFORMINDICES
-	gpGetUniformLocation                          C.GPGETUNIFORMLOCATION
-	gpGetUniformSubroutineuiv                     C.GPGETUNIFORMSUBROUTINEUIV
-	gpGetUniformdv                                C.GPGETUNIFORMDV
-	gpGetUniformfv                                C.GPGETUNIFORMFV
-	gpGetUniformiv                                C.GPGETUNIFORMIV
-	gpGetUniformuiv                               C.GPGETUNIFORMUIV
-	gpGetVertexArrayIndexed64iv                   C.GPGETVERTEXARRAYINDEXED64IV
-	gpGetVertexArrayIndexediv                     C.GPGETVERTEXARRAYINDEXEDIV
-	gpGetVertexArrayiv                            C.GPGETVERTEXARRAYIV
-	gpGetVertexAttribIiv                          C.GPGETVERTEXATTRIBIIV
-	gpGetVertexAttribIuiv                         C.GPGETVERTEXATTRIBIUIV
-	gpGetVertexAttribLdv                          C.GPGETVERTEXATTRIBLDV
-	gpGetVertexAttribLui64vARB                    C.GPGETVERTEXATTRIBLUI64VARB
-	gpGetVertexAttribPointerv                     C.GPGETVERTEXATTRIBPOINTERV
-	gpGetVertexAttribdv                           C.GPGETVERTEXATTRIBDV
-	gpGetVertexAttribfv                           C.GPGETVERTEXATTRIBFV
-	gpGetVertexAttribiv                           C.GPGETVERTEXATTRIBIV
-	gpGetnCompressedTexImageARB                   C.GPGETNCOMPRESSEDTEXIMAGEARB
-	gpGetnTexImageARB                             C.GPGETNTEXIMAGEARB
-	gpGetnUniformdvARB                            C.GPGETNUNIFORMDVARB
-	gpGetnUniformfv                               C.GPGETNUNIFORMFV
-	gpGetnUniformfvARB                            C.GPGETNUNIFORMFVARB
-	gpGetnUniformfvKHR                            C.GPGETNUNIFORMFVKHR
-	gpGetnUniformiv                               C.GPGETNUNIFORMIV
-	gpGetnUniformivARB                            C.GPGETNUNIFORMIVARB
-	gpGetnUniformivKHR                            C.GPGETNUNIFORMIVKHR
-	gpGetnUniformuiv                              C.GPGETNUNIFORMUIV
-	gpGetnUniformuivARB                           C.GPGETNUNIFORMUIVARB
-	gpGetnUniformuivKHR                           C.GPGETNUNIFORMUIVKHR
-	gpHint                                        C.GPHINT
-	gpInvalidateBufferData                        C.GPINVALIDATEBUFFERDATA
-	gpInvalidateBufferSubData                     C.GPINVALIDATEBUFFERSUBDATA
-	gpInvalidateFramebuffer                       C.GPINVALIDATEFRAMEBUFFER
-	gpInvalidateNamedFramebufferData              C.GPINVALIDATENAMEDFRAMEBUFFERDATA
-	gpInvalidateNamedFramebufferSubData           C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
-	gpInvalidateSubFramebuffer                    C.GPINVALIDATESUBFRAMEBUFFER
-	gpInvalidateTexImage                          C.GPINVALIDATETEXIMAGE
-	gpInvalidateTexSubImage                       C.GPINVALIDATETEXSUBIMAGE
-	gpIsBuffer                                    C.GPISBUFFER
-	gpIsEnabled                                   C.GPISENABLED
-	gpIsEnabledi                                  C.GPISENABLEDI
-	gpIsFramebuffer                               C.GPISFRAMEBUFFER
-	gpIsImageHandleResidentARB                    C.GPISIMAGEHANDLERESIDENTARB
-	gpIsNamedStringARB                            C.GPISNAMEDSTRINGARB
-	gpIsProgram                                   C.GPISPROGRAM
-	gpIsProgramPipeline                           C.GPISPROGRAMPIPELINE
-	gpIsQuery                                     C.GPISQUERY
-	gpIsRenderbuffer                              C.GPISRENDERBUFFER
-	gpIsSampler                                   C.GPISSAMPLER
-	gpIsShader                                    C.GPISSHADER
-	gpIsSync                                      C.GPISSYNC
-	gpIsTexture                                   C.GPISTEXTURE
-	gpIsTextureHandleResidentARB                  C.GPISTEXTUREHANDLERESIDENTARB
-	gpIsTransformFeedback                         C.GPISTRANSFORMFEEDBACK
-	gpIsVertexArray                               C.GPISVERTEXARRAY
-	gpLineWidth                                   C.GPLINEWIDTH
-	gpLinkProgram                                 C.GPLINKPROGRAM
-	gpLogicOp                                     C.GPLOGICOP
-	gpMakeImageHandleNonResidentARB               C.GPMAKEIMAGEHANDLENONRESIDENTARB
-	gpMakeImageHandleResidentARB                  C.GPMAKEIMAGEHANDLERESIDENTARB
-	gpMakeTextureHandleNonResidentARB             C.GPMAKETEXTUREHANDLENONRESIDENTARB
-	gpMakeTextureHandleResidentARB                C.GPMAKETEXTUREHANDLERESIDENTARB
-	gpMapBuffer                                   C.GPMAPBUFFER
-	gpMapBufferRange                              C.GPMAPBUFFERRANGE
-	gpMapNamedBuffer                              C.GPMAPNAMEDBUFFER
-	gpMapNamedBufferRange                         C.GPMAPNAMEDBUFFERRANGE
-	gpMemoryBarrier                               C.GPMEMORYBARRIER
-	gpMemoryBarrierByRegion                       C.GPMEMORYBARRIERBYREGION
-	gpMinSampleShading                            C.GPMINSAMPLESHADING
-	gpMinSampleShadingARB                         C.GPMINSAMPLESHADINGARB
-	gpMultiDrawArrays                             C.GPMULTIDRAWARRAYS
-	gpMultiDrawArraysIndirect                     C.GPMULTIDRAWARRAYSINDIRECT
-	gpMultiDrawArraysIndirectCountARB             C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
-	gpMultiDrawElements                           C.GPMULTIDRAWELEMENTS
-	gpMultiDrawElementsBaseVertex                 C.GPMULTIDRAWELEMENTSBASEVERTEX
-	gpMultiDrawElementsIndirect                   C.GPMULTIDRAWELEMENTSINDIRECT
-	gpMultiDrawElementsIndirectCountARB           C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
-	gpNamedBufferData                             C.GPNAMEDBUFFERDATA
-	gpNamedBufferPageCommitmentARB                C.GPNAMEDBUFFERPAGECOMMITMENTARB
-	gpNamedBufferPageCommitmentEXT                C.GPNAMEDBUFFERPAGECOMMITMENTEXT
-	gpNamedBufferStorage                          C.GPNAMEDBUFFERSTORAGE
-	gpNamedBufferSubData                          C.GPNAMEDBUFFERSUBDATA
-	gpNamedFramebufferDrawBuffer                  C.GPNAMEDFRAMEBUFFERDRAWBUFFER
-	gpNamedFramebufferDrawBuffers                 C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
-	gpNamedFramebufferParameteri                  C.GPNAMEDFRAMEBUFFERPARAMETERI
-	gpNamedFramebufferReadBuffer                  C.GPNAMEDFRAMEBUFFERREADBUFFER
-	gpNamedFramebufferRenderbuffer                C.GPNAMEDFRAMEBUFFERRENDERBUFFER
-	gpNamedFramebufferTexture                     C.GPNAMEDFRAMEBUFFERTEXTURE
-	gpNamedFramebufferTextureLayer                C.GPNAMEDFRAMEBUFFERTEXTURELAYER
-	gpNamedRenderbufferStorage                    C.GPNAMEDRENDERBUFFERSTORAGE
-	gpNamedRenderbufferStorageMultisample         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
-	gpNamedStringARB                              C.GPNAMEDSTRINGARB
-	gpObjectLabel                                 C.GPOBJECTLABEL
-	gpObjectLabelKHR                              C.GPOBJECTLABELKHR
-	gpObjectPtrLabel                              C.GPOBJECTPTRLABEL
-	gpObjectPtrLabelKHR                           C.GPOBJECTPTRLABELKHR
-	gpPatchParameterfv                            C.GPPATCHPARAMETERFV
-	gpPatchParameteri                             C.GPPATCHPARAMETERI
-	gpPauseTransformFeedback                      C.GPPAUSETRANSFORMFEEDBACK
-	gpPixelStoref                                 C.GPPIXELSTOREF
-	gpPixelStorei                                 C.GPPIXELSTOREI
-	gpPointParameterf                             C.GPPOINTPARAMETERF
-	gpPointParameterfv                            C.GPPOINTPARAMETERFV
-	gpPointParameteri                             C.GPPOINTPARAMETERI
-	gpPointParameteriv                            C.GPPOINTPARAMETERIV
-	gpPointSize                                   C.GPPOINTSIZE
-	gpPolygonMode                                 C.GPPOLYGONMODE
-	gpPolygonOffset                               C.GPPOLYGONOFFSET
-	gpPopDebugGroup                               C.GPPOPDEBUGGROUP
-	gpPopDebugGroupKHR                            C.GPPOPDEBUGGROUPKHR
-	gpPrimitiveRestartIndex                       C.GPPRIMITIVERESTARTINDEX
-	gpProgramBinary                               C.GPPROGRAMBINARY
-	gpProgramParameteri                           C.GPPROGRAMPARAMETERI
-	gpProgramUniform1d                            C.GPPROGRAMUNIFORM1D
-	gpProgramUniform1dv                           C.GPPROGRAMUNIFORM1DV
-	gpProgramUniform1f                            C.GPPROGRAMUNIFORM1F
-	gpProgramUniform1fv                           C.GPPROGRAMUNIFORM1FV
-	gpProgramUniform1i                            C.GPPROGRAMUNIFORM1I
-	gpProgramUniform1iv                           C.GPPROGRAMUNIFORM1IV
-	gpProgramUniform1ui                           C.GPPROGRAMUNIFORM1UI
-	gpProgramUniform1uiv                          C.GPPROGRAMUNIFORM1UIV
-	gpProgramUniform2d                            C.GPPROGRAMUNIFORM2D
-	gpProgramUniform2dv                           C.GPPROGRAMUNIFORM2DV
-	gpProgramUniform2f                            C.GPPROGRAMUNIFORM2F
-	gpProgramUniform2fv                           C.GPPROGRAMUNIFORM2FV
-	gpProgramUniform2i                            C.GPPROGRAMUNIFORM2I
-	gpProgramUniform2iv                           C.GPPROGRAMUNIFORM2IV
-	gpProgramUniform2ui                           C.GPPROGRAMUNIFORM2UI
-	gpProgramUniform2uiv                          C.GPPROGRAMUNIFORM2UIV
-	gpProgramUniform3d                            C.GPPROGRAMUNIFORM3D
-	gpProgramUniform3dv                           C.GPPROGRAMUNIFORM3DV
-	gpProgramUniform3f                            C.GPPROGRAMUNIFORM3F
-	gpProgramUniform3fv                           C.GPPROGRAMUNIFORM3FV
-	gpProgramUniform3i                            C.GPPROGRAMUNIFORM3I
-	gpProgramUniform3iv                           C.GPPROGRAMUNIFORM3IV
-	gpProgramUniform3ui                           C.GPPROGRAMUNIFORM3UI
-	gpProgramUniform3uiv                          C.GPPROGRAMUNIFORM3UIV
-	gpProgramUniform4d                            C.GPPROGRAMUNIFORM4D
-	gpProgramUniform4dv                           C.GPPROGRAMUNIFORM4DV
-	gpProgramUniform4f                            C.GPPROGRAMUNIFORM4F
-	gpProgramUniform4fv                           C.GPPROGRAMUNIFORM4FV
-	gpProgramUniform4i                            C.GPPROGRAMUNIFORM4I
-	gpProgramUniform4iv                           C.GPPROGRAMUNIFORM4IV
-	gpProgramUniform4ui                           C.GPPROGRAMUNIFORM4UI
-	gpProgramUniform4uiv                          C.GPPROGRAMUNIFORM4UIV
-	gpProgramUniformHandleui64ARB                 C.GPPROGRAMUNIFORMHANDLEUI64ARB
-	gpProgramUniformHandleui64vARB                C.GPPROGRAMUNIFORMHANDLEUI64VARB
-	gpProgramUniformMatrix2dv                     C.GPPROGRAMUNIFORMMATRIX2DV
-	gpProgramUniformMatrix2fv                     C.GPPROGRAMUNIFORMMATRIX2FV
-	gpProgramUniformMatrix2x3dv                   C.GPPROGRAMUNIFORMMATRIX2X3DV
-	gpProgramUniformMatrix2x3fv                   C.GPPROGRAMUNIFORMMATRIX2X3FV
-	gpProgramUniformMatrix2x4dv                   C.GPPROGRAMUNIFORMMATRIX2X4DV
-	gpProgramUniformMatrix2x4fv                   C.GPPROGRAMUNIFORMMATRIX2X4FV
-	gpProgramUniformMatrix3dv                     C.GPPROGRAMUNIFORMMATRIX3DV
-	gpProgramUniformMatrix3fv                     C.GPPROGRAMUNIFORMMATRIX3FV
-	gpProgramUniformMatrix3x2dv                   C.GPPROGRAMUNIFORMMATRIX3X2DV
-	gpProgramUniformMatrix3x2fv                   C.GPPROGRAMUNIFORMMATRIX3X2FV
-	gpProgramUniformMatrix3x4dv                   C.GPPROGRAMUNIFORMMATRIX3X4DV
-	gpProgramUniformMatrix3x4fv                   C.GPPROGRAMUNIFORMMATRIX3X4FV
-	gpProgramUniformMatrix4dv                     C.GPPROGRAMUNIFORMMATRIX4DV
-	gpProgramUniformMatrix4fv                     C.GPPROGRAMUNIFORMMATRIX4FV
-	gpProgramUniformMatrix4x2dv                   C.GPPROGRAMUNIFORMMATRIX4X2DV
-	gpProgramUniformMatrix4x2fv                   C.GPPROGRAMUNIFORMMATRIX4X2FV
-	gpProgramUniformMatrix4x3dv                   C.GPPROGRAMUNIFORMMATRIX4X3DV
-	gpProgramUniformMatrix4x3fv                   C.GPPROGRAMUNIFORMMATRIX4X3FV
-	gpProvokingVertex                             C.GPPROVOKINGVERTEX
-	gpPushDebugGroup                              C.GPPUSHDEBUGGROUP
-	gpPushDebugGroupKHR                           C.GPPUSHDEBUGGROUPKHR
-	gpQueryCounter                                C.GPQUERYCOUNTER
-	gpReadBuffer                                  C.GPREADBUFFER
-	gpReadPixels                                  C.GPREADPIXELS
-	gpReadnPixels                                 C.GPREADNPIXELS
-	gpReadnPixelsARB                              C.GPREADNPIXELSARB
-	gpReadnPixelsKHR                              C.GPREADNPIXELSKHR
-	gpReleaseShaderCompiler                       C.GPRELEASESHADERCOMPILER
-	gpRenderbufferStorage                         C.GPRENDERBUFFERSTORAGE
-	gpRenderbufferStorageMultisample              C.GPRENDERBUFFERSTORAGEMULTISAMPLE
-	gpResumeTransformFeedback                     C.GPRESUMETRANSFORMFEEDBACK
-	gpSampleCoverage                              C.GPSAMPLECOVERAGE
-	gpSampleMaski                                 C.GPSAMPLEMASKI
-	gpSamplerParameterIiv                         C.GPSAMPLERPARAMETERIIV
-	gpSamplerParameterIuiv                        C.GPSAMPLERPARAMETERIUIV
-	gpSamplerParameterf                           C.GPSAMPLERPARAMETERF
-	gpSamplerParameterfv                          C.GPSAMPLERPARAMETERFV
-	gpSamplerParameteri                           C.GPSAMPLERPARAMETERI
-	gpSamplerParameteriv                          C.GPSAMPLERPARAMETERIV
-	gpScissor                                     C.GPSCISSOR
-	gpScissorArrayv                               C.GPSCISSORARRAYV
-	gpScissorIndexed                              C.GPSCISSORINDEXED
-	gpScissorIndexedv                             C.GPSCISSORINDEXEDV
-	gpShaderBinary                                C.GPSHADERBINARY
-	gpShaderSource                                C.GPSHADERSOURCE
-	gpShaderStorageBlockBinding                   C.GPSHADERSTORAGEBLOCKBINDING
-	gpStencilFunc                                 C.GPSTENCILFUNC
-	gpStencilFuncSeparate                         C.GPSTENCILFUNCSEPARATE
-	gpStencilMask                                 C.GPSTENCILMASK
-	gpStencilMaskSeparate                         C.GPSTENCILMASKSEPARATE
-	gpStencilOp                                   C.GPSTENCILOP
-	gpStencilOpSeparate                           C.GPSTENCILOPSEPARATE
-	gpTexBuffer                                   C.GPTEXBUFFER
-	gpTexBufferRange                              C.GPTEXBUFFERRANGE
-	gpTexImage1D                                  C.GPTEXIMAGE1D
-	gpTexImage2D                                  C.GPTEXIMAGE2D
-	gpTexImage2DMultisample                       C.GPTEXIMAGE2DMULTISAMPLE
-	gpTexImage3D                                  C.GPTEXIMAGE3D
-	gpTexImage3DMultisample                       C.GPTEXIMAGE3DMULTISAMPLE
-	gpTexPageCommitmentARB                        C.GPTEXPAGECOMMITMENTARB
-	gpTexParameterIiv                             C.GPTEXPARAMETERIIV
-	gpTexParameterIuiv                            C.GPTEXPARAMETERIUIV
-	gpTexParameterf                               C.GPTEXPARAMETERF
-	gpTexParameterfv                              C.GPTEXPARAMETERFV
-	gpTexParameteri                               C.GPTEXPARAMETERI
-	gpTexParameteriv                              C.GPTEXPARAMETERIV
-	gpTexStorage1D                                C.GPTEXSTORAGE1D
-	gpTexStorage2D                                C.GPTEXSTORAGE2D
-	gpTexStorage2DMultisample                     C.GPTEXSTORAGE2DMULTISAMPLE
-	gpTexStorage3D                                C.GPTEXSTORAGE3D
-	gpTexStorage3DMultisample                     C.GPTEXSTORAGE3DMULTISAMPLE
-	gpTexSubImage1D                               C.GPTEXSUBIMAGE1D
-	gpTexSubImage2D                               C.GPTEXSUBIMAGE2D
-	gpTexSubImage3D                               C.GPTEXSUBIMAGE3D
-	gpTextureBarrier                              C.GPTEXTUREBARRIER
-	gpTextureBuffer                               C.GPTEXTUREBUFFER
-	gpTextureBufferRange                          C.GPTEXTUREBUFFERRANGE
-	gpTextureParameterIiv                         C.GPTEXTUREPARAMETERIIV
-	gpTextureParameterIuiv                        C.GPTEXTUREPARAMETERIUIV
-	gpTextureParameterf                           C.GPTEXTUREPARAMETERF
-	gpTextureParameterfv                          C.GPTEXTUREPARAMETERFV
-	gpTextureParameteri                           C.GPTEXTUREPARAMETERI
-	gpTextureParameteriv                          C.GPTEXTUREPARAMETERIV
-	gpTextureStorage1D                            C.GPTEXTURESTORAGE1D
-	gpTextureStorage2D                            C.GPTEXTURESTORAGE2D
-	gpTextureStorage2DMultisample                 C.GPTEXTURESTORAGE2DMULTISAMPLE
-	gpTextureStorage3D                            C.GPTEXTURESTORAGE3D
-	gpTextureStorage3DMultisample                 C.GPTEXTURESTORAGE3DMULTISAMPLE
-	gpTextureSubImage1D                           C.GPTEXTURESUBIMAGE1D
-	gpTextureSubImage2D                           C.GPTEXTURESUBIMAGE2D
-	gpTextureSubImage3D                           C.GPTEXTURESUBIMAGE3D
-	gpTextureView                                 C.GPTEXTUREVIEW
-	gpTransformFeedbackBufferBase                 C.GPTRANSFORMFEEDBACKBUFFERBASE
-	gpTransformFeedbackBufferRange                C.GPTRANSFORMFEEDBACKBUFFERRANGE
-	gpTransformFeedbackVaryings                   C.GPTRANSFORMFEEDBACKVARYINGS
-	gpUniform1d                                   C.GPUNIFORM1D
-	gpUniform1dv                                  C.GPUNIFORM1DV
-	gpUniform1f                                   C.GPUNIFORM1F
-	gpUniform1fv                                  C.GPUNIFORM1FV
-	gpUniform1i                                   C.GPUNIFORM1I
-	gpUniform1iv                                  C.GPUNIFORM1IV
-	gpUniform1ui                                  C.GPUNIFORM1UI
-	gpUniform1uiv                                 C.GPUNIFORM1UIV
-	gpUniform2d                                   C.GPUNIFORM2D
-	gpUniform2dv                                  C.GPUNIFORM2DV
-	gpUniform2f                                   C.GPUNIFORM2F
-	gpUniform2fv                                  C.GPUNIFORM2FV
-	gpUniform2i                                   C.GPUNIFORM2I
-	gpUniform2iv                                  C.GPUNIFORM2IV
-	gpUniform2ui                                  C.GPUNIFORM2UI
-	gpUniform2uiv                                 C.GPUNIFORM2UIV
-	gpUniform3d                                   C.GPUNIFORM3D
-	gpUniform3dv                                  C.GPUNIFORM3DV
-	gpUniform3f                                   C.GPUNIFORM3F
-	gpUniform3fv                                  C.GPUNIFORM3FV
-	gpUniform3i                                   C.GPUNIFORM3I
-	gpUniform3iv                                  C.GPUNIFORM3IV
-	gpUniform3ui                                  C.GPUNIFORM3UI
-	gpUniform3uiv                                 C.GPUNIFORM3UIV
-	gpUniform4d                                   C.GPUNIFORM4D
-	gpUniform4dv                                  C.GPUNIFORM4DV
-	gpUniform4f                                   C.GPUNIFORM4F
-	gpUniform4fv                                  C.GPUNIFORM4FV
-	gpUniform4i                                   C.GPUNIFORM4I
-	gpUniform4iv                                  C.GPUNIFORM4IV
-	gpUniform4ui                                  C.GPUNIFORM4UI
-	gpUniform4uiv                                 C.GPUNIFORM4UIV
-	gpUniformBlockBinding                         C.GPUNIFORMBLOCKBINDING
-	gpUniformHandleui64ARB                        C.GPUNIFORMHANDLEUI64ARB
-	gpUniformHandleui64vARB                       C.GPUNIFORMHANDLEUI64VARB
-	gpUniformMatrix2dv                            C.GPUNIFORMMATRIX2DV
-	gpUniformMatrix2fv                            C.GPUNIFORMMATRIX2FV
-	gpUniformMatrix2x3dv                          C.GPUNIFORMMATRIX2X3DV
-	gpUniformMatrix2x3fv                          C.GPUNIFORMMATRIX2X3FV
-	gpUniformMatrix2x4dv                          C.GPUNIFORMMATRIX2X4DV
-	gpUniformMatrix2x4fv                          C.GPUNIFORMMATRIX2X4FV
-	gpUniformMatrix3dv                            C.GPUNIFORMMATRIX3DV
-	gpUniformMatrix3fv                            C.GPUNIFORMMATRIX3FV
-	gpUniformMatrix3x2dv                          C.GPUNIFORMMATRIX3X2DV
-	gpUniformMatrix3x2fv                          C.GPUNIFORMMATRIX3X2FV
-	gpUniformMatrix3x4dv                          C.GPUNIFORMMATRIX3X4DV
-	gpUniformMatrix3x4fv                          C.GPUNIFORMMATRIX3X4FV
-	gpUniformMatrix4dv                            C.GPUNIFORMMATRIX4DV
-	gpUniformMatrix4fv                            C.GPUNIFORMMATRIX4FV
-	gpUniformMatrix4x2dv                          C.GPUNIFORMMATRIX4X2DV
-	gpUniformMatrix4x2fv                          C.GPUNIFORMMATRIX4X2FV
-	gpUniformMatrix4x3dv                          C.GPUNIFORMMATRIX4X3DV
-	gpUniformMatrix4x3fv                          C.GPUNIFORMMATRIX4X3FV
-	gpUniformSubroutinesuiv                       C.GPUNIFORMSUBROUTINESUIV
-	gpUnmapBuffer                                 C.GPUNMAPBUFFER
-	gpUnmapNamedBuffer                            C.GPUNMAPNAMEDBUFFER
-	gpUseProgram                                  C.GPUSEPROGRAM
-	gpUseProgramStages                            C.GPUSEPROGRAMSTAGES
-	gpValidateProgram                             C.GPVALIDATEPROGRAM
-	gpValidateProgramPipeline                     C.GPVALIDATEPROGRAMPIPELINE
-	gpVertexArrayAttribBinding                    C.GPVERTEXARRAYATTRIBBINDING
-	gpVertexArrayAttribFormat                     C.GPVERTEXARRAYATTRIBFORMAT
-	gpVertexArrayAttribIFormat                    C.GPVERTEXARRAYATTRIBIFORMAT
-	gpVertexArrayAttribLFormat                    C.GPVERTEXARRAYATTRIBLFORMAT
-	gpVertexArrayBindingDivisor                   C.GPVERTEXARRAYBINDINGDIVISOR
-	gpVertexArrayElementBuffer                    C.GPVERTEXARRAYELEMENTBUFFER
-	gpVertexArrayVertexBuffer                     C.GPVERTEXARRAYVERTEXBUFFER
-	gpVertexArrayVertexBuffers                    C.GPVERTEXARRAYVERTEXBUFFERS
-	gpVertexAttrib1d                              C.GPVERTEXATTRIB1D
-	gpVertexAttrib1dv                             C.GPVERTEXATTRIB1DV
-	gpVertexAttrib1f                              C.GPVERTEXATTRIB1F
-	gpVertexAttrib1fv                             C.GPVERTEXATTRIB1FV
-	gpVertexAttrib1s                              C.GPVERTEXATTRIB1S
-	gpVertexAttrib1sv                             C.GPVERTEXATTRIB1SV
-	gpVertexAttrib2d                              C.GPVERTEXATTRIB2D
-	gpVertexAttrib2dv                             C.GPVERTEXATTRIB2DV
-	gpVertexAttrib2f                              C.GPVERTEXATTRIB2F
-	gpVertexAttrib2fv                             C.GPVERTEXATTRIB2FV
-	gpVertexAttrib2s                              C.GPVERTEXATTRIB2S
-	gpVertexAttrib2sv                             C.GPVERTEXATTRIB2SV
-	gpVertexAttrib3d                              C.GPVERTEXATTRIB3D
-	gpVertexAttrib3dv                             C.GPVERTEXATTRIB3DV
-	gpVertexAttrib3f                              C.GPVERTEXATTRIB3F
-	gpVertexAttrib3fv                             C.GPVERTEXATTRIB3FV
-	gpVertexAttrib3s                              C.GPVERTEXATTRIB3S
-	gpVertexAttrib3sv                             C.GPVERTEXATTRIB3SV
-	gpVertexAttrib4Nbv                            C.GPVERTEXATTRIB4NBV
-	gpVertexAttrib4Niv                            C.GPVERTEXATTRIB4NIV
-	gpVertexAttrib4Nsv                            C.GPVERTEXATTRIB4NSV
-	gpVertexAttrib4Nub                            C.GPVERTEXATTRIB4NUB
-	gpVertexAttrib4Nubv                           C.GPVERTEXATTRIB4NUBV
-	gpVertexAttrib4Nuiv                           C.GPVERTEXATTRIB4NUIV
-	gpVertexAttrib4Nusv                           C.GPVERTEXATTRIB4NUSV
-	gpVertexAttrib4bv                             C.GPVERTEXATTRIB4BV
-	gpVertexAttrib4d                              C.GPVERTEXATTRIB4D
-	gpVertexAttrib4dv                             C.GPVERTEXATTRIB4DV
-	gpVertexAttrib4f                              C.GPVERTEXATTRIB4F
-	gpVertexAttrib4fv                             C.GPVERTEXATTRIB4FV
-	gpVertexAttrib4iv                             C.GPVERTEXATTRIB4IV
-	gpVertexAttrib4s                              C.GPVERTEXATTRIB4S
-	gpVertexAttrib4sv                             C.GPVERTEXATTRIB4SV
-	gpVertexAttrib4ubv                            C.GPVERTEXATTRIB4UBV
-	gpVertexAttrib4uiv                            C.GPVERTEXATTRIB4UIV
-	gpVertexAttrib4usv                            C.GPVERTEXATTRIB4USV
-	gpVertexAttribBinding                         C.GPVERTEXATTRIBBINDING
-	gpVertexAttribDivisor                         C.GPVERTEXATTRIBDIVISOR
-	gpVertexAttribFormat                          C.GPVERTEXATTRIBFORMAT
-	gpVertexAttribI1i                             C.GPVERTEXATTRIBI1I
-	gpVertexAttribI1iv                            C.GPVERTEXATTRIBI1IV
-	gpVertexAttribI1ui                            C.GPVERTEXATTRIBI1UI
-	gpVertexAttribI1uiv                           C.GPVERTEXATTRIBI1UIV
-	gpVertexAttribI2i                             C.GPVERTEXATTRIBI2I
-	gpVertexAttribI2iv                            C.GPVERTEXATTRIBI2IV
-	gpVertexAttribI2ui                            C.GPVERTEXATTRIBI2UI
-	gpVertexAttribI2uiv                           C.GPVERTEXATTRIBI2UIV
-	gpVertexAttribI3i                             C.GPVERTEXATTRIBI3I
-	gpVertexAttribI3iv                            C.GPVERTEXATTRIBI3IV
-	gpVertexAttribI3ui                            C.GPVERTEXATTRIBI3UI
-	gpVertexAttribI3uiv                           C.GPVERTEXATTRIBI3UIV
-	gpVertexAttribI4bv                            C.GPVERTEXATTRIBI4BV
-	gpVertexAttribI4i                             C.GPVERTEXATTRIBI4I
-	gpVertexAttribI4iv                            C.GPVERTEXATTRIBI4IV
-	gpVertexAttribI4sv                            C.GPVERTEXATTRIBI4SV
-	gpVertexAttribI4ubv                           C.GPVERTEXATTRIBI4UBV
-	gpVertexAttribI4ui                            C.GPVERTEXATTRIBI4UI
-	gpVertexAttribI4uiv                           C.GPVERTEXATTRIBI4UIV
-	gpVertexAttribI4usv                           C.GPVERTEXATTRIBI4USV
-	gpVertexAttribIFormat                         C.GPVERTEXATTRIBIFORMAT
-	gpVertexAttribIPointer                        C.GPVERTEXATTRIBIPOINTER
-	gpVertexAttribL1d                             C.GPVERTEXATTRIBL1D
-	gpVertexAttribL1dv                            C.GPVERTEXATTRIBL1DV
-	gpVertexAttribL1ui64ARB                       C.GPVERTEXATTRIBL1UI64ARB
-	gpVertexAttribL1ui64vARB                      C.GPVERTEXATTRIBL1UI64VARB
-	gpVertexAttribL2d                             C.GPVERTEXATTRIBL2D
-	gpVertexAttribL2dv                            C.GPVERTEXATTRIBL2DV
-	gpVertexAttribL3d                             C.GPVERTEXATTRIBL3D
-	gpVertexAttribL3dv                            C.GPVERTEXATTRIBL3DV
-	gpVertexAttribL4d                             C.GPVERTEXATTRIBL4D
-	gpVertexAttribL4dv                            C.GPVERTEXATTRIBL4DV
-	gpVertexAttribLFormat                         C.GPVERTEXATTRIBLFORMAT
-	gpVertexAttribLPointer                        C.GPVERTEXATTRIBLPOINTER
-	gpVertexAttribP1ui                            C.GPVERTEXATTRIBP1UI
-	gpVertexAttribP1uiv                           C.GPVERTEXATTRIBP1UIV
-	gpVertexAttribP2ui                            C.GPVERTEXATTRIBP2UI
-	gpVertexAttribP2uiv                           C.GPVERTEXATTRIBP2UIV
-	gpVertexAttribP3ui                            C.GPVERTEXATTRIBP3UI
-	gpVertexAttribP3uiv                           C.GPVERTEXATTRIBP3UIV
-	gpVertexAttribP4ui                            C.GPVERTEXATTRIBP4UI
-	gpVertexAttribP4uiv                           C.GPVERTEXATTRIBP4UIV
-	gpVertexAttribPointer                         C.GPVERTEXATTRIBPOINTER
-	gpVertexBindingDivisor                        C.GPVERTEXBINDINGDIVISOR
-	gpViewport                                    C.GPVIEWPORT
-	gpViewportArrayv                              C.GPVIEWPORTARRAYV
-	gpViewportIndexedf                            C.GPVIEWPORTINDEXEDF
-	gpViewportIndexedfv                           C.GPVIEWPORTINDEXEDFV
-	gpWaitSync                                    C.GPWAITSYNC
+	gpActiveProgramEXT                               C.GPACTIVEPROGRAMEXT
+	gpActiveShaderProgram                            C.GPACTIVESHADERPROGRAM
+	gpActiveShaderProgramEXT                         C.GPACTIVESHADERPROGRAMEXT
+	gpActiveTexture                                  C.GPACTIVETEXTURE
+	gpApplyFramebufferAttachmentCMAAINTEL            C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
+	gpAttachShader                                   C.GPATTACHSHADER
+	gpBeginConditionalRender                         C.GPBEGINCONDITIONALRENDER
+	gpBeginConditionalRenderNV                       C.GPBEGINCONDITIONALRENDERNV
+	gpBeginPerfMonitorAMD                            C.GPBEGINPERFMONITORAMD
+	gpBeginPerfQueryINTEL                            C.GPBEGINPERFQUERYINTEL
+	gpBeginQuery                                     C.GPBEGINQUERY
+	gpBeginQueryIndexed                              C.GPBEGINQUERYINDEXED
+	gpBeginTransformFeedback                         C.GPBEGINTRANSFORMFEEDBACK
+	gpBindAttribLocation                             C.GPBINDATTRIBLOCATION
+	gpBindBuffer                                     C.GPBINDBUFFER
+	gpBindBufferBase                                 C.GPBINDBUFFERBASE
+	gpBindBufferRange                                C.GPBINDBUFFERRANGE
+	gpBindBuffersBase                                C.GPBINDBUFFERSBASE
+	gpBindBuffersRange                               C.GPBINDBUFFERSRANGE
+	gpBindFragDataLocation                           C.GPBINDFRAGDATALOCATION
+	gpBindFragDataLocationIndexed                    C.GPBINDFRAGDATALOCATIONINDEXED
+	gpBindFramebuffer                                C.GPBINDFRAMEBUFFER
+	gpBindImageTexture                               C.GPBINDIMAGETEXTURE
+	gpBindImageTextures                              C.GPBINDIMAGETEXTURES
+	gpBindMultiTextureEXT                            C.GPBINDMULTITEXTUREEXT
+	gpBindProgramPipeline                            C.GPBINDPROGRAMPIPELINE
+	gpBindProgramPipelineEXT                         C.GPBINDPROGRAMPIPELINEEXT
+	gpBindRenderbuffer                               C.GPBINDRENDERBUFFER
+	gpBindSampler                                    C.GPBINDSAMPLER
+	gpBindSamplers                                   C.GPBINDSAMPLERS
+	gpBindTexture                                    C.GPBINDTEXTURE
+	gpBindTextureUnit                                C.GPBINDTEXTUREUNIT
+	gpBindTextures                                   C.GPBINDTEXTURES
+	gpBindTransformFeedback                          C.GPBINDTRANSFORMFEEDBACK
+	gpBindVertexArray                                C.GPBINDVERTEXARRAY
+	gpBindVertexBuffer                               C.GPBINDVERTEXBUFFER
+	gpBindVertexBuffers                              C.GPBINDVERTEXBUFFERS
+	gpBlendBarrierKHR                                C.GPBLENDBARRIERKHR
+	gpBlendBarrierNV                                 C.GPBLENDBARRIERNV
+	gpBlendColor                                     C.GPBLENDCOLOR
+	gpBlendEquation                                  C.GPBLENDEQUATION
+	gpBlendEquationSeparate                          C.GPBLENDEQUATIONSEPARATE
+	gpBlendEquationSeparatei                         C.GPBLENDEQUATIONSEPARATEI
+	gpBlendEquationSeparateiARB                      C.GPBLENDEQUATIONSEPARATEIARB
+	gpBlendEquationi                                 C.GPBLENDEQUATIONI
+	gpBlendEquationiARB                              C.GPBLENDEQUATIONIARB
+	gpBlendFunc                                      C.GPBLENDFUNC
+	gpBlendFuncSeparate                              C.GPBLENDFUNCSEPARATE
+	gpBlendFuncSeparatei                             C.GPBLENDFUNCSEPARATEI
+	gpBlendFuncSeparateiARB                          C.GPBLENDFUNCSEPARATEIARB
+	gpBlendFunci                                     C.GPBLENDFUNCI
+	gpBlendFunciARB                                  C.GPBLENDFUNCIARB
+	gpBlendParameteriNV                              C.GPBLENDPARAMETERINV
+	gpBlitFramebuffer                                C.GPBLITFRAMEBUFFER
+	gpBlitNamedFramebuffer                           C.GPBLITNAMEDFRAMEBUFFER
+	gpBufferAddressRangeNV                           C.GPBUFFERADDRESSRANGENV
+	gpBufferData                                     C.GPBUFFERDATA
+	gpBufferPageCommitmentARB                        C.GPBUFFERPAGECOMMITMENTARB
+	gpBufferStorage                                  C.GPBUFFERSTORAGE
+	gpBufferSubData                                  C.GPBUFFERSUBDATA
+	gpCallCommandListNV                              C.GPCALLCOMMANDLISTNV
+	gpCheckFramebufferStatus                         C.GPCHECKFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatus                    C.GPCHECKNAMEDFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatusEXT                 C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT
+	gpClampColor                                     C.GPCLAMPCOLOR
+	gpClear                                          C.GPCLEAR
+	gpClearBufferData                                C.GPCLEARBUFFERDATA
+	gpClearBufferSubData                             C.GPCLEARBUFFERSUBDATA
+	gpClearBufferfi                                  C.GPCLEARBUFFERFI
+	gpClearBufferfv                                  C.GPCLEARBUFFERFV
+	gpClearBufferiv                                  C.GPCLEARBUFFERIV
+	gpClearBufferuiv                                 C.GPCLEARBUFFERUIV
+	gpClearColor                                     C.GPCLEARCOLOR
+	gpClearDepth                                     C.GPCLEARDEPTH
+	gpClearDepthf                                    C.GPCLEARDEPTHF
+	gpClearNamedBufferData                           C.GPCLEARNAMEDBUFFERDATA
+	gpClearNamedBufferDataEXT                        C.GPCLEARNAMEDBUFFERDATAEXT
+	gpClearNamedBufferSubData                        C.GPCLEARNAMEDBUFFERSUBDATA
+	gpClearNamedBufferSubDataEXT                     C.GPCLEARNAMEDBUFFERSUBDATAEXT
+	gpClearNamedFramebufferfi                        C.GPCLEARNAMEDFRAMEBUFFERFI
+	gpClearNamedFramebufferfv                        C.GPCLEARNAMEDFRAMEBUFFERFV
+	gpClearNamedFramebufferiv                        C.GPCLEARNAMEDFRAMEBUFFERIV
+	gpClearNamedFramebufferuiv                       C.GPCLEARNAMEDFRAMEBUFFERUIV
+	gpClearStencil                                   C.GPCLEARSTENCIL
+	gpClearTexImage                                  C.GPCLEARTEXIMAGE
+	gpClearTexSubImage                               C.GPCLEARTEXSUBIMAGE
+	gpClientAttribDefaultEXT                         C.GPCLIENTATTRIBDEFAULTEXT
+	gpClientWaitSync                                 C.GPCLIENTWAITSYNC
+	gpClipControl                                    C.GPCLIPCONTROL
+	gpColorFormatNV                                  C.GPCOLORFORMATNV
+	gpColorMask                                      C.GPCOLORMASK
+	gpColorMaski                                     C.GPCOLORMASKI
+	gpCommandListSegmentsNV                          C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                           C.GPCOMPILECOMMANDLISTNV
+	gpCompileShader                                  C.GPCOMPILESHADER
+	gpCompileShaderIncludeARB                        C.GPCOMPILESHADERINCLUDEARB
+	gpCompressedMultiTexImage1DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE1DEXT
+	gpCompressedMultiTexImage2DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE2DEXT
+	gpCompressedMultiTexImage3DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE3DEXT
+	gpCompressedMultiTexSubImage1DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT
+	gpCompressedMultiTexSubImage2DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT
+	gpCompressedMultiTexSubImage3DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT
+	gpCompressedTexImage1D                           C.GPCOMPRESSEDTEXIMAGE1D
+	gpCompressedTexImage2D                           C.GPCOMPRESSEDTEXIMAGE2D
+	gpCompressedTexImage3D                           C.GPCOMPRESSEDTEXIMAGE3D
+	gpCompressedTexSubImage1D                        C.GPCOMPRESSEDTEXSUBIMAGE1D
+	gpCompressedTexSubImage2D                        C.GPCOMPRESSEDTEXSUBIMAGE2D
+	gpCompressedTexSubImage3D                        C.GPCOMPRESSEDTEXSUBIMAGE3D
+	gpCompressedTextureImage1DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE1DEXT
+	gpCompressedTextureImage2DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE2DEXT
+	gpCompressedTextureImage3DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE3DEXT
+	gpCompressedTextureSubImage1D                    C.GPCOMPRESSEDTEXTURESUBIMAGE1D
+	gpCompressedTextureSubImage1DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT
+	gpCompressedTextureSubImage2D                    C.GPCOMPRESSEDTEXTURESUBIMAGE2D
+	gpCompressedTextureSubImage2DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
+	gpCompressedTextureSubImage3D                    C.GPCOMPRESSEDTEXTURESUBIMAGE3D
+	gpCompressedTextureSubImage3DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                 C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                 C.GPCONSERVATIVERASTERPARAMETERINV
+	gpCopyBufferSubData                              C.GPCOPYBUFFERSUBDATA
+	gpCopyImageSubData                               C.GPCOPYIMAGESUBDATA
+	gpCopyMultiTexImage1DEXT                         C.GPCOPYMULTITEXIMAGE1DEXT
+	gpCopyMultiTexImage2DEXT                         C.GPCOPYMULTITEXIMAGE2DEXT
+	gpCopyMultiTexSubImage1DEXT                      C.GPCOPYMULTITEXSUBIMAGE1DEXT
+	gpCopyMultiTexSubImage2DEXT                      C.GPCOPYMULTITEXSUBIMAGE2DEXT
+	gpCopyMultiTexSubImage3DEXT                      C.GPCOPYMULTITEXSUBIMAGE3DEXT
+	gpCopyNamedBufferSubData                         C.GPCOPYNAMEDBUFFERSUBDATA
+	gpCopyPathNV                                     C.GPCOPYPATHNV
+	gpCopyTexImage1D                                 C.GPCOPYTEXIMAGE1D
+	gpCopyTexImage2D                                 C.GPCOPYTEXIMAGE2D
+	gpCopyTexSubImage1D                              C.GPCOPYTEXSUBIMAGE1D
+	gpCopyTexSubImage2D                              C.GPCOPYTEXSUBIMAGE2D
+	gpCopyTexSubImage3D                              C.GPCOPYTEXSUBIMAGE3D
+	gpCopyTextureImage1DEXT                          C.GPCOPYTEXTUREIMAGE1DEXT
+	gpCopyTextureImage2DEXT                          C.GPCOPYTEXTUREIMAGE2DEXT
+	gpCopyTextureSubImage1D                          C.GPCOPYTEXTURESUBIMAGE1D
+	gpCopyTextureSubImage1DEXT                       C.GPCOPYTEXTURESUBIMAGE1DEXT
+	gpCopyTextureSubImage2D                          C.GPCOPYTEXTURESUBIMAGE2D
+	gpCopyTextureSubImage2DEXT                       C.GPCOPYTEXTURESUBIMAGE2DEXT
+	gpCopyTextureSubImage3D                          C.GPCOPYTEXTURESUBIMAGE3D
+	gpCopyTextureSubImage3DEXT                       C.GPCOPYTEXTURESUBIMAGE3DEXT
+	gpCoverFillPathInstancedNV                       C.GPCOVERFILLPATHINSTANCEDNV
+	gpCoverFillPathNV                                C.GPCOVERFILLPATHNV
+	gpCoverStrokePathInstancedNV                     C.GPCOVERSTROKEPATHINSTANCEDNV
+	gpCoverStrokePathNV                              C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                           C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                      C.GPCOVERAGEMODULATIONTABLENV
+	gpCreateBuffers                                  C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                           C.GPCREATECOMMANDLISTSNV
+	gpCreateFramebuffers                             C.GPCREATEFRAMEBUFFERS
+	gpCreatePerfQueryINTEL                           C.GPCREATEPERFQUERYINTEL
+	gpCreateProgram                                  C.GPCREATEPROGRAM
+	gpCreateProgramPipelines                         C.GPCREATEPROGRAMPIPELINES
+	gpCreateQueries                                  C.GPCREATEQUERIES
+	gpCreateRenderbuffers                            C.GPCREATERENDERBUFFERS
+	gpCreateSamplers                                 C.GPCREATESAMPLERS
+	gpCreateShader                                   C.GPCREATESHADER
+	gpCreateShaderProgramEXT                         C.GPCREATESHADERPROGRAMEXT
+	gpCreateShaderProgramv                           C.GPCREATESHADERPROGRAMV
+	gpCreateShaderProgramvEXT                        C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                 C.GPCREATESTATESNV
+	gpCreateSyncFromCLeventARB                       C.GPCREATESYNCFROMCLEVENTARB
+	gpCreateTextures                                 C.GPCREATETEXTURES
+	gpCreateTransformFeedbacks                       C.GPCREATETRANSFORMFEEDBACKS
+	gpCreateVertexArrays                             C.GPCREATEVERTEXARRAYS
+	gpCullFace                                       C.GPCULLFACE
+	gpDebugMessageCallback                           C.GPDEBUGMESSAGECALLBACK
+	gpDebugMessageCallbackARB                        C.GPDEBUGMESSAGECALLBACKARB
+	gpDebugMessageCallbackKHR                        C.GPDEBUGMESSAGECALLBACKKHR
+	gpDebugMessageControl                            C.GPDEBUGMESSAGECONTROL
+	gpDebugMessageControlARB                         C.GPDEBUGMESSAGECONTROLARB
+	gpDebugMessageControlKHR                         C.GPDEBUGMESSAGECONTROLKHR
+	gpDebugMessageInsert                             C.GPDEBUGMESSAGEINSERT
+	gpDebugMessageInsertARB                          C.GPDEBUGMESSAGEINSERTARB
+	gpDebugMessageInsertKHR                          C.GPDEBUGMESSAGEINSERTKHR
+	gpDeleteBuffers                                  C.GPDELETEBUFFERS
+	gpDeleteCommandListsNV                           C.GPDELETECOMMANDLISTSNV
+	gpDeleteFramebuffers                             C.GPDELETEFRAMEBUFFERS
+	gpDeleteNamedStringARB                           C.GPDELETENAMEDSTRINGARB
+	gpDeletePathsNV                                  C.GPDELETEPATHSNV
+	gpDeletePerfMonitorsAMD                          C.GPDELETEPERFMONITORSAMD
+	gpDeletePerfQueryINTEL                           C.GPDELETEPERFQUERYINTEL
+	gpDeleteProgram                                  C.GPDELETEPROGRAM
+	gpDeleteProgramPipelines                         C.GPDELETEPROGRAMPIPELINES
+	gpDeleteProgramPipelinesEXT                      C.GPDELETEPROGRAMPIPELINESEXT
+	gpDeleteQueries                                  C.GPDELETEQUERIES
+	gpDeleteRenderbuffers                            C.GPDELETERENDERBUFFERS
+	gpDeleteSamplers                                 C.GPDELETESAMPLERS
+	gpDeleteShader                                   C.GPDELETESHADER
+	gpDeleteStatesNV                                 C.GPDELETESTATESNV
+	gpDeleteSync                                     C.GPDELETESYNC
+	gpDeleteTextures                                 C.GPDELETETEXTURES
+	gpDeleteTransformFeedbacks                       C.GPDELETETRANSFORMFEEDBACKS
+	gpDeleteVertexArrays                             C.GPDELETEVERTEXARRAYS
+	gpDepthFunc                                      C.GPDEPTHFUNC
+	gpDepthMask                                      C.GPDEPTHMASK
+	gpDepthRange                                     C.GPDEPTHRANGE
+	gpDepthRangeArrayv                               C.GPDEPTHRANGEARRAYV
+	gpDepthRangeIndexed                              C.GPDEPTHRANGEINDEXED
+	gpDepthRangef                                    C.GPDEPTHRANGEF
+	gpDetachShader                                   C.GPDETACHSHADER
+	gpDisable                                        C.GPDISABLE
+	gpDisableClientStateIndexedEXT                   C.GPDISABLECLIENTSTATEINDEXEDEXT
+	gpDisableClientStateiEXT                         C.GPDISABLECLIENTSTATEIEXT
+	gpDisableIndexedEXT                              C.GPDISABLEINDEXEDEXT
+	gpDisableVertexArrayAttrib                       C.GPDISABLEVERTEXARRAYATTRIB
+	gpDisableVertexArrayAttribEXT                    C.GPDISABLEVERTEXARRAYATTRIBEXT
+	gpDisableVertexArrayEXT                          C.GPDISABLEVERTEXARRAYEXT
+	gpDisableVertexAttribArray                       C.GPDISABLEVERTEXATTRIBARRAY
+	gpDisablei                                       C.GPDISABLEI
+	gpDispatchCompute                                C.GPDISPATCHCOMPUTE
+	gpDispatchComputeGroupSizeARB                    C.GPDISPATCHCOMPUTEGROUPSIZEARB
+	gpDispatchComputeIndirect                        C.GPDISPATCHCOMPUTEINDIRECT
+	gpDrawArrays                                     C.GPDRAWARRAYS
+	gpDrawArraysIndirect                             C.GPDRAWARRAYSINDIRECT
+	gpDrawArraysInstanced                            C.GPDRAWARRAYSINSTANCED
+	gpDrawArraysInstancedARB                         C.GPDRAWARRAYSINSTANCEDARB
+	gpDrawArraysInstancedBaseInstance                C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
+	gpDrawArraysInstancedEXT                         C.GPDRAWARRAYSINSTANCEDEXT
+	gpDrawBuffer                                     C.GPDRAWBUFFER
+	gpDrawBuffers                                    C.GPDRAWBUFFERS
+	gpDrawCommandsAddressNV                          C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                 C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                    C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                           C.GPDRAWCOMMANDSSTATESNV
+	gpDrawElements                                   C.GPDRAWELEMENTS
+	gpDrawElementsBaseVertex                         C.GPDRAWELEMENTSBASEVERTEX
+	gpDrawElementsIndirect                           C.GPDRAWELEMENTSINDIRECT
+	gpDrawElementsInstanced                          C.GPDRAWELEMENTSINSTANCED
+	gpDrawElementsInstancedARB                       C.GPDRAWELEMENTSINSTANCEDARB
+	gpDrawElementsInstancedBaseInstance              C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
+	gpDrawElementsInstancedBaseVertex                C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
+	gpDrawElementsInstancedBaseVertexBaseInstance    C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
+	gpDrawElementsInstancedEXT                       C.GPDRAWELEMENTSINSTANCEDEXT
+	gpDrawRangeElements                              C.GPDRAWRANGEELEMENTS
+	gpDrawRangeElementsBaseVertex                    C.GPDRAWRANGEELEMENTSBASEVERTEX
+	gpDrawTransformFeedback                          C.GPDRAWTRANSFORMFEEDBACK
+	gpDrawTransformFeedbackInstanced                 C.GPDRAWTRANSFORMFEEDBACKINSTANCED
+	gpDrawTransformFeedbackStream                    C.GPDRAWTRANSFORMFEEDBACKSTREAM
+	gpDrawTransformFeedbackStreamInstanced           C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                  C.GPDRAWVKIMAGENV
+	gpEdgeFlagFormatNV                               C.GPEDGEFLAGFORMATNV
+	gpEnable                                         C.GPENABLE
+	gpEnableClientStateIndexedEXT                    C.GPENABLECLIENTSTATEINDEXEDEXT
+	gpEnableClientStateiEXT                          C.GPENABLECLIENTSTATEIEXT
+	gpEnableIndexedEXT                               C.GPENABLEINDEXEDEXT
+	gpEnableVertexArrayAttrib                        C.GPENABLEVERTEXARRAYATTRIB
+	gpEnableVertexArrayAttribEXT                     C.GPENABLEVERTEXARRAYATTRIBEXT
+	gpEnableVertexArrayEXT                           C.GPENABLEVERTEXARRAYEXT
+	gpEnableVertexAttribArray                        C.GPENABLEVERTEXATTRIBARRAY
+	gpEnablei                                        C.GPENABLEI
+	gpEndConditionalRender                           C.GPENDCONDITIONALRENDER
+	gpEndConditionalRenderNV                         C.GPENDCONDITIONALRENDERNV
+	gpEndPerfMonitorAMD                              C.GPENDPERFMONITORAMD
+	gpEndPerfQueryINTEL                              C.GPENDPERFQUERYINTEL
+	gpEndQuery                                       C.GPENDQUERY
+	gpEndQueryIndexed                                C.GPENDQUERYINDEXED
+	gpEndTransformFeedback                           C.GPENDTRANSFORMFEEDBACK
+	gpEvaluateDepthValuesARB                         C.GPEVALUATEDEPTHVALUESARB
+	gpFenceSync                                      C.GPFENCESYNC
+	gpFinish                                         C.GPFINISH
+	gpFlush                                          C.GPFLUSH
+	gpFlushMappedBufferRange                         C.GPFLUSHMAPPEDBUFFERRANGE
+	gpFlushMappedNamedBufferRange                    C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
+	gpFlushMappedNamedBufferRangeEXT                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT
+	gpFogCoordFormatNV                               C.GPFOGCOORDFORMATNV
+	gpFragmentCoverageColorNV                        C.GPFRAGMENTCOVERAGECOLORNV
+	gpFramebufferDrawBufferEXT                       C.GPFRAMEBUFFERDRAWBUFFEREXT
+	gpFramebufferDrawBuffersEXT                      C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                     C.GPFRAMEBUFFERFETCHBARRIEREXT
+	gpFramebufferParameteri                          C.GPFRAMEBUFFERPARAMETERI
+	gpFramebufferReadBufferEXT                       C.GPFRAMEBUFFERREADBUFFEREXT
+	gpFramebufferRenderbuffer                        C.GPFRAMEBUFFERRENDERBUFFER
+	gpFramebufferSampleLocationsfvARB                C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                 C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferTexture                             C.GPFRAMEBUFFERTEXTURE
+	gpFramebufferTexture1D                           C.GPFRAMEBUFFERTEXTURE1D
+	gpFramebufferTexture2D                           C.GPFRAMEBUFFERTEXTURE2D
+	gpFramebufferTexture3D                           C.GPFRAMEBUFFERTEXTURE3D
+	gpFramebufferTextureARB                          C.GPFRAMEBUFFERTEXTUREARB
+	gpFramebufferTextureFaceARB                      C.GPFRAMEBUFFERTEXTUREFACEARB
+	gpFramebufferTextureLayer                        C.GPFRAMEBUFFERTEXTURELAYER
+	gpFramebufferTextureLayerARB                     C.GPFRAMEBUFFERTEXTURELAYERARB
+	gpFramebufferTextureMultiviewOVR                 C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
+	gpFrontFace                                      C.GPFRONTFACE
+	gpGenBuffers                                     C.GPGENBUFFERS
+	gpGenFramebuffers                                C.GPGENFRAMEBUFFERS
+	gpGenPathsNV                                     C.GPGENPATHSNV
+	gpGenPerfMonitorsAMD                             C.GPGENPERFMONITORSAMD
+	gpGenProgramPipelines                            C.GPGENPROGRAMPIPELINES
+	gpGenProgramPipelinesEXT                         C.GPGENPROGRAMPIPELINESEXT
+	gpGenQueries                                     C.GPGENQUERIES
+	gpGenRenderbuffers                               C.GPGENRENDERBUFFERS
+	gpGenSamplers                                    C.GPGENSAMPLERS
+	gpGenTextures                                    C.GPGENTEXTURES
+	gpGenTransformFeedbacks                          C.GPGENTRANSFORMFEEDBACKS
+	gpGenVertexArrays                                C.GPGENVERTEXARRAYS
+	gpGenerateMipmap                                 C.GPGENERATEMIPMAP
+	gpGenerateMultiTexMipmapEXT                      C.GPGENERATEMULTITEXMIPMAPEXT
+	gpGenerateTextureMipmap                          C.GPGENERATETEXTUREMIPMAP
+	gpGenerateTextureMipmapEXT                       C.GPGENERATETEXTUREMIPMAPEXT
+	gpGetActiveAtomicCounterBufferiv                 C.GPGETACTIVEATOMICCOUNTERBUFFERIV
+	gpGetActiveAttrib                                C.GPGETACTIVEATTRIB
+	gpGetActiveSubroutineName                        C.GPGETACTIVESUBROUTINENAME
+	gpGetActiveSubroutineUniformName                 C.GPGETACTIVESUBROUTINEUNIFORMNAME
+	gpGetActiveSubroutineUniformiv                   C.GPGETACTIVESUBROUTINEUNIFORMIV
+	gpGetActiveUniform                               C.GPGETACTIVEUNIFORM
+	gpGetActiveUniformBlockName                      C.GPGETACTIVEUNIFORMBLOCKNAME
+	gpGetActiveUniformBlockiv                        C.GPGETACTIVEUNIFORMBLOCKIV
+	gpGetActiveUniformName                           C.GPGETACTIVEUNIFORMNAME
+	gpGetActiveUniformsiv                            C.GPGETACTIVEUNIFORMSIV
+	gpGetAttachedShaders                             C.GPGETATTACHEDSHADERS
+	gpGetAttribLocation                              C.GPGETATTRIBLOCATION
+	gpGetBooleanIndexedvEXT                          C.GPGETBOOLEANINDEXEDVEXT
+	gpGetBooleani_v                                  C.GPGETBOOLEANI_V
+	gpGetBooleanv                                    C.GPGETBOOLEANV
+	gpGetBufferParameteri64v                         C.GPGETBUFFERPARAMETERI64V
+	gpGetBufferParameteriv                           C.GPGETBUFFERPARAMETERIV
+	gpGetBufferParameterui64vNV                      C.GPGETBUFFERPARAMETERUI64VNV
+	gpGetBufferPointerv                              C.GPGETBUFFERPOINTERV
+	gpGetBufferSubData                               C.GPGETBUFFERSUBDATA
+	gpGetCommandHeaderNV                             C.GPGETCOMMANDHEADERNV
+	gpGetCompressedMultiTexImageEXT                  C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
+	gpGetCompressedTexImage                          C.GPGETCOMPRESSEDTEXIMAGE
+	gpGetCompressedTextureImage                      C.GPGETCOMPRESSEDTEXTUREIMAGE
+	gpGetCompressedTextureImageEXT                   C.GPGETCOMPRESSEDTEXTUREIMAGEEXT
+	gpGetCompressedTextureSubImage                   C.GPGETCOMPRESSEDTEXTURESUBIMAGE
+	gpGetCoverageModulationTableNV                   C.GPGETCOVERAGEMODULATIONTABLENV
+	gpGetDebugMessageLog                             C.GPGETDEBUGMESSAGELOG
+	gpGetDebugMessageLogARB                          C.GPGETDEBUGMESSAGELOGARB
+	gpGetDebugMessageLogKHR                          C.GPGETDEBUGMESSAGELOGKHR
+	gpGetDoubleIndexedvEXT                           C.GPGETDOUBLEINDEXEDVEXT
+	gpGetDoublei_v                                   C.GPGETDOUBLEI_V
+	gpGetDoublei_vEXT                                C.GPGETDOUBLEI_VEXT
+	gpGetDoublev                                     C.GPGETDOUBLEV
+	gpGetError                                       C.GPGETERROR
+	gpGetFirstPerfQueryIdINTEL                       C.GPGETFIRSTPERFQUERYIDINTEL
+	gpGetFloatIndexedvEXT                            C.GPGETFLOATINDEXEDVEXT
+	gpGetFloati_v                                    C.GPGETFLOATI_V
+	gpGetFloati_vEXT                                 C.GPGETFLOATI_VEXT
+	gpGetFloatv                                      C.GPGETFLOATV
+	gpGetFragDataIndex                               C.GPGETFRAGDATAINDEX
+	gpGetFragDataLocation                            C.GPGETFRAGDATALOCATION
+	gpGetFramebufferAttachmentParameteriv            C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetFramebufferParameteriv                      C.GPGETFRAMEBUFFERPARAMETERIV
+	gpGetFramebufferParameterivEXT                   C.GPGETFRAMEBUFFERPARAMETERIVEXT
+	gpGetGraphicsResetStatus                         C.GPGETGRAPHICSRESETSTATUS
+	gpGetGraphicsResetStatusARB                      C.GPGETGRAPHICSRESETSTATUSARB
+	gpGetGraphicsResetStatusKHR                      C.GPGETGRAPHICSRESETSTATUSKHR
+	gpGetImageHandleARB                              C.GPGETIMAGEHANDLEARB
+	gpGetImageHandleNV                               C.GPGETIMAGEHANDLENV
+	gpGetInteger64i_v                                C.GPGETINTEGER64I_V
+	gpGetInteger64v                                  C.GPGETINTEGER64V
+	gpGetIntegerIndexedvEXT                          C.GPGETINTEGERINDEXEDVEXT
+	gpGetIntegeri_v                                  C.GPGETINTEGERI_V
+	gpGetIntegerui64i_vNV                            C.GPGETINTEGERUI64I_VNV
+	gpGetIntegerui64vNV                              C.GPGETINTEGERUI64VNV
+	gpGetIntegerv                                    C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                    C.GPGETINTERNALFORMATSAMPLEIVNV
+	gpGetInternalformati64v                          C.GPGETINTERNALFORMATI64V
+	gpGetInternalformativ                            C.GPGETINTERNALFORMATIV
+	gpGetMultiTexEnvfvEXT                            C.GPGETMULTITEXENVFVEXT
+	gpGetMultiTexEnvivEXT                            C.GPGETMULTITEXENVIVEXT
+	gpGetMultiTexGendvEXT                            C.GPGETMULTITEXGENDVEXT
+	gpGetMultiTexGenfvEXT                            C.GPGETMULTITEXGENFVEXT
+	gpGetMultiTexGenivEXT                            C.GPGETMULTITEXGENIVEXT
+	gpGetMultiTexImageEXT                            C.GPGETMULTITEXIMAGEEXT
+	gpGetMultiTexLevelParameterfvEXT                 C.GPGETMULTITEXLEVELPARAMETERFVEXT
+	gpGetMultiTexLevelParameterivEXT                 C.GPGETMULTITEXLEVELPARAMETERIVEXT
+	gpGetMultiTexParameterIivEXT                     C.GPGETMULTITEXPARAMETERIIVEXT
+	gpGetMultiTexParameterIuivEXT                    C.GPGETMULTITEXPARAMETERIUIVEXT
+	gpGetMultiTexParameterfvEXT                      C.GPGETMULTITEXPARAMETERFVEXT
+	gpGetMultiTexParameterivEXT                      C.GPGETMULTITEXPARAMETERIVEXT
+	gpGetMultisamplefv                               C.GPGETMULTISAMPLEFV
+	gpGetNamedBufferParameteri64v                    C.GPGETNAMEDBUFFERPARAMETERI64V
+	gpGetNamedBufferParameteriv                      C.GPGETNAMEDBUFFERPARAMETERIV
+	gpGetNamedBufferParameterivEXT                   C.GPGETNAMEDBUFFERPARAMETERIVEXT
+	gpGetNamedBufferParameterui64vNV                 C.GPGETNAMEDBUFFERPARAMETERUI64VNV
+	gpGetNamedBufferPointerv                         C.GPGETNAMEDBUFFERPOINTERV
+	gpGetNamedBufferPointervEXT                      C.GPGETNAMEDBUFFERPOINTERVEXT
+	gpGetNamedBufferSubData                          C.GPGETNAMEDBUFFERSUBDATA
+	gpGetNamedBufferSubDataEXT                       C.GPGETNAMEDBUFFERSUBDATAEXT
+	gpGetNamedFramebufferAttachmentParameteriv       C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetNamedFramebufferAttachmentParameterivEXT    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameteriv                 C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
+	gpGetNamedFramebufferParameterivEXT              C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
+	gpGetNamedProgramLocalParameterIivEXT            C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
+	gpGetNamedProgramLocalParameterIuivEXT           C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT
+	gpGetNamedProgramLocalParameterdvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT
+	gpGetNamedProgramLocalParameterfvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT
+	gpGetNamedProgramStringEXT                       C.GPGETNAMEDPROGRAMSTRINGEXT
+	gpGetNamedProgramivEXT                           C.GPGETNAMEDPROGRAMIVEXT
+	gpGetNamedRenderbufferParameteriv                C.GPGETNAMEDRENDERBUFFERPARAMETERIV
+	gpGetNamedRenderbufferParameterivEXT             C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT
+	gpGetNamedStringARB                              C.GPGETNAMEDSTRINGARB
+	gpGetNamedStringivARB                            C.GPGETNAMEDSTRINGIVARB
+	gpGetNextPerfQueryIdINTEL                        C.GPGETNEXTPERFQUERYIDINTEL
+	gpGetObjectLabel                                 C.GPGETOBJECTLABEL
+	gpGetObjectLabelEXT                              C.GPGETOBJECTLABELEXT
+	gpGetObjectLabelKHR                              C.GPGETOBJECTLABELKHR
+	gpGetObjectPtrLabel                              C.GPGETOBJECTPTRLABEL
+	gpGetObjectPtrLabelKHR                           C.GPGETOBJECTPTRLABELKHR
+	gpGetPathCommandsNV                              C.GPGETPATHCOMMANDSNV
+	gpGetPathCoordsNV                                C.GPGETPATHCOORDSNV
+	gpGetPathDashArrayNV                             C.GPGETPATHDASHARRAYNV
+	gpGetPathLengthNV                                C.GPGETPATHLENGTHNV
+	gpGetPathMetricRangeNV                           C.GPGETPATHMETRICRANGENV
+	gpGetPathMetricsNV                               C.GPGETPATHMETRICSNV
+	gpGetPathParameterfvNV                           C.GPGETPATHPARAMETERFVNV
+	gpGetPathParameterivNV                           C.GPGETPATHPARAMETERIVNV
+	gpGetPathSpacingNV                               C.GPGETPATHSPACINGNV
+	gpGetPerfCounterInfoINTEL                        C.GPGETPERFCOUNTERINFOINTEL
+	gpGetPerfMonitorCounterDataAMD                   C.GPGETPERFMONITORCOUNTERDATAAMD
+	gpGetPerfMonitorCounterInfoAMD                   C.GPGETPERFMONITORCOUNTERINFOAMD
+	gpGetPerfMonitorCounterStringAMD                 C.GPGETPERFMONITORCOUNTERSTRINGAMD
+	gpGetPerfMonitorCountersAMD                      C.GPGETPERFMONITORCOUNTERSAMD
+	gpGetPerfMonitorGroupStringAMD                   C.GPGETPERFMONITORGROUPSTRINGAMD
+	gpGetPerfMonitorGroupsAMD                        C.GPGETPERFMONITORGROUPSAMD
+	gpGetPerfQueryDataINTEL                          C.GPGETPERFQUERYDATAINTEL
+	gpGetPerfQueryIdByNameINTEL                      C.GPGETPERFQUERYIDBYNAMEINTEL
+	gpGetPerfQueryInfoINTEL                          C.GPGETPERFQUERYINFOINTEL
+	gpGetPointerIndexedvEXT                          C.GPGETPOINTERINDEXEDVEXT
+	gpGetPointeri_vEXT                               C.GPGETPOINTERI_VEXT
+	gpGetPointerv                                    C.GPGETPOINTERV
+	gpGetPointervKHR                                 C.GPGETPOINTERVKHR
+	gpGetProgramBinary                               C.GPGETPROGRAMBINARY
+	gpGetProgramInfoLog                              C.GPGETPROGRAMINFOLOG
+	gpGetProgramInterfaceiv                          C.GPGETPROGRAMINTERFACEIV
+	gpGetProgramPipelineInfoLog                      C.GPGETPROGRAMPIPELINEINFOLOG
+	gpGetProgramPipelineInfoLogEXT                   C.GPGETPROGRAMPIPELINEINFOLOGEXT
+	gpGetProgramPipelineiv                           C.GPGETPROGRAMPIPELINEIV
+	gpGetProgramPipelineivEXT                        C.GPGETPROGRAMPIPELINEIVEXT
+	gpGetProgramResourceIndex                        C.GPGETPROGRAMRESOURCEINDEX
+	gpGetProgramResourceLocation                     C.GPGETPROGRAMRESOURCELOCATION
+	gpGetProgramResourceLocationIndex                C.GPGETPROGRAMRESOURCELOCATIONINDEX
+	gpGetProgramResourceName                         C.GPGETPROGRAMRESOURCENAME
+	gpGetProgramResourcefvNV                         C.GPGETPROGRAMRESOURCEFVNV
+	gpGetProgramResourceiv                           C.GPGETPROGRAMRESOURCEIV
+	gpGetProgramStageiv                              C.GPGETPROGRAMSTAGEIV
+	gpGetProgramiv                                   C.GPGETPROGRAMIV
+	gpGetQueryBufferObjecti64v                       C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                         C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                      C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                        C.GPGETQUERYBUFFEROBJECTUIV
+	gpGetQueryIndexediv                              C.GPGETQUERYINDEXEDIV
+	gpGetQueryObjecti64v                             C.GPGETQUERYOBJECTI64V
+	gpGetQueryObjectiv                               C.GPGETQUERYOBJECTIV
+	gpGetQueryObjectui64v                            C.GPGETQUERYOBJECTUI64V
+	gpGetQueryObjectuiv                              C.GPGETQUERYOBJECTUIV
+	gpGetQueryiv                                     C.GPGETQUERYIV
+	gpGetRenderbufferParameteriv                     C.GPGETRENDERBUFFERPARAMETERIV
+	gpGetSamplerParameterIiv                         C.GPGETSAMPLERPARAMETERIIV
+	gpGetSamplerParameterIuiv                        C.GPGETSAMPLERPARAMETERIUIV
+	gpGetSamplerParameterfv                          C.GPGETSAMPLERPARAMETERFV
+	gpGetSamplerParameteriv                          C.GPGETSAMPLERPARAMETERIV
+	gpGetShaderInfoLog                               C.GPGETSHADERINFOLOG
+	gpGetShaderPrecisionFormat                       C.GPGETSHADERPRECISIONFORMAT
+	gpGetShaderSource                                C.GPGETSHADERSOURCE
+	gpGetShaderiv                                    C.GPGETSHADERIV
+	gpGetStageIndexNV                                C.GPGETSTAGEINDEXNV
+	gpGetString                                      C.GPGETSTRING
+	gpGetStringi                                     C.GPGETSTRINGI
+	gpGetSubroutineIndex                             C.GPGETSUBROUTINEINDEX
+	gpGetSubroutineUniformLocation                   C.GPGETSUBROUTINEUNIFORMLOCATION
+	gpGetSynciv                                      C.GPGETSYNCIV
+	gpGetTexImage                                    C.GPGETTEXIMAGE
+	gpGetTexLevelParameterfv                         C.GPGETTEXLEVELPARAMETERFV
+	gpGetTexLevelParameteriv                         C.GPGETTEXLEVELPARAMETERIV
+	gpGetTexParameterIiv                             C.GPGETTEXPARAMETERIIV
+	gpGetTexParameterIuiv                            C.GPGETTEXPARAMETERIUIV
+	gpGetTexParameterfv                              C.GPGETTEXPARAMETERFV
+	gpGetTexParameteriv                              C.GPGETTEXPARAMETERIV
+	gpGetTextureHandleARB                            C.GPGETTEXTUREHANDLEARB
+	gpGetTextureHandleNV                             C.GPGETTEXTUREHANDLENV
+	gpGetTextureImage                                C.GPGETTEXTUREIMAGE
+	gpGetTextureImageEXT                             C.GPGETTEXTUREIMAGEEXT
+	gpGetTextureLevelParameterfv                     C.GPGETTEXTURELEVELPARAMETERFV
+	gpGetTextureLevelParameterfvEXT                  C.GPGETTEXTURELEVELPARAMETERFVEXT
+	gpGetTextureLevelParameteriv                     C.GPGETTEXTURELEVELPARAMETERIV
+	gpGetTextureLevelParameterivEXT                  C.GPGETTEXTURELEVELPARAMETERIVEXT
+	gpGetTextureParameterIiv                         C.GPGETTEXTUREPARAMETERIIV
+	gpGetTextureParameterIivEXT                      C.GPGETTEXTUREPARAMETERIIVEXT
+	gpGetTextureParameterIuiv                        C.GPGETTEXTUREPARAMETERIUIV
+	gpGetTextureParameterIuivEXT                     C.GPGETTEXTUREPARAMETERIUIVEXT
+	gpGetTextureParameterfv                          C.GPGETTEXTUREPARAMETERFV
+	gpGetTextureParameterfvEXT                       C.GPGETTEXTUREPARAMETERFVEXT
+	gpGetTextureParameteriv                          C.GPGETTEXTUREPARAMETERIV
+	gpGetTextureParameterivEXT                       C.GPGETTEXTUREPARAMETERIVEXT
+	gpGetTextureSamplerHandleARB                     C.GPGETTEXTURESAMPLERHANDLEARB
+	gpGetTextureSamplerHandleNV                      C.GPGETTEXTURESAMPLERHANDLENV
+	gpGetTextureSubImage                             C.GPGETTEXTURESUBIMAGE
+	gpGetTransformFeedbackVarying                    C.GPGETTRANSFORMFEEDBACKVARYING
+	gpGetTransformFeedbacki64_v                      C.GPGETTRANSFORMFEEDBACKI64_V
+	gpGetTransformFeedbacki_v                        C.GPGETTRANSFORMFEEDBACKI_V
+	gpGetTransformFeedbackiv                         C.GPGETTRANSFORMFEEDBACKIV
+	gpGetUniformBlockIndex                           C.GPGETUNIFORMBLOCKINDEX
+	gpGetUniformIndices                              C.GPGETUNIFORMINDICES
+	gpGetUniformLocation                             C.GPGETUNIFORMLOCATION
+	gpGetUniformSubroutineuiv                        C.GPGETUNIFORMSUBROUTINEUIV
+	gpGetUniformdv                                   C.GPGETUNIFORMDV
+	gpGetUniformfv                                   C.GPGETUNIFORMFV
+	gpGetUniformi64vARB                              C.GPGETUNIFORMI64VARB
+	gpGetUniformi64vNV                               C.GPGETUNIFORMI64VNV
+	gpGetUniformiv                                   C.GPGETUNIFORMIV
+	gpGetUniformui64vARB                             C.GPGETUNIFORMUI64VARB
+	gpGetUniformui64vNV                              C.GPGETUNIFORMUI64VNV
+	gpGetUniformuiv                                  C.GPGETUNIFORMUIV
+	gpGetVertexArrayIndexed64iv                      C.GPGETVERTEXARRAYINDEXED64IV
+	gpGetVertexArrayIndexediv                        C.GPGETVERTEXARRAYINDEXEDIV
+	gpGetVertexArrayIntegeri_vEXT                    C.GPGETVERTEXARRAYINTEGERI_VEXT
+	gpGetVertexArrayIntegervEXT                      C.GPGETVERTEXARRAYINTEGERVEXT
+	gpGetVertexArrayPointeri_vEXT                    C.GPGETVERTEXARRAYPOINTERI_VEXT
+	gpGetVertexArrayPointervEXT                      C.GPGETVERTEXARRAYPOINTERVEXT
+	gpGetVertexArrayiv                               C.GPGETVERTEXARRAYIV
+	gpGetVertexAttribIiv                             C.GPGETVERTEXATTRIBIIV
+	gpGetVertexAttribIuiv                            C.GPGETVERTEXATTRIBIUIV
+	gpGetVertexAttribLdv                             C.GPGETVERTEXATTRIBLDV
+	gpGetVertexAttribLi64vNV                         C.GPGETVERTEXATTRIBLI64VNV
+	gpGetVertexAttribLui64vARB                       C.GPGETVERTEXATTRIBLUI64VARB
+	gpGetVertexAttribLui64vNV                        C.GPGETVERTEXATTRIBLUI64VNV
+	gpGetVertexAttribPointerv                        C.GPGETVERTEXATTRIBPOINTERV
+	gpGetVertexAttribdv                              C.GPGETVERTEXATTRIBDV
+	gpGetVertexAttribfv                              C.GPGETVERTEXATTRIBFV
+	gpGetVertexAttribiv                              C.GPGETVERTEXATTRIBIV
+	gpGetVkProcAddrNV                                C.GPGETVKPROCADDRNV
+	gpGetnCompressedTexImageARB                      C.GPGETNCOMPRESSEDTEXIMAGEARB
+	gpGetnTexImageARB                                C.GPGETNTEXIMAGEARB
+	gpGetnUniformdvARB                               C.GPGETNUNIFORMDVARB
+	gpGetnUniformfv                                  C.GPGETNUNIFORMFV
+	gpGetnUniformfvARB                               C.GPGETNUNIFORMFVARB
+	gpGetnUniformfvKHR                               C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                             C.GPGETNUNIFORMI64VARB
+	gpGetnUniformiv                                  C.GPGETNUNIFORMIV
+	gpGetnUniformivARB                               C.GPGETNUNIFORMIVARB
+	gpGetnUniformivKHR                               C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                            C.GPGETNUNIFORMUI64VARB
+	gpGetnUniformuiv                                 C.GPGETNUNIFORMUIV
+	gpGetnUniformuivARB                              C.GPGETNUNIFORMUIVARB
+	gpGetnUniformuivKHR                              C.GPGETNUNIFORMUIVKHR
+	gpHint                                           C.GPHINT
+	gpIndexFormatNV                                  C.GPINDEXFORMATNV
+	gpInsertEventMarkerEXT                           C.GPINSERTEVENTMARKEREXT
+	gpInterpolatePathsNV                             C.GPINTERPOLATEPATHSNV
+	gpInvalidateBufferData                           C.GPINVALIDATEBUFFERDATA
+	gpInvalidateBufferSubData                        C.GPINVALIDATEBUFFERSUBDATA
+	gpInvalidateFramebuffer                          C.GPINVALIDATEFRAMEBUFFER
+	gpInvalidateNamedFramebufferData                 C.GPINVALIDATENAMEDFRAMEBUFFERDATA
+	gpInvalidateNamedFramebufferSubData              C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
+	gpInvalidateSubFramebuffer                       C.GPINVALIDATESUBFRAMEBUFFER
+	gpInvalidateTexImage                             C.GPINVALIDATETEXIMAGE
+	gpInvalidateTexSubImage                          C.GPINVALIDATETEXSUBIMAGE
+	gpIsBuffer                                       C.GPISBUFFER
+	gpIsBufferResidentNV                             C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                C.GPISCOMMANDLISTNV
+	gpIsEnabled                                      C.GPISENABLED
+	gpIsEnabledIndexedEXT                            C.GPISENABLEDINDEXEDEXT
+	gpIsEnabledi                                     C.GPISENABLEDI
+	gpIsFramebuffer                                  C.GPISFRAMEBUFFER
+	gpIsImageHandleResidentARB                       C.GPISIMAGEHANDLERESIDENTARB
+	gpIsImageHandleResidentNV                        C.GPISIMAGEHANDLERESIDENTNV
+	gpIsNamedBufferResidentNV                        C.GPISNAMEDBUFFERRESIDENTNV
+	gpIsNamedStringARB                               C.GPISNAMEDSTRINGARB
+	gpIsPathNV                                       C.GPISPATHNV
+	gpIsPointInFillPathNV                            C.GPISPOINTINFILLPATHNV
+	gpIsPointInStrokePathNV                          C.GPISPOINTINSTROKEPATHNV
+	gpIsProgram                                      C.GPISPROGRAM
+	gpIsProgramPipeline                              C.GPISPROGRAMPIPELINE
+	gpIsProgramPipelineEXT                           C.GPISPROGRAMPIPELINEEXT
+	gpIsQuery                                        C.GPISQUERY
+	gpIsRenderbuffer                                 C.GPISRENDERBUFFER
+	gpIsSampler                                      C.GPISSAMPLER
+	gpIsShader                                       C.GPISSHADER
+	gpIsStateNV                                      C.GPISSTATENV
+	gpIsSync                                         C.GPISSYNC
+	gpIsTexture                                      C.GPISTEXTURE
+	gpIsTextureHandleResidentARB                     C.GPISTEXTUREHANDLERESIDENTARB
+	gpIsTextureHandleResidentNV                      C.GPISTEXTUREHANDLERESIDENTNV
+	gpIsTransformFeedback                            C.GPISTRANSFORMFEEDBACK
+	gpIsVertexArray                                  C.GPISVERTEXARRAY
+	gpLabelObjectEXT                                 C.GPLABELOBJECTEXT
+	gpLineWidth                                      C.GPLINEWIDTH
+	gpLinkProgram                                    C.GPLINKPROGRAM
+	gpListDrawCommandsStatesClientNV                 C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
+	gpLogicOp                                        C.GPLOGICOP
+	gpMakeBufferNonResidentNV                        C.GPMAKEBUFFERNONRESIDENTNV
+	gpMakeBufferResidentNV                           C.GPMAKEBUFFERRESIDENTNV
+	gpMakeImageHandleNonResidentARB                  C.GPMAKEIMAGEHANDLENONRESIDENTARB
+	gpMakeImageHandleNonResidentNV                   C.GPMAKEIMAGEHANDLENONRESIDENTNV
+	gpMakeImageHandleResidentARB                     C.GPMAKEIMAGEHANDLERESIDENTARB
+	gpMakeImageHandleResidentNV                      C.GPMAKEIMAGEHANDLERESIDENTNV
+	gpMakeNamedBufferNonResidentNV                   C.GPMAKENAMEDBUFFERNONRESIDENTNV
+	gpMakeNamedBufferResidentNV                      C.GPMAKENAMEDBUFFERRESIDENTNV
+	gpMakeTextureHandleNonResidentARB                C.GPMAKETEXTUREHANDLENONRESIDENTARB
+	gpMakeTextureHandleNonResidentNV                 C.GPMAKETEXTUREHANDLENONRESIDENTNV
+	gpMakeTextureHandleResidentARB                   C.GPMAKETEXTUREHANDLERESIDENTARB
+	gpMakeTextureHandleResidentNV                    C.GPMAKETEXTUREHANDLERESIDENTNV
+	gpMapBuffer                                      C.GPMAPBUFFER
+	gpMapBufferRange                                 C.GPMAPBUFFERRANGE
+	gpMapNamedBuffer                                 C.GPMAPNAMEDBUFFER
+	gpMapNamedBufferEXT                              C.GPMAPNAMEDBUFFEREXT
+	gpMapNamedBufferRange                            C.GPMAPNAMEDBUFFERRANGE
+	gpMapNamedBufferRangeEXT                         C.GPMAPNAMEDBUFFERRANGEEXT
+	gpMatrixFrustumEXT                               C.GPMATRIXFRUSTUMEXT
+	gpMatrixLoad3x2fNV                               C.GPMATRIXLOAD3X2FNV
+	gpMatrixLoad3x3fNV                               C.GPMATRIXLOAD3X3FNV
+	gpMatrixLoadIdentityEXT                          C.GPMATRIXLOADIDENTITYEXT
+	gpMatrixLoadTranspose3x3fNV                      C.GPMATRIXLOADTRANSPOSE3X3FNV
+	gpMatrixLoadTransposedEXT                        C.GPMATRIXLOADTRANSPOSEDEXT
+	gpMatrixLoadTransposefEXT                        C.GPMATRIXLOADTRANSPOSEFEXT
+	gpMatrixLoaddEXT                                 C.GPMATRIXLOADDEXT
+	gpMatrixLoadfEXT                                 C.GPMATRIXLOADFEXT
+	gpMatrixMult3x2fNV                               C.GPMATRIXMULT3X2FNV
+	gpMatrixMult3x3fNV                               C.GPMATRIXMULT3X3FNV
+	gpMatrixMultTranspose3x3fNV                      C.GPMATRIXMULTTRANSPOSE3X3FNV
+	gpMatrixMultTransposedEXT                        C.GPMATRIXMULTTRANSPOSEDEXT
+	gpMatrixMultTransposefEXT                        C.GPMATRIXMULTTRANSPOSEFEXT
+	gpMatrixMultdEXT                                 C.GPMATRIXMULTDEXT
+	gpMatrixMultfEXT                                 C.GPMATRIXMULTFEXT
+	gpMatrixOrthoEXT                                 C.GPMATRIXORTHOEXT
+	gpMatrixPopEXT                                   C.GPMATRIXPOPEXT
+	gpMatrixPushEXT                                  C.GPMATRIXPUSHEXT
+	gpMatrixRotatedEXT                               C.GPMATRIXROTATEDEXT
+	gpMatrixRotatefEXT                               C.GPMATRIXROTATEFEXT
+	gpMatrixScaledEXT                                C.GPMATRIXSCALEDEXT
+	gpMatrixScalefEXT                                C.GPMATRIXSCALEFEXT
+	gpMatrixTranslatedEXT                            C.GPMATRIXTRANSLATEDEXT
+	gpMatrixTranslatefEXT                            C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                    C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                    C.GPMAXSHADERCOMPILERTHREADSKHR
+	gpMemoryBarrier                                  C.GPMEMORYBARRIER
+	gpMemoryBarrierByRegion                          C.GPMEMORYBARRIERBYREGION
+	gpMinSampleShading                               C.GPMINSAMPLESHADING
+	gpMinSampleShadingARB                            C.GPMINSAMPLESHADINGARB
+	gpMultiDrawArrays                                C.GPMULTIDRAWARRAYS
+	gpMultiDrawArraysIndirect                        C.GPMULTIDRAWARRAYSINDIRECT
+	gpMultiDrawArraysIndirectBindlessCountNV         C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawArraysIndirectBindlessNV              C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV
+	gpMultiDrawArraysIndirectCountARB                C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
+	gpMultiDrawElements                              C.GPMULTIDRAWELEMENTS
+	gpMultiDrawElementsBaseVertex                    C.GPMULTIDRAWELEMENTSBASEVERTEX
+	gpMultiDrawElementsIndirect                      C.GPMULTIDRAWELEMENTSINDIRECT
+	gpMultiDrawElementsIndirectBindlessCountNV       C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawElementsIndirectBindlessNV            C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV
+	gpMultiDrawElementsIndirectCountARB              C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
+	gpMultiTexBufferEXT                              C.GPMULTITEXBUFFEREXT
+	gpMultiTexCoordPointerEXT                        C.GPMULTITEXCOORDPOINTEREXT
+	gpMultiTexEnvfEXT                                C.GPMULTITEXENVFEXT
+	gpMultiTexEnvfvEXT                               C.GPMULTITEXENVFVEXT
+	gpMultiTexEnviEXT                                C.GPMULTITEXENVIEXT
+	gpMultiTexEnvivEXT                               C.GPMULTITEXENVIVEXT
+	gpMultiTexGendEXT                                C.GPMULTITEXGENDEXT
+	gpMultiTexGendvEXT                               C.GPMULTITEXGENDVEXT
+	gpMultiTexGenfEXT                                C.GPMULTITEXGENFEXT
+	gpMultiTexGenfvEXT                               C.GPMULTITEXGENFVEXT
+	gpMultiTexGeniEXT                                C.GPMULTITEXGENIEXT
+	gpMultiTexGenivEXT                               C.GPMULTITEXGENIVEXT
+	gpMultiTexImage1DEXT                             C.GPMULTITEXIMAGE1DEXT
+	gpMultiTexImage2DEXT                             C.GPMULTITEXIMAGE2DEXT
+	gpMultiTexImage3DEXT                             C.GPMULTITEXIMAGE3DEXT
+	gpMultiTexParameterIivEXT                        C.GPMULTITEXPARAMETERIIVEXT
+	gpMultiTexParameterIuivEXT                       C.GPMULTITEXPARAMETERIUIVEXT
+	gpMultiTexParameterfEXT                          C.GPMULTITEXPARAMETERFEXT
+	gpMultiTexParameterfvEXT                         C.GPMULTITEXPARAMETERFVEXT
+	gpMultiTexParameteriEXT                          C.GPMULTITEXPARAMETERIEXT
+	gpMultiTexParameterivEXT                         C.GPMULTITEXPARAMETERIVEXT
+	gpMultiTexRenderbufferEXT                        C.GPMULTITEXRENDERBUFFEREXT
+	gpMultiTexSubImage1DEXT                          C.GPMULTITEXSUBIMAGE1DEXT
+	gpMultiTexSubImage2DEXT                          C.GPMULTITEXSUBIMAGE2DEXT
+	gpMultiTexSubImage3DEXT                          C.GPMULTITEXSUBIMAGE3DEXT
+	gpNamedBufferData                                C.GPNAMEDBUFFERDATA
+	gpNamedBufferDataEXT                             C.GPNAMEDBUFFERDATAEXT
+	gpNamedBufferPageCommitmentARB                   C.GPNAMEDBUFFERPAGECOMMITMENTARB
+	gpNamedBufferPageCommitmentEXT                   C.GPNAMEDBUFFERPAGECOMMITMENTEXT
+	gpNamedBufferStorage                             C.GPNAMEDBUFFERSTORAGE
+	gpNamedBufferStorageEXT                          C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferSubData                             C.GPNAMEDBUFFERSUBDATA
+	gpNamedBufferSubDataEXT                          C.GPNAMEDBUFFERSUBDATAEXT
+	gpNamedCopyBufferSubDataEXT                      C.GPNAMEDCOPYBUFFERSUBDATAEXT
+	gpNamedFramebufferDrawBuffer                     C.GPNAMEDFRAMEBUFFERDRAWBUFFER
+	gpNamedFramebufferDrawBuffers                    C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
+	gpNamedFramebufferParameteri                     C.GPNAMEDFRAMEBUFFERPARAMETERI
+	gpNamedFramebufferParameteriEXT                  C.GPNAMEDFRAMEBUFFERPARAMETERIEXT
+	gpNamedFramebufferReadBuffer                     C.GPNAMEDFRAMEBUFFERREADBUFFER
+	gpNamedFramebufferRenderbuffer                   C.GPNAMEDFRAMEBUFFERRENDERBUFFER
+	gpNamedFramebufferRenderbufferEXT                C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB           C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV            C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferTexture                        C.GPNAMEDFRAMEBUFFERTEXTURE
+	gpNamedFramebufferTexture1DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
+	gpNamedFramebufferTexture2DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
+	gpNamedFramebufferTexture3DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT
+	gpNamedFramebufferTextureEXT                     C.GPNAMEDFRAMEBUFFERTEXTUREEXT
+	gpNamedFramebufferTextureFaceEXT                 C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT
+	gpNamedFramebufferTextureLayer                   C.GPNAMEDFRAMEBUFFERTEXTURELAYER
+	gpNamedFramebufferTextureLayerEXT                C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT
+	gpNamedProgramLocalParameter4dEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT
+	gpNamedProgramLocalParameter4dvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT
+	gpNamedProgramLocalParameter4fEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT
+	gpNamedProgramLocalParameter4fvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT
+	gpNamedProgramLocalParameterI4iEXT               C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT
+	gpNamedProgramLocalParameterI4ivEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT
+	gpNamedProgramLocalParameterI4uiEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT
+	gpNamedProgramLocalParameterI4uivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT
+	gpNamedProgramLocalParameters4fvEXT              C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT
+	gpNamedProgramLocalParametersI4ivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT
+	gpNamedProgramLocalParametersI4uivEXT            C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT
+	gpNamedProgramStringEXT                          C.GPNAMEDPROGRAMSTRINGEXT
+	gpNamedRenderbufferStorage                       C.GPNAMEDRENDERBUFFERSTORAGE
+	gpNamedRenderbufferStorageEXT                    C.GPNAMEDRENDERBUFFERSTORAGEEXT
+	gpNamedRenderbufferStorageMultisample            C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
+	gpNamedRenderbufferStorageMultisampleCoverageEXT C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT
+	gpNamedRenderbufferStorageMultisampleEXT         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT
+	gpNamedStringARB                                 C.GPNAMEDSTRINGARB
+	gpNormalFormatNV                                 C.GPNORMALFORMATNV
+	gpObjectLabel                                    C.GPOBJECTLABEL
+	gpObjectLabelKHR                                 C.GPOBJECTLABELKHR
+	gpObjectPtrLabel                                 C.GPOBJECTPTRLABEL
+	gpObjectPtrLabelKHR                              C.GPOBJECTPTRLABELKHR
+	gpPatchParameterfv                               C.GPPATCHPARAMETERFV
+	gpPatchParameteri                                C.GPPATCHPARAMETERI
+	gpPathCommandsNV                                 C.GPPATHCOMMANDSNV
+	gpPathCoordsNV                                   C.GPPATHCOORDSNV
+	gpPathCoverDepthFuncNV                           C.GPPATHCOVERDEPTHFUNCNV
+	gpPathDashArrayNV                                C.GPPATHDASHARRAYNV
+	gpPathGlyphIndexArrayNV                          C.GPPATHGLYPHINDEXARRAYNV
+	gpPathGlyphIndexRangeNV                          C.GPPATHGLYPHINDEXRANGENV
+	gpPathGlyphRangeNV                               C.GPPATHGLYPHRANGENV
+	gpPathGlyphsNV                                   C.GPPATHGLYPHSNV
+	gpPathMemoryGlyphIndexArrayNV                    C.GPPATHMEMORYGLYPHINDEXARRAYNV
+	gpPathParameterfNV                               C.GPPATHPARAMETERFNV
+	gpPathParameterfvNV                              C.GPPATHPARAMETERFVNV
+	gpPathParameteriNV                               C.GPPATHPARAMETERINV
+	gpPathParameterivNV                              C.GPPATHPARAMETERIVNV
+	gpPathStencilDepthOffsetNV                       C.GPPATHSTENCILDEPTHOFFSETNV
+	gpPathStencilFuncNV                              C.GPPATHSTENCILFUNCNV
+	gpPathStringNV                                   C.GPPATHSTRINGNV
+	gpPathSubCommandsNV                              C.GPPATHSUBCOMMANDSNV
+	gpPathSubCoordsNV                                C.GPPATHSUBCOORDSNV
+	gpPauseTransformFeedback                         C.GPPAUSETRANSFORMFEEDBACK
+	gpPixelStoref                                    C.GPPIXELSTOREF
+	gpPixelStorei                                    C.GPPIXELSTOREI
+	gpPointAlongPathNV                               C.GPPOINTALONGPATHNV
+	gpPointParameterf                                C.GPPOINTPARAMETERF
+	gpPointParameterfv                               C.GPPOINTPARAMETERFV
+	gpPointParameteri                                C.GPPOINTPARAMETERI
+	gpPointParameteriv                               C.GPPOINTPARAMETERIV
+	gpPointSize                                      C.GPPOINTSIZE
+	gpPolygonMode                                    C.GPPOLYGONMODE
+	gpPolygonOffset                                  C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                             C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                          C.GPPOLYGONOFFSETCLAMPEXT
+	gpPopDebugGroup                                  C.GPPOPDEBUGGROUP
+	gpPopDebugGroupKHR                               C.GPPOPDEBUGGROUPKHR
+	gpPopGroupMarkerEXT                              C.GPPOPGROUPMARKEREXT
+	gpPrimitiveBoundingBoxARB                        C.GPPRIMITIVEBOUNDINGBOXARB
+	gpPrimitiveRestartIndex                          C.GPPRIMITIVERESTARTINDEX
+	gpProgramBinary                                  C.GPPROGRAMBINARY
+	gpProgramParameteri                              C.GPPROGRAMPARAMETERI
+	gpProgramParameteriARB                           C.GPPROGRAMPARAMETERIARB
+	gpProgramParameteriEXT                           C.GPPROGRAMPARAMETERIEXT
+	gpProgramPathFragmentInputGenNV                  C.GPPROGRAMPATHFRAGMENTINPUTGENNV
+	gpProgramUniform1d                               C.GPPROGRAMUNIFORM1D
+	gpProgramUniform1dEXT                            C.GPPROGRAMUNIFORM1DEXT
+	gpProgramUniform1dv                              C.GPPROGRAMUNIFORM1DV
+	gpProgramUniform1dvEXT                           C.GPPROGRAMUNIFORM1DVEXT
+	gpProgramUniform1f                               C.GPPROGRAMUNIFORM1F
+	gpProgramUniform1fEXT                            C.GPPROGRAMUNIFORM1FEXT
+	gpProgramUniform1fv                              C.GPPROGRAMUNIFORM1FV
+	gpProgramUniform1fvEXT                           C.GPPROGRAMUNIFORM1FVEXT
+	gpProgramUniform1i                               C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                          C.GPPROGRAMUNIFORM1I64ARB
+	gpProgramUniform1i64NV                           C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                         C.GPPROGRAMUNIFORM1I64VARB
+	gpProgramUniform1i64vNV                          C.GPPROGRAMUNIFORM1I64VNV
+	gpProgramUniform1iEXT                            C.GPPROGRAMUNIFORM1IEXT
+	gpProgramUniform1iv                              C.GPPROGRAMUNIFORM1IV
+	gpProgramUniform1ivEXT                           C.GPPROGRAMUNIFORM1IVEXT
+	gpProgramUniform1ui                              C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                         C.GPPROGRAMUNIFORM1UI64ARB
+	gpProgramUniform1ui64NV                          C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                        C.GPPROGRAMUNIFORM1UI64VARB
+	gpProgramUniform1ui64vNV                         C.GPPROGRAMUNIFORM1UI64VNV
+	gpProgramUniform1uiEXT                           C.GPPROGRAMUNIFORM1UIEXT
+	gpProgramUniform1uiv                             C.GPPROGRAMUNIFORM1UIV
+	gpProgramUniform1uivEXT                          C.GPPROGRAMUNIFORM1UIVEXT
+	gpProgramUniform2d                               C.GPPROGRAMUNIFORM2D
+	gpProgramUniform2dEXT                            C.GPPROGRAMUNIFORM2DEXT
+	gpProgramUniform2dv                              C.GPPROGRAMUNIFORM2DV
+	gpProgramUniform2dvEXT                           C.GPPROGRAMUNIFORM2DVEXT
+	gpProgramUniform2f                               C.GPPROGRAMUNIFORM2F
+	gpProgramUniform2fEXT                            C.GPPROGRAMUNIFORM2FEXT
+	gpProgramUniform2fv                              C.GPPROGRAMUNIFORM2FV
+	gpProgramUniform2fvEXT                           C.GPPROGRAMUNIFORM2FVEXT
+	gpProgramUniform2i                               C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                          C.GPPROGRAMUNIFORM2I64ARB
+	gpProgramUniform2i64NV                           C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                         C.GPPROGRAMUNIFORM2I64VARB
+	gpProgramUniform2i64vNV                          C.GPPROGRAMUNIFORM2I64VNV
+	gpProgramUniform2iEXT                            C.GPPROGRAMUNIFORM2IEXT
+	gpProgramUniform2iv                              C.GPPROGRAMUNIFORM2IV
+	gpProgramUniform2ivEXT                           C.GPPROGRAMUNIFORM2IVEXT
+	gpProgramUniform2ui                              C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                         C.GPPROGRAMUNIFORM2UI64ARB
+	gpProgramUniform2ui64NV                          C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                        C.GPPROGRAMUNIFORM2UI64VARB
+	gpProgramUniform2ui64vNV                         C.GPPROGRAMUNIFORM2UI64VNV
+	gpProgramUniform2uiEXT                           C.GPPROGRAMUNIFORM2UIEXT
+	gpProgramUniform2uiv                             C.GPPROGRAMUNIFORM2UIV
+	gpProgramUniform2uivEXT                          C.GPPROGRAMUNIFORM2UIVEXT
+	gpProgramUniform3d                               C.GPPROGRAMUNIFORM3D
+	gpProgramUniform3dEXT                            C.GPPROGRAMUNIFORM3DEXT
+	gpProgramUniform3dv                              C.GPPROGRAMUNIFORM3DV
+	gpProgramUniform3dvEXT                           C.GPPROGRAMUNIFORM3DVEXT
+	gpProgramUniform3f                               C.GPPROGRAMUNIFORM3F
+	gpProgramUniform3fEXT                            C.GPPROGRAMUNIFORM3FEXT
+	gpProgramUniform3fv                              C.GPPROGRAMUNIFORM3FV
+	gpProgramUniform3fvEXT                           C.GPPROGRAMUNIFORM3FVEXT
+	gpProgramUniform3i                               C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                          C.GPPROGRAMUNIFORM3I64ARB
+	gpProgramUniform3i64NV                           C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                         C.GPPROGRAMUNIFORM3I64VARB
+	gpProgramUniform3i64vNV                          C.GPPROGRAMUNIFORM3I64VNV
+	gpProgramUniform3iEXT                            C.GPPROGRAMUNIFORM3IEXT
+	gpProgramUniform3iv                              C.GPPROGRAMUNIFORM3IV
+	gpProgramUniform3ivEXT                           C.GPPROGRAMUNIFORM3IVEXT
+	gpProgramUniform3ui                              C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                         C.GPPROGRAMUNIFORM3UI64ARB
+	gpProgramUniform3ui64NV                          C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                        C.GPPROGRAMUNIFORM3UI64VARB
+	gpProgramUniform3ui64vNV                         C.GPPROGRAMUNIFORM3UI64VNV
+	gpProgramUniform3uiEXT                           C.GPPROGRAMUNIFORM3UIEXT
+	gpProgramUniform3uiv                             C.GPPROGRAMUNIFORM3UIV
+	gpProgramUniform3uivEXT                          C.GPPROGRAMUNIFORM3UIVEXT
+	gpProgramUniform4d                               C.GPPROGRAMUNIFORM4D
+	gpProgramUniform4dEXT                            C.GPPROGRAMUNIFORM4DEXT
+	gpProgramUniform4dv                              C.GPPROGRAMUNIFORM4DV
+	gpProgramUniform4dvEXT                           C.GPPROGRAMUNIFORM4DVEXT
+	gpProgramUniform4f                               C.GPPROGRAMUNIFORM4F
+	gpProgramUniform4fEXT                            C.GPPROGRAMUNIFORM4FEXT
+	gpProgramUniform4fv                              C.GPPROGRAMUNIFORM4FV
+	gpProgramUniform4fvEXT                           C.GPPROGRAMUNIFORM4FVEXT
+	gpProgramUniform4i                               C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                          C.GPPROGRAMUNIFORM4I64ARB
+	gpProgramUniform4i64NV                           C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                         C.GPPROGRAMUNIFORM4I64VARB
+	gpProgramUniform4i64vNV                          C.GPPROGRAMUNIFORM4I64VNV
+	gpProgramUniform4iEXT                            C.GPPROGRAMUNIFORM4IEXT
+	gpProgramUniform4iv                              C.GPPROGRAMUNIFORM4IV
+	gpProgramUniform4ivEXT                           C.GPPROGRAMUNIFORM4IVEXT
+	gpProgramUniform4ui                              C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                         C.GPPROGRAMUNIFORM4UI64ARB
+	gpProgramUniform4ui64NV                          C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                        C.GPPROGRAMUNIFORM4UI64VARB
+	gpProgramUniform4ui64vNV                         C.GPPROGRAMUNIFORM4UI64VNV
+	gpProgramUniform4uiEXT                           C.GPPROGRAMUNIFORM4UIEXT
+	gpProgramUniform4uiv                             C.GPPROGRAMUNIFORM4UIV
+	gpProgramUniform4uivEXT                          C.GPPROGRAMUNIFORM4UIVEXT
+	gpProgramUniformHandleui64ARB                    C.GPPROGRAMUNIFORMHANDLEUI64ARB
+	gpProgramUniformHandleui64NV                     C.GPPROGRAMUNIFORMHANDLEUI64NV
+	gpProgramUniformHandleui64vARB                   C.GPPROGRAMUNIFORMHANDLEUI64VARB
+	gpProgramUniformHandleui64vNV                    C.GPPROGRAMUNIFORMHANDLEUI64VNV
+	gpProgramUniformMatrix2dv                        C.GPPROGRAMUNIFORMMATRIX2DV
+	gpProgramUniformMatrix2dvEXT                     C.GPPROGRAMUNIFORMMATRIX2DVEXT
+	gpProgramUniformMatrix2fv                        C.GPPROGRAMUNIFORMMATRIX2FV
+	gpProgramUniformMatrix2fvEXT                     C.GPPROGRAMUNIFORMMATRIX2FVEXT
+	gpProgramUniformMatrix2x3dv                      C.GPPROGRAMUNIFORMMATRIX2X3DV
+	gpProgramUniformMatrix2x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3DVEXT
+	gpProgramUniformMatrix2x3fv                      C.GPPROGRAMUNIFORMMATRIX2X3FV
+	gpProgramUniformMatrix2x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3FVEXT
+	gpProgramUniformMatrix2x4dv                      C.GPPROGRAMUNIFORMMATRIX2X4DV
+	gpProgramUniformMatrix2x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4DVEXT
+	gpProgramUniformMatrix2x4fv                      C.GPPROGRAMUNIFORMMATRIX2X4FV
+	gpProgramUniformMatrix2x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4FVEXT
+	gpProgramUniformMatrix3dv                        C.GPPROGRAMUNIFORMMATRIX3DV
+	gpProgramUniformMatrix3dvEXT                     C.GPPROGRAMUNIFORMMATRIX3DVEXT
+	gpProgramUniformMatrix3fv                        C.GPPROGRAMUNIFORMMATRIX3FV
+	gpProgramUniformMatrix3fvEXT                     C.GPPROGRAMUNIFORMMATRIX3FVEXT
+	gpProgramUniformMatrix3x2dv                      C.GPPROGRAMUNIFORMMATRIX3X2DV
+	gpProgramUniformMatrix3x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2DVEXT
+	gpProgramUniformMatrix3x2fv                      C.GPPROGRAMUNIFORMMATRIX3X2FV
+	gpProgramUniformMatrix3x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2FVEXT
+	gpProgramUniformMatrix3x4dv                      C.GPPROGRAMUNIFORMMATRIX3X4DV
+	gpProgramUniformMatrix3x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4DVEXT
+	gpProgramUniformMatrix3x4fv                      C.GPPROGRAMUNIFORMMATRIX3X4FV
+	gpProgramUniformMatrix3x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4FVEXT
+	gpProgramUniformMatrix4dv                        C.GPPROGRAMUNIFORMMATRIX4DV
+	gpProgramUniformMatrix4dvEXT                     C.GPPROGRAMUNIFORMMATRIX4DVEXT
+	gpProgramUniformMatrix4fv                        C.GPPROGRAMUNIFORMMATRIX4FV
+	gpProgramUniformMatrix4fvEXT                     C.GPPROGRAMUNIFORMMATRIX4FVEXT
+	gpProgramUniformMatrix4x2dv                      C.GPPROGRAMUNIFORMMATRIX4X2DV
+	gpProgramUniformMatrix4x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2DVEXT
+	gpProgramUniformMatrix4x2fv                      C.GPPROGRAMUNIFORMMATRIX4X2FV
+	gpProgramUniformMatrix4x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2FVEXT
+	gpProgramUniformMatrix4x3dv                      C.GPPROGRAMUNIFORMMATRIX4X3DV
+	gpProgramUniformMatrix4x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3DVEXT
+	gpProgramUniformMatrix4x3fv                      C.GPPROGRAMUNIFORMMATRIX4X3FV
+	gpProgramUniformMatrix4x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3FVEXT
+	gpProgramUniformui64NV                           C.GPPROGRAMUNIFORMUI64NV
+	gpProgramUniformui64vNV                          C.GPPROGRAMUNIFORMUI64VNV
+	gpProvokingVertex                                C.GPPROVOKINGVERTEX
+	gpPushClientAttribDefaultEXT                     C.GPPUSHCLIENTATTRIBDEFAULTEXT
+	gpPushDebugGroup                                 C.GPPUSHDEBUGGROUP
+	gpPushDebugGroupKHR                              C.GPPUSHDEBUGGROUPKHR
+	gpPushGroupMarkerEXT                             C.GPPUSHGROUPMARKEREXT
+	gpQueryCounter                                   C.GPQUERYCOUNTER
+	gpRasterSamplesEXT                               C.GPRASTERSAMPLESEXT
+	gpReadBuffer                                     C.GPREADBUFFER
+	gpReadPixels                                     C.GPREADPIXELS
+	gpReadnPixels                                    C.GPREADNPIXELS
+	gpReadnPixelsARB                                 C.GPREADNPIXELSARB
+	gpReadnPixelsKHR                                 C.GPREADNPIXELSKHR
+	gpReleaseShaderCompiler                          C.GPRELEASESHADERCOMPILER
+	gpRenderbufferStorage                            C.GPRENDERBUFFERSTORAGE
+	gpRenderbufferStorageMultisample                 C.GPRENDERBUFFERSTORAGEMULTISAMPLE
+	gpRenderbufferStorageMultisampleCoverageNV       C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV
+	gpResolveDepthValuesNV                           C.GPRESOLVEDEPTHVALUESNV
+	gpResumeTransformFeedback                        C.GPRESUMETRANSFORMFEEDBACK
+	gpSampleCoverage                                 C.GPSAMPLECOVERAGE
+	gpSampleMaski                                    C.GPSAMPLEMASKI
+	gpSamplerParameterIiv                            C.GPSAMPLERPARAMETERIIV
+	gpSamplerParameterIuiv                           C.GPSAMPLERPARAMETERIUIV
+	gpSamplerParameterf                              C.GPSAMPLERPARAMETERF
+	gpSamplerParameterfv                             C.GPSAMPLERPARAMETERFV
+	gpSamplerParameteri                              C.GPSAMPLERPARAMETERI
+	gpSamplerParameteriv                             C.GPSAMPLERPARAMETERIV
+	gpScissor                                        C.GPSCISSOR
+	gpScissorArrayv                                  C.GPSCISSORARRAYV
+	gpScissorIndexed                                 C.GPSCISSORINDEXED
+	gpScissorIndexedv                                C.GPSCISSORINDEXEDV
+	gpSecondaryColorFormatNV                         C.GPSECONDARYCOLORFORMATNV
+	gpSelectPerfMonitorCountersAMD                   C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpShaderBinary                                   C.GPSHADERBINARY
+	gpShaderSource                                   C.GPSHADERSOURCE
+	gpShaderStorageBlockBinding                      C.GPSHADERSTORAGEBLOCKBINDING
+	gpSignalVkFenceNV                                C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                            C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                            C.GPSPECIALIZESHADERARB
+	gpStateCaptureNV                                 C.GPSTATECAPTURENV
+	gpStencilFillPathInstancedNV                     C.GPSTENCILFILLPATHINSTANCEDNV
+	gpStencilFillPathNV                              C.GPSTENCILFILLPATHNV
+	gpStencilFunc                                    C.GPSTENCILFUNC
+	gpStencilFuncSeparate                            C.GPSTENCILFUNCSEPARATE
+	gpStencilMask                                    C.GPSTENCILMASK
+	gpStencilMaskSeparate                            C.GPSTENCILMASKSEPARATE
+	gpStencilOp                                      C.GPSTENCILOP
+	gpStencilOpSeparate                              C.GPSTENCILOPSEPARATE
+	gpStencilStrokePathInstancedNV                   C.GPSTENCILSTROKEPATHINSTANCEDNV
+	gpStencilStrokePathNV                            C.GPSTENCILSTROKEPATHNV
+	gpStencilThenCoverFillPathInstancedNV            C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV
+	gpStencilThenCoverFillPathNV                     C.GPSTENCILTHENCOVERFILLPATHNV
+	gpStencilThenCoverStrokePathInstancedNV          C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV
+	gpStencilThenCoverStrokePathNV                   C.GPSTENCILTHENCOVERSTROKEPATHNV
+	gpSubpixelPrecisionBiasNV                        C.GPSUBPIXELPRECISIONBIASNV
+	gpTexBuffer                                      C.GPTEXBUFFER
+	gpTexBufferARB                                   C.GPTEXBUFFERARB
+	gpTexBufferRange                                 C.GPTEXBUFFERRANGE
+	gpTexCoordFormatNV                               C.GPTEXCOORDFORMATNV
+	gpTexImage1D                                     C.GPTEXIMAGE1D
+	gpTexImage2D                                     C.GPTEXIMAGE2D
+	gpTexImage2DMultisample                          C.GPTEXIMAGE2DMULTISAMPLE
+	gpTexImage3D                                     C.GPTEXIMAGE3D
+	gpTexImage3DMultisample                          C.GPTEXIMAGE3DMULTISAMPLE
+	gpTexPageCommitmentARB                           C.GPTEXPAGECOMMITMENTARB
+	gpTexParameterIiv                                C.GPTEXPARAMETERIIV
+	gpTexParameterIuiv                               C.GPTEXPARAMETERIUIV
+	gpTexParameterf                                  C.GPTEXPARAMETERF
+	gpTexParameterfv                                 C.GPTEXPARAMETERFV
+	gpTexParameteri                                  C.GPTEXPARAMETERI
+	gpTexParameteriv                                 C.GPTEXPARAMETERIV
+	gpTexStorage1D                                   C.GPTEXSTORAGE1D
+	gpTexStorage2D                                   C.GPTEXSTORAGE2D
+	gpTexStorage2DMultisample                        C.GPTEXSTORAGE2DMULTISAMPLE
+	gpTexStorage3D                                   C.GPTEXSTORAGE3D
+	gpTexStorage3DMultisample                        C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexSubImage1D                                  C.GPTEXSUBIMAGE1D
+	gpTexSubImage2D                                  C.GPTEXSUBIMAGE2D
+	gpTexSubImage3D                                  C.GPTEXSUBIMAGE3D
+	gpTextureBarrier                                 C.GPTEXTUREBARRIER
+	gpTextureBarrierNV                               C.GPTEXTUREBARRIERNV
+	gpTextureBuffer                                  C.GPTEXTUREBUFFER
+	gpTextureBufferEXT                               C.GPTEXTUREBUFFEREXT
+	gpTextureBufferRange                             C.GPTEXTUREBUFFERRANGE
+	gpTextureBufferRangeEXT                          C.GPTEXTUREBUFFERRANGEEXT
+	gpTextureImage1DEXT                              C.GPTEXTUREIMAGE1DEXT
+	gpTextureImage2DEXT                              C.GPTEXTUREIMAGE2DEXT
+	gpTextureImage3DEXT                              C.GPTEXTUREIMAGE3DEXT
+	gpTexturePageCommitmentEXT                       C.GPTEXTUREPAGECOMMITMENTEXT
+	gpTextureParameterIiv                            C.GPTEXTUREPARAMETERIIV
+	gpTextureParameterIivEXT                         C.GPTEXTUREPARAMETERIIVEXT
+	gpTextureParameterIuiv                           C.GPTEXTUREPARAMETERIUIV
+	gpTextureParameterIuivEXT                        C.GPTEXTUREPARAMETERIUIVEXT
+	gpTextureParameterf                              C.GPTEXTUREPARAMETERF
+	gpTextureParameterfEXT                           C.GPTEXTUREPARAMETERFEXT
+	gpTextureParameterfv                             C.GPTEXTUREPARAMETERFV
+	gpTextureParameterfvEXT                          C.GPTEXTUREPARAMETERFVEXT
+	gpTextureParameteri                              C.GPTEXTUREPARAMETERI
+	gpTextureParameteriEXT                           C.GPTEXTUREPARAMETERIEXT
+	gpTextureParameteriv                             C.GPTEXTUREPARAMETERIV
+	gpTextureParameterivEXT                          C.GPTEXTUREPARAMETERIVEXT
+	gpTextureRenderbufferEXT                         C.GPTEXTURERENDERBUFFEREXT
+	gpTextureStorage1D                               C.GPTEXTURESTORAGE1D
+	gpTextureStorage1DEXT                            C.GPTEXTURESTORAGE1DEXT
+	gpTextureStorage2D                               C.GPTEXTURESTORAGE2D
+	gpTextureStorage2DEXT                            C.GPTEXTURESTORAGE2DEXT
+	gpTextureStorage2DMultisample                    C.GPTEXTURESTORAGE2DMULTISAMPLE
+	gpTextureStorage2DMultisampleEXT                 C.GPTEXTURESTORAGE2DMULTISAMPLEEXT
+	gpTextureStorage3D                               C.GPTEXTURESTORAGE3D
+	gpTextureStorage3DEXT                            C.GPTEXTURESTORAGE3DEXT
+	gpTextureStorage3DMultisample                    C.GPTEXTURESTORAGE3DMULTISAMPLE
+	gpTextureStorage3DMultisampleEXT                 C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureSubImage1D                              C.GPTEXTURESUBIMAGE1D
+	gpTextureSubImage1DEXT                           C.GPTEXTURESUBIMAGE1DEXT
+	gpTextureSubImage2D                              C.GPTEXTURESUBIMAGE2D
+	gpTextureSubImage2DEXT                           C.GPTEXTURESUBIMAGE2DEXT
+	gpTextureSubImage3D                              C.GPTEXTURESUBIMAGE3D
+	gpTextureSubImage3DEXT                           C.GPTEXTURESUBIMAGE3DEXT
+	gpTextureView                                    C.GPTEXTUREVIEW
+	gpTransformFeedbackBufferBase                    C.GPTRANSFORMFEEDBACKBUFFERBASE
+	gpTransformFeedbackBufferRange                   C.GPTRANSFORMFEEDBACKBUFFERRANGE
+	gpTransformFeedbackVaryings                      C.GPTRANSFORMFEEDBACKVARYINGS
+	gpTransformPathNV                                C.GPTRANSFORMPATHNV
+	gpUniform1d                                      C.GPUNIFORM1D
+	gpUniform1dv                                     C.GPUNIFORM1DV
+	gpUniform1f                                      C.GPUNIFORM1F
+	gpUniform1fv                                     C.GPUNIFORM1FV
+	gpUniform1i                                      C.GPUNIFORM1I
+	gpUniform1i64ARB                                 C.GPUNIFORM1I64ARB
+	gpUniform1i64NV                                  C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                C.GPUNIFORM1I64VARB
+	gpUniform1i64vNV                                 C.GPUNIFORM1I64VNV
+	gpUniform1iv                                     C.GPUNIFORM1IV
+	gpUniform1ui                                     C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                C.GPUNIFORM1UI64ARB
+	gpUniform1ui64NV                                 C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                               C.GPUNIFORM1UI64VARB
+	gpUniform1ui64vNV                                C.GPUNIFORM1UI64VNV
+	gpUniform1uiv                                    C.GPUNIFORM1UIV
+	gpUniform2d                                      C.GPUNIFORM2D
+	gpUniform2dv                                     C.GPUNIFORM2DV
+	gpUniform2f                                      C.GPUNIFORM2F
+	gpUniform2fv                                     C.GPUNIFORM2FV
+	gpUniform2i                                      C.GPUNIFORM2I
+	gpUniform2i64ARB                                 C.GPUNIFORM2I64ARB
+	gpUniform2i64NV                                  C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                C.GPUNIFORM2I64VARB
+	gpUniform2i64vNV                                 C.GPUNIFORM2I64VNV
+	gpUniform2iv                                     C.GPUNIFORM2IV
+	gpUniform2ui                                     C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                C.GPUNIFORM2UI64ARB
+	gpUniform2ui64NV                                 C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                               C.GPUNIFORM2UI64VARB
+	gpUniform2ui64vNV                                C.GPUNIFORM2UI64VNV
+	gpUniform2uiv                                    C.GPUNIFORM2UIV
+	gpUniform3d                                      C.GPUNIFORM3D
+	gpUniform3dv                                     C.GPUNIFORM3DV
+	gpUniform3f                                      C.GPUNIFORM3F
+	gpUniform3fv                                     C.GPUNIFORM3FV
+	gpUniform3i                                      C.GPUNIFORM3I
+	gpUniform3i64ARB                                 C.GPUNIFORM3I64ARB
+	gpUniform3i64NV                                  C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                C.GPUNIFORM3I64VARB
+	gpUniform3i64vNV                                 C.GPUNIFORM3I64VNV
+	gpUniform3iv                                     C.GPUNIFORM3IV
+	gpUniform3ui                                     C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                C.GPUNIFORM3UI64ARB
+	gpUniform3ui64NV                                 C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                               C.GPUNIFORM3UI64VARB
+	gpUniform3ui64vNV                                C.GPUNIFORM3UI64VNV
+	gpUniform3uiv                                    C.GPUNIFORM3UIV
+	gpUniform4d                                      C.GPUNIFORM4D
+	gpUniform4dv                                     C.GPUNIFORM4DV
+	gpUniform4f                                      C.GPUNIFORM4F
+	gpUniform4fv                                     C.GPUNIFORM4FV
+	gpUniform4i                                      C.GPUNIFORM4I
+	gpUniform4i64ARB                                 C.GPUNIFORM4I64ARB
+	gpUniform4i64NV                                  C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                C.GPUNIFORM4I64VARB
+	gpUniform4i64vNV                                 C.GPUNIFORM4I64VNV
+	gpUniform4iv                                     C.GPUNIFORM4IV
+	gpUniform4ui                                     C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                C.GPUNIFORM4UI64ARB
+	gpUniform4ui64NV                                 C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                               C.GPUNIFORM4UI64VARB
+	gpUniform4ui64vNV                                C.GPUNIFORM4UI64VNV
+	gpUniform4uiv                                    C.GPUNIFORM4UIV
+	gpUniformBlockBinding                            C.GPUNIFORMBLOCKBINDING
+	gpUniformHandleui64ARB                           C.GPUNIFORMHANDLEUI64ARB
+	gpUniformHandleui64NV                            C.GPUNIFORMHANDLEUI64NV
+	gpUniformHandleui64vARB                          C.GPUNIFORMHANDLEUI64VARB
+	gpUniformHandleui64vNV                           C.GPUNIFORMHANDLEUI64VNV
+	gpUniformMatrix2dv                               C.GPUNIFORMMATRIX2DV
+	gpUniformMatrix2fv                               C.GPUNIFORMMATRIX2FV
+	gpUniformMatrix2x3dv                             C.GPUNIFORMMATRIX2X3DV
+	gpUniformMatrix2x3fv                             C.GPUNIFORMMATRIX2X3FV
+	gpUniformMatrix2x4dv                             C.GPUNIFORMMATRIX2X4DV
+	gpUniformMatrix2x4fv                             C.GPUNIFORMMATRIX2X4FV
+	gpUniformMatrix3dv                               C.GPUNIFORMMATRIX3DV
+	gpUniformMatrix3fv                               C.GPUNIFORMMATRIX3FV
+	gpUniformMatrix3x2dv                             C.GPUNIFORMMATRIX3X2DV
+	gpUniformMatrix3x2fv                             C.GPUNIFORMMATRIX3X2FV
+	gpUniformMatrix3x4dv                             C.GPUNIFORMMATRIX3X4DV
+	gpUniformMatrix3x4fv                             C.GPUNIFORMMATRIX3X4FV
+	gpUniformMatrix4dv                               C.GPUNIFORMMATRIX4DV
+	gpUniformMatrix4fv                               C.GPUNIFORMMATRIX4FV
+	gpUniformMatrix4x2dv                             C.GPUNIFORMMATRIX4X2DV
+	gpUniformMatrix4x2fv                             C.GPUNIFORMMATRIX4X2FV
+	gpUniformMatrix4x3dv                             C.GPUNIFORMMATRIX4X3DV
+	gpUniformMatrix4x3fv                             C.GPUNIFORMMATRIX4X3FV
+	gpUniformSubroutinesuiv                          C.GPUNIFORMSUBROUTINESUIV
+	gpUniformui64NV                                  C.GPUNIFORMUI64NV
+	gpUniformui64vNV                                 C.GPUNIFORMUI64VNV
+	gpUnmapBuffer                                    C.GPUNMAPBUFFER
+	gpUnmapNamedBuffer                               C.GPUNMAPNAMEDBUFFER
+	gpUnmapNamedBufferEXT                            C.GPUNMAPNAMEDBUFFEREXT
+	gpUseProgram                                     C.GPUSEPROGRAM
+	gpUseProgramStages                               C.GPUSEPROGRAMSTAGES
+	gpUseProgramStagesEXT                            C.GPUSEPROGRAMSTAGESEXT
+	gpUseShaderProgramEXT                            C.GPUSESHADERPROGRAMEXT
+	gpValidateProgram                                C.GPVALIDATEPROGRAM
+	gpValidateProgramPipeline                        C.GPVALIDATEPROGRAMPIPELINE
+	gpValidateProgramPipelineEXT                     C.GPVALIDATEPROGRAMPIPELINEEXT
+	gpVertexArrayAttribBinding                       C.GPVERTEXARRAYATTRIBBINDING
+	gpVertexArrayAttribFormat                        C.GPVERTEXARRAYATTRIBFORMAT
+	gpVertexArrayAttribIFormat                       C.GPVERTEXARRAYATTRIBIFORMAT
+	gpVertexArrayAttribLFormat                       C.GPVERTEXARRAYATTRIBLFORMAT
+	gpVertexArrayBindVertexBufferEXT                 C.GPVERTEXARRAYBINDVERTEXBUFFEREXT
+	gpVertexArrayBindingDivisor                      C.GPVERTEXARRAYBINDINGDIVISOR
+	gpVertexArrayColorOffsetEXT                      C.GPVERTEXARRAYCOLOROFFSETEXT
+	gpVertexArrayEdgeFlagOffsetEXT                   C.GPVERTEXARRAYEDGEFLAGOFFSETEXT
+	gpVertexArrayElementBuffer                       C.GPVERTEXARRAYELEMENTBUFFER
+	gpVertexArrayFogCoordOffsetEXT                   C.GPVERTEXARRAYFOGCOORDOFFSETEXT
+	gpVertexArrayIndexOffsetEXT                      C.GPVERTEXARRAYINDEXOFFSETEXT
+	gpVertexArrayMultiTexCoordOffsetEXT              C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT
+	gpVertexArrayNormalOffsetEXT                     C.GPVERTEXARRAYNORMALOFFSETEXT
+	gpVertexArraySecondaryColorOffsetEXT             C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT
+	gpVertexArrayTexCoordOffsetEXT                   C.GPVERTEXARRAYTEXCOORDOFFSETEXT
+	gpVertexArrayVertexAttribBindingEXT              C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT
+	gpVertexArrayVertexAttribDivisorEXT              C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT
+	gpVertexArrayVertexAttribFormatEXT               C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT
+	gpVertexArrayVertexAttribIFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT
+	gpVertexArrayVertexAttribIOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT
+	gpVertexArrayVertexAttribLFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT
+	gpVertexArrayVertexAttribLOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT
+	gpVertexArrayVertexAttribOffsetEXT               C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT
+	gpVertexArrayVertexBindingDivisorEXT             C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT
+	gpVertexArrayVertexBuffer                        C.GPVERTEXARRAYVERTEXBUFFER
+	gpVertexArrayVertexBuffers                       C.GPVERTEXARRAYVERTEXBUFFERS
+	gpVertexArrayVertexOffsetEXT                     C.GPVERTEXARRAYVERTEXOFFSETEXT
+	gpVertexAttrib1d                                 C.GPVERTEXATTRIB1D
+	gpVertexAttrib1dv                                C.GPVERTEXATTRIB1DV
+	gpVertexAttrib1f                                 C.GPVERTEXATTRIB1F
+	gpVertexAttrib1fv                                C.GPVERTEXATTRIB1FV
+	gpVertexAttrib1s                                 C.GPVERTEXATTRIB1S
+	gpVertexAttrib1sv                                C.GPVERTEXATTRIB1SV
+	gpVertexAttrib2d                                 C.GPVERTEXATTRIB2D
+	gpVertexAttrib2dv                                C.GPVERTEXATTRIB2DV
+	gpVertexAttrib2f                                 C.GPVERTEXATTRIB2F
+	gpVertexAttrib2fv                                C.GPVERTEXATTRIB2FV
+	gpVertexAttrib2s                                 C.GPVERTEXATTRIB2S
+	gpVertexAttrib2sv                                C.GPVERTEXATTRIB2SV
+	gpVertexAttrib3d                                 C.GPVERTEXATTRIB3D
+	gpVertexAttrib3dv                                C.GPVERTEXATTRIB3DV
+	gpVertexAttrib3f                                 C.GPVERTEXATTRIB3F
+	gpVertexAttrib3fv                                C.GPVERTEXATTRIB3FV
+	gpVertexAttrib3s                                 C.GPVERTEXATTRIB3S
+	gpVertexAttrib3sv                                C.GPVERTEXATTRIB3SV
+	gpVertexAttrib4Nbv                               C.GPVERTEXATTRIB4NBV
+	gpVertexAttrib4Niv                               C.GPVERTEXATTRIB4NIV
+	gpVertexAttrib4Nsv                               C.GPVERTEXATTRIB4NSV
+	gpVertexAttrib4Nub                               C.GPVERTEXATTRIB4NUB
+	gpVertexAttrib4Nubv                              C.GPVERTEXATTRIB4NUBV
+	gpVertexAttrib4Nuiv                              C.GPVERTEXATTRIB4NUIV
+	gpVertexAttrib4Nusv                              C.GPVERTEXATTRIB4NUSV
+	gpVertexAttrib4bv                                C.GPVERTEXATTRIB4BV
+	gpVertexAttrib4d                                 C.GPVERTEXATTRIB4D
+	gpVertexAttrib4dv                                C.GPVERTEXATTRIB4DV
+	gpVertexAttrib4f                                 C.GPVERTEXATTRIB4F
+	gpVertexAttrib4fv                                C.GPVERTEXATTRIB4FV
+	gpVertexAttrib4iv                                C.GPVERTEXATTRIB4IV
+	gpVertexAttrib4s                                 C.GPVERTEXATTRIB4S
+	gpVertexAttrib4sv                                C.GPVERTEXATTRIB4SV
+	gpVertexAttrib4ubv                               C.GPVERTEXATTRIB4UBV
+	gpVertexAttrib4uiv                               C.GPVERTEXATTRIB4UIV
+	gpVertexAttrib4usv                               C.GPVERTEXATTRIB4USV
+	gpVertexAttribBinding                            C.GPVERTEXATTRIBBINDING
+	gpVertexAttribDivisor                            C.GPVERTEXATTRIBDIVISOR
+	gpVertexAttribDivisorARB                         C.GPVERTEXATTRIBDIVISORARB
+	gpVertexAttribFormat                             C.GPVERTEXATTRIBFORMAT
+	gpVertexAttribFormatNV                           C.GPVERTEXATTRIBFORMATNV
+	gpVertexAttribI1i                                C.GPVERTEXATTRIBI1I
+	gpVertexAttribI1iv                               C.GPVERTEXATTRIBI1IV
+	gpVertexAttribI1ui                               C.GPVERTEXATTRIBI1UI
+	gpVertexAttribI1uiv                              C.GPVERTEXATTRIBI1UIV
+	gpVertexAttribI2i                                C.GPVERTEXATTRIBI2I
+	gpVertexAttribI2iv                               C.GPVERTEXATTRIBI2IV
+	gpVertexAttribI2ui                               C.GPVERTEXATTRIBI2UI
+	gpVertexAttribI2uiv                              C.GPVERTEXATTRIBI2UIV
+	gpVertexAttribI3i                                C.GPVERTEXATTRIBI3I
+	gpVertexAttribI3iv                               C.GPVERTEXATTRIBI3IV
+	gpVertexAttribI3ui                               C.GPVERTEXATTRIBI3UI
+	gpVertexAttribI3uiv                              C.GPVERTEXATTRIBI3UIV
+	gpVertexAttribI4bv                               C.GPVERTEXATTRIBI4BV
+	gpVertexAttribI4i                                C.GPVERTEXATTRIBI4I
+	gpVertexAttribI4iv                               C.GPVERTEXATTRIBI4IV
+	gpVertexAttribI4sv                               C.GPVERTEXATTRIBI4SV
+	gpVertexAttribI4ubv                              C.GPVERTEXATTRIBI4UBV
+	gpVertexAttribI4ui                               C.GPVERTEXATTRIBI4UI
+	gpVertexAttribI4uiv                              C.GPVERTEXATTRIBI4UIV
+	gpVertexAttribI4usv                              C.GPVERTEXATTRIBI4USV
+	gpVertexAttribIFormat                            C.GPVERTEXATTRIBIFORMAT
+	gpVertexAttribIFormatNV                          C.GPVERTEXATTRIBIFORMATNV
+	gpVertexAttribIPointer                           C.GPVERTEXATTRIBIPOINTER
+	gpVertexAttribL1d                                C.GPVERTEXATTRIBL1D
+	gpVertexAttribL1dv                               C.GPVERTEXATTRIBL1DV
+	gpVertexAttribL1i64NV                            C.GPVERTEXATTRIBL1I64NV
+	gpVertexAttribL1i64vNV                           C.GPVERTEXATTRIBL1I64VNV
+	gpVertexAttribL1ui64ARB                          C.GPVERTEXATTRIBL1UI64ARB
+	gpVertexAttribL1ui64NV                           C.GPVERTEXATTRIBL1UI64NV
+	gpVertexAttribL1ui64vARB                         C.GPVERTEXATTRIBL1UI64VARB
+	gpVertexAttribL1ui64vNV                          C.GPVERTEXATTRIBL1UI64VNV
+	gpVertexAttribL2d                                C.GPVERTEXATTRIBL2D
+	gpVertexAttribL2dv                               C.GPVERTEXATTRIBL2DV
+	gpVertexAttribL2i64NV                            C.GPVERTEXATTRIBL2I64NV
+	gpVertexAttribL2i64vNV                           C.GPVERTEXATTRIBL2I64VNV
+	gpVertexAttribL2ui64NV                           C.GPVERTEXATTRIBL2UI64NV
+	gpVertexAttribL2ui64vNV                          C.GPVERTEXATTRIBL2UI64VNV
+	gpVertexAttribL3d                                C.GPVERTEXATTRIBL3D
+	gpVertexAttribL3dv                               C.GPVERTEXATTRIBL3DV
+	gpVertexAttribL3i64NV                            C.GPVERTEXATTRIBL3I64NV
+	gpVertexAttribL3i64vNV                           C.GPVERTEXATTRIBL3I64VNV
+	gpVertexAttribL3ui64NV                           C.GPVERTEXATTRIBL3UI64NV
+	gpVertexAttribL3ui64vNV                          C.GPVERTEXATTRIBL3UI64VNV
+	gpVertexAttribL4d                                C.GPVERTEXATTRIBL4D
+	gpVertexAttribL4dv                               C.GPVERTEXATTRIBL4DV
+	gpVertexAttribL4i64NV                            C.GPVERTEXATTRIBL4I64NV
+	gpVertexAttribL4i64vNV                           C.GPVERTEXATTRIBL4I64VNV
+	gpVertexAttribL4ui64NV                           C.GPVERTEXATTRIBL4UI64NV
+	gpVertexAttribL4ui64vNV                          C.GPVERTEXATTRIBL4UI64VNV
+	gpVertexAttribLFormat                            C.GPVERTEXATTRIBLFORMAT
+	gpVertexAttribLFormatNV                          C.GPVERTEXATTRIBLFORMATNV
+	gpVertexAttribLPointer                           C.GPVERTEXATTRIBLPOINTER
+	gpVertexAttribP1ui                               C.GPVERTEXATTRIBP1UI
+	gpVertexAttribP1uiv                              C.GPVERTEXATTRIBP1UIV
+	gpVertexAttribP2ui                               C.GPVERTEXATTRIBP2UI
+	gpVertexAttribP2uiv                              C.GPVERTEXATTRIBP2UIV
+	gpVertexAttribP3ui                               C.GPVERTEXATTRIBP3UI
+	gpVertexAttribP3uiv                              C.GPVERTEXATTRIBP3UIV
+	gpVertexAttribP4ui                               C.GPVERTEXATTRIBP4UI
+	gpVertexAttribP4uiv                              C.GPVERTEXATTRIBP4UIV
+	gpVertexAttribPointer                            C.GPVERTEXATTRIBPOINTER
+	gpVertexBindingDivisor                           C.GPVERTEXBINDINGDIVISOR
+	gpVertexFormatNV                                 C.GPVERTEXFORMATNV
+	gpViewport                                       C.GPVIEWPORT
+	gpViewportArrayv                                 C.GPVIEWPORTARRAYV
+	gpViewportIndexedf                               C.GPVIEWPORTINDEXEDF
+	gpViewportIndexedfv                              C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                       C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                              C.GPVIEWPORTSWIZZLENV
+	gpWaitSync                                       C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                              C.GPWAITVKSEMAPHORENV
+	gpWeightPathsNV                                  C.GPWEIGHTPATHSNV
+	gpWindowRectanglesEXT                            C.GPWINDOWRECTANGLESEXT
 )
 
 // Helper functions
@@ -5144,15 +8418,24 @@ func boolToInt(b bool) int {
 	}
 	return 0
 }
+func ActiveProgramEXT(program uint32) {
+	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
+}
 
 // set the active program object for a program pipeline object
 func ActiveShaderProgram(pipeline uint32, program uint32) {
 	C.glowActiveShaderProgram(gpActiveShaderProgram, (C.GLuint)(pipeline), (C.GLuint)(program))
 }
+func ActiveShaderProgramEXT(pipeline uint32, program uint32) {
+	C.glowActiveShaderProgramEXT(gpActiveShaderProgramEXT, (C.GLuint)(pipeline), (C.GLuint)(program))
+}
 
 // select active texture unit
 func ActiveTexture(texture uint32) {
 	C.glowActiveTexture(gpActiveTexture, (C.GLenum)(texture))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 
 // Attaches a shader object to a program object
@@ -5163,6 +8446,15 @@ func AttachShader(program uint32, shader uint32) {
 // start conditional rendering
 func BeginConditionalRender(id uint32, mode uint32) {
 	C.glowBeginConditionalRender(gpBeginConditionalRender, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginConditionalRenderNV(id uint32, mode uint32) {
+	C.glowBeginConditionalRenderNV(gpBeginConditionalRenderNV, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginPerfMonitorAMD(monitor uint32) {
+	C.glowBeginPerfMonitorAMD(gpBeginPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func BeginPerfQueryINTEL(queryHandle uint32) {
+	C.glowBeginPerfQueryINTEL(gpBeginPerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // delimit the boundaries of a query object
@@ -5232,10 +8524,16 @@ func BindImageTexture(unit uint32, texture uint32, level int32, layered bool, la
 func BindImageTextures(first uint32, count int32, textures *uint32) {
 	C.glowBindImageTextures(gpBindImageTextures, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(textures)))
 }
+func BindMultiTextureEXT(texunit uint32, target uint32, texture uint32) {
+	C.glowBindMultiTextureEXT(gpBindMultiTextureEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(texture))
+}
 
 // bind a program pipeline to the current context
 func BindProgramPipeline(pipeline uint32) {
 	C.glowBindProgramPipeline(gpBindProgramPipeline, (C.GLuint)(pipeline))
+}
+func BindProgramPipelineEXT(pipeline uint32) {
+	C.glowBindProgramPipelineEXT(gpBindProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 
 // bind a renderbuffer to a renderbuffer target
@@ -5287,6 +8585,12 @@ func BindVertexBuffer(bindingindex uint32, buffer uint32, offset int, stride int
 func BindVertexBuffers(first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowBindVertexBuffers(gpBindVertexBuffers, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
 }
+func BlendBarrierKHR() {
+	C.glowBlendBarrierKHR(gpBlendBarrierKHR)
+}
+func BlendBarrierNV() {
+	C.glowBlendBarrierNV(gpBlendBarrierNV)
+}
 
 // set the blend color
 func BlendColor(red float32, green float32, blue float32, alpha float32) {
@@ -5336,6 +8640,9 @@ func BlendFunci(buf uint32, src uint32, dst uint32) {
 func BlendFunciARB(buf uint32, src uint32, dst uint32) {
 	C.glowBlendFunciARB(gpBlendFunciARB, (C.GLuint)(buf), (C.GLenum)(src), (C.GLenum)(dst))
 }
+func BlendParameteriNV(pname uint32, value int32) {
+	C.glowBlendParameteriNV(gpBlendParameteriNV, (C.GLenum)(pname), (C.GLint)(value))
+}
 
 // copy a block of pixels from one framebuffer object to another
 func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
@@ -5346,13 +8653,16 @@ func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 i
 func BlitNamedFramebuffer(readFramebuffer uint32, drawFramebuffer uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
 	C.glowBlitNamedFramebuffer(gpBlitNamedFramebuffer, (C.GLuint)(readFramebuffer), (C.GLuint)(drawFramebuffer), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
 }
+func BufferAddressRangeNV(pname uint32, index uint32, address uint64, length int) {
+	C.glowBufferAddressRangeNV(gpBufferAddressRangeNV, (C.GLenum)(pname), (C.GLuint)(index), (C.GLuint64EXT)(address), (C.GLsizeiptr)(length))
+}
 
 // creates and initializes a buffer object's data     store
 func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferData(gpBufferData, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
@@ -5364,6 +8674,9 @@ func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubData(gpBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
+}
 
 // check the completeness status of a framebuffer
 func CheckFramebufferStatus(target uint32) uint32 {
@@ -5374,6 +8687,10 @@ func CheckFramebufferStatus(target uint32) uint32 {
 // check the completeness status of a framebuffer
 func CheckNamedFramebufferStatus(framebuffer uint32, target uint32) uint32 {
 	ret := C.glowCheckNamedFramebufferStatus(gpCheckNamedFramebufferStatus, (C.GLuint)(framebuffer), (C.GLenum)(target))
+	return (uint32)(ret)
+}
+func CheckNamedFramebufferStatusEXT(framebuffer uint32, target uint32) uint32 {
+	ret := C.glowCheckNamedFramebufferStatusEXT(gpCheckNamedFramebufferStatusEXT, (C.GLuint)(framebuffer), (C.GLenum)(target))
 	return (uint32)(ret)
 }
 
@@ -5418,6 +8735,8 @@ func ClearColor(red float32, green float32, blue float32, alpha float32) {
 func ClearDepth(depth float64) {
 	C.glowClearDepth(gpClearDepth, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -5426,13 +8745,19 @@ func ClearDepthf(d float32) {
 func ClearNamedBufferData(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferData(gpClearNamedBufferData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferDataEXT(gpClearNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -5458,9 +8783,12 @@ func ClearTexImage(texture uint32, level int32, format uint32, xtype uint32, dat
 func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearTexSubImage(gpClearTexSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClientAttribDefaultEXT(mask uint32) {
+	C.glowClientAttribDefaultEXT(gpClientAttribDefaultEXT, (C.GLbitfield)(mask))
+}
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -5469,11 +8797,20 @@ func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
 func ClipControl(origin uint32, depth uint32) {
 	C.glowClipControl(gpClipControl, (C.GLenum)(origin), (C.GLenum)(depth))
 }
+func ColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowColorFormatNV(gpColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func ColorMask(red bool, green bool, blue bool, alpha bool) {
 	C.glowColorMask(gpColorMask, (C.GLboolean)(boolToInt(red)), (C.GLboolean)(boolToInt(green)), (C.GLboolean)(boolToInt(blue)), (C.GLboolean)(boolToInt(alpha)))
 }
 func ColorMaski(index uint32, r bool, g bool, b bool, a bool) {
 	C.glowColorMaski(gpColorMaski, (C.GLuint)(index), (C.GLboolean)(boolToInt(r)), (C.GLboolean)(boolToInt(g)), (C.GLboolean)(boolToInt(b)), (C.GLboolean)(boolToInt(a)))
+}
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
 }
 
 // Compiles a shader object
@@ -5482,6 +8819,24 @@ func CompileShader(shader uint32) {
 }
 func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
+}
+func CompressedMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage1DEXT(gpCompressedMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage2DEXT(gpCompressedMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage3DEXT(gpCompressedMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage1DEXT(gpCompressedMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage2DEXT(gpCompressedMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage3DEXT(gpCompressedMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a one-dimensional texture image in a compressed format
@@ -5513,20 +8868,44 @@ func CompressedTexSubImage2D(target uint32, level int32, xoffset int32, yoffset 
 func CompressedTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTexSubImage3D(gpCompressedTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage1DEXT(gpCompressedTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage2DEXT(gpCompressedTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage3DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage3DEXT(gpCompressedTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a one-dimensional texture subimage in a compressed     format
 func CompressedTextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage1D(gpCompressedTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage1DEXT(gpCompressedTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a two-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage2D(gpCompressedTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage2DEXT(gpCompressedTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a three-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3D(gpCompressedTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
@@ -5538,10 +8917,28 @@ func CopyBufferSubData(readTarget uint32, writeTarget uint32, readOffset int, wr
 func CopyImageSubData(srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
 	C.glowCopyImageSubData(gpCopyImageSubData, (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
 }
+func CopyMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyMultiTexImage1DEXT(gpCopyMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyMultiTexImage2DEXT(gpCopyMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
+func CopyMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyMultiTexSubImage1DEXT(gpCopyMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage2DEXT(gpCopyMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage3DEXT(gpCopyMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func CopyPathNV(resultPath uint32, srcPath uint32) {
+	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
 }
 
 // copy pixels into a 1D texture image
@@ -5568,30 +8965,69 @@ func CopyTexSubImage2D(target uint32, level int32, xoffset int32, yoffset int32,
 func CopyTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTexSubImage3D(gpCopyTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyTextureImage1DEXT(gpCopyTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyTextureImage2DEXT(gpCopyTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
 
 // copy a one-dimensional texture subimage
 func CopyTextureSubImage1D(texture uint32, level int32, xoffset int32, x int32, y int32, width int32) {
 	C.glowCopyTextureSubImage1D(gpCopyTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyTextureSubImage1DEXT(gpCopyTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
 }
 
 // copy a two-dimensional texture subimage
 func CopyTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage2D(gpCopyTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage2DEXT(gpCopyTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy a three-dimensional texture subimage
 func CopyTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage3D(gpCopyTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage3DEXT(gpCopyTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverFillPathInstancedNV(gpCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverFillPathNV(path uint32, coverMode uint32) {
+	C.glowCoverFillPathNV(gpCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverStrokePathInstancedNV(gpCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverStrokePathNV(path uint32, coverMode uint32) {
+	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
+	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
 }
 
 // Creates a program object
@@ -5625,15 +9061,26 @@ func CreateShader(xtype uint32) uint32 {
 	ret := C.glowCreateShader(gpCreateShader, (C.GLenum)(xtype))
 	return (uint32)(ret)
 }
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
+	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
+	return (uint32)(ret)
+}
 
 // create a stand-alone program from an array of null-terminated source code strings
 func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
+	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
+	return (uint32)(ret)
+}
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -5696,6 +9143,9 @@ func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint
 func DeleteBuffers(n int32, buffers *uint32) {
 	C.glowDeleteBuffers(gpDeleteBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // delete framebuffer objects
 func DeleteFramebuffers(n int32, framebuffers *uint32) {
@@ -5703,6 +9153,15 @@ func DeleteFramebuffers(n int32, framebuffers *uint32) {
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+}
+func DeletePathsNV(path uint32, xrange int32) {
+	C.glowDeletePathsNV(gpDeletePathsNV, (C.GLuint)(path), (C.GLsizei)(xrange))
+}
+func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowDeletePerfMonitorsAMD(gpDeletePerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
+func DeletePerfQueryINTEL(queryHandle uint32) {
+	C.glowDeletePerfQueryINTEL(gpDeletePerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // Deletes a program object
@@ -5713,6 +9172,9 @@ func DeleteProgram(program uint32) {
 // delete program pipeline objects
 func DeleteProgramPipelines(n int32, pipelines *uint32) {
 	C.glowDeleteProgramPipelines(gpDeleteProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func DeleteProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowDeleteProgramPipelinesEXT(gpDeleteProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // delete named query objects
@@ -5734,9 +9196,12 @@ func DeleteSamplers(count int32, samplers *uint32) {
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -5777,6 +9242,8 @@ func DepthRangeArrayv(first uint32, count int32, v *float64) {
 func DepthRangeIndexed(index uint32, n float64, f float64) {
 	C.glowDepthRangeIndexed(gpDepthRangeIndexed, (C.GLuint)(index), (C.GLdouble)(n), (C.GLdouble)(f))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -5788,10 +9255,25 @@ func DetachShader(program uint32, shader uint32) {
 func Disable(cap uint32) {
 	C.glowDisable(gpDisable, (C.GLenum)(cap))
 }
+func DisableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowDisableClientStateIndexedEXT(gpDisableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableClientStateiEXT(array uint32, index uint32) {
+	C.glowDisableClientStateiEXT(gpDisableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableIndexedEXT(target uint32, index uint32) {
+	C.glowDisableIndexedEXT(gpDisableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func DisableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowDisableVertexArrayAttrib(gpDisableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowDisableVertexArrayAttribEXT(gpDisableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowDisableVertexArrayEXT(gpDisableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -5829,10 +9311,16 @@ func DrawArraysIndirect(mode uint32, indirect unsafe.Pointer) {
 func DrawArraysInstanced(mode uint32, first int32, count int32, instancecount int32) {
 	C.glowDrawArraysInstanced(gpDrawArraysInstanced, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount))
 }
+func DrawArraysInstancedARB(mode uint32, first int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedARB(gpDrawArraysInstancedARB, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a range of elements with offset applied to instanced attributes
 func DrawArraysInstancedBaseInstance(mode uint32, first int32, count int32, instancecount int32, baseinstance uint32) {
 	C.glowDrawArraysInstancedBaseInstance(gpDrawArraysInstancedBaseInstance, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount), (C.GLuint)(baseinstance))
+}
+func DrawArraysInstancedEXT(mode uint32, start int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedEXT(gpDrawArraysInstancedEXT, (C.GLenum)(mode), (C.GLint)(start), (C.GLsizei)(count), (C.GLsizei)(primcount))
 }
 
 // specify which color buffers are to be drawn into
@@ -5843,6 +9331,18 @@ func DrawBuffer(buf uint32) {
 // Specifies a list of color buffers to be drawn     into
 func DrawBuffers(n int32, bufs *uint32) {
 	C.glowDrawBuffers(gpDrawBuffers, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 
 // render primitives from array data
@@ -5864,6 +9364,9 @@ func DrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer) {
 func DrawElementsInstanced(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32) {
 	C.glowDrawElementsInstanced(gpDrawElementsInstanced, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount))
 }
+func DrawElementsInstancedARB(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedARB(gpDrawElementsInstancedARB, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a set of elements with offset applied to instanced attributes
 func DrawElementsInstancedBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, baseinstance uint32) {
@@ -5878,6 +9381,9 @@ func DrawElementsInstancedBaseVertex(mode uint32, count int32, xtype uint32, ind
 // render multiple instances of a set of primitives from array data with a per-element offset
 func DrawElementsInstancedBaseVertexBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, basevertex int32, baseinstance uint32) {
 	C.glowDrawElementsInstancedBaseVertexBaseInstance(gpDrawElementsInstancedBaseVertexBaseInstance, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount), (C.GLint)(basevertex), (C.GLuint)(baseinstance))
+}
+func DrawElementsInstancedEXT(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedEXT(gpDrawElementsInstancedEXT, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
 }
 
 // render primitives from array data
@@ -5909,15 +9415,36 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
 }
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
+}
+func EdgeFlagFormatNV(stride int32) {
+	C.glowEdgeFlagFormatNV(gpEdgeFlagFormatNV, (C.GLsizei)(stride))
+}
 
 // enable or disable server-side GL capabilities
 func Enable(cap uint32) {
 	C.glowEnable(gpEnable, (C.GLenum)(cap))
 }
+func EnableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowEnableClientStateIndexedEXT(gpEnableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableClientStateiEXT(array uint32, index uint32) {
+	C.glowEnableClientStateiEXT(gpEnableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableIndexedEXT(target uint32, index uint32) {
+	C.glowEnableIndexedEXT(gpEnableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func EnableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowEnableVertexArrayAttrib(gpEnableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowEnableVertexArrayAttribEXT(gpEnableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowEnableVertexArrayEXT(gpEnableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -5930,6 +9457,15 @@ func Enablei(target uint32, index uint32) {
 func EndConditionalRender() {
 	C.glowEndConditionalRender(gpEndConditionalRender)
 }
+func EndConditionalRenderNV() {
+	C.glowEndConditionalRenderNV(gpEndConditionalRenderNV)
+}
+func EndPerfMonitorAMD(monitor uint32) {
+	C.glowEndPerfMonitorAMD(gpEndPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func EndPerfQueryINTEL(queryHandle uint32) {
+	C.glowEndPerfQueryINTEL(gpEndPerfQueryINTEL, (C.GLuint)(queryHandle))
+}
 func EndQuery(target uint32) {
 	C.glowEndQuery(gpEndQuery, (C.GLenum)(target))
 }
@@ -5939,11 +9475,14 @@ func EndQueryIndexed(target uint32, index uint32) {
 func EndTransformFeedback() {
 	C.glowEndTransformFeedback(gpEndTransformFeedback)
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -5962,18 +9501,45 @@ func FlushMappedBufferRange(target uint32, offset int, length int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FogCoordFormatNV(xtype uint32, stride int32) {
+	C.glowFogCoordFormatNV(gpFogCoordFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
+func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferDrawBufferEXT(gpFramebufferDrawBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
+func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
+	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
 }
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
 	C.glowFramebufferParameteri(gpFramebufferParameteri, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
 }
+func FramebufferReadBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferReadBufferEXT(gpFramebufferReadBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
 
 // attach a renderbuffer as a logical buffer of a framebuffer object
 func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbuffer(gpFramebufferRenderbuffer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
@@ -5983,16 +9549,30 @@ func FramebufferTexture(target uint32, attachment uint32, texture uint32, level 
 func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1D(gpFramebufferTexture1D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
 func FramebufferTexture3D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
 	C.glowFramebufferTexture3D(gpFramebufferTexture3D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
 }
+func FramebufferTextureARB(target uint32, attachment uint32, texture uint32, level int32) {
+	C.glowFramebufferTextureARB(gpFramebufferTextureARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func FramebufferTextureFaceARB(target uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowFramebufferTextureFaceARB(gpFramebufferTextureFaceARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
+}
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func FramebufferTextureLayer(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayer(gpFramebufferTextureLayer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowFramebufferTextureLayerARB(gpFramebufferTextureLayerARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 
 // define front- and back-facing polygons
@@ -6009,10 +9589,20 @@ func GenBuffers(n int32, buffers *uint32) {
 func GenFramebuffers(n int32, framebuffers *uint32) {
 	C.glowGenFramebuffers(gpGenFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
 }
+func GenPathsNV(xrange int32) uint32 {
+	ret := C.glowGenPathsNV(gpGenPathsNV, (C.GLsizei)(xrange))
+	return (uint32)(ret)
+}
+func GenPerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowGenPerfMonitorsAMD(gpGenPerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
 
 // reserve program pipeline object names
 func GenProgramPipelines(n int32, pipelines *uint32) {
 	C.glowGenProgramPipelines(gpGenProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func GenProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowGenProgramPipelinesEXT(gpGenProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // generate query object names
@@ -6049,10 +9639,16 @@ func GenVertexArrays(n int32, arrays *uint32) {
 func GenerateMipmap(target uint32) {
 	C.glowGenerateMipmap(gpGenerateMipmap, (C.GLenum)(target))
 }
+func GenerateMultiTexMipmapEXT(texunit uint32, target uint32) {
+	C.glowGenerateMultiTexMipmapEXT(gpGenerateMultiTexMipmapEXT, (C.GLenum)(texunit), (C.GLenum)(target))
+}
 
 // generate mipmaps for a specified texture object
 func GenerateTextureMipmap(texture uint32) {
 	C.glowGenerateTextureMipmap(gpGenerateTextureMipmap, (C.GLuint)(texture))
+}
+func GenerateTextureMipmapEXT(texture uint32, target uint32) {
+	C.glowGenerateTextureMipmapEXT(gpGenerateTextureMipmapEXT, (C.GLuint)(texture), (C.GLenum)(target))
 }
 
 // retrieve information about the set of active atomic counter buffers for a program
@@ -6087,6 +9683,8 @@ func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6111,6 +9709,9 @@ func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
+func GetBooleanIndexedvEXT(target uint32, index uint32, data *bool) {
+	C.glowGetBooleanIndexedvEXT(gpGetBooleanIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
+}
 func GetBooleani_v(target uint32, index uint32, data *bool) {
 	C.glowGetBooleani_v(gpGetBooleani_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
 }
@@ -6127,6 +9728,9 @@ func GetBufferParameteri64v(target uint32, pname uint32, params *int64) {
 func GetBufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetBufferParameteriv(gpGetBufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetBufferParameterui64vNV(target uint32, pname uint32, params *uint64) {
+	C.glowGetBufferParameterui64vNV(gpGetBufferParameterui64vNV, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
@@ -6136,6 +9740,13 @@ func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
 // returns a subset of a buffer object's data store
 func GetBufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetBufferSubData(gpGetBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
+func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
 
 // return a compressed texture image
@@ -6147,10 +9758,16 @@ func GetCompressedTexImage(target uint32, level int32, img unsafe.Pointer) {
 func GetCompressedTextureImage(texture uint32, level int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureImage(gpGetCompressedTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLsizei)(bufSize), pixels)
 }
+func GetCompressedTextureImageEXT(texture uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedTextureImageEXT(gpGetCompressedTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(lod), img)
+}
 
 // retrieve a sub-region of a compressed texture image from a     compressed texture object
 func GetCompressedTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureSubImage(gpGetCompressedTextureSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(bufSize), pixels)
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -6166,8 +9783,14 @@ func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
+func GetDoubleIndexedvEXT(target uint32, index uint32, data *float64) {
+	C.glowGetDoubleIndexedvEXT(gpGetDoubleIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
 func GetDoublei_v(target uint32, index uint32, data *float64) {
 	C.glowGetDoublei_v(gpGetDoublei_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
+func GetDoublei_vEXT(pname uint32, index uint32, params *float64) {
+	C.glowGetDoublei_vEXT(gpGetDoublei_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
 }
 func GetDoublev(pname uint32, data *float64) {
 	C.glowGetDoublev(gpGetDoublev, (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(data)))
@@ -6178,8 +9801,17 @@ func GetError() uint32 {
 	ret := C.glowGetError(gpGetError)
 	return (uint32)(ret)
 }
+func GetFirstPerfQueryIdINTEL(queryId *uint32) {
+	C.glowGetFirstPerfQueryIdINTEL(gpGetFirstPerfQueryIdINTEL, (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetFloatIndexedvEXT(target uint32, index uint32, data *float32) {
+	C.glowGetFloatIndexedvEXT(gpGetFloatIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
 func GetFloati_v(target uint32, index uint32, data *float32) {
 	C.glowGetFloati_v(gpGetFloati_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
+func GetFloati_vEXT(pname uint32, index uint32, params *float32) {
+	C.glowGetFloati_vEXT(gpGetFloati_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetFloatv(pname uint32, data *float32) {
 	C.glowGetFloatv(gpGetFloatv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(data)))
@@ -6197,14 +9829,17 @@ func GetFragDataLocation(program uint32, name *uint8) int32 {
 	return (int32)(ret)
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetFramebufferParameterivEXT(gpGetFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // check if the rendering context has not been lost due to software or hardware issues
@@ -6224,23 +9859,77 @@ func GetImageHandleARB(texture uint32, level int32, layered bool, layer int32, f
 	ret := C.glowGetImageHandleARB(gpGetImageHandleARB, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
 	return (uint64)(ret)
 }
+func GetImageHandleNV(texture uint32, level int32, layered bool, layer int32, format uint32) uint64 {
+	ret := C.glowGetImageHandleNV(gpGetImageHandleNV, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
+	return (uint64)(ret)
+}
 func GetInteger64i_v(target uint32, index uint32, data *int64) {
 	C.glowGetInteger64i_v(gpGetInteger64i_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint64)(unsafe.Pointer(data)))
 }
 func GetInteger64v(pname uint32, data *int64) {
 	C.glowGetInteger64v(gpGetInteger64v, (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(data)))
 }
+func GetIntegerIndexedvEXT(target uint32, index uint32, data *int32) {
+	C.glowGetIntegerIndexedvEXT(gpGetIntegerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
 func GetIntegeri_v(target uint32, index uint32, data *int32) {
 	C.glowGetIntegeri_v(gpGetIntegeri_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
+func GetIntegerui64i_vNV(value uint32, index uint32, result *uint64) {
+	C.glowGetIntegerui64i_vNV(gpGetIntegerui64i_vNV, (C.GLenum)(value), (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(result)))
+}
+func GetIntegerui64vNV(value uint32, result *uint64) {
+	C.glowGetIntegerui64vNV(gpGetIntegerui64vNV, (C.GLenum)(value), (*C.GLuint64EXT)(unsafe.Pointer(result)))
 }
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexEnvfvEXT(gpGetMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexEnvivEXT(gpGetMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowGetMultiTexGendvEXT(gpGetMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexGenfvEXT(gpGetMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexGenivEXT(gpGetMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexImageEXT(texunit uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetMultiTexImageEXT(gpGetMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func GetMultiTexLevelParameterfvEXT(texunit uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetMultiTexLevelParameterfvEXT(gpGetMultiTexLevelParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexLevelParameterivEXT(texunit uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetMultiTexLevelParameterivEXT(gpGetMultiTexLevelParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterIivEXT(gpGetMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetMultiTexParameterIuivEXT(gpGetMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexParameterfvEXT(gpGetMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterivEXT(gpGetMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // retrieve the location of a sample
@@ -6257,30 +9946,69 @@ func GetNamedBufferParameteri64v(buffer uint32, pname uint32, params *int64) {
 func GetNamedBufferParameteriv(buffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedBufferParameteriv(gpGetNamedBufferParameteriv, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedBufferParameterivEXT(buffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedBufferParameterivEXT(gpGetNamedBufferParameterivEXT, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedBufferParameterui64vNV(buffer uint32, pname uint32, params *uint64) {
+	C.glowGetNamedBufferParameterui64vNV(gpGetNamedBufferParameterui64vNV, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetNamedBufferPointerv(buffer uint32, pname uint32, params *unsafe.Pointer) {
 	C.glowGetNamedBufferPointerv(gpGetNamedBufferPointerv, (C.GLuint)(buffer), (C.GLenum)(pname), params)
 }
+func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Pointer) {
+	C.glowGetNamedBufferPointervEXT(gpGetNamedBufferPointervEXT, (C.GLuint)(buffer), (C.GLenum)(pname), params)
+}
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 
 // retrieve information about attachments of a framebuffer object
 func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameteriv(gpGetNamedFramebufferAttachmentParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a framebuffer object
 func GetNamedFramebufferParameteriv(framebuffer uint32, pname uint32, param *int32) {
 	C.glowGetNamedFramebufferParameteriv(gpGetNamedFramebufferParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
 }
+func GetNamedFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferParameterivEXT(gpGetNamedFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowGetNamedProgramLocalParameterIivEXT(gpGetNamedProgramLocalParameterIivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIuivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowGetNamedProgramLocalParameterIuivEXT(gpGetNamedProgramLocalParameterIuivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterdvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowGetNamedProgramLocalParameterdvEXT(gpGetNamedProgramLocalParameterdvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterfvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowGetNamedProgramLocalParameterfvEXT(gpGetNamedProgramLocalParameterfvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetNamedProgramStringEXT(program uint32, target uint32, pname uint32, xstring unsafe.Pointer) {
+	C.glowGetNamedProgramStringEXT(gpGetNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), xstring)
+}
+func GetNamedProgramivEXT(program uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetNamedProgramivEXT(gpGetNamedProgramivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a renderbuffer object
 func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameteriv(gpGetNamedRenderbufferParameteriv, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedRenderbufferParameterivEXT(renderbuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedRenderbufferParameterivEXT(gpGetNamedRenderbufferParameterivEXT, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
@@ -6288,10 +10016,16 @@ func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int
 func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
+	C.glowGetNextPerfQueryIdINTEL(gpGetNextPerfQueryIdINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(nextQueryId)))
+}
 
 // retrieve the label of a named object identified within a namespace
 func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
+	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
@@ -6303,6 +10037,70 @@ func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *
 }
 func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetPathCommandsNV(path uint32, commands *uint8) {
+	C.glowGetPathCommandsNV(gpGetPathCommandsNV, (C.GLuint)(path), (*C.GLubyte)(unsafe.Pointer(commands)))
+}
+func GetPathCoordsNV(path uint32, coords *float32) {
+	C.glowGetPathCoordsNV(gpGetPathCoordsNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(coords)))
+}
+func GetPathDashArrayNV(path uint32, dashArray *float32) {
+	C.glowGetPathDashArrayNV(gpGetPathDashArrayNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func GetPathLengthNV(path uint32, startSegment int32, numSegments int32) float32 {
+	ret := C.glowGetPathLengthNV(gpGetPathLengthNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments))
+	return (float32)(ret)
+}
+func GetPathMetricRangeNV(metricQueryMask uint32, firstPathName uint32, numPaths int32, stride int32, metrics *float32) {
+	C.glowGetPathMetricRangeNV(gpGetPathMetricRangeNV, (C.GLbitfield)(metricQueryMask), (C.GLuint)(firstPathName), (C.GLsizei)(numPaths), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathMetricsNV(metricQueryMask uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, stride int32, metrics *float32) {
+	C.glowGetPathMetricsNV(gpGetPathMetricsNV, (C.GLbitfield)(metricQueryMask), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowGetPathParameterfvNV(gpGetPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func GetPathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowGetPathParameterivNV(gpGetPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func GetPathSpacingNV(pathListMode uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, advanceScale float32, kerningScale float32, transformType uint32, returnedSpacing *float32) {
+	C.glowGetPathSpacingNV(gpGetPathSpacingNV, (C.GLenum)(pathListMode), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLfloat)(advanceScale), (C.GLfloat)(kerningScale), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(returnedSpacing)))
+}
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
+}
+func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
+	C.glowGetPerfMonitorCounterDataAMD(gpGetPerfMonitorCounterDataAMD, (C.GLuint)(monitor), (C.GLenum)(pname), (C.GLsizei)(dataSize), (*C.GLuint)(unsafe.Pointer(data)), (*C.GLint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
+	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
+}
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
+	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
+}
+func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
+	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
+}
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
+	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
+}
+func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
+	C.glowGetPerfMonitorGroupsAMD(gpGetPerfMonitorGroupsAMD, (*C.GLint)(unsafe.Pointer(numGroups)), (C.GLsizei)(groupsSize), (*C.GLuint)(unsafe.Pointer(groups)))
+}
+func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
+	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
+	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
+}
+func GetPointerIndexedvEXT(target uint32, index uint32, data *unsafe.Pointer) {
+	C.glowGetPointerIndexedvEXT(gpGetPointerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), data)
+}
+func GetPointeri_vEXT(pname uint32, index uint32, params *unsafe.Pointer) {
+	C.glowGetPointeri_vEXT(gpGetPointeri_vEXT, (C.GLenum)(pname), (C.GLuint)(index), params)
 }
 
 // return the address of the specified pointer
@@ -6330,8 +10128,14 @@ func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32
 func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
+	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
+}
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
 	C.glowGetProgramPipelineiv(gpGetProgramPipelineiv, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
+	C.glowGetProgramPipelineivEXT(gpGetProgramPipelineivEXT, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // query the index of a named resource within a program
@@ -6356,6 +10160,9 @@ func GetProgramResourceLocationIndex(program uint32, programInterface uint32, na
 func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
+func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
+	C.glowGetProgramResourcefvNV(gpGetProgramResourcefvNV, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLfloat)(unsafe.Pointer(params)))
+}
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
 	C.glowGetProgramResourceiv(gpGetProgramResourceiv, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6366,6 +10173,18 @@ func GetProgramStageiv(program uint32, shadertype uint32, pname uint32, values *
 // Returns a parameter from a program object
 func GetProgramiv(program uint32, pname uint32, params *int32) {
 	C.glowGetProgramiv(gpGetProgramiv, (C.GLuint)(program), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
 }
 
 // return parameters of an indexed query object target
@@ -6381,6 +10200,8 @@ func GetQueryObjectiv(id uint32, pname uint32, params *int32) {
 func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64v(gpGetQueryObjectui64v, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -6390,7 +10211,7 @@ func GetQueryiv(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryiv(gpGetQueryiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6426,6 +10247,10 @@ func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8)
 func GetShaderiv(shader uint32, pname uint32, params *int32) {
 	C.glowGetShaderiv(gpGetShaderiv, (C.GLuint)(shader), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -6450,7 +10275,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 
@@ -6480,31 +10305,60 @@ func GetTextureHandleARB(texture uint32) uint64 {
 	ret := C.glowGetTextureHandleARB(gpGetTextureHandleARB, (C.GLuint)(texture))
 	return (uint64)(ret)
 }
+func GetTextureHandleNV(texture uint32) uint64 {
+	ret := C.glowGetTextureHandleNV(gpGetTextureHandleNV, (C.GLuint)(texture))
+	return (uint64)(ret)
+}
 
 // return a texture image
 func GetTextureImage(texture uint32, level int32, format uint32, xtype uint32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetTextureImage(gpGetTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), pixels)
 }
+func GetTextureImageEXT(texture uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetTextureImageEXT(gpGetTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 func GetTextureLevelParameterfv(texture uint32, level int32, pname uint32, params *float32) {
 	C.glowGetTextureLevelParameterfv(gpGetTextureLevelParameterfv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureLevelParameterfvEXT(texture uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetTextureLevelParameterfvEXT(gpGetTextureLevelParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureLevelParameteriv(texture uint32, level int32, pname uint32, params *int32) {
 	C.glowGetTextureLevelParameteriv(gpGetTextureLevelParameteriv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureLevelParameterivEXT(texture uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetTextureLevelParameterivEXT(gpGetTextureLevelParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameterIiv(gpGetTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetTextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterIivEXT(gpGetTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetTextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowGetTextureParameterIuiv(gpGetTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetTextureParameterIuivEXT(gpGetTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterfv(texture uint32, pname uint32, params *float32) {
 	C.glowGetTextureParameterfv(gpGetTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetTextureParameterfvEXT(gpGetTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureParameteriv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameteriv(gpGetTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterivEXT(gpGetTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureSamplerHandleARB(texture uint32, sampler uint32) uint64 {
 	ret := C.glowGetTextureSamplerHandleARB(gpGetTextureSamplerHandleARB, (C.GLuint)(texture), (C.GLuint)(sampler))
+	return (uint64)(ret)
+}
+func GetTextureSamplerHandleNV(texture uint32, sampler uint32) uint64 {
+	ret := C.glowGetTextureSamplerHandleNV(gpGetTextureSamplerHandleNV, (C.GLuint)(texture), (C.GLuint)(sampler))
 	return (uint64)(ret)
 }
 
@@ -6556,10 +10410,22 @@ func GetUniformdv(program uint32, location int32, params *float64) {
 func GetUniformfv(program uint32, location int32, params *float32) {
 	C.glowGetUniformfv(gpGetUniformfv, (C.GLuint)(program), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func GetUniformi64vNV(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 
 // Returns the value of a uniform variable
 func GetUniformiv(program uint32, location int32, params *int32) {
 	C.glowGetUniformiv(gpGetUniformiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func GetUniformui64vNV(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 func GetUniformuiv(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuiv(gpGetUniformuiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
@@ -6569,6 +10435,18 @@ func GetVertexArrayIndexed64iv(vaobj uint32, index uint32, pname uint32, param *
 }
 func GetVertexArrayIndexediv(vaobj uint32, index uint32, pname uint32, param *int32) {
 	C.glowGetVertexArrayIndexediv(gpGetVertexArrayIndexediv, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegeri_vEXT(vaobj uint32, index uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegeri_vEXT(gpGetVertexArrayIntegeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegervEXT(vaobj uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegervEXT(gpGetVertexArrayIntegervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayPointeri_vEXT(vaobj uint32, index uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointeri_vEXT(gpGetVertexArrayPointeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), param)
+}
+func GetVertexArrayPointervEXT(vaobj uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointervEXT(gpGetVertexArrayPointervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), param)
 }
 
 // retrieve parameters of a vertex array object
@@ -6590,8 +10468,14 @@ func GetVertexAttribIuiv(index uint32, pname uint32, params *uint32) {
 func GetVertexAttribLdv(index uint32, pname uint32, params *float64) {
 	C.glowGetVertexAttribLdv(gpGetVertexAttribLdv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
 }
+func GetVertexAttribLi64vNV(index uint32, pname uint32, params *int64) {
+	C.glowGetVertexAttribLi64vNV(gpGetVertexAttribLi64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 func GetVertexAttribLui64vARB(index uint32, pname uint32, params *uint64) {
 	C.glowGetVertexAttribLui64vARB(gpGetVertexAttribLui64vARB, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
+func GetVertexAttribLui64vNV(index uint32, pname uint32, params *uint64) {
+	C.glowGetVertexAttribLui64vNV(gpGetVertexAttribLui64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 
 // return the address of the specified generic vertex attribute pointer
@@ -6613,6 +10497,10 @@ func GetVertexAttribfv(index uint32, pname uint32, params *float32) {
 func GetVertexAttribiv(index uint32, pname uint32, params *int32) {
 	C.glowGetVertexAttribiv(gpGetVertexAttribiv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
+}
 func GetnCompressedTexImageARB(target uint32, lod int32, bufSize int32, img unsafe.Pointer) {
 	C.glowGetnCompressedTexImageARB(gpGetnCompressedTexImageARB, (C.GLenum)(target), (C.GLint)(lod), (C.GLsizei)(bufSize), img)
 }
@@ -6631,6 +10519,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6639,6 +10530,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -6653,6 +10547,15 @@ func GetnUniformuivKHR(program uint32, location int32, bufSize int32, params *ui
 // specify implementation-specific hints
 func Hint(target uint32, mode uint32) {
 	C.glowHint(gpHint, (C.GLenum)(target), (C.GLenum)(mode))
+}
+func IndexFormatNV(xtype uint32, stride int32) {
+	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func InsertEventMarkerEXT(length int32, marker *uint8) {
+	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
+func InterpolatePathsNV(resultPath uint32, pathA uint32, pathB uint32, weight float32) {
+	C.glowInterpolatePathsNV(gpInterpolatePathsNV, (C.GLuint)(resultPath), (C.GLuint)(pathA), (C.GLuint)(pathB), (C.GLfloat)(weight))
 }
 
 // invalidate the content of a buffer object's data store
@@ -6700,8 +10603,20 @@ func IsBuffer(buffer uint32) bool {
 	ret := C.glowIsBuffer(gpIsBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func IsBufferResidentNV(target uint32) bool {
+	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
+	return ret == TRUE
+}
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
+	return ret == TRUE
+}
+func IsEnabledIndexedEXT(target uint32, index uint32) bool {
+	ret := C.glowIsEnabledIndexedEXT(gpIsEnabledIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
 	return ret == TRUE
 }
 func IsEnabledi(target uint32, index uint32) bool {
@@ -6718,8 +10633,28 @@ func IsImageHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsImageHandleResidentARB(gpIsImageHandleResidentARB, (C.GLuint64)(handle))
 	return ret == TRUE
 }
+func IsImageHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsImageHandleResidentNV(gpIsImageHandleResidentNV, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsNamedBufferResidentNV(buffer uint32) bool {
+	ret := C.glowIsNamedBufferResidentNV(gpIsNamedBufferResidentNV, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+	return ret == TRUE
+}
+func IsPathNV(path uint32) bool {
+	ret := C.glowIsPathNV(gpIsPathNV, (C.GLuint)(path))
+	return ret == TRUE
+}
+func IsPointInFillPathNV(path uint32, mask uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInFillPathNV(gpIsPointInFillPathNV, (C.GLuint)(path), (C.GLuint)(mask), (C.GLfloat)(x), (C.GLfloat)(y))
+	return ret == TRUE
+}
+func IsPointInStrokePathNV(path uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInStrokePathNV(gpIsPointInStrokePathNV, (C.GLuint)(path), (C.GLfloat)(x), (C.GLfloat)(y))
 	return ret == TRUE
 }
 
@@ -6732,6 +10667,10 @@ func IsProgram(program uint32) bool {
 // determine if a name corresponds to a program pipeline object
 func IsProgramPipeline(pipeline uint32) bool {
 	ret := C.glowIsProgramPipeline(gpIsProgramPipeline, (C.GLuint)(pipeline))
+	return ret == TRUE
+}
+func IsProgramPipelineEXT(pipeline uint32) bool {
+	ret := C.glowIsProgramPipelineEXT(gpIsProgramPipelineEXT, (C.GLuint)(pipeline))
 	return ret == TRUE
 }
 
@@ -6758,9 +10697,13 @@ func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -6772,6 +10715,10 @@ func IsTexture(texture uint32) bool {
 }
 func IsTextureHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsTextureHandleResidentARB(gpIsTextureHandleResidentARB, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsTextureHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsTextureHandleResidentNV(gpIsTextureHandleResidentNV, (C.GLuint64)(handle))
 	return ret == TRUE
 }
 
@@ -6786,6 +10733,9 @@ func IsVertexArray(array uint32) bool {
 	ret := C.glowIsVertexArray(gpIsVertexArray, (C.GLuint)(array))
 	return ret == TRUE
 }
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
+	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
+}
 
 // specify the width of rasterized lines
 func LineWidth(width float32) {
@@ -6796,22 +10746,49 @@ func LineWidth(width float32) {
 func LinkProgram(program uint32) {
 	C.glowLinkProgram(gpLinkProgram, (C.GLuint)(program))
 }
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 
 // specify a logical pixel operation for rendering
 func LogicOp(opcode uint32) {
 	C.glowLogicOp(gpLogicOp, (C.GLenum)(opcode))
 }
+func MakeBufferNonResidentNV(target uint32) {
+	C.glowMakeBufferNonResidentNV(gpMakeBufferNonResidentNV, (C.GLenum)(target))
+}
+func MakeBufferResidentNV(target uint32, access uint32) {
+	C.glowMakeBufferResidentNV(gpMakeBufferResidentNV, (C.GLenum)(target), (C.GLenum)(access))
+}
 func MakeImageHandleNonResidentARB(handle uint64) {
 	C.glowMakeImageHandleNonResidentARB(gpMakeImageHandleNonResidentARB, (C.GLuint64)(handle))
+}
+func MakeImageHandleNonResidentNV(handle uint64) {
+	C.glowMakeImageHandleNonResidentNV(gpMakeImageHandleNonResidentNV, (C.GLuint64)(handle))
 }
 func MakeImageHandleResidentARB(handle uint64, access uint32) {
 	C.glowMakeImageHandleResidentARB(gpMakeImageHandleResidentARB, (C.GLuint64)(handle), (C.GLenum)(access))
 }
+func MakeImageHandleResidentNV(handle uint64, access uint32) {
+	C.glowMakeImageHandleResidentNV(gpMakeImageHandleResidentNV, (C.GLuint64)(handle), (C.GLenum)(access))
+}
+func MakeNamedBufferNonResidentNV(buffer uint32) {
+	C.glowMakeNamedBufferNonResidentNV(gpMakeNamedBufferNonResidentNV, (C.GLuint)(buffer))
+}
+func MakeNamedBufferResidentNV(buffer uint32, access uint32) {
+	C.glowMakeNamedBufferResidentNV(gpMakeNamedBufferResidentNV, (C.GLuint)(buffer), (C.GLenum)(access))
+}
 func MakeTextureHandleNonResidentARB(handle uint64) {
 	C.glowMakeTextureHandleNonResidentARB(gpMakeTextureHandleNonResidentARB, (C.GLuint64)(handle))
 }
+func MakeTextureHandleNonResidentNV(handle uint64) {
+	C.glowMakeTextureHandleNonResidentNV(gpMakeTextureHandleNonResidentNV, (C.GLuint64)(handle))
+}
 func MakeTextureHandleResidentARB(handle uint64) {
 	C.glowMakeTextureHandleResidentARB(gpMakeTextureHandleResidentARB, (C.GLuint64)(handle))
+}
+func MakeTextureHandleResidentNV(handle uint64) {
+	C.glowMakeTextureHandleResidentNV(gpMakeTextureHandleResidentNV, (C.GLuint64)(handle))
 }
 
 // map all of a buffer object's data store into the client's address space
@@ -6831,11 +10808,100 @@ func MapNamedBuffer(buffer uint32, access uint32) unsafe.Pointer {
 	ret := C.glowMapNamedBuffer(gpMapNamedBuffer, (C.GLuint)(buffer), (C.GLenum)(access))
 	return (unsafe.Pointer)(ret)
 }
+func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferEXT(gpMapNamedBufferEXT, (C.GLuint)(buffer), (C.GLenum)(access))
+	return (unsafe.Pointer)(ret)
+}
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
+}
+func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRangeEXT(gpMapNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
+	return (unsafe.Pointer)(ret)
+}
+func MatrixFrustumEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixFrustumEXT(gpMatrixFrustumEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixLoad3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x2fNV(gpMatrixLoad3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoad3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x3fNV(gpMatrixLoad3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadIdentityEXT(mode uint32) {
+	C.glowMatrixLoadIdentityEXT(gpMatrixLoadIdentityEXT, (C.GLenum)(mode))
+}
+func MatrixLoadTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoadTranspose3x3fNV(gpMatrixLoadTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixLoadTransposedEXT(gpMatrixLoadTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadTransposefEXT(gpMatrixLoadTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoaddEXT(mode uint32, m *float64) {
+	C.glowMatrixLoaddEXT(gpMatrixLoaddEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadfEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadfEXT(gpMatrixLoadfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x2fNV(gpMatrixMult3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x3fNV(gpMatrixMult3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMultTranspose3x3fNV(gpMatrixMultTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixMultTransposedEXT(gpMatrixMultTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixMultTransposefEXT(gpMatrixMultTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultdEXT(mode uint32, m *float64) {
+	C.glowMatrixMultdEXT(gpMatrixMultdEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultfEXT(mode uint32, m *float32) {
+	C.glowMatrixMultfEXT(gpMatrixMultfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixOrthoEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixOrthoEXT(gpMatrixOrthoEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixPopEXT(mode uint32) {
+	C.glowMatrixPopEXT(gpMatrixPopEXT, (C.GLenum)(mode))
+}
+func MatrixPushEXT(mode uint32) {
+	C.glowMatrixPushEXT(gpMatrixPushEXT, (C.GLenum)(mode))
+}
+func MatrixRotatedEXT(mode uint32, angle float64, x float64, y float64, z float64) {
+	C.glowMatrixRotatedEXT(gpMatrixRotatedEXT, (C.GLenum)(mode), (C.GLdouble)(angle), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixRotatefEXT(mode uint32, angle float32, x float32, y float32, z float32) {
+	C.glowMatrixRotatefEXT(gpMatrixRotatefEXT, (C.GLenum)(mode), (C.GLfloat)(angle), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixScaledEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixScaledEXT(gpMatrixScaledEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixScalefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixScalefEXT(gpMatrixScalefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixTranslatedEXT(gpMatrixTranslatedEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
 }
 
 // defines a barrier ordering memory transactions
@@ -6863,8 +10929,14 @@ func MultiDrawArrays(mode uint32, first *int32, count *int32, drawcount int32) {
 func MultiDrawArraysIndirect(mode uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawArraysIndirect(gpMultiDrawArraysIndirect, (C.GLenum)(mode), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessCountNV(gpMultiDrawArraysIndirectBindlessCountNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 
 // render multiple sets of primitives by specifying indices of array data elements
@@ -6881,29 +10953,122 @@ func MultiDrawElementsBaseVertex(mode uint32, count *int32, xtype uint32, indice
 func MultiDrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawElementsIndirect(gpMultiDrawElementsIndirect, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessCountNV(gpMultiDrawElementsIndirectBindlessCountNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+}
+func MultiTexBufferEXT(texunit uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowMultiTexBufferEXT(gpMultiTexBufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
+func MultiTexCoordPointerEXT(texunit uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
+	C.glowMultiTexCoordPointerEXT(gpMultiTexCoordPointerEXT, (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
+}
+func MultiTexEnvfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexEnvfEXT(gpMultiTexEnvfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexEnvfvEXT(gpMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexEnviEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexEnviEXT(gpMultiTexEnviEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexEnvivEXT(gpMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexGendEXT(texunit uint32, coord uint32, pname uint32, param float64) {
+	C.glowMultiTexGendEXT(gpMultiTexGendEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLdouble)(param))
+}
+func MultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowMultiTexGendvEXT(gpMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func MultiTexGenfEXT(texunit uint32, coord uint32, pname uint32, param float32) {
+	C.glowMultiTexGenfEXT(gpMultiTexGenfEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowMultiTexGenfvEXT(gpMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexGeniEXT(texunit uint32, coord uint32, pname uint32, param int32) {
+	C.glowMultiTexGeniEXT(gpMultiTexGeniEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowMultiTexGenivEXT(gpMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage1DEXT(gpMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage2DEXT(gpMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage3DEXT(gpMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterIivEXT(gpMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowMultiTexParameterIuivEXT(gpMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexParameterfEXT(gpMultiTexParameterfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexParameterfvEXT(gpMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexParameteriEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexParameteriEXT(gpMultiTexParameteriEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterivEXT(gpMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexRenderbufferEXT(texunit uint32, target uint32, renderbuffer uint32) {
+	C.glowMultiTexRenderbufferEXT(gpMultiTexRenderbufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(renderbuffer))
+}
+func MultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage1DEXT(gpMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage2DEXT(gpMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
+}
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
+}
+func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedCopyBufferSubDataEXT(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowNamedCopyBufferSubDataEXT(gpNamedCopyBufferSubDataEXT, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 
 // specify which color buffers are to be drawn into
@@ -6920,6 +11085,9 @@ func NamedFramebufferDrawBuffers(framebuffer uint32, n int32, bufs *uint32) {
 func NamedFramebufferParameteri(framebuffer uint32, pname uint32, param int32) {
 	C.glowNamedFramebufferParameteri(gpNamedFramebufferParameteri, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
 }
+func NamedFramebufferParameteriEXT(framebuffer uint32, pname uint32, param int32) {
+	C.glowNamedFramebufferParameteriEXT(gpNamedFramebufferParameteriEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // select a color buffer source for pixels
 func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
@@ -6930,26 +11098,101 @@ func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
 func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbuffer(gpNamedFramebufferRenderbuffer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
+	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture1DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture1DEXT(gpNamedFramebufferTexture1DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture2DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture2DEXT(gpNamedFramebufferTexture2DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture3DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
+	C.glowNamedFramebufferTexture3DEXT(gpNamedFramebufferTexture3DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
+}
+func NamedFramebufferTextureEXT(framebuffer uint32, attachment uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTextureEXT(gpNamedFramebufferTextureEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTextureFaceEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowNamedFramebufferTextureFaceEXT(gpNamedFramebufferTextureFaceEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
 }
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func NamedFramebufferTextureLayer(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowNamedFramebufferTextureLayer(gpNamedFramebufferTextureLayer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
 }
+func NamedFramebufferTextureLayerEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowNamedFramebufferTextureLayerEXT(gpNamedFramebufferTextureLayerEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func NamedProgramLocalParameter4dEXT(program uint32, target uint32, index uint32, x float64, y float64, z float64, w float64) {
+	C.glowNamedProgramLocalParameter4dEXT(gpNamedProgramLocalParameter4dEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
+func NamedProgramLocalParameter4dvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowNamedProgramLocalParameter4dvEXT(gpNamedProgramLocalParameter4dvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameter4fEXT(program uint32, target uint32, index uint32, x float32, y float32, z float32, w float32) {
+	C.glowNamedProgramLocalParameter4fEXT(gpNamedProgramLocalParameter4fEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z), (C.GLfloat)(w))
+}
+func NamedProgramLocalParameter4fvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowNamedProgramLocalParameter4fvEXT(gpNamedProgramLocalParameter4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4iEXT(program uint32, target uint32, index uint32, x int32, y int32, z int32, w int32) {
+	C.glowNamedProgramLocalParameterI4iEXT(gpNamedProgramLocalParameterI4iEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLint)(x), (C.GLint)(y), (C.GLint)(z), (C.GLint)(w))
+}
+func NamedProgramLocalParameterI4ivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowNamedProgramLocalParameterI4ivEXT(gpNamedProgramLocalParameterI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4uiEXT(program uint32, target uint32, index uint32, x uint32, y uint32, z uint32, w uint32) {
+	C.glowNamedProgramLocalParameterI4uiEXT(gpNamedProgramLocalParameterI4uiEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(x), (C.GLuint)(y), (C.GLuint)(z), (C.GLuint)(w))
+}
+func NamedProgramLocalParameterI4uivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowNamedProgramLocalParameterI4uivEXT(gpNamedProgramLocalParameterI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameters4fvEXT(program uint32, target uint32, index uint32, count int32, params *float32) {
+	C.glowNamedProgramLocalParameters4fvEXT(gpNamedProgramLocalParameters4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4ivEXT(program uint32, target uint32, index uint32, count int32, params *int32) {
+	C.glowNamedProgramLocalParametersI4ivEXT(gpNamedProgramLocalParametersI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4uivEXT(program uint32, target uint32, index uint32, count int32, params *uint32) {
+	C.glowNamedProgramLocalParametersI4uivEXT(gpNamedProgramLocalParametersI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramStringEXT(program uint32, target uint32, format uint32, len int32, xstring unsafe.Pointer) {
+	C.glowNamedProgramStringEXT(gpNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(format), (C.GLsizei)(len), xstring)
+}
 
 // establish data storage, format and dimensions of a     renderbuffer object's image
 func NamedRenderbufferStorage(renderbuffer uint32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorage(gpNamedRenderbufferStorage, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageEXT(renderbuffer uint32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageEXT(gpNamedRenderbufferStorageEXT, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func NamedRenderbufferStorageMultisample(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisample(gpNamedRenderbufferStorageMultisample, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func NamedRenderbufferStorageMultisampleCoverageEXT(renderbuffer uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleCoverageEXT(gpNamedRenderbufferStorageMultisampleCoverageEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageMultisampleEXT(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleEXT(gpNamedRenderbufferStorageMultisampleEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
+}
+func NormalFormatNV(xtype uint32, stride int32) {
+	C.glowNormalFormatNV(gpNormalFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // label a named object identified within a namespace
@@ -6970,8 +11213,67 @@ func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathCommandsNV(path uint32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCommandsNV(gpPathCommandsNV, (C.GLuint)(path), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoordsNV(path uint32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCoordsNV(gpPathCoordsNV, (C.GLuint)(path), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoverDepthFuncNV(xfunc uint32) {
+	C.glowPathCoverDepthFuncNV(gpPathCoverDepthFuncNV, (C.GLenum)(xfunc))
+}
+func PathDashArrayNV(path uint32, dashCount int32, dashArray *float32) {
+	C.glowPathDashArrayNV(gpPathDashArrayNV, (C.GLuint)(path), (C.GLsizei)(dashCount), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func PathGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathGlyphIndexArrayNV(gpPathGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathGlyphIndexRangeNV(fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, pathParameterTemplate uint32, emScale float32, baseAndCount *uint32) uint32 {
+	ret := C.glowPathGlyphIndexRangeNV(gpPathGlyphIndexRangeNV, (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale), (*C.GLuint)(unsafe.Pointer(baseAndCount)))
+	return (uint32)(ret)
+}
+func PathGlyphRangeNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyph uint32, numGlyphs int32, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphRangeNV(gpPathGlyphRangeNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyph), (C.GLsizei)(numGlyphs), (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathGlyphsNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, numGlyphs int32, xtype uint32, charcodes unsafe.Pointer, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphsNV(gpPathGlyphsNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLsizei)(numGlyphs), (C.GLenum)(xtype), charcodes, (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathMemoryGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontSize int, fontData unsafe.Pointer, faceIndex int32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathMemoryGlyphIndexArrayNV(gpPathMemoryGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), (C.GLsizeiptr)(fontSize), fontData, (C.GLsizei)(faceIndex), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathParameterfNV(path uint32, pname uint32, value float32) {
+	C.glowPathParameterfNV(gpPathParameterfNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func PathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowPathParameterfvNV(gpPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func PathParameteriNV(path uint32, pname uint32, value int32) {
+	C.glowPathParameteriNV(gpPathParameteriNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowPathParameterivNV(gpPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func PathStencilDepthOffsetNV(factor float32, units float32) {
+	C.glowPathStencilDepthOffsetNV(gpPathStencilDepthOffsetNV, (C.GLfloat)(factor), (C.GLfloat)(units))
+}
+func PathStencilFuncNV(xfunc uint32, ref int32, mask uint32) {
+	C.glowPathStencilFuncNV(gpPathStencilFuncNV, (C.GLenum)(xfunc), (C.GLint)(ref), (C.GLuint)(mask))
+}
+func PathStringNV(path uint32, format uint32, length int32, pathString unsafe.Pointer) {
+	C.glowPathStringNV(gpPathStringNV, (C.GLuint)(path), (C.GLenum)(format), (C.GLsizei)(length), pathString)
+}
+func PathSubCommandsNV(path uint32, commandStart int32, commandsToDelete int32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCommandsNV(gpPathSubCommandsNV, (C.GLuint)(path), (C.GLsizei)(commandStart), (C.GLsizei)(commandsToDelete), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathSubCoordsNV(path uint32, coordStart int32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCoordsNV(gpPathSubCoordsNV, (C.GLuint)(path), (C.GLsizei)(coordStart), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
 }
 
 // pause transform feedback operations
@@ -6981,8 +11283,14 @@ func PauseTransformFeedback() {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
+}
+func PointAlongPathNV(path uint32, startSegment int32, numSegments int32, distance float32, x *float32, y *float32, tangentX *float32, tangentY *float32) bool {
+	ret := C.glowPointAlongPathNV(gpPointAlongPathNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments), (C.GLfloat)(distance), (*C.GLfloat)(unsafe.Pointer(x)), (*C.GLfloat)(unsafe.Pointer(y)), (*C.GLfloat)(unsafe.Pointer(tangentX)), (*C.GLfloat)(unsafe.Pointer(tangentY)))
+	return ret == TRUE
 }
 func PointParameterf(pname uint32, param float32) {
 	C.glowPointParameterf(gpPointParameterf, (C.GLenum)(pname), (C.GLfloat)(param))
@@ -7011,6 +11319,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 
 // pop the active debug group
 func PopDebugGroup() {
@@ -7018,6 +11332,12 @@ func PopDebugGroup() {
 }
 func PopDebugGroupKHR() {
 	C.glowPopDebugGroupKHR(gpPopDebugGroupKHR)
+}
+func PopGroupMarkerEXT() {
+	C.glowPopGroupMarkerEXT(gpPopGroupMarkerEXT)
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -7029,235 +11349,507 @@ func PrimitiveRestartIndex(index uint32) {
 func ProgramBinary(program uint32, binaryFormat uint32, binary unsafe.Pointer, length int32) {
 	C.glowProgramBinary(gpProgramBinary, (C.GLuint)(program), (C.GLenum)(binaryFormat), binary, (C.GLsizei)(length))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriARB(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriARB(gpProgramParameteriARB, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriEXT(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriEXT(gpProgramParameteriEXT, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramPathFragmentInputGenNV(program uint32, location int32, genMode uint32, components int32, coeffs *float32) {
+	C.glowProgramPathFragmentInputGenNV(gpProgramPathFragmentInputGenNV, (C.GLuint)(program), (C.GLint)(location), (C.GLenum)(genMode), (C.GLint)(components), (*C.GLfloat)(unsafe.Pointer(coeffs)))
 }
 func ProgramUniform1d(program uint32, location int32, v0 float64) {
 	C.glowProgramUniform1d(gpProgramUniform1d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0))
 }
+func ProgramUniform1dEXT(program uint32, location int32, x float64) {
+	C.glowProgramUniform1dEXT(gpProgramUniform1dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x))
+}
 func ProgramUniform1dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform1dv(gpProgramUniform1dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform1dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform1dvEXT(gpProgramUniform1dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1f(program uint32, location int32, v0 float32) {
 	C.glowProgramUniform1f(gpProgramUniform1f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
 }
+func ProgramUniform1fEXT(program uint32, location int32, v0 float32) {
+	C.glowProgramUniform1fEXT(gpProgramUniform1fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform1fv(gpProgramUniform1fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform1fvEXT(gpProgramUniform1fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
+func ProgramUniform1i64NV(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1iEXT(program uint32, location int32, v0 int32) {
+	C.glowProgramUniform1iEXT(gpProgramUniform1iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform1iv(gpProgramUniform1iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform1ivEXT(gpProgramUniform1ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
+func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1uiEXT(program uint32, location int32, v0 uint32) {
+	C.glowProgramUniform1uiEXT(gpProgramUniform1uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform1uiv(gpProgramUniform1uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform1uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform1uivEXT(gpProgramUniform1uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform2d(program uint32, location int32, v0 float64, v1 float64) {
 	C.glowProgramUniform2d(gpProgramUniform2d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1))
 }
+func ProgramUniform2dEXT(program uint32, location int32, x float64, y float64) {
+	C.glowProgramUniform2dEXT(gpProgramUniform2dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y))
+}
 func ProgramUniform2dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform2dv(gpProgramUniform2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform2dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform2dvEXT(gpProgramUniform2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2f(program uint32, location int32, v0 float32, v1 float32) {
 	C.glowProgramUniform2f(gpProgramUniform2f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
 }
+func ProgramUniform2fEXT(program uint32, location int32, v0 float32, v1 float32) {
+	C.glowProgramUniform2fEXT(gpProgramUniform2fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform2fv(gpProgramUniform2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform2fvEXT(gpProgramUniform2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2iEXT(program uint32, location int32, v0 int32, v1 int32) {
+	C.glowProgramUniform2iEXT(gpProgramUniform2iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform2iv(gpProgramUniform2iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform2ivEXT(gpProgramUniform2ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2uiEXT(program uint32, location int32, v0 uint32, v1 uint32) {
+	C.glowProgramUniform2uiEXT(gpProgramUniform2uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform2uiv(gpProgramUniform2uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform2uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform2uivEXT(gpProgramUniform2uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform3d(program uint32, location int32, v0 float64, v1 float64, v2 float64) {
 	C.glowProgramUniform3d(gpProgramUniform3d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2))
 }
+func ProgramUniform3dEXT(program uint32, location int32, x float64, y float64, z float64) {
+	C.glowProgramUniform3dEXT(gpProgramUniform3dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
 func ProgramUniform3dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform3dv(gpProgramUniform3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform3dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform3dvEXT(gpProgramUniform3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3f(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
 	C.glowProgramUniform3f(gpProgramUniform3f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
 }
+func ProgramUniform3fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
+	C.glowProgramUniform3fEXT(gpProgramUniform3fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform3fv(gpProgramUniform3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform3fvEXT(gpProgramUniform3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
+	C.glowProgramUniform3iEXT(gpProgramUniform3iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform3iv(gpProgramUniform3iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform3ivEXT(gpProgramUniform3ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
+	C.glowProgramUniform3uiEXT(gpProgramUniform3uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform3uiv(gpProgramUniform3uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform3uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform3uivEXT(gpProgramUniform3uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform4d(program uint32, location int32, v0 float64, v1 float64, v2 float64, v3 float64) {
 	C.glowProgramUniform4d(gpProgramUniform4d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2), (C.GLdouble)(v3))
 }
+func ProgramUniform4dEXT(program uint32, location int32, x float64, y float64, z float64, w float64) {
+	C.glowProgramUniform4dEXT(gpProgramUniform4dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
 func ProgramUniform4dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform4dv(gpProgramUniform4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform4dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform4dvEXT(gpProgramUniform4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4f(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
 	C.glowProgramUniform4f(gpProgramUniform4f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
 }
+func ProgramUniform4fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
+	C.glowProgramUniform4fEXT(gpProgramUniform4fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform4fv(gpProgramUniform4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform4fvEXT(gpProgramUniform4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
+	C.glowProgramUniform4iEXT(gpProgramUniform4iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform4iv(gpProgramUniform4iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform4ivEXT(gpProgramUniform4ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
+	C.glowProgramUniform4uiEXT(gpProgramUniform4uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform4uiv(gpProgramUniform4uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform4uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform4uivEXT(gpProgramUniform4uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniformHandleui64ARB(program uint32, location int32, value uint64) {
 	C.glowProgramUniformHandleui64ARB(gpProgramUniformHandleui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
+}
+func ProgramUniformHandleui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformHandleui64NV(gpProgramUniformHandleui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
 }
 func ProgramUniformHandleui64vARB(program uint32, location int32, count int32, values *uint64) {
 	C.glowProgramUniformHandleui64vARB(gpProgramUniformHandleui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
 }
+func ProgramUniformHandleui64vNV(program uint32, location int32, count int32, values *uint64) {
+	C.glowProgramUniformHandleui64vNV(gpProgramUniformHandleui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
+}
 func ProgramUniformMatrix2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2dv(gpProgramUniformMatrix2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2dvEXT(gpProgramUniformMatrix2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2fv(gpProgramUniformMatrix2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2fvEXT(gpProgramUniformMatrix2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x3dv(gpProgramUniformMatrix2x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x3dvEXT(gpProgramUniformMatrix2x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x3fv(gpProgramUniformMatrix2x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x3fvEXT(gpProgramUniformMatrix2x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x4dv(gpProgramUniformMatrix2x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x4dvEXT(gpProgramUniformMatrix2x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x4fv(gpProgramUniformMatrix2x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x4fvEXT(gpProgramUniformMatrix2x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3dv(gpProgramUniformMatrix3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3dvEXT(gpProgramUniformMatrix3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3fv(gpProgramUniformMatrix3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3fvEXT(gpProgramUniformMatrix3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x2dv(gpProgramUniformMatrix3x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x2dvEXT(gpProgramUniformMatrix3x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x2fv(gpProgramUniformMatrix3x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x2fvEXT(gpProgramUniformMatrix3x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x4dv(gpProgramUniformMatrix3x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x4dvEXT(gpProgramUniformMatrix3x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x4fv(gpProgramUniformMatrix3x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x4fvEXT(gpProgramUniformMatrix3x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4dv(gpProgramUniformMatrix4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4dvEXT(gpProgramUniformMatrix4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4fv(gpProgramUniformMatrix4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4fvEXT(gpProgramUniformMatrix4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x2dv(gpProgramUniformMatrix4x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x2dvEXT(gpProgramUniformMatrix4x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x2fv(gpProgramUniformMatrix4x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x2fvEXT(gpProgramUniformMatrix4x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x3dv(gpProgramUniformMatrix4x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x3dvEXT(gpProgramUniformMatrix4x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x3fv(gpProgramUniformMatrix4x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x3fvEXT(gpProgramUniformMatrix4x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniformui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformui64NV(gpProgramUniformui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func ProgramUniformui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniformui64vNV(gpProgramUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // specifiy the vertex to be used as the source of data for flat shaded varyings
 func ProvokingVertex(mode uint32) {
 	C.glowProvokingVertex(gpProvokingVertex, (C.GLenum)(mode))
+}
+func PushClientAttribDefaultEXT(mask uint32) {
+	C.glowPushClientAttribDefaultEXT(gpPushClientAttribDefaultEXT, (C.GLbitfield)(mask))
 }
 
 // push a named debug group into the command stream
@@ -7267,10 +11859,16 @@ func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
+func PushGroupMarkerEXT(length int32, marker *uint8) {
+	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
 
 // record the GL time into a query object after all previous commands have reached the GL server but have not yet necessarily executed.
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
+}
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
 
 // select a color buffer source for pixels
@@ -7307,6 +11905,12 @@ func RenderbufferStorage(target uint32, internalformat uint32, width int32, heig
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func RenderbufferStorageMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowRenderbufferStorageMultisample(gpRenderbufferStorageMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func RenderbufferStorageMultisampleCoverageNV(target uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowRenderbufferStorageMultisampleCoverageNV(gpRenderbufferStorageMultisampleCoverageNV, (C.GLenum)(target), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
 }
 
 // resume transform feedback operations
@@ -7357,6 +11961,12 @@ func ScissorIndexed(index uint32, left int32, bottom int32, width int32, height 
 func ScissorIndexedv(index uint32, v *int32) {
 	C.glowScissorIndexedv(gpScissorIndexedv, (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(v)))
 }
+func SecondaryColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowSecondaryColorFormatNV(gpSecondaryColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
+	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
+}
 
 // load pre-compiled shader binaries
 func ShaderBinary(count int32, shaders *uint32, binaryformat uint32, binary unsafe.Pointer, length int32) {
@@ -7371,6 +11981,24 @@ func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 // change an active shader storage block binding
 func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storageBlockBinding uint32) {
 	C.glowShaderStorageBlockBinding(gpShaderStorageBlockBinding, (C.GLuint)(program), (C.GLuint)(storageBlockIndex), (C.GLuint)(storageBlockBinding))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
+}
+func StencilFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilFillPathInstancedNV(gpStencilFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilFillPathNV(path uint32, fillMode uint32, mask uint32) {
+	C.glowStencilFillPathNV(gpStencilFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask))
 }
 
 // set front and back function and reference value for stencil testing
@@ -7402,15 +12030,42 @@ func StencilOp(fail uint32, zfail uint32, zpass uint32) {
 func StencilOpSeparate(face uint32, sfail uint32, dpfail uint32, dppass uint32) {
 	C.glowStencilOpSeparate(gpStencilOpSeparate, (C.GLenum)(face), (C.GLenum)(sfail), (C.GLenum)(dpfail), (C.GLenum)(dppass))
 }
+func StencilStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilStrokePathInstancedNV(gpStencilStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilStrokePathNV(path uint32, reference int32, mask uint32) {
+	C.glowStencilStrokePathNV(gpStencilStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask))
+}
+func StencilThenCoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverFillPathInstancedNV(gpStencilThenCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverFillPathNV(path uint32, fillMode uint32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverFillPathNV(gpStencilThenCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func StencilThenCoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverStrokePathInstancedNV(gpStencilThenCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverStrokePathNV(path uint32, reference int32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverStrokePathNV(gpStencilThenCoverStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TexBuffer(target uint32, internalformat uint32, buffer uint32) {
 	C.glowTexBuffer(gpTexBuffer, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TexBufferARB(target uint32, internalformat uint32, buffer uint32) {
+	C.glowTexBufferARB(gpTexBufferARB, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
 func TexBufferRange(target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTexBufferRange(gpTexBufferRange, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TexCoordFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowTexCoordFormatNV(gpTexCoordFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // specify a one-dimensional texture image
@@ -7437,8 +12092,8 @@ func TexImage3D(target uint32, level int32, internalformat int32, width int32, h
 func TexImage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexImage3DMultisample(gpTexImage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -7503,73 +12158,139 @@ func TexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zof
 func TextureBarrier() {
 	C.glowTextureBarrier(gpTextureBarrier)
 }
+func TextureBarrierNV() {
+	C.glowTextureBarrierNV(gpTextureBarrierNV)
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TextureBuffer(texture uint32, internalformat uint32, buffer uint32) {
 	C.glowTextureBuffer(gpTextureBuffer, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowTextureBufferEXT(gpTextureBufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureImage1DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage1DEXT(gpTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage2DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage2DEXT(gpTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage3DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage3DEXT(gpTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func TextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterIivEXT(gpTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func TextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowTextureParameterIuiv(gpTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func TextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowTextureParameterIuivEXT(gpTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
 func TextureParameterf(texture uint32, pname uint32, param float32) {
 	C.glowTextureParameterf(gpTextureParameterf, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLfloat)(param))
 }
+func TextureParameterfEXT(texture uint32, target uint32, pname uint32, param float32) {
+	C.glowTextureParameterfEXT(gpTextureParameterfEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
 func TextureParameterfv(texture uint32, pname uint32, param *float32) {
 	C.glowTextureParameterfv(gpTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(param)))
+}
+func TextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowTextureParameterfvEXT(gpTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func TextureParameteri(texture uint32, pname uint32, param int32) {
 	C.glowTextureParameteri(gpTextureParameteri, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLint)(param))
 }
+func TextureParameteriEXT(texture uint32, target uint32, pname uint32, param int32) {
+	C.glowTextureParameteriEXT(gpTextureParameteriEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
 func TextureParameteriv(texture uint32, pname uint32, param *int32) {
 	C.glowTextureParameteriv(gpTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func TextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterivEXT(gpTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func TextureRenderbufferEXT(texture uint32, target uint32, renderbuffer uint32) {
+	C.glowTextureRenderbufferEXT(gpTextureRenderbufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLuint)(renderbuffer))
 }
 
 // simultaneously specify storage for all levels of a one-dimensional texture
 func TextureStorage1D(texture uint32, levels int32, internalformat uint32, width int32) {
 	C.glowTextureStorage1D(gpTextureStorage1D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
 }
+func TextureStorage1DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32) {
+	C.glowTextureStorage1DEXT(gpTextureStorage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
+}
 
 // simultaneously specify storage for all levels of a two-dimensional or one-dimensional array texture
 func TextureStorage2D(texture uint32, levels int32, internalformat uint32, width int32, height int32) {
 	C.glowTextureStorage2D(gpTextureStorage2D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func TextureStorage2DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32) {
+	C.glowTextureStorage2DEXT(gpTextureStorage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // specify storage for a two-dimensional multisample texture
 func TextureStorage2DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
 	C.glowTextureStorage2DMultisample(gpTextureStorage2DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage2DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
+	C.glowTextureStorage2DMultisampleEXT(gpTextureStorage2DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // simultaneously specify storage for all levels of a three-dimensional, two-dimensional array or cube-map array texture
 func TextureStorage3D(texture uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
 	C.glowTextureStorage3D(gpTextureStorage3D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func TextureStorage3DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
+	C.glowTextureStorage3DEXT(gpTextureStorage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
 }
 
 // specify storage for a two-dimensional multisample array texture
 func TextureStorage3DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisample(gpTextureStorage3DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
+	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // specify a one-dimensional texture subimage
 func TextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage1D(gpTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage1DEXT(gpTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // specify a two-dimensional texture subimage
 func TextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage2D(gpTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func TextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage2DEXT(gpTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 
 // specify a three-dimensional texture subimage
 func TextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage3D(gpTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage3DEXT(gpTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // initialize a texture as a data alias of another texture's data store
@@ -7583,13 +12304,16 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 
 // specify values to record in transform feedback buffers
 func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
+}
+func TransformPathNV(resultPath uint32, srcPath uint32, transformType uint32, transformValues *float32) {
+	C.glowTransformPathNV(gpTransformPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
 }
 func Uniform1d(location int32, x float64) {
 	C.glowUniform1d(gpUniform1d, (C.GLint)(location), (C.GLdouble)(x))
@@ -7612,6 +12336,18 @@ func Uniform1fv(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
+func Uniform1i64NV(location int32, x int64) {
+	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform1i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform1iv(location int32, count int32, value *int32) {
@@ -7621,6 +12357,18 @@ func Uniform1iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
+}
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
+func Uniform1ui64NV(location int32, x uint64) {
+	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform1ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7648,6 +12396,18 @@ func Uniform2fv(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func Uniform2i64NV(location int32, x int64, y int64) {
+	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform2i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform2iv(location int32, count int32, value *int32) {
@@ -7657,6 +12417,18 @@ func Uniform2iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func Uniform2ui64NV(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform2ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7684,6 +12456,18 @@ func Uniform3fv(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func Uniform3i64NV(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform3i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform3iv(location int32, count int32, value *int32) {
@@ -7693,6 +12477,18 @@ func Uniform3iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform3ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7720,6 +12516,18 @@ func Uniform4fv(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform4i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform4iv(location int32, count int32, value *int32) {
@@ -7729,6 +12537,18 @@ func Uniform4iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform4ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7743,8 +12563,14 @@ func UniformBlockBinding(program uint32, uniformBlockIndex uint32, uniformBlockB
 func UniformHandleui64ARB(location int32, value uint64) {
 	C.glowUniformHandleui64ARB(gpUniformHandleui64ARB, (C.GLint)(location), (C.GLuint64)(value))
 }
+func UniformHandleui64NV(location int32, value uint64) {
+	C.glowUniformHandleui64NV(gpUniformHandleui64NV, (C.GLint)(location), (C.GLuint64)(value))
+}
 func UniformHandleui64vARB(location int32, count int32, value *uint64) {
 	C.glowUniformHandleui64vARB(gpUniformHandleui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func UniformHandleui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformHandleui64vNV(gpUniformHandleui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func UniformMatrix2dv(location int32, count int32, transpose bool, value *float64) {
 	C.glowUniformMatrix2dv(gpUniformMatrix2dv, (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
@@ -7821,6 +12647,12 @@ func UniformMatrix4x3fv(location int32, count int32, transpose bool, value *floa
 func UniformSubroutinesuiv(shadertype uint32, count int32, indices *uint32) {
 	C.glowUniformSubroutinesuiv(gpUniformSubroutinesuiv, (C.GLenum)(shadertype), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(indices)))
 }
+func Uniformui64NV(location int32, value uint64) {
+	C.glowUniformui64NV(gpUniformui64NV, (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func Uniformui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformui64vNV(gpUniformui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // release the mapping of a buffer object's data store into the client's address space
 func UnmapBuffer(target uint32) bool {
@@ -7833,6 +12665,10 @@ func UnmapNamedBuffer(buffer uint32) bool {
 	ret := C.glowUnmapNamedBuffer(gpUnmapNamedBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func UnmapNamedBufferEXT(buffer uint32) bool {
+	ret := C.glowUnmapNamedBufferEXT(gpUnmapNamedBufferEXT, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 
 // Installs a program object as part of current rendering state
 func UseProgram(program uint32) {
@@ -7843,6 +12679,12 @@ func UseProgram(program uint32) {
 func UseProgramStages(pipeline uint32, stages uint32, program uint32) {
 	C.glowUseProgramStages(gpUseProgramStages, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
 }
+func UseProgramStagesEXT(pipeline uint32, stages uint32, program uint32) {
+	C.glowUseProgramStagesEXT(gpUseProgramStagesEXT, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
+}
+func UseShaderProgramEXT(xtype uint32, program uint32) {
+	C.glowUseShaderProgramEXT(gpUseShaderProgramEXT, (C.GLenum)(xtype), (C.GLuint)(program))
+}
 
 // Validates a program object
 func ValidateProgram(program uint32) {
@@ -7852,6 +12694,9 @@ func ValidateProgram(program uint32) {
 // validate a program pipeline object against current GL state
 func ValidateProgramPipeline(pipeline uint32) {
 	C.glowValidateProgramPipeline(gpValidateProgramPipeline, (C.GLuint)(pipeline))
+}
+func ValidateProgramPipelineEXT(pipeline uint32) {
+	C.glowValidateProgramPipelineEXT(gpValidateProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 func VertexArrayAttribBinding(vaobj uint32, attribindex uint32, bindingindex uint32) {
 	C.glowVertexArrayAttribBinding(gpVertexArrayAttribBinding, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
@@ -7867,15 +12712,69 @@ func VertexArrayAttribIFormat(vaobj uint32, attribindex uint32, size int32, xtyp
 func VertexArrayAttribLFormat(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexArrayAttribLFormat(gpVertexArrayAttribLFormat, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexArrayBindVertexBufferEXT(vaobj uint32, bindingindex uint32, buffer uint32, offset int, stride int32) {
+	C.glowVertexArrayBindVertexBufferEXT(gpVertexArrayBindVertexBufferEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(stride))
+}
 
 // modify the rate at which generic vertex attributes     advance
 func VertexArrayBindingDivisor(vaobj uint32, bindingindex uint32, divisor uint32) {
 	C.glowVertexArrayBindingDivisor(gpVertexArrayBindingDivisor, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexArrayColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayColorOffsetEXT(gpVertexArrayColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayEdgeFlagOffsetEXT(vaobj uint32, buffer uint32, stride int32, offset int) {
+	C.glowVertexArrayEdgeFlagOffsetEXT(gpVertexArrayEdgeFlagOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
 
 // configures element array buffer binding of a vertex array object
 func VertexArrayElementBuffer(vaobj uint32, buffer uint32) {
 	C.glowVertexArrayElementBuffer(gpVertexArrayElementBuffer, (C.GLuint)(vaobj), (C.GLuint)(buffer))
+}
+func VertexArrayFogCoordOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayFogCoordOffsetEXT(gpVertexArrayFogCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayIndexOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayIndexOffsetEXT(gpVertexArrayIndexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayMultiTexCoordOffsetEXT(vaobj uint32, buffer uint32, texunit uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayMultiTexCoordOffsetEXT(gpVertexArrayMultiTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayNormalOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayNormalOffsetEXT(gpVertexArrayNormalOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArraySecondaryColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArraySecondaryColorOffsetEXT(gpVertexArraySecondaryColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayTexCoordOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayTexCoordOffsetEXT(gpVertexArrayTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribBindingEXT(vaobj uint32, attribindex uint32, bindingindex uint32) {
+	C.glowVertexArrayVertexAttribBindingEXT(gpVertexArrayVertexAttribBindingEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
+}
+func VertexArrayVertexAttribDivisorEXT(vaobj uint32, index uint32, divisor uint32) {
+	C.glowVertexArrayVertexAttribDivisorEXT(gpVertexArrayVertexAttribDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLuint)(divisor))
+}
+func VertexArrayVertexAttribFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribFormatEXT(gpVertexArrayVertexAttribFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribIFormatEXT(gpVertexArrayVertexAttribIFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribIOffsetEXT(gpVertexArrayVertexAttribIOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribLFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribLFormatEXT(gpVertexArrayVertexAttribLFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribLOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribLOffsetEXT(gpVertexArrayVertexAttribLOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, normalized bool, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribOffsetEXT(gpVertexArrayVertexAttribOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexBindingDivisorEXT(vaobj uint32, bindingindex uint32, divisor uint32) {
+	C.glowVertexArrayVertexBindingDivisorEXT(gpVertexArrayVertexBindingDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
 
 // bind a buffer to a vertex buffer bind point
@@ -7886,6 +12785,9 @@ func VertexArrayVertexBuffer(vaobj uint32, bindingindex uint32, buffer uint32, o
 // attach multiple buffer objects to a vertex array object
 func VertexArrayVertexBuffers(vaobj uint32, first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowVertexArrayVertexBuffers(gpVertexArrayVertexBuffers, (C.GLuint)(vaobj), (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
+}
+func VertexArrayVertexOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexOffsetEXT(gpVertexArrayVertexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
 }
 func VertexAttrib1d(index uint32, x float64) {
 	C.glowVertexAttrib1d(gpVertexAttrib1d, (C.GLuint)(index), (C.GLdouble)(x))
@@ -8005,10 +12907,16 @@ func VertexAttribBinding(attribindex uint32, bindingindex uint32) {
 func VertexAttribDivisor(index uint32, divisor uint32) {
 	C.glowVertexAttribDivisor(gpVertexAttribDivisor, (C.GLuint)(index), (C.GLuint)(divisor))
 }
+func VertexAttribDivisorARB(index uint32, divisor uint32) {
+	C.glowVertexAttribDivisorARB(gpVertexAttribDivisorARB, (C.GLuint)(index), (C.GLuint)(divisor))
+}
 
 // specify the organization of vertex arrays
 func VertexAttribFormat(attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
 	C.glowVertexAttribFormat(gpVertexAttribFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexAttribFormatNV(index uint32, size int32, xtype uint32, normalized bool, stride int32) {
+	C.glowVertexAttribFormatNV(gpVertexAttribFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride))
 }
 func VertexAttribI1i(index uint32, x int32) {
 	C.glowVertexAttribI1i(gpVertexAttribI1i, (C.GLuint)(index), (C.GLint)(x))
@@ -8073,6 +12981,9 @@ func VertexAttribI4usv(index uint32, v *uint16) {
 func VertexAttribIFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribIFormat(gpVertexAttribIFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexAttribIFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribIFormatNV(gpVertexAttribIFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func VertexAttribIPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribIPointer(gpVertexAttribIPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
 }
@@ -8082,11 +12993,23 @@ func VertexAttribL1d(index uint32, x float64) {
 func VertexAttribL1dv(index uint32, v *float64) {
 	C.glowVertexAttribL1dv(gpVertexAttribL1dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL1i64NV(index uint32, x int64) {
+	C.glowVertexAttribL1i64NV(gpVertexAttribL1i64NV, (C.GLuint)(index), (C.GLint64EXT)(x))
+}
+func VertexAttribL1i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL1i64vNV(gpVertexAttribL1i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL1ui64ARB(index uint32, x uint64) {
 	C.glowVertexAttribL1ui64ARB(gpVertexAttribL1ui64ARB, (C.GLuint)(index), (C.GLuint64EXT)(x))
 }
+func VertexAttribL1ui64NV(index uint32, x uint64) {
+	C.glowVertexAttribL1ui64NV(gpVertexAttribL1ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x))
+}
 func VertexAttribL1ui64vARB(index uint32, v *uint64) {
 	C.glowVertexAttribL1ui64vARB(gpVertexAttribL1ui64vARB, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL1ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL1ui64vNV(gpVertexAttribL1ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL2d(index uint32, x float64, y float64) {
 	C.glowVertexAttribL2d(gpVertexAttribL2d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y))
@@ -8094,11 +13017,35 @@ func VertexAttribL2d(index uint32, x float64, y float64) {
 func VertexAttribL2dv(index uint32, v *float64) {
 	C.glowVertexAttribL2dv(gpVertexAttribL2dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL2i64NV(index uint32, x int64, y int64) {
+	C.glowVertexAttribL2i64NV(gpVertexAttribL2i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func VertexAttribL2i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL2i64vNV(gpVertexAttribL2i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL2ui64NV(index uint32, x uint64, y uint64) {
+	C.glowVertexAttribL2ui64NV(gpVertexAttribL2ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func VertexAttribL2ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL2ui64vNV(gpVertexAttribL2ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL3d(index uint32, x float64, y float64, z float64) {
 	C.glowVertexAttribL3d(gpVertexAttribL3d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
 }
 func VertexAttribL3dv(index uint32, v *float64) {
 	C.glowVertexAttribL3dv(gpVertexAttribL3dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
+}
+func VertexAttribL3i64NV(index uint32, x int64, y int64, z int64) {
+	C.glowVertexAttribL3i64NV(gpVertexAttribL3i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func VertexAttribL3i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL3i64vNV(gpVertexAttribL3i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL3ui64NV(index uint32, x uint64, y uint64, z uint64) {
+	C.glowVertexAttribL3ui64NV(gpVertexAttribL3ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func VertexAttribL3ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL3ui64vNV(gpVertexAttribL3ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 	C.glowVertexAttribL4d(gpVertexAttribL4d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
@@ -8106,8 +13053,23 @@ func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 func VertexAttribL4dv(index uint32, v *float64) {
 	C.glowVertexAttribL4dv(gpVertexAttribL4dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL4i64NV(index uint32, x int64, y int64, z int64, w int64) {
+	C.glowVertexAttribL4i64NV(gpVertexAttribL4i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func VertexAttribL4i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL4i64vNV(gpVertexAttribL4i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL4ui64NV(index uint32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowVertexAttribL4ui64NV(gpVertexAttribL4ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func VertexAttribL4ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL4ui64vNV(gpVertexAttribL4ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribLFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribLFormat(gpVertexAttribLFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexAttribLFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribLFormatNV(gpVertexAttribLFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 func VertexAttribLPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribLPointer(gpVertexAttribLPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
@@ -8146,6 +13108,9 @@ func VertexAttribPointer(index uint32, size int32, xtype uint32, normalized bool
 func VertexBindingDivisor(bindingindex uint32, divisor uint32) {
 	C.glowVertexBindingDivisor(gpVertexBindingDivisor, (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowVertexFormatNV(gpVertexFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 
 // set the viewport
 func Viewport(x int32, y int32, width int32, height int32) {
@@ -8160,10 +13125,25 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
+	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
+}
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
 }
 
 // Init initializes the OpenGL bindings by loading the function pointers (for
@@ -8193,14 +13173,17 @@ func Init() error {
 // function pointer loading function. For more cases Init should be used
 // instead.
 func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
+	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
 	if gpActiveShaderProgram == nil {
 		return errors.New("glActiveShaderProgram")
 	}
+	gpActiveShaderProgramEXT = (C.GPACTIVESHADERPROGRAMEXT)(getProcAddr("glActiveShaderProgramEXT"))
 	gpActiveTexture = (C.GPACTIVETEXTURE)(getProcAddr("glActiveTexture"))
 	if gpActiveTexture == nil {
 		return errors.New("glActiveTexture")
 	}
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpAttachShader = (C.GPATTACHSHADER)(getProcAddr("glAttachShader"))
 	if gpAttachShader == nil {
 		return errors.New("glAttachShader")
@@ -8209,6 +13192,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBeginConditionalRender == nil {
 		return errors.New("glBeginConditionalRender")
 	}
+	gpBeginConditionalRenderNV = (C.GPBEGINCONDITIONALRENDERNV)(getProcAddr("glBeginConditionalRenderNV"))
+	gpBeginPerfMonitorAMD = (C.GPBEGINPERFMONITORAMD)(getProcAddr("glBeginPerfMonitorAMD"))
+	gpBeginPerfQueryINTEL = (C.GPBEGINPERFQUERYINTEL)(getProcAddr("glBeginPerfQueryINTEL"))
 	gpBeginQuery = (C.GPBEGINQUERY)(getProcAddr("glBeginQuery"))
 	if gpBeginQuery == nil {
 		return errors.New("glBeginQuery")
@@ -8253,10 +13239,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpBindImageTexture = (C.GPBINDIMAGETEXTURE)(getProcAddr("glBindImageTexture"))
 	gpBindImageTextures = (C.GPBINDIMAGETEXTURES)(getProcAddr("glBindImageTextures"))
+	gpBindMultiTextureEXT = (C.GPBINDMULTITEXTUREEXT)(getProcAddr("glBindMultiTextureEXT"))
 	gpBindProgramPipeline = (C.GPBINDPROGRAMPIPELINE)(getProcAddr("glBindProgramPipeline"))
 	if gpBindProgramPipeline == nil {
 		return errors.New("glBindProgramPipeline")
 	}
+	gpBindProgramPipelineEXT = (C.GPBINDPROGRAMPIPELINEEXT)(getProcAddr("glBindProgramPipelineEXT"))
 	gpBindRenderbuffer = (C.GPBINDRENDERBUFFER)(getProcAddr("glBindRenderbuffer"))
 	if gpBindRenderbuffer == nil {
 		return errors.New("glBindRenderbuffer")
@@ -8282,6 +13270,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpBindVertexBuffer = (C.GPBINDVERTEXBUFFER)(getProcAddr("glBindVertexBuffer"))
 	gpBindVertexBuffers = (C.GPBINDVERTEXBUFFERS)(getProcAddr("glBindVertexBuffers"))
+	gpBlendBarrierKHR = (C.GPBLENDBARRIERKHR)(getProcAddr("glBlendBarrierKHR"))
+	gpBlendBarrierNV = (C.GPBLENDBARRIERNV)(getProcAddr("glBlendBarrierNV"))
 	gpBlendColor = (C.GPBLENDCOLOR)(getProcAddr("glBlendColor"))
 	if gpBlendColor == nil {
 		return errors.New("glBlendColor")
@@ -8322,11 +13312,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glBlendFunci")
 	}
 	gpBlendFunciARB = (C.GPBLENDFUNCIARB)(getProcAddr("glBlendFunciARB"))
+	gpBlendParameteriNV = (C.GPBLENDPARAMETERINV)(getProcAddr("glBlendParameteriNV"))
 	gpBlitFramebuffer = (C.GPBLITFRAMEBUFFER)(getProcAddr("glBlitFramebuffer"))
 	if gpBlitFramebuffer == nil {
 		return errors.New("glBlitFramebuffer")
 	}
 	gpBlitNamedFramebuffer = (C.GPBLITNAMEDFRAMEBUFFER)(getProcAddr("glBlitNamedFramebuffer"))
+	gpBufferAddressRangeNV = (C.GPBUFFERADDRESSRANGENV)(getProcAddr("glBufferAddressRangeNV"))
 	gpBufferData = (C.GPBUFFERDATA)(getProcAddr("glBufferData"))
 	if gpBufferData == nil {
 		return errors.New("glBufferData")
@@ -8337,11 +13329,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCheckFramebufferStatus = (C.GPCHECKFRAMEBUFFERSTATUS)(getProcAddr("glCheckFramebufferStatus"))
 	if gpCheckFramebufferStatus == nil {
 		return errors.New("glCheckFramebufferStatus")
 	}
 	gpCheckNamedFramebufferStatus = (C.GPCHECKNAMEDFRAMEBUFFERSTATUS)(getProcAddr("glCheckNamedFramebufferStatus"))
+	gpCheckNamedFramebufferStatusEXT = (C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(getProcAddr("glCheckNamedFramebufferStatusEXT"))
 	gpClampColor = (C.GPCLAMPCOLOR)(getProcAddr("glClampColor"))
 	if gpClampColor == nil {
 		return errors.New("glClampColor")
@@ -8381,7 +13375,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glClearDepthf")
 	}
 	gpClearNamedBufferData = (C.GPCLEARNAMEDBUFFERDATA)(getProcAddr("glClearNamedBufferData"))
+	gpClearNamedBufferDataEXT = (C.GPCLEARNAMEDBUFFERDATAEXT)(getProcAddr("glClearNamedBufferDataEXT"))
 	gpClearNamedBufferSubData = (C.GPCLEARNAMEDBUFFERSUBDATA)(getProcAddr("glClearNamedBufferSubData"))
+	gpClearNamedBufferSubDataEXT = (C.GPCLEARNAMEDBUFFERSUBDATAEXT)(getProcAddr("glClearNamedBufferSubDataEXT"))
 	gpClearNamedFramebufferfi = (C.GPCLEARNAMEDFRAMEBUFFERFI)(getProcAddr("glClearNamedFramebufferfi"))
 	gpClearNamedFramebufferfv = (C.GPCLEARNAMEDFRAMEBUFFERFV)(getProcAddr("glClearNamedFramebufferfv"))
 	gpClearNamedFramebufferiv = (C.GPCLEARNAMEDFRAMEBUFFERIV)(getProcAddr("glClearNamedFramebufferiv"))
@@ -8392,11 +13388,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpClearTexImage = (C.GPCLEARTEXIMAGE)(getProcAddr("glClearTexImage"))
 	gpClearTexSubImage = (C.GPCLEARTEXSUBIMAGE)(getProcAddr("glClearTexSubImage"))
+	gpClientAttribDefaultEXT = (C.GPCLIENTATTRIBDEFAULTEXT)(getProcAddr("glClientAttribDefaultEXT"))
 	gpClientWaitSync = (C.GPCLIENTWAITSYNC)(getProcAddr("glClientWaitSync"))
 	if gpClientWaitSync == nil {
 		return errors.New("glClientWaitSync")
 	}
 	gpClipControl = (C.GPCLIPCONTROL)(getProcAddr("glClipControl"))
+	gpColorFormatNV = (C.GPCOLORFORMATNV)(getProcAddr("glColorFormatNV"))
 	gpColorMask = (C.GPCOLORMASK)(getProcAddr("glColorMask"))
 	if gpColorMask == nil {
 		return errors.New("glColorMask")
@@ -8405,11 +13403,19 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpColorMaski == nil {
 		return errors.New("glColorMaski")
 	}
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
 	}
 	gpCompileShaderIncludeARB = (C.GPCOMPILESHADERINCLUDEARB)(getProcAddr("glCompileShaderIncludeARB"))
+	gpCompressedMultiTexImage1DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE1DEXT)(getProcAddr("glCompressedMultiTexImage1DEXT"))
+	gpCompressedMultiTexImage2DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE2DEXT)(getProcAddr("glCompressedMultiTexImage2DEXT"))
+	gpCompressedMultiTexImage3DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE3DEXT)(getProcAddr("glCompressedMultiTexImage3DEXT"))
+	gpCompressedMultiTexSubImage1DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCompressedMultiTexSubImage1DEXT"))
+	gpCompressedMultiTexSubImage2DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCompressedMultiTexSubImage2DEXT"))
+	gpCompressedMultiTexSubImage3DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCompressedMultiTexSubImage3DEXT"))
 	gpCompressedTexImage1D = (C.GPCOMPRESSEDTEXIMAGE1D)(getProcAddr("glCompressedTexImage1D"))
 	if gpCompressedTexImage1D == nil {
 		return errors.New("glCompressedTexImage1D")
@@ -8434,15 +13440,29 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCompressedTexSubImage3D == nil {
 		return errors.New("glCompressedTexSubImage3D")
 	}
+	gpCompressedTextureImage1DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE1DEXT)(getProcAddr("glCompressedTextureImage1DEXT"))
+	gpCompressedTextureImage2DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE2DEXT)(getProcAddr("glCompressedTextureImage2DEXT"))
+	gpCompressedTextureImage3DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE3DEXT)(getProcAddr("glCompressedTextureImage3DEXT"))
 	gpCompressedTextureSubImage1D = (C.GPCOMPRESSEDTEXTURESUBIMAGE1D)(getProcAddr("glCompressedTextureSubImage1D"))
+	gpCompressedTextureSubImage1DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(getProcAddr("glCompressedTextureSubImage1DEXT"))
 	gpCompressedTextureSubImage2D = (C.GPCOMPRESSEDTEXTURESUBIMAGE2D)(getProcAddr("glCompressedTextureSubImage2D"))
+	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
+	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpCopyBufferSubData = (C.GPCOPYBUFFERSUBDATA)(getProcAddr("glCopyBufferSubData"))
 	if gpCopyBufferSubData == nil {
 		return errors.New("glCopyBufferSubData")
 	}
 	gpCopyImageSubData = (C.GPCOPYIMAGESUBDATA)(getProcAddr("glCopyImageSubData"))
+	gpCopyMultiTexImage1DEXT = (C.GPCOPYMULTITEXIMAGE1DEXT)(getProcAddr("glCopyMultiTexImage1DEXT"))
+	gpCopyMultiTexImage2DEXT = (C.GPCOPYMULTITEXIMAGE2DEXT)(getProcAddr("glCopyMultiTexImage2DEXT"))
+	gpCopyMultiTexSubImage1DEXT = (C.GPCOPYMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCopyMultiTexSubImage1DEXT"))
+	gpCopyMultiTexSubImage2DEXT = (C.GPCOPYMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCopyMultiTexSubImage2DEXT"))
+	gpCopyMultiTexSubImage3DEXT = (C.GPCOPYMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCopyMultiTexSubImage3DEXT"))
 	gpCopyNamedBufferSubData = (C.GPCOPYNAMEDBUFFERSUBDATA)(getProcAddr("glCopyNamedBufferSubData"))
+	gpCopyPathNV = (C.GPCOPYPATHNV)(getProcAddr("glCopyPathNV"))
 	gpCopyTexImage1D = (C.GPCOPYTEXIMAGE1D)(getProcAddr("glCopyTexImage1D"))
 	if gpCopyTexImage1D == nil {
 		return errors.New("glCopyTexImage1D")
@@ -8463,11 +13483,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCopyTexSubImage3D == nil {
 		return errors.New("glCopyTexSubImage3D")
 	}
+	gpCopyTextureImage1DEXT = (C.GPCOPYTEXTUREIMAGE1DEXT)(getProcAddr("glCopyTextureImage1DEXT"))
+	gpCopyTextureImage2DEXT = (C.GPCOPYTEXTUREIMAGE2DEXT)(getProcAddr("glCopyTextureImage2DEXT"))
 	gpCopyTextureSubImage1D = (C.GPCOPYTEXTURESUBIMAGE1D)(getProcAddr("glCopyTextureSubImage1D"))
+	gpCopyTextureSubImage1DEXT = (C.GPCOPYTEXTURESUBIMAGE1DEXT)(getProcAddr("glCopyTextureSubImage1DEXT"))
 	gpCopyTextureSubImage2D = (C.GPCOPYTEXTURESUBIMAGE2D)(getProcAddr("glCopyTextureSubImage2D"))
+	gpCopyTextureSubImage2DEXT = (C.GPCOPYTEXTURESUBIMAGE2DEXT)(getProcAddr("glCopyTextureSubImage2DEXT"))
 	gpCopyTextureSubImage3D = (C.GPCOPYTEXTURESUBIMAGE3D)(getProcAddr("glCopyTextureSubImage3D"))
+	gpCopyTextureSubImage3DEXT = (C.GPCOPYTEXTURESUBIMAGE3DEXT)(getProcAddr("glCopyTextureSubImage3DEXT"))
+	gpCoverFillPathInstancedNV = (C.GPCOVERFILLPATHINSTANCEDNV)(getProcAddr("glCoverFillPathInstancedNV"))
+	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
+	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
+	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
+	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
 		return errors.New("glCreateProgram")
@@ -8480,10 +13513,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCreateShader == nil {
 		return errors.New("glCreateShader")
 	}
+	gpCreateShaderProgramEXT = (C.GPCREATESHADERPROGRAMEXT)(getProcAddr("glCreateShaderProgramEXT"))
 	gpCreateShaderProgramv = (C.GPCREATESHADERPROGRAMV)(getProcAddr("glCreateShaderProgramv"))
 	if gpCreateShaderProgramv == nil {
 		return errors.New("glCreateShaderProgramv")
 	}
+	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	gpCreateTransformFeedbacks = (C.GPCREATETRANSFORMFEEDBACKS)(getProcAddr("glCreateTransformFeedbacks"))
@@ -8505,11 +13541,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteBuffers == nil {
 		return errors.New("glDeleteBuffers")
 	}
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFramebuffers = (C.GPDELETEFRAMEBUFFERS)(getProcAddr("glDeleteFramebuffers"))
 	if gpDeleteFramebuffers == nil {
 		return errors.New("glDeleteFramebuffers")
 	}
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
+	gpDeletePathsNV = (C.GPDELETEPATHSNV)(getProcAddr("glDeletePathsNV"))
+	gpDeletePerfMonitorsAMD = (C.GPDELETEPERFMONITORSAMD)(getProcAddr("glDeletePerfMonitorsAMD"))
+	gpDeletePerfQueryINTEL = (C.GPDELETEPERFQUERYINTEL)(getProcAddr("glDeletePerfQueryINTEL"))
 	gpDeleteProgram = (C.GPDELETEPROGRAM)(getProcAddr("glDeleteProgram"))
 	if gpDeleteProgram == nil {
 		return errors.New("glDeleteProgram")
@@ -8518,6 +13558,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteProgramPipelines == nil {
 		return errors.New("glDeleteProgramPipelines")
 	}
+	gpDeleteProgramPipelinesEXT = (C.GPDELETEPROGRAMPIPELINESEXT)(getProcAddr("glDeleteProgramPipelinesEXT"))
 	gpDeleteQueries = (C.GPDELETEQUERIES)(getProcAddr("glDeleteQueries"))
 	if gpDeleteQueries == nil {
 		return errors.New("glDeleteQueries")
@@ -8534,6 +13575,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	if gpDeleteSync == nil {
 		return errors.New("glDeleteSync")
@@ -8582,7 +13624,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDisable == nil {
 		return errors.New("glDisable")
 	}
+	gpDisableClientStateIndexedEXT = (C.GPDISABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glDisableClientStateIndexedEXT"))
+	gpDisableClientStateiEXT = (C.GPDISABLECLIENTSTATEIEXT)(getProcAddr("glDisableClientStateiEXT"))
+	gpDisableIndexedEXT = (C.GPDISABLEINDEXEDEXT)(getProcAddr("glDisableIndexedEXT"))
 	gpDisableVertexArrayAttrib = (C.GPDISABLEVERTEXARRAYATTRIB)(getProcAddr("glDisableVertexArrayAttrib"))
+	gpDisableVertexArrayAttribEXT = (C.GPDISABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glDisableVertexArrayAttribEXT"))
+	gpDisableVertexArrayEXT = (C.GPDISABLEVERTEXARRAYEXT)(getProcAddr("glDisableVertexArrayEXT"))
 	gpDisableVertexAttribArray = (C.GPDISABLEVERTEXATTRIBARRAY)(getProcAddr("glDisableVertexAttribArray"))
 	if gpDisableVertexAttribArray == nil {
 		return errors.New("glDisableVertexAttribArray")
@@ -8606,7 +13653,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawArraysInstanced == nil {
 		return errors.New("glDrawArraysInstanced")
 	}
+	gpDrawArraysInstancedARB = (C.GPDRAWARRAYSINSTANCEDARB)(getProcAddr("glDrawArraysInstancedARB"))
 	gpDrawArraysInstancedBaseInstance = (C.GPDRAWARRAYSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawArraysInstancedBaseInstance"))
+	gpDrawArraysInstancedEXT = (C.GPDRAWARRAYSINSTANCEDEXT)(getProcAddr("glDrawArraysInstancedEXT"))
 	gpDrawBuffer = (C.GPDRAWBUFFER)(getProcAddr("glDrawBuffer"))
 	if gpDrawBuffer == nil {
 		return errors.New("glDrawBuffer")
@@ -8615,6 +13664,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawBuffers == nil {
 		return errors.New("glDrawBuffers")
 	}
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
 	if gpDrawElements == nil {
 		return errors.New("glDrawElements")
@@ -8631,12 +13684,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawElementsInstanced == nil {
 		return errors.New("glDrawElementsInstanced")
 	}
+	gpDrawElementsInstancedARB = (C.GPDRAWELEMENTSINSTANCEDARB)(getProcAddr("glDrawElementsInstancedARB"))
 	gpDrawElementsInstancedBaseInstance = (C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawElementsInstancedBaseInstance"))
 	gpDrawElementsInstancedBaseVertex = (C.GPDRAWELEMENTSINSTANCEDBASEVERTEX)(getProcAddr("glDrawElementsInstancedBaseVertex"))
 	if gpDrawElementsInstancedBaseVertex == nil {
 		return errors.New("glDrawElementsInstancedBaseVertex")
 	}
 	gpDrawElementsInstancedBaseVertexBaseInstance = (C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE)(getProcAddr("glDrawElementsInstancedBaseVertexBaseInstance"))
+	gpDrawElementsInstancedEXT = (C.GPDRAWELEMENTSINSTANCEDEXT)(getProcAddr("glDrawElementsInstancedEXT"))
 	gpDrawRangeElements = (C.GPDRAWRANGEELEMENTS)(getProcAddr("glDrawRangeElements"))
 	if gpDrawRangeElements == nil {
 		return errors.New("glDrawRangeElements")
@@ -8655,11 +13710,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDrawTransformFeedbackStream")
 	}
 	gpDrawTransformFeedbackStreamInstanced = (C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(getProcAddr("glDrawTransformFeedbackStreamInstanced"))
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
+	gpEdgeFlagFormatNV = (C.GPEDGEFLAGFORMATNV)(getProcAddr("glEdgeFlagFormatNV"))
 	gpEnable = (C.GPENABLE)(getProcAddr("glEnable"))
 	if gpEnable == nil {
 		return errors.New("glEnable")
 	}
+	gpEnableClientStateIndexedEXT = (C.GPENABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glEnableClientStateIndexedEXT"))
+	gpEnableClientStateiEXT = (C.GPENABLECLIENTSTATEIEXT)(getProcAddr("glEnableClientStateiEXT"))
+	gpEnableIndexedEXT = (C.GPENABLEINDEXEDEXT)(getProcAddr("glEnableIndexedEXT"))
 	gpEnableVertexArrayAttrib = (C.GPENABLEVERTEXARRAYATTRIB)(getProcAddr("glEnableVertexArrayAttrib"))
+	gpEnableVertexArrayAttribEXT = (C.GPENABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glEnableVertexArrayAttribEXT"))
+	gpEnableVertexArrayEXT = (C.GPENABLEVERTEXARRAYEXT)(getProcAddr("glEnableVertexArrayEXT"))
 	gpEnableVertexAttribArray = (C.GPENABLEVERTEXATTRIBARRAY)(getProcAddr("glEnableVertexAttribArray"))
 	if gpEnableVertexAttribArray == nil {
 		return errors.New("glEnableVertexAttribArray")
@@ -8672,6 +13734,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEndConditionalRender == nil {
 		return errors.New("glEndConditionalRender")
 	}
+	gpEndConditionalRenderNV = (C.GPENDCONDITIONALRENDERNV)(getProcAddr("glEndConditionalRenderNV"))
+	gpEndPerfMonitorAMD = (C.GPENDPERFMONITORAMD)(getProcAddr("glEndPerfMonitorAMD"))
+	gpEndPerfQueryINTEL = (C.GPENDPERFQUERYINTEL)(getProcAddr("glEndPerfQueryINTEL"))
 	gpEndQuery = (C.GPENDQUERY)(getProcAddr("glEndQuery"))
 	if gpEndQuery == nil {
 		return errors.New("glEndQuery")
@@ -8684,6 +13749,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEndTransformFeedback == nil {
 		return errors.New("glEndTransformFeedback")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpFenceSync = (C.GPFENCESYNC)(getProcAddr("glFenceSync"))
 	if gpFenceSync == nil {
 		return errors.New("glFenceSync")
@@ -8701,11 +13767,20 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glFlushMappedBufferRange")
 	}
 	gpFlushMappedNamedBufferRange = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGE)(getProcAddr("glFlushMappedNamedBufferRange"))
+	gpFlushMappedNamedBufferRangeEXT = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(getProcAddr("glFlushMappedNamedBufferRangeEXT"))
+	gpFogCoordFormatNV = (C.GPFOGCOORDFORMATNV)(getProcAddr("glFogCoordFormatNV"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
+	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
+	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
+	gpFramebufferReadBufferEXT = (C.GPFRAMEBUFFERREADBUFFEREXT)(getProcAddr("glFramebufferReadBufferEXT"))
 	gpFramebufferRenderbuffer = (C.GPFRAMEBUFFERRENDERBUFFER)(getProcAddr("glFramebufferRenderbuffer"))
 	if gpFramebufferRenderbuffer == nil {
 		return errors.New("glFramebufferRenderbuffer")
 	}
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	if gpFramebufferTexture == nil {
 		return errors.New("glFramebufferTexture")
@@ -8722,10 +13797,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpFramebufferTexture3D == nil {
 		return errors.New("glFramebufferTexture3D")
 	}
+	gpFramebufferTextureARB = (C.GPFRAMEBUFFERTEXTUREARB)(getProcAddr("glFramebufferTextureARB"))
+	gpFramebufferTextureFaceARB = (C.GPFRAMEBUFFERTEXTUREFACEARB)(getProcAddr("glFramebufferTextureFaceARB"))
 	gpFramebufferTextureLayer = (C.GPFRAMEBUFFERTEXTURELAYER)(getProcAddr("glFramebufferTextureLayer"))
 	if gpFramebufferTextureLayer == nil {
 		return errors.New("glFramebufferTextureLayer")
 	}
+	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
 		return errors.New("glFrontFace")
@@ -8738,10 +13817,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenFramebuffers == nil {
 		return errors.New("glGenFramebuffers")
 	}
+	gpGenPathsNV = (C.GPGENPATHSNV)(getProcAddr("glGenPathsNV"))
+	gpGenPerfMonitorsAMD = (C.GPGENPERFMONITORSAMD)(getProcAddr("glGenPerfMonitorsAMD"))
 	gpGenProgramPipelines = (C.GPGENPROGRAMPIPELINES)(getProcAddr("glGenProgramPipelines"))
 	if gpGenProgramPipelines == nil {
 		return errors.New("glGenProgramPipelines")
 	}
+	gpGenProgramPipelinesEXT = (C.GPGENPROGRAMPIPELINESEXT)(getProcAddr("glGenProgramPipelinesEXT"))
 	gpGenQueries = (C.GPGENQUERIES)(getProcAddr("glGenQueries"))
 	if gpGenQueries == nil {
 		return errors.New("glGenQueries")
@@ -8770,7 +13852,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenerateMipmap == nil {
 		return errors.New("glGenerateMipmap")
 	}
+	gpGenerateMultiTexMipmapEXT = (C.GPGENERATEMULTITEXMIPMAPEXT)(getProcAddr("glGenerateMultiTexMipmapEXT"))
 	gpGenerateTextureMipmap = (C.GPGENERATETEXTUREMIPMAP)(getProcAddr("glGenerateTextureMipmap"))
+	gpGenerateTextureMipmapEXT = (C.GPGENERATETEXTUREMIPMAPEXT)(getProcAddr("glGenerateTextureMipmapEXT"))
 	gpGetActiveAtomicCounterBufferiv = (C.GPGETACTIVEATOMICCOUNTERBUFFERIV)(getProcAddr("glGetActiveAtomicCounterBufferiv"))
 	gpGetActiveAttrib = (C.GPGETACTIVEATTRIB)(getProcAddr("glGetActiveAttrib"))
 	if gpGetActiveAttrib == nil {
@@ -8816,6 +13900,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetAttribLocation == nil {
 		return errors.New("glGetAttribLocation")
 	}
+	gpGetBooleanIndexedvEXT = (C.GPGETBOOLEANINDEXEDVEXT)(getProcAddr("glGetBooleanIndexedvEXT"))
 	gpGetBooleani_v = (C.GPGETBOOLEANI_V)(getProcAddr("glGetBooleani_v"))
 	if gpGetBooleani_v == nil {
 		return errors.New("glGetBooleani_v")
@@ -8832,6 +13917,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetBufferParameteriv == nil {
 		return errors.New("glGetBufferParameteriv")
 	}
+	gpGetBufferParameterui64vNV = (C.GPGETBUFFERPARAMETERUI64VNV)(getProcAddr("glGetBufferParameterui64vNV"))
 	gpGetBufferPointerv = (C.GPGETBUFFERPOINTERV)(getProcAddr("glGetBufferPointerv"))
 	if gpGetBufferPointerv == nil {
 		return errors.New("glGetBufferPointerv")
@@ -8840,19 +13926,25 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetBufferSubData == nil {
 		return errors.New("glGetBufferSubData")
 	}
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
+	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
 		return errors.New("glGetCompressedTexImage")
 	}
 	gpGetCompressedTextureImage = (C.GPGETCOMPRESSEDTEXTUREIMAGE)(getProcAddr("glGetCompressedTextureImage"))
+	gpGetCompressedTextureImageEXT = (C.GPGETCOMPRESSEDTEXTUREIMAGEEXT)(getProcAddr("glGetCompressedTextureImageEXT"))
 	gpGetCompressedTextureSubImage = (C.GPGETCOMPRESSEDTEXTURESUBIMAGE)(getProcAddr("glGetCompressedTextureSubImage"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	gpGetDebugMessageLogARB = (C.GPGETDEBUGMESSAGELOGARB)(getProcAddr("glGetDebugMessageLogARB"))
 	gpGetDebugMessageLogKHR = (C.GPGETDEBUGMESSAGELOGKHR)(getProcAddr("glGetDebugMessageLogKHR"))
+	gpGetDoubleIndexedvEXT = (C.GPGETDOUBLEINDEXEDVEXT)(getProcAddr("glGetDoubleIndexedvEXT"))
 	gpGetDoublei_v = (C.GPGETDOUBLEI_V)(getProcAddr("glGetDoublei_v"))
 	if gpGetDoublei_v == nil {
 		return errors.New("glGetDoublei_v")
 	}
+	gpGetDoublei_vEXT = (C.GPGETDOUBLEI_VEXT)(getProcAddr("glGetDoublei_vEXT"))
 	gpGetDoublev = (C.GPGETDOUBLEV)(getProcAddr("glGetDoublev"))
 	if gpGetDoublev == nil {
 		return errors.New("glGetDoublev")
@@ -8861,10 +13953,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetError == nil {
 		return errors.New("glGetError")
 	}
+	gpGetFirstPerfQueryIdINTEL = (C.GPGETFIRSTPERFQUERYIDINTEL)(getProcAddr("glGetFirstPerfQueryIdINTEL"))
+	gpGetFloatIndexedvEXT = (C.GPGETFLOATINDEXEDVEXT)(getProcAddr("glGetFloatIndexedvEXT"))
 	gpGetFloati_v = (C.GPGETFLOATI_V)(getProcAddr("glGetFloati_v"))
 	if gpGetFloati_v == nil {
 		return errors.New("glGetFloati_v")
 	}
+	gpGetFloati_vEXT = (C.GPGETFLOATI_VEXT)(getProcAddr("glGetFloati_vEXT"))
 	gpGetFloatv = (C.GPGETFLOATV)(getProcAddr("glGetFloatv"))
 	if gpGetFloatv == nil {
 		return errors.New("glGetFloatv")
@@ -8882,10 +13977,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetFramebufferAttachmentParameteriv")
 	}
 	gpGetFramebufferParameteriv = (C.GPGETFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetFramebufferParameteriv"))
+	gpGetFramebufferParameterivEXT = (C.GPGETFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetFramebufferParameterivEXT"))
 	gpGetGraphicsResetStatus = (C.GPGETGRAPHICSRESETSTATUS)(getProcAddr("glGetGraphicsResetStatus"))
 	gpGetGraphicsResetStatusARB = (C.GPGETGRAPHICSRESETSTATUSARB)(getProcAddr("glGetGraphicsResetStatusARB"))
 	gpGetGraphicsResetStatusKHR = (C.GPGETGRAPHICSRESETSTATUSKHR)(getProcAddr("glGetGraphicsResetStatusKHR"))
 	gpGetImageHandleARB = (C.GPGETIMAGEHANDLEARB)(getProcAddr("glGetImageHandleARB"))
+	gpGetImageHandleNV = (C.GPGETIMAGEHANDLENV)(getProcAddr("glGetImageHandleNV"))
 	gpGetInteger64i_v = (C.GPGETINTEGER64I_V)(getProcAddr("glGetInteger64i_v"))
 	if gpGetInteger64i_v == nil {
 		return errors.New("glGetInteger64i_v")
@@ -8894,33 +13991,85 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetInteger64v == nil {
 		return errors.New("glGetInteger64v")
 	}
+	gpGetIntegerIndexedvEXT = (C.GPGETINTEGERINDEXEDVEXT)(getProcAddr("glGetIntegerIndexedvEXT"))
 	gpGetIntegeri_v = (C.GPGETINTEGERI_V)(getProcAddr("glGetIntegeri_v"))
 	if gpGetIntegeri_v == nil {
 		return errors.New("glGetIntegeri_v")
 	}
+	gpGetIntegerui64i_vNV = (C.GPGETINTEGERUI64I_VNV)(getProcAddr("glGetIntegerui64i_vNV"))
+	gpGetIntegerui64vNV = (C.GPGETINTEGERUI64VNV)(getProcAddr("glGetIntegerui64vNV"))
 	gpGetIntegerv = (C.GPGETINTEGERV)(getProcAddr("glGetIntegerv"))
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	gpGetInternalformativ = (C.GPGETINTERNALFORMATIV)(getProcAddr("glGetInternalformativ"))
+	gpGetMultiTexEnvfvEXT = (C.GPGETMULTITEXENVFVEXT)(getProcAddr("glGetMultiTexEnvfvEXT"))
+	gpGetMultiTexEnvivEXT = (C.GPGETMULTITEXENVIVEXT)(getProcAddr("glGetMultiTexEnvivEXT"))
+	gpGetMultiTexGendvEXT = (C.GPGETMULTITEXGENDVEXT)(getProcAddr("glGetMultiTexGendvEXT"))
+	gpGetMultiTexGenfvEXT = (C.GPGETMULTITEXGENFVEXT)(getProcAddr("glGetMultiTexGenfvEXT"))
+	gpGetMultiTexGenivEXT = (C.GPGETMULTITEXGENIVEXT)(getProcAddr("glGetMultiTexGenivEXT"))
+	gpGetMultiTexImageEXT = (C.GPGETMULTITEXIMAGEEXT)(getProcAddr("glGetMultiTexImageEXT"))
+	gpGetMultiTexLevelParameterfvEXT = (C.GPGETMULTITEXLEVELPARAMETERFVEXT)(getProcAddr("glGetMultiTexLevelParameterfvEXT"))
+	gpGetMultiTexLevelParameterivEXT = (C.GPGETMULTITEXLEVELPARAMETERIVEXT)(getProcAddr("glGetMultiTexLevelParameterivEXT"))
+	gpGetMultiTexParameterIivEXT = (C.GPGETMULTITEXPARAMETERIIVEXT)(getProcAddr("glGetMultiTexParameterIivEXT"))
+	gpGetMultiTexParameterIuivEXT = (C.GPGETMULTITEXPARAMETERIUIVEXT)(getProcAddr("glGetMultiTexParameterIuivEXT"))
+	gpGetMultiTexParameterfvEXT = (C.GPGETMULTITEXPARAMETERFVEXT)(getProcAddr("glGetMultiTexParameterfvEXT"))
+	gpGetMultiTexParameterivEXT = (C.GPGETMULTITEXPARAMETERIVEXT)(getProcAddr("glGetMultiTexParameterivEXT"))
 	gpGetMultisamplefv = (C.GPGETMULTISAMPLEFV)(getProcAddr("glGetMultisamplefv"))
 	if gpGetMultisamplefv == nil {
 		return errors.New("glGetMultisamplefv")
 	}
 	gpGetNamedBufferParameteri64v = (C.GPGETNAMEDBUFFERPARAMETERI64V)(getProcAddr("glGetNamedBufferParameteri64v"))
 	gpGetNamedBufferParameteriv = (C.GPGETNAMEDBUFFERPARAMETERIV)(getProcAddr("glGetNamedBufferParameteriv"))
+	gpGetNamedBufferParameterivEXT = (C.GPGETNAMEDBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedBufferParameterivEXT"))
+	gpGetNamedBufferParameterui64vNV = (C.GPGETNAMEDBUFFERPARAMETERUI64VNV)(getProcAddr("glGetNamedBufferParameterui64vNV"))
 	gpGetNamedBufferPointerv = (C.GPGETNAMEDBUFFERPOINTERV)(getProcAddr("glGetNamedBufferPointerv"))
+	gpGetNamedBufferPointervEXT = (C.GPGETNAMEDBUFFERPOINTERVEXT)(getProcAddr("glGetNamedBufferPointervEXT"))
 	gpGetNamedBufferSubData = (C.GPGETNAMEDBUFFERSUBDATA)(getProcAddr("glGetNamedBufferSubData"))
+	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
+	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
+	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
+	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
+	gpGetNamedProgramLocalParameterIuivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIuivEXT"))
+	gpGetNamedProgramLocalParameterdvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(getProcAddr("glGetNamedProgramLocalParameterdvEXT"))
+	gpGetNamedProgramLocalParameterfvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(getProcAddr("glGetNamedProgramLocalParameterfvEXT"))
+	gpGetNamedProgramStringEXT = (C.GPGETNAMEDPROGRAMSTRINGEXT)(getProcAddr("glGetNamedProgramStringEXT"))
+	gpGetNamedProgramivEXT = (C.GPGETNAMEDPROGRAMIVEXT)(getProcAddr("glGetNamedProgramivEXT"))
 	gpGetNamedRenderbufferParameteriv = (C.GPGETNAMEDRENDERBUFFERPARAMETERIV)(getProcAddr("glGetNamedRenderbufferParameteriv"))
+	gpGetNamedRenderbufferParameterivEXT = (C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedRenderbufferParameterivEXT"))
 	gpGetNamedStringARB = (C.GPGETNAMEDSTRINGARB)(getProcAddr("glGetNamedStringARB"))
 	gpGetNamedStringivARB = (C.GPGETNAMEDSTRINGIVARB)(getProcAddr("glGetNamedStringivARB"))
+	gpGetNextPerfQueryIdINTEL = (C.GPGETNEXTPERFQUERYIDINTEL)(getProcAddr("glGetNextPerfQueryIdINTEL"))
 	gpGetObjectLabel = (C.GPGETOBJECTLABEL)(getProcAddr("glGetObjectLabel"))
+	gpGetObjectLabelEXT = (C.GPGETOBJECTLABELEXT)(getProcAddr("glGetObjectLabelEXT"))
 	gpGetObjectLabelKHR = (C.GPGETOBJECTLABELKHR)(getProcAddr("glGetObjectLabelKHR"))
 	gpGetObjectPtrLabel = (C.GPGETOBJECTPTRLABEL)(getProcAddr("glGetObjectPtrLabel"))
 	gpGetObjectPtrLabelKHR = (C.GPGETOBJECTPTRLABELKHR)(getProcAddr("glGetObjectPtrLabelKHR"))
+	gpGetPathCommandsNV = (C.GPGETPATHCOMMANDSNV)(getProcAddr("glGetPathCommandsNV"))
+	gpGetPathCoordsNV = (C.GPGETPATHCOORDSNV)(getProcAddr("glGetPathCoordsNV"))
+	gpGetPathDashArrayNV = (C.GPGETPATHDASHARRAYNV)(getProcAddr("glGetPathDashArrayNV"))
+	gpGetPathLengthNV = (C.GPGETPATHLENGTHNV)(getProcAddr("glGetPathLengthNV"))
+	gpGetPathMetricRangeNV = (C.GPGETPATHMETRICRANGENV)(getProcAddr("glGetPathMetricRangeNV"))
+	gpGetPathMetricsNV = (C.GPGETPATHMETRICSNV)(getProcAddr("glGetPathMetricsNV"))
+	gpGetPathParameterfvNV = (C.GPGETPATHPARAMETERFVNV)(getProcAddr("glGetPathParameterfvNV"))
+	gpGetPathParameterivNV = (C.GPGETPATHPARAMETERIVNV)(getProcAddr("glGetPathParameterivNV"))
+	gpGetPathSpacingNV = (C.GPGETPATHSPACINGNV)(getProcAddr("glGetPathSpacingNV"))
+	gpGetPerfCounterInfoINTEL = (C.GPGETPERFCOUNTERINFOINTEL)(getProcAddr("glGetPerfCounterInfoINTEL"))
+	gpGetPerfMonitorCounterDataAMD = (C.GPGETPERFMONITORCOUNTERDATAAMD)(getProcAddr("glGetPerfMonitorCounterDataAMD"))
+	gpGetPerfMonitorCounterInfoAMD = (C.GPGETPERFMONITORCOUNTERINFOAMD)(getProcAddr("glGetPerfMonitorCounterInfoAMD"))
+	gpGetPerfMonitorCounterStringAMD = (C.GPGETPERFMONITORCOUNTERSTRINGAMD)(getProcAddr("glGetPerfMonitorCounterStringAMD"))
+	gpGetPerfMonitorCountersAMD = (C.GPGETPERFMONITORCOUNTERSAMD)(getProcAddr("glGetPerfMonitorCountersAMD"))
+	gpGetPerfMonitorGroupStringAMD = (C.GPGETPERFMONITORGROUPSTRINGAMD)(getProcAddr("glGetPerfMonitorGroupStringAMD"))
+	gpGetPerfMonitorGroupsAMD = (C.GPGETPERFMONITORGROUPSAMD)(getProcAddr("glGetPerfMonitorGroupsAMD"))
+	gpGetPerfQueryDataINTEL = (C.GPGETPERFQUERYDATAINTEL)(getProcAddr("glGetPerfQueryDataINTEL"))
+	gpGetPerfQueryIdByNameINTEL = (C.GPGETPERFQUERYIDBYNAMEINTEL)(getProcAddr("glGetPerfQueryIdByNameINTEL"))
+	gpGetPerfQueryInfoINTEL = (C.GPGETPERFQUERYINFOINTEL)(getProcAddr("glGetPerfQueryInfoINTEL"))
+	gpGetPointerIndexedvEXT = (C.GPGETPOINTERINDEXEDVEXT)(getProcAddr("glGetPointerIndexedvEXT"))
+	gpGetPointeri_vEXT = (C.GPGETPOINTERI_VEXT)(getProcAddr("glGetPointeri_vEXT"))
 	gpGetPointerv = (C.GPGETPOINTERV)(getProcAddr("glGetPointerv"))
 	gpGetPointervKHR = (C.GPGETPOINTERVKHR)(getProcAddr("glGetPointervKHR"))
 	gpGetProgramBinary = (C.GPGETPROGRAMBINARY)(getProcAddr("glGetProgramBinary"))
@@ -8936,14 +14085,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetProgramPipelineInfoLog == nil {
 		return errors.New("glGetProgramPipelineInfoLog")
 	}
+	gpGetProgramPipelineInfoLogEXT = (C.GPGETPROGRAMPIPELINEINFOLOGEXT)(getProcAddr("glGetProgramPipelineInfoLogEXT"))
 	gpGetProgramPipelineiv = (C.GPGETPROGRAMPIPELINEIV)(getProcAddr("glGetProgramPipelineiv"))
 	if gpGetProgramPipelineiv == nil {
 		return errors.New("glGetProgramPipelineiv")
 	}
+	gpGetProgramPipelineivEXT = (C.GPGETPROGRAMPIPELINEIVEXT)(getProcAddr("glGetProgramPipelineivEXT"))
 	gpGetProgramResourceIndex = (C.GPGETPROGRAMRESOURCEINDEX)(getProcAddr("glGetProgramResourceIndex"))
 	gpGetProgramResourceLocation = (C.GPGETPROGRAMRESOURCELOCATION)(getProcAddr("glGetProgramResourceLocation"))
 	gpGetProgramResourceLocationIndex = (C.GPGETPROGRAMRESOURCELOCATIONINDEX)(getProcAddr("glGetProgramResourceLocationIndex"))
 	gpGetProgramResourceName = (C.GPGETPROGRAMRESOURCENAME)(getProcAddr("glGetProgramResourceName"))
+	gpGetProgramResourcefvNV = (C.GPGETPROGRAMRESOURCEFVNV)(getProcAddr("glGetProgramResourcefvNV"))
 	gpGetProgramResourceiv = (C.GPGETPROGRAMRESOURCEIV)(getProcAddr("glGetProgramResourceiv"))
 	gpGetProgramStageiv = (C.GPGETPROGRAMSTAGEIV)(getProcAddr("glGetProgramStageiv"))
 	if gpGetProgramStageiv == nil {
@@ -8953,6 +14105,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetProgramiv == nil {
 		return errors.New("glGetProgramiv")
 	}
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	if gpGetQueryIndexediv == nil {
 		return errors.New("glGetQueryIndexediv")
@@ -9013,6 +14169,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetShaderiv == nil {
 		return errors.New("glGetShaderiv")
 	}
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -9062,14 +14219,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetTexParameteriv")
 	}
 	gpGetTextureHandleARB = (C.GPGETTEXTUREHANDLEARB)(getProcAddr("glGetTextureHandleARB"))
+	gpGetTextureHandleNV = (C.GPGETTEXTUREHANDLENV)(getProcAddr("glGetTextureHandleNV"))
 	gpGetTextureImage = (C.GPGETTEXTUREIMAGE)(getProcAddr("glGetTextureImage"))
+	gpGetTextureImageEXT = (C.GPGETTEXTUREIMAGEEXT)(getProcAddr("glGetTextureImageEXT"))
 	gpGetTextureLevelParameterfv = (C.GPGETTEXTURELEVELPARAMETERFV)(getProcAddr("glGetTextureLevelParameterfv"))
+	gpGetTextureLevelParameterfvEXT = (C.GPGETTEXTURELEVELPARAMETERFVEXT)(getProcAddr("glGetTextureLevelParameterfvEXT"))
 	gpGetTextureLevelParameteriv = (C.GPGETTEXTURELEVELPARAMETERIV)(getProcAddr("glGetTextureLevelParameteriv"))
+	gpGetTextureLevelParameterivEXT = (C.GPGETTEXTURELEVELPARAMETERIVEXT)(getProcAddr("glGetTextureLevelParameterivEXT"))
 	gpGetTextureParameterIiv = (C.GPGETTEXTUREPARAMETERIIV)(getProcAddr("glGetTextureParameterIiv"))
+	gpGetTextureParameterIivEXT = (C.GPGETTEXTUREPARAMETERIIVEXT)(getProcAddr("glGetTextureParameterIivEXT"))
 	gpGetTextureParameterIuiv = (C.GPGETTEXTUREPARAMETERIUIV)(getProcAddr("glGetTextureParameterIuiv"))
+	gpGetTextureParameterIuivEXT = (C.GPGETTEXTUREPARAMETERIUIVEXT)(getProcAddr("glGetTextureParameterIuivEXT"))
 	gpGetTextureParameterfv = (C.GPGETTEXTUREPARAMETERFV)(getProcAddr("glGetTextureParameterfv"))
+	gpGetTextureParameterfvEXT = (C.GPGETTEXTUREPARAMETERFVEXT)(getProcAddr("glGetTextureParameterfvEXT"))
 	gpGetTextureParameteriv = (C.GPGETTEXTUREPARAMETERIV)(getProcAddr("glGetTextureParameteriv"))
+	gpGetTextureParameterivEXT = (C.GPGETTEXTUREPARAMETERIVEXT)(getProcAddr("glGetTextureParameterivEXT"))
 	gpGetTextureSamplerHandleARB = (C.GPGETTEXTURESAMPLERHANDLEARB)(getProcAddr("glGetTextureSamplerHandleARB"))
+	gpGetTextureSamplerHandleNV = (C.GPGETTEXTURESAMPLERHANDLENV)(getProcAddr("glGetTextureSamplerHandleNV"))
 	gpGetTextureSubImage = (C.GPGETTEXTURESUBIMAGE)(getProcAddr("glGetTextureSubImage"))
 	gpGetTransformFeedbackVarying = (C.GPGETTRANSFORMFEEDBACKVARYING)(getProcAddr("glGetTransformFeedbackVarying"))
 	if gpGetTransformFeedbackVarying == nil {
@@ -9102,16 +14268,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetUniformfv == nil {
 		return errors.New("glGetUniformfv")
 	}
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
+	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
+	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
 	}
 	gpGetVertexArrayIndexed64iv = (C.GPGETVERTEXARRAYINDEXED64IV)(getProcAddr("glGetVertexArrayIndexed64iv"))
 	gpGetVertexArrayIndexediv = (C.GPGETVERTEXARRAYINDEXEDIV)(getProcAddr("glGetVertexArrayIndexediv"))
+	gpGetVertexArrayIntegeri_vEXT = (C.GPGETVERTEXARRAYINTEGERI_VEXT)(getProcAddr("glGetVertexArrayIntegeri_vEXT"))
+	gpGetVertexArrayIntegervEXT = (C.GPGETVERTEXARRAYINTEGERVEXT)(getProcAddr("glGetVertexArrayIntegervEXT"))
+	gpGetVertexArrayPointeri_vEXT = (C.GPGETVERTEXARRAYPOINTERI_VEXT)(getProcAddr("glGetVertexArrayPointeri_vEXT"))
+	gpGetVertexArrayPointervEXT = (C.GPGETVERTEXARRAYPOINTERVEXT)(getProcAddr("glGetVertexArrayPointervEXT"))
 	gpGetVertexArrayiv = (C.GPGETVERTEXARRAYIV)(getProcAddr("glGetVertexArrayiv"))
 	gpGetVertexAttribIiv = (C.GPGETVERTEXATTRIBIIV)(getProcAddr("glGetVertexAttribIiv"))
 	if gpGetVertexAttribIiv == nil {
@@ -9125,7 +14299,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetVertexAttribLdv == nil {
 		return errors.New("glGetVertexAttribLdv")
 	}
+	gpGetVertexAttribLi64vNV = (C.GPGETVERTEXATTRIBLI64VNV)(getProcAddr("glGetVertexAttribLi64vNV"))
 	gpGetVertexAttribLui64vARB = (C.GPGETVERTEXATTRIBLUI64VARB)(getProcAddr("glGetVertexAttribLui64vARB"))
+	gpGetVertexAttribLui64vNV = (C.GPGETVERTEXATTRIBLUI64VNV)(getProcAddr("glGetVertexAttribLui64vNV"))
 	gpGetVertexAttribPointerv = (C.GPGETVERTEXATTRIBPOINTERV)(getProcAddr("glGetVertexAttribPointerv"))
 	if gpGetVertexAttribPointerv == nil {
 		return errors.New("glGetVertexAttribPointerv")
@@ -9142,15 +14318,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetVertexAttribiv == nil {
 		return errors.New("glGetVertexAttribiv")
 	}
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnCompressedTexImageARB = (C.GPGETNCOMPRESSEDTEXIMAGEARB)(getProcAddr("glGetnCompressedTexImageARB"))
 	gpGetnTexImageARB = (C.GPGETNTEXIMAGEARB)(getProcAddr("glGetnTexImageARB"))
 	gpGetnUniformdvARB = (C.GPGETNUNIFORMDVARB)(getProcAddr("glGetnUniformdvARB"))
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	gpGetnUniformuivARB = (C.GPGETNUNIFORMUIVARB)(getProcAddr("glGetnUniformuivARB"))
 	gpGetnUniformuivKHR = (C.GPGETNUNIFORMUIVKHR)(getProcAddr("glGetnUniformuivKHR"))
@@ -9158,6 +14337,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpHint == nil {
 		return errors.New("glHint")
 	}
+	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
+	gpInsertEventMarkerEXT = (C.GPINSERTEVENTMARKEREXT)(getProcAddr("glInsertEventMarkerEXT"))
+	gpInterpolatePathsNV = (C.GPINTERPOLATEPATHSNV)(getProcAddr("glInterpolatePathsNV"))
 	gpInvalidateBufferData = (C.GPINVALIDATEBUFFERDATA)(getProcAddr("glInvalidateBufferData"))
 	gpInvalidateBufferSubData = (C.GPINVALIDATEBUFFERSUBDATA)(getProcAddr("glInvalidateBufferSubData"))
 	gpInvalidateFramebuffer = (C.GPINVALIDATEFRAMEBUFFER)(getProcAddr("glInvalidateFramebuffer"))
@@ -9170,10 +14352,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsBuffer == nil {
 		return errors.New("glIsBuffer")
 	}
+	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
 	}
+	gpIsEnabledIndexedEXT = (C.GPISENABLEDINDEXEDEXT)(getProcAddr("glIsEnabledIndexedEXT"))
 	gpIsEnabledi = (C.GPISENABLEDI)(getProcAddr("glIsEnabledi"))
 	if gpIsEnabledi == nil {
 		return errors.New("glIsEnabledi")
@@ -9183,7 +14368,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsFramebuffer")
 	}
 	gpIsImageHandleResidentARB = (C.GPISIMAGEHANDLERESIDENTARB)(getProcAddr("glIsImageHandleResidentARB"))
+	gpIsImageHandleResidentNV = (C.GPISIMAGEHANDLERESIDENTNV)(getProcAddr("glIsImageHandleResidentNV"))
+	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
+	gpIsPathNV = (C.GPISPATHNV)(getProcAddr("glIsPathNV"))
+	gpIsPointInFillPathNV = (C.GPISPOINTINFILLPATHNV)(getProcAddr("glIsPointInFillPathNV"))
+	gpIsPointInStrokePathNV = (C.GPISPOINTINSTROKEPATHNV)(getProcAddr("glIsPointInStrokePathNV"))
 	gpIsProgram = (C.GPISPROGRAM)(getProcAddr("glIsProgram"))
 	if gpIsProgram == nil {
 		return errors.New("glIsProgram")
@@ -9192,6 +14382,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsProgramPipeline == nil {
 		return errors.New("glIsProgramPipeline")
 	}
+	gpIsProgramPipelineEXT = (C.GPISPROGRAMPIPELINEEXT)(getProcAddr("glIsProgramPipelineEXT"))
 	gpIsQuery = (C.GPISQUERY)(getProcAddr("glIsQuery"))
 	if gpIsQuery == nil {
 		return errors.New("glIsQuery")
@@ -9208,6 +14399,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	if gpIsSync == nil {
 		return errors.New("glIsSync")
@@ -9217,6 +14409,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsTexture")
 	}
 	gpIsTextureHandleResidentARB = (C.GPISTEXTUREHANDLERESIDENTARB)(getProcAddr("glIsTextureHandleResidentARB"))
+	gpIsTextureHandleResidentNV = (C.GPISTEXTUREHANDLERESIDENTNV)(getProcAddr("glIsTextureHandleResidentNV"))
 	gpIsTransformFeedback = (C.GPISTRANSFORMFEEDBACK)(getProcAddr("glIsTransformFeedback"))
 	if gpIsTransformFeedback == nil {
 		return errors.New("glIsTransformFeedback")
@@ -9225,6 +14418,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsVertexArray == nil {
 		return errors.New("glIsVertexArray")
 	}
+	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLineWidth = (C.GPLINEWIDTH)(getProcAddr("glLineWidth"))
 	if gpLineWidth == nil {
 		return errors.New("glLineWidth")
@@ -9233,14 +14427,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpLinkProgram == nil {
 		return errors.New("glLinkProgram")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpLogicOp = (C.GPLOGICOP)(getProcAddr("glLogicOp"))
 	if gpLogicOp == nil {
 		return errors.New("glLogicOp")
 	}
+	gpMakeBufferNonResidentNV = (C.GPMAKEBUFFERNONRESIDENTNV)(getProcAddr("glMakeBufferNonResidentNV"))
+	gpMakeBufferResidentNV = (C.GPMAKEBUFFERRESIDENTNV)(getProcAddr("glMakeBufferResidentNV"))
 	gpMakeImageHandleNonResidentARB = (C.GPMAKEIMAGEHANDLENONRESIDENTARB)(getProcAddr("glMakeImageHandleNonResidentARB"))
+	gpMakeImageHandleNonResidentNV = (C.GPMAKEIMAGEHANDLENONRESIDENTNV)(getProcAddr("glMakeImageHandleNonResidentNV"))
 	gpMakeImageHandleResidentARB = (C.GPMAKEIMAGEHANDLERESIDENTARB)(getProcAddr("glMakeImageHandleResidentARB"))
+	gpMakeImageHandleResidentNV = (C.GPMAKEIMAGEHANDLERESIDENTNV)(getProcAddr("glMakeImageHandleResidentNV"))
+	gpMakeNamedBufferNonResidentNV = (C.GPMAKENAMEDBUFFERNONRESIDENTNV)(getProcAddr("glMakeNamedBufferNonResidentNV"))
+	gpMakeNamedBufferResidentNV = (C.GPMAKENAMEDBUFFERRESIDENTNV)(getProcAddr("glMakeNamedBufferResidentNV"))
 	gpMakeTextureHandleNonResidentARB = (C.GPMAKETEXTUREHANDLENONRESIDENTARB)(getProcAddr("glMakeTextureHandleNonResidentARB"))
+	gpMakeTextureHandleNonResidentNV = (C.GPMAKETEXTUREHANDLENONRESIDENTNV)(getProcAddr("glMakeTextureHandleNonResidentNV"))
 	gpMakeTextureHandleResidentARB = (C.GPMAKETEXTUREHANDLERESIDENTARB)(getProcAddr("glMakeTextureHandleResidentARB"))
+	gpMakeTextureHandleResidentNV = (C.GPMAKETEXTUREHANDLERESIDENTNV)(getProcAddr("glMakeTextureHandleResidentNV"))
 	gpMapBuffer = (C.GPMAPBUFFER)(getProcAddr("glMapBuffer"))
 	if gpMapBuffer == nil {
 		return errors.New("glMapBuffer")
@@ -9250,7 +14453,36 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMapBufferRange")
 	}
 	gpMapNamedBuffer = (C.GPMAPNAMEDBUFFER)(getProcAddr("glMapNamedBuffer"))
+	gpMapNamedBufferEXT = (C.GPMAPNAMEDBUFFEREXT)(getProcAddr("glMapNamedBufferEXT"))
 	gpMapNamedBufferRange = (C.GPMAPNAMEDBUFFERRANGE)(getProcAddr("glMapNamedBufferRange"))
+	gpMapNamedBufferRangeEXT = (C.GPMAPNAMEDBUFFERRANGEEXT)(getProcAddr("glMapNamedBufferRangeEXT"))
+	gpMatrixFrustumEXT = (C.GPMATRIXFRUSTUMEXT)(getProcAddr("glMatrixFrustumEXT"))
+	gpMatrixLoad3x2fNV = (C.GPMATRIXLOAD3X2FNV)(getProcAddr("glMatrixLoad3x2fNV"))
+	gpMatrixLoad3x3fNV = (C.GPMATRIXLOAD3X3FNV)(getProcAddr("glMatrixLoad3x3fNV"))
+	gpMatrixLoadIdentityEXT = (C.GPMATRIXLOADIDENTITYEXT)(getProcAddr("glMatrixLoadIdentityEXT"))
+	gpMatrixLoadTranspose3x3fNV = (C.GPMATRIXLOADTRANSPOSE3X3FNV)(getProcAddr("glMatrixLoadTranspose3x3fNV"))
+	gpMatrixLoadTransposedEXT = (C.GPMATRIXLOADTRANSPOSEDEXT)(getProcAddr("glMatrixLoadTransposedEXT"))
+	gpMatrixLoadTransposefEXT = (C.GPMATRIXLOADTRANSPOSEFEXT)(getProcAddr("glMatrixLoadTransposefEXT"))
+	gpMatrixLoaddEXT = (C.GPMATRIXLOADDEXT)(getProcAddr("glMatrixLoaddEXT"))
+	gpMatrixLoadfEXT = (C.GPMATRIXLOADFEXT)(getProcAddr("glMatrixLoadfEXT"))
+	gpMatrixMult3x2fNV = (C.GPMATRIXMULT3X2FNV)(getProcAddr("glMatrixMult3x2fNV"))
+	gpMatrixMult3x3fNV = (C.GPMATRIXMULT3X3FNV)(getProcAddr("glMatrixMult3x3fNV"))
+	gpMatrixMultTranspose3x3fNV = (C.GPMATRIXMULTTRANSPOSE3X3FNV)(getProcAddr("glMatrixMultTranspose3x3fNV"))
+	gpMatrixMultTransposedEXT = (C.GPMATRIXMULTTRANSPOSEDEXT)(getProcAddr("glMatrixMultTransposedEXT"))
+	gpMatrixMultTransposefEXT = (C.GPMATRIXMULTTRANSPOSEFEXT)(getProcAddr("glMatrixMultTransposefEXT"))
+	gpMatrixMultdEXT = (C.GPMATRIXMULTDEXT)(getProcAddr("glMatrixMultdEXT"))
+	gpMatrixMultfEXT = (C.GPMATRIXMULTFEXT)(getProcAddr("glMatrixMultfEXT"))
+	gpMatrixOrthoEXT = (C.GPMATRIXORTHOEXT)(getProcAddr("glMatrixOrthoEXT"))
+	gpMatrixPopEXT = (C.GPMATRIXPOPEXT)(getProcAddr("glMatrixPopEXT"))
+	gpMatrixPushEXT = (C.GPMATRIXPUSHEXT)(getProcAddr("glMatrixPushEXT"))
+	gpMatrixRotatedEXT = (C.GPMATRIXROTATEDEXT)(getProcAddr("glMatrixRotatedEXT"))
+	gpMatrixRotatefEXT = (C.GPMATRIXROTATEFEXT)(getProcAddr("glMatrixRotatefEXT"))
+	gpMatrixScaledEXT = (C.GPMATRIXSCALEDEXT)(getProcAddr("glMatrixScaledEXT"))
+	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
+	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
+	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	gpMemoryBarrierByRegion = (C.GPMEMORYBARRIERBYREGION)(getProcAddr("glMemoryBarrierByRegion"))
 	gpMinSampleShading = (C.GPMINSAMPLESHADING)(getProcAddr("glMinSampleShading"))
@@ -9263,6 +14495,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMultiDrawArrays")
 	}
 	gpMultiDrawArraysIndirect = (C.GPMULTIDRAWARRAYSINDIRECT)(getProcAddr("glMultiDrawArraysIndirect"))
+	gpMultiDrawArraysIndirectBindlessCountNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawArraysIndirectBindlessCountNV"))
+	gpMultiDrawArraysIndirectBindlessNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawArraysIndirectBindlessNV"))
 	gpMultiDrawArraysIndirectCountARB = (C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawArraysIndirectCountARB"))
 	gpMultiDrawElements = (C.GPMULTIDRAWELEMENTS)(getProcAddr("glMultiDrawElements"))
 	if gpMultiDrawElements == nil {
@@ -9273,22 +14507,79 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMultiDrawElementsBaseVertex")
 	}
 	gpMultiDrawElementsIndirect = (C.GPMULTIDRAWELEMENTSINDIRECT)(getProcAddr("glMultiDrawElementsIndirect"))
+	gpMultiDrawElementsIndirectBindlessCountNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawElementsIndirectBindlessCountNV"))
+	gpMultiDrawElementsIndirectBindlessNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawElementsIndirectBindlessNV"))
 	gpMultiDrawElementsIndirectCountARB = (C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawElementsIndirectCountARB"))
+	gpMultiTexBufferEXT = (C.GPMULTITEXBUFFEREXT)(getProcAddr("glMultiTexBufferEXT"))
+	gpMultiTexCoordPointerEXT = (C.GPMULTITEXCOORDPOINTEREXT)(getProcAddr("glMultiTexCoordPointerEXT"))
+	gpMultiTexEnvfEXT = (C.GPMULTITEXENVFEXT)(getProcAddr("glMultiTexEnvfEXT"))
+	gpMultiTexEnvfvEXT = (C.GPMULTITEXENVFVEXT)(getProcAddr("glMultiTexEnvfvEXT"))
+	gpMultiTexEnviEXT = (C.GPMULTITEXENVIEXT)(getProcAddr("glMultiTexEnviEXT"))
+	gpMultiTexEnvivEXT = (C.GPMULTITEXENVIVEXT)(getProcAddr("glMultiTexEnvivEXT"))
+	gpMultiTexGendEXT = (C.GPMULTITEXGENDEXT)(getProcAddr("glMultiTexGendEXT"))
+	gpMultiTexGendvEXT = (C.GPMULTITEXGENDVEXT)(getProcAddr("glMultiTexGendvEXT"))
+	gpMultiTexGenfEXT = (C.GPMULTITEXGENFEXT)(getProcAddr("glMultiTexGenfEXT"))
+	gpMultiTexGenfvEXT = (C.GPMULTITEXGENFVEXT)(getProcAddr("glMultiTexGenfvEXT"))
+	gpMultiTexGeniEXT = (C.GPMULTITEXGENIEXT)(getProcAddr("glMultiTexGeniEXT"))
+	gpMultiTexGenivEXT = (C.GPMULTITEXGENIVEXT)(getProcAddr("glMultiTexGenivEXT"))
+	gpMultiTexImage1DEXT = (C.GPMULTITEXIMAGE1DEXT)(getProcAddr("glMultiTexImage1DEXT"))
+	gpMultiTexImage2DEXT = (C.GPMULTITEXIMAGE2DEXT)(getProcAddr("glMultiTexImage2DEXT"))
+	gpMultiTexImage3DEXT = (C.GPMULTITEXIMAGE3DEXT)(getProcAddr("glMultiTexImage3DEXT"))
+	gpMultiTexParameterIivEXT = (C.GPMULTITEXPARAMETERIIVEXT)(getProcAddr("glMultiTexParameterIivEXT"))
+	gpMultiTexParameterIuivEXT = (C.GPMULTITEXPARAMETERIUIVEXT)(getProcAddr("glMultiTexParameterIuivEXT"))
+	gpMultiTexParameterfEXT = (C.GPMULTITEXPARAMETERFEXT)(getProcAddr("glMultiTexParameterfEXT"))
+	gpMultiTexParameterfvEXT = (C.GPMULTITEXPARAMETERFVEXT)(getProcAddr("glMultiTexParameterfvEXT"))
+	gpMultiTexParameteriEXT = (C.GPMULTITEXPARAMETERIEXT)(getProcAddr("glMultiTexParameteriEXT"))
+	gpMultiTexParameterivEXT = (C.GPMULTITEXPARAMETERIVEXT)(getProcAddr("glMultiTexParameterivEXT"))
+	gpMultiTexRenderbufferEXT = (C.GPMULTITEXRENDERBUFFEREXT)(getProcAddr("glMultiTexRenderbufferEXT"))
+	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
+	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
+	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
+	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
+	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
+	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
+	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
 	gpNamedFramebufferDrawBuffer = (C.GPNAMEDFRAMEBUFFERDRAWBUFFER)(getProcAddr("glNamedFramebufferDrawBuffer"))
 	gpNamedFramebufferDrawBuffers = (C.GPNAMEDFRAMEBUFFERDRAWBUFFERS)(getProcAddr("glNamedFramebufferDrawBuffers"))
 	gpNamedFramebufferParameteri = (C.GPNAMEDFRAMEBUFFERPARAMETERI)(getProcAddr("glNamedFramebufferParameteri"))
+	gpNamedFramebufferParameteriEXT = (C.GPNAMEDFRAMEBUFFERPARAMETERIEXT)(getProcAddr("glNamedFramebufferParameteriEXT"))
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	gpNamedFramebufferRenderbuffer = (C.GPNAMEDFRAMEBUFFERRENDERBUFFER)(getProcAddr("glNamedFramebufferRenderbuffer"))
+	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
+	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
+	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
+	gpNamedFramebufferTexture3DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(getProcAddr("glNamedFramebufferTexture3DEXT"))
+	gpNamedFramebufferTextureEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREEXT)(getProcAddr("glNamedFramebufferTextureEXT"))
+	gpNamedFramebufferTextureFaceEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(getProcAddr("glNamedFramebufferTextureFaceEXT"))
 	gpNamedFramebufferTextureLayer = (C.GPNAMEDFRAMEBUFFERTEXTURELAYER)(getProcAddr("glNamedFramebufferTextureLayer"))
+	gpNamedFramebufferTextureLayerEXT = (C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glNamedFramebufferTextureLayerEXT"))
+	gpNamedProgramLocalParameter4dEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(getProcAddr("glNamedProgramLocalParameter4dEXT"))
+	gpNamedProgramLocalParameter4dvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(getProcAddr("glNamedProgramLocalParameter4dvEXT"))
+	gpNamedProgramLocalParameter4fEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(getProcAddr("glNamedProgramLocalParameter4fEXT"))
+	gpNamedProgramLocalParameter4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(getProcAddr("glNamedProgramLocalParameter4fvEXT"))
+	gpNamedProgramLocalParameterI4iEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(getProcAddr("glNamedProgramLocalParameterI4iEXT"))
+	gpNamedProgramLocalParameterI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(getProcAddr("glNamedProgramLocalParameterI4ivEXT"))
+	gpNamedProgramLocalParameterI4uiEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(getProcAddr("glNamedProgramLocalParameterI4uiEXT"))
+	gpNamedProgramLocalParameterI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(getProcAddr("glNamedProgramLocalParameterI4uivEXT"))
+	gpNamedProgramLocalParameters4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(getProcAddr("glNamedProgramLocalParameters4fvEXT"))
+	gpNamedProgramLocalParametersI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(getProcAddr("glNamedProgramLocalParametersI4ivEXT"))
+	gpNamedProgramLocalParametersI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(getProcAddr("glNamedProgramLocalParametersI4uivEXT"))
+	gpNamedProgramStringEXT = (C.GPNAMEDPROGRAMSTRINGEXT)(getProcAddr("glNamedProgramStringEXT"))
 	gpNamedRenderbufferStorage = (C.GPNAMEDRENDERBUFFERSTORAGE)(getProcAddr("glNamedRenderbufferStorage"))
+	gpNamedRenderbufferStorageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEEXT)(getProcAddr("glNamedRenderbufferStorageEXT"))
 	gpNamedRenderbufferStorageMultisample = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(getProcAddr("glNamedRenderbufferStorageMultisample"))
+	gpNamedRenderbufferStorageMultisampleCoverageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleCoverageEXT"))
+	gpNamedRenderbufferStorageMultisampleEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleEXT"))
 	gpNamedStringARB = (C.GPNAMEDSTRINGARB)(getProcAddr("glNamedStringARB"))
+	gpNormalFormatNV = (C.GPNORMALFORMATNV)(getProcAddr("glNormalFormatNV"))
 	gpObjectLabel = (C.GPOBJECTLABEL)(getProcAddr("glObjectLabel"))
 	gpObjectLabelKHR = (C.GPOBJECTLABELKHR)(getProcAddr("glObjectLabelKHR"))
 	gpObjectPtrLabel = (C.GPOBJECTPTRLABEL)(getProcAddr("glObjectPtrLabel"))
@@ -9301,6 +14592,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPatchParameteri == nil {
 		return errors.New("glPatchParameteri")
 	}
+	gpPathCommandsNV = (C.GPPATHCOMMANDSNV)(getProcAddr("glPathCommandsNV"))
+	gpPathCoordsNV = (C.GPPATHCOORDSNV)(getProcAddr("glPathCoordsNV"))
+	gpPathCoverDepthFuncNV = (C.GPPATHCOVERDEPTHFUNCNV)(getProcAddr("glPathCoverDepthFuncNV"))
+	gpPathDashArrayNV = (C.GPPATHDASHARRAYNV)(getProcAddr("glPathDashArrayNV"))
+	gpPathGlyphIndexArrayNV = (C.GPPATHGLYPHINDEXARRAYNV)(getProcAddr("glPathGlyphIndexArrayNV"))
+	gpPathGlyphIndexRangeNV = (C.GPPATHGLYPHINDEXRANGENV)(getProcAddr("glPathGlyphIndexRangeNV"))
+	gpPathGlyphRangeNV = (C.GPPATHGLYPHRANGENV)(getProcAddr("glPathGlyphRangeNV"))
+	gpPathGlyphsNV = (C.GPPATHGLYPHSNV)(getProcAddr("glPathGlyphsNV"))
+	gpPathMemoryGlyphIndexArrayNV = (C.GPPATHMEMORYGLYPHINDEXARRAYNV)(getProcAddr("glPathMemoryGlyphIndexArrayNV"))
+	gpPathParameterfNV = (C.GPPATHPARAMETERFNV)(getProcAddr("glPathParameterfNV"))
+	gpPathParameterfvNV = (C.GPPATHPARAMETERFVNV)(getProcAddr("glPathParameterfvNV"))
+	gpPathParameteriNV = (C.GPPATHPARAMETERINV)(getProcAddr("glPathParameteriNV"))
+	gpPathParameterivNV = (C.GPPATHPARAMETERIVNV)(getProcAddr("glPathParameterivNV"))
+	gpPathStencilDepthOffsetNV = (C.GPPATHSTENCILDEPTHOFFSETNV)(getProcAddr("glPathStencilDepthOffsetNV"))
+	gpPathStencilFuncNV = (C.GPPATHSTENCILFUNCNV)(getProcAddr("glPathStencilFuncNV"))
+	gpPathStringNV = (C.GPPATHSTRINGNV)(getProcAddr("glPathStringNV"))
+	gpPathSubCommandsNV = (C.GPPATHSUBCOMMANDSNV)(getProcAddr("glPathSubCommandsNV"))
+	gpPathSubCoordsNV = (C.GPPATHSUBCOORDSNV)(getProcAddr("glPathSubCoordsNV"))
 	gpPauseTransformFeedback = (C.GPPAUSETRANSFORMFEEDBACK)(getProcAddr("glPauseTransformFeedback"))
 	if gpPauseTransformFeedback == nil {
 		return errors.New("glPauseTransformFeedback")
@@ -9313,6 +14622,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPixelStorei == nil {
 		return errors.New("glPixelStorei")
 	}
+	gpPointAlongPathNV = (C.GPPOINTALONGPATHNV)(getProcAddr("glPointAlongPathNV"))
 	gpPointParameterf = (C.GPPOINTPARAMETERF)(getProcAddr("glPointParameterf"))
 	if gpPointParameterf == nil {
 		return errors.New("glPointParameterf")
@@ -9341,8 +14651,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPopDebugGroup = (C.GPPOPDEBUGGROUP)(getProcAddr("glPopDebugGroup"))
 	gpPopDebugGroupKHR = (C.GPPOPDEBUGGROUPKHR)(getProcAddr("glPopDebugGroupKHR"))
+	gpPopGroupMarkerEXT = (C.GPPOPGROUPMARKEREXT)(getProcAddr("glPopGroupMarkerEXT"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	if gpPrimitiveRestartIndex == nil {
 		return errors.New("glPrimitiveRestartIndex")
@@ -9355,218 +14669,310 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramParameteri == nil {
 		return errors.New("glProgramParameteri")
 	}
+	gpProgramParameteriARB = (C.GPPROGRAMPARAMETERIARB)(getProcAddr("glProgramParameteriARB"))
+	gpProgramParameteriEXT = (C.GPPROGRAMPARAMETERIEXT)(getProcAddr("glProgramParameteriEXT"))
+	gpProgramPathFragmentInputGenNV = (C.GPPROGRAMPATHFRAGMENTINPUTGENNV)(getProcAddr("glProgramPathFragmentInputGenNV"))
 	gpProgramUniform1d = (C.GPPROGRAMUNIFORM1D)(getProcAddr("glProgramUniform1d"))
 	if gpProgramUniform1d == nil {
 		return errors.New("glProgramUniform1d")
 	}
+	gpProgramUniform1dEXT = (C.GPPROGRAMUNIFORM1DEXT)(getProcAddr("glProgramUniform1dEXT"))
 	gpProgramUniform1dv = (C.GPPROGRAMUNIFORM1DV)(getProcAddr("glProgramUniform1dv"))
 	if gpProgramUniform1dv == nil {
 		return errors.New("glProgramUniform1dv")
 	}
+	gpProgramUniform1dvEXT = (C.GPPROGRAMUNIFORM1DVEXT)(getProcAddr("glProgramUniform1dvEXT"))
 	gpProgramUniform1f = (C.GPPROGRAMUNIFORM1F)(getProcAddr("glProgramUniform1f"))
 	if gpProgramUniform1f == nil {
 		return errors.New("glProgramUniform1f")
 	}
+	gpProgramUniform1fEXT = (C.GPPROGRAMUNIFORM1FEXT)(getProcAddr("glProgramUniform1fEXT"))
 	gpProgramUniform1fv = (C.GPPROGRAMUNIFORM1FV)(getProcAddr("glProgramUniform1fv"))
 	if gpProgramUniform1fv == nil {
 		return errors.New("glProgramUniform1fv")
 	}
+	gpProgramUniform1fvEXT = (C.GPPROGRAMUNIFORM1FVEXT)(getProcAddr("glProgramUniform1fvEXT"))
 	gpProgramUniform1i = (C.GPPROGRAMUNIFORM1I)(getProcAddr("glProgramUniform1i"))
 	if gpProgramUniform1i == nil {
 		return errors.New("glProgramUniform1i")
 	}
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
+	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
+	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
+	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
 	if gpProgramUniform1iv == nil {
 		return errors.New("glProgramUniform1iv")
 	}
+	gpProgramUniform1ivEXT = (C.GPPROGRAMUNIFORM1IVEXT)(getProcAddr("glProgramUniform1ivEXT"))
 	gpProgramUniform1ui = (C.GPPROGRAMUNIFORM1UI)(getProcAddr("glProgramUniform1ui"))
 	if gpProgramUniform1ui == nil {
 		return errors.New("glProgramUniform1ui")
 	}
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
+	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
+	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
+	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
 	if gpProgramUniform1uiv == nil {
 		return errors.New("glProgramUniform1uiv")
 	}
+	gpProgramUniform1uivEXT = (C.GPPROGRAMUNIFORM1UIVEXT)(getProcAddr("glProgramUniform1uivEXT"))
 	gpProgramUniform2d = (C.GPPROGRAMUNIFORM2D)(getProcAddr("glProgramUniform2d"))
 	if gpProgramUniform2d == nil {
 		return errors.New("glProgramUniform2d")
 	}
+	gpProgramUniform2dEXT = (C.GPPROGRAMUNIFORM2DEXT)(getProcAddr("glProgramUniform2dEXT"))
 	gpProgramUniform2dv = (C.GPPROGRAMUNIFORM2DV)(getProcAddr("glProgramUniform2dv"))
 	if gpProgramUniform2dv == nil {
 		return errors.New("glProgramUniform2dv")
 	}
+	gpProgramUniform2dvEXT = (C.GPPROGRAMUNIFORM2DVEXT)(getProcAddr("glProgramUniform2dvEXT"))
 	gpProgramUniform2f = (C.GPPROGRAMUNIFORM2F)(getProcAddr("glProgramUniform2f"))
 	if gpProgramUniform2f == nil {
 		return errors.New("glProgramUniform2f")
 	}
+	gpProgramUniform2fEXT = (C.GPPROGRAMUNIFORM2FEXT)(getProcAddr("glProgramUniform2fEXT"))
 	gpProgramUniform2fv = (C.GPPROGRAMUNIFORM2FV)(getProcAddr("glProgramUniform2fv"))
 	if gpProgramUniform2fv == nil {
 		return errors.New("glProgramUniform2fv")
 	}
+	gpProgramUniform2fvEXT = (C.GPPROGRAMUNIFORM2FVEXT)(getProcAddr("glProgramUniform2fvEXT"))
 	gpProgramUniform2i = (C.GPPROGRAMUNIFORM2I)(getProcAddr("glProgramUniform2i"))
 	if gpProgramUniform2i == nil {
 		return errors.New("glProgramUniform2i")
 	}
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
+	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
+	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
+	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
 	if gpProgramUniform2iv == nil {
 		return errors.New("glProgramUniform2iv")
 	}
+	gpProgramUniform2ivEXT = (C.GPPROGRAMUNIFORM2IVEXT)(getProcAddr("glProgramUniform2ivEXT"))
 	gpProgramUniform2ui = (C.GPPROGRAMUNIFORM2UI)(getProcAddr("glProgramUniform2ui"))
 	if gpProgramUniform2ui == nil {
 		return errors.New("glProgramUniform2ui")
 	}
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
+	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
+	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
+	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
 	if gpProgramUniform2uiv == nil {
 		return errors.New("glProgramUniform2uiv")
 	}
+	gpProgramUniform2uivEXT = (C.GPPROGRAMUNIFORM2UIVEXT)(getProcAddr("glProgramUniform2uivEXT"))
 	gpProgramUniform3d = (C.GPPROGRAMUNIFORM3D)(getProcAddr("glProgramUniform3d"))
 	if gpProgramUniform3d == nil {
 		return errors.New("glProgramUniform3d")
 	}
+	gpProgramUniform3dEXT = (C.GPPROGRAMUNIFORM3DEXT)(getProcAddr("glProgramUniform3dEXT"))
 	gpProgramUniform3dv = (C.GPPROGRAMUNIFORM3DV)(getProcAddr("glProgramUniform3dv"))
 	if gpProgramUniform3dv == nil {
 		return errors.New("glProgramUniform3dv")
 	}
+	gpProgramUniform3dvEXT = (C.GPPROGRAMUNIFORM3DVEXT)(getProcAddr("glProgramUniform3dvEXT"))
 	gpProgramUniform3f = (C.GPPROGRAMUNIFORM3F)(getProcAddr("glProgramUniform3f"))
 	if gpProgramUniform3f == nil {
 		return errors.New("glProgramUniform3f")
 	}
+	gpProgramUniform3fEXT = (C.GPPROGRAMUNIFORM3FEXT)(getProcAddr("glProgramUniform3fEXT"))
 	gpProgramUniform3fv = (C.GPPROGRAMUNIFORM3FV)(getProcAddr("glProgramUniform3fv"))
 	if gpProgramUniform3fv == nil {
 		return errors.New("glProgramUniform3fv")
 	}
+	gpProgramUniform3fvEXT = (C.GPPROGRAMUNIFORM3FVEXT)(getProcAddr("glProgramUniform3fvEXT"))
 	gpProgramUniform3i = (C.GPPROGRAMUNIFORM3I)(getProcAddr("glProgramUniform3i"))
 	if gpProgramUniform3i == nil {
 		return errors.New("glProgramUniform3i")
 	}
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
+	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
+	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
+	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
 	if gpProgramUniform3iv == nil {
 		return errors.New("glProgramUniform3iv")
 	}
+	gpProgramUniform3ivEXT = (C.GPPROGRAMUNIFORM3IVEXT)(getProcAddr("glProgramUniform3ivEXT"))
 	gpProgramUniform3ui = (C.GPPROGRAMUNIFORM3UI)(getProcAddr("glProgramUniform3ui"))
 	if gpProgramUniform3ui == nil {
 		return errors.New("glProgramUniform3ui")
 	}
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
+	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
+	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
+	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
 	if gpProgramUniform3uiv == nil {
 		return errors.New("glProgramUniform3uiv")
 	}
+	gpProgramUniform3uivEXT = (C.GPPROGRAMUNIFORM3UIVEXT)(getProcAddr("glProgramUniform3uivEXT"))
 	gpProgramUniform4d = (C.GPPROGRAMUNIFORM4D)(getProcAddr("glProgramUniform4d"))
 	if gpProgramUniform4d == nil {
 		return errors.New("glProgramUniform4d")
 	}
+	gpProgramUniform4dEXT = (C.GPPROGRAMUNIFORM4DEXT)(getProcAddr("glProgramUniform4dEXT"))
 	gpProgramUniform4dv = (C.GPPROGRAMUNIFORM4DV)(getProcAddr("glProgramUniform4dv"))
 	if gpProgramUniform4dv == nil {
 		return errors.New("glProgramUniform4dv")
 	}
+	gpProgramUniform4dvEXT = (C.GPPROGRAMUNIFORM4DVEXT)(getProcAddr("glProgramUniform4dvEXT"))
 	gpProgramUniform4f = (C.GPPROGRAMUNIFORM4F)(getProcAddr("glProgramUniform4f"))
 	if gpProgramUniform4f == nil {
 		return errors.New("glProgramUniform4f")
 	}
+	gpProgramUniform4fEXT = (C.GPPROGRAMUNIFORM4FEXT)(getProcAddr("glProgramUniform4fEXT"))
 	gpProgramUniform4fv = (C.GPPROGRAMUNIFORM4FV)(getProcAddr("glProgramUniform4fv"))
 	if gpProgramUniform4fv == nil {
 		return errors.New("glProgramUniform4fv")
 	}
+	gpProgramUniform4fvEXT = (C.GPPROGRAMUNIFORM4FVEXT)(getProcAddr("glProgramUniform4fvEXT"))
 	gpProgramUniform4i = (C.GPPROGRAMUNIFORM4I)(getProcAddr("glProgramUniform4i"))
 	if gpProgramUniform4i == nil {
 		return errors.New("glProgramUniform4i")
 	}
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
+	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
+	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
+	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
 	if gpProgramUniform4iv == nil {
 		return errors.New("glProgramUniform4iv")
 	}
+	gpProgramUniform4ivEXT = (C.GPPROGRAMUNIFORM4IVEXT)(getProcAddr("glProgramUniform4ivEXT"))
 	gpProgramUniform4ui = (C.GPPROGRAMUNIFORM4UI)(getProcAddr("glProgramUniform4ui"))
 	if gpProgramUniform4ui == nil {
 		return errors.New("glProgramUniform4ui")
 	}
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
+	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
+	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
+	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
 	if gpProgramUniform4uiv == nil {
 		return errors.New("glProgramUniform4uiv")
 	}
+	gpProgramUniform4uivEXT = (C.GPPROGRAMUNIFORM4UIVEXT)(getProcAddr("glProgramUniform4uivEXT"))
 	gpProgramUniformHandleui64ARB = (C.GPPROGRAMUNIFORMHANDLEUI64ARB)(getProcAddr("glProgramUniformHandleui64ARB"))
+	gpProgramUniformHandleui64NV = (C.GPPROGRAMUNIFORMHANDLEUI64NV)(getProcAddr("glProgramUniformHandleui64NV"))
 	gpProgramUniformHandleui64vARB = (C.GPPROGRAMUNIFORMHANDLEUI64VARB)(getProcAddr("glProgramUniformHandleui64vARB"))
+	gpProgramUniformHandleui64vNV = (C.GPPROGRAMUNIFORMHANDLEUI64VNV)(getProcAddr("glProgramUniformHandleui64vNV"))
 	gpProgramUniformMatrix2dv = (C.GPPROGRAMUNIFORMMATRIX2DV)(getProcAddr("glProgramUniformMatrix2dv"))
 	if gpProgramUniformMatrix2dv == nil {
 		return errors.New("glProgramUniformMatrix2dv")
 	}
+	gpProgramUniformMatrix2dvEXT = (C.GPPROGRAMUNIFORMMATRIX2DVEXT)(getProcAddr("glProgramUniformMatrix2dvEXT"))
 	gpProgramUniformMatrix2fv = (C.GPPROGRAMUNIFORMMATRIX2FV)(getProcAddr("glProgramUniformMatrix2fv"))
 	if gpProgramUniformMatrix2fv == nil {
 		return errors.New("glProgramUniformMatrix2fv")
 	}
+	gpProgramUniformMatrix2fvEXT = (C.GPPROGRAMUNIFORMMATRIX2FVEXT)(getProcAddr("glProgramUniformMatrix2fvEXT"))
 	gpProgramUniformMatrix2x3dv = (C.GPPROGRAMUNIFORMMATRIX2X3DV)(getProcAddr("glProgramUniformMatrix2x3dv"))
 	if gpProgramUniformMatrix2x3dv == nil {
 		return errors.New("glProgramUniformMatrix2x3dv")
 	}
+	gpProgramUniformMatrix2x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3DVEXT)(getProcAddr("glProgramUniformMatrix2x3dvEXT"))
 	gpProgramUniformMatrix2x3fv = (C.GPPROGRAMUNIFORMMATRIX2X3FV)(getProcAddr("glProgramUniformMatrix2x3fv"))
 	if gpProgramUniformMatrix2x3fv == nil {
 		return errors.New("glProgramUniformMatrix2x3fv")
 	}
+	gpProgramUniformMatrix2x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3FVEXT)(getProcAddr("glProgramUniformMatrix2x3fvEXT"))
 	gpProgramUniformMatrix2x4dv = (C.GPPROGRAMUNIFORMMATRIX2X4DV)(getProcAddr("glProgramUniformMatrix2x4dv"))
 	if gpProgramUniformMatrix2x4dv == nil {
 		return errors.New("glProgramUniformMatrix2x4dv")
 	}
+	gpProgramUniformMatrix2x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4DVEXT)(getProcAddr("glProgramUniformMatrix2x4dvEXT"))
 	gpProgramUniformMatrix2x4fv = (C.GPPROGRAMUNIFORMMATRIX2X4FV)(getProcAddr("glProgramUniformMatrix2x4fv"))
 	if gpProgramUniformMatrix2x4fv == nil {
 		return errors.New("glProgramUniformMatrix2x4fv")
 	}
+	gpProgramUniformMatrix2x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4FVEXT)(getProcAddr("glProgramUniformMatrix2x4fvEXT"))
 	gpProgramUniformMatrix3dv = (C.GPPROGRAMUNIFORMMATRIX3DV)(getProcAddr("glProgramUniformMatrix3dv"))
 	if gpProgramUniformMatrix3dv == nil {
 		return errors.New("glProgramUniformMatrix3dv")
 	}
+	gpProgramUniformMatrix3dvEXT = (C.GPPROGRAMUNIFORMMATRIX3DVEXT)(getProcAddr("glProgramUniformMatrix3dvEXT"))
 	gpProgramUniformMatrix3fv = (C.GPPROGRAMUNIFORMMATRIX3FV)(getProcAddr("glProgramUniformMatrix3fv"))
 	if gpProgramUniformMatrix3fv == nil {
 		return errors.New("glProgramUniformMatrix3fv")
 	}
+	gpProgramUniformMatrix3fvEXT = (C.GPPROGRAMUNIFORMMATRIX3FVEXT)(getProcAddr("glProgramUniformMatrix3fvEXT"))
 	gpProgramUniformMatrix3x2dv = (C.GPPROGRAMUNIFORMMATRIX3X2DV)(getProcAddr("glProgramUniformMatrix3x2dv"))
 	if gpProgramUniformMatrix3x2dv == nil {
 		return errors.New("glProgramUniformMatrix3x2dv")
 	}
+	gpProgramUniformMatrix3x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2DVEXT)(getProcAddr("glProgramUniformMatrix3x2dvEXT"))
 	gpProgramUniformMatrix3x2fv = (C.GPPROGRAMUNIFORMMATRIX3X2FV)(getProcAddr("glProgramUniformMatrix3x2fv"))
 	if gpProgramUniformMatrix3x2fv == nil {
 		return errors.New("glProgramUniformMatrix3x2fv")
 	}
+	gpProgramUniformMatrix3x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2FVEXT)(getProcAddr("glProgramUniformMatrix3x2fvEXT"))
 	gpProgramUniformMatrix3x4dv = (C.GPPROGRAMUNIFORMMATRIX3X4DV)(getProcAddr("glProgramUniformMatrix3x4dv"))
 	if gpProgramUniformMatrix3x4dv == nil {
 		return errors.New("glProgramUniformMatrix3x4dv")
 	}
+	gpProgramUniformMatrix3x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4DVEXT)(getProcAddr("glProgramUniformMatrix3x4dvEXT"))
 	gpProgramUniformMatrix3x4fv = (C.GPPROGRAMUNIFORMMATRIX3X4FV)(getProcAddr("glProgramUniformMatrix3x4fv"))
 	if gpProgramUniformMatrix3x4fv == nil {
 		return errors.New("glProgramUniformMatrix3x4fv")
 	}
+	gpProgramUniformMatrix3x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4FVEXT)(getProcAddr("glProgramUniformMatrix3x4fvEXT"))
 	gpProgramUniformMatrix4dv = (C.GPPROGRAMUNIFORMMATRIX4DV)(getProcAddr("glProgramUniformMatrix4dv"))
 	if gpProgramUniformMatrix4dv == nil {
 		return errors.New("glProgramUniformMatrix4dv")
 	}
+	gpProgramUniformMatrix4dvEXT = (C.GPPROGRAMUNIFORMMATRIX4DVEXT)(getProcAddr("glProgramUniformMatrix4dvEXT"))
 	gpProgramUniformMatrix4fv = (C.GPPROGRAMUNIFORMMATRIX4FV)(getProcAddr("glProgramUniformMatrix4fv"))
 	if gpProgramUniformMatrix4fv == nil {
 		return errors.New("glProgramUniformMatrix4fv")
 	}
+	gpProgramUniformMatrix4fvEXT = (C.GPPROGRAMUNIFORMMATRIX4FVEXT)(getProcAddr("glProgramUniformMatrix4fvEXT"))
 	gpProgramUniformMatrix4x2dv = (C.GPPROGRAMUNIFORMMATRIX4X2DV)(getProcAddr("glProgramUniformMatrix4x2dv"))
 	if gpProgramUniformMatrix4x2dv == nil {
 		return errors.New("glProgramUniformMatrix4x2dv")
 	}
+	gpProgramUniformMatrix4x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2DVEXT)(getProcAddr("glProgramUniformMatrix4x2dvEXT"))
 	gpProgramUniformMatrix4x2fv = (C.GPPROGRAMUNIFORMMATRIX4X2FV)(getProcAddr("glProgramUniformMatrix4x2fv"))
 	if gpProgramUniformMatrix4x2fv == nil {
 		return errors.New("glProgramUniformMatrix4x2fv")
 	}
+	gpProgramUniformMatrix4x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2FVEXT)(getProcAddr("glProgramUniformMatrix4x2fvEXT"))
 	gpProgramUniformMatrix4x3dv = (C.GPPROGRAMUNIFORMMATRIX4X3DV)(getProcAddr("glProgramUniformMatrix4x3dv"))
 	if gpProgramUniformMatrix4x3dv == nil {
 		return errors.New("glProgramUniformMatrix4x3dv")
 	}
+	gpProgramUniformMatrix4x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3DVEXT)(getProcAddr("glProgramUniformMatrix4x3dvEXT"))
 	gpProgramUniformMatrix4x3fv = (C.GPPROGRAMUNIFORMMATRIX4X3FV)(getProcAddr("glProgramUniformMatrix4x3fv"))
 	if gpProgramUniformMatrix4x3fv == nil {
 		return errors.New("glProgramUniformMatrix4x3fv")
 	}
+	gpProgramUniformMatrix4x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3FVEXT)(getProcAddr("glProgramUniformMatrix4x3fvEXT"))
+	gpProgramUniformui64NV = (C.GPPROGRAMUNIFORMUI64NV)(getProcAddr("glProgramUniformui64NV"))
+	gpProgramUniformui64vNV = (C.GPPROGRAMUNIFORMUI64VNV)(getProcAddr("glProgramUniformui64vNV"))
 	gpProvokingVertex = (C.GPPROVOKINGVERTEX)(getProcAddr("glProvokingVertex"))
 	if gpProvokingVertex == nil {
 		return errors.New("glProvokingVertex")
 	}
+	gpPushClientAttribDefaultEXT = (C.GPPUSHCLIENTATTRIBDEFAULTEXT)(getProcAddr("glPushClientAttribDefaultEXT"))
 	gpPushDebugGroup = (C.GPPUSHDEBUGGROUP)(getProcAddr("glPushDebugGroup"))
 	gpPushDebugGroupKHR = (C.GPPUSHDEBUGGROUPKHR)(getProcAddr("glPushDebugGroupKHR"))
+	gpPushGroupMarkerEXT = (C.GPPUSHGROUPMARKEREXT)(getProcAddr("glPushGroupMarkerEXT"))
 	gpQueryCounter = (C.GPQUERYCOUNTER)(getProcAddr("glQueryCounter"))
 	if gpQueryCounter == nil {
 		return errors.New("glQueryCounter")
 	}
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -9590,6 +14996,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpRenderbufferStorageMultisample == nil {
 		return errors.New("glRenderbufferStorageMultisample")
 	}
+	gpRenderbufferStorageMultisampleCoverageNV = (C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(getProcAddr("glRenderbufferStorageMultisampleCoverageNV"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	if gpResumeTransformFeedback == nil {
 		return errors.New("glResumeTransformFeedback")
@@ -9642,6 +15050,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpScissorIndexedv == nil {
 		return errors.New("glScissorIndexedv")
 	}
+	gpSecondaryColorFormatNV = (C.GPSECONDARYCOLORFORMATNV)(getProcAddr("glSecondaryColorFormatNV"))
+	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
 	gpShaderBinary = (C.GPSHADERBINARY)(getProcAddr("glShaderBinary"))
 	if gpShaderBinary == nil {
 		return errors.New("glShaderBinary")
@@ -9651,6 +15061,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glShaderSource")
 	}
 	gpShaderStorageBlockBinding = (C.GPSHADERSTORAGEBLOCKBINDING)(getProcAddr("glShaderStorageBlockBinding"))
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
+	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
+	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
 	gpStencilFunc = (C.GPSTENCILFUNC)(getProcAddr("glStencilFunc"))
 	if gpStencilFunc == nil {
 		return errors.New("glStencilFunc")
@@ -9675,11 +15091,20 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpStencilOpSeparate == nil {
 		return errors.New("glStencilOpSeparate")
 	}
+	gpStencilStrokePathInstancedNV = (C.GPSTENCILSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilStrokePathInstancedNV"))
+	gpStencilStrokePathNV = (C.GPSTENCILSTROKEPATHNV)(getProcAddr("glStencilStrokePathNV"))
+	gpStencilThenCoverFillPathInstancedNV = (C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverFillPathInstancedNV"))
+	gpStencilThenCoverFillPathNV = (C.GPSTENCILTHENCOVERFILLPATHNV)(getProcAddr("glStencilThenCoverFillPathNV"))
+	gpStencilThenCoverStrokePathInstancedNV = (C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverStrokePathInstancedNV"))
+	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpTexBuffer = (C.GPTEXBUFFER)(getProcAddr("glTexBuffer"))
 	if gpTexBuffer == nil {
 		return errors.New("glTexBuffer")
 	}
+	gpTexBufferARB = (C.GPTEXBUFFERARB)(getProcAddr("glTexBufferARB"))
 	gpTexBufferRange = (C.GPTEXBUFFERRANGE)(getProcAddr("glTexBufferRange"))
+	gpTexCoordFormatNV = (C.GPTEXCOORDFORMATNV)(getProcAddr("glTexCoordFormatNV"))
 	gpTexImage1D = (C.GPTEXIMAGE1D)(getProcAddr("glTexImage1D"))
 	if gpTexImage1D == nil {
 		return errors.New("glTexImage1D")
@@ -9743,22 +15168,44 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glTexSubImage3D")
 	}
 	gpTextureBarrier = (C.GPTEXTUREBARRIER)(getProcAddr("glTextureBarrier"))
+	gpTextureBarrierNV = (C.GPTEXTUREBARRIERNV)(getProcAddr("glTextureBarrierNV"))
 	gpTextureBuffer = (C.GPTEXTUREBUFFER)(getProcAddr("glTextureBuffer"))
+	gpTextureBufferEXT = (C.GPTEXTUREBUFFEREXT)(getProcAddr("glTextureBufferEXT"))
 	gpTextureBufferRange = (C.GPTEXTUREBUFFERRANGE)(getProcAddr("glTextureBufferRange"))
+	gpTextureBufferRangeEXT = (C.GPTEXTUREBUFFERRANGEEXT)(getProcAddr("glTextureBufferRangeEXT"))
+	gpTextureImage1DEXT = (C.GPTEXTUREIMAGE1DEXT)(getProcAddr("glTextureImage1DEXT"))
+	gpTextureImage2DEXT = (C.GPTEXTUREIMAGE2DEXT)(getProcAddr("glTextureImage2DEXT"))
+	gpTextureImage3DEXT = (C.GPTEXTUREIMAGE3DEXT)(getProcAddr("glTextureImage3DEXT"))
+	gpTexturePageCommitmentEXT = (C.GPTEXTUREPAGECOMMITMENTEXT)(getProcAddr("glTexturePageCommitmentEXT"))
 	gpTextureParameterIiv = (C.GPTEXTUREPARAMETERIIV)(getProcAddr("glTextureParameterIiv"))
+	gpTextureParameterIivEXT = (C.GPTEXTUREPARAMETERIIVEXT)(getProcAddr("glTextureParameterIivEXT"))
 	gpTextureParameterIuiv = (C.GPTEXTUREPARAMETERIUIV)(getProcAddr("glTextureParameterIuiv"))
+	gpTextureParameterIuivEXT = (C.GPTEXTUREPARAMETERIUIVEXT)(getProcAddr("glTextureParameterIuivEXT"))
 	gpTextureParameterf = (C.GPTEXTUREPARAMETERF)(getProcAddr("glTextureParameterf"))
+	gpTextureParameterfEXT = (C.GPTEXTUREPARAMETERFEXT)(getProcAddr("glTextureParameterfEXT"))
 	gpTextureParameterfv = (C.GPTEXTUREPARAMETERFV)(getProcAddr("glTextureParameterfv"))
+	gpTextureParameterfvEXT = (C.GPTEXTUREPARAMETERFVEXT)(getProcAddr("glTextureParameterfvEXT"))
 	gpTextureParameteri = (C.GPTEXTUREPARAMETERI)(getProcAddr("glTextureParameteri"))
+	gpTextureParameteriEXT = (C.GPTEXTUREPARAMETERIEXT)(getProcAddr("glTextureParameteriEXT"))
 	gpTextureParameteriv = (C.GPTEXTUREPARAMETERIV)(getProcAddr("glTextureParameteriv"))
+	gpTextureParameterivEXT = (C.GPTEXTUREPARAMETERIVEXT)(getProcAddr("glTextureParameterivEXT"))
+	gpTextureRenderbufferEXT = (C.GPTEXTURERENDERBUFFEREXT)(getProcAddr("glTextureRenderbufferEXT"))
 	gpTextureStorage1D = (C.GPTEXTURESTORAGE1D)(getProcAddr("glTextureStorage1D"))
+	gpTextureStorage1DEXT = (C.GPTEXTURESTORAGE1DEXT)(getProcAddr("glTextureStorage1DEXT"))
 	gpTextureStorage2D = (C.GPTEXTURESTORAGE2D)(getProcAddr("glTextureStorage2D"))
+	gpTextureStorage2DEXT = (C.GPTEXTURESTORAGE2DEXT)(getProcAddr("glTextureStorage2DEXT"))
 	gpTextureStorage2DMultisample = (C.GPTEXTURESTORAGE2DMULTISAMPLE)(getProcAddr("glTextureStorage2DMultisample"))
+	gpTextureStorage2DMultisampleEXT = (C.GPTEXTURESTORAGE2DMULTISAMPLEEXT)(getProcAddr("glTextureStorage2DMultisampleEXT"))
 	gpTextureStorage3D = (C.GPTEXTURESTORAGE3D)(getProcAddr("glTextureStorage3D"))
+	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
+	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
+	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
 	gpTextureSubImage2D = (C.GPTEXTURESUBIMAGE2D)(getProcAddr("glTextureSubImage2D"))
+	gpTextureSubImage2DEXT = (C.GPTEXTURESUBIMAGE2DEXT)(getProcAddr("glTextureSubImage2DEXT"))
 	gpTextureSubImage3D = (C.GPTEXTURESUBIMAGE3D)(getProcAddr("glTextureSubImage3D"))
+	gpTextureSubImage3DEXT = (C.GPTEXTURESUBIMAGE3DEXT)(getProcAddr("glTextureSubImage3DEXT"))
 	gpTextureView = (C.GPTEXTUREVIEW)(getProcAddr("glTextureView"))
 	gpTransformFeedbackBufferBase = (C.GPTRANSFORMFEEDBACKBUFFERBASE)(getProcAddr("glTransformFeedbackBufferBase"))
 	gpTransformFeedbackBufferRange = (C.GPTRANSFORMFEEDBACKBUFFERRANGE)(getProcAddr("glTransformFeedbackBufferRange"))
@@ -9766,6 +15213,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpTransformFeedbackVaryings == nil {
 		return errors.New("glTransformFeedbackVaryings")
 	}
+	gpTransformPathNV = (C.GPTRANSFORMPATHNV)(getProcAddr("glTransformPathNV"))
 	gpUniform1d = (C.GPUNIFORM1D)(getProcAddr("glUniform1d"))
 	if gpUniform1d == nil {
 		return errors.New("glUniform1d")
@@ -9786,6 +15234,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
+	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
+	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
 	if gpUniform1iv == nil {
 		return errors.New("glUniform1iv")
@@ -9794,6 +15246,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
+	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
+	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
 	if gpUniform1uiv == nil {
 		return errors.New("glUniform1uiv")
@@ -9818,6 +15274,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
+	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
+	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
 	if gpUniform2iv == nil {
 		return errors.New("glUniform2iv")
@@ -9826,6 +15286,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
+	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
+	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
 	if gpUniform2uiv == nil {
 		return errors.New("glUniform2uiv")
@@ -9850,6 +15314,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
+	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
+	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
 	if gpUniform3iv == nil {
 		return errors.New("glUniform3iv")
@@ -9858,6 +15326,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
+	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
+	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
 	if gpUniform3uiv == nil {
 		return errors.New("glUniform3uiv")
@@ -9882,6 +15354,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
+	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
+	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
 	if gpUniform4iv == nil {
 		return errors.New("glUniform4iv")
@@ -9890,6 +15366,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
+	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
+	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
 	if gpUniform4uiv == nil {
 		return errors.New("glUniform4uiv")
@@ -9899,7 +15379,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glUniformBlockBinding")
 	}
 	gpUniformHandleui64ARB = (C.GPUNIFORMHANDLEUI64ARB)(getProcAddr("glUniformHandleui64ARB"))
+	gpUniformHandleui64NV = (C.GPUNIFORMHANDLEUI64NV)(getProcAddr("glUniformHandleui64NV"))
 	gpUniformHandleui64vARB = (C.GPUNIFORMHANDLEUI64VARB)(getProcAddr("glUniformHandleui64vARB"))
+	gpUniformHandleui64vNV = (C.GPUNIFORMHANDLEUI64VNV)(getProcAddr("glUniformHandleui64vNV"))
 	gpUniformMatrix2dv = (C.GPUNIFORMMATRIX2DV)(getProcAddr("glUniformMatrix2dv"))
 	if gpUniformMatrix2dv == nil {
 		return errors.New("glUniformMatrix2dv")
@@ -9976,11 +15458,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniformSubroutinesuiv == nil {
 		return errors.New("glUniformSubroutinesuiv")
 	}
+	gpUniformui64NV = (C.GPUNIFORMUI64NV)(getProcAddr("glUniformui64NV"))
+	gpUniformui64vNV = (C.GPUNIFORMUI64VNV)(getProcAddr("glUniformui64vNV"))
 	gpUnmapBuffer = (C.GPUNMAPBUFFER)(getProcAddr("glUnmapBuffer"))
 	if gpUnmapBuffer == nil {
 		return errors.New("glUnmapBuffer")
 	}
 	gpUnmapNamedBuffer = (C.GPUNMAPNAMEDBUFFER)(getProcAddr("glUnmapNamedBuffer"))
+	gpUnmapNamedBufferEXT = (C.GPUNMAPNAMEDBUFFEREXT)(getProcAddr("glUnmapNamedBufferEXT"))
 	gpUseProgram = (C.GPUSEPROGRAM)(getProcAddr("glUseProgram"))
 	if gpUseProgram == nil {
 		return errors.New("glUseProgram")
@@ -9989,6 +15474,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUseProgramStages == nil {
 		return errors.New("glUseProgramStages")
 	}
+	gpUseProgramStagesEXT = (C.GPUSEPROGRAMSTAGESEXT)(getProcAddr("glUseProgramStagesEXT"))
+	gpUseShaderProgramEXT = (C.GPUSESHADERPROGRAMEXT)(getProcAddr("glUseShaderProgramEXT"))
 	gpValidateProgram = (C.GPVALIDATEPROGRAM)(getProcAddr("glValidateProgram"))
 	if gpValidateProgram == nil {
 		return errors.New("glValidateProgram")
@@ -9997,14 +15484,34 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpValidateProgramPipeline == nil {
 		return errors.New("glValidateProgramPipeline")
 	}
+	gpValidateProgramPipelineEXT = (C.GPVALIDATEPROGRAMPIPELINEEXT)(getProcAddr("glValidateProgramPipelineEXT"))
 	gpVertexArrayAttribBinding = (C.GPVERTEXARRAYATTRIBBINDING)(getProcAddr("glVertexArrayAttribBinding"))
 	gpVertexArrayAttribFormat = (C.GPVERTEXARRAYATTRIBFORMAT)(getProcAddr("glVertexArrayAttribFormat"))
 	gpVertexArrayAttribIFormat = (C.GPVERTEXARRAYATTRIBIFORMAT)(getProcAddr("glVertexArrayAttribIFormat"))
 	gpVertexArrayAttribLFormat = (C.GPVERTEXARRAYATTRIBLFORMAT)(getProcAddr("glVertexArrayAttribLFormat"))
+	gpVertexArrayBindVertexBufferEXT = (C.GPVERTEXARRAYBINDVERTEXBUFFEREXT)(getProcAddr("glVertexArrayBindVertexBufferEXT"))
 	gpVertexArrayBindingDivisor = (C.GPVERTEXARRAYBINDINGDIVISOR)(getProcAddr("glVertexArrayBindingDivisor"))
+	gpVertexArrayColorOffsetEXT = (C.GPVERTEXARRAYCOLOROFFSETEXT)(getProcAddr("glVertexArrayColorOffsetEXT"))
+	gpVertexArrayEdgeFlagOffsetEXT = (C.GPVERTEXARRAYEDGEFLAGOFFSETEXT)(getProcAddr("glVertexArrayEdgeFlagOffsetEXT"))
 	gpVertexArrayElementBuffer = (C.GPVERTEXARRAYELEMENTBUFFER)(getProcAddr("glVertexArrayElementBuffer"))
+	gpVertexArrayFogCoordOffsetEXT = (C.GPVERTEXARRAYFOGCOORDOFFSETEXT)(getProcAddr("glVertexArrayFogCoordOffsetEXT"))
+	gpVertexArrayIndexOffsetEXT = (C.GPVERTEXARRAYINDEXOFFSETEXT)(getProcAddr("glVertexArrayIndexOffsetEXT"))
+	gpVertexArrayMultiTexCoordOffsetEXT = (C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayMultiTexCoordOffsetEXT"))
+	gpVertexArrayNormalOffsetEXT = (C.GPVERTEXARRAYNORMALOFFSETEXT)(getProcAddr("glVertexArrayNormalOffsetEXT"))
+	gpVertexArraySecondaryColorOffsetEXT = (C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(getProcAddr("glVertexArraySecondaryColorOffsetEXT"))
+	gpVertexArrayTexCoordOffsetEXT = (C.GPVERTEXARRAYTEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayTexCoordOffsetEXT"))
+	gpVertexArrayVertexAttribBindingEXT = (C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(getProcAddr("glVertexArrayVertexAttribBindingEXT"))
+	gpVertexArrayVertexAttribDivisorEXT = (C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(getProcAddr("glVertexArrayVertexAttribDivisorEXT"))
+	gpVertexArrayVertexAttribFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(getProcAddr("glVertexArrayVertexAttribFormatEXT"))
+	gpVertexArrayVertexAttribIFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(getProcAddr("glVertexArrayVertexAttribIFormatEXT"))
+	gpVertexArrayVertexAttribIOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribIOffsetEXT"))
+	gpVertexArrayVertexAttribLFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(getProcAddr("glVertexArrayVertexAttribLFormatEXT"))
+	gpVertexArrayVertexAttribLOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribLOffsetEXT"))
+	gpVertexArrayVertexAttribOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribOffsetEXT"))
+	gpVertexArrayVertexBindingDivisorEXT = (C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(getProcAddr("glVertexArrayVertexBindingDivisorEXT"))
 	gpVertexArrayVertexBuffer = (C.GPVERTEXARRAYVERTEXBUFFER)(getProcAddr("glVertexArrayVertexBuffer"))
 	gpVertexArrayVertexBuffers = (C.GPVERTEXARRAYVERTEXBUFFERS)(getProcAddr("glVertexArrayVertexBuffers"))
+	gpVertexArrayVertexOffsetEXT = (C.GPVERTEXARRAYVERTEXOFFSETEXT)(getProcAddr("glVertexArrayVertexOffsetEXT"))
 	gpVertexAttrib1d = (C.GPVERTEXATTRIB1D)(getProcAddr("glVertexAttrib1d"))
 	if gpVertexAttrib1d == nil {
 		return errors.New("glVertexAttrib1d")
@@ -10154,7 +15661,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribDivisor == nil {
 		return errors.New("glVertexAttribDivisor")
 	}
+	gpVertexAttribDivisorARB = (C.GPVERTEXATTRIBDIVISORARB)(getProcAddr("glVertexAttribDivisorARB"))
 	gpVertexAttribFormat = (C.GPVERTEXATTRIBFORMAT)(getProcAddr("glVertexAttribFormat"))
+	gpVertexAttribFormatNV = (C.GPVERTEXATTRIBFORMATNV)(getProcAddr("glVertexAttribFormatNV"))
 	gpVertexAttribI1i = (C.GPVERTEXATTRIBI1I)(getProcAddr("glVertexAttribI1i"))
 	if gpVertexAttribI1i == nil {
 		return errors.New("glVertexAttribI1i")
@@ -10236,6 +15745,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glVertexAttribI4usv")
 	}
 	gpVertexAttribIFormat = (C.GPVERTEXATTRIBIFORMAT)(getProcAddr("glVertexAttribIFormat"))
+	gpVertexAttribIFormatNV = (C.GPVERTEXATTRIBIFORMATNV)(getProcAddr("glVertexAttribIFormatNV"))
 	gpVertexAttribIPointer = (C.GPVERTEXATTRIBIPOINTER)(getProcAddr("glVertexAttribIPointer"))
 	if gpVertexAttribIPointer == nil {
 		return errors.New("glVertexAttribIPointer")
@@ -10248,8 +15758,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL1dv == nil {
 		return errors.New("glVertexAttribL1dv")
 	}
+	gpVertexAttribL1i64NV = (C.GPVERTEXATTRIBL1I64NV)(getProcAddr("glVertexAttribL1i64NV"))
+	gpVertexAttribL1i64vNV = (C.GPVERTEXATTRIBL1I64VNV)(getProcAddr("glVertexAttribL1i64vNV"))
 	gpVertexAttribL1ui64ARB = (C.GPVERTEXATTRIBL1UI64ARB)(getProcAddr("glVertexAttribL1ui64ARB"))
+	gpVertexAttribL1ui64NV = (C.GPVERTEXATTRIBL1UI64NV)(getProcAddr("glVertexAttribL1ui64NV"))
 	gpVertexAttribL1ui64vARB = (C.GPVERTEXATTRIBL1UI64VARB)(getProcAddr("glVertexAttribL1ui64vARB"))
+	gpVertexAttribL1ui64vNV = (C.GPVERTEXATTRIBL1UI64VNV)(getProcAddr("glVertexAttribL1ui64vNV"))
 	gpVertexAttribL2d = (C.GPVERTEXATTRIBL2D)(getProcAddr("glVertexAttribL2d"))
 	if gpVertexAttribL2d == nil {
 		return errors.New("glVertexAttribL2d")
@@ -10258,6 +15772,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL2dv == nil {
 		return errors.New("glVertexAttribL2dv")
 	}
+	gpVertexAttribL2i64NV = (C.GPVERTEXATTRIBL2I64NV)(getProcAddr("glVertexAttribL2i64NV"))
+	gpVertexAttribL2i64vNV = (C.GPVERTEXATTRIBL2I64VNV)(getProcAddr("glVertexAttribL2i64vNV"))
+	gpVertexAttribL2ui64NV = (C.GPVERTEXATTRIBL2UI64NV)(getProcAddr("glVertexAttribL2ui64NV"))
+	gpVertexAttribL2ui64vNV = (C.GPVERTEXATTRIBL2UI64VNV)(getProcAddr("glVertexAttribL2ui64vNV"))
 	gpVertexAttribL3d = (C.GPVERTEXATTRIBL3D)(getProcAddr("glVertexAttribL3d"))
 	if gpVertexAttribL3d == nil {
 		return errors.New("glVertexAttribL3d")
@@ -10266,6 +15784,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL3dv == nil {
 		return errors.New("glVertexAttribL3dv")
 	}
+	gpVertexAttribL3i64NV = (C.GPVERTEXATTRIBL3I64NV)(getProcAddr("glVertexAttribL3i64NV"))
+	gpVertexAttribL3i64vNV = (C.GPVERTEXATTRIBL3I64VNV)(getProcAddr("glVertexAttribL3i64vNV"))
+	gpVertexAttribL3ui64NV = (C.GPVERTEXATTRIBL3UI64NV)(getProcAddr("glVertexAttribL3ui64NV"))
+	gpVertexAttribL3ui64vNV = (C.GPVERTEXATTRIBL3UI64VNV)(getProcAddr("glVertexAttribL3ui64vNV"))
 	gpVertexAttribL4d = (C.GPVERTEXATTRIBL4D)(getProcAddr("glVertexAttribL4d"))
 	if gpVertexAttribL4d == nil {
 		return errors.New("glVertexAttribL4d")
@@ -10274,7 +15796,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL4dv == nil {
 		return errors.New("glVertexAttribL4dv")
 	}
+	gpVertexAttribL4i64NV = (C.GPVERTEXATTRIBL4I64NV)(getProcAddr("glVertexAttribL4i64NV"))
+	gpVertexAttribL4i64vNV = (C.GPVERTEXATTRIBL4I64VNV)(getProcAddr("glVertexAttribL4i64vNV"))
+	gpVertexAttribL4ui64NV = (C.GPVERTEXATTRIBL4UI64NV)(getProcAddr("glVertexAttribL4ui64NV"))
+	gpVertexAttribL4ui64vNV = (C.GPVERTEXATTRIBL4UI64VNV)(getProcAddr("glVertexAttribL4ui64vNV"))
 	gpVertexAttribLFormat = (C.GPVERTEXATTRIBLFORMAT)(getProcAddr("glVertexAttribLFormat"))
+	gpVertexAttribLFormatNV = (C.GPVERTEXATTRIBLFORMATNV)(getProcAddr("glVertexAttribLFormatNV"))
 	gpVertexAttribLPointer = (C.GPVERTEXATTRIBLPOINTER)(getProcAddr("glVertexAttribLPointer"))
 	if gpVertexAttribLPointer == nil {
 		return errors.New("glVertexAttribLPointer")
@@ -10316,6 +15843,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glVertexAttribPointer")
 	}
 	gpVertexBindingDivisor = (C.GPVERTEXBINDINGDIVISOR)(getProcAddr("glVertexBindingDivisor"))
+	gpVertexFormatNV = (C.GPVERTEXFORMATNV)(getProcAddr("glVertexFormatNV"))
 	gpViewport = (C.GPVIEWPORT)(getProcAddr("glViewport"))
 	if gpViewport == nil {
 		return errors.New("glViewport")
@@ -10332,9 +15860,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpViewportIndexedfv == nil {
 		return errors.New("glViewportIndexedfv")
 	}
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
+	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	return nil
 }

--- a/v4.1-core/gl/procaddr.go
+++ b/v4.1-core/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcore41(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v4.2-compatibility/gl/package.go
+++ b/v4.2-compatibility/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -75,7 +73,6 @@ package gl
 // typedef unsigned int GLenum;
 // typedef unsigned char GLboolean;
 // typedef unsigned int GLbitfield;
-// typedef void GLvoid;
 // typedef signed char GLbyte;
 // typedef short GLshort;
 // typedef int GLint;
@@ -88,6 +85,7 @@ package gl
 // typedef float GLclampf;
 // typedef double GLdouble;
 // typedef double GLclampd;
+// typedef void *GLeglClientBufferEXT;
 // typedef char GLchar;
 // typedef char GLcharARB;
 // #ifdef __APPLE__
@@ -104,7 +102,7 @@ package gl
 // typedef ptrdiff_t GLsizeiptrARB;
 // typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
@@ -113,12 +111,14 @@ package gl
 // typedef void (APIENTRY *GLDEBUGPROCAMD)(GLuint id,GLenum category,GLenum severity,GLsizei length,const GLchar *message,void *userParam);
 // typedef unsigned short GLhalfNV;
 // typedef GLintptr GLvdpauSurfaceNV;
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcompatibility42(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcompatibility42(source, type, id, severity, length, message, userParam);
 // }
 // typedef void  (APIENTRYP GPACCUM)(GLenum  op, GLfloat  value);
 // typedef void  (APIENTRYP GPACCUMXOES)(GLenum  op, GLfixed  value);
+// typedef GLboolean  (APIENTRYP GPACQUIREKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key, GLuint  timeout);
 // typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
@@ -131,6 +131,8 @@ package gl
 // typedef void  (APIENTRYP GPALPHAFRAGMENTOP3ATI)(GLenum  op, GLuint  dst, GLuint  dstMod, GLuint  arg1, GLuint  arg1Rep, GLuint  arg1Mod, GLuint  arg2, GLuint  arg2Rep, GLuint  arg2Mod, GLuint  arg3, GLuint  arg3Rep, GLuint  arg3Mod);
 // typedef void  (APIENTRYP GPALPHAFUNC)(GLenum  func, GLfloat  ref);
 // typedef void  (APIENTRYP GPALPHAFUNCXOES)(GLenum  func, GLfixed  ref);
+// typedef void  (APIENTRYP GPALPHATOCOVERAGEDITHERCONTROLNV)(GLenum  mode);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPAPPLYTEXTUREEXT)(GLenum  mode);
 // typedef GLboolean  (APIENTRYP GPAREPROGRAMSRESIDENTNV)(GLsizei  n, const GLuint * programs, GLboolean * residences);
 // typedef GLboolean  (APIENTRYP GPARETEXTURESRESIDENT)(GLsizei  n, const GLuint * textures, GLboolean * residences);
@@ -252,11 +254,14 @@ package gl
 // typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPBUFFERDATAARB)(GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERPARAMETERIAPPLE)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEEXTERNALEXT)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEMEMEXT)(GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPBUFFERSUBDATAARB)(GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLIST)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLISTS)(GLsizei  n, GLenum  type, const void * lists);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
@@ -286,9 +291,9 @@ package gl
 // typedef void  (APIENTRYP GPCLEARINDEX)(GLfloat  c);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
@@ -384,6 +389,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERIVNV)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERARB)(GLhandleARB  shaderObj);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
@@ -414,6 +421,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER2D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * image);
@@ -444,7 +453,7 @@ package gl
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  type);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
@@ -469,8 +478,12 @@ package gl
 // typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEMEMORYOBJECTSEXT)(GLsizei  n, GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef GLhandleARB  (APIENTRYP GPCREATEPROGRAMOBJECTARB)();
@@ -483,6 +496,7 @@ package gl
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -509,12 +523,14 @@ package gl
 // typedef void  (APIENTRYP GPDELETEASYNCMARKERSSGIX)(GLuint  marker, GLsizei  range);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
 // typedef void  (APIENTRYP GPDELETEBUFFERSARB)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFENCESAPPLE)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFENCESNV)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFRAGMENTSHADERATI)(GLuint  id);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERSEXT)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETELISTS)(GLuint  list, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEMEMORYOBJECTSEXT)(GLsizei  n, const GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
 // typedef void  (APIENTRYP GPDELETENAMESAMD)(GLenum  identifier, GLuint  num, const GLuint * names);
 // typedef void  (APIENTRYP GPDELETEOBJECTARB)(GLhandleARB  obj);
@@ -529,10 +545,13 @@ package gl
 // typedef void  (APIENTRYP GPDELETEPROGRAMSNV)(GLsizei  n, const GLuint * programs);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETEQUERIESARB)(GLsizei  n, const GLuint * ids);
+// typedef void  (APIENTRYP GPDELETEQUERYRESOURCETAGNV)(GLsizei  n, const GLint * tagIds);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERSEXT)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
+// typedef void  (APIENTRYP GPDELETESEMAPHORESEXT)(GLsizei  n, const GLuint * semaphores);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETEXTURESEXT)(GLsizei  n, const GLuint * textures);
@@ -582,6 +601,10 @@ package gl
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSARB)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSATI)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYAPPLE)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYATI)(GLenum  mode, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
@@ -606,6 +629,7 @@ package gl
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKNV)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
 // typedef void  (APIENTRYP GPEDGEFLAG)(GLboolean  flag);
 // typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPEDGEFLAGPOINTER)(GLsizei  stride, const void * pointer);
@@ -661,6 +685,7 @@ package gl
 // typedef void  (APIENTRYP GPEVALMESH2)(GLenum  mode, GLint  i1, GLint  i2, GLint  j1, GLint  j2);
 // typedef void  (APIENTRYP GPEVALPOINT1)(GLint  i);
 // typedef void  (APIENTRYP GPEVALPOINT2)(GLint  i, GLint  j);
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef void  (APIENTRYP GPEXECUTEPROGRAMNV)(GLenum  target, GLuint  id, const GLfloat * params);
 // typedef void  (APIENTRYP GPEXTRACTCOMPONENTEXT)(GLuint  res, GLuint  src, GLuint  num);
 // typedef void  (APIENTRYP GPFEEDBACKBUFFER)(GLsizei  size, GLenum  type, GLfloat * buffer);
@@ -676,7 +701,7 @@ package gl
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGEAPPLE)(GLenum  target, GLintptr  offset, GLsizeiptr  size);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHPIXELDATARANGENV)(GLenum  target);
 // typedef void  (APIENTRYP GPFLUSHRASTERSGIX)();
@@ -705,6 +730,7 @@ package gl
 // typedef void  (APIENTRYP GPFOGXOES)(GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPFOGXVOES)(GLenum  pname, const GLfixed * param);
 // typedef void  (APIENTRYP GPFRAGMENTCOLORMATERIALSGIX)(GLenum  face, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELISGIX)(GLenum  pname, GLint  param);
@@ -721,10 +747,14 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEZOOMSGIX)(GLint  factor);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFEREXT)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1DEXT)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -739,6 +769,7 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYEREXT)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFREEOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPFRUSTUM)(GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
@@ -763,9 +794,11 @@ package gl
 // typedef void  (APIENTRYP GPGENPROGRAMSNV)(GLsizei  n, GLuint * programs);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENQUERIESARB)(GLsizei  n, GLuint * ids);
+// typedef void  (APIENTRYP GPGENQUERYRESOURCETAGNV)(GLsizei  n, GLint * tagIds);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERSEXT)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
+// typedef void  (APIENTRYP GPGENSEMAPHORESEXT)(GLsizei  n, GLuint * semaphores);
 // typedef GLuint  (APIENTRYP GPGENSYMBOLSEXT)(GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components);
 // typedef void  (APIENTRYP GPGENTEXTURES)(GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPGENTEXTURESEXT)(GLsizei  n, GLuint * textures);
@@ -826,6 +859,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERFVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERIVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, GLfloat * params);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  level, void * img);
@@ -839,6 +873,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIVEXT)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERXVOES)(GLenum  target, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGAMD)(GLuint  count, GLsizei  bufsize, GLenum * categories, GLuint * severities, GLuint * ids, GLsizei * lengths, GLchar * message);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
@@ -868,6 +903,7 @@ package gl
 // typedef void  (APIENTRYP GPGETFRAGMENTMATERIALIVSGIX)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERFVAMD)(GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
@@ -894,6 +930,7 @@ package gl
 // typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -921,6 +958,7 @@ package gl
 // typedef void  (APIENTRYP GPGETMATERIALIV)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMATERIALXOES)(GLenum  face, GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPGETMATERIALXVOES)(GLenum  face, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMINMAX)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXEXT)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
@@ -947,10 +985,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
@@ -996,7 +1035,7 @@ package gl
 // typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
-// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
 // typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
 // typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
 // typedef void  (APIENTRYP GPGETPIXELMAPFV)(GLenum  map, GLfloat * values);
@@ -1045,6 +1084,10 @@ package gl
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVARB)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVNV)(GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64VEXT)(GLuint  id, GLenum  pname, GLint64 * params);
@@ -1062,6 +1105,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIUIV)(GLuint  sampler, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERFV)(GLuint  sampler, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIV)(GLuint  sampler, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTER)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTEREXT)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSHADERINFOLOG)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
@@ -1070,6 +1114,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERSOURCEARB)(GLhandleARB  obj, GLsizei  maxLength, GLsizei * length, GLcharARB * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETSHARPENTEXFUNCSGIS)(GLenum  target, GLfloat * points);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -1133,12 +1178,16 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFVARB)(GLhandleARB  programObj, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIVARB)(GLhandleARB  programObj, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIVEXT)(GLuint  program, GLint  location, GLuint * params);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEI_VEXT)(GLenum  target, GLuint  index, GLubyte * data);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEVEXT)(GLenum  pname, GLubyte * data);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTFVATI)(GLuint  id, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTIVATI)(GLuint  id, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -1184,6 +1233,7 @@ package gl
 // typedef void  (APIENTRYP GPGETVIDEOIVNV)(GLuint  video_slot, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVIDEOUI64VNV)(GLuint  video_slot, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVIDEOUIVNV)(GLuint  video_slot, GLenum  pname, GLuint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOLORTABLEARB)(GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNCONVOLUTIONFILTERARB)(GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * image);
@@ -1202,9 +1252,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
@@ -1225,6 +1277,12 @@ package gl
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERFVHP)(GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIHP)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIVHP)(GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPIMPORTMEMORYFDEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32HANDLEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32NAMEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, const void * name);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREFDEXT)(GLuint  semaphore, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32HANDLEEXT)(GLuint  semaphore, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32NAMEEXT)(GLuint  semaphore, GLenum  handleType, const void * name);
 // typedef GLsync  (APIENTRYP GPIMPORTSYNCEXT)(GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags);
 // typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPINDEXFUNCEXT)(GLenum  func, GLclampf  ref);
@@ -1263,6 +1321,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERARB)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
 // typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
@@ -1273,6 +1332,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISLIST)(GLuint  list);
+// typedef GLboolean  (APIENTRYP GPISMEMORYOBJECTEXT)(GLuint  memoryObject);
 // typedef GLboolean  (APIENTRYP GPISNAMEAMD)(GLenum  identifier, GLuint  name);
 // typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
@@ -1291,7 +1351,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFEREXT)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
+// typedef GLboolean  (APIENTRYP GPISSEMAPHOREEXT)(GLuint  semaphore);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREEXT)(GLuint  texture);
@@ -1303,6 +1365,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAYAPPLE)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXATTRIBENABLEDAPPLE)(GLuint  index, GLenum  pname);
+// typedef void  (APIENTRYP GPLGPUCOPYIMAGESUBDATANVX)(GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPLGPUINTERLOCKNVX)();
+// typedef void  (APIENTRYP GPLGPUNAMEDBUFFERSUBDATANVX)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLIGHTENVISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPLIGHTMODELF)(GLenum  pname, GLfloat  param);
@@ -1323,6 +1388,7 @@ package gl
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPLINKPROGRAMARB)(GLhandleARB  programObj);
 // typedef void  (APIENTRYP GPLISTBASE)(GLuint  base);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLISTPARAMETERFSGIX)(GLuint  list, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPLISTPARAMETERFVSGIX)(GLuint  list, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPLISTPARAMETERISGIX)(GLuint  list, GLenum  pname, GLint  param);
@@ -1371,7 +1437,7 @@ package gl
 // typedef void  (APIENTRYP GPMAPGRID2XOES)(GLint  n, GLfixed  u1, GLfixed  u2, GLfixed  v1, GLfixed  v2);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPMAPPARAMETERFVNV)(GLenum  target, GLenum  pname, const GLfloat * params);
@@ -1417,9 +1483,12 @@ package gl
 // typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIEREXT)(GLbitfield  barriers);
+// typedef void  (APIENTRYP GPMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPMINSAMPLESHADING)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINMAX)(GLenum  target, GLenum  internalformat, GLboolean  sink);
@@ -1438,7 +1507,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTAMD)(GLenum  mode, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTARRAYAPPLE)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
@@ -1447,7 +1516,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTAMD)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWRANGEELEMENTARRAYAPPLE)(GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWARRAYSIBM)(const GLenum * mode, const GLint * first, const GLsizei * count, GLsizei  primcount, GLint  modestride);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWELEMENTSIBM)(const GLenum * mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  primcount, GLint  modestride);
@@ -1572,13 +1641,26 @@ package gl
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPMULTICASTBARRIERNV)();
+// typedef void  (APIENTRYP GPMULTICASTBLITFRAMEBUFFERNV)(GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPMULTICASTBUFFERSUBDATANV)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPMULTICASTCOPYBUFFERSUBDATANV)(GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPMULTICASTCOPYIMAGESUBDATANV)(GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
+// typedef void  (APIENTRYP GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPMULTICASTWAITSYNCNV)(GLuint  signalGpu, GLbitfield  waitGpuMask);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXTERNALEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEMEMEXT)(GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
@@ -1588,6 +1670,9 @@ package gl
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -1731,6 +1816,8 @@ package gl
 // typedef GLint  (APIENTRYP GPPOLLINSTRUMENTSSGIX)(GLint * marker_p);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETEXT)(GLfloat  factor, GLfloat  bias);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETXOES)(GLfixed  factor, GLfixed  units);
 // typedef void  (APIENTRYP GPPOLYGONSTIPPLE)(const GLubyte * mask);
@@ -1743,6 +1830,7 @@ package gl
 // typedef void  (APIENTRYP GPPOPNAME)();
 // typedef void  (APIENTRYP GPPRESENTFRAMEDUALFILLNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLenum  target1, GLuint  fill1, GLenum  target2, GLuint  fill2, GLenum  target3, GLuint  fill3);
 // typedef void  (APIENTRYP GPPRESENTFRAMEKEYEDNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1);
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEXNV)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTNV)();
@@ -1800,13 +1888,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1820,13 +1912,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1840,13 +1936,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1860,13 +1960,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1927,6 +2031,8 @@ package gl
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
 // typedef GLbitfield  (APIENTRYP GPQUERYMATRIXXOES)(GLfixed * mantissa, GLint * exponent);
 // typedef void  (APIENTRYP GPQUERYOBJECTPARAMETERUIAMD)(GLenum  target, GLuint  id, GLenum  pname, GLuint  param);
+// typedef GLint  (APIENTRYP GPQUERYRESOURCENV)(GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer);
+// typedef void  (APIENTRYP GPQUERYRESOURCETAGNV)(GLint  tagId, const GLchar * tagString);
 // typedef void  (APIENTRYP GPRASTERPOS2D)(GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPRASTERPOS2DV)(const GLdouble * v);
 // typedef void  (APIENTRYP GPRASTERPOS2F)(GLfloat  x, GLfloat  y);
@@ -1957,6 +2063,7 @@ package gl
 // typedef void  (APIENTRYP GPRASTERPOS4SV)(const GLshort * v);
 // typedef void  (APIENTRYP GPRASTERPOS4XOES)(GLfixed  x, GLfixed  y, GLfixed  z, GLfixed  w);
 // typedef void  (APIENTRYP GPRASTERPOS4XVOES)(const GLfixed * coords);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
@@ -1974,7 +2081,9 @@ package gl
 // typedef void  (APIENTRYP GPRECTXOES)(GLfixed  x1, GLfixed  y1, GLfixed  x2, GLfixed  y2);
 // typedef void  (APIENTRYP GPRECTXVOES)(const GLfixed * v1, const GLfixed * v2);
 // typedef void  (APIENTRYP GPREFERENCEPLANESGIX)(const GLdouble * equation);
+// typedef GLboolean  (APIENTRYP GPRELEASEKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key);
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
+// typedef void  (APIENTRYP GPRENDERGPUMASKNV)(GLbitfield  mask);
 // typedef GLint  (APIENTRYP GPRENDERMODE)(GLenum  mode);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
@@ -2010,6 +2119,7 @@ package gl
 // typedef void  (APIENTRYP GPRESETMINMAX)(GLenum  target);
 // typedef void  (APIENTRYP GPRESETMINMAXEXT)(GLenum  target);
 // typedef void  (APIENTRYP GPRESIZEBUFFERSMESA)();
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACKNV)();
 // typedef void  (APIENTRYP GPROTATED)(GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
@@ -2017,7 +2127,6 @@ package gl
 // typedef void  (APIENTRYP GPROTATEXOES)(GLfixed  angle, GLfixed  x, GLfixed  y, GLfixed  z);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEARB)(GLfloat  value, GLboolean  invert);
-// typedef void  (APIENTRYP GPSAMPLECOVERAGEOES)(GLfixed  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEXOES)(GLclampx  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMAPATI)(GLuint  dst, GLuint  interp, GLenum  swizzle);
 // typedef void  (APIENTRYP GPSAMPLEMASKEXT)(GLclampf  value, GLboolean  invert);
@@ -2081,6 +2190,7 @@ package gl
 // typedef void  (APIENTRYP GPSECONDARYCOLORPOINTERLISTIBM)(GLint  size, GLenum  type, GLint  stride, const void ** pointer, GLint  ptrstride);
 // typedef void  (APIENTRYP GPSELECTBUFFER)(GLsizei  size, GLuint * buffer);
 // typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
+// typedef void  (APIENTRYP GPSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, const GLuint64 * params);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSETFENCEAPPLE)(GLuint  fence);
@@ -2098,11 +2208,16 @@ package gl
 // typedef void  (APIENTRYP GPSHADERSOURCEARB)(GLhandleARB  shaderObj, GLsizei  count, const GLcharARB ** string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
 // typedef void  (APIENTRYP GPSHARPENTEXFUNCSGIS)(GLenum  target, GLsizei  n, const GLfloat * points);
+// typedef void  (APIENTRYP GPSIGNALSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERIVSGIX)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPSTARTINSTRUMENTSSGIX)();
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
 // typedef void  (APIENTRYP GPSTENCILCLEARTAGEXT)(GLsizei  stencilTagBits, GLuint  stencilClearTag);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
@@ -2123,6 +2238,7 @@ package gl
 // typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
 // typedef void  (APIENTRYP GPSTOPINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPSTRINGMARKERGREMEDY)(GLsizei  len, const void * string);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPSWIZZLEEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // typedef void  (APIENTRYP GPSYNCTEXTUREINTEL)(GLuint  texture);
 // typedef void  (APIENTRYP GPTAGSAMPLEBUFFERSGIX)();
@@ -2256,7 +2372,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLint  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations);
 // typedef void  (APIENTRYP GPTEXIMAGE4DSGIS)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIVEXT)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
@@ -2273,6 +2389,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXSTORAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXSTORAGE3D)(GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXSTORAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM1DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXSTORAGESPARSEAMD)(GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1DEXT)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2285,7 +2406,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTURECOLORMASKSGIS)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
@@ -2298,7 +2419,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURELIGHTEXT)(GLenum  pname);
 // typedef void  (APIENTRYP GPTEXTUREMATERIALEXT)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPTEXTURENORMALEXT)(GLenum  mode);
-// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
@@ -2323,6 +2444,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM1DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXTURESTORAGESPARSEAMD)(GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2334,7 +2460,7 @@ package gl
 // typedef void  (APIENTRYP GPTRACKMATRIXNV)(GLenum  target, GLuint  address, GLenum  matrix, GLenum  transform);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKATTRIBSNV)(GLsizei  count, const GLint * attribs, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKSTREAMATTRIBSNV)(GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGSEXT)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
@@ -2350,13 +2476,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IARB)(GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIEXT)(GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2368,13 +2498,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IARB)(GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIEXT)(GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2386,13 +2520,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2404,13 +2542,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2837,7 +2979,11 @@ package gl
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
+// typedef void  (APIENTRYP GPWAITSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
 // typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
 // typedef void  (APIENTRYP GPWEIGHTPOINTERARB)(GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPWEIGHTBVARB)(GLint  size, const GLbyte * weights);
@@ -2904,12 +3050,16 @@ package gl
 // typedef void  (APIENTRYP GPWINDOWPOS4IVMESA)(const GLint * v);
 // typedef void  (APIENTRYP GPWINDOWPOS4SMESA)(GLshort  x, GLshort  y, GLshort  z, GLshort  w);
 // typedef void  (APIENTRYP GPWINDOWPOS4SVMESA)(const GLshort * v);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
 // typedef void  (APIENTRYP GPWRITEMASKEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // static void  glowAccum(GPACCUM fnptr, GLenum  op, GLfloat  value) {
 //   (*fnptr)(op, value);
 // }
 // static void  glowAccumxOES(GPACCUMXOES fnptr, GLenum  op, GLfixed  value) {
 //   (*fnptr)(op, value);
+// }
+// static GLboolean  glowAcquireKeyedMutexWin32EXT(GPACQUIREKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key, GLuint  timeout) {
+//   return (*fnptr)(memory, key, timeout);
 // }
 // static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
 //   (*fnptr)(program);
@@ -2946,6 +3096,12 @@ package gl
 // }
 // static void  glowAlphaFuncxOES(GPALPHAFUNCXOES fnptr, GLenum  func, GLfixed  ref) {
 //   (*fnptr)(func, ref);
+// }
+// static void  glowAlphaToCoverageDitherControlNV(GPALPHATOCOVERAGEDITHERCONTROLNV fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowApplyTextureEXT(GPAPPLYTEXTUREEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -3310,7 +3466,7 @@ package gl
 // static void  glowBufferDataARB(GPBUFFERDATAARB fnptr, GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferParameteriAPPLE(GPBUFFERPARAMETERIAPPLE fnptr, GLenum  target, GLenum  pname, GLint  param) {
@@ -3319,11 +3475,20 @@ package gl
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(target, size, data, flags);
 // }
+// static void  glowBufferStorageExternalEXT(GPBUFFERSTORAGEEXTERNALEXT fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(target, offset, size, clientBuffer, flags);
+// }
+// static void  glowBufferStorageMemEXT(GPBUFFERSTORAGEMEMEXT fnptr, GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, size, memory, offset);
+// }
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
 // static void  glowBufferSubDataARB(GPBUFFERSUBDATAARB fnptr, GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
 // }
 // static void  glowCallList(GPCALLLIST fnptr, GLuint  list) {
 //   (*fnptr)(list);
@@ -3412,14 +3577,14 @@ package gl
 // static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
 // static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -3706,6 +3871,12 @@ package gl
 // static void  glowCombinerStageParameterfvNV(GPCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, const GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
@@ -3795,6 +3966,12 @@ package gl
 // }
 // static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
 //   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowConvolutionFilter1D(GPCONVOLUTIONFILTER1D fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image) {
 //   (*fnptr)(target, internalformat, width, format, type, image);
@@ -3886,7 +4063,7 @@ package gl
 // static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
@@ -3961,11 +4138,23 @@ package gl
 // static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
 //   (*fnptr)(path, coverMode);
 // }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
+// }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreateMemoryObjectsEXT(GPCREATEMEMORYOBJECTSEXT fnptr, GLsizei  n, GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
 //   (*fnptr)(queryId, queryHandle);
@@ -4002,6 +4191,9 @@ package gl
 // }
 // static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -4081,6 +4273,9 @@ package gl
 // static void  glowDeleteBuffersARB(GPDELETEBUFFERSARB fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFencesAPPLE(GPDELETEFENCESAPPLE fnptr, GLsizei  n, const GLuint * fences) {
 //   (*fnptr)(n, fences);
 // }
@@ -4098,6 +4293,9 @@ package gl
 // }
 // static void  glowDeleteLists(GPDELETELISTS fnptr, GLuint  list, GLsizei  range) {
 //   (*fnptr)(list, range);
+// }
+// static void  glowDeleteMemoryObjectsEXT(GPDELETEMEMORYOBJECTSEXT fnptr, GLsizei  n, const GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
@@ -4141,6 +4339,9 @@ package gl
 // static void  glowDeleteQueriesARB(GPDELETEQUERIESARB fnptr, GLsizei  n, const GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowDeleteQueryResourceTagNV(GPDELETEQUERYRESOURCETAGNV fnptr, GLsizei  n, const GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowDeleteRenderbuffers(GPDELETERENDERBUFFERS fnptr, GLsizei  n, const GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4150,8 +4351,14 @@ package gl
 // static void  glowDeleteSamplers(GPDELETESAMPLERS fnptr, GLsizei  count, const GLuint * samplers) {
 //   (*fnptr)(count, samplers);
 // }
+// static void  glowDeleteSemaphoresEXT(GPDELETESEMAPHORESEXT fnptr, GLsizei  n, const GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
+// }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -4300,6 +4507,18 @@ package gl
 // static void  glowDrawBuffersATI(GPDRAWBUFFERSATI fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
 // }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
+// }
 // static void  glowDrawElementArrayAPPLE(GPDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, GLint  first, GLsizei  count) {
 //   (*fnptr)(mode, first, count);
 // }
@@ -4371,6 +4590,9 @@ package gl
 // }
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
+// }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
 // }
 // static void  glowEdgeFlag(GPEDGEFLAG fnptr, GLboolean  flag) {
 //   (*fnptr)(flag);
@@ -4537,6 +4759,9 @@ package gl
 // static void  glowEvalPoint2(GPEVALPOINT2 fnptr, GLint  i, GLint  j) {
 //   (*fnptr)(i, j);
 // }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowExecuteProgramNV(GPEXECUTEPROGRAMNV fnptr, GLenum  target, GLuint  id, const GLfloat * params) {
 //   (*fnptr)(target, id, params);
 // }
@@ -4582,7 +4807,7 @@ package gl
 // static void  glowFlushMappedBufferRangeAPPLE(GPFLUSHMAPPEDBUFFERRANGEAPPLE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, offset, size);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
 // }
 // static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
@@ -4669,6 +4894,9 @@ package gl
 // static void  glowFragmentColorMaterialSGIX(GPFRAGMENTCOLORMATERIALSGIX fnptr, GLenum  face, GLenum  mode) {
 //   (*fnptr)(face, mode);
 // }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
 // static void  glowFragmentLightModelfSGIX(GPFRAGMENTLIGHTMODELFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -4717,6 +4945,9 @@ package gl
 // static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(framebuffer, n, bufs);
 // }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
@@ -4728,6 +4959,15 @@ package gl
 // }
 // static void  glowFramebufferRenderbufferEXT(GPFRAMEBUFFERRENDERBUFFEREXT fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSamplePositionsfvAMD(GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(target, numsamples, pixelindex, values);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -4770,6 +5010,9 @@ package gl
 // }
 // static void  glowFramebufferTextureLayerEXT(GPFRAMEBUFFERTEXTURELAYEREXT fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFreeObjectBufferATI(GPFREEOBJECTBUFFERATI fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -4843,6 +5086,9 @@ package gl
 // static void  glowGenQueriesARB(GPGENQUERIESARB fnptr, GLsizei  n, GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowGenQueryResourceTagNV(GPGENQUERYRESOURCETAGNV fnptr, GLsizei  n, GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowGenRenderbuffers(GPGENRENDERBUFFERS fnptr, GLsizei  n, GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4851,6 +5097,9 @@ package gl
 // }
 // static void  glowGenSamplers(GPGENSAMPLERS fnptr, GLsizei  count, GLuint * samplers) {
 //   (*fnptr)(count, samplers);
+// }
+// static void  glowGenSemaphoresEXT(GPGENSEMAPHORESEXT fnptr, GLsizei  n, GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
 // }
 // static GLuint  glowGenSymbolsEXT(GPGENSYMBOLSEXT fnptr, GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components) {
 //   return (*fnptr)(datatype, storagetype, range, components);
@@ -5032,6 +5281,9 @@ package gl
 // static void  glowGetCombinerStageParameterfvNV(GPGETCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
 // static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
 //   (*fnptr)(texunit, target, lod, img);
 // }
@@ -5070,6 +5322,9 @@ package gl
 // }
 // static void  glowGetConvolutionParameterxvOES(GPGETCONVOLUTIONPARAMETERXVOES fnptr, GLenum  target, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -5158,6 +5413,9 @@ package gl
 // static void  glowGetFramebufferAttachmentParameterivEXT(GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLenum  target, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, attachment, pname, params);
 // }
+// static void  glowGetFramebufferParameterfvAMD(GPGETFRAMEBUFFERPARAMETERFVAMD fnptr, GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(target, pname, numsamples, pixelindex, size, values);
+// }
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
@@ -5235,6 +5493,9 @@ package gl
 // }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
@@ -5317,6 +5578,9 @@ package gl
 // static void  glowGetMaterialxvOES(GPGETMATERIALXVOES fnptr, GLenum  face, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(face, pname, params);
 // }
+// static void  glowGetMemoryObjectParameterivEXT(GPGETMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
+// }
 // static void  glowGetMinmax(GPGETMINMAX fnptr, GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values) {
 //   (*fnptr)(target, reset, format, type, values);
 // }
@@ -5395,7 +5659,7 @@ package gl
 // static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
@@ -5406,6 +5670,9 @@ package gl
 // }
 // static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
+// }
+// static void  glowGetNamedFramebufferParameterfvAMD(GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD fnptr, GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(framebuffer, pname, numsamples, pixelindex, size, values);
 // }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
@@ -5542,7 +5809,7 @@ package gl
 // static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
 //   (*fnptr)(numGroups, groupsSize, groups);
 // }
-// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten) {
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
 //   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
 // }
 // static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
@@ -5689,6 +5956,18 @@ package gl
 // static void  glowGetProgramivNV(GPGETPROGRAMIVNV fnptr, GLuint  id, GLenum  pname, GLint * params) {
 //   (*fnptr)(id, pname, params);
 // }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
 // }
@@ -5740,6 +6019,9 @@ package gl
 // static void  glowGetSamplerParameteriv(GPGETSAMPLERPARAMETERIV fnptr, GLuint  sampler, GLenum  pname, GLint * params) {
 //   (*fnptr)(sampler, pname, params);
 // }
+// static void  glowGetSemaphoreParameterui64vEXT(GPGETSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowGetSeparableFilter(GPGETSEPARABLEFILTER fnptr, GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span) {
 //   (*fnptr)(target, format, type, row, column, span);
 // }
@@ -5763,6 +6045,9 @@ package gl
 // }
 // static void  glowGetSharpenTexFuncSGIS(GPGETSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLfloat * points) {
 //   (*fnptr)(target, points);
+// }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
 // }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
@@ -5953,6 +6238,9 @@ package gl
 // static void  glowGetUniformfvARB(GPGETUNIFORMFVARB fnptr, GLhandleARB  programObj, GLint  location, GLfloat * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5962,6 +6250,9 @@ package gl
 // static void  glowGetUniformivARB(GPGETUNIFORMIVARB fnptr, GLhandleARB  programObj, GLint  location, GLint * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5970,6 +6261,12 @@ package gl
 // }
 // static void  glowGetUniformuivEXT(GPGETUNIFORMUIVEXT fnptr, GLuint  program, GLint  location, GLuint * params) {
 //   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUnsignedBytei_vEXT(GPGETUNSIGNEDBYTEI_VEXT fnptr, GLenum  target, GLuint  index, GLubyte * data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetUnsignedBytevEXT(GPGETUNSIGNEDBYTEVEXT fnptr, GLenum  pname, GLubyte * data) {
+//   (*fnptr)(pname, data);
 // }
 // static void  glowGetVariantArrayObjectfvATI(GPGETVARIANTARRAYOBJECTFVATI fnptr, GLuint  id, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(id, pname, params);
@@ -6106,6 +6403,9 @@ package gl
 // static void  glowGetVideouivNV(GPGETVIDEOUIVNV fnptr, GLuint  video_slot, GLenum  pname, GLuint * params) {
 //   (*fnptr)(video_slot, pname, params);
 // }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
+// }
 // static void  glowGetnColorTableARB(GPGETNCOLORTABLEARB fnptr, GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table) {
 //   (*fnptr)(target, format, type, bufSize, table);
 // }
@@ -6160,6 +6460,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -6167,6 +6470,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -6228,6 +6534,24 @@ package gl
 // }
 // static void  glowImageTransformParameterivHP(GPIMAGETRANSFORMPARAMETERIVHP fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowImportMemoryFdEXT(GPIMPORTMEMORYFDEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(memory, size, handleType, fd);
+// }
+// static void  glowImportMemoryWin32HandleEXT(GPIMPORTMEMORYWIN32HANDLEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, void * handle) {
+//   (*fnptr)(memory, size, handleType, handle);
+// }
+// static void  glowImportMemoryWin32NameEXT(GPIMPORTMEMORYWIN32NAMEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, const void * name) {
+//   (*fnptr)(memory, size, handleType, name);
+// }
+// static void  glowImportSemaphoreFdEXT(GPIMPORTSEMAPHOREFDEXT fnptr, GLuint  semaphore, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(semaphore, handleType, fd);
+// }
+// static void  glowImportSemaphoreWin32HandleEXT(GPIMPORTSEMAPHOREWIN32HANDLEEXT fnptr, GLuint  semaphore, GLenum  handleType, void * handle) {
+//   (*fnptr)(semaphore, handleType, handle);
+// }
+// static void  glowImportSemaphoreWin32NameEXT(GPIMPORTSEMAPHOREWIN32NAMEEXT fnptr, GLuint  semaphore, GLenum  handleType, const void * name) {
+//   (*fnptr)(semaphore, handleType, name);
 // }
 // static GLsync  glowImportSyncEXT(GPIMPORTSYNCEXT fnptr, GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags) {
 //   return (*fnptr)(external_sync_type, external_sync, flags);
@@ -6343,6 +6667,9 @@ package gl
 // static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
 // }
@@ -6372,6 +6699,9 @@ package gl
 // }
 // static GLboolean  glowIsList(GPISLIST fnptr, GLuint  list) {
 //   return (*fnptr)(list);
+// }
+// static GLboolean  glowIsMemoryObjectEXT(GPISMEMORYOBJECTEXT fnptr, GLuint  memoryObject) {
+//   return (*fnptr)(memoryObject);
 // }
 // static GLboolean  glowIsNameAMD(GPISNAMEAMD fnptr, GLenum  identifier, GLuint  name) {
 //   return (*fnptr)(identifier, name);
@@ -6427,8 +6757,14 @@ package gl
 // static GLboolean  glowIsSampler(GPISSAMPLER fnptr, GLuint  sampler) {
 //   return (*fnptr)(sampler);
 // }
+// static GLboolean  glowIsSemaphoreEXT(GPISSEMAPHOREEXT fnptr, GLuint  semaphore) {
+//   return (*fnptr)(semaphore);
+// }
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
+// }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
 // }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
@@ -6462,6 +6798,15 @@ package gl
 // }
 // static GLboolean  glowIsVertexAttribEnabledAPPLE(GPISVERTEXATTRIBENABLEDAPPLE fnptr, GLuint  index, GLenum  pname) {
 //   return (*fnptr)(index, pname);
+// }
+// static void  glowLGPUCopyImageSubDataNVX(GPLGPUCOPYIMAGESUBDATANVX fnptr, GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(sourceGpu, destinationGpuMask, srcName, srcTarget, srcLevel, srcX, srxY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, width, height, depth);
+// }
+// static void  glowLGPUInterlockNVX(GPLGPUINTERLOCKNVX fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowLGPUNamedBufferSubDataNVX(GPLGPUNAMEDBUFFERSUBDATANVX fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
 // }
 // static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(type, object, length, label);
@@ -6522,6 +6867,9 @@ package gl
 // }
 // static void  glowListBase(GPLISTBASE fnptr, GLuint  base) {
 //   (*fnptr)(base);
+// }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
 // }
 // static void  glowListParameterfSGIX(GPLISTPARAMETERFSGIX fnptr, GLuint  list, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(list, pname, param);
@@ -6667,7 +7015,7 @@ package gl
 // static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
 // }
 // static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
@@ -6805,6 +7153,12 @@ package gl
 // static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
 //   (*fnptr)(mode, x, y, z);
 // }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
 // }
@@ -6813,6 +7167,9 @@ package gl
 // }
 // static void  glowMemoryBarrierEXT(GPMEMORYBARRIEREXT fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
+// }
+// static void  glowMemoryObjectParameterivEXT(GPMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, const GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
 // }
 // static void  glowMinSampleShading(GPMINSAMPLESHADING fnptr, GLfloat  value) {
 //   (*fnptr)(value);
@@ -6868,7 +7225,7 @@ package gl
 // static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElementArrayAPPLE(GPMULTIDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -6895,7 +7252,7 @@ package gl
 // static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawRangeElementArrayAPPLE(GPMULTIDRAWRANGEELEMENTARRAYAPPLE fnptr, GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -7270,25 +7627,64 @@ package gl
 // static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMulticastBarrierNV(GPMULTICASTBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowMulticastBlitFramebufferNV(GPMULTICASTBLITFRAMEBUFFERNV fnptr, GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
+//   (*fnptr)(srcGpu, dstGpu, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+// }
+// static void  glowMulticastBufferSubDataNV(GPMULTICASTBUFFERSUBDATANV fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
+// }
+// static void  glowMulticastCopyBufferSubDataNV(GPMULTICASTCOPYBUFFERSUBDATANV fnptr, GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readGpu, writeGpuMask, readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowMulticastCopyImageSubDataNV(GPMULTICASTCOPYIMAGESUBDATANV fnptr, GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
+//   (*fnptr)(srcGpu, dstGpuMask, srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
+// }
+// static void  glowMulticastFramebufferSampleLocationsfvNV(GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(gpu, framebuffer, start, count, v);
+// }
+// static void  glowMulticastGetQueryObjecti64vNV(GPMULTICASTGETQUERYOBJECTI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectivNV(GPMULTICASTGETQUERYOBJECTIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectui64vNV(GPMULTICASTGETQUERYOBJECTUI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectuivNV(GPMULTICASTGETQUERYOBJECTUIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastWaitSyncNV(GPMULTICASTWAITSYNCNV fnptr, GLuint  signalGpu, GLbitfield  waitGpuMask) {
+//   (*fnptr)(signalGpu, waitGpuMask);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
 // static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
 // static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageExternalEXT(GPNAMEDBUFFERSTORAGEEXTERNALEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(buffer, offset, size, clientBuffer, flags);
+// }
+// static void  glowNamedBufferStorageMemEXT(GPNAMEDBUFFERSTORAGEMEMEXT fnptr, GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(buffer, size, memory, offset);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
@@ -7317,6 +7713,15 @@ package gl
 // }
 // static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSamplePositionsfvAMD(GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(framebuffer, numsamples, pixelindex, values);
 // }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
@@ -7747,6 +8152,12 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPolygonOffsetEXT(GPPOLYGONOFFSETEXT fnptr, GLfloat  factor, GLfloat  bias) {
 //   (*fnptr)(factor, bias);
 // }
@@ -7782,6 +8193,9 @@ package gl
 // }
 // static void  glowPresentFrameKeyedNV(GPPRESENTFRAMEKEYEDNV fnptr, GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1) {
 //   (*fnptr)(video_slot, minPresentTime, beginPresentTimeId, presentDurationId, type, target0, fill0, key0, target1, fill1, key1);
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -7954,8 +8368,14 @@ package gl
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7972,8 +8392,14 @@ package gl
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8014,8 +8440,14 @@ package gl
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8032,8 +8464,14 @@ package gl
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8074,8 +8512,14 @@ package gl
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8092,8 +8536,14 @@ package gl
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8134,8 +8584,14 @@ package gl
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8152,8 +8608,14 @@ package gl
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8335,6 +8797,12 @@ package gl
 // static void  glowQueryObjectParameteruiAMD(GPQUERYOBJECTPARAMETERUIAMD fnptr, GLenum  target, GLuint  id, GLenum  pname, GLuint  param) {
 //   (*fnptr)(target, id, pname, param);
 // }
+// static GLint  glowQueryResourceNV(GPQUERYRESOURCENV fnptr, GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer) {
+//   return (*fnptr)(queryType, tagId, bufSize, buffer);
+// }
+// static void  glowQueryResourceTagNV(GPQUERYRESOURCETAGNV fnptr, GLint  tagId, const GLchar * tagString) {
+//   (*fnptr)(tagId, tagString);
+// }
 // static void  glowRasterPos2d(GPRASTERPOS2D fnptr, GLdouble  x, GLdouble  y) {
 //   (*fnptr)(x, y);
 // }
@@ -8425,6 +8893,9 @@ package gl
 // static void  glowRasterPos4xvOES(GPRASTERPOS4XVOES fnptr, const GLfixed * coords) {
 //   (*fnptr)(coords);
 // }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
+// }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
 // }
@@ -8476,8 +8947,14 @@ package gl
 // static void  glowReferencePlaneSGIX(GPREFERENCEPLANESGIX fnptr, const GLdouble * equation) {
 //   (*fnptr)(equation);
 // }
+// static GLboolean  glowReleaseKeyedMutexWin32EXT(GPRELEASEKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key) {
+//   return (*fnptr)(memory, key);
+// }
 // static void  glowReleaseShaderCompiler(GPRELEASESHADERCOMPILER fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowRenderGpuMaskNV(GPRENDERGPUMASKNV fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static GLint  glowRenderMode(GPRENDERMODE fnptr, GLenum  mode) {
 //   return (*fnptr)(mode);
@@ -8584,6 +9061,9 @@ package gl
 // static void  glowResizeBuffersMESA(GPRESIZEBUFFERSMESA fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -8603,9 +9083,6 @@ package gl
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoverageARB(GPSAMPLECOVERAGEARB fnptr, GLfloat  value, GLboolean  invert) {
-//   (*fnptr)(value, invert);
-// }
-// static void  glowSampleCoverageOES(GPSAMPLECOVERAGEOES fnptr, GLfixed  value, GLboolean  invert) {
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoveragexOES(GPSAMPLECOVERAGEXOES fnptr, GLclampx  value, GLboolean  invert) {
@@ -8797,6 +9274,9 @@ package gl
 // static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
 //   (*fnptr)(monitor, enable, group, numCounters, counterList);
 // }
+// static void  glowSemaphoreParameterui64vEXT(GPSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, const GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowSeparableFilter2D(GPSEPARABLEFILTER2D fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column) {
 //   (*fnptr)(target, internalformat, width, height, format, type, row, column);
 // }
@@ -8848,6 +9328,18 @@ package gl
 // static void  glowSharpenTexFuncSGIS(GPSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLsizei  n, const GLfloat * points) {
 //   (*fnptr)(target, n, points);
 // }
+// static void  glowSignalSemaphoreEXT(GPSIGNALSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, dstLayouts);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
 // static void  glowSpriteParameterfSGIX(GPSPRITEPARAMETERFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -8862,6 +9354,9 @@ package gl
 // }
 // static void  glowStartInstrumentsSGIX(GPSTARTINSTRUMENTSSGIX fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
 // }
 // static void  glowStencilClearTagEXT(GPSTENCILCLEARTAGEXT fnptr, GLsizei  stencilTagBits, GLuint  stencilClearTag) {
 //   (*fnptr)(stencilTagBits, stencilClearTag);
@@ -8922,6 +9417,9 @@ package gl
 // }
 // static void  glowStringMarkerGREMEDY(GPSTRINGMARKERGREMEDY fnptr, GLsizei  len, const void * string) {
 //   (*fnptr)(len, string);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
 // }
 // static void  glowSwizzleEXT(GPSWIZZLEEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
@@ -9322,8 +9820,8 @@ package gl
 // static void  glowTexImage4DSGIS(GPTEXIMAGE4DSGIS fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, height, depth, size4d, border, format, type, pixels);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -9373,6 +9871,21 @@ package gl
 // static void  glowTexStorage3DMultisample(GPTEXSTORAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTexStorageMem1DEXT(GPTEXSTORAGEMEM1DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTexStorageMem2DEXT(GPTEXSTORAGEMEM2DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTexStorageMem2DMultisampleEXT(GPTEXSTORAGEMEM2DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTexStorageMem3DEXT(GPTEXSTORAGEMEM3DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTexStorageMem3DMultisampleEXT(GPTEXSTORAGEMEM3DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTexStorageSparseAMD(GPTEXSTORAGESPARSEAMD fnptr, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9409,7 +9922,7 @@ package gl
 // static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, target, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
 // }
 // static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
@@ -9448,8 +9961,8 @@ package gl
 // static void  glowTextureNormalEXT(GPTEXTURENORMALEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
 // }
-// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
@@ -9523,6 +10036,21 @@ package gl
 // static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorageMem1DEXT(GPTEXTURESTORAGEMEM1DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTextureStorageMem2DEXT(GPTEXTURESTORAGEMEM2DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTextureStorageMem2DMultisampleEXT(GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTextureStorageMem3DEXT(GPTEXTURESTORAGEMEM3DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTextureStorageMem3DMultisampleEXT(GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTextureStorageSparseAMD(GPTEXTURESTORAGESPARSEAMD fnptr, GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(texture, target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9556,7 +10084,7 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackStreamAttribsNV(GPTRANSFORMFEEDBACKSTREAMATTRIBSNV fnptr, GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode) {
@@ -9604,8 +10132,14 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9622,8 +10156,14 @@ package gl
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9658,8 +10198,14 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9676,8 +10222,14 @@ package gl
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9712,8 +10264,14 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9730,8 +10288,14 @@ package gl
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9766,8 +10330,14 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9784,8 +10354,14 @@ package gl
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -11065,8 +11641,20 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
+// static void  glowWaitSemaphoreEXT(GPWAITSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, srcLayouts);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
 // }
 // static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
 //   (*fnptr)(resultPath, numPaths, paths, weights);
@@ -11266,6 +11854,9 @@ package gl
 // static void  glowWindowPos4svMESA(GPWINDOWPOS4SVMESA fnptr, const GLshort * v) {
 //   (*fnptr)(v);
 // }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
+// }
 // static void  glowWriteMaskEXT(GPWRITEMASKEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
 // }
@@ -11357,6 +11948,7 @@ const (
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_BARRIER_BITS_EXT                                       = 0xFFFFFFFF
 	ALL_COMPLETED_NV                                           = 0x84F2
+	ALL_PIXELS_AMD                                             = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
 	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALL_STATIC_DATA_IBM                                        = 103060
@@ -11391,11 +11983,16 @@ const (
 	ALPHA_MAX_SGIX                                             = 0x8321
 	ALPHA_MIN_CLAMP_INGR                                       = 0x8563
 	ALPHA_MIN_SGIX                                             = 0x8320
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALPHA_SCALE                                                = 0x0D1C
 	ALPHA_SNORM                                                = 0x9010
 	ALPHA_TEST                                                 = 0x0BC0
 	ALPHA_TEST_FUNC                                            = 0x0BC1
 	ALPHA_TEST_REF                                             = 0x0BC2
+	ALPHA_TO_COVERAGE_DITHER_DEFAULT_NV                        = 0x934D
+	ALPHA_TO_COVERAGE_DITHER_DISABLE_NV                        = 0x934F
+	ALPHA_TO_COVERAGE_DITHER_ENABLE_NV                         = 0x934E
+	ALPHA_TO_COVERAGE_DITHER_MODE_NV                           = 0x92BF
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	ALWAYS_FAST_HINT_PGI                                       = 0x1A20C
@@ -11441,6 +12038,7 @@ const (
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
 	ATTENUATION_EXT                                            = 0x834D
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	ATTRIB_ARRAY_POINTER_NV                                    = 0x8645
 	ATTRIB_ARRAY_SIZE_NV                                       = 0x8623
 	ATTRIB_ARRAY_STRIDE_NV                                     = 0x8624
@@ -11483,6 +12081,7 @@ const (
 	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
 	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_COLOR_EXT                                            = 0x8005
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
@@ -11660,10 +12259,26 @@ const (
 	COLOR_ATTACHMENT14_EXT                                     = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
 	COLOR_ATTACHMENT15_EXT                                     = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT1_EXT                                      = 0x8CE1
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT2_EXT                                      = 0x8CE2
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT3_EXT                                      = 0x8CE3
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT4_EXT                                      = 0x8CE4
@@ -11767,6 +12382,8 @@ const (
 	COMPILE                                                    = 0x1300
 	COMPILE_AND_EXECUTE                                        = 0x1301
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_ALPHA                                           = 0x84E9
 	COMPRESSED_ALPHA_ARB                                       = 0x84E9
 	COMPRESSED_INTENSITY                                       = 0x84EC
@@ -11870,8 +12487,18 @@ const (
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	COMP_BIT_ATI                                               = 0x00000002
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
 	CONIC_CURVE_TO_NV                                          = 0x1A
 	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSERVE_MEMORY_HINT_PGI                                   = 0x1A1FD
 	CONSTANT                                                   = 0x8576
 	CONSTANT_ALPHA                                             = 0x8003
@@ -11893,6 +12520,7 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
 	CONTEXT_LOST_KHR                                           = 0x0507
@@ -11971,6 +12599,9 @@ const (
 	COUNTER_TYPE_AMD                                           = 0x8BC0
 	COUNT_DOWN_NV                                              = 0x9089
 	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
 	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CUBIC_EXT                                                  = 0x8334
 	CUBIC_HP                                                   = 0x815F
@@ -12020,6 +12651,7 @@ const (
 	CURRENT_VERTEX_WEIGHT_EXT                                  = 0x850B
 	CURRENT_WEIGHT_ARB                                         = 0x86A8
 	CW                                                         = 0x0900
+	D3D12_FENCE_VALUE_EXT                                      = 0x9595
 	DARKEN_KHR                                                 = 0x9297
 	DARKEN_NV                                                  = 0x9297
 	DATA_BUFFER_AMD                                            = 0x9151
@@ -12112,6 +12744,7 @@ const (
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DECR_WRAP_EXT                                              = 0x8508
+	DEDICATED_MEMORY_OBJECT_EXT                                = 0x9581
 	DEFORMATIONS_MASK_SGIX                                     = 0x8196
 	DELETE_STATUS                                              = 0x8B80
 	DEPENDENT_AR_TEXTURE_2D_NV                                 = 0x86E9
@@ -12153,6 +12786,7 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_SCALE                                                = 0x0D1E
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
@@ -12170,6 +12804,9 @@ const (
 	DETAIL_TEXTURE_FUNC_POINTS_SGIS                            = 0x809C
 	DETAIL_TEXTURE_LEVEL_SGIS                                  = 0x809A
 	DETAIL_TEXTURE_MODE_SGIS                                   = 0x809B
+	DEVICE_LUID_EXT                                            = 0x9599
+	DEVICE_NODE_MASK_EXT                                       = 0x959A
+	DEVICE_UUID_EXT                                            = 0x9597
 	DIFFERENCE_KHR                                             = 0x929E
 	DIFFERENCE_NV                                              = 0x929E
 	DIFFUSE                                                    = 0x1201
@@ -12232,6 +12869,9 @@ const (
 	DOUBLE_VEC3_EXT                                            = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
 	DOUBLE_VEC4_EXT                                            = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER0_ARB                                           = 0x8825
@@ -12281,6 +12921,9 @@ const (
 	DRAW_BUFFER9                                               = 0x882E
 	DRAW_BUFFER9_ARB                                           = 0x882E
 	DRAW_BUFFER9_ATI                                           = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
 	DRAW_FRAMEBUFFER_BINDING_EXT                               = 0x8CA6
@@ -12292,6 +12935,7 @@ const (
 	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DRAW_PIXELS_APPLE                                          = 0x8A0A
 	DRAW_PIXEL_TOKEN                                           = 0x0705
+	DRIVER_UUID_EXT                                            = 0x9598
 	DSDT8_MAG8_INTENSITY8_NV                                   = 0x870B
 	DSDT8_MAG8_NV                                              = 0x870A
 	DSDT8_NV                                                   = 0x8709
@@ -12352,7 +12996,9 @@ const (
 	EDGE_FLAG_ARRAY_POINTER_EXT                                = 0x8093
 	EDGE_FLAG_ARRAY_STRIDE                                     = 0x808C
 	EDGE_FLAG_ARRAY_STRIDE_EXT                                 = 0x808C
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
 	EIGHTH_BIT_ATI                                             = 0x00000020
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
 	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_APPLE                                        = 0x8A0C
 	ELEMENT_ARRAY_ATI                                          = 0x8768
@@ -12397,6 +13043,7 @@ const (
 	EVAL_VERTEX_ATTRIB9_NV                                     = 0x86CF
 	EXCLUSION_KHR                                              = 0x92A0
 	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXP                                                        = 0x0800
 	EXP2                                                       = 0x0801
 	EXPAND_NEGATE_NV                                           = 0x8539
@@ -12430,6 +13077,7 @@ const (
 	FIELD_UPPER_NV                                             = 0x9022
 	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
 	FILTER4_SGIS                                               = 0x8146
 	FIRST_TO_REST_NV                                           = 0x90AF
@@ -12441,6 +13089,15 @@ const (
 	FIXED_ONLY_ARB                                             = 0x891D
 	FLAT                                                       = 0x1D00
 	FLOAT                                                      = 0x1406
+	FLOAT16_MAT2_AMD                                           = 0x91C5
+	FLOAT16_MAT2x3_AMD                                         = 0x91C8
+	FLOAT16_MAT2x4_AMD                                         = 0x91C9
+	FLOAT16_MAT3_AMD                                           = 0x91C6
+	FLOAT16_MAT3x2_AMD                                         = 0x91CA
+	FLOAT16_MAT3x4_AMD                                         = 0x91CB
+	FLOAT16_MAT4_AMD                                           = 0x91C7
+	FLOAT16_MAT4x2_AMD                                         = 0x91CC
+	FLOAT16_MAT4x3_AMD                                         = 0x91CD
 	FLOAT16_NV                                                 = 0x8FF8
 	FLOAT16_VEC2_NV                                            = 0x8FF9
 	FLOAT16_VEC3_NV                                            = 0x8FFA
@@ -12546,6 +13203,8 @@ const (
 	FRAGMENT_COLOR_MATERIAL_FACE_SGIX                          = 0x8402
 	FRAGMENT_COLOR_MATERIAL_PARAMETER_SGIX                     = 0x8403
 	FRAGMENT_COLOR_MATERIAL_SGIX                               = 0x8401
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
 	FRAGMENT_DEPTH                                             = 0x8452
 	FRAGMENT_DEPTH_EXT                                         = 0x8452
 	FRAGMENT_INPUT_NV                                          = 0x936D
@@ -12577,6 +13236,7 @@ const (
 	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
 	FRAGMENT_SHADER_DERIVATIVE_HINT_ARB                        = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -12598,12 +13258,14 @@ const (
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_3D_ZOFFSET_EXT              = 0x8CD4
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE_EXT           = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER_EXT                   = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL_EXT                   = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BARRIER_BIT_EXT                                = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
@@ -12635,8 +13297,13 @@ const (
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_EXT                     = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER_EXT                     = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_SRGB_CAPABLE_EXT                               = 0x8DBA
 	FRAMEBUFFER_SRGB_EXT                                       = 0x8DB9
@@ -12649,6 +13316,7 @@ const (
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_RANGE_EXT                                             = 0x87E1
@@ -12728,6 +13396,14 @@ const (
 	HALF_FLOAT                                                 = 0x140B
 	HALF_FLOAT_ARB                                             = 0x140B
 	HALF_FLOAT_NV                                              = 0x140B
+	HANDLE_TYPE_D3D11_IMAGE_EXT                                = 0x958B
+	HANDLE_TYPE_D3D11_IMAGE_KMT_EXT                            = 0x958C
+	HANDLE_TYPE_D3D12_FENCE_EXT                                = 0x9594
+	HANDLE_TYPE_D3D12_RESOURCE_EXT                             = 0x958A
+	HANDLE_TYPE_D3D12_TILEPOOL_EXT                             = 0x9589
+	HANDLE_TYPE_OPAQUE_FD_EXT                                  = 0x9586
+	HANDLE_TYPE_OPAQUE_WIN32_EXT                               = 0x9587
+	HANDLE_TYPE_OPAQUE_WIN32_KMT_EXT                           = 0x9588
 	HARDLIGHT_KHR                                              = 0x929B
 	HARDLIGHT_NV                                               = 0x929B
 	HARDMIX_NV                                                 = 0x92A9
@@ -12835,6 +13511,7 @@ const (
 	IMPLEMENTATION_COLOR_READ_FORMAT_OES                       = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
 	IMPLEMENTATION_COLOR_READ_TYPE_OES                         = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
 	INCR_WRAP_EXT                                              = 0x8507
@@ -12879,9 +13556,13 @@ const (
 	INT16_VEC2_NV                                              = 0x8FE5
 	INT16_VEC3_NV                                              = 0x8FE6
 	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
 	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
 	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
 	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
 	INT64_VEC4_NV                                              = 0x8FEB
 	INT8_NV                                                    = 0x8FE0
 	INT8_VEC2_NV                                               = 0x8FE1
@@ -13020,13 +13701,23 @@ const (
 	LAST_VIDEO_CAPTURE_STATUS_NV                               = 0x9027
 	LAYER_NV                                                   = 0x8DAA
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
+	LAYOUT_COLOR_ATTACHMENT_EXT                                = 0x958E
 	LAYOUT_DEFAULT_INTEL                                       = 0
+	LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT              = 0x9531
+	LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT              = 0x9530
+	LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT                        = 0x958F
+	LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT                         = 0x9590
+	LAYOUT_GENERAL_EXT                                         = 0x958D
 	LAYOUT_LINEAR_CPU_CACHED_INTEL                             = 2
 	LAYOUT_LINEAR_INTEL                                        = 1
+	LAYOUT_SHADER_READ_ONLY_EXT                                = 0x9591
+	LAYOUT_TRANSFER_DST_EXT                                    = 0x9593
+	LAYOUT_TRANSFER_SRC_EXT                                    = 0x9592
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LERP_ATI                                                   = 0x8969
 	LESS                                                       = 0x0201
+	LGPU_SEPARATE_STORAGE_BIT_NVX                              = 0x0800
 	LIGHT0                                                     = 0x4000
 	LIGHT1                                                     = 0x4001
 	LIGHT2                                                     = 0x4002
@@ -13062,6 +13753,7 @@ const (
 	LINEAR_SHARPEN_ALPHA_SGIS                                  = 0x80AE
 	LINEAR_SHARPEN_COLOR_SGIS                                  = 0x80AF
 	LINEAR_SHARPEN_SGIS                                        = 0x80AD
+	LINEAR_TILING_EXT                                          = 0x9585
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
 	LINES_ADJACENCY_ARB                                        = 0x000A
@@ -13081,6 +13773,7 @@ const (
 	LINE_TOKEN                                                 = 0x0702
 	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -13107,6 +13800,7 @@ const (
 	LOW_INT                                                    = 0x8DF3
 	LO_BIAS_NV                                                 = 0x8715
 	LO_SCALE_NV                                                = 0x870F
+	LUID_SIZE_EXT                                              = 8
 	LUMINANCE                                                  = 0x1909
 	LUMINANCE12                                                = 0x8041
 	LUMINANCE12_ALPHA12                                        = 0x8047
@@ -13440,6 +14134,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_LGPU_GPUS_NVX                                          = 0x92BA
 	MAX_LIGHTS                                                 = 0x0D31
 	MAX_LIST_NESTING                                           = 0x0B31
 	MAX_MAP_TESSELLATION_NV                                    = 0x86D6
@@ -13504,6 +14199,7 @@ const (
 	MAX_PROGRAM_TEX_INSTRUCTIONS_ARB                           = 0x880C
 	MAX_PROGRAM_TOTAL_OUTPUT_COMPONENTS_NV                     = 0x8C28
 	MAX_PROJECTION_STACK_DEPTH                                 = 0x0D38
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RATIONAL_EVAL_ORDER_NV                                 = 0x86D7
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RECTANGLE_TEXTURE_SIZE_ARB                             = 0x84F8
@@ -13516,6 +14212,8 @@ const (
 	MAX_SAMPLE_MASK_WORDS_NV                                   = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
 	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SHININESS_NV                                           = 0x8504
@@ -13526,6 +14224,7 @@ const (
 	MAX_SPARSE_TEXTURE_SIZE_AMD                                = 0x9198
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
 	MAX_SPOT_EXPONENT_NV                                       = 0x8505
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -13560,6 +14259,7 @@ const (
 	MAX_TEXTURE_IMAGE_UNITS_NV                                 = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
 	MAX_TEXTURE_LOD_BIAS_EXT                                   = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_MAX_ANISOTROPY_EXT                             = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TEXTURE_STACK_DEPTH                                    = 0x0D39
@@ -13615,7 +14315,9 @@ const (
 	MAX_VERTEX_VARYING_COMPONENTS_EXT                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
@@ -13642,7 +14344,6 @@ const (
 	MIN_SAMPLE_SHADING_VALUE                                   = 0x8C37
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
 	MIN_SPARSE_LEVEL_AMD                                       = 0x919B
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
 	MIRRORED_REPEAT_ARB                                        = 0x8370
@@ -13655,6 +14356,8 @@ const (
 	MIRROR_CLAMP_TO_EDGE_EXT                                   = 0x8743
 	MITER_REVERT_NV                                            = 0x90A7
 	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
 	MODELVIEW                                                  = 0x1700
 	MODELVIEW0_ARB                                             = 0x1700
 	MODELVIEW0_EXT                                             = 0x1700
@@ -13706,9 +14409,12 @@ const (
 	MOVE_TO_RESETS_NV                                          = 0x90B5
 	MOV_ATI                                                    = 0x8961
 	MULT                                                       = 0x0103
+	MULTICAST_GPUS_NV                                          = 0x92BA
+	MULTICAST_PROGRAMMABLE_SAMPLE_LOCATION_NV                  = 0x9549
 	MULTIPLY_KHR                                               = 0x9294
 	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
 	MULTISAMPLE_3DFX                                           = 0x86B2
 	MULTISAMPLE_ARB                                            = 0x809D
 	MULTISAMPLE_BIT                                            = 0x20000000
@@ -13718,6 +14424,9 @@ const (
 	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
 	MULTISAMPLE_EXT                                            = 0x809D
 	MULTISAMPLE_FILTER_HINT_NV                                 = 0x8534
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	MULTISAMPLE_SGIS                                           = 0x809D
 	MUL_ATI                                                    = 0x8964
 	MVP_MATRIX_EXT                                             = 0x87E3
@@ -13748,6 +14457,7 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
 	NORMALIZE                                                  = 0x0BA1
 	NORMALIZED_RANGE_EXT                                       = 0x87E0
@@ -13781,6 +14491,7 @@ const (
 	NUM_COMPATIBLE_SUBROUTINES                                 = 0x8E4A
 	NUM_COMPRESSED_TEXTURE_FORMATS                             = 0x86A2
 	NUM_COMPRESSED_TEXTURE_FORMATS_ARB                         = 0x86A2
+	NUM_DEVICE_UUIDS_EXT                                       = 0x9596
 	NUM_EXTENSIONS                                             = 0x821D
 	NUM_FILL_STREAMS_NV                                        = 0x8E29
 	NUM_FRAGMENT_CONSTANTS_ATI                                 = 0x896F
@@ -13794,8 +14505,12 @@ const (
 	NUM_PROGRAM_BINARY_FORMATS                                 = 0x87FE
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
+	NUM_TILING_TYPES_EXT                                       = 0x9582
 	NUM_VIDEO_CAPTURE_STREAMS_NV                               = 0x9024
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_ACTIVE_ATTRIBUTES_ARB                               = 0x8B89
 	OBJECT_ACTIVE_ATTRIBUTE_MAX_LENGTH_ARB                     = 0x8B8A
 	OBJECT_ACTIVE_UNIFORMS_ARB                                 = 0x8B86
@@ -13872,6 +14587,7 @@ const (
 	OPERAND2_RGB_EXT                                           = 0x8592
 	OPERAND3_ALPHA_NV                                          = 0x859B
 	OPERAND3_RGB_NV                                            = 0x8593
+	OPTIMAL_TILING_EXT                                         = 0x9584
 	OP_ADD_EXT                                                 = 0x8787
 	OP_CLAMP_EXT                                               = 0x878E
 	OP_CROSS_PRODUCT_EXT                                       = 0x8797
@@ -13951,7 +14667,7 @@ const (
 	PACK_INVERT_MESA                                           = 0x8758
 	PACK_LSB_FIRST                                             = 0x0D01
 	PACK_RESAMPLE_OML                                          = 0x8984
-	PACK_RESAMPLE_SGIX                                         = 0x842C
+	PACK_RESAMPLE_SGIX                                         = 0x842E
 	PACK_ROW_BYTES_APPLE                                       = 0x8A15
 	PACK_ROW_LENGTH                                            = 0x0D02
 	PACK_SKIP_IMAGES                                           = 0x806B
@@ -14056,10 +14772,14 @@ const (
 	PERFQUERY_WAIT_INTEL                                       = 0x83FB
 	PERSPECTIVE_CORRECTION_HINT                                = 0x0C50
 	PERTURB_EXT                                                = 0x85AE
+	PER_GPU_STORAGE_BIT_NV                                     = 0x0800
+	PER_GPU_STORAGE_NV                                         = 0x9548
 	PER_STAGE_CONSTANTS_NV                                     = 0x8535
 	PHONG_HINT_WIN                                             = 0x80EB
 	PHONG_WIN                                                  = 0x80EA
 	PINLIGHT_NV                                                = 0x92A8
+	PIXELS_PER_SAMPLE_PATTERN_X_AMD                            = 0x91AE
+	PIXELS_PER_SAMPLE_PATTERN_Y_AMD                            = 0x91AF
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_BUFFER_BARRIER_BIT_EXT                               = 0x00000080
 	PIXEL_COUNTER_BITS_NV                                      = 0x8864
@@ -14165,6 +14885,9 @@ const (
 	POLYGON_BIT                                                = 0x00000008
 	POLYGON_MODE                                               = 0x0B40
 	POLYGON_OFFSET_BIAS_EXT                                    = 0x8039
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_EXT                                         = 0x8037
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FACTOR_EXT                                  = 0x8038
@@ -14235,6 +14958,7 @@ const (
 	PRIMITIVES_GENERATED_EXT                                   = 0x8C87
 	PRIMITIVES_GENERATED_NV                                    = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_ID_NV                                            = 0x8C7C
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
@@ -14242,11 +14966,16 @@ const (
 	PRIMITIVE_RESTART_INDEX_NV                                 = 0x8559
 	PRIMITIVE_RESTART_NV                                       = 0x8558
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_ADDRESS_REGISTERS_ARB                              = 0x88B0
 	PROGRAM_ALU_INSTRUCTIONS_ARB                               = 0x8805
 	PROGRAM_ATTRIBS_ARB                                        = 0x88AC
 	PROGRAM_ATTRIB_COMPONENTS_NV                               = 0x8906
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
+	PROGRAM_BINARY_FORMAT_MESA                                 = 0x875F
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_BINDING_ARB                                        = 0x8677
@@ -14279,6 +15008,7 @@ const (
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
 	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
 	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
 	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
@@ -14297,6 +15027,7 @@ const (
 	PROJECTION                                                 = 0x1701
 	PROJECTION_MATRIX                                          = 0x0BA7
 	PROJECTION_STACK_DEPTH                                     = 0x0BA4
+	PROTECTED_MEMORY_OBJECT_EXT                                = 0x959B
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROVOKING_VERTEX_EXT                                       = 0x8E4F
 	PROXY_COLOR_TABLE                                          = 0x80D3
@@ -14333,6 +15064,7 @@ const (
 	PROXY_TEXTURE_RECTANGLE_ARB                                = 0x84F7
 	PROXY_TEXTURE_RECTANGLE_NV                                 = 0x84F7
 	PURGEABLE_APPLE                                            = 0x8A1D
+	PURGED_CONTEXT_RESET_NV                                    = 0x92BB
 	Q                                                          = 0x2003
 	QUADRATIC_ATTENUATION                                      = 0x1209
 	QUADRATIC_CURVE_TO_NV                                      = 0x0A
@@ -14373,6 +15105,12 @@ const (
 	QUERY_NO_WAIT_NV                                           = 0x8E14
 	QUERY_OBJECT_AMD                                           = 0x9153
 	QUERY_OBJECT_EXT                                           = 0x9153
+	QUERY_RESOURCE_BUFFEROBJECT_NV                             = 0x9547
+	QUERY_RESOURCE_MEMTYPE_VIDMEM_NV                           = 0x9542
+	QUERY_RESOURCE_RENDERBUFFER_NV                             = 0x9546
+	QUERY_RESOURCE_SYS_RESERVED_NV                             = 0x9544
+	QUERY_RESOURCE_TEXTURE_NV                                  = 0x9545
+	QUERY_RESOURCE_TYPE_VIDMEM_ALLOC_NV                        = 0x9540
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_ARB                                           = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
@@ -14411,7 +15149,10 @@ const (
 	RASTERIZER_DISCARD                                         = 0x8C89
 	RASTERIZER_DISCARD_EXT                                     = 0x8C89
 	RASTERIZER_DISCARD_NV                                      = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
 	RASTER_POSITION_UNCLIPPED_IBM                              = 0x19262
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -14536,6 +15277,7 @@ const (
 	RENDERBUFFER_WIDTH                                         = 0x8D42
 	RENDERBUFFER_WIDTH_EXT                                     = 0x8D42
 	RENDERER                                                   = 0x1F01
+	RENDER_GPU_MASK_NV                                         = 0x9558
 	RENDER_MODE                                                = 0x0C40
 	REPEAT                                                     = 0x2901
 	REPLACE                                                    = 0x1E01
@@ -14554,9 +15296,9 @@ const (
 	RESAMPLE_DECIMATE_OML                                      = 0x8989
 	RESAMPLE_DECIMATE_SGIX                                     = 0x8430
 	RESAMPLE_REPLICATE_OML                                     = 0x8986
-	RESAMPLE_REPLICATE_SGIX                                    = 0x842E
+	RESAMPLE_REPLICATE_SGIX                                    = 0x8433
 	RESAMPLE_ZERO_FILL_OML                                     = 0x8987
-	RESAMPLE_ZERO_FILL_SGIX                                    = 0x842F
+	RESAMPLE_ZERO_FILL_SGIX                                    = 0x8434
 	RESCALE_NORMAL                                             = 0x803A
 	RESCALE_NORMAL_EXT                                         = 0x803A
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
@@ -14754,6 +15496,14 @@ const (
 	SAMPLE_COVERAGE_INVERT_ARB                                 = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
 	SAMPLE_COVERAGE_VALUE_ARB                                  = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_EXT                                            = 0x80A0
 	SAMPLE_MASK_INVERT_EXT                                     = 0x80AB
@@ -14780,6 +15530,7 @@ const (
 	SCALE_BY_TWO_NV                                            = 0x853E
 	SCISSOR_BIT                                                = 0x00080000
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
 	SCREEN_COORDINATES_REND                                    = 0x8490
 	SCREEN_KHR                                                 = 0x9295
@@ -14816,6 +15567,7 @@ const (
 	SET_AMD                                                    = 0x874A
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
 	SHADER_CONSISTENT_NV                                       = 0x86DD
 	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
@@ -14843,6 +15595,7 @@ const (
 	SHADING_LANGUAGE_VERSION_ARB                               = 0x8B8C
 	SHADOW_AMBIENT_SGIX                                        = 0x80BF
 	SHADOW_ATTENUATION_EXT                                     = 0x834E
+	SHARED_EDGE_NV                                             = 0xC0
 	SHARED_TEXTURE_PALETTE_EXT                                 = 0x81FB
 	SHARPEN_TEXTURE_FUNC_POINTS_SGIS                           = 0x80B0
 	SHININESS                                                  = 0x1601
@@ -14929,6 +15682,8 @@ const (
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
 	SPECULAR                                                   = 0x1202
 	SPHERE_MAP                                                 = 0x2402
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
 	SPOT_CUTOFF                                                = 0x1206
 	SPOT_DIRECTION                                             = 0x1204
 	SPOT_EXPONENT                                              = 0x1205
@@ -15015,7 +15770,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TAG_BITS_EXT                                       = 0x88F2
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_TEST_TWO_SIDE_EXT                                  = 0x8910
@@ -15037,11 +15794,15 @@ const (
 	STRICT_LIGHTING_HINT_PGI                                   = 0x1A217
 	STRICT_SCISSOR_HINT_PGI                                    = 0x1A218
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
 	SUBSAMPLE_DISTANCE_AMD                                     = 0x883F
 	SUBTRACT                                                   = 0x84E7
 	SUBTRACT_ARB                                               = 0x84E7
 	SUB_ATI                                                    = 0x8965
 	SUCCESS_NV                                                 = 0x902F
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SURFACE_MAPPED_NV                                          = 0x8700
 	SURFACE_REGISTERED_NV                                      = 0x86FD
 	SURFACE_STATE_NV                                           = 0x86EB
@@ -15079,6 +15840,7 @@ const (
 	TANGENT_ARRAY_POINTER_EXT                                  = 0x8442
 	TANGENT_ARRAY_STRIDE_EXT                                   = 0x843F
 	TANGENT_ARRAY_TYPE_EXT                                     = 0x843E
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESSELLATION_FACTOR_AMD                                    = 0x9005
 	TESSELLATION_MODE_AMD                                      = 0x9004
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
@@ -15198,7 +15960,6 @@ const (
 	TEXTURE_APPLICATION_MODE_EXT                               = 0x834F
 	TEXTURE_BASE_LEVEL                                         = 0x813C
 	TEXTURE_BASE_LEVEL_SGIS                                    = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_1D_ARRAY_EXT                               = 0x8C1C
@@ -15374,6 +16135,7 @@ const (
 	TEXTURE_MATERIAL_FACE_EXT                                  = 0x8351
 	TEXTURE_MATERIAL_PARAMETER_EXT                             = 0x8352
 	TEXTURE_MATRIX                                             = 0x0BA8
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_ANISOTROPY_EXT                                 = 0x84FE
 	TEXTURE_MAX_CLAMP_R_SGIX                                   = 0x836B
 	TEXTURE_MAX_CLAMP_S_SGIX                                   = 0x8369
@@ -15397,6 +16159,8 @@ const (
 	TEXTURE_RECTANGLE                                          = 0x84F5
 	TEXTURE_RECTANGLE_ARB                                      = 0x84F5
 	TEXTURE_RECTANGLE_NV                                       = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_SIZE_EXT                                       = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
@@ -15428,6 +16192,7 @@ const (
 	TEXTURE_SWIZZLE_RGBA_EXT                                   = 0x8E46
 	TEXTURE_SWIZZLE_R_EXT                                      = 0x8E42
 	TEXTURE_TARGET                                             = 0x1006
+	TEXTURE_TILING_EXT                                         = 0x9580
 	TEXTURE_TOO_LARGE_EXT                                      = 0x8065
 	TEXTURE_UNSIGNED_REMAP_MODE_NV                             = 0x888F
 	TEXTURE_UPDATE_BARRIER_BIT                                 = 0x00000100
@@ -15444,6 +16209,10 @@ const (
 	TEXTURE_WRAP_S                                             = 0x2802
 	TEXTURE_WRAP_T                                             = 0x2803
 	TEXT_FRAGMENT_SHADER_ATI                                   = 0x8200
+	TILE_RASTER_ORDER_FIXED_MESA                               = 0x8BB8
+	TILE_RASTER_ORDER_INCREASING_X_MESA                        = 0x8BB9
+	TILE_RASTER_ORDER_INCREASING_Y_MESA                        = 0x8BBA
+	TILING_TYPES_EXT                                           = 0x9583
 	TIMEOUT_EXPIRED                                            = 0x911B
 	TIMEOUT_IGNORED                                            = 0xFFFFFFFFFFFFFFFF
 	TIMESTAMP                                                  = 0x8E28
@@ -15532,6 +16301,7 @@ const (
 	UNDEFINED_APPLE                                            = 0x8A1C
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -15550,12 +16320,15 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
 	UNIFORM_BUFFER_BINDING_EXT                                 = 0x8DEF
 	UNIFORM_BUFFER_EXT                                         = 0x8DEE
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -15578,7 +16351,7 @@ const (
 	UNPACK_IMAGE_HEIGHT_EXT                                    = 0x806E
 	UNPACK_LSB_FIRST                                           = 0x0CF1
 	UNPACK_RESAMPLE_OML                                        = 0x8985
-	UNPACK_RESAMPLE_SGIX                                       = 0x842D
+	UNPACK_RESAMPLE_SGIX                                       = 0x842F
 	UNPACK_ROW_BYTES_APPLE                                     = 0x8A16
 	UNPACK_ROW_LENGTH                                          = 0x0CF2
 	UNPACK_SKIP_IMAGES                                         = 0x806D
@@ -15602,8 +16375,11 @@ const (
 	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
 	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
 	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
 	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
 	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
 	UNSIGNED_INT8_NV                                           = 0x8FEC
 	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
@@ -15695,6 +16471,7 @@ const (
 	USE_MISSING_GLYPH_NV                                       = 0x90AA
 	UTF16_NV                                                   = 0x909B
 	UTF8_NV                                                    = 0x909A
+	UUID_SIZE_EXT                                              = 16
 	V2F                                                        = 0x2A20
 	V3F                                                        = 0x2A21
 	VALIDATE_STATUS                                            = 0x8B83
@@ -15876,8 +16653,24 @@ const (
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BIT                                               = 0x00000800
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -15907,6 +16700,8 @@ const (
 	WAIT_FAILED                                                = 0x911D
 	WARPS_PER_SM_NV                                            = 0x933A
 	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
 	WEIGHT_ARRAY_ARB                                           = 0x86AD
 	WEIGHT_ARRAY_BUFFER_BINDING                                = 0x889E
 	WEIGHT_ARRAY_BUFFER_BINDING_ARB                            = 0x889E
@@ -15916,6 +16711,8 @@ const (
 	WEIGHT_ARRAY_TYPE_ARB                                      = 0x86A9
 	WEIGHT_SUM_UNITY_ARB                                       = 0x86A6
 	WIDE_LINE_HINT_PGI                                         = 0x1A222
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRAP_BORDER_SUN                                            = 0x81D4
 	WRITE_DISCARD_NV                                           = 0x88BE
 	WRITE_ONLY                                                 = 0x88B9
@@ -15952,6 +16749,7 @@ const (
 var (
 	gpAccum                                                  C.GPACCUM
 	gpAccumxOES                                              C.GPACCUMXOES
+	gpAcquireKeyedMutexWin32EXT                              C.GPACQUIREKEYEDMUTEXWIN32EXT
 	gpActiveProgramEXT                                       C.GPACTIVEPROGRAMEXT
 	gpActiveShaderProgram                                    C.GPACTIVESHADERPROGRAM
 	gpActiveShaderProgramEXT                                 C.GPACTIVESHADERPROGRAMEXT
@@ -15964,6 +16762,8 @@ var (
 	gpAlphaFragmentOp3ATI                                    C.GPALPHAFRAGMENTOP3ATI
 	gpAlphaFunc                                              C.GPALPHAFUNC
 	gpAlphaFuncxOES                                          C.GPALPHAFUNCXOES
+	gpAlphaToCoverageDitherControlNV                         C.GPALPHATOCOVERAGEDITHERCONTROLNV
+	gpApplyFramebufferAttachmentCMAAINTEL                    C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
 	gpApplyTextureEXT                                        C.GPAPPLYTEXTUREEXT
 	gpAreProgramsResidentNV                                  C.GPAREPROGRAMSRESIDENTNV
 	gpAreTexturesResident                                    C.GPARETEXTURESRESIDENT
@@ -16088,8 +16888,11 @@ var (
 	gpBufferPageCommitmentARB                                C.GPBUFFERPAGECOMMITMENTARB
 	gpBufferParameteriAPPLE                                  C.GPBUFFERPARAMETERIAPPLE
 	gpBufferStorage                                          C.GPBUFFERSTORAGE
+	gpBufferStorageExternalEXT                               C.GPBUFFERSTORAGEEXTERNALEXT
+	gpBufferStorageMemEXT                                    C.GPBUFFERSTORAGEMEMEXT
 	gpBufferSubData                                          C.GPBUFFERSUBDATA
 	gpBufferSubDataARB                                       C.GPBUFFERSUBDATAARB
+	gpCallCommandListNV                                      C.GPCALLCOMMANDLISTNV
 	gpCallList                                               C.GPCALLLIST
 	gpCallLists                                              C.GPCALLLISTS
 	gpCheckFramebufferStatus                                 C.GPCHECKFRAMEBUFFERSTATUS
@@ -16217,6 +17020,8 @@ var (
 	gpCombinerParameteriNV                                   C.GPCOMBINERPARAMETERINV
 	gpCombinerParameterivNV                                  C.GPCOMBINERPARAMETERIVNV
 	gpCombinerStageParameterfvNV                             C.GPCOMBINERSTAGEPARAMETERFVNV
+	gpCommandListSegmentsNV                                  C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                                   C.GPCOMPILECOMMANDLISTNV
 	gpCompileShader                                          C.GPCOMPILESHADER
 	gpCompileShaderARB                                       C.GPCOMPILESHADERARB
 	gpCompileShaderIncludeARB                                C.GPCOMPILESHADERINCLUDEARB
@@ -16247,6 +17052,8 @@ var (
 	gpCompressedTextureSubImage2DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
 	gpCompressedTextureSubImage3D                            C.GPCOMPRESSEDTEXTURESUBIMAGE3D
 	gpCompressedTextureSubImage3DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                         C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                         C.GPCONSERVATIVERASTERPARAMETERINV
 	gpConvolutionFilter1D                                    C.GPCONVOLUTIONFILTER1D
 	gpConvolutionFilter1DEXT                                 C.GPCONVOLUTIONFILTER1DEXT
 	gpConvolutionFilter2D                                    C.GPCONVOLUTIONFILTER2D
@@ -16302,8 +17109,12 @@ var (
 	gpCoverFillPathNV                                        C.GPCOVERFILLPATHNV
 	gpCoverStrokePathInstancedNV                             C.GPCOVERSTROKEPATHINSTANCEDNV
 	gpCoverStrokePathNV                                      C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                                   C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                              C.GPCOVERAGEMODULATIONTABLENV
 	gpCreateBuffers                                          C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                                   C.GPCREATECOMMANDLISTSNV
 	gpCreateFramebuffers                                     C.GPCREATEFRAMEBUFFERS
+	gpCreateMemoryObjectsEXT                                 C.GPCREATEMEMORYOBJECTSEXT
 	gpCreatePerfQueryINTEL                                   C.GPCREATEPERFQUERYINTEL
 	gpCreateProgram                                          C.GPCREATEPROGRAM
 	gpCreateProgramObjectARB                                 C.GPCREATEPROGRAMOBJECTARB
@@ -16316,6 +17127,7 @@ var (
 	gpCreateShaderProgramEXT                                 C.GPCREATESHADERPROGRAMEXT
 	gpCreateShaderProgramv                                   C.GPCREATESHADERPROGRAMV
 	gpCreateShaderProgramvEXT                                C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                         C.GPCREATESTATESNV
 	gpCreateSyncFromCLeventARB                               C.GPCREATESYNCFROMCLEVENTARB
 	gpCreateTextures                                         C.GPCREATETEXTURES
 	gpCreateTransformFeedbacks                               C.GPCREATETRANSFORMFEEDBACKS
@@ -16342,12 +17154,14 @@ var (
 	gpDeleteAsyncMarkersSGIX                                 C.GPDELETEASYNCMARKERSSGIX
 	gpDeleteBuffers                                          C.GPDELETEBUFFERS
 	gpDeleteBuffersARB                                       C.GPDELETEBUFFERSARB
+	gpDeleteCommandListsNV                                   C.GPDELETECOMMANDLISTSNV
 	gpDeleteFencesAPPLE                                      C.GPDELETEFENCESAPPLE
 	gpDeleteFencesNV                                         C.GPDELETEFENCESNV
 	gpDeleteFragmentShaderATI                                C.GPDELETEFRAGMENTSHADERATI
 	gpDeleteFramebuffers                                     C.GPDELETEFRAMEBUFFERS
 	gpDeleteFramebuffersEXT                                  C.GPDELETEFRAMEBUFFERSEXT
 	gpDeleteLists                                            C.GPDELETELISTS
+	gpDeleteMemoryObjectsEXT                                 C.GPDELETEMEMORYOBJECTSEXT
 	gpDeleteNamedStringARB                                   C.GPDELETENAMEDSTRINGARB
 	gpDeleteNamesAMD                                         C.GPDELETENAMESAMD
 	gpDeleteObjectARB                                        C.GPDELETEOBJECTARB
@@ -16362,10 +17176,13 @@ var (
 	gpDeleteProgramsNV                                       C.GPDELETEPROGRAMSNV
 	gpDeleteQueries                                          C.GPDELETEQUERIES
 	gpDeleteQueriesARB                                       C.GPDELETEQUERIESARB
+	gpDeleteQueryResourceTagNV                               C.GPDELETEQUERYRESOURCETAGNV
 	gpDeleteRenderbuffers                                    C.GPDELETERENDERBUFFERS
 	gpDeleteRenderbuffersEXT                                 C.GPDELETERENDERBUFFERSEXT
 	gpDeleteSamplers                                         C.GPDELETESAMPLERS
+	gpDeleteSemaphoresEXT                                    C.GPDELETESEMAPHORESEXT
 	gpDeleteShader                                           C.GPDELETESHADER
+	gpDeleteStatesNV                                         C.GPDELETESTATESNV
 	gpDeleteSync                                             C.GPDELETESYNC
 	gpDeleteTextures                                         C.GPDELETETEXTURES
 	gpDeleteTexturesEXT                                      C.GPDELETETEXTURESEXT
@@ -16415,6 +17232,10 @@ var (
 	gpDrawBuffers                                            C.GPDRAWBUFFERS
 	gpDrawBuffersARB                                         C.GPDRAWBUFFERSARB
 	gpDrawBuffersATI                                         C.GPDRAWBUFFERSATI
+	gpDrawCommandsAddressNV                                  C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                         C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                            C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                                   C.GPDRAWCOMMANDSSTATESNV
 	gpDrawElementArrayAPPLE                                  C.GPDRAWELEMENTARRAYAPPLE
 	gpDrawElementArrayATI                                    C.GPDRAWELEMENTARRAYATI
 	gpDrawElements                                           C.GPDRAWELEMENTS
@@ -16439,6 +17260,7 @@ var (
 	gpDrawTransformFeedbackNV                                C.GPDRAWTRANSFORMFEEDBACKNV
 	gpDrawTransformFeedbackStream                            C.GPDRAWTRANSFORMFEEDBACKSTREAM
 	gpDrawTransformFeedbackStreamInstanced                   C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                          C.GPDRAWVKIMAGENV
 	gpEdgeFlag                                               C.GPEDGEFLAG
 	gpEdgeFlagFormatNV                                       C.GPEDGEFLAGFORMATNV
 	gpEdgeFlagPointer                                        C.GPEDGEFLAGPOINTER
@@ -16494,6 +17316,7 @@ var (
 	gpEvalMesh2                                              C.GPEVALMESH2
 	gpEvalPoint1                                             C.GPEVALPOINT1
 	gpEvalPoint2                                             C.GPEVALPOINT2
+	gpEvaluateDepthValuesARB                                 C.GPEVALUATEDEPTHVALUESARB
 	gpExecuteProgramNV                                       C.GPEXECUTEPROGRAMNV
 	gpExtractComponentEXT                                    C.GPEXTRACTCOMPONENTEXT
 	gpFeedbackBuffer                                         C.GPFEEDBACKBUFFER
@@ -16538,6 +17361,7 @@ var (
 	gpFogxOES                                                C.GPFOGXOES
 	gpFogxvOES                                               C.GPFOGXVOES
 	gpFragmentColorMaterialSGIX                              C.GPFRAGMENTCOLORMATERIALSGIX
+	gpFragmentCoverageColorNV                                C.GPFRAGMENTCOVERAGECOLORNV
 	gpFragmentLightModelfSGIX                                C.GPFRAGMENTLIGHTMODELFSGIX
 	gpFragmentLightModelfvSGIX                               C.GPFRAGMENTLIGHTMODELFVSGIX
 	gpFragmentLightModeliSGIX                                C.GPFRAGMENTLIGHTMODELISGIX
@@ -16554,10 +17378,14 @@ var (
 	gpFrameZoomSGIX                                          C.GPFRAMEZOOMSGIX
 	gpFramebufferDrawBufferEXT                               C.GPFRAMEBUFFERDRAWBUFFEREXT
 	gpFramebufferDrawBuffersEXT                              C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                             C.GPFRAMEBUFFERFETCHBARRIEREXT
 	gpFramebufferParameteri                                  C.GPFRAMEBUFFERPARAMETERI
 	gpFramebufferReadBufferEXT                               C.GPFRAMEBUFFERREADBUFFEREXT
 	gpFramebufferRenderbuffer                                C.GPFRAMEBUFFERRENDERBUFFER
 	gpFramebufferRenderbufferEXT                             C.GPFRAMEBUFFERRENDERBUFFEREXT
+	gpFramebufferSampleLocationsfvARB                        C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                         C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferSamplePositionsfvAMD                        C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpFramebufferTexture                                     C.GPFRAMEBUFFERTEXTURE
 	gpFramebufferTexture1D                                   C.GPFRAMEBUFFERTEXTURE1D
 	gpFramebufferTexture1DEXT                                C.GPFRAMEBUFFERTEXTURE1DEXT
@@ -16572,6 +17400,7 @@ var (
 	gpFramebufferTextureLayer                                C.GPFRAMEBUFFERTEXTURELAYER
 	gpFramebufferTextureLayerARB                             C.GPFRAMEBUFFERTEXTURELAYERARB
 	gpFramebufferTextureLayerEXT                             C.GPFRAMEBUFFERTEXTURELAYEREXT
+	gpFramebufferTextureMultiviewOVR                         C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
 	gpFreeObjectBufferATI                                    C.GPFREEOBJECTBUFFERATI
 	gpFrontFace                                              C.GPFRONTFACE
 	gpFrustum                                                C.GPFRUSTUM
@@ -16596,9 +17425,11 @@ var (
 	gpGenProgramsNV                                          C.GPGENPROGRAMSNV
 	gpGenQueries                                             C.GPGENQUERIES
 	gpGenQueriesARB                                          C.GPGENQUERIESARB
+	gpGenQueryResourceTagNV                                  C.GPGENQUERYRESOURCETAGNV
 	gpGenRenderbuffers                                       C.GPGENRENDERBUFFERS
 	gpGenRenderbuffersEXT                                    C.GPGENRENDERBUFFERSEXT
 	gpGenSamplers                                            C.GPGENSAMPLERS
+	gpGenSemaphoresEXT                                       C.GPGENSEMAPHORESEXT
 	gpGenSymbolsEXT                                          C.GPGENSYMBOLSEXT
 	gpGenTextures                                            C.GPGENTEXTURES
 	gpGenTexturesEXT                                         C.GPGENTEXTURESEXT
@@ -16659,6 +17490,7 @@ var (
 	gpGetCombinerOutputParameterfvNV                         C.GPGETCOMBINEROUTPUTPARAMETERFVNV
 	gpGetCombinerOutputParameterivNV                         C.GPGETCOMBINEROUTPUTPARAMETERIVNV
 	gpGetCombinerStageParameterfvNV                          C.GPGETCOMBINERSTAGEPARAMETERFVNV
+	gpGetCommandHeaderNV                                     C.GPGETCOMMANDHEADERNV
 	gpGetCompressedMultiTexImageEXT                          C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
 	gpGetCompressedTexImage                                  C.GPGETCOMPRESSEDTEXIMAGE
 	gpGetCompressedTexImageARB                               C.GPGETCOMPRESSEDTEXIMAGEARB
@@ -16672,6 +17504,7 @@ var (
 	gpGetConvolutionParameteriv                              C.GPGETCONVOLUTIONPARAMETERIV
 	gpGetConvolutionParameterivEXT                           C.GPGETCONVOLUTIONPARAMETERIVEXT
 	gpGetConvolutionParameterxvOES                           C.GPGETCONVOLUTIONPARAMETERXVOES
+	gpGetCoverageModulationTableNV                           C.GPGETCOVERAGEMODULATIONTABLENV
 	gpGetDebugMessageLog                                     C.GPGETDEBUGMESSAGELOG
 	gpGetDebugMessageLogAMD                                  C.GPGETDEBUGMESSAGELOGAMD
 	gpGetDebugMessageLogARB                                  C.GPGETDEBUGMESSAGELOGARB
@@ -16701,6 +17534,7 @@ var (
 	gpGetFragmentMaterialivSGIX                              C.GPGETFRAGMENTMATERIALIVSGIX
 	gpGetFramebufferAttachmentParameteriv                    C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetFramebufferAttachmentParameterivEXT                 C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetFramebufferParameterfvAMD                           C.GPGETFRAMEBUFFERPARAMETERFVAMD
 	gpGetFramebufferParameteriv                              C.GPGETFRAMEBUFFERPARAMETERIV
 	gpGetFramebufferParameterivEXT                           C.GPGETFRAMEBUFFERPARAMETERIVEXT
 	gpGetGraphicsResetStatus                                 C.GPGETGRAPHICSRESETSTATUS
@@ -16727,6 +17561,7 @@ var (
 	gpGetIntegerui64i_vNV                                    C.GPGETINTEGERUI64I_VNV
 	gpGetIntegerui64vNV                                      C.GPGETINTEGERUI64VNV
 	gpGetIntegerv                                            C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                            C.GPGETINTERNALFORMATSAMPLEIVNV
 	gpGetInternalformati64v                                  C.GPGETINTERNALFORMATI64V
 	gpGetInternalformativ                                    C.GPGETINTERNALFORMATIV
 	gpGetInvariantBooleanvEXT                                C.GPGETINVARIANTBOOLEANVEXT
@@ -16754,6 +17589,7 @@ var (
 	gpGetMaterialiv                                          C.GPGETMATERIALIV
 	gpGetMaterialxOES                                        C.GPGETMATERIALXOES
 	gpGetMaterialxvOES                                       C.GPGETMATERIALXVOES
+	gpGetMemoryObjectParameterivEXT                          C.GPGETMEMORYOBJECTPARAMETERIVEXT
 	gpGetMinmax                                              C.GPGETMINMAX
 	gpGetMinmaxEXT                                           C.GPGETMINMAXEXT
 	gpGetMinmaxParameterfv                                   C.GPGETMINMAXPARAMETERFV
@@ -16784,6 +17620,7 @@ var (
 	gpGetNamedBufferSubDataEXT                               C.GPGETNAMEDBUFFERSUBDATAEXT
 	gpGetNamedFramebufferAttachmentParameteriv               C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetNamedFramebufferAttachmentParameterivEXT            C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameterfvAMD                      C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD
 	gpGetNamedFramebufferParameteriv                         C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
 	gpGetNamedFramebufferParameterivEXT                      C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
 	gpGetNamedProgramLocalParameterIivEXT                    C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
@@ -16878,6 +17715,10 @@ var (
 	gpGetProgramiv                                           C.GPGETPROGRAMIV
 	gpGetProgramivARB                                        C.GPGETPROGRAMIVARB
 	gpGetProgramivNV                                         C.GPGETPROGRAMIVNV
+	gpGetQueryBufferObjecti64v                               C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                                 C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                              C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                                C.GPGETQUERYBUFFEROBJECTUIV
 	gpGetQueryIndexediv                                      C.GPGETQUERYINDEXEDIV
 	gpGetQueryObjecti64v                                     C.GPGETQUERYOBJECTI64V
 	gpGetQueryObjecti64vEXT                                  C.GPGETQUERYOBJECTI64VEXT
@@ -16895,6 +17736,7 @@ var (
 	gpGetSamplerParameterIuiv                                C.GPGETSAMPLERPARAMETERIUIV
 	gpGetSamplerParameterfv                                  C.GPGETSAMPLERPARAMETERFV
 	gpGetSamplerParameteriv                                  C.GPGETSAMPLERPARAMETERIV
+	gpGetSemaphoreParameterui64vEXT                          C.GPGETSEMAPHOREPARAMETERUI64VEXT
 	gpGetSeparableFilter                                     C.GPGETSEPARABLEFILTER
 	gpGetSeparableFilterEXT                                  C.GPGETSEPARABLEFILTEREXT
 	gpGetShaderInfoLog                                       C.GPGETSHADERINFOLOG
@@ -16903,6 +17745,7 @@ var (
 	gpGetShaderSourceARB                                     C.GPGETSHADERSOURCEARB
 	gpGetShaderiv                                            C.GPGETSHADERIV
 	gpGetSharpenTexFuncSGIS                                  C.GPGETSHARPENTEXFUNCSGIS
+	gpGetStageIndexNV                                        C.GPGETSTAGEINDEXNV
 	gpGetString                                              C.GPGETSTRING
 	gpGetStringi                                             C.GPGETSTRINGI
 	gpGetSubroutineIndex                                     C.GPGETSUBROUTINEINDEX
@@ -16966,12 +17809,16 @@ var (
 	gpGetUniformdv                                           C.GPGETUNIFORMDV
 	gpGetUniformfv                                           C.GPGETUNIFORMFV
 	gpGetUniformfvARB                                        C.GPGETUNIFORMFVARB
+	gpGetUniformi64vARB                                      C.GPGETUNIFORMI64VARB
 	gpGetUniformi64vNV                                       C.GPGETUNIFORMI64VNV
 	gpGetUniformiv                                           C.GPGETUNIFORMIV
 	gpGetUniformivARB                                        C.GPGETUNIFORMIVARB
+	gpGetUniformui64vARB                                     C.GPGETUNIFORMUI64VARB
 	gpGetUniformui64vNV                                      C.GPGETUNIFORMUI64VNV
 	gpGetUniformuiv                                          C.GPGETUNIFORMUIV
 	gpGetUniformuivEXT                                       C.GPGETUNIFORMUIVEXT
+	gpGetUnsignedBytei_vEXT                                  C.GPGETUNSIGNEDBYTEI_VEXT
+	gpGetUnsignedBytevEXT                                    C.GPGETUNSIGNEDBYTEVEXT
 	gpGetVariantArrayObjectfvATI                             C.GPGETVARIANTARRAYOBJECTFVATI
 	gpGetVariantArrayObjectivATI                             C.GPGETVARIANTARRAYOBJECTIVATI
 	gpGetVariantBooleanvEXT                                  C.GPGETVARIANTBOOLEANVEXT
@@ -17017,6 +17864,7 @@ var (
 	gpGetVideoivNV                                           C.GPGETVIDEOIVNV
 	gpGetVideoui64vNV                                        C.GPGETVIDEOUI64VNV
 	gpGetVideouivNV                                          C.GPGETVIDEOUIVNV
+	gpGetVkProcAddrNV                                        C.GPGETVKPROCADDRNV
 	gpGetnColorTableARB                                      C.GPGETNCOLORTABLEARB
 	gpGetnCompressedTexImageARB                              C.GPGETNCOMPRESSEDTEXIMAGEARB
 	gpGetnConvolutionFilterARB                               C.GPGETNCONVOLUTIONFILTERARB
@@ -17035,9 +17883,11 @@ var (
 	gpGetnUniformfv                                          C.GPGETNUNIFORMFV
 	gpGetnUniformfvARB                                       C.GPGETNUNIFORMFVARB
 	gpGetnUniformfvKHR                                       C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                                     C.GPGETNUNIFORMI64VARB
 	gpGetnUniformiv                                          C.GPGETNUNIFORMIV
 	gpGetnUniformivARB                                       C.GPGETNUNIFORMIVARB
 	gpGetnUniformivKHR                                       C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                                    C.GPGETNUNIFORMUI64VARB
 	gpGetnUniformuiv                                         C.GPGETNUNIFORMUIV
 	gpGetnUniformuivARB                                      C.GPGETNUNIFORMUIVARB
 	gpGetnUniformuivKHR                                      C.GPGETNUNIFORMUIVKHR
@@ -17058,6 +17908,12 @@ var (
 	gpImageTransformParameterfvHP                            C.GPIMAGETRANSFORMPARAMETERFVHP
 	gpImageTransformParameteriHP                             C.GPIMAGETRANSFORMPARAMETERIHP
 	gpImageTransformParameterivHP                            C.GPIMAGETRANSFORMPARAMETERIVHP
+	gpImportMemoryFdEXT                                      C.GPIMPORTMEMORYFDEXT
+	gpImportMemoryWin32HandleEXT                             C.GPIMPORTMEMORYWIN32HANDLEEXT
+	gpImportMemoryWin32NameEXT                               C.GPIMPORTMEMORYWIN32NAMEEXT
+	gpImportSemaphoreFdEXT                                   C.GPIMPORTSEMAPHOREFDEXT
+	gpImportSemaphoreWin32HandleEXT                          C.GPIMPORTSEMAPHOREWIN32HANDLEEXT
+	gpImportSemaphoreWin32NameEXT                            C.GPIMPORTSEMAPHOREWIN32NAMEEXT
 	gpImportSyncEXT                                          C.GPIMPORTSYNCEXT
 	gpIndexFormatNV                                          C.GPINDEXFORMATNV
 	gpIndexFuncEXT                                           C.GPINDEXFUNCEXT
@@ -17096,6 +17952,7 @@ var (
 	gpIsBuffer                                               C.GPISBUFFER
 	gpIsBufferARB                                            C.GPISBUFFERARB
 	gpIsBufferResidentNV                                     C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                        C.GPISCOMMANDLISTNV
 	gpIsEnabled                                              C.GPISENABLED
 	gpIsEnabledIndexedEXT                                    C.GPISENABLEDINDEXEDEXT
 	gpIsEnabledi                                             C.GPISENABLEDI
@@ -17106,6 +17963,7 @@ var (
 	gpIsImageHandleResidentARB                               C.GPISIMAGEHANDLERESIDENTARB
 	gpIsImageHandleResidentNV                                C.GPISIMAGEHANDLERESIDENTNV
 	gpIsList                                                 C.GPISLIST
+	gpIsMemoryObjectEXT                                      C.GPISMEMORYOBJECTEXT
 	gpIsNameAMD                                              C.GPISNAMEAMD
 	gpIsNamedBufferResidentNV                                C.GPISNAMEDBUFFERRESIDENTNV
 	gpIsNamedStringARB                                       C.GPISNAMEDSTRINGARB
@@ -17124,7 +17982,9 @@ var (
 	gpIsRenderbuffer                                         C.GPISRENDERBUFFER
 	gpIsRenderbufferEXT                                      C.GPISRENDERBUFFEREXT
 	gpIsSampler                                              C.GPISSAMPLER
+	gpIsSemaphoreEXT                                         C.GPISSEMAPHOREEXT
 	gpIsShader                                               C.GPISSHADER
+	gpIsStateNV                                              C.GPISSTATENV
 	gpIsSync                                                 C.GPISSYNC
 	gpIsTexture                                              C.GPISTEXTURE
 	gpIsTextureEXT                                           C.GPISTEXTUREEXT
@@ -17136,6 +17996,9 @@ var (
 	gpIsVertexArray                                          C.GPISVERTEXARRAY
 	gpIsVertexArrayAPPLE                                     C.GPISVERTEXARRAYAPPLE
 	gpIsVertexAttribEnabledAPPLE                             C.GPISVERTEXATTRIBENABLEDAPPLE
+	gpLGPUCopyImageSubDataNVX                                C.GPLGPUCOPYIMAGESUBDATANVX
+	gpLGPUInterlockNVX                                       C.GPLGPUINTERLOCKNVX
+	gpLGPUNamedBufferSubDataNVX                              C.GPLGPUNAMEDBUFFERSUBDATANVX
 	gpLabelObjectEXT                                         C.GPLABELOBJECTEXT
 	gpLightEnviSGIX                                          C.GPLIGHTENVISGIX
 	gpLightModelf                                            C.GPLIGHTMODELF
@@ -17156,6 +18019,7 @@ var (
 	gpLinkProgram                                            C.GPLINKPROGRAM
 	gpLinkProgramARB                                         C.GPLINKPROGRAMARB
 	gpListBase                                               C.GPLISTBASE
+	gpListDrawCommandsStatesClientNV                         C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
 	gpListParameterfSGIX                                     C.GPLISTPARAMETERFSGIX
 	gpListParameterfvSGIX                                    C.GPLISTPARAMETERFVSGIX
 	gpListParameteriSGIX                                     C.GPLISTPARAMETERISGIX
@@ -17250,9 +18114,12 @@ var (
 	gpMatrixScalefEXT                                        C.GPMATRIXSCALEFEXT
 	gpMatrixTranslatedEXT                                    C.GPMATRIXTRANSLATEDEXT
 	gpMatrixTranslatefEXT                                    C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                            C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                            C.GPMAXSHADERCOMPILERTHREADSKHR
 	gpMemoryBarrier                                          C.GPMEMORYBARRIER
 	gpMemoryBarrierByRegion                                  C.GPMEMORYBARRIERBYREGION
 	gpMemoryBarrierEXT                                       C.GPMEMORYBARRIEREXT
+	gpMemoryObjectParameterivEXT                             C.GPMEMORYOBJECTPARAMETERIVEXT
 	gpMinSampleShading                                       C.GPMINSAMPLESHADING
 	gpMinSampleShadingARB                                    C.GPMINSAMPLESHADINGARB
 	gpMinmax                                                 C.GPMINMAX
@@ -17405,12 +18272,25 @@ var (
 	gpMultiTexSubImage1DEXT                                  C.GPMULTITEXSUBIMAGE1DEXT
 	gpMultiTexSubImage2DEXT                                  C.GPMULTITEXSUBIMAGE2DEXT
 	gpMultiTexSubImage3DEXT                                  C.GPMULTITEXSUBIMAGE3DEXT
+	gpMulticastBarrierNV                                     C.GPMULTICASTBARRIERNV
+	gpMulticastBlitFramebufferNV                             C.GPMULTICASTBLITFRAMEBUFFERNV
+	gpMulticastBufferSubDataNV                               C.GPMULTICASTBUFFERSUBDATANV
+	gpMulticastCopyBufferSubDataNV                           C.GPMULTICASTCOPYBUFFERSUBDATANV
+	gpMulticastCopyImageSubDataNV                            C.GPMULTICASTCOPYIMAGESUBDATANV
+	gpMulticastFramebufferSampleLocationsfvNV                C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpMulticastGetQueryObjecti64vNV                          C.GPMULTICASTGETQUERYOBJECTI64VNV
+	gpMulticastGetQueryObjectivNV                            C.GPMULTICASTGETQUERYOBJECTIVNV
+	gpMulticastGetQueryObjectui64vNV                         C.GPMULTICASTGETQUERYOBJECTUI64VNV
+	gpMulticastGetQueryObjectuivNV                           C.GPMULTICASTGETQUERYOBJECTUIVNV
+	gpMulticastWaitSyncNV                                    C.GPMULTICASTWAITSYNCNV
 	gpNamedBufferData                                        C.GPNAMEDBUFFERDATA
 	gpNamedBufferDataEXT                                     C.GPNAMEDBUFFERDATAEXT
 	gpNamedBufferPageCommitmentARB                           C.GPNAMEDBUFFERPAGECOMMITMENTARB
 	gpNamedBufferPageCommitmentEXT                           C.GPNAMEDBUFFERPAGECOMMITMENTEXT
 	gpNamedBufferStorage                                     C.GPNAMEDBUFFERSTORAGE
 	gpNamedBufferStorageEXT                                  C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferStorageExternalEXT                          C.GPNAMEDBUFFERSTORAGEEXTERNALEXT
+	gpNamedBufferStorageMemEXT                               C.GPNAMEDBUFFERSTORAGEMEMEXT
 	gpNamedBufferSubData                                     C.GPNAMEDBUFFERSUBDATA
 	gpNamedBufferSubDataEXT                                  C.GPNAMEDBUFFERSUBDATAEXT
 	gpNamedCopyBufferSubDataEXT                              C.GPNAMEDCOPYBUFFERSUBDATAEXT
@@ -17421,6 +18301,9 @@ var (
 	gpNamedFramebufferReadBuffer                             C.GPNAMEDFRAMEBUFFERREADBUFFER
 	gpNamedFramebufferRenderbuffer                           C.GPNAMEDFRAMEBUFFERRENDERBUFFER
 	gpNamedFramebufferRenderbufferEXT                        C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB                   C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV                    C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferSamplePositionsfvAMD                   C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpNamedFramebufferTexture                                C.GPNAMEDFRAMEBUFFERTEXTURE
 	gpNamedFramebufferTexture1DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
 	gpNamedFramebufferTexture2DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
@@ -17564,6 +18447,8 @@ var (
 	gpPollInstrumentsSGIX                                    C.GPPOLLINSTRUMENTSSGIX
 	gpPolygonMode                                            C.GPPOLYGONMODE
 	gpPolygonOffset                                          C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                                     C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                                  C.GPPOLYGONOFFSETCLAMPEXT
 	gpPolygonOffsetEXT                                       C.GPPOLYGONOFFSETEXT
 	gpPolygonOffsetxOES                                      C.GPPOLYGONOFFSETXOES
 	gpPolygonStipple                                         C.GPPOLYGONSTIPPLE
@@ -17576,6 +18461,7 @@ var (
 	gpPopName                                                C.GPPOPNAME
 	gpPresentFrameDualFillNV                                 C.GPPRESENTFRAMEDUALFILLNV
 	gpPresentFrameKeyedNV                                    C.GPPRESENTFRAMEKEYEDNV
+	gpPrimitiveBoundingBoxARB                                C.GPPRIMITIVEBOUNDINGBOXARB
 	gpPrimitiveRestartIndex                                  C.GPPRIMITIVERESTARTINDEX
 	gpPrimitiveRestartIndexNV                                C.GPPRIMITIVERESTARTINDEXNV
 	gpPrimitiveRestartNV                                     C.GPPRIMITIVERESTARTNV
@@ -17633,13 +18519,17 @@ var (
 	gpProgramUniform1fv                                      C.GPPROGRAMUNIFORM1FV
 	gpProgramUniform1fvEXT                                   C.GPPROGRAMUNIFORM1FVEXT
 	gpProgramUniform1i                                       C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                                  C.GPPROGRAMUNIFORM1I64ARB
 	gpProgramUniform1i64NV                                   C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                                 C.GPPROGRAMUNIFORM1I64VARB
 	gpProgramUniform1i64vNV                                  C.GPPROGRAMUNIFORM1I64VNV
 	gpProgramUniform1iEXT                                    C.GPPROGRAMUNIFORM1IEXT
 	gpProgramUniform1iv                                      C.GPPROGRAMUNIFORM1IV
 	gpProgramUniform1ivEXT                                   C.GPPROGRAMUNIFORM1IVEXT
 	gpProgramUniform1ui                                      C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                                 C.GPPROGRAMUNIFORM1UI64ARB
 	gpProgramUniform1ui64NV                                  C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                                C.GPPROGRAMUNIFORM1UI64VARB
 	gpProgramUniform1ui64vNV                                 C.GPPROGRAMUNIFORM1UI64VNV
 	gpProgramUniform1uiEXT                                   C.GPPROGRAMUNIFORM1UIEXT
 	gpProgramUniform1uiv                                     C.GPPROGRAMUNIFORM1UIV
@@ -17653,13 +18543,17 @@ var (
 	gpProgramUniform2fv                                      C.GPPROGRAMUNIFORM2FV
 	gpProgramUniform2fvEXT                                   C.GPPROGRAMUNIFORM2FVEXT
 	gpProgramUniform2i                                       C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                                  C.GPPROGRAMUNIFORM2I64ARB
 	gpProgramUniform2i64NV                                   C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                                 C.GPPROGRAMUNIFORM2I64VARB
 	gpProgramUniform2i64vNV                                  C.GPPROGRAMUNIFORM2I64VNV
 	gpProgramUniform2iEXT                                    C.GPPROGRAMUNIFORM2IEXT
 	gpProgramUniform2iv                                      C.GPPROGRAMUNIFORM2IV
 	gpProgramUniform2ivEXT                                   C.GPPROGRAMUNIFORM2IVEXT
 	gpProgramUniform2ui                                      C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                                 C.GPPROGRAMUNIFORM2UI64ARB
 	gpProgramUniform2ui64NV                                  C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                                C.GPPROGRAMUNIFORM2UI64VARB
 	gpProgramUniform2ui64vNV                                 C.GPPROGRAMUNIFORM2UI64VNV
 	gpProgramUniform2uiEXT                                   C.GPPROGRAMUNIFORM2UIEXT
 	gpProgramUniform2uiv                                     C.GPPROGRAMUNIFORM2UIV
@@ -17673,13 +18567,17 @@ var (
 	gpProgramUniform3fv                                      C.GPPROGRAMUNIFORM3FV
 	gpProgramUniform3fvEXT                                   C.GPPROGRAMUNIFORM3FVEXT
 	gpProgramUniform3i                                       C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                                  C.GPPROGRAMUNIFORM3I64ARB
 	gpProgramUniform3i64NV                                   C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                                 C.GPPROGRAMUNIFORM3I64VARB
 	gpProgramUniform3i64vNV                                  C.GPPROGRAMUNIFORM3I64VNV
 	gpProgramUniform3iEXT                                    C.GPPROGRAMUNIFORM3IEXT
 	gpProgramUniform3iv                                      C.GPPROGRAMUNIFORM3IV
 	gpProgramUniform3ivEXT                                   C.GPPROGRAMUNIFORM3IVEXT
 	gpProgramUniform3ui                                      C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                                 C.GPPROGRAMUNIFORM3UI64ARB
 	gpProgramUniform3ui64NV                                  C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                                C.GPPROGRAMUNIFORM3UI64VARB
 	gpProgramUniform3ui64vNV                                 C.GPPROGRAMUNIFORM3UI64VNV
 	gpProgramUniform3uiEXT                                   C.GPPROGRAMUNIFORM3UIEXT
 	gpProgramUniform3uiv                                     C.GPPROGRAMUNIFORM3UIV
@@ -17693,13 +18591,17 @@ var (
 	gpProgramUniform4fv                                      C.GPPROGRAMUNIFORM4FV
 	gpProgramUniform4fvEXT                                   C.GPPROGRAMUNIFORM4FVEXT
 	gpProgramUniform4i                                       C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                                  C.GPPROGRAMUNIFORM4I64ARB
 	gpProgramUniform4i64NV                                   C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                                 C.GPPROGRAMUNIFORM4I64VARB
 	gpProgramUniform4i64vNV                                  C.GPPROGRAMUNIFORM4I64VNV
 	gpProgramUniform4iEXT                                    C.GPPROGRAMUNIFORM4IEXT
 	gpProgramUniform4iv                                      C.GPPROGRAMUNIFORM4IV
 	gpProgramUniform4ivEXT                                   C.GPPROGRAMUNIFORM4IVEXT
 	gpProgramUniform4ui                                      C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                                 C.GPPROGRAMUNIFORM4UI64ARB
 	gpProgramUniform4ui64NV                                  C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                                C.GPPROGRAMUNIFORM4UI64VARB
 	gpProgramUniform4ui64vNV                                 C.GPPROGRAMUNIFORM4UI64VNV
 	gpProgramUniform4uiEXT                                   C.GPPROGRAMUNIFORM4UIEXT
 	gpProgramUniform4uiv                                     C.GPPROGRAMUNIFORM4UIV
@@ -17760,6 +18662,8 @@ var (
 	gpQueryCounter                                           C.GPQUERYCOUNTER
 	gpQueryMatrixxOES                                        C.GPQUERYMATRIXXOES
 	gpQueryObjectParameteruiAMD                              C.GPQUERYOBJECTPARAMETERUIAMD
+	gpQueryResourceNV                                        C.GPQUERYRESOURCENV
+	gpQueryResourceTagNV                                     C.GPQUERYRESOURCETAGNV
 	gpRasterPos2d                                            C.GPRASTERPOS2D
 	gpRasterPos2dv                                           C.GPRASTERPOS2DV
 	gpRasterPos2f                                            C.GPRASTERPOS2F
@@ -17790,6 +18694,7 @@ var (
 	gpRasterPos4sv                                           C.GPRASTERPOS4SV
 	gpRasterPos4xOES                                         C.GPRASTERPOS4XOES
 	gpRasterPos4xvOES                                        C.GPRASTERPOS4XVOES
+	gpRasterSamplesEXT                                       C.GPRASTERSAMPLESEXT
 	gpReadBuffer                                             C.GPREADBUFFER
 	gpReadInstrumentsSGIX                                    C.GPREADINSTRUMENTSSGIX
 	gpReadPixels                                             C.GPREADPIXELS
@@ -17807,7 +18712,9 @@ var (
 	gpRectxOES                                               C.GPRECTXOES
 	gpRectxvOES                                              C.GPRECTXVOES
 	gpReferencePlaneSGIX                                     C.GPREFERENCEPLANESGIX
+	gpReleaseKeyedMutexWin32EXT                              C.GPRELEASEKEYEDMUTEXWIN32EXT
 	gpReleaseShaderCompiler                                  C.GPRELEASESHADERCOMPILER
+	gpRenderGpuMaskNV                                        C.GPRENDERGPUMASKNV
 	gpRenderMode                                             C.GPRENDERMODE
 	gpRenderbufferStorage                                    C.GPRENDERBUFFERSTORAGE
 	gpRenderbufferStorageEXT                                 C.GPRENDERBUFFERSTORAGEEXT
@@ -17843,6 +18750,7 @@ var (
 	gpResetMinmax                                            C.GPRESETMINMAX
 	gpResetMinmaxEXT                                         C.GPRESETMINMAXEXT
 	gpResizeBuffersMESA                                      C.GPRESIZEBUFFERSMESA
+	gpResolveDepthValuesNV                                   C.GPRESOLVEDEPTHVALUESNV
 	gpResumeTransformFeedback                                C.GPRESUMETRANSFORMFEEDBACK
 	gpResumeTransformFeedbackNV                              C.GPRESUMETRANSFORMFEEDBACKNV
 	gpRotated                                                C.GPROTATED
@@ -17850,7 +18758,6 @@ var (
 	gpRotatexOES                                             C.GPROTATEXOES
 	gpSampleCoverage                                         C.GPSAMPLECOVERAGE
 	gpSampleCoverageARB                                      C.GPSAMPLECOVERAGEARB
-	gpSampleCoverageOES                                      C.GPSAMPLECOVERAGEOES
 	gpSampleCoveragexOES                                     C.GPSAMPLECOVERAGEXOES
 	gpSampleMapATI                                           C.GPSAMPLEMAPATI
 	gpSampleMaskEXT                                          C.GPSAMPLEMASKEXT
@@ -17914,6 +18821,7 @@ var (
 	gpSecondaryColorPointerListIBM                           C.GPSECONDARYCOLORPOINTERLISTIBM
 	gpSelectBuffer                                           C.GPSELECTBUFFER
 	gpSelectPerfMonitorCountersAMD                           C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpSemaphoreParameterui64vEXT                             C.GPSEMAPHOREPARAMETERUI64VEXT
 	gpSeparableFilter2D                                      C.GPSEPARABLEFILTER2D
 	gpSeparableFilter2DEXT                                   C.GPSEPARABLEFILTER2DEXT
 	gpSetFenceAPPLE                                          C.GPSETFENCEAPPLE
@@ -17931,11 +18839,16 @@ var (
 	gpShaderSourceARB                                        C.GPSHADERSOURCEARB
 	gpShaderStorageBlockBinding                              C.GPSHADERSTORAGEBLOCKBINDING
 	gpSharpenTexFuncSGIS                                     C.GPSHARPENTEXFUNCSGIS
+	gpSignalSemaphoreEXT                                     C.GPSIGNALSEMAPHOREEXT
+	gpSignalVkFenceNV                                        C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                                    C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                                    C.GPSPECIALIZESHADERARB
 	gpSpriteParameterfSGIX                                   C.GPSPRITEPARAMETERFSGIX
 	gpSpriteParameterfvSGIX                                  C.GPSPRITEPARAMETERFVSGIX
 	gpSpriteParameteriSGIX                                   C.GPSPRITEPARAMETERISGIX
 	gpSpriteParameterivSGIX                                  C.GPSPRITEPARAMETERIVSGIX
 	gpStartInstrumentsSGIX                                   C.GPSTARTINSTRUMENTSSGIX
+	gpStateCaptureNV                                         C.GPSTATECAPTURENV
 	gpStencilClearTagEXT                                     C.GPSTENCILCLEARTAGEXT
 	gpStencilFillPathInstancedNV                             C.GPSTENCILFILLPATHINSTANCEDNV
 	gpStencilFillPathNV                                      C.GPSTENCILFILLPATHNV
@@ -17956,6 +18869,7 @@ var (
 	gpStencilThenCoverStrokePathNV                           C.GPSTENCILTHENCOVERSTROKEPATHNV
 	gpStopInstrumentsSGIX                                    C.GPSTOPINSTRUMENTSSGIX
 	gpStringMarkerGREMEDY                                    C.GPSTRINGMARKERGREMEDY
+	gpSubpixelPrecisionBiasNV                                C.GPSUBPIXELPRECISIONBIASNV
 	gpSwizzleEXT                                             C.GPSWIZZLEEXT
 	gpSyncTextureINTEL                                       C.GPSYNCTEXTUREINTEL
 	gpTagSampleBufferSGIX                                    C.GPTAGSAMPLEBUFFERSGIX
@@ -18106,6 +19020,11 @@ var (
 	gpTexStorage2DMultisample                                C.GPTEXSTORAGE2DMULTISAMPLE
 	gpTexStorage3D                                           C.GPTEXSTORAGE3D
 	gpTexStorage3DMultisample                                C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexStorageMem1DEXT                                     C.GPTEXSTORAGEMEM1DEXT
+	gpTexStorageMem2DEXT                                     C.GPTEXSTORAGEMEM2DEXT
+	gpTexStorageMem2DMultisampleEXT                          C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT
+	gpTexStorageMem3DEXT                                     C.GPTEXSTORAGEMEM3DEXT
+	gpTexStorageMem3DMultisampleEXT                          C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT
 	gpTexStorageSparseAMD                                    C.GPTEXSTORAGESPARSEAMD
 	gpTexSubImage1D                                          C.GPTEXSUBIMAGE1D
 	gpTexSubImage1DEXT                                       C.GPTEXSUBIMAGE1DEXT
@@ -18156,6 +19075,11 @@ var (
 	gpTextureStorage3DEXT                                    C.GPTEXTURESTORAGE3DEXT
 	gpTextureStorage3DMultisample                            C.GPTEXTURESTORAGE3DMULTISAMPLE
 	gpTextureStorage3DMultisampleEXT                         C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureStorageMem1DEXT                                 C.GPTEXTURESTORAGEMEM1DEXT
+	gpTextureStorageMem2DEXT                                 C.GPTEXTURESTORAGEMEM2DEXT
+	gpTextureStorageMem2DMultisampleEXT                      C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT
+	gpTextureStorageMem3DEXT                                 C.GPTEXTURESTORAGEMEM3DEXT
+	gpTextureStorageMem3DMultisampleEXT                      C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT
 	gpTextureStorageSparseAMD                                C.GPTEXTURESTORAGESPARSEAMD
 	gpTextureSubImage1D                                      C.GPTEXTURESUBIMAGE1D
 	gpTextureSubImage1DEXT                                   C.GPTEXTURESUBIMAGE1DEXT
@@ -18183,13 +19107,17 @@ var (
 	gpUniform1fv                                             C.GPUNIFORM1FV
 	gpUniform1fvARB                                          C.GPUNIFORM1FVARB
 	gpUniform1i                                              C.GPUNIFORM1I
+	gpUniform1i64ARB                                         C.GPUNIFORM1I64ARB
 	gpUniform1i64NV                                          C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                        C.GPUNIFORM1I64VARB
 	gpUniform1i64vNV                                         C.GPUNIFORM1I64VNV
 	gpUniform1iARB                                           C.GPUNIFORM1IARB
 	gpUniform1iv                                             C.GPUNIFORM1IV
 	gpUniform1ivARB                                          C.GPUNIFORM1IVARB
 	gpUniform1ui                                             C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                        C.GPUNIFORM1UI64ARB
 	gpUniform1ui64NV                                         C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                                       C.GPUNIFORM1UI64VARB
 	gpUniform1ui64vNV                                        C.GPUNIFORM1UI64VNV
 	gpUniform1uiEXT                                          C.GPUNIFORM1UIEXT
 	gpUniform1uiv                                            C.GPUNIFORM1UIV
@@ -18201,13 +19129,17 @@ var (
 	gpUniform2fv                                             C.GPUNIFORM2FV
 	gpUniform2fvARB                                          C.GPUNIFORM2FVARB
 	gpUniform2i                                              C.GPUNIFORM2I
+	gpUniform2i64ARB                                         C.GPUNIFORM2I64ARB
 	gpUniform2i64NV                                          C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                        C.GPUNIFORM2I64VARB
 	gpUniform2i64vNV                                         C.GPUNIFORM2I64VNV
 	gpUniform2iARB                                           C.GPUNIFORM2IARB
 	gpUniform2iv                                             C.GPUNIFORM2IV
 	gpUniform2ivARB                                          C.GPUNIFORM2IVARB
 	gpUniform2ui                                             C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                        C.GPUNIFORM2UI64ARB
 	gpUniform2ui64NV                                         C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                                       C.GPUNIFORM2UI64VARB
 	gpUniform2ui64vNV                                        C.GPUNIFORM2UI64VNV
 	gpUniform2uiEXT                                          C.GPUNIFORM2UIEXT
 	gpUniform2uiv                                            C.GPUNIFORM2UIV
@@ -18219,13 +19151,17 @@ var (
 	gpUniform3fv                                             C.GPUNIFORM3FV
 	gpUniform3fvARB                                          C.GPUNIFORM3FVARB
 	gpUniform3i                                              C.GPUNIFORM3I
+	gpUniform3i64ARB                                         C.GPUNIFORM3I64ARB
 	gpUniform3i64NV                                          C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                        C.GPUNIFORM3I64VARB
 	gpUniform3i64vNV                                         C.GPUNIFORM3I64VNV
 	gpUniform3iARB                                           C.GPUNIFORM3IARB
 	gpUniform3iv                                             C.GPUNIFORM3IV
 	gpUniform3ivARB                                          C.GPUNIFORM3IVARB
 	gpUniform3ui                                             C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                        C.GPUNIFORM3UI64ARB
 	gpUniform3ui64NV                                         C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                                       C.GPUNIFORM3UI64VARB
 	gpUniform3ui64vNV                                        C.GPUNIFORM3UI64VNV
 	gpUniform3uiEXT                                          C.GPUNIFORM3UIEXT
 	gpUniform3uiv                                            C.GPUNIFORM3UIV
@@ -18237,13 +19173,17 @@ var (
 	gpUniform4fv                                             C.GPUNIFORM4FV
 	gpUniform4fvARB                                          C.GPUNIFORM4FVARB
 	gpUniform4i                                              C.GPUNIFORM4I
+	gpUniform4i64ARB                                         C.GPUNIFORM4I64ARB
 	gpUniform4i64NV                                          C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                        C.GPUNIFORM4I64VARB
 	gpUniform4i64vNV                                         C.GPUNIFORM4I64VNV
 	gpUniform4iARB                                           C.GPUNIFORM4IARB
 	gpUniform4iv                                             C.GPUNIFORM4IV
 	gpUniform4ivARB                                          C.GPUNIFORM4IVARB
 	gpUniform4ui                                             C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                        C.GPUNIFORM4UI64ARB
 	gpUniform4ui64NV                                         C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                                       C.GPUNIFORM4UI64VARB
 	gpUniform4ui64vNV                                        C.GPUNIFORM4UI64VNV
 	gpUniform4uiEXT                                          C.GPUNIFORM4UIEXT
 	gpUniform4uiv                                            C.GPUNIFORM4UIV
@@ -18670,7 +19610,11 @@ var (
 	gpViewportArrayv                                         C.GPVIEWPORTARRAYV
 	gpViewportIndexedf                                       C.GPVIEWPORTINDEXEDF
 	gpViewportIndexedfv                                      C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                               C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                                      C.GPVIEWPORTSWIZZLENV
+	gpWaitSemaphoreEXT                                       C.GPWAITSEMAPHOREEXT
 	gpWaitSync                                               C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                                      C.GPWAITVKSEMAPHORENV
 	gpWeightPathsNV                                          C.GPWEIGHTPATHSNV
 	gpWeightPointerARB                                       C.GPWEIGHTPOINTERARB
 	gpWeightbvARB                                            C.GPWEIGHTBVARB
@@ -18737,6 +19681,7 @@ var (
 	gpWindowPos4ivMESA                                       C.GPWINDOWPOS4IVMESA
 	gpWindowPos4sMESA                                        C.GPWINDOWPOS4SMESA
 	gpWindowPos4svMESA                                       C.GPWINDOWPOS4SVMESA
+	gpWindowRectanglesEXT                                    C.GPWINDOWRECTANGLESEXT
 	gpWriteMaskEXT                                           C.GPWRITEMASKEXT
 )
 
@@ -18754,6 +19699,10 @@ func Accum(op uint32, value float32) {
 }
 func AccumxOES(op uint32, value int32) {
 	C.glowAccumxOES(gpAccumxOES, (C.GLenum)(op), (C.GLfixed)(value))
+}
+func AcquireKeyedMutexWin32EXT(memory uint32, key uint64, timeout uint32) bool {
+	ret := C.glowAcquireKeyedMutexWin32EXT(gpAcquireKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key), (C.GLuint)(timeout))
+	return ret == TRUE
 }
 func ActiveProgramEXT(program uint32) {
 	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
@@ -18796,6 +19745,12 @@ func AlphaFunc(xfunc uint32, ref float32) {
 }
 func AlphaFuncxOES(xfunc uint32, ref int32) {
 	C.glowAlphaFuncxOES(gpAlphaFuncxOES, (C.GLenum)(xfunc), (C.GLfixed)(ref))
+}
+func AlphaToCoverageDitherControlNV(mode uint32) {
+	C.glowAlphaToCoverageDitherControlNV(gpAlphaToCoverageDitherControlNV, (C.GLenum)(mode))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 func ApplyTextureEXT(mode uint32) {
 	C.glowApplyTextureEXT(gpApplyTextureEXT, (C.GLenum)(mode))
@@ -19244,8 +20199,8 @@ func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 func BufferDataARB(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferDataARB(gpBufferDataARB, (C.GLenum)(target), (C.GLsizeiptrARB)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 	C.glowBufferParameteriAPPLE(gpBufferParameteriAPPLE, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
@@ -19255,6 +20210,12 @@ func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowBufferStorage(gpBufferStorage, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func BufferStorageExternalEXT(target uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowBufferStorageExternalEXT(gpBufferStorageExternalEXT, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func BufferStorageMemEXT(target uint32, size int, memory uint32, offset uint64) {
+	C.glowBufferStorageMemEXT(gpBufferStorageMemEXT, (C.GLenum)(target), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
@@ -19262,6 +20223,9 @@ func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 }
 func BufferSubDataARB(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubDataARB(gpBufferSubDataARB, (C.GLenum)(target), (C.GLintptrARB)(offset), (C.GLsizeiptrARB)(size), data)
+}
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
 }
 
 // execute a display list
@@ -19358,6 +20322,8 @@ func ClearDepth(depth float64) {
 func ClearDepthdNV(depth float64) {
 	C.glowClearDepthdNV(gpClearDepthdNV, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -19382,14 +20348,14 @@ func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32
 }
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
 func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -19431,7 +20397,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -19699,6 +20665,12 @@ func CombinerParameterivNV(pname uint32, params *int32) {
 func CombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowCombinerStageParameterfvNV(gpCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
+}
 
 // Compiles a shader object
 func CompileShader(shader uint32) {
@@ -19809,6 +20781,12 @@ func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yof
 func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // define a one-dimensional convolution filter
 func ConvolutionFilter1D(target uint32, internalformat uint32, width int32, format uint32, xtype uint32, image unsafe.Pointer) {
@@ -19917,8 +20895,8 @@ func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffs
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 func CopyPathNV(resultPath uint32, srcPath uint32) {
 	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
@@ -20010,15 +20988,27 @@ func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsaf
 func CoverStrokePathNV(path uint32, coverMode uint32) {
 	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
 }
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreateMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowCreateMemoryObjectsEXT(gpCreateMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
 	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
@@ -20077,9 +21067,12 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -20175,6 +21168,9 @@ func DeleteBuffers(n int32, buffers *uint32) {
 func DeleteBuffersARB(n int32, buffers *uint32) {
 	C.glowDeleteBuffersARB(gpDeleteBuffersARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 func DeleteFencesAPPLE(n int32, fences *uint32) {
 	C.glowDeleteFencesAPPLE(gpDeleteFencesAPPLE, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(fences)))
 }
@@ -20196,6 +21192,9 @@ func DeleteFramebuffersEXT(n int32, framebuffers *uint32) {
 // delete a contiguous group of display lists
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
+}
+func DeleteMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowDeleteMemoryObjectsEXT(gpDeleteMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
@@ -20245,6 +21244,9 @@ func DeleteQueries(n int32, ids *uint32) {
 func DeleteQueriesARB(n int32, ids *uint32) {
 	C.glowDeleteQueriesARB(gpDeleteQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func DeleteQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowDeleteQueryResourceTagNV(gpDeleteQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // delete renderbuffer objects
 func DeleteRenderbuffers(n int32, renderbuffers *uint32) {
@@ -20258,14 +21260,20 @@ func DeleteRenderbuffersEXT(n int32, renderbuffers *uint32) {
 func DeleteSamplers(count int32, samplers *uint32) {
 	C.glowDeleteSamplers(gpDeleteSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
 }
+func DeleteSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowDeleteSemaphoresEXT(gpDeleteSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
+}
 
 // Deletes a shader object
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -20327,6 +21335,8 @@ func DepthRangeIndexed(index uint32, n float64, f float64) {
 func DepthRangedNV(zNear float64, zFar float64) {
 	C.glowDepthRangedNV(gpDepthRangedNV, (C.GLdouble)(zNear), (C.GLdouble)(zFar))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -20448,6 +21458,18 @@ func DrawBuffersARB(n int32, bufs *uint32) {
 func DrawBuffersATI(n int32, bufs *uint32) {
 	C.glowDrawBuffersATI(gpDrawBuffersATI, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 func DrawElementArrayAPPLE(mode uint32, first int32, count int32) {
 	C.glowDrawElementArrayAPPLE(gpDrawElementArrayAPPLE, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count))
 }
@@ -20547,6 +21569,9 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 // render multiple instances of primitives using a count derived from a specifed stream of a transform feedback object
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
+}
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
 }
 
 // flag edges as either boundary or nonboundary
@@ -20725,6 +21750,9 @@ func EvalPoint1(i int32) {
 func EvalPoint2(i int32, j int32) {
 	C.glowEvalPoint2(gpEvalPoint2, (C.GLint)(i), (C.GLint)(j))
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 func ExecuteProgramNV(target uint32, id uint32, params *float32) {
 	C.glowExecuteProgramNV(gpExecuteProgramNV, (C.GLenum)(target), (C.GLuint)(id), (*C.GLfloat)(unsafe.Pointer(params)))
 }
@@ -20741,9 +21769,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -20784,8 +21812,8 @@ func FlushMappedBufferRangeAPPLE(target uint32, offset int, size int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
 }
 func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
 	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
@@ -20873,6 +21901,9 @@ func FogxvOES(pname uint32, param *int32) {
 func FragmentColorMaterialSGIX(face uint32, mode uint32) {
 	C.glowFragmentColorMaterialSGIX(gpFragmentColorMaterialSGIX, (C.GLenum)(face), (C.GLenum)(mode))
 }
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
 func FragmentLightModelfSGIX(pname uint32, param float32) {
 	C.glowFragmentLightModelfSGIX(gpFragmentLightModelfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -20921,6 +21952,9 @@ func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
 func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
 	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
+}
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
@@ -20937,6 +21971,15 @@ func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarge
 func FramebufferRenderbufferEXT(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbufferEXT(gpFramebufferRenderbufferEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSamplePositionsfvAMD(target uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowFramebufferSamplePositionsfvAMD(gpFramebufferSamplePositionsfvAMD, (C.GLenum)(target), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
 func FramebufferTexture(target uint32, attachment uint32, texture uint32, level int32) {
@@ -20948,6 +21991,8 @@ func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, te
 func FramebufferTexture1DEXT(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1DEXT(gpFramebufferTexture1DEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
@@ -20982,6 +22027,9 @@ func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32
 }
 func FramebufferTextureLayerEXT(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayerEXT(gpFramebufferTextureLayerEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 func FreeObjectBufferATI(buffer uint32) {
 	C.glowFreeObjectBufferATI(gpFreeObjectBufferATI, (C.GLuint)(buffer))
@@ -21073,6 +22121,9 @@ func GenQueries(n int32, ids *uint32) {
 func GenQueriesARB(n int32, ids *uint32) {
 	C.glowGenQueriesARB(gpGenQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func GenQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowGenQueryResourceTagNV(gpGenQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // generate renderbuffer object names
 func GenRenderbuffers(n int32, renderbuffers *uint32) {
@@ -21085,6 +22136,9 @@ func GenRenderbuffersEXT(n int32, renderbuffers *uint32) {
 // generate sampler object names
 func GenSamplers(count int32, samplers *uint32) {
 	C.glowGenSamplers(gpGenSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
+}
+func GenSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowGenSemaphoresEXT(gpGenSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
 }
 func GenSymbolsEXT(datatype uint32, storagetype uint32, xrange uint32, components uint32) uint32 {
 	ret := C.glowGenSymbolsEXT(gpGenSymbolsEXT, (C.GLenum)(datatype), (C.GLenum)(storagetype), (C.GLenum)(xrange), (C.GLuint)(components))
@@ -21176,6 +22230,8 @@ func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, leng
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21312,6 +22368,10 @@ func GetCombinerOutputParameterivNV(stage uint32, portion uint32, pname uint32, 
 func GetCombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowGetCombinerStageParameterfvNV(gpGetCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
 func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
 	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
@@ -21358,6 +22418,9 @@ func GetConvolutionParameterivEXT(target uint32, pname uint32, params *int32) {
 }
 func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 	C.glowGetConvolutionParameterxvOES(gpGetConvolutionParameterxvOES, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -21457,15 +22520,18 @@ func GetFragmentMaterialivSGIX(face uint32, pname uint32, params *int32) {
 	C.glowGetFragmentMaterialivSGIX(gpGetFragmentMaterialivSGIX, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetFramebufferAttachmentParameterivEXT(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameterivEXT(gpGetFramebufferAttachmentParameterivEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetFramebufferParameterfvAMD(target uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetFramebufferParameterfvAMD(gpGetFramebufferParameterfvAMD, (C.GLenum)(target), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21555,9 +22621,14 @@ func GetIntegerui64vNV(value uint32, result *uint64) {
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21635,6 +22706,9 @@ func GetMaterialxOES(face uint32, pname uint32, param int32) {
 }
 func GetMaterialxvOES(face uint32, pname uint32, params *int32) {
 	C.glowGetMaterialxvOES(gpGetMaterialxvOES, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetMemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowGetMemoryObjectParameterivEXT(gpGetMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // get minimum and maximum pixel values
@@ -21726,8 +22800,8 @@ func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Point
 }
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -21739,6 +22813,9 @@ func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uin
 }
 func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedFramebufferParameterfvAMD(framebuffer uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetNamedFramebufferParameterfvAMD(gpGetNamedFramebufferParameterfvAMD, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 
 // query a named parameter of a framebuffer object
@@ -22054,6 +23131,18 @@ func GetProgramivARB(target uint32, pname uint32, params *int32) {
 func GetProgramivNV(id uint32, pname uint32, params *int32) {
 	C.glowGetProgramivNV(gpGetProgramivNV, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
 
 // return parameters of an indexed query object target
 func GetQueryIndexediv(target uint32, index uint32, pname uint32, params *int32) {
@@ -22077,6 +23166,8 @@ func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 func GetQueryObjectui64vEXT(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64vEXT(gpGetQueryObjectui64vEXT, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -22092,7 +23183,7 @@ func GetQueryivARB(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryivARB(gpGetQueryivARB, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -22110,6 +23201,9 @@ func GetSamplerParameterfv(sampler uint32, pname uint32, params *float32) {
 }
 func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 	C.glowGetSamplerParameteriv(gpGetSamplerParameteriv, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetSemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowGetSemaphoreParameterui64vEXT(gpGetSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 
 // get separable convolution filter kernel images
@@ -22145,6 +23239,10 @@ func GetShaderiv(shader uint32, pname uint32, params *int32) {
 func GetSharpenTexFuncSGIS(target uint32, points *float32) {
 	C.glowGetSharpenTexFuncSGIS(gpGetSharpenTexFuncSGIS, (C.GLenum)(target), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -22169,7 +23267,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -22373,6 +23471,9 @@ func GetUniformfv(program uint32, location int32, params *float32) {
 func GetUniformfvARB(programObj uintptr, location int32, params *float32) {
 	C.glowGetUniformfvARB(gpGetUniformfvARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetUniformi64vNV(program uint32, location int32, params *int64) {
 	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
 }
@@ -22384,6 +23485,9 @@ func GetUniformiv(program uint32, location int32, params *int32) {
 func GetUniformivARB(programObj uintptr, location int32, params *int32) {
 	C.glowGetUniformivARB(gpGetUniformivARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 func GetUniformui64vNV(program uint32, location int32, params *uint64) {
 	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
@@ -22392,6 +23496,12 @@ func GetUniformuiv(program uint32, location int32, params *uint32) {
 }
 func GetUniformuivEXT(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuivEXT(gpGetUniformuivEXT, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetUnsignedBytei_vEXT(target uint32, index uint32, data *uint8) {
+	C.glowGetUnsignedBytei_vEXT(gpGetUnsignedBytei_vEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLubyte)(unsafe.Pointer(data)))
+}
+func GetUnsignedBytevEXT(pname uint32, data *uint8) {
+	C.glowGetUnsignedBytevEXT(gpGetUnsignedBytevEXT, (C.GLenum)(pname), (*C.GLubyte)(unsafe.Pointer(data)))
 }
 func GetVariantArrayObjectfvATI(id uint32, pname uint32, params *float32) {
 	C.glowGetVariantArrayObjectfvATI(gpGetVariantArrayObjectfvATI, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
@@ -22545,6 +23655,10 @@ func GetVideoui64vNV(video_slot uint32, pname uint32, params *uint64) {
 func GetVideouivNV(video_slot uint32, pname uint32, params *uint32) {
 	C.glowGetVideouivNV(gpGetVideouivNV, (C.GLuint)(video_slot), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
+}
 func GetnColorTableARB(target uint32, format uint32, xtype uint32, bufSize int32, table unsafe.Pointer) {
 	C.glowGetnColorTableARB(gpGetnColorTableARB, (C.GLenum)(target), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), table)
 }
@@ -22599,6 +23713,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -22607,6 +23724,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -22672,9 +23792,27 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportMemoryFdEXT(memory uint32, size uint64, handleType uint32, fd int32) {
+	C.glowImportMemoryFdEXT(gpImportMemoryFdEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportMemoryWin32HandleEXT(memory uint32, size uint64, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportMemoryWin32HandleEXT(gpImportMemoryWin32HandleEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), handle)
+}
+func ImportMemoryWin32NameEXT(memory uint32, size uint64, handleType uint32, name unsafe.Pointer) {
+	C.glowImportMemoryWin32NameEXT(gpImportMemoryWin32NameEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), name)
+}
+func ImportSemaphoreFdEXT(semaphore uint32, handleType uint32, fd int32) {
+	C.glowImportSemaphoreFdEXT(gpImportSemaphoreFdEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportSemaphoreWin32HandleEXT(semaphore uint32, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportSemaphoreWin32HandleEXT(gpImportSemaphoreWin32HandleEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), handle)
+}
+func ImportSemaphoreWin32NameEXT(semaphore uint32, handleType uint32, name unsafe.Pointer) {
+	C.glowImportSemaphoreWin32NameEXT(gpImportSemaphoreWin32NameEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), name)
+}
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -22817,6 +23955,10 @@ func IsBufferResidentNV(target uint32) bool {
 	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
 	return ret == TRUE
 }
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
 	return ret == TRUE
@@ -22859,6 +24001,10 @@ func IsImageHandleResidentNV(handle uint64) bool {
 // determine if a name corresponds to a display list
 func IsList(list uint32) bool {
 	ret := C.glowIsList(gpIsList, (C.GLuint)(list))
+	return ret == TRUE
+}
+func IsMemoryObjectEXT(memoryObject uint32) bool {
+	ret := C.glowIsMemoryObjectEXT(gpIsMemoryObjectEXT, (C.GLuint)(memoryObject))
 	return ret == TRUE
 }
 func IsNameAMD(identifier uint32, name uint32) bool {
@@ -22943,15 +24089,23 @@ func IsSampler(sampler uint32) bool {
 	ret := C.glowIsSampler(gpIsSampler, (C.GLuint)(sampler))
 	return ret == TRUE
 }
+func IsSemaphoreEXT(semaphore uint32) bool {
+	ret := C.glowIsSemaphoreEXT(gpIsSemaphoreEXT, (C.GLuint)(semaphore))
+	return ret == TRUE
+}
 
 // Determines if a name corresponds to a shader object
 func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -23000,6 +24154,15 @@ func IsVertexArrayAPPLE(array uint32) bool {
 func IsVertexAttribEnabledAPPLE(index uint32, pname uint32) bool {
 	ret := C.glowIsVertexAttribEnabledAPPLE(gpIsVertexAttribEnabledAPPLE, (C.GLuint)(index), (C.GLenum)(pname))
 	return ret == TRUE
+}
+func LGPUCopyImageSubDataNVX(sourceGpu uint32, destinationGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srxY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, width int32, height int32, depth int32) {
+	C.glowLGPUCopyImageSubDataNVX(gpLGPUCopyImageSubDataNVX, (C.GLuint)(sourceGpu), (C.GLbitfield)(destinationGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srxY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func LGPUInterlockNVX() {
+	C.glowLGPUInterlockNVX(gpLGPUInterlockNVX)
+}
+func LGPUNamedBufferSubDataNVX(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowLGPUNamedBufferSubDataNVX(gpLGPUNamedBufferSubDataNVX, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
@@ -23068,6 +24231,9 @@ func LinkProgramARB(programObj uintptr) {
 // set the display-list base for
 func ListBase(base uint32) {
 	C.glowListBase(gpListBase, (C.GLuint)(base))
+}
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 func ListParameterfSGIX(list uint32, pname uint32, param float32) {
 	C.glowListParameterfSGIX(gpListParameterfSGIX, (C.GLuint)(list), (C.GLenum)(pname), (C.GLfloat)(param))
@@ -23232,8 +24398,8 @@ func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
 }
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
 }
 func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
@@ -23376,6 +24542,12 @@ func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
 func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
 	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
 }
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
+}
 
 // defines a barrier ordering memory transactions
 func MemoryBarrier(barriers uint32) {
@@ -23386,6 +24558,9 @@ func MemoryBarrierByRegion(barriers uint32) {
 }
 func MemoryBarrierEXT(barriers uint32) {
 	C.glowMemoryBarrierEXT(gpMemoryBarrierEXT, (C.GLbitfield)(barriers))
+}
+func MemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowMemoryObjectParameterivEXT(gpMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // specifies minimum rate at which sample shaing takes place
@@ -23449,8 +24624,8 @@ func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer
 func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawElementArrayAPPLE(mode uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawElementArrayAPPLE(gpMultiDrawElementArrayAPPLE, (C.GLenum)(mode), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -23482,8 +24657,8 @@ func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirec
 func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawRangeElementArrayAPPLE(mode uint32, start uint32, end uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawRangeElementArrayAPPLE(gpMultiDrawRangeElementArrayAPPLE, (C.GLenum)(mode), (C.GLuint)(start), (C.GLuint)(end), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -23857,32 +25032,71 @@ func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset i
 func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func MulticastBarrierNV() {
+	C.glowMulticastBarrierNV(gpMulticastBarrierNV)
+}
+func MulticastBlitFramebufferNV(srcGpu uint32, dstGpu uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
+	C.glowMulticastBlitFramebufferNV(gpMulticastBlitFramebufferNV, (C.GLuint)(srcGpu), (C.GLuint)(dstGpu), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
+}
+func MulticastBufferSubDataNV(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowMulticastBufferSubDataNV(gpMulticastBufferSubDataNV, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func MulticastCopyBufferSubDataNV(readGpu uint32, writeGpuMask uint32, readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowMulticastCopyBufferSubDataNV(gpMulticastCopyBufferSubDataNV, (C.GLuint)(readGpu), (C.GLbitfield)(writeGpuMask), (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func MulticastCopyImageSubDataNV(srcGpu uint32, dstGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
+	C.glowMulticastCopyImageSubDataNV(gpMulticastCopyImageSubDataNV, (C.GLuint)(srcGpu), (C.GLbitfield)(dstGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
+}
+func MulticastFramebufferSampleLocationsfvNV(gpu uint32, framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowMulticastFramebufferSampleLocationsfvNV(gpMulticastFramebufferSampleLocationsfvNV, (C.GLuint)(gpu), (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func MulticastGetQueryObjecti64vNV(gpu uint32, id uint32, pname uint32, params *int64) {
+	C.glowMulticastGetQueryObjecti64vNV(gpMulticastGetQueryObjecti64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectivNV(gpu uint32, id uint32, pname uint32, params *int32) {
+	C.glowMulticastGetQueryObjectivNV(gpMulticastGetQueryObjectivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectui64vNV(gpu uint32, id uint32, pname uint32, params *uint64) {
+	C.glowMulticastGetQueryObjectui64vNV(gpMulticastGetQueryObjectui64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectuivNV(gpu uint32, id uint32, pname uint32, params *uint32) {
+	C.glowMulticastGetQueryObjectuivNV(gpMulticastGetQueryObjectuivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MulticastWaitSyncNV(signalGpu uint32, waitGpuMask uint32) {
+	C.glowMulticastWaitSyncNV(gpMulticastWaitSyncNV, (C.GLuint)(signalGpu), (C.GLbitfield)(waitGpuMask))
+}
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
 func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func NamedBufferStorageExternalEXT(buffer uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowNamedBufferStorageExternalEXT(gpNamedBufferStorageExternalEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func NamedBufferStorageMemEXT(buffer uint32, size int, memory uint32, offset uint64) {
+	C.glowNamedBufferStorageMemEXT(gpNamedBufferStorageMemEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -23920,6 +25134,15 @@ func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderb
 }
 func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSamplePositionsfvAMD(framebuffer uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowNamedFramebufferSamplePositionsfvAMD(gpNamedFramebufferSamplePositionsfvAMD, (C.GLuint)(framebuffer), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
@@ -24170,6 +25393,8 @@ func PassThroughxOES(token int32) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -24265,6 +25490,8 @@ func PixelMapx(xmap uint32, size int32, values *int32) {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
 }
@@ -24387,6 +25614,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 func PolygonOffsetEXT(factor float32, bias float32) {
 	C.glowPolygonOffsetEXT(gpPolygonOffsetEXT, (C.GLfloat)(factor), (C.GLfloat)(bias))
 }
@@ -24426,6 +25659,9 @@ func PresentFrameDualFillNV(video_slot uint32, minPresentTime uint64, beginPrese
 }
 func PresentFrameKeyedNV(video_slot uint32, minPresentTime uint64, beginPresentTimeId uint32, presentDurationId uint32, xtype uint32, target0 uint32, fill0 uint32, key0 uint32, target1 uint32, fill1 uint32, key1 uint32) {
 	C.glowPresentFrameKeyedNV(gpPresentFrameKeyedNV, (C.GLuint)(video_slot), (C.GLuint64EXT)(minPresentTime), (C.GLuint)(beginPresentTimeId), (C.GLuint)(presentDurationId), (C.GLenum)(xtype), (C.GLenum)(target0), (C.GLuint)(fill0), (C.GLuint)(key0), (C.GLenum)(target1), (C.GLuint)(fill1), (C.GLuint)(key1))
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -24553,6 +25789,8 @@ func ProgramParameter4fNV(target uint32, index uint32, x float32, y float32, z f
 func ProgramParameter4fvNV(target uint32, index uint32, v *float32) {
 	C.glowProgramParameter4fvNV(gpProgramParameter4fvNV, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -24610,8 +25848,14 @@ func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
 func ProgramUniform1i64NV(program uint32, location int32, x int64) {
 	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24632,8 +25876,14 @@ func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
 func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
 	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24682,8 +25932,14 @@ func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
 	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24704,8 +25960,14 @@ func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
 	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24754,8 +26016,14 @@ func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
 	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24776,8 +26044,14 @@ func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
 	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24826,8 +26100,14 @@ func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
 	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24848,8 +26128,14 @@ func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -25059,12 +26345,21 @@ func PushName(name uint32) {
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
 }
+
+// return the values of the current matrix
 func QueryMatrixxOES(mantissa *int32, exponent *int32) uint32 {
 	ret := C.glowQueryMatrixxOES(gpQueryMatrixxOES, (*C.GLfixed)(unsafe.Pointer(mantissa)), (*C.GLint)(unsafe.Pointer(exponent)))
 	return (uint32)(ret)
 }
 func QueryObjectParameteruiAMD(target uint32, id uint32, pname uint32, param uint32) {
 	C.glowQueryObjectParameteruiAMD(gpQueryObjectParameteruiAMD, (C.GLenum)(target), (C.GLuint)(id), (C.GLenum)(pname), (C.GLuint)(param))
+}
+func QueryResourceNV(queryType uint32, tagId int32, bufSize uint32, buffer *int32) int32 {
+	ret := C.glowQueryResourceNV(gpQueryResourceNV, (C.GLenum)(queryType), (C.GLint)(tagId), (C.GLuint)(bufSize), (*C.GLint)(unsafe.Pointer(buffer)))
+	return (int32)(ret)
+}
+func QueryResourceTagNV(tagId int32, tagString *uint8) {
+	C.glowQueryResourceTagNV(gpQueryResourceTagNV, (C.GLint)(tagId), (*C.GLchar)(unsafe.Pointer(tagString)))
 }
 func RasterPos2d(x float64, y float64) {
 	C.glowRasterPos2d(gpRasterPos2d, (C.GLdouble)(x), (C.GLdouble)(y))
@@ -25156,6 +26451,9 @@ func RasterPos4xOES(x int32, y int32, z int32, w int32) {
 func RasterPos4xvOES(coords *int32) {
 	C.glowRasterPos4xvOES(gpRasterPos4xvOES, (*C.GLfixed)(unsafe.Pointer(coords)))
 }
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // select a color buffer source for pixels
 func ReadBuffer(src uint32) {
@@ -25213,10 +26511,17 @@ func RectxvOES(v1 *int32, v2 *int32) {
 func ReferencePlaneSGIX(equation *float64) {
 	C.glowReferencePlaneSGIX(gpReferencePlaneSGIX, (*C.GLdouble)(unsafe.Pointer(equation)))
 }
+func ReleaseKeyedMutexWin32EXT(memory uint32, key uint64) bool {
+	ret := C.glowReleaseKeyedMutexWin32EXT(gpReleaseKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key))
+	return ret == TRUE
+}
 
 // release resources consumed by the implementation's shader compiler
 func ReleaseShaderCompiler() {
 	C.glowReleaseShaderCompiler(gpReleaseShaderCompiler)
+}
+func RenderGpuMaskNV(mask uint32) {
+	C.glowRenderGpuMaskNV(gpRenderGpuMaskNV, (C.GLbitfield)(mask))
 }
 
 // set rasterization mode
@@ -25334,6 +26639,9 @@ func ResetMinmaxEXT(target uint32) {
 func ResizeBuffersMESA() {
 	C.glowResizeBuffersMESA(gpResizeBuffersMESA)
 }
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
+}
 
 // resume transform feedback operations
 func ResumeTransformFeedback() {
@@ -25358,9 +26666,6 @@ func SampleCoverage(value float32, invert bool) {
 }
 func SampleCoverageARB(value float32, invert bool) {
 	C.glowSampleCoverageARB(gpSampleCoverageARB, (C.GLfloat)(value), (C.GLboolean)(boolToInt(invert)))
-}
-func SampleCoverageOES(value int32, invert bool) {
-	C.glowSampleCoverageOES(gpSampleCoverageOES, (C.GLfixed)(value), (C.GLboolean)(boolToInt(invert)))
 }
 func SampleCoveragexOES(value int32, invert bool) {
 	C.glowSampleCoveragexOES(gpSampleCoveragexOES, (C.GLclampx)(value), (C.GLboolean)(boolToInt(invert)))
@@ -25561,6 +26866,9 @@ func SelectBuffer(size int32, buffer *uint32) {
 func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
 	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
 }
+func SemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowSemaphoreParameterui64vEXT(gpSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 
 // define a separable two-dimensional convolution filter
 func SeparableFilter2D(target uint32, internalformat uint32, width int32, height int32, format uint32, xtype uint32, row unsafe.Pointer, column unsafe.Pointer) {
@@ -25622,6 +26930,18 @@ func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storage
 func SharpenTexFuncSGIS(target uint32, n int32, points *float32) {
 	C.glowSharpenTexFuncSGIS(gpSharpenTexFuncSGIS, (C.GLenum)(target), (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func SignalSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, dstLayouts *uint32) {
+	C.glowSignalSemaphoreEXT(gpSignalSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(dstLayouts)))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
 func SpriteParameterfSGIX(pname uint32, param float32) {
 	C.glowSpriteParameterfSGIX(gpSpriteParameterfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -25636,6 +26956,9 @@ func SpriteParameterivSGIX(pname uint32, params *int32) {
 }
 func StartInstrumentsSGIX() {
 	C.glowStartInstrumentsSGIX(gpStartInstrumentsSGIX)
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
 }
 func StencilClearTagEXT(stencilTagBits int32, stencilClearTag uint32) {
 	C.glowStencilClearTagEXT(gpStencilClearTagEXT, (C.GLsizei)(stencilTagBits), (C.GLuint)(stencilClearTag))
@@ -25708,6 +27031,9 @@ func StopInstrumentsSGIX(marker int32) {
 }
 func StringMarkerGREMEDY(len int32, xstring unsafe.Pointer) {
 	C.glowStringMarkerGREMEDY(gpStringMarkerGREMEDY, (C.GLsizei)(len), xstring)
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
 }
 func SwizzleEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowSwizzleEXT(gpSwizzleEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
@@ -26127,8 +27453,8 @@ func TexImage3DMultisampleCoverageNV(target uint32, coverageSamples int32, color
 func TexImage4DSGIS(target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, size4d int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTexImage4DSGIS(gpTexImage4DSGIS, (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(size4d), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -26188,6 +27514,21 @@ func TexStorage3D(target uint32, levels int32, internalformat uint32, width int3
 func TexStorage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexStorage3DMultisample(gpTexStorage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TexStorageMem1DEXT(target uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem1DEXT(gpTexStorageMem1DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DEXT(gpTexStorageMem2DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DMultisampleEXT(gpTexStorageMem2DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DEXT(gpTexStorageMem3DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DMultisampleEXT(gpTexStorageMem3DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TexStorageSparseAMD(target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTexStorageSparseAMD(gpTexStorageSparseAMD, (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -26236,8 +27577,8 @@ func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buff
 }
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
@@ -26275,8 +27616,8 @@ func TextureMaterialEXT(face uint32, mode uint32) {
 func TextureNormalEXT(mode uint32) {
 	C.glowTextureNormalEXT(gpTextureNormalEXT, (C.GLenum)(mode))
 }
-func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -26360,6 +27701,21 @@ func TextureStorage3DMultisample(texture uint32, samples int32, internalformat u
 func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorageMem1DEXT(texture uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem1DEXT(gpTextureStorageMem1DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DEXT(gpTextureStorageMem2DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DMultisampleEXT(gpTextureStorageMem2DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DEXT(gpTextureStorageMem3DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DMultisampleEXT(gpTextureStorageMem3DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TextureStorageSparseAMD(texture uint32, target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTextureStorageSparseAMD(gpTextureStorageSparseAMD, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -26405,8 +27761,8 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TransformFeedbackStreamAttribsNV(count int32, attribs *int32, nbuffers int32, bufstreams *int32, bufferMode uint32) {
 	C.glowTransformFeedbackStreamAttribsNV(gpTransformFeedbackStreamAttribsNV, (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(attribs)), (C.GLsizei)(nbuffers), (*C.GLint)(unsafe.Pointer(bufstreams)), (C.GLenum)(bufferMode))
@@ -26461,8 +27817,14 @@ func Uniform1fvARB(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
 func Uniform1i64NV(location int32, x int64) {
 	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform1i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26483,8 +27845,14 @@ func Uniform1ivARB(location int32, count int32, value *int32) {
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
 }
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
 func Uniform1ui64NV(location int32, x uint64) {
 	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform1ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26527,8 +27895,14 @@ func Uniform2fvARB(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func Uniform2i64NV(location int32, x int64, y int64) {
 	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform2i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26549,8 +27923,14 @@ func Uniform2ivARB(location int32, count int32, value *int32) {
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func Uniform2ui64NV(location int32, x uint64, y uint64) {
 	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform2ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26593,8 +27973,14 @@ func Uniform3fvARB(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func Uniform3i64NV(location int32, x int64, y int64, z int64) {
 	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform3i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26615,8 +28001,14 @@ func Uniform3ivARB(location int32, count int32, value *int32) {
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
 	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform3ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26659,8 +28051,14 @@ func Uniform4fvARB(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
 	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform4i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26681,8 +28079,14 @@ func Uniform4ivARB(location int32, count int32, value *int32) {
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform4ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -28028,10 +29432,22 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
+func WaitSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, srcLayouts *uint32) {
+	C.glowWaitSemaphoreEXT(gpWaitSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(srcLayouts)))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
 	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
@@ -28231,6 +29647,9 @@ func WindowPos4sMESA(x int16, y int16, z int16, w int16) {
 func WindowPos4svMESA(v *int16) {
 	C.glowWindowPos4svMESA(gpWindowPos4svMESA, (*C.GLshort)(unsafe.Pointer(v)))
 }
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
+}
 func WriteMaskEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowWriteMaskEXT(gpWriteMaskEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
 }
@@ -28267,6 +29686,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAccum")
 	}
 	gpAccumxOES = (C.GPACCUMXOES)(getProcAddr("glAccumxOES"))
+	gpAcquireKeyedMutexWin32EXT = (C.GPACQUIREKEYEDMUTEXWIN32EXT)(getProcAddr("glAcquireKeyedMutexWin32EXT"))
 	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
 	if gpActiveShaderProgram == nil {
@@ -28288,6 +29708,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAlphaFunc")
 	}
 	gpAlphaFuncxOES = (C.GPALPHAFUNCXOES)(getProcAddr("glAlphaFuncxOES"))
+	gpAlphaToCoverageDitherControlNV = (C.GPALPHATOCOVERAGEDITHERCONTROLNV)(getProcAddr("glAlphaToCoverageDitherControlNV"))
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpApplyTextureEXT = (C.GPAPPLYTEXTUREEXT)(getProcAddr("glApplyTextureEXT"))
 	gpAreProgramsResidentNV = (C.GPAREPROGRAMSRESIDENTNV)(getProcAddr("glAreProgramsResidentNV"))
 	gpAreTexturesResident = (C.GPARETEXTURESRESIDENT)(getProcAddr("glAreTexturesResident"))
@@ -28514,11 +29936,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpBufferPageCommitmentARB = (C.GPBUFFERPAGECOMMITMENTARB)(getProcAddr("glBufferPageCommitmentARB"))
 	gpBufferParameteriAPPLE = (C.GPBUFFERPARAMETERIAPPLE)(getProcAddr("glBufferParameteriAPPLE"))
 	gpBufferStorage = (C.GPBUFFERSTORAGE)(getProcAddr("glBufferStorage"))
+	gpBufferStorageExternalEXT = (C.GPBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glBufferStorageExternalEXT"))
+	gpBufferStorageMemEXT = (C.GPBUFFERSTORAGEMEMEXT)(getProcAddr("glBufferStorageMemEXT"))
 	gpBufferSubData = (C.GPBUFFERSUBDATA)(getProcAddr("glBufferSubData"))
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
 	gpBufferSubDataARB = (C.GPBUFFERSUBDATAARB)(getProcAddr("glBufferSubDataARB"))
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCallList = (C.GPCALLLIST)(getProcAddr("glCallList"))
 	if gpCallList == nil {
 		return errors.New("glCallList")
@@ -28820,6 +30245,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCombinerParameteriNV = (C.GPCOMBINERPARAMETERINV)(getProcAddr("glCombinerParameteriNV"))
 	gpCombinerParameterivNV = (C.GPCOMBINERPARAMETERIVNV)(getProcAddr("glCombinerParameterivNV"))
 	gpCombinerStageParameterfvNV = (C.GPCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glCombinerStageParameterfvNV"))
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
@@ -28871,6 +30298,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
 	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpConvolutionFilter1D = (C.GPCONVOLUTIONFILTER1D)(getProcAddr("glConvolutionFilter1D"))
 	gpConvolutionFilter1DEXT = (C.GPCONVOLUTIONFILTER1DEXT)(getProcAddr("glConvolutionFilter1DEXT"))
 	gpConvolutionFilter2D = (C.GPCONVOLUTIONFILTER2D)(getProcAddr("glConvolutionFilter2D"))
@@ -28947,8 +30376,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
 	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
 	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
+	gpCreateMemoryObjectsEXT = (C.GPCREATEMEMORYOBJECTSEXT)(getProcAddr("glCreateMemoryObjectsEXT"))
 	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
@@ -28970,6 +30403,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glCreateShaderProgramv")
 	}
 	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	gpCreateTransformFeedbacks = (C.GPCREATETRANSFORMFEEDBACKS)(getProcAddr("glCreateTransformFeedbacks"))
@@ -29002,6 +30436,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteBuffers")
 	}
 	gpDeleteBuffersARB = (C.GPDELETEBUFFERSARB)(getProcAddr("glDeleteBuffersARB"))
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFencesAPPLE = (C.GPDELETEFENCESAPPLE)(getProcAddr("glDeleteFencesAPPLE"))
 	gpDeleteFencesNV = (C.GPDELETEFENCESNV)(getProcAddr("glDeleteFencesNV"))
 	gpDeleteFragmentShaderATI = (C.GPDELETEFRAGMENTSHADERATI)(getProcAddr("glDeleteFragmentShaderATI"))
@@ -29014,6 +30449,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteLists == nil {
 		return errors.New("glDeleteLists")
 	}
+	gpDeleteMemoryObjectsEXT = (C.GPDELETEMEMORYOBJECTSEXT)(getProcAddr("glDeleteMemoryObjectsEXT"))
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
 	gpDeleteNamesAMD = (C.GPDELETENAMESAMD)(getProcAddr("glDeleteNamesAMD"))
 	gpDeleteObjectARB = (C.GPDELETEOBJECTARB)(getProcAddr("glDeleteObjectARB"))
@@ -29037,6 +30473,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteQueries")
 	}
 	gpDeleteQueriesARB = (C.GPDELETEQUERIESARB)(getProcAddr("glDeleteQueriesARB"))
+	gpDeleteQueryResourceTagNV = (C.GPDELETEQUERYRESOURCETAGNV)(getProcAddr("glDeleteQueryResourceTagNV"))
 	gpDeleteRenderbuffers = (C.GPDELETERENDERBUFFERS)(getProcAddr("glDeleteRenderbuffers"))
 	if gpDeleteRenderbuffers == nil {
 		return errors.New("glDeleteRenderbuffers")
@@ -29046,10 +30483,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteSamplers == nil {
 		return errors.New("glDeleteSamplers")
 	}
+	gpDeleteSemaphoresEXT = (C.GPDELETESEMAPHORESEXT)(getProcAddr("glDeleteSemaphoresEXT"))
 	gpDeleteShader = (C.GPDELETESHADER)(getProcAddr("glDeleteShader"))
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	if gpDeleteSync == nil {
 		return errors.New("glDeleteSync")
@@ -29162,6 +30601,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpDrawBuffersARB = (C.GPDRAWBUFFERSARB)(getProcAddr("glDrawBuffersARB"))
 	gpDrawBuffersATI = (C.GPDRAWBUFFERSATI)(getProcAddr("glDrawBuffersATI"))
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElementArrayAPPLE = (C.GPDRAWELEMENTARRAYAPPLE)(getProcAddr("glDrawElementArrayAPPLE"))
 	gpDrawElementArrayATI = (C.GPDRAWELEMENTARRAYATI)(getProcAddr("glDrawElementArrayATI"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
@@ -29228,6 +30671,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawTransformFeedbackStreamInstanced == nil {
 		return errors.New("glDrawTransformFeedbackStreamInstanced")
 	}
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
 	gpEdgeFlag = (C.GPEDGEFLAG)(getProcAddr("glEdgeFlag"))
 	if gpEdgeFlag == nil {
 		return errors.New("glEdgeFlag")
@@ -29358,6 +30802,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEvalPoint2 == nil {
 		return errors.New("glEvalPoint2")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpExecuteProgramNV = (C.GPEXECUTEPROGRAMNV)(getProcAddr("glExecuteProgramNV"))
 	gpExtractComponentEXT = (C.GPEXTRACTCOMPONENTEXT)(getProcAddr("glExtractComponentEXT"))
 	gpFeedbackBuffer = (C.GPFEEDBACKBUFFER)(getProcAddr("glFeedbackBuffer"))
@@ -29444,6 +30889,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFogxOES = (C.GPFOGXOES)(getProcAddr("glFogxOES"))
 	gpFogxvOES = (C.GPFOGXVOES)(getProcAddr("glFogxvOES"))
 	gpFragmentColorMaterialSGIX = (C.GPFRAGMENTCOLORMATERIALSGIX)(getProcAddr("glFragmentColorMaterialSGIX"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
 	gpFragmentLightModelfSGIX = (C.GPFRAGMENTLIGHTMODELFSGIX)(getProcAddr("glFragmentLightModelfSGIX"))
 	gpFragmentLightModelfvSGIX = (C.GPFRAGMENTLIGHTMODELFVSGIX)(getProcAddr("glFragmentLightModelfvSGIX"))
 	gpFragmentLightModeliSGIX = (C.GPFRAGMENTLIGHTMODELISGIX)(getProcAddr("glFragmentLightModeliSGIX"))
@@ -29460,6 +30906,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFrameZoomSGIX = (C.GPFRAMEZOOMSGIX)(getProcAddr("glFrameZoomSGIX"))
 	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
 	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
 	gpFramebufferReadBufferEXT = (C.GPFRAMEBUFFERREADBUFFEREXT)(getProcAddr("glFramebufferReadBufferEXT"))
 	gpFramebufferRenderbuffer = (C.GPFRAMEBUFFERRENDERBUFFER)(getProcAddr("glFramebufferRenderbuffer"))
@@ -29467,6 +30914,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glFramebufferRenderbuffer")
 	}
 	gpFramebufferRenderbufferEXT = (C.GPFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glFramebufferRenderbufferEXT"))
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
+	gpFramebufferSamplePositionsfvAMD = (C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glFramebufferSamplePositionsfvAMD"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	if gpFramebufferTexture == nil {
 		return errors.New("glFramebufferTexture")
@@ -29496,6 +30946,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
 	gpFramebufferTextureLayerEXT = (C.GPFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glFramebufferTextureLayerEXT"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFreeObjectBufferATI = (C.GPFREEOBJECTBUFFERATI)(getProcAddr("glFreeObjectBufferATI"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
@@ -29541,6 +30992,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGenQueries")
 	}
 	gpGenQueriesARB = (C.GPGENQUERIESARB)(getProcAddr("glGenQueriesARB"))
+	gpGenQueryResourceTagNV = (C.GPGENQUERYRESOURCETAGNV)(getProcAddr("glGenQueryResourceTagNV"))
 	gpGenRenderbuffers = (C.GPGENRENDERBUFFERS)(getProcAddr("glGenRenderbuffers"))
 	if gpGenRenderbuffers == nil {
 		return errors.New("glGenRenderbuffers")
@@ -29550,6 +31002,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenSamplers == nil {
 		return errors.New("glGenSamplers")
 	}
+	gpGenSemaphoresEXT = (C.GPGENSEMAPHORESEXT)(getProcAddr("glGenSemaphoresEXT"))
 	gpGenSymbolsEXT = (C.GPGENSYMBOLSEXT)(getProcAddr("glGenSymbolsEXT"))
 	gpGenTextures = (C.GPGENTEXTURES)(getProcAddr("glGenTextures"))
 	if gpGenTextures == nil {
@@ -29679,6 +31132,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetCombinerOutputParameterfvNV = (C.GPGETCOMBINEROUTPUTPARAMETERFVNV)(getProcAddr("glGetCombinerOutputParameterfvNV"))
 	gpGetCombinerOutputParameterivNV = (C.GPGETCOMBINEROUTPUTPARAMETERIVNV)(getProcAddr("glGetCombinerOutputParameterivNV"))
 	gpGetCombinerStageParameterfvNV = (C.GPGETCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glGetCombinerStageParameterfvNV"))
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
 	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
@@ -29695,6 +31149,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetConvolutionParameteriv = (C.GPGETCONVOLUTIONPARAMETERIV)(getProcAddr("glGetConvolutionParameteriv"))
 	gpGetConvolutionParameterivEXT = (C.GPGETCONVOLUTIONPARAMETERIVEXT)(getProcAddr("glGetConvolutionParameterivEXT"))
 	gpGetConvolutionParameterxvOES = (C.GPGETCONVOLUTIONPARAMETERXVOES)(getProcAddr("glGetConvolutionParameterxvOES"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	gpGetDebugMessageLogAMD = (C.GPGETDEBUGMESSAGELOGAMD)(getProcAddr("glGetDebugMessageLogAMD"))
 	gpGetDebugMessageLogARB = (C.GPGETDEBUGMESSAGELOGARB)(getProcAddr("glGetDebugMessageLogARB"))
@@ -29748,6 +31203,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetFramebufferAttachmentParameteriv")
 	}
 	gpGetFramebufferAttachmentParameterivEXT = (C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetFramebufferAttachmentParameterivEXT"))
+	gpGetFramebufferParameterfvAMD = (C.GPGETFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetFramebufferParameterfvAMD"))
 	gpGetFramebufferParameteriv = (C.GPGETFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetFramebufferParameteriv"))
 	gpGetFramebufferParameterivEXT = (C.GPGETFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetFramebufferParameterivEXT"))
 	gpGetGraphicsResetStatus = (C.GPGETGRAPHICSRESETSTATUS)(getProcAddr("glGetGraphicsResetStatus"))
@@ -29786,6 +31242,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	gpGetInternalformativ = (C.GPGETINTERNALFORMATIV)(getProcAddr("glGetInternalformativ"))
 	if gpGetInternalformativ == nil {
@@ -29837,6 +31294,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetMaterialxOES = (C.GPGETMATERIALXOES)(getProcAddr("glGetMaterialxOES"))
 	gpGetMaterialxvOES = (C.GPGETMATERIALXVOES)(getProcAddr("glGetMaterialxvOES"))
+	gpGetMemoryObjectParameterivEXT = (C.GPGETMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glGetMemoryObjectParameterivEXT"))
 	gpGetMinmax = (C.GPGETMINMAX)(getProcAddr("glGetMinmax"))
 	gpGetMinmaxEXT = (C.GPGETMINMAXEXT)(getProcAddr("glGetMinmaxEXT"))
 	gpGetMinmaxParameterfv = (C.GPGETMINMAXPARAMETERFV)(getProcAddr("glGetMinmaxParameterfv"))
@@ -29870,6 +31328,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
 	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
+	gpGetNamedFramebufferParameterfvAMD = (C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetNamedFramebufferParameterfvAMD"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
 	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
 	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
@@ -29997,6 +31456,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetProgramivARB = (C.GPGETPROGRAMIVARB)(getProcAddr("glGetProgramivARB"))
 	gpGetProgramivNV = (C.GPGETPROGRAMIVNV)(getProcAddr("glGetProgramivNV"))
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	if gpGetQueryIndexediv == nil {
 		return errors.New("glGetQueryIndexediv")
@@ -30047,6 +31510,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetSamplerParameteriv == nil {
 		return errors.New("glGetSamplerParameteriv")
 	}
+	gpGetSemaphoreParameterui64vEXT = (C.GPGETSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glGetSemaphoreParameterui64vEXT"))
 	gpGetSeparableFilter = (C.GPGETSEPARABLEFILTER)(getProcAddr("glGetSeparableFilter"))
 	gpGetSeparableFilterEXT = (C.GPGETSEPARABLEFILTEREXT)(getProcAddr("glGetSeparableFilterEXT"))
 	gpGetShaderInfoLog = (C.GPGETSHADERINFOLOG)(getProcAddr("glGetShaderInfoLog"))
@@ -30067,6 +31531,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetShaderiv")
 	}
 	gpGetSharpenTexFuncSGIS = (C.GPGETSHARPENTEXFUNCSGIS)(getProcAddr("glGetSharpenTexFuncSGIS"))
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -30202,18 +31667,22 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetUniformfv")
 	}
 	gpGetUniformfvARB = (C.GPGETUNIFORMFVARB)(getProcAddr("glGetUniformfvARB"))
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
 	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
 	gpGetUniformivARB = (C.GPGETUNIFORMIVARB)(getProcAddr("glGetUniformivARB"))
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
 	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
 	}
 	gpGetUniformuivEXT = (C.GPGETUNIFORMUIVEXT)(getProcAddr("glGetUniformuivEXT"))
+	gpGetUnsignedBytei_vEXT = (C.GPGETUNSIGNEDBYTEI_VEXT)(getProcAddr("glGetUnsignedBytei_vEXT"))
+	gpGetUnsignedBytevEXT = (C.GPGETUNSIGNEDBYTEVEXT)(getProcAddr("glGetUnsignedBytevEXT"))
 	gpGetVariantArrayObjectfvATI = (C.GPGETVARIANTARRAYOBJECTFVATI)(getProcAddr("glGetVariantArrayObjectfvATI"))
 	gpGetVariantArrayObjectivATI = (C.GPGETVARIANTARRAYOBJECTIVATI)(getProcAddr("glGetVariantArrayObjectivATI"))
 	gpGetVariantBooleanvEXT = (C.GPGETVARIANTBOOLEANVEXT)(getProcAddr("glGetVariantBooleanvEXT"))
@@ -30280,6 +31749,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetVideoivNV = (C.GPGETVIDEOIVNV)(getProcAddr("glGetVideoivNV"))
 	gpGetVideoui64vNV = (C.GPGETVIDEOUI64VNV)(getProcAddr("glGetVideoui64vNV"))
 	gpGetVideouivNV = (C.GPGETVIDEOUIVNV)(getProcAddr("glGetVideouivNV"))
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnColorTableARB = (C.GPGETNCOLORTABLEARB)(getProcAddr("glGetnColorTableARB"))
 	gpGetnCompressedTexImageARB = (C.GPGETNCOMPRESSEDTEXIMAGEARB)(getProcAddr("glGetnCompressedTexImageARB"))
 	gpGetnConvolutionFilterARB = (C.GPGETNCONVOLUTIONFILTERARB)(getProcAddr("glGetnConvolutionFilterARB"))
@@ -30298,9 +31768,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	gpGetnUniformuivARB = (C.GPGETNUNIFORMUIVARB)(getProcAddr("glGetnUniformuivARB"))
 	gpGetnUniformuivKHR = (C.GPGETNUNIFORMUIVKHR)(getProcAddr("glGetnUniformuivKHR"))
@@ -30324,6 +31796,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpImageTransformParameterfvHP = (C.GPIMAGETRANSFORMPARAMETERFVHP)(getProcAddr("glImageTransformParameterfvHP"))
 	gpImageTransformParameteriHP = (C.GPIMAGETRANSFORMPARAMETERIHP)(getProcAddr("glImageTransformParameteriHP"))
 	gpImageTransformParameterivHP = (C.GPIMAGETRANSFORMPARAMETERIVHP)(getProcAddr("glImageTransformParameterivHP"))
+	gpImportMemoryFdEXT = (C.GPIMPORTMEMORYFDEXT)(getProcAddr("glImportMemoryFdEXT"))
+	gpImportMemoryWin32HandleEXT = (C.GPIMPORTMEMORYWIN32HANDLEEXT)(getProcAddr("glImportMemoryWin32HandleEXT"))
+	gpImportMemoryWin32NameEXT = (C.GPIMPORTMEMORYWIN32NAMEEXT)(getProcAddr("glImportMemoryWin32NameEXT"))
+	gpImportSemaphoreFdEXT = (C.GPIMPORTSEMAPHOREFDEXT)(getProcAddr("glImportSemaphoreFdEXT"))
+	gpImportSemaphoreWin32HandleEXT = (C.GPIMPORTSEMAPHOREWIN32HANDLEEXT)(getProcAddr("glImportSemaphoreWin32HandleEXT"))
+	gpImportSemaphoreWin32NameEXT = (C.GPIMPORTSEMAPHOREWIN32NAMEEXT)(getProcAddr("glImportSemaphoreWin32NameEXT"))
 	gpImportSyncEXT = (C.GPIMPORTSYNCEXT)(getProcAddr("glImportSyncEXT"))
 	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
 	gpIndexFuncEXT = (C.GPINDEXFUNCEXT)(getProcAddr("glIndexFuncEXT"))
@@ -30407,6 +31885,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsBufferARB = (C.GPISBUFFERARB)(getProcAddr("glIsBufferARB"))
 	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
@@ -30429,6 +31908,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsList == nil {
 		return errors.New("glIsList")
 	}
+	gpIsMemoryObjectEXT = (C.GPISMEMORYOBJECTEXT)(getProcAddr("glIsMemoryObjectEXT"))
 	gpIsNameAMD = (C.GPISNAMEAMD)(getProcAddr("glIsNameAMD"))
 	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
@@ -30462,10 +31942,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsSampler == nil {
 		return errors.New("glIsSampler")
 	}
+	gpIsSemaphoreEXT = (C.GPISSEMAPHOREEXT)(getProcAddr("glIsSemaphoreEXT"))
 	gpIsShader = (C.GPISSHADER)(getProcAddr("glIsShader"))
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	if gpIsSync == nil {
 		return errors.New("glIsSync")
@@ -30489,6 +31971,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsVertexArrayAPPLE = (C.GPISVERTEXARRAYAPPLE)(getProcAddr("glIsVertexArrayAPPLE"))
 	gpIsVertexAttribEnabledAPPLE = (C.GPISVERTEXATTRIBENABLEDAPPLE)(getProcAddr("glIsVertexAttribEnabledAPPLE"))
+	gpLGPUCopyImageSubDataNVX = (C.GPLGPUCOPYIMAGESUBDATANVX)(getProcAddr("glLGPUCopyImageSubDataNVX"))
+	gpLGPUInterlockNVX = (C.GPLGPUINTERLOCKNVX)(getProcAddr("glLGPUInterlockNVX"))
+	gpLGPUNamedBufferSubDataNVX = (C.GPLGPUNAMEDBUFFERSUBDATANVX)(getProcAddr("glLGPUNamedBufferSubDataNVX"))
 	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLightEnviSGIX = (C.GPLIGHTENVISGIX)(getProcAddr("glLightEnviSGIX"))
 	gpLightModelf = (C.GPLIGHTMODELF)(getProcAddr("glLightModelf"))
@@ -30545,6 +32030,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpListBase == nil {
 		return errors.New("glListBase")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpListParameterfSGIX = (C.GPLISTPARAMETERFSGIX)(getProcAddr("glListParameterfSGIX"))
 	gpListParameterfvSGIX = (C.GPLISTPARAMETERFVSGIX)(getProcAddr("glListParameterfvSGIX"))
 	gpListParameteriSGIX = (C.GPLISTPARAMETERISGIX)(getProcAddr("glListParameteriSGIX"))
@@ -30705,12 +32191,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
 	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
 	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	if gpMemoryBarrier == nil {
 		return errors.New("glMemoryBarrier")
 	}
 	gpMemoryBarrierByRegion = (C.GPMEMORYBARRIERBYREGION)(getProcAddr("glMemoryBarrierByRegion"))
 	gpMemoryBarrierEXT = (C.GPMEMORYBARRIEREXT)(getProcAddr("glMemoryBarrierEXT"))
+	gpMemoryObjectParameterivEXT = (C.GPMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glMemoryObjectParameterivEXT"))
 	gpMinSampleShading = (C.GPMINSAMPLESHADING)(getProcAddr("glMinSampleShading"))
 	if gpMinSampleShading == nil {
 		return errors.New("glMinSampleShading")
@@ -31007,12 +32496,25 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
 	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
 	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
+	gpMulticastBarrierNV = (C.GPMULTICASTBARRIERNV)(getProcAddr("glMulticastBarrierNV"))
+	gpMulticastBlitFramebufferNV = (C.GPMULTICASTBLITFRAMEBUFFERNV)(getProcAddr("glMulticastBlitFramebufferNV"))
+	gpMulticastBufferSubDataNV = (C.GPMULTICASTBUFFERSUBDATANV)(getProcAddr("glMulticastBufferSubDataNV"))
+	gpMulticastCopyBufferSubDataNV = (C.GPMULTICASTCOPYBUFFERSUBDATANV)(getProcAddr("glMulticastCopyBufferSubDataNV"))
+	gpMulticastCopyImageSubDataNV = (C.GPMULTICASTCOPYIMAGESUBDATANV)(getProcAddr("glMulticastCopyImageSubDataNV"))
+	gpMulticastFramebufferSampleLocationsfvNV = (C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glMulticastFramebufferSampleLocationsfvNV"))
+	gpMulticastGetQueryObjecti64vNV = (C.GPMULTICASTGETQUERYOBJECTI64VNV)(getProcAddr("glMulticastGetQueryObjecti64vNV"))
+	gpMulticastGetQueryObjectivNV = (C.GPMULTICASTGETQUERYOBJECTIVNV)(getProcAddr("glMulticastGetQueryObjectivNV"))
+	gpMulticastGetQueryObjectui64vNV = (C.GPMULTICASTGETQUERYOBJECTUI64VNV)(getProcAddr("glMulticastGetQueryObjectui64vNV"))
+	gpMulticastGetQueryObjectuivNV = (C.GPMULTICASTGETQUERYOBJECTUIVNV)(getProcAddr("glMulticastGetQueryObjectuivNV"))
+	gpMulticastWaitSyncNV = (C.GPMULTICASTWAITSYNCNV)(getProcAddr("glMulticastWaitSyncNV"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
 	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
 	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
+	gpNamedBufferStorageExternalEXT = (C.GPNAMEDBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glNamedBufferStorageExternalEXT"))
+	gpNamedBufferStorageMemEXT = (C.GPNAMEDBUFFERSTORAGEMEMEXT)(getProcAddr("glNamedBufferStorageMemEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
 	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
 	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
@@ -31023,6 +32525,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	gpNamedFramebufferRenderbuffer = (C.GPNAMEDFRAMEBUFFERRENDERBUFFER)(getProcAddr("glNamedFramebufferRenderbuffer"))
 	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
+	gpNamedFramebufferSamplePositionsfvAMD = (C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glNamedFramebufferSamplePositionsfvAMD"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
 	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
 	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
@@ -31268,6 +32773,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPolygonOffsetEXT = (C.GPPOLYGONOFFSETEXT)(getProcAddr("glPolygonOffsetEXT"))
 	gpPolygonOffsetxOES = (C.GPPOLYGONOFFSETXOES)(getProcAddr("glPolygonOffsetxOES"))
 	gpPolygonStipple = (C.GPPOLYGONSTIPPLE)(getProcAddr("glPolygonStipple"))
@@ -31295,6 +32802,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpPresentFrameDualFillNV = (C.GPPRESENTFRAMEDUALFILLNV)(getProcAddr("glPresentFrameDualFillNV"))
 	gpPresentFrameKeyedNV = (C.GPPRESENTFRAMEKEYEDNV)(getProcAddr("glPresentFrameKeyedNV"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	if gpPrimitiveRestartIndex == nil {
 		return errors.New("glPrimitiveRestartIndex")
@@ -31379,7 +32887,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform1i == nil {
 		return errors.New("glProgramUniform1i")
 	}
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
 	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
 	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
 	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
@@ -31391,7 +32901,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform1ui == nil {
 		return errors.New("glProgramUniform1ui")
 	}
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
 	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
 	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
 	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
@@ -31423,7 +32935,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform2i == nil {
 		return errors.New("glProgramUniform2i")
 	}
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
 	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
 	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
 	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
@@ -31435,7 +32949,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform2ui == nil {
 		return errors.New("glProgramUniform2ui")
 	}
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
 	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
 	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
 	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
@@ -31467,7 +32983,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform3i == nil {
 		return errors.New("glProgramUniform3i")
 	}
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
 	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
 	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
 	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
@@ -31479,7 +32997,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform3ui == nil {
 		return errors.New("glProgramUniform3ui")
 	}
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
 	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
 	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
 	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
@@ -31511,7 +33031,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform4i == nil {
 		return errors.New("glProgramUniform4i")
 	}
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
 	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
 	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
 	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
@@ -31523,7 +33045,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform4ui == nil {
 		return errors.New("glProgramUniform4ui")
 	}
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
 	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
 	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
 	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
@@ -31659,6 +33183,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpQueryMatrixxOES = (C.GPQUERYMATRIXXOES)(getProcAddr("glQueryMatrixxOES"))
 	gpQueryObjectParameteruiAMD = (C.GPQUERYOBJECTPARAMETERUIAMD)(getProcAddr("glQueryObjectParameteruiAMD"))
+	gpQueryResourceNV = (C.GPQUERYRESOURCENV)(getProcAddr("glQueryResourceNV"))
+	gpQueryResourceTagNV = (C.GPQUERYRESOURCETAGNV)(getProcAddr("glQueryResourceTagNV"))
 	gpRasterPos2d = (C.GPRASTERPOS2D)(getProcAddr("glRasterPos2d"))
 	if gpRasterPos2d == nil {
 		return errors.New("glRasterPos2d")
@@ -31761,6 +33287,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpRasterPos4xOES = (C.GPRASTERPOS4XOES)(getProcAddr("glRasterPos4xOES"))
 	gpRasterPos4xvOES = (C.GPRASTERPOS4XVOES)(getProcAddr("glRasterPos4xvOES"))
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -31808,10 +33335,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpRectxOES = (C.GPRECTXOES)(getProcAddr("glRectxOES"))
 	gpRectxvOES = (C.GPRECTXVOES)(getProcAddr("glRectxvOES"))
 	gpReferencePlaneSGIX = (C.GPREFERENCEPLANESGIX)(getProcAddr("glReferencePlaneSGIX"))
+	gpReleaseKeyedMutexWin32EXT = (C.GPRELEASEKEYEDMUTEXWIN32EXT)(getProcAddr("glReleaseKeyedMutexWin32EXT"))
 	gpReleaseShaderCompiler = (C.GPRELEASESHADERCOMPILER)(getProcAddr("glReleaseShaderCompiler"))
 	if gpReleaseShaderCompiler == nil {
 		return errors.New("glReleaseShaderCompiler")
 	}
+	gpRenderGpuMaskNV = (C.GPRENDERGPUMASKNV)(getProcAddr("glRenderGpuMaskNV"))
 	gpRenderMode = (C.GPRENDERMODE)(getProcAddr("glRenderMode"))
 	if gpRenderMode == nil {
 		return errors.New("glRenderMode")
@@ -31856,6 +33385,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpResetMinmax = (C.GPRESETMINMAX)(getProcAddr("glResetMinmax"))
 	gpResetMinmaxEXT = (C.GPRESETMINMAXEXT)(getProcAddr("glResetMinmaxEXT"))
 	gpResizeBuffersMESA = (C.GPRESIZEBUFFERSMESA)(getProcAddr("glResizeBuffersMESA"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	if gpResumeTransformFeedback == nil {
 		return errors.New("glResumeTransformFeedback")
@@ -31875,7 +33405,6 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSampleCoverage")
 	}
 	gpSampleCoverageARB = (C.GPSAMPLECOVERAGEARB)(getProcAddr("glSampleCoverageARB"))
-	gpSampleCoverageOES = (C.GPSAMPLECOVERAGEOES)(getProcAddr("glSampleCoverageOES"))
 	gpSampleCoveragexOES = (C.GPSAMPLECOVERAGEXOES)(getProcAddr("glSampleCoveragexOES"))
 	gpSampleMapATI = (C.GPSAMPLEMAPATI)(getProcAddr("glSampleMapATI"))
 	gpSampleMaskEXT = (C.GPSAMPLEMASKEXT)(getProcAddr("glSampleMaskEXT"))
@@ -32038,6 +33567,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSelectBuffer")
 	}
 	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
+	gpSemaphoreParameterui64vEXT = (C.GPSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glSemaphoreParameterui64vEXT"))
 	gpSeparableFilter2D = (C.GPSEPARABLEFILTER2D)(getProcAddr("glSeparableFilter2D"))
 	gpSeparableFilter2DEXT = (C.GPSEPARABLEFILTER2DEXT)(getProcAddr("glSeparableFilter2DEXT"))
 	gpSetFenceAPPLE = (C.GPSETFENCEAPPLE)(getProcAddr("glSetFenceAPPLE"))
@@ -32064,11 +33594,16 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpShaderSourceARB = (C.GPSHADERSOURCEARB)(getProcAddr("glShaderSourceARB"))
 	gpShaderStorageBlockBinding = (C.GPSHADERSTORAGEBLOCKBINDING)(getProcAddr("glShaderStorageBlockBinding"))
 	gpSharpenTexFuncSGIS = (C.GPSHARPENTEXFUNCSGIS)(getProcAddr("glSharpenTexFuncSGIS"))
+	gpSignalSemaphoreEXT = (C.GPSIGNALSEMAPHOREEXT)(getProcAddr("glSignalSemaphoreEXT"))
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
 	gpSpriteParameterfSGIX = (C.GPSPRITEPARAMETERFSGIX)(getProcAddr("glSpriteParameterfSGIX"))
 	gpSpriteParameterfvSGIX = (C.GPSPRITEPARAMETERFVSGIX)(getProcAddr("glSpriteParameterfvSGIX"))
 	gpSpriteParameteriSGIX = (C.GPSPRITEPARAMETERISGIX)(getProcAddr("glSpriteParameteriSGIX"))
 	gpSpriteParameterivSGIX = (C.GPSPRITEPARAMETERIVSGIX)(getProcAddr("glSpriteParameterivSGIX"))
 	gpStartInstrumentsSGIX = (C.GPSTARTINSTRUMENTSSGIX)(getProcAddr("glStartInstrumentsSGIX"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
 	gpStencilClearTagEXT = (C.GPSTENCILCLEARTAGEXT)(getProcAddr("glStencilClearTagEXT"))
 	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
 	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
@@ -32107,6 +33642,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
 	gpStopInstrumentsSGIX = (C.GPSTOPINSTRUMENTSSGIX)(getProcAddr("glStopInstrumentsSGIX"))
 	gpStringMarkerGREMEDY = (C.GPSTRINGMARKERGREMEDY)(getProcAddr("glStringMarkerGREMEDY"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpSwizzleEXT = (C.GPSWIZZLEEXT)(getProcAddr("glSwizzleEXT"))
 	gpSyncTextureINTEL = (C.GPSYNCTEXTUREINTEL)(getProcAddr("glSyncTextureINTEL"))
 	gpTagSampleBufferSGIX = (C.GPTAGSAMPLEBUFFERSGIX)(getProcAddr("glTagSampleBufferSGIX"))
@@ -32455,6 +33991,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glTexStorage3D")
 	}
 	gpTexStorage3DMultisample = (C.GPTEXSTORAGE3DMULTISAMPLE)(getProcAddr("glTexStorage3DMultisample"))
+	gpTexStorageMem1DEXT = (C.GPTEXSTORAGEMEM1DEXT)(getProcAddr("glTexStorageMem1DEXT"))
+	gpTexStorageMem2DEXT = (C.GPTEXSTORAGEMEM2DEXT)(getProcAddr("glTexStorageMem2DEXT"))
+	gpTexStorageMem2DMultisampleEXT = (C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem2DMultisampleEXT"))
+	gpTexStorageMem3DEXT = (C.GPTEXSTORAGEMEM3DEXT)(getProcAddr("glTexStorageMem3DEXT"))
+	gpTexStorageMem3DMultisampleEXT = (C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem3DMultisampleEXT"))
 	gpTexStorageSparseAMD = (C.GPTEXSTORAGESPARSEAMD)(getProcAddr("glTexStorageSparseAMD"))
 	gpTexSubImage1D = (C.GPTEXSUBIMAGE1D)(getProcAddr("glTexSubImage1D"))
 	if gpTexSubImage1D == nil {
@@ -32514,6 +34055,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
 	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
+	gpTextureStorageMem1DEXT = (C.GPTEXTURESTORAGEMEM1DEXT)(getProcAddr("glTextureStorageMem1DEXT"))
+	gpTextureStorageMem2DEXT = (C.GPTEXTURESTORAGEMEM2DEXT)(getProcAddr("glTextureStorageMem2DEXT"))
+	gpTextureStorageMem2DMultisampleEXT = (C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem2DMultisampleEXT"))
+	gpTextureStorageMem3DEXT = (C.GPTEXTURESTORAGEMEM3DEXT)(getProcAddr("glTextureStorageMem3DEXT"))
+	gpTextureStorageMem3DMultisampleEXT = (C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem3DMultisampleEXT"))
 	gpTextureStorageSparseAMD = (C.GPTEXTURESTORAGESPARSEAMD)(getProcAddr("glTextureStorageSparseAMD"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
 	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
@@ -32565,7 +34111,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
 	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
 	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iARB = (C.GPUNIFORM1IARB)(getProcAddr("glUniform1iARB"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
@@ -32577,7 +34125,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
 	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
 	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiEXT = (C.GPUNIFORM1UIEXT)(getProcAddr("glUniform1uiEXT"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
@@ -32607,7 +34157,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
 	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
 	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iARB = (C.GPUNIFORM2IARB)(getProcAddr("glUniform2iARB"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
@@ -32619,7 +34171,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
 	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
 	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiEXT = (C.GPUNIFORM2UIEXT)(getProcAddr("glUniform2uiEXT"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
@@ -32649,7 +34203,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
 	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
 	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iARB = (C.GPUNIFORM3IARB)(getProcAddr("glUniform3iARB"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
@@ -32661,7 +34217,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
 	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
 	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiEXT = (C.GPUNIFORM3UIEXT)(getProcAddr("glUniform3uiEXT"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
@@ -32691,7 +34249,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
 	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
 	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iARB = (C.GPUNIFORM4IARB)(getProcAddr("glUniform4iARB"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
@@ -32703,7 +34263,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
 	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
 	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiEXT = (C.GPUNIFORM4UIEXT)(getProcAddr("glUniform4uiEXT"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
@@ -33541,10 +35103,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpViewportIndexedfv == nil {
 		return errors.New("glViewportIndexedfv")
 	}
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
+	gpWaitSemaphoreEXT = (C.GPWAITSEMAPHOREEXT)(getProcAddr("glWaitSemaphoreEXT"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
 	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
 	gpWeightPointerARB = (C.GPWEIGHTPOINTERARB)(getProcAddr("glWeightPointerARB"))
 	gpWeightbvARB = (C.GPWEIGHTBVARB)(getProcAddr("glWeightbvARB"))
@@ -33659,6 +35225,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpWindowPos4ivMESA = (C.GPWINDOWPOS4IVMESA)(getProcAddr("glWindowPos4ivMESA"))
 	gpWindowPos4sMESA = (C.GPWINDOWPOS4SMESA)(getProcAddr("glWindowPos4sMESA"))
 	gpWindowPos4svMESA = (C.GPWINDOWPOS4SVMESA)(getProcAddr("glWindowPos4svMESA"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	gpWriteMaskEXT = (C.GPWRITEMASKEXT)(getProcAddr("glWriteMaskEXT"))
 	return nil
 }

--- a/v4.2-compatibility/gl/procaddr.go
+++ b/v4.2-compatibility/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcompatibility42(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v4.2-core/gl/package.go
+++ b/v4.2-core/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -89,21 +87,29 @@ package gl
 // typedef ptrdiff_t GLsizeiptr;
 // typedef int64_t GLint64;
 // typedef uint64_t GLuint64;
+// typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCARB)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCKHR)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcore42(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcore42(source, type, id, severity, length, message, userParam);
 // }
+// typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
+// typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVETEXTURE)(GLenum  texture);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPATTACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPBEGINCONDITIONALRENDER)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINCONDITIONALRENDERNV)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPBEGINPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPBEGINQUERY)(GLenum  target, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINQUERYINDEXED)(GLenum  target, GLuint  index, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINTRANSFORMFEEDBACK)(GLenum  primitiveMode);
@@ -118,7 +124,9 @@ package gl
 // typedef void  (APIENTRYP GPBINDFRAMEBUFFER)(GLenum  target, GLuint  framebuffer);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURE)(GLuint  unit, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  access, GLenum  format);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURES)(GLuint  first, GLsizei  count, const GLuint * textures);
+// typedef void  (APIENTRYP GPBINDMULTITEXTUREEXT)(GLenum  texunit, GLenum  target, GLuint  texture);
 // typedef void  (APIENTRYP GPBINDPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPBINDPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPBINDRENDERBUFFER)(GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPBINDSAMPLER)(GLuint  unit, GLuint  sampler);
 // typedef void  (APIENTRYP GPBINDSAMPLERS)(GLuint  first, GLsizei  count, const GLuint * samplers);
@@ -129,6 +137,8 @@ package gl
 // typedef void  (APIENTRYP GPBINDVERTEXARRAY)(GLuint  array);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFER)(GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFERS)(GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPBLENDBARRIERKHR)();
+// typedef void  (APIENTRYP GPBLENDBARRIERNV)();
 // typedef void  (APIENTRYP GPBLENDCOLOR)(GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha);
 // typedef void  (APIENTRYP GPBLENDEQUATION)(GLenum  mode);
 // typedef void  (APIENTRYP GPBLENDEQUATIONSEPARATE)(GLenum  modeRGB, GLenum  modeAlpha);
@@ -142,14 +152,18 @@ package gl
 // typedef void  (APIENTRYP GPBLENDFUNCSEPARATEIARB)(GLuint  buf, GLenum  srcRGB, GLenum  dstRGB, GLenum  srcAlpha, GLenum  dstAlpha);
 // typedef void  (APIENTRYP GPBLENDFUNCI)(GLuint  buf, GLenum  src, GLenum  dst);
 // typedef void  (APIENTRYP GPBLENDFUNCIARB)(GLuint  buf, GLenum  src, GLenum  dst);
+// typedef void  (APIENTRYP GPBLENDPARAMETERINV)(GLenum  pname, GLint  value);
 // typedef void  (APIENTRYP GPBLITFRAMEBUFFER)(GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
 // typedef void  (APIENTRYP GPBLITNAMEDFRAMEBUFFER)(GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
 // typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUS)(GLuint  framebuffer, GLenum  target);
+// typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(GLuint  framebuffer, GLenum  target);
 // typedef void  (APIENTRYP GPCLAMPCOLOR)(GLenum  target, GLenum  clamp);
 // typedef void  (APIENTRYP GPCLEAR)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPCLEARBUFFERDATA)(GLenum  target, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
@@ -162,49 +176,91 @@ package gl
 // typedef void  (APIENTRYP GPCLEARDEPTH)(GLdouble  depth);
 // typedef void  (APIENTRYP GPCLEARDEPTHF)(GLfloat  d);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
 // typedef void  (APIENTRYP GPCLEARSTENCIL)(GLint  s);
 // typedef void  (APIENTRYP GPCLEARTEXIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARTEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef GLenum  (APIENTRYP GPCLIENTWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
 // typedef void  (APIENTRYP GPCLIPCONTROL)(GLenum  origin, GLenum  depth);
+// typedef void  (APIENTRYP GPCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPCOLORMASK)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPCOLORMASKI)(GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE3D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOPYBUFFERSUBDATA)(GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYIMAGESUBDATA)(GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef void  (APIENTRYP GPCREATEPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPCREATEQUERIES)(GLenum  target, GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPCREATERENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPCREATESAMPLERS)(GLsizei  n, GLuint * samplers);
 // typedef GLuint  (APIENTRYP GPCREATESHADER)(GLenum  type);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -220,14 +276,20 @@ package gl
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTARB)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTKHR)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef void  (APIENTRYP GPDELETEPATHSNV)(GLuint  path, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
+// typedef void  (APIENTRYP GPDELETEPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPDELETEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINES)(GLsizei  n, const GLuint * pipelines);
+// typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINESEXT)(GLsizei  n, const GLuint * pipelines);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETRANSFORMFEEDBACKS)(GLsizei  n, const GLuint * ids);
@@ -240,7 +302,12 @@ package gl
 // typedef void  (APIENTRYP GPDEPTHRANGEF)(GLfloat  n, GLfloat  f);
 // typedef void  (APIENTRYP GPDETACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPDISABLE)(GLenum  cap);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPDISABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISPATCHCOMPUTE)(GLuint  num_groups_x, GLuint  num_groups_y, GLuint  num_groups_z);
@@ -249,46 +316,81 @@ package gl
 // typedef void  (APIENTRYP GPDRAWARRAYS)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCED)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDARB)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDBASEINSTANCE)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDEXT)(GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWBUFFER)(GLenum  buf);
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWELEMENTSBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCED)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDARB)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDEXT)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTS)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTSBASEVERTEX)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACK)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKINSTANCED)(GLenum  mode, GLuint  id, GLsizei  instancecount);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
+// typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPENABLE)(GLenum  cap);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPENABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPENABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDCONDITIONALRENDER)();
+// typedef void  (APIENTRYP GPENDCONDITIONALRENDERNV)();
+// typedef void  (APIENTRYP GPENDPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPENDPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPENDQUERY)(GLenum  target);
 // typedef void  (APIENTRYP GPENDQUERYINDEXED)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDTRANSFORMFEEDBACK)();
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef GLsync  (APIENTRYP GPFENCESYNC)(GLenum  condition, GLbitfield  flags);
 // typedef void  (APIENTRYP GPFINISH)();
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFOGCOORDFORMATNV)(GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE2D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE3D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREFACEARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPGENBUFFERS)(GLsizei  n, GLuint * buffers);
 // typedef void  (APIENTRYP GPGENFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef GLuint  (APIENTRYP GPGENPATHSNV)(GLsizei  range);
+// typedef void  (APIENTRYP GPGENPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
 // typedef void  (APIENTRYP GPGENPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
+// typedef void  (APIENTRYP GPGENPROGRAMPIPELINESEXT)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
@@ -296,7 +398,9 @@ package gl
 // typedef void  (APIENTRYP GPGENTRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENVERTEXARRAYS)(GLsizei  n, GLuint * arrays);
 // typedef void  (APIENTRYP GPGENERATEMIPMAP)(GLenum  target);
+// typedef void  (APIENTRYP GPGENERATEMULTITEXMIPMAPEXT)(GLenum  texunit, GLenum  target);
 // typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAP)(GLuint  texture);
+// typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAPEXT)(GLuint  texture, GLenum  target);
 // typedef void  (APIENTRYP GPGETACTIVEATOMICCOUNTERBUFFERIV)(GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETACTIVEATTRIB)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLint * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETACTIVESUBROUTINENAME)(GLuint  program, GLenum  shadertype, GLuint  index, GLsizei  bufsize, GLsizei * length, GLchar * name);
@@ -309,65 +413,137 @@ package gl
 // typedef void  (APIENTRYP GPGETACTIVEUNIFORMSIV)(GLuint  program, GLsizei  uniformCount, const GLuint * uniformIndices, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETATTACHEDSHADERS)(GLuint  program, GLsizei  maxCount, GLsizei * count, GLuint * shaders);
 // typedef GLint  (APIENTRYP GPGETATTRIBLOCATION)(GLuint  program, const GLchar * name);
+// typedef void  (APIENTRYP GPGETBOOLEANINDEXEDVEXT)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANI_V)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANV)(GLenum  pname, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERI64V)(GLenum  target, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETBUFFERPARAMETERUI64VNV)(GLenum  target, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETBUFFERPOINTERV)(GLenum  target, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGE)(GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGKHR)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
+// typedef void  (APIENTRYP GPGETDOUBLEINDEXEDVEXT)(GLenum  target, GLuint  index, GLdouble * data);
 // typedef void  (APIENTRYP GPGETDOUBLEI_V)(GLenum  target, GLuint  index, GLdouble * data);
+// typedef void  (APIENTRYP GPGETDOUBLEI_VEXT)(GLenum  pname, GLuint  index, GLdouble * params);
 // typedef void  (APIENTRYP GPGETDOUBLEV)(GLenum  pname, GLdouble * data);
 // typedef GLenum  (APIENTRYP GPGETERROR)();
+// typedef void  (APIENTRYP GPGETFIRSTPERFQUERYIDINTEL)(GLuint * queryId);
+// typedef void  (APIENTRYP GPGETFLOATINDEXEDVEXT)(GLenum  target, GLuint  index, GLfloat * data);
 // typedef void  (APIENTRYP GPGETFLOATI_V)(GLenum  target, GLuint  index, GLfloat * data);
+// typedef void  (APIENTRYP GPGETFLOATI_VEXT)(GLenum  pname, GLuint  index, GLfloat * params);
 // typedef void  (APIENTRYP GPGETFLOATV)(GLenum  pname, GLfloat * data);
 // typedef GLint  (APIENTRYP GPGETFRAGDATAINDEX)(GLuint  program, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETFRAGDATALOCATION)(GLuint  program, const GLchar * name);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSARB)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSKHR)();
 // typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLEARB)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
+// typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLENV)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
 // typedef void  (APIENTRYP GPGETINTEGER64I_V)(GLenum  target, GLuint  index, GLint64 * data);
 // typedef void  (APIENTRYP GPGETINTEGER64V)(GLenum  pname, GLint64 * data);
+// typedef void  (APIENTRYP GPGETINTEGERINDEXEDVEXT)(GLenum  target, GLuint  index, GLint * data);
 // typedef void  (APIENTRYP GPGETINTEGERI_V)(GLenum  target, GLuint  index, GLint * data);
+// typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
+// typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMULTISAMPLEFV)(GLenum  pname, GLuint  index, GLfloat * val);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERI64V)(GLuint  buffer, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIV)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIVEXT)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  pname, void * string);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMIVEXT)(GLuint  program, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIV)(GLuint  renderbuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(GLuint  renderbuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGARB)(GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGIVARB)(GLint  namelen, const GLchar * name, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNEXTPERFQUERYIDINTEL)(GLuint  queryId, GLuint * nextQueryId);
 // typedef void  (APIENTRYP GPGETOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETOBJECTLABELEXT)(GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABEL)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABELKHR)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETPATHCOMMANDSNV)(GLuint  path, GLubyte * commands);
+// typedef void  (APIENTRYP GPGETPATHCOORDSNV)(GLuint  path, GLfloat * coords);
+// typedef void  (APIENTRYP GPGETPATHDASHARRAYNV)(GLuint  path, GLfloat * dashArray);
+// typedef GLfloat  (APIENTRYP GPGETPATHLENGTHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments);
+// typedef void  (APIENTRYP GPGETPATHMETRICRANGENV)(GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHMETRICSNV)(GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, GLfloat * value);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, GLint * value);
+// typedef void  (APIENTRYP GPGETPATHSPACINGNV)(GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing);
+// typedef void  (APIENTRYP GPGETPERFCOUNTERINFOINTEL)(GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERDATAAMD)(GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERINFOAMD)(GLuint  group, GLuint  counter, GLenum  pname, void * data);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSTRINGAMD)(GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
+// typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
+// typedef void  (APIENTRYP GPGETPOINTERINDEXEDVEXT)(GLenum  target, GLuint  index, void ** data);
+// typedef void  (APIENTRYP GPGETPOINTERI_VEXT)(GLenum  pname, GLuint  index, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERV)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERVKHR)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPROGRAMBINARY)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLenum * binaryFormat, void * binary);
 // typedef void  (APIENTRYP GPGETPROGRAMINFOLOG)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMINTERFACEIV)(GLuint  program, GLenum  programInterface, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOG)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOGEXT)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIV)(GLuint  pipeline, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIVEXT)(GLuint  pipeline, GLenum  pname, GLint * params);
 // typedef GLuint  (APIENTRYP GPGETPROGRAMRESOURCEINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATION)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATIONINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCENAME)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name);
+// typedef void  (APIENTRYP GPGETPROGRAMRESOURCEFVNV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCEIV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMSTAGEIV)(GLuint  program, GLenum  shadertype, GLenum  pname, GLint * values);
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTIV)(GLuint  id, GLenum  pname, GLint * params);
@@ -383,6 +559,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERPRECISIONFORMAT)(GLenum  shadertype, GLenum  precisiontype, GLint * range, GLint * precision);
 // typedef void  (APIENTRYP GPGETSHADERSOURCE)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -396,14 +573,23 @@ package gl
 // typedef void  (APIENTRYP GPGETTEXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLEARB)(GLuint  texture);
+// typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLENV)(GLuint  texture);
 // typedef void  (APIENTRYP GPGETTEXTUREIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFV)(GLuint  texture, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIV)(GLuint  texture, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLEARB)(GLuint  texture, GLuint  sampler);
+// typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLENV)(GLuint  texture, GLuint  sampler);
 // typedef void  (APIENTRYP GPGETTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKVARYING)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLsizei * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKI64_V)(GLuint  xfb, GLenum  pname, GLuint  index, GLint64 * param);
@@ -415,32 +601,48 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMSUBROUTINEUIV)(GLenum  shadertype, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXED64IV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint64 * param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXEDIV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERVEXT)(GLuint  vaobj, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, void ** param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERVEXT)(GLuint  vaobj, GLenum  pname, void ** param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYIV)(GLuint  vaobj, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIIV)(GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIUIV)(GLuint  index, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLDV)(GLuint  index, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLI64VNV)(GLuint  index, GLenum  pname, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VARB)(GLuint  index, GLenum  pname, GLuint64EXT * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VNV)(GLuint  index, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBPOINTERV)(GLuint  index, GLenum  pname, void ** pointer);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBDV)(GLuint  index, GLenum  pname, GLdouble * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBFV)(GLuint  index, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIV)(GLuint  index, GLenum  pname, GLint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNTEXIMAGEARB)(GLenum  target, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNUNIFORMDVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLdouble * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPHINT)(GLenum  target, GLenum  mode);
+// typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPINSERTEVENTMARKEREXT)(GLsizei  length, const GLchar * marker);
+// typedef void  (APIENTRYP GPINTERPOLATEPATHSNV)(GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERDATA)(GLuint  buffer);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPINVALIDATEFRAMEBUFFER)(GLenum  target, GLsizei  numAttachments, const GLenum * attachments);
@@ -450,68 +652,196 @@ package gl
 // typedef void  (APIENTRYP GPINVALIDATETEXIMAGE)(GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPINVALIDATETEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
+// typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISFRAMEBUFFER)(GLuint  framebuffer);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef GLboolean  (APIENTRYP GPISPATHNV)(GLuint  path);
+// typedef GLboolean  (APIENTRYP GPISPOINTINFILLPATHNV)(GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y);
+// typedef GLboolean  (APIENTRYP GPISPOINTINSTROKEPATHNV)(GLuint  path, GLfloat  x, GLfloat  y);
 // typedef GLboolean  (APIENTRYP GPISPROGRAM)(GLuint  program);
 // typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef GLboolean  (APIENTRYP GPISQUERY)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISTRANSFORMFEEDBACK)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
+// typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLINEWIDTH)(GLfloat  width);
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLOGICOP)(GLenum  opcode);
+// typedef void  (APIENTRYP GPMAKEBUFFERNONRESIDENTNV)(GLenum  target);
+// typedef void  (APIENTRYP GPMAKEBUFFERRESIDENTNV)(GLenum  target, GLenum  access);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTARB)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTNV)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERNONRESIDENTNV)(GLuint  buffer);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERRESIDENTNV)(GLuint  buffer, GLenum  access);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef void * (APIENTRYP GPMAPBUFFER)(GLenum  target, GLenum  access);
 // typedef void * (APIENTRYP GPMAPBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void  (APIENTRYP GPMATRIXFRUSTUMEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADIDENTITYEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXORTHOEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXPOPEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXPUSHEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXROTATEDEXT)(GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXROTATEFEXT)(GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMINSAMPLESHADING)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYS)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTITEXBUFFEREXT)(GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPMULTITEXCOORDPOINTEREXT)(GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
+// typedef void  (APIENTRYP GPMULTITEXENVFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXENVIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXGENDEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param);
+// typedef void  (APIENTRYP GPMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params);
+// typedef void  (APIENTRYP GPMULTITEXGENFEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXGENIEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXRENDERBUFFEREXT)(GLenum  texunit, GLenum  target, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFERS)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERI)(GLuint  framebuffer, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERIEXT)(GLuint  framebuffer, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYER)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLdouble * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGE)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEEXT)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDSTRINGARB)(GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string);
+// typedef void  (APIENTRYP GPNORMALFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABEL)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABELKHR)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPPATCHPARAMETERFV)(GLenum  pname, const GLfloat * values);
 // typedef void  (APIENTRYP GPPATCHPARAMETERI)(GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHCOMMANDSNV)(GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOORDSNV)(GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOVERDEPTHFUNCNV)(GLenum  func);
+// typedef void  (APIENTRYP GPPATHDASHARRAYNV)(GLuint  path, GLsizei  dashCount, const GLfloat * dashArray);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXRANGENV)(GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount);
+// typedef void  (APIENTRYP GPPATHGLYPHRANGENV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHGLYPHSNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHMEMORYGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHPARAMETERFNV)(GLuint  path, GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, const GLfloat * value);
+// typedef void  (APIENTRYP GPPATHPARAMETERINV)(GLuint  path, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, const GLint * value);
+// typedef void  (APIENTRYP GPPATHSTENCILDEPTHOFFSETNV)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPATHSTENCILFUNCNV)(GLenum  func, GLint  ref, GLuint  mask);
+// typedef void  (APIENTRYP GPPATHSTRINGNV)(GLuint  path, GLenum  format, GLsizei  length, const void * pathString);
+// typedef void  (APIENTRYP GPPATHSUBCOMMANDSNV)(GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHSUBCOORDSNV)(GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords);
 // typedef void  (APIENTRYP GPPAUSETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPPIXELSTOREF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPIXELSTOREI)(GLenum  pname, GLint  param);
+// typedef GLboolean  (APIENTRYP GPPOINTALONGPATHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY);
 // typedef void  (APIENTRYP GPPOINTPARAMETERF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPOINTPARAMETERFV)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPPOINTPARAMETERI)(GLenum  pname, GLint  param);
@@ -519,67 +849,163 @@ package gl
 // typedef void  (APIENTRYP GPPOINTSIZE)(GLfloat  size);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOPDEBUGGROUP)();
 // typedef void  (APIENTRYP GPPOPDEBUGGROUPKHR)();
+// typedef void  (APIENTRYP GPPOPGROUPMARKEREXT)();
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPROGRAMBINARY)(GLuint  program, GLenum  binaryFormat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPPROGRAMPARAMETERI)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIARB)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIEXT)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPATHFRAGMENTINPUTGENNV)(GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1D)(GLuint  program, GLint  location, GLdouble  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DEXT)(GLuint  program, GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1F)(GLuint  program, GLint  location, GLfloat  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FEXT)(GLuint  program, GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64ARB)(GLuint  program, GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64NV)(GLuint  program, GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64NV)(GLuint  program, GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROVOKINGVERTEX)(GLenum  mode);
+// typedef void  (APIENTRYP GPPUSHCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUP)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUPKHR)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
+// typedef void  (APIENTRYP GPPUSHGROUPMARKEREXT)(GLsizei  length, const GLchar * marker);
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPREADNPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, GLsizei  bufSize, void * data);
@@ -588,6 +1014,8 @@ package gl
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMASKI)(GLuint  maskNumber, GLbitfield  mask);
@@ -601,23 +1029,40 @@ package gl
 // typedef void  (APIENTRYP GPSCISSORARRAYV)(GLuint  first, GLsizei  count, const GLint * v);
 // typedef void  (APIENTRYP GPSCISSORINDEXED)(GLuint  index, GLint  left, GLint  bottom, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPSCISSORINDEXEDV)(GLuint  index, const GLint * v);
+// typedef void  (APIENTRYP GPSECONDARYCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
 // typedef void  (APIENTRYP GPSHADERBINARY)(GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPSHADERSOURCE)(GLuint  shader, GLsizei  count, const GLchar *const* string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNC)(GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNCSEPARATE)(GLenum  face, GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASK)(GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASKSEPARATE)(GLenum  face, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILOP)(GLenum  fail, GLenum  zfail, GLenum  zpass);
 // typedef void  (APIENTRYP GPSTENCILOPSEPARATE)(GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPTEXBUFFER)(GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXBUFFERARB)(GLenum  target, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXBUFFERRANGE)(GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXCOORDFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPTEXIMAGE1D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE2D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERF)(GLenum  target, GLenum  pname, GLfloat  param);
@@ -633,61 +1078,118 @@ package gl
 // typedef void  (APIENTRYP GPTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREBARRIER)();
+// typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERF)(GLuint  texture, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, const GLfloat * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERI)(GLuint  texture, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, const GLint * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTURERENDERBUFFEREXT)(GLuint  texture, GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE1D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE1DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREVIEW)(GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
+// typedef void  (APIENTRYP GPTRANSFORMPATHNV)(GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPUNIFORM1D)(GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPUNIFORM1DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM1F)(GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM2D)(GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPUNIFORM2DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM2F)(GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM3D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPUNIFORM3DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM3F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM4D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPUNIFORM4DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM4F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORMBLOCKBINDING)(GLuint  program, GLuint  uniformBlockIndex, GLuint  uniformBlockBinding);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64ARB)(GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64NV)(GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VNV)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
@@ -707,20 +1209,45 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMSUBROUTINESUIV)(GLenum  shadertype, GLsizei  count, const GLuint * indices);
+// typedef void  (APIENTRYP GPUNIFORMUI64NV)(GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPUNIFORMUI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef GLboolean  (APIENTRYP GPUNMAPBUFFER)(GLenum  target);
 // typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFEREXT)(GLuint  buffer);
 // typedef void  (APIENTRYP GPUSEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPUSEPROGRAMSTAGES)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSEPROGRAMSTAGESEXT)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSESHADERPROGRAMEXT)(GLenum  type, GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBBINDING)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBIFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBLFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYBINDVERTEXBUFFEREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYBINDINGDIVISOR)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYEDGEFLAGOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXARRAYELEMENTBUFFER)(GLuint  vaobj, GLuint  buffer);
+// typedef void  (APIENTRYP GPVERTEXARRAYFOGCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYINDEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYNORMALOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYTEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(GLuint  vaobj, GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFER)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFERS)(GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1DV)(GLuint  index, const GLdouble * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1F)(GLuint  index, GLfloat  x);
@@ -759,7 +1286,9 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIB4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBBINDING)(GLuint  attribindex, GLuint  bindingindex);
 // typedef void  (APIENTRYP GPVERTEXATTRIBDIVISOR)(GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXATTRIBDIVISORARB)(GLuint  index, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXATTRIBFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1I)(GLuint  index, GLint  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1IV)(GLuint  index, const GLint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1UI)(GLuint  index, GLuint  x);
@@ -781,18 +1310,36 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4UIV)(GLuint  index, const GLuint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBIFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64NV)(GLuint  index, GLint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64VNV)(GLuint  index, const GLint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64ARB)(GLuint  index, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64NV)(GLuint  index, GLuint64EXT  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VARB)(GLuint  index, const GLuint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2D)(GLuint  index, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBLFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UI)(GLuint  index, GLenum  type, GLboolean  normalized, GLuint  value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
@@ -804,22 +1351,46 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBP4UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBPOINTER)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXBINDINGDIVISOR)(GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVIEWPORT)(GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
+// static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
+//   (*fnptr)(program);
+// }
 // static void  glowActiveShaderProgram(GPACTIVESHADERPROGRAM fnptr, GLuint  pipeline, GLuint  program) {
+//   (*fnptr)(pipeline, program);
+// }
+// static void  glowActiveShaderProgramEXT(GPACTIVESHADERPROGRAMEXT fnptr, GLuint  pipeline, GLuint  program) {
 //   (*fnptr)(pipeline, program);
 // }
 // static void  glowActiveTexture(GPACTIVETEXTURE fnptr, GLenum  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowAttachShader(GPATTACHSHADER fnptr, GLuint  program, GLuint  shader) {
 //   (*fnptr)(program, shader);
 // }
 // static void  glowBeginConditionalRender(GPBEGINCONDITIONALRENDER fnptr, GLuint  id, GLenum  mode) {
 //   (*fnptr)(id, mode);
+// }
+// static void  glowBeginConditionalRenderNV(GPBEGINCONDITIONALRENDERNV fnptr, GLuint  id, GLenum  mode) {
+//   (*fnptr)(id, mode);
+// }
+// static void  glowBeginPerfMonitorAMD(GPBEGINPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowBeginPerfQueryINTEL(GPBEGINPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
 // }
 // static void  glowBeginQuery(GPBEGINQUERY fnptr, GLenum  target, GLuint  id) {
 //   (*fnptr)(target, id);
@@ -863,7 +1434,13 @@ package gl
 // static void  glowBindImageTextures(GPBINDIMAGETEXTURES fnptr, GLuint  first, GLsizei  count, const GLuint * textures) {
 //   (*fnptr)(first, count, textures);
 // }
+// static void  glowBindMultiTextureEXT(GPBINDMULTITEXTUREEXT fnptr, GLenum  texunit, GLenum  target, GLuint  texture) {
+//   (*fnptr)(texunit, target, texture);
+// }
 // static void  glowBindProgramPipeline(GPBINDPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowBindProgramPipelineEXT(GPBINDPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowBindRenderbuffer(GPBINDRENDERBUFFER fnptr, GLenum  target, GLuint  renderbuffer) {
@@ -895,6 +1472,12 @@ package gl
 // }
 // static void  glowBindVertexBuffers(GPBINDVERTEXBUFFERS fnptr, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(first, count, buffers, offsets, strides);
+// }
+// static void  glowBlendBarrierKHR(GPBLENDBARRIERKHR fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowBlendBarrierNV(GPBLENDBARRIERNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowBlendColor(GPBLENDCOLOR fnptr, GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
@@ -935,16 +1518,22 @@ package gl
 // static void  glowBlendFunciARB(GPBLENDFUNCIARB fnptr, GLuint  buf, GLenum  src, GLenum  dst) {
 //   (*fnptr)(buf, src, dst);
 // }
+// static void  glowBlendParameteriNV(GPBLENDPARAMETERINV fnptr, GLenum  pname, GLint  value) {
+//   (*fnptr)(pname, value);
+// }
 // static void  glowBlitFramebuffer(GPBLITFRAMEBUFFER fnptr, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
 // static void  glowBlitNamedFramebuffer(GPBLITNAMEDFRAMEBUFFER fnptr, GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
+// static void  glowBufferAddressRangeNV(GPBUFFERADDRESSRANGENV fnptr, GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length) {
+//   (*fnptr)(pname, index, address, length);
+// }
 // static void  glowBufferData(GPBUFFERDATA fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
@@ -953,10 +1542,16 @@ package gl
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static GLenum  glowCheckFramebufferStatus(GPCHECKFRAMEBUFFERSTATUS fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLenum  glowCheckNamedFramebufferStatus(GPCHECKNAMEDFRAMEBUFFERSTATUS fnptr, GLuint  framebuffer, GLenum  target) {
+//   return (*fnptr)(framebuffer, target);
+// }
+// static GLenum  glowCheckNamedFramebufferStatusEXT(GPCHECKNAMEDFRAMEBUFFERSTATUSEXT fnptr, GLuint  framebuffer, GLenum  target) {
 //   return (*fnptr)(framebuffer, target);
 // }
 // static void  glowClampColor(GPCLAMPCOLOR fnptr, GLenum  target, GLenum  clamp) {
@@ -995,11 +1590,17 @@ package gl
 // static void  glowClearNamedBufferData(GPCLEARNAMEDBUFFERDATA fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, format, type, data);
+// }
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
+// }
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -1019,11 +1620,17 @@ package gl
 // static void  glowClearTexSubImage(GPCLEARTEXSUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data);
 // }
+// static void  glowClientAttribDefaultEXT(GPCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
+// }
 // static GLenum  glowClientWaitSync(GPCLIENTWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   return (*fnptr)(sync, flags, timeout);
 // }
 // static void  glowClipControl(GPCLIPCONTROL fnptr, GLenum  origin, GLenum  depth) {
 //   (*fnptr)(origin, depth);
+// }
+// static void  glowColorFormatNV(GPCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
 // }
 // static void  glowColorMask(GPCOLORMASK fnptr, GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
@@ -1031,11 +1638,35 @@ package gl
 // static void  glowColorMaski(GPCOLORMASKI fnptr, GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a) {
 //   (*fnptr)(index, r, g, b, a);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
 // static void  glowCompileShaderIncludeARB(GPCOMPILESHADERINCLUDEARB fnptr, GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length) {
 //   (*fnptr)(shader, count, path, length);
+// }
+// static void  glowCompressedMultiTexImage1DEXT(GPCOMPRESSEDMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage2DEXT(GPCOMPRESSEDMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage3DEXT(GPCOMPRESSEDMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage1DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage2DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage3DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
 // }
 // static void  glowCompressedTexImage1D(GPCOMPRESSEDTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, internalformat, width, border, imageSize, data);
@@ -1055,14 +1686,38 @@ package gl
 // static void  glowCompressedTexSubImage3D(GPCOMPRESSEDTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
 // }
+// static void  glowCompressedTextureImage1DEXT(GPCOMPRESSEDTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage2DEXT(GPCOMPRESSEDTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage3DEXT(GPCOMPRESSEDTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage1D(GPCOMPRESSEDTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, width, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage1DEXT(GPCOMPRESSEDTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, imageSize, bits);
 // }
 // static void  glowCompressedTextureSubImage2D(GPCOMPRESSEDTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, imageSize, data);
 // }
+// static void  glowCompressedTextureSubImage2DEXT(GPCOMPRESSEDTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage3D(GPCOMPRESSEDTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowCopyBufferSubData(GPCOPYBUFFERSUBDATA fnptr, GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readTarget, writeTarget, readOffset, writeOffset, size);
@@ -1070,8 +1725,26 @@ package gl
 // static void  glowCopyImageSubData(GPCOPYIMAGESUBDATA fnptr, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
 //   (*fnptr)(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyMultiTexImage1DEXT(GPCOPYMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyMultiTexImage2DEXT(GPCOPYMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, height, border);
+// }
+// static void  glowCopyMultiTexSubImage1DEXT(GPCOPYMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texunit, target, level, xoffset, x, y, width);
+// }
+// static void  glowCopyMultiTexSubImage2DEXT(GPCOPYMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, x, y, width, height);
+// }
+// static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
+//   (*fnptr)(resultPath, srcPath);
 // }
 // static void  glowCopyTexImage1D(GPCOPYTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
 //   (*fnptr)(target, level, internalformat, x, y, width, border);
@@ -1088,20 +1761,59 @@ package gl
 // static void  glowCopyTexSubImage3D(GPCOPYTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureImage1DEXT(GPCOPYTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyTextureImage2DEXT(GPCOPYTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, height, border);
+// }
 // static void  glowCopyTextureSubImage1D(GPCOPYTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
 //   (*fnptr)(texture, level, xoffset, x, y, width);
+// }
+// static void  glowCopyTextureSubImage1DEXT(GPCOPYTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texture, target, level, xoffset, x, y, width);
 // }
 // static void  glowCopyTextureSubImage2D(GPCOPYTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureSubImage2DEXT(GPCOPYTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, x, y, width, height);
+// }
 // static void  glowCopyTextureSubImage3D(GPCOPYTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyTextureSubImage3DEXT(GPCOPYTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCoverFillPathInstancedNV(GPCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverFillPathNV(GPCOVERFILLPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverStrokePathInstancedNV(GPCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
 // }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
+//   (*fnptr)(queryId, queryHandle);
 // }
 // static GLuint  glowCreateProgram(GPCREATEPROGRAM fnptr) {
 //   return (*fnptr)();
@@ -1121,8 +1833,17 @@ package gl
 // static GLuint  glowCreateShader(GPCREATESHADER fnptr, GLenum  type) {
 //   return (*fnptr)(type);
 // }
+// static GLuint  glowCreateShaderProgramEXT(GPCREATESHADERPROGRAMEXT fnptr, GLenum  type, const GLchar * string) {
+//   return (*fnptr)(type, string);
+// }
 // static GLuint  glowCreateShaderProgramv(GPCREATESHADERPROGRAMV fnptr, GLenum  type, GLsizei  count, const GLchar *const* strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
+//   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -1169,16 +1890,31 @@ package gl
 // static void  glowDeleteBuffers(GPDELETEBUFFERS fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFramebuffers(GPDELETEFRAMEBUFFERS fnptr, GLsizei  n, const GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
 // }
+// static void  glowDeletePathsNV(GPDELETEPATHSNV fnptr, GLuint  path, GLsizei  range) {
+//   (*fnptr)(path, range);
+// }
+// static void  glowDeletePerfMonitorsAMD(GPDELETEPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
+// static void  glowDeletePerfQueryINTEL(GPDELETEPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowDeleteProgram(GPDELETEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowDeleteProgramPipelines(GPDELETEPROGRAMPIPELINES fnptr, GLsizei  n, const GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowDeleteProgramPipelinesEXT(GPDELETEPROGRAMPIPELINESEXT fnptr, GLsizei  n, const GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowDeleteQueries(GPDELETEQUERIES fnptr, GLsizei  n, const GLuint * ids) {
@@ -1192,6 +1928,9 @@ package gl
 // }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -1229,8 +1968,23 @@ package gl
 // static void  glowDisable(GPDISABLE fnptr, GLenum  cap) {
 //   (*fnptr)(cap);
 // }
+// static void  glowDisableClientStateIndexedEXT(GPDISABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableClientStateiEXT(GPDISABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableIndexedEXT(GPDISABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowDisableVertexArrayAttrib(GPDISABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayAttribEXT(GPDISABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayEXT(GPDISABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowDisableVertexAttribArray(GPDISABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1256,14 +2010,32 @@ package gl
 // static void  glowDrawArraysInstanced(GPDRAWARRAYSINSTANCED fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount) {
 //   (*fnptr)(mode, first, count, instancecount);
 // }
+// static void  glowDrawArraysInstancedARB(GPDRAWARRAYSINSTANCEDARB fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, first, count, primcount);
+// }
 // static void  glowDrawArraysInstancedBaseInstance(GPDRAWARRAYSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, first, count, instancecount, baseinstance);
+// }
+// static void  glowDrawArraysInstancedEXT(GPDRAWARRAYSINSTANCEDEXT fnptr, GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, start, count, primcount);
 // }
 // static void  glowDrawBuffer(GPDRAWBUFFER fnptr, GLenum  buf) {
 //   (*fnptr)(buf);
 // }
 // static void  glowDrawBuffers(GPDRAWBUFFERS fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
+// }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
 // }
 // static void  glowDrawElements(GPDRAWELEMENTS fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, count, type, indices);
@@ -1277,6 +2049,9 @@ package gl
 // static void  glowDrawElementsInstanced(GPDRAWELEMENTSINSTANCED fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount) {
 //   (*fnptr)(mode, count, type, indices, instancecount);
 // }
+// static void  glowDrawElementsInstancedARB(GPDRAWELEMENTSINSTANCEDARB fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
+// }
 // static void  glowDrawElementsInstancedBaseInstance(GPDRAWELEMENTSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, baseinstance);
 // }
@@ -1285,6 +2060,9 @@ package gl
 // }
 // static void  glowDrawElementsInstancedBaseVertexBaseInstance(GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, basevertex, baseinstance);
+// }
+// static void  glowDrawElementsInstancedEXT(GPDRAWELEMENTSINSTANCEDEXT fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
 // }
 // static void  glowDrawRangeElements(GPDRAWRANGEELEMENTS fnptr, GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, start, end, count, type, indices);
@@ -1304,11 +2082,32 @@ package gl
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
 // }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
+// }
+// static void  glowEdgeFlagFormatNV(GPEDGEFLAGFORMATNV fnptr, GLsizei  stride) {
+//   (*fnptr)(stride);
+// }
 // static void  glowEnable(GPENABLE fnptr, GLenum  cap) {
 //   (*fnptr)(cap);
 // }
+// static void  glowEnableClientStateIndexedEXT(GPENABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableClientStateiEXT(GPENABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableIndexedEXT(GPENABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowEnableVertexArrayAttrib(GPENABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayAttribEXT(GPENABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayEXT(GPENABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowEnableVertexAttribArray(GPENABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1319,6 +2118,15 @@ package gl
 // static void  glowEndConditionalRender(GPENDCONDITIONALRENDER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowEndConditionalRenderNV(GPENDCONDITIONALRENDERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowEndPerfMonitorAMD(GPENDPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowEndPerfQueryINTEL(GPENDPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowEndQuery(GPENDQUERY fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
@@ -1326,6 +2134,9 @@ package gl
 //   (*fnptr)(target, index);
 // }
 // static void  glowEndTransformFeedback(GPENDTRANSFORMFEEDBACK fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
 //   (*fnptr)();
 // }
 // static GLsync  glowFenceSync(GPFENCESYNC fnptr, GLenum  condition, GLbitfield  flags) {
@@ -1340,14 +2151,41 @@ package gl
 // static void  glowFlushMappedBufferRange(GPFLUSHMAPPEDBUFFERRANGE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(target, offset, length);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
+//   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFogCoordFormatNV(GPFOGCOORDFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
+// static void  glowFramebufferDrawBufferEXT(GPFRAMEBUFFERDRAWBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
+// static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
+//   (*fnptr)(framebuffer, n, bufs);
+// }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
+// static void  glowFramebufferReadBufferEXT(GPFRAMEBUFFERREADBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
 // static void  glowFramebufferRenderbuffer(GPFRAMEBUFFERRENDERBUFFER fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -1361,8 +2199,20 @@ package gl
 // static void  glowFramebufferTexture3D(GPFRAMEBUFFERTEXTURE3D fnptr, GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
 //   (*fnptr)(target, attachment, textarget, texture, level, zoffset);
 // }
+// static void  glowFramebufferTextureARB(GPFRAMEBUFFERTEXTUREARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(target, attachment, texture, level);
+// }
+// static void  glowFramebufferTextureFaceARB(GPFRAMEBUFFERTEXTUREFACEARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(target, attachment, texture, level, face);
+// }
 // static void  glowFramebufferTextureLayer(GPFRAMEBUFFERTEXTURELAYER fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureLayerARB(GPFRAMEBUFFERTEXTURELAYERARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFrontFace(GPFRONTFACE fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -1373,7 +2223,16 @@ package gl
 // static void  glowGenFramebuffers(GPGENFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
+// static GLuint  glowGenPathsNV(GPGENPATHSNV fnptr, GLsizei  range) {
+//   return (*fnptr)(range);
+// }
+// static void  glowGenPerfMonitorsAMD(GPGENPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
 // static void  glowGenProgramPipelines(GPGENPROGRAMPIPELINES fnptr, GLsizei  n, GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowGenProgramPipelinesEXT(GPGENPROGRAMPIPELINESEXT fnptr, GLsizei  n, GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowGenQueries(GPGENQUERIES fnptr, GLsizei  n, GLuint * ids) {
@@ -1397,8 +2256,14 @@ package gl
 // static void  glowGenerateMipmap(GPGENERATEMIPMAP fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
+// static void  glowGenerateMultiTexMipmapEXT(GPGENERATEMULTITEXMIPMAPEXT fnptr, GLenum  texunit, GLenum  target) {
+//   (*fnptr)(texunit, target);
+// }
 // static void  glowGenerateTextureMipmap(GPGENERATETEXTUREMIPMAP fnptr, GLuint  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowGenerateTextureMipmapEXT(GPGENERATETEXTUREMIPMAPEXT fnptr, GLuint  texture, GLenum  target) {
+//   (*fnptr)(texture, target);
 // }
 // static void  glowGetActiveAtomicCounterBufferiv(GPGETACTIVEATOMICCOUNTERBUFFERIV fnptr, GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, bufferIndex, pname, params);
@@ -1436,6 +2301,9 @@ package gl
 // static GLint  glowGetAttribLocation(GPGETATTRIBLOCATION fnptr, GLuint  program, const GLchar * name) {
 //   return (*fnptr)(program, name);
 // }
+// static void  glowGetBooleanIndexedvEXT(GPGETBOOLEANINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLboolean * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetBooleani_v(GPGETBOOLEANI_V fnptr, GLenum  target, GLuint  index, GLboolean * data) {
 //   (*fnptr)(target, index, data);
 // }
@@ -1448,11 +2316,20 @@ package gl
 // static void  glowGetBufferParameteriv(GPGETBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetBufferParameterui64vNV(GPGETBUFFERPARAMETERUI64VNV fnptr, GLenum  target, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(target, pname, params);
+// }
 // static void  glowGetBufferPointerv(GPGETBUFFERPOINTERV fnptr, GLenum  target, GLenum  pname, void ** params) {
 //   (*fnptr)(target, pname, params);
 // }
 // static void  glowGetBufferSubData(GPGETBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
+// static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texunit, target, lod, img);
 // }
 // static void  glowGetCompressedTexImage(GPGETCOMPRESSEDTEXIMAGE fnptr, GLenum  target, GLint  level, void * img) {
 //   (*fnptr)(target, level, img);
@@ -1460,8 +2337,14 @@ package gl
 // static void  glowGetCompressedTextureImage(GPGETCOMPRESSEDTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, bufSize, pixels);
 // }
+// static void  glowGetCompressedTextureImageEXT(GPGETCOMPRESSEDTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texture, target, lod, img);
+// }
 // static void  glowGetCompressedTextureSubImage(GPGETCOMPRESSEDTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -1472,8 +2355,14 @@ package gl
 // static GLuint  glowGetDebugMessageLogKHR(GPGETDEBUGMESSAGELOGKHR fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
 // }
+// static void  glowGetDoubleIndexedvEXT(GPGETDOUBLEINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLdouble * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetDoublei_v(GPGETDOUBLEI_V fnptr, GLenum  target, GLuint  index, GLdouble * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetDoublei_vEXT(GPGETDOUBLEI_VEXT fnptr, GLenum  pname, GLuint  index, GLdouble * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetDoublev(GPGETDOUBLEV fnptr, GLenum  pname, GLdouble * data) {
 //   (*fnptr)(pname, data);
@@ -1481,8 +2370,17 @@ package gl
 // static GLenum  glowGetError(GPGETERROR fnptr) {
 //   return (*fnptr)();
 // }
+// static void  glowGetFirstPerfQueryIdINTEL(GPGETFIRSTPERFQUERYIDINTEL fnptr, GLuint * queryId) {
+//   (*fnptr)(queryId);
+// }
+// static void  glowGetFloatIndexedvEXT(GPGETFLOATINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLfloat * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetFloati_v(GPGETFLOATI_V fnptr, GLenum  target, GLuint  index, GLfloat * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetFloati_vEXT(GPGETFLOATI_VEXT fnptr, GLenum  pname, GLuint  index, GLfloat * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetFloatv(GPGETFLOATV fnptr, GLenum  pname, GLfloat * data) {
 //   (*fnptr)(pname, data);
@@ -1499,6 +2397,9 @@ package gl
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetFramebufferParameterivEXT(GPGETFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
 // static GLenum  glowGetGraphicsResetStatus(GPGETGRAPHICSRESETSTATUS fnptr) {
 //   return (*fnptr)();
 // }
@@ -1511,23 +2412,74 @@ package gl
 // static GLuint64  glowGetImageHandleARB(GPGETIMAGEHANDLEARB fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
 //   return (*fnptr)(texture, level, layered, layer, format);
 // }
+// static GLuint64  glowGetImageHandleNV(GPGETIMAGEHANDLENV fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
+//   return (*fnptr)(texture, level, layered, layer, format);
+// }
 // static void  glowGetInteger64i_v(GPGETINTEGER64I_V fnptr, GLenum  target, GLuint  index, GLint64 * data) {
 //   (*fnptr)(target, index, data);
 // }
 // static void  glowGetInteger64v(GPGETINTEGER64V fnptr, GLenum  pname, GLint64 * data) {
 //   (*fnptr)(pname, data);
 // }
+// static void  glowGetIntegerIndexedvEXT(GPGETINTEGERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLint * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetIntegeri_v(GPGETINTEGERI_V fnptr, GLenum  target, GLuint  index, GLint * data) {
 //   (*fnptr)(target, index, data);
 // }
+// static void  glowGetIntegerui64i_vNV(GPGETINTEGERUI64I_VNV fnptr, GLenum  value, GLuint  index, GLuint64EXT * result) {
+//   (*fnptr)(value, index, result);
+// }
+// static void  glowGetIntegerui64vNV(GPGETINTEGERUI64VNV fnptr, GLenum  value, GLuint64EXT * result) {
+//   (*fnptr)(value, result);
+// }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
 // }
 // static void  glowGetInternalformativ(GPGETINTERNALFORMATIV fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
+// }
+// static void  glowGetMultiTexEnvfvEXT(GPGETMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexEnvivEXT(GPGETMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexGendvEXT(GPGETMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenfvEXT(GPGETMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenivEXT(GPGETMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexImageEXT(GPGETMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texunit, target, level, format, type, pixels);
+// }
+// static void  glowGetMultiTexLevelParameterfvEXT(GPGETMULTITEXLEVELPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexLevelParameterivEXT(GPGETMULTITEXLEVELPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexParameterIivEXT(GPGETMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterIuivEXT(GPGETMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterfvEXT(GPGETMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterivEXT(GPGETMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
 // }
 // static void  glowGetMultisamplefv(GPGETMULTISAMPLEFV fnptr, GLenum  pname, GLuint  index, GLfloat * val) {
 //   (*fnptr)(pname, index, val);
@@ -1538,19 +2490,58 @@ package gl
 // static void  glowGetNamedBufferParameteriv(GPGETNAMEDBUFFERPARAMETERIV fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(buffer, pname, params);
 // }
+// static void  glowGetNamedBufferParameterivEXT(GPGETNAMEDBUFFERPARAMETERIVEXT fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferParameterui64vNV(GPGETNAMEDBUFFERPARAMETERUI64VNV fnptr, GLuint  buffer, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
 // static void  glowGetNamedBufferPointerv(GPGETNAMEDBUFFERPOINTERV fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedFramebufferAttachmentParameteriv(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
 // }
+// static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, attachment, pname, params);
+// }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowGetNamedFramebufferParameterivEXT(GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIuivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterdvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterfvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramStringEXT(GPGETNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, void * string) {
+//   (*fnptr)(program, target, pname, string);
+// }
+// static void  glowGetNamedProgramivEXT(GPGETNAMEDPROGRAMIVEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(program, target, pname, params);
+// }
 // static void  glowGetNamedRenderbufferParameteriv(GPGETNAMEDRENDERBUFFERPARAMETERIV fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(renderbuffer, pname, params);
+// }
+// static void  glowGetNamedRenderbufferParameterivEXT(GPGETNAMEDRENDERBUFFERPARAMETERIVEXT fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(renderbuffer, pname, params);
 // }
 // static void  glowGetNamedStringARB(GPGETNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string) {
@@ -1559,8 +2550,14 @@ package gl
 // static void  glowGetNamedStringivARB(GPGETNAMEDSTRINGIVARB fnptr, GLint  namelen, const GLchar * name, GLenum  pname, GLint * params) {
 //   (*fnptr)(namelen, name, pname, params);
 // }
+// static void  glowGetNextPerfQueryIdINTEL(GPGETNEXTPERFQUERYIDINTEL fnptr, GLuint  queryId, GLuint * nextQueryId) {
+//   (*fnptr)(queryId, nextQueryId);
+// }
 // static void  glowGetObjectLabel(GPGETOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
+// }
+// static void  glowGetObjectLabelEXT(GPGETOBJECTLABELEXT fnptr, GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label) {
+//   (*fnptr)(type, object, bufSize, length, label);
 // }
 // static void  glowGetObjectLabelKHR(GPGETOBJECTLABELKHR fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
@@ -1570,6 +2567,69 @@ package gl
 // }
 // static void  glowGetObjectPtrLabelKHR(GPGETOBJECTPTRLABELKHR fnptr, const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(ptr, bufSize, length, label);
+// }
+// static void  glowGetPathCommandsNV(GPGETPATHCOMMANDSNV fnptr, GLuint  path, GLubyte * commands) {
+//   (*fnptr)(path, commands);
+// }
+// static void  glowGetPathCoordsNV(GPGETPATHCOORDSNV fnptr, GLuint  path, GLfloat * coords) {
+//   (*fnptr)(path, coords);
+// }
+// static void  glowGetPathDashArrayNV(GPGETPATHDASHARRAYNV fnptr, GLuint  path, GLfloat * dashArray) {
+//   (*fnptr)(path, dashArray);
+// }
+// static GLfloat  glowGetPathLengthNV(GPGETPATHLENGTHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments) {
+//   return (*fnptr)(path, startSegment, numSegments);
+// }
+// static void  glowGetPathMetricRangeNV(GPGETPATHMETRICRANGENV fnptr, GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, firstPathName, numPaths, stride, metrics);
+// }
+// static void  glowGetPathMetricsNV(GPGETPATHMETRICSNV fnptr, GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, numPaths, pathNameType, paths, pathBase, stride, metrics);
+// }
+// static void  glowGetPathParameterfvNV(GPGETPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathParameterivNV(GPGETPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathSpacingNV(GPGETPATHSPACINGNV fnptr, GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing) {
+//   (*fnptr)(pathListMode, numPaths, pathNameType, paths, pathBase, advanceScale, kerningScale, transformType, returnedSpacing);
+// }
+// static void  glowGetPerfCounterInfoINTEL(GPGETPERFCOUNTERINFOINTEL fnptr, GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue) {
+//   (*fnptr)(queryId, counterId, counterNameLength, counterName, counterDescLength, counterDesc, counterOffset, counterDataSize, counterTypeEnum, counterDataTypeEnum, rawCounterMaxValue);
+// }
+// static void  glowGetPerfMonitorCounterDataAMD(GPGETPERFMONITORCOUNTERDATAAMD fnptr, GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten) {
+//   (*fnptr)(monitor, pname, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfMonitorCounterInfoAMD(GPGETPERFMONITORCOUNTERINFOAMD fnptr, GLuint  group, GLuint  counter, GLenum  pname, void * data) {
+//   (*fnptr)(group, counter, pname, data);
+// }
+// static void  glowGetPerfMonitorCounterStringAMD(GPGETPERFMONITORCOUNTERSTRINGAMD fnptr, GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString) {
+//   (*fnptr)(group, counter, bufSize, length, counterString);
+// }
+// static void  glowGetPerfMonitorCountersAMD(GPGETPERFMONITORCOUNTERSAMD fnptr, GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters) {
+//   (*fnptr)(group, numCounters, maxActiveCounters, counterSize, counters);
+// }
+// static void  glowGetPerfMonitorGroupStringAMD(GPGETPERFMONITORGROUPSTRINGAMD fnptr, GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString) {
+//   (*fnptr)(group, bufSize, length, groupString);
+// }
+// static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
+//   (*fnptr)(numGroups, groupsSize, groups);
+// }
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
+//   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
+//   (*fnptr)(queryName, queryId);
+// }
+// static void  glowGetPerfQueryInfoINTEL(GPGETPERFQUERYINFOINTEL fnptr, GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask) {
+//   (*fnptr)(queryId, queryNameLength, queryName, dataSize, noCounters, noInstances, capsMask);
+// }
+// static void  glowGetPointerIndexedvEXT(GPGETPOINTERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, void ** data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetPointeri_vEXT(GPGETPOINTERI_VEXT fnptr, GLenum  pname, GLuint  index, void ** params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetPointerv(GPGETPOINTERV fnptr, GLenum  pname, void ** params) {
 //   (*fnptr)(pname, params);
@@ -1589,7 +2649,13 @@ package gl
 // static void  glowGetProgramPipelineInfoLog(GPGETPROGRAMPIPELINEINFOLOG fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
 //   (*fnptr)(pipeline, bufSize, length, infoLog);
 // }
+// static void  glowGetProgramPipelineInfoLogEXT(GPGETPROGRAMPIPELINEINFOLOGEXT fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
+//   (*fnptr)(pipeline, bufSize, length, infoLog);
+// }
 // static void  glowGetProgramPipelineiv(GPGETPROGRAMPIPELINEIV fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
+//   (*fnptr)(pipeline, pname, params);
+// }
+// static void  glowGetProgramPipelineivEXT(GPGETPROGRAMPIPELINEIVEXT fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
 //   (*fnptr)(pipeline, pname, params);
 // }
 // static GLuint  glowGetProgramResourceIndex(GPGETPROGRAMRESOURCEINDEX fnptr, GLuint  program, GLenum  programInterface, const GLchar * name) {
@@ -1604,6 +2670,9 @@ package gl
 // static void  glowGetProgramResourceName(GPGETPROGRAMRESOURCENAME fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name) {
 //   (*fnptr)(program, programInterface, index, bufSize, length, name);
 // }
+// static void  glowGetProgramResourcefvNV(GPGETPROGRAMRESOURCEFVNV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params) {
+//   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
+// }
 // static void  glowGetProgramResourceiv(GPGETPROGRAMRESOURCEIV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params) {
 //   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
 // }
@@ -1612,6 +2681,18 @@ package gl
 // }
 // static void  glowGetProgramiv(GPGETPROGRAMIV fnptr, GLuint  program, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, pname, params);
+// }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
 // }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
@@ -1658,6 +2739,9 @@ package gl
 // static void  glowGetShaderiv(GPGETSHADERIV fnptr, GLuint  shader, GLenum  pname, GLint * params) {
 //   (*fnptr)(shader, pname, params);
 // }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
+// }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
 // }
@@ -1697,28 +2781,55 @@ package gl
 // static GLuint64  glowGetTextureHandleARB(GPGETTEXTUREHANDLEARB fnptr, GLuint  texture) {
 //   return (*fnptr)(texture);
 // }
+// static GLuint64  glowGetTextureHandleNV(GPGETTEXTUREHANDLENV fnptr, GLuint  texture) {
+//   return (*fnptr)(texture);
+// }
 // static void  glowGetTextureImage(GPGETTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, format, type, bufSize, pixels);
+// }
+// static void  glowGetTextureImageEXT(GPGETTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texture, target, level, format, type, pixels);
 // }
 // static void  glowGetTextureLevelParameterfv(GPGETTEXTURELEVELPARAMETERFV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, level, pname, params);
 // }
+// static void  glowGetTextureLevelParameterfvEXT(GPGETTEXTURELEVELPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, level, pname, params);
+// }
 // static void  glowGetTextureLevelParameteriv(GPGETTEXTURELEVELPARAMETERIV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, level, pname, params);
+// }
+// static void  glowGetTextureLevelParameterivEXT(GPGETTEXTURELEVELPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, level, pname, params);
 // }
 // static void  glowGetTextureParameterIiv(GPGETTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterIivEXT(GPGETTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameterIuiv(GPGETTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowGetTextureParameterIuivEXT(GPGETTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowGetTextureParameterfv(GPGETTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterfvEXT(GPGETTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameteriv(GPGETTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterivEXT(GPGETTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static GLuint64  glowGetTextureSamplerHandleARB(GPGETTEXTURESAMPLERHANDLEARB fnptr, GLuint  texture, GLuint  sampler) {
+//   return (*fnptr)(texture, sampler);
+// }
+// static GLuint64  glowGetTextureSamplerHandleNV(GPGETTEXTURESAMPLERHANDLENV fnptr, GLuint  texture, GLuint  sampler) {
 //   return (*fnptr)(texture, sampler);
 // }
 // static void  glowGetTextureSubImage(GPGETTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
@@ -1754,7 +2865,19 @@ package gl
 // static void  glowGetUniformfv(GPGETUNIFORMFV fnptr, GLuint  program, GLint  location, GLfloat * params) {
 //   (*fnptr)(program, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformiv(GPGETUNIFORMIV fnptr, GLuint  program, GLint  location, GLint * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
 // static void  glowGetUniformuiv(GPGETUNIFORMUIV fnptr, GLuint  program, GLint  location, GLuint * params) {
@@ -1765,6 +2888,18 @@ package gl
 // }
 // static void  glowGetVertexArrayIndexediv(GPGETVERTEXARRAYINDEXEDIV fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegeri_vEXT(GPGETVERTEXARRAYINTEGERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegervEXT(GPGETVERTEXARRAYINTEGERVEXT fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, pname, param);
+// }
+// static void  glowGetVertexArrayPointeri_vEXT(GPGETVERTEXARRAYPOINTERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayPointervEXT(GPGETVERTEXARRAYPOINTERVEXT fnptr, GLuint  vaobj, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, pname, param);
 // }
 // static void  glowGetVertexArrayiv(GPGETVERTEXARRAYIV fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, pname, param);
@@ -1778,7 +2913,13 @@ package gl
 // static void  glowGetVertexAttribLdv(GPGETVERTEXATTRIBLDV fnptr, GLuint  index, GLenum  pname, GLdouble * params) {
 //   (*fnptr)(index, pname, params);
 // }
+// static void  glowGetVertexAttribLi64vNV(GPGETVERTEXATTRIBLI64VNV fnptr, GLuint  index, GLenum  pname, GLint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
 // static void  glowGetVertexAttribLui64vARB(GPGETVERTEXATTRIBLUI64VARB fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
+// static void  glowGetVertexAttribLui64vNV(GPGETVERTEXATTRIBLUI64VNV fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
 //   (*fnptr)(index, pname, params);
 // }
 // static void  glowGetVertexAttribPointerv(GPGETVERTEXATTRIBPOINTERV fnptr, GLuint  index, GLenum  pname, void ** pointer) {
@@ -1792,6 +2933,9 @@ package gl
 // }
 // static void  glowGetVertexAttribiv(GPGETVERTEXATTRIBIV fnptr, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(index, pname, params);
+// }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
 // }
 // static void  glowGetnCompressedTexImageARB(GPGETNCOMPRESSEDTEXIMAGEARB fnptr, GLenum  target, GLint  lod, GLsizei  bufSize, void * img) {
 //   (*fnptr)(target, lod, bufSize, img);
@@ -1811,6 +2955,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -1818,6 +2965,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -1831,6 +2981,15 @@ package gl
 // }
 // static void  glowHint(GPHINT fnptr, GLenum  target, GLenum  mode) {
 //   (*fnptr)(target, mode);
+// }
+// static void  glowIndexFormatNV(GPINDEXFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
+// static void  glowInsertEventMarkerEXT(GPINSERTEVENTMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
+// static void  glowInterpolatePathsNV(GPINTERPOLATEPATHSNV fnptr, GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight) {
+//   (*fnptr)(resultPath, pathA, pathB, weight);
 // }
 // static void  glowInvalidateBufferData(GPINVALIDATEBUFFERDATA fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -1859,8 +3018,17 @@ package gl
 // static GLboolean  glowIsBuffer(GPISBUFFER fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
+// static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
+//   return (*fnptr)(target);
+// }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
+// }
+// static GLboolean  glowIsEnabledIndexedEXT(GPISENABLEDINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   return (*fnptr)(target, index);
 // }
 // static GLboolean  glowIsEnabledi(GPISENABLEDI fnptr, GLenum  target, GLuint  index) {
 //   return (*fnptr)(target, index);
@@ -1871,13 +3039,31 @@ package gl
 // static GLboolean  glowIsImageHandleResidentARB(GPISIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsImageHandleResidentNV(GPISIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
+// static GLboolean  glowIsNamedBufferResidentNV(GPISNAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
 // static GLboolean  glowIsNamedStringARB(GPISNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   return (*fnptr)(namelen, name);
+// }
+// static GLboolean  glowIsPathNV(GPISPATHNV fnptr, GLuint  path) {
+//   return (*fnptr)(path);
+// }
+// static GLboolean  glowIsPointInFillPathNV(GPISPOINTINFILLPATHNV fnptr, GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, mask, x, y);
+// }
+// static GLboolean  glowIsPointInStrokePathNV(GPISPOINTINSTROKEPATHNV fnptr, GLuint  path, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, x, y);
 // }
 // static GLboolean  glowIsProgram(GPISPROGRAM fnptr, GLuint  program) {
 //   return (*fnptr)(program);
 // }
 // static GLboolean  glowIsProgramPipeline(GPISPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   return (*fnptr)(pipeline);
+// }
+// static GLboolean  glowIsProgramPipelineEXT(GPISPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   return (*fnptr)(pipeline);
 // }
 // static GLboolean  glowIsQuery(GPISQUERY fnptr, GLuint  id) {
@@ -1892,6 +3078,9 @@ package gl
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
 // }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
+// }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
 // }
@@ -1901,11 +3090,17 @@ package gl
 // static GLboolean  glowIsTextureHandleResidentARB(GPISTEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsTextureHandleResidentNV(GPISTEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
 // static GLboolean  glowIsTransformFeedback(GPISTRANSFORMFEEDBACK fnptr, GLuint  id) {
 //   return (*fnptr)(id);
 // }
 // static GLboolean  glowIsVertexArray(GPISVERTEXARRAY fnptr, GLuint  array) {
 //   return (*fnptr)(array);
+// }
+// static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
+//   (*fnptr)(type, object, length, label);
 // }
 // static void  glowLineWidth(GPLINEWIDTH fnptr, GLfloat  width) {
 //   (*fnptr)(width);
@@ -1913,19 +3108,46 @@ package gl
 // static void  glowLinkProgram(GPLINKPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
+// }
 // static void  glowLogicOp(GPLOGICOP fnptr, GLenum  opcode) {
 //   (*fnptr)(opcode);
 // }
+// static void  glowMakeBufferNonResidentNV(GPMAKEBUFFERNONRESIDENTNV fnptr, GLenum  target) {
+//   (*fnptr)(target);
+// }
+// static void  glowMakeBufferResidentNV(GPMAKEBUFFERRESIDENTNV fnptr, GLenum  target, GLenum  access) {
+//   (*fnptr)(target, access);
+// }
 // static void  glowMakeImageHandleNonResidentARB(GPMAKEIMAGEHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeImageHandleNonResidentNV(GPMAKEIMAGEHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void  glowMakeImageHandleResidentARB(GPMAKEIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle, GLenum  access) {
 //   (*fnptr)(handle, access);
 // }
+// static void  glowMakeImageHandleResidentNV(GPMAKEIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle, GLenum  access) {
+//   (*fnptr)(handle, access);
+// }
+// static void  glowMakeNamedBufferNonResidentNV(GPMAKENAMEDBUFFERNONRESIDENTNV fnptr, GLuint  buffer) {
+//   (*fnptr)(buffer);
+// }
+// static void  glowMakeNamedBufferResidentNV(GPMAKENAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer, GLenum  access) {
+//   (*fnptr)(buffer, access);
+// }
 // static void  glowMakeTextureHandleNonResidentARB(GPMAKETEXTUREHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
+// static void  glowMakeTextureHandleNonResidentNV(GPMAKETEXTUREHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
 // static void  glowMakeTextureHandleResidentARB(GPMAKETEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeTextureHandleResidentNV(GPMAKETEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void * glowMapBuffer(GPMAPBUFFER fnptr, GLenum  target, GLenum  access) {
@@ -1937,8 +3159,95 @@ package gl
 // static void * glowMapNamedBuffer(GPMAPNAMEDBUFFER fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
+//   return (*fnptr)(buffer, access);
+// }
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
+//   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void  glowMatrixFrustumEXT(GPMATRIXFRUSTUMEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixLoad3x2fNV(GPMATRIXLOAD3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoad3x3fNV(GPMATRIXLOAD3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadIdentityEXT(GPMATRIXLOADIDENTITYEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixLoadTranspose3x3fNV(GPMATRIXLOADTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadTransposedEXT(GPMATRIXLOADTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadTransposefEXT(GPMATRIXLOADTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoaddEXT(GPMATRIXLOADDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadfEXT(GPMATRIXLOADFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMult3x2fNV(GPMATRIXMULT3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMult3x3fNV(GPMATRIXMULT3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTranspose3x3fNV(GPMATRIXMULTTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTransposedEXT(GPMATRIXMULTTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultTransposefEXT(GPMATRIXMULTTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultdEXT(GPMATRIXMULTDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultfEXT(GPMATRIXMULTFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixOrthoEXT(GPMATRIXORTHOEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixPopEXT(GPMATRIXPOPEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixPushEXT(GPMATRIXPUSHEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixRotatedEXT(GPMATRIXROTATEDEXT fnptr, GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixRotatefEXT(GPMATRIXROTATEFEXT fnptr, GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixScaledEXT(GPMATRIXSCALEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixScalefEXT(GPMATRIXSCALEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatedEXT(GPMATRIXTRANSLATEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
 // }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
@@ -1958,7 +3267,13 @@ package gl
 // static void  glowMultiDrawArraysIndirect(GPMULTIDRAWARRAYSINDIRECT fnptr, GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectBindlessCountNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElements(GPMULTIDRAWELEMENTS fnptr, GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount) {
@@ -1970,23 +3285,116 @@ package gl
 // static void  glowMultiDrawElementsIndirect(GPMULTIDRAWELEMENTSINDIRECT fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectBindlessCountNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMultiTexBufferEXT(GPMULTITEXBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texunit, target, internalformat, buffer);
+// }
+// static void  glowMultiTexCoordPointerEXT(GPMULTITEXCOORDPOINTEREXT fnptr, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
+//   (*fnptr)(texunit, size, type, stride, pointer);
+// }
+// static void  glowMultiTexEnvfEXT(GPMULTITEXENVFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvfvEXT(GPMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexEnviEXT(GPMULTITEXENVIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvivEXT(GPMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexGendEXT(GPMULTITEXGENDEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGendvEXT(GPMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGenfEXT(GPMULTITEXGENFEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenfvEXT(GPMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGeniEXT(GPMULTITEXGENIEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenivEXT(GPMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexImage1DEXT(GPMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage2DEXT(GPMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage3DEXT(GPMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowMultiTexParameterIivEXT(GPMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterIuivEXT(GPMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterfEXT(GPMULTITEXPARAMETERFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterfvEXT(GPMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameteriEXT(GPMULTITEXPARAMETERIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterivEXT(GPMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexRenderbufferEXT(GPMULTITEXRENDERBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texunit, target, renderbuffer);
+// }
+// static void  glowMultiTexSubImage1DEXT(GPMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage2DEXT(GPMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
+//   (*fnptr)(buffer, size, data, usage);
+// }
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
+//   (*fnptr)(buffer, size, data, flags);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedCopyBufferSubDataEXT(GPNAMEDCOPYBUFFERSUBDATAEXT fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowNamedFramebufferDrawBuffer(GPNAMEDFRAMEBUFFERDRAWBUFFER fnptr, GLuint  framebuffer, GLenum  buf) {
 //   (*fnptr)(framebuffer, buf);
@@ -1997,26 +3405,104 @@ package gl
 // static void  glowNamedFramebufferParameteri(GPNAMEDFRAMEBUFFERPARAMETERI fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowNamedFramebufferParameteriEXT(GPNAMEDFRAMEBUFFERPARAMETERIEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
+//   (*fnptr)(framebuffer, pname, param);
+// }
 // static void  glowNamedFramebufferReadBuffer(GPNAMEDFRAMEBUFFERREADBUFFER fnptr, GLuint  framebuffer, GLenum  src) {
 //   (*fnptr)(framebuffer, src);
 // }
 // static void  glowNamedFramebufferRenderbuffer(GPNAMEDFRAMEBUFFERRENDERBUFFER fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
 // }
+// static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
+//   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTexture1DEXT(GPNAMEDFRAMEBUFFERTEXTURE1DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture2DEXT(GPNAMEDFRAMEBUFFERTEXTURE2DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture3DEXT(GPNAMEDFRAMEBUFFERTEXTURE3DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level, zoffset);
+// }
+// static void  glowNamedFramebufferTextureEXT(GPNAMEDFRAMEBUFFERTEXTUREEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTextureFaceEXT(GPNAMEDFRAMEBUFFERTEXTUREFACEEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(framebuffer, attachment, texture, level, face);
 // }
 // static void  glowNamedFramebufferTextureLayer(GPNAMEDFRAMEBUFFERTEXTURELAYER fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(framebuffer, attachment, texture, level, layer);
 // }
+// static void  glowNamedFramebufferTextureLayerEXT(GPNAMEDFRAMEBUFFERTEXTURELAYEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(framebuffer, attachment, texture, level, layer);
+// }
+// static void  glowNamedProgramLocalParameter4dEXT(GPNAMEDPROGRAMLOCALPARAMETER4DEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4dvEXT(GPNAMEDPROGRAMLOCALPARAMETER4DVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameter4fEXT(GPNAMEDPROGRAMLOCALPARAMETER4FEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4fvEXT(GPNAMEDPROGRAMLOCALPARAMETER4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4iEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4uiEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameters4fvEXT(GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramStringEXT(GPNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string) {
+//   (*fnptr)(program, target, format, len, string);
+// }
 // static void  glowNamedRenderbufferStorage(GPNAMEDRENDERBUFFERSTORAGE fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageEXT(GPNAMEDRENDERBUFFERSTORAGEEXT fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, internalformat, width, height);
 // }
 // static void  glowNamedRenderbufferStorageMultisample(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, samples, internalformat, width, height);
 // }
+// static void  glowNamedRenderbufferStorageMultisampleCoverageEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT fnptr, GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageMultisampleEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, samples, internalformat, width, height);
+// }
 // static void  glowNamedStringARB(GPNAMEDSTRINGARB fnptr, GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string) {
 //   (*fnptr)(type, namelen, name, stringlen, string);
+// }
+// static void  glowNormalFormatNV(GPNORMALFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
 // }
 // static void  glowObjectLabel(GPOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(identifier, name, length, label);
@@ -2036,6 +3522,60 @@ package gl
 // static void  glowPatchParameteri(GPPATCHPARAMETERI fnptr, GLenum  pname, GLint  value) {
 //   (*fnptr)(pname, value);
 // }
+// static void  glowPathCommandsNV(GPPATHCOMMANDSNV fnptr, GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathCoordsNV(GPPATHCOORDSNV fnptr, GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCoords, coordType, coords);
+// }
+// static void  glowPathCoverDepthFuncNV(GPPATHCOVERDEPTHFUNCNV fnptr, GLenum  func) {
+//   (*fnptr)(func);
+// }
+// static void  glowPathDashArrayNV(GPPATHDASHARRAYNV fnptr, GLuint  path, GLsizei  dashCount, const GLfloat * dashArray) {
+//   (*fnptr)(path, dashCount, dashArray);
+// }
+// static GLenum  glowPathGlyphIndexArrayNV(GPPATHGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathGlyphIndexRangeNV(GPPATHGLYPHINDEXRANGENV fnptr, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount) {
+//   return (*fnptr)(fontTarget, fontName, fontStyle, pathParameterTemplate, emScale, baseAndCount);
+// }
+// static void  glowPathGlyphRangeNV(GPPATHGLYPHRANGENV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyph, numGlyphs, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathGlyphsNV(GPPATHGLYPHSNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, numGlyphs, type, charcodes, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathMemoryGlyphIndexArrayNV(GPPATHMEMORYGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontSize, fontData, faceIndex, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathParameterfNV(GPPATHPARAMETERFNV fnptr, GLuint  path, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterfvNV(GPPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, const GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameteriNV(GPPATHPARAMETERINV fnptr, GLuint  path, GLenum  pname, GLint  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterivNV(GPPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, const GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathStencilDepthOffsetNV(GPPATHSTENCILDEPTHOFFSETNV fnptr, GLfloat  factor, GLfloat  units) {
+//   (*fnptr)(factor, units);
+// }
+// static void  glowPathStencilFuncNV(GPPATHSTENCILFUNCNV fnptr, GLenum  func, GLint  ref, GLuint  mask) {
+//   (*fnptr)(func, ref, mask);
+// }
+// static void  glowPathStringNV(GPPATHSTRINGNV fnptr, GLuint  path, GLenum  format, GLsizei  length, const void * pathString) {
+//   (*fnptr)(path, format, length, pathString);
+// }
+// static void  glowPathSubCommandsNV(GPPATHSUBCOMMANDSNV fnptr, GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, commandStart, commandsToDelete, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathSubCoordsNV(GPPATHSUBCOORDSNV fnptr, GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, coordStart, numCoords, coordType, coords);
+// }
 // static void  glowPauseTransformFeedback(GPPAUSETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -2044,6 +3584,9 @@ package gl
 // }
 // static void  glowPixelStorei(GPPIXELSTOREI fnptr, GLenum  pname, GLint  param) {
 //   (*fnptr)(pname, param);
+// }
+// static GLboolean  glowPointAlongPathNV(GPPOINTALONGPATHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY) {
+//   return (*fnptr)(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
 // }
 // static void  glowPointParameterf(GPPOINTPARAMETERF fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
@@ -2066,11 +3609,23 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPopDebugGroup(GPPOPDEBUGGROUP fnptr) {
 //   (*fnptr)();
 // }
 // static void  glowPopDebugGroupKHR(GPPOPDEBUGGROUPKHR fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowPopGroupMarkerEXT(GPPOPGROUPMARKEREXT fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -2081,164 +3636,434 @@ package gl
 // static void  glowProgramParameteri(GPPROGRAMPARAMETERI fnptr, GLuint  program, GLenum  pname, GLint  value) {
 //   (*fnptr)(program, pname, value);
 // }
+// static void  glowProgramParameteriARB(GPPROGRAMPARAMETERIARB fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramParameteriEXT(GPPROGRAMPARAMETERIEXT fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramPathFragmentInputGenNV(GPPROGRAMPATHFRAGMENTINPUTGENNV fnptr, GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs) {
+//   (*fnptr)(program, location, genMode, components, coeffs);
+// }
 // static void  glowProgramUniform1d(GPPROGRAMUNIFORM1D fnptr, GLuint  program, GLint  location, GLdouble  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1dEXT(GPPROGRAMUNIFORM1DEXT fnptr, GLuint  program, GLint  location, GLdouble  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1dv(GPPROGRAMUNIFORM1DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1dvEXT(GPPROGRAMUNIFORM1DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1f(GPPROGRAMUNIFORM1F fnptr, GLuint  program, GLint  location, GLfloat  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1fEXT(GPPROGRAMUNIFORM1FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1fv(GPPROGRAMUNIFORM1FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1fvEXT(GPPROGRAMUNIFORM1FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1iEXT(GPPROGRAMUNIFORM1IEXT fnptr, GLuint  program, GLint  location, GLint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1iv(GPPROGRAMUNIFORM1IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ivEXT(GPPROGRAMUNIFORM1IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uiEXT(GPPROGRAMUNIFORM1UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1uiv(GPPROGRAMUNIFORM1UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uivEXT(GPPROGRAMUNIFORM1UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2d(GPPROGRAMUNIFORM2D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2dEXT(GPPROGRAMUNIFORM2DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2dv(GPPROGRAMUNIFORM2DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2dvEXT(GPPROGRAMUNIFORM2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2f(GPPROGRAMUNIFORM2F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2fEXT(GPPROGRAMUNIFORM2FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2fv(GPPROGRAMUNIFORM2FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2fvEXT(GPPROGRAMUNIFORM2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2iEXT(GPPROGRAMUNIFORM2IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2iv(GPPROGRAMUNIFORM2IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ivEXT(GPPROGRAMUNIFORM2IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uiEXT(GPPROGRAMUNIFORM2UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2uiv(GPPROGRAMUNIFORM2UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uivEXT(GPPROGRAMUNIFORM2UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3d(GPPROGRAMUNIFORM3D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3dEXT(GPPROGRAMUNIFORM3DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3dv(GPPROGRAMUNIFORM3DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3dvEXT(GPPROGRAMUNIFORM3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3f(GPPROGRAMUNIFORM3F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3fEXT(GPPROGRAMUNIFORM3FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3fv(GPPROGRAMUNIFORM3FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3fvEXT(GPPROGRAMUNIFORM3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3iEXT(GPPROGRAMUNIFORM3IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3iv(GPPROGRAMUNIFORM3IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ivEXT(GPPROGRAMUNIFORM3IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uiEXT(GPPROGRAMUNIFORM3UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3uiv(GPPROGRAMUNIFORM3UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uivEXT(GPPROGRAMUNIFORM3UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4d(GPPROGRAMUNIFORM4D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4dEXT(GPPROGRAMUNIFORM4DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4dv(GPPROGRAMUNIFORM4DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4dvEXT(GPPROGRAMUNIFORM4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4f(GPPROGRAMUNIFORM4F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4fEXT(GPPROGRAMUNIFORM4FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4fv(GPPROGRAMUNIFORM4FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4fvEXT(GPPROGRAMUNIFORM4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4iEXT(GPPROGRAMUNIFORM4IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4iv(GPPROGRAMUNIFORM4IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ivEXT(GPPROGRAMUNIFORM4IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uiEXT(GPPROGRAMUNIFORM4UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4uiv(GPPROGRAMUNIFORM4UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uivEXT(GPPROGRAMUNIFORM4UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniformHandleui64ARB(GPPROGRAMUNIFORMHANDLEUI64ARB fnptr, GLuint  program, GLint  location, GLuint64  value) {
 //   (*fnptr)(program, location, value);
 // }
+// static void  glowProgramUniformHandleui64NV(GPPROGRAMUNIFORMHANDLEUI64NV fnptr, GLuint  program, GLint  location, GLuint64  value) {
+//   (*fnptr)(program, location, value);
+// }
 // static void  glowProgramUniformHandleui64vARB(GPPROGRAMUNIFORMHANDLEUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
+//   (*fnptr)(program, location, count, values);
+// }
+// static void  glowProgramUniformHandleui64vNV(GPPROGRAMUNIFORMHANDLEUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
 //   (*fnptr)(program, location, count, values);
 // }
 // static void  glowProgramUniformMatrix2dv(GPPROGRAMUNIFORMMATRIX2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2dvEXT(GPPROGRAMUNIFORMMATRIX2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2fv(GPPROGRAMUNIFORMMATRIX2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2fvEXT(GPPROGRAMUNIFORMMATRIX2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x3dv(GPPROGRAMUNIFORMMATRIX2X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x3dvEXT(GPPROGRAMUNIFORMMATRIX2X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x3fv(GPPROGRAMUNIFORMMATRIX2X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x3fvEXT(GPPROGRAMUNIFORMMATRIX2X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x4dv(GPPROGRAMUNIFORMMATRIX2X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x4dvEXT(GPPROGRAMUNIFORMMATRIX2X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x4fv(GPPROGRAMUNIFORMMATRIX2X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x4fvEXT(GPPROGRAMUNIFORMMATRIX2X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3dv(GPPROGRAMUNIFORMMATRIX3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3dvEXT(GPPROGRAMUNIFORMMATRIX3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3fv(GPPROGRAMUNIFORMMATRIX3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3fvEXT(GPPROGRAMUNIFORMMATRIX3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x2dv(GPPROGRAMUNIFORMMATRIX3X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x2dvEXT(GPPROGRAMUNIFORMMATRIX3X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x2fv(GPPROGRAMUNIFORMMATRIX3X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x2fvEXT(GPPROGRAMUNIFORMMATRIX3X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x4dv(GPPROGRAMUNIFORMMATRIX3X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x4dvEXT(GPPROGRAMUNIFORMMATRIX3X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x4fv(GPPROGRAMUNIFORMMATRIX3X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x4fvEXT(GPPROGRAMUNIFORMMATRIX3X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4dv(GPPROGRAMUNIFORMMATRIX4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4dvEXT(GPPROGRAMUNIFORMMATRIX4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4fv(GPPROGRAMUNIFORMMATRIX4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4fvEXT(GPPROGRAMUNIFORMMATRIX4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x2dv(GPPROGRAMUNIFORMMATRIX4X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x2dvEXT(GPPROGRAMUNIFORMMATRIX4X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x2fv(GPPROGRAMUNIFORMMATRIX4X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4x2fvEXT(GPPROGRAMUNIFORMMATRIX4X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x3dv(GPPROGRAMUNIFORMMATRIX4X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3dvEXT(GPPROGRAMUNIFORMMATRIX4X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x3fv(GPPROGRAMUNIFORMMATRIX4X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3fvEXT(GPPROGRAMUNIFORMMATRIX4X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformui64NV(GPPROGRAMUNIFORMUI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(program, location, value);
+// }
+// static void  glowProgramUniformui64vNV(GPPROGRAMUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
 // static void  glowProvokingVertex(GPPROVOKINGVERTEX fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
+// }
+// static void  glowPushClientAttribDefaultEXT(GPPUSHCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static void  glowPushDebugGroup(GPPUSHDEBUGGROUP fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
@@ -2246,8 +4071,14 @@ package gl
 // static void  glowPushDebugGroupKHR(GPPUSHDEBUGGROUPKHR fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
 // }
+// static void  glowPushGroupMarkerEXT(GPPUSHGROUPMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
 // static void  glowQueryCounter(GPQUERYCOUNTER fnptr, GLuint  id, GLenum  target) {
 //   (*fnptr)(id, target);
+// }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
 // }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
@@ -2272,6 +4103,12 @@ package gl
 // }
 // static void  glowRenderbufferStorageMultisample(GPRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, samples, internalformat, width, height);
+// }
+// static void  glowRenderbufferStorageMultisampleCoverageNV(GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV fnptr, GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(target, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
@@ -2312,6 +4149,12 @@ package gl
 // static void  glowScissorIndexedv(GPSCISSORINDEXEDV fnptr, GLuint  index, const GLint * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowSecondaryColorFormatNV(GPSECONDARYCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
+// static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
+//   (*fnptr)(monitor, enable, group, numCounters, counterList);
+// }
 // static void  glowShaderBinary(GPSHADERBINARY fnptr, GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length) {
 //   (*fnptr)(count, shaders, binaryformat, binary, length);
 // }
@@ -2320,6 +4163,24 @@ package gl
 // }
 // static void  glowShaderStorageBlockBinding(GPSHADERSTORAGEBLOCKBINDING fnptr, GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding) {
 //   (*fnptr)(program, storageBlockIndex, storageBlockBinding);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
+// }
+// static void  glowStencilFillPathInstancedNV(GPSTENCILFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, transformType, transformValues);
+// }
+// static void  glowStencilFillPathNV(GPSTENCILFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask) {
+//   (*fnptr)(path, fillMode, mask);
 // }
 // static void  glowStencilFunc(GPSTENCILFUNC fnptr, GLenum  func, GLint  ref, GLuint  mask) {
 //   (*fnptr)(func, ref, mask);
@@ -2339,11 +4200,38 @@ package gl
 // static void  glowStencilOpSeparate(GPSTENCILOPSEPARATE fnptr, GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass) {
 //   (*fnptr)(face, sfail, dpfail, dppass);
 // }
+// static void  glowStencilStrokePathInstancedNV(GPSTENCILSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, transformType, transformValues);
+// }
+// static void  glowStencilStrokePathNV(GPSTENCILSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask) {
+//   (*fnptr)(path, reference, mask);
+// }
+// static void  glowStencilThenCoverFillPathInstancedNV(GPSTENCILTHENCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverFillPathNV(GPSTENCILTHENCOVERFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, fillMode, mask, coverMode);
+// }
+// static void  glowStencilThenCoverStrokePathInstancedNV(GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverStrokePathNV(GPSTENCILTHENCOVERSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, reference, mask, coverMode);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
+// }
 // static void  glowTexBuffer(GPTEXBUFFER fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(target, internalformat, buffer);
+// }
+// static void  glowTexBufferARB(GPTEXBUFFERARB fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(target, internalformat, buffer);
 // }
 // static void  glowTexBufferRange(GPTEXBUFFERRANGE fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, internalformat, buffer, offset, size);
+// }
+// static void  glowTexCoordFormatNV(GPTEXCOORDFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
 // }
 // static void  glowTexImage1D(GPTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, border, format, type, pixels);
@@ -2360,8 +4248,8 @@ package gl
 // static void  glowTexImage3DMultisample(GPTEXIMAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -2408,53 +4296,119 @@ package gl
 // static void  glowTextureBarrier(GPTEXTUREBARRIER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowTextureBarrierNV(GPTEXTUREBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowTextureBuffer(GPTEXTUREBUFFER fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texture, target, internalformat, buffer);
+// }
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
+//   (*fnptr)(texture, target, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureImage1DEXT(GPTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowTextureImage2DEXT(GPTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowTextureImage3DEXT(GPTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowTextureParameterIivEXT(GPTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowTextureParameterIuiv(GPTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, const GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowTextureParameterIuivEXT(GPTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameterf(GPTEXTUREPARAMETERF fnptr, GLuint  texture, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameterfEXT(GPTEXTUREPARAMETERFEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameterfv(GPTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, const GLfloat * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterfvEXT(GPTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameteri(GPTEXTUREPARAMETERI fnptr, GLuint  texture, GLenum  pname, GLint  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameteriEXT(GPTEXTUREPARAMETERIEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameteriv(GPTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, const GLint * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterivEXT(GPTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
+// static void  glowTextureRenderbufferEXT(GPTEXTURERENDERBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texture, target, renderbuffer);
 // }
 // static void  glowTextureStorage1D(GPTEXTURESTORAGE1D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
 //   (*fnptr)(texture, levels, internalformat, width);
 // }
+// static void  glowTextureStorage1DEXT(GPTEXTURESTORAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
+//   (*fnptr)(texture, target, levels, internalformat, width);
+// }
 // static void  glowTextureStorage2D(GPTEXTURESTORAGE2D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, levels, internalformat, width, height);
+// }
+// static void  glowTextureStorage2DEXT(GPTEXTURESTORAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height);
 // }
 // static void  glowTextureStorage2DMultisample(GPTEXTURESTORAGE2DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, fixedsamplelocations);
 // }
+// static void  glowTextureStorage2DMultisampleEXT(GPTEXTURESTORAGE2DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, fixedsamplelocations);
+// }
 // static void  glowTextureStorage3D(GPTEXTURESTORAGE3D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
 //   (*fnptr)(texture, levels, internalformat, width, height, depth);
+// }
+// static void  glowTextureStorage3DEXT(GPTEXTURESTORAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height, depth);
 // }
 // static void  glowTextureStorage3DMultisample(GPTEXTURESTORAGE3DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
+// }
 // static void  glowTextureSubImage1D(GPTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowTextureSubImage1DEXT(GPTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, type, pixels);
 // }
 // static void  glowTextureSubImage2D(GPTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, type, pixels);
 // }
+// static void  glowTextureSubImage2DEXT(GPTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
 // static void  glowTextureSubImage3D(GPTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowTextureSubImage3DEXT(GPTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
 // static void  glowTextureView(GPTEXTUREVIEW fnptr, GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers) {
 //   (*fnptr)(texture, target, origtexture, internalformat, minlevel, numlevels, minlayer, numlayers);
@@ -2462,11 +4416,14 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackVaryings(GPTRANSFORMFEEDBACKVARYINGS fnptr, GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode) {
 //   (*fnptr)(program, count, varyings, bufferMode);
+// }
+// static void  glowTransformPathNV(GPTRANSFORMPATHNV fnptr, GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(resultPath, srcPath, transformType, transformValues);
 // }
 // static void  glowUniform1d(GPUNIFORM1D fnptr, GLint  location, GLdouble  x) {
 //   (*fnptr)(location, x);
@@ -2483,11 +4440,35 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform1iv(GPUNIFORM1IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
+// }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1uiv(GPUNIFORM1UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2507,11 +4488,35 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform2iv(GPUNIFORM2IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
+// }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2uiv(GPUNIFORM2UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2531,11 +4536,35 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform3iv(GPUNIFORM3IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
+// }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3uiv(GPUNIFORM3UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2555,11 +4584,35 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform4iv(GPUNIFORM4IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
+// }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4uiv(GPUNIFORM4UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2570,7 +4623,13 @@ package gl
 // static void  glowUniformHandleui64ARB(GPUNIFORMHANDLEUI64ARB fnptr, GLint  location, GLuint64  value) {
 //   (*fnptr)(location, value);
 // }
+// static void  glowUniformHandleui64NV(GPUNIFORMHANDLEUI64NV fnptr, GLint  location, GLuint64  value) {
+//   (*fnptr)(location, value);
+// }
 // static void  glowUniformHandleui64vARB(GPUNIFORMHANDLEUI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniformHandleui64vNV(GPUNIFORMHANDLEUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniformMatrix2dv(GPUNIFORMMATRIX2DV fnptr, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
@@ -2630,10 +4689,19 @@ package gl
 // static void  glowUniformSubroutinesuiv(GPUNIFORMSUBROUTINESUIV fnptr, GLenum  shadertype, GLsizei  count, const GLuint * indices) {
 //   (*fnptr)(shadertype, count, indices);
 // }
+// static void  glowUniformui64NV(GPUNIFORMUI64NV fnptr, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(location, value);
+// }
+// static void  glowUniformui64vNV(GPUNIFORMUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static GLboolean  glowUnmapBuffer(GPUNMAPBUFFER fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLboolean  glowUnmapNamedBuffer(GPUNMAPNAMEDBUFFER fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
+// static GLboolean  glowUnmapNamedBufferEXT(GPUNMAPNAMEDBUFFEREXT fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
 // static void  glowUseProgram(GPUSEPROGRAM fnptr, GLuint  program) {
@@ -2642,10 +4710,19 @@ package gl
 // static void  glowUseProgramStages(GPUSEPROGRAMSTAGES fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
 //   (*fnptr)(pipeline, stages, program);
 // }
+// static void  glowUseProgramStagesEXT(GPUSEPROGRAMSTAGESEXT fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
+//   (*fnptr)(pipeline, stages, program);
+// }
+// static void  glowUseShaderProgramEXT(GPUSESHADERPROGRAMEXT fnptr, GLenum  type, GLuint  program) {
+//   (*fnptr)(type, program);
+// }
 // static void  glowValidateProgram(GPVALIDATEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowValidateProgramPipeline(GPVALIDATEPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowValidateProgramPipelineEXT(GPVALIDATEPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowVertexArrayAttribBinding(GPVERTEXARRAYATTRIBBINDING fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
@@ -2660,17 +4737,74 @@ package gl
 // static void  glowVertexArrayAttribLFormat(GPVERTEXARRAYATTRIBLFORMAT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexArrayBindVertexBufferEXT(GPVERTEXARRAYBINDVERTEXBUFFEREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
+//   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
+// }
 // static void  glowVertexArrayBindingDivisor(GPVERTEXARRAYBINDINGDIVISOR fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(vaobj, bindingindex, divisor);
 // }
+// static void  glowVertexArrayColorOffsetEXT(GPVERTEXARRAYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayEdgeFlagOffsetEXT(GPVERTEXARRAYEDGEFLAGOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, stride, offset);
+// }
 // static void  glowVertexArrayElementBuffer(GPVERTEXARRAYELEMENTBUFFER fnptr, GLuint  vaobj, GLuint  buffer) {
 //   (*fnptr)(vaobj, buffer);
+// }
+// static void  glowVertexArrayFogCoordOffsetEXT(GPVERTEXARRAYFOGCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayIndexOffsetEXT(GPVERTEXARRAYINDEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayMultiTexCoordOffsetEXT(GPVERTEXARRAYMULTITEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, texunit, size, type, stride, offset);
+// }
+// static void  glowVertexArrayNormalOffsetEXT(GPVERTEXARRAYNORMALOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArraySecondaryColorOffsetEXT(GPVERTEXARRAYSECONDARYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayTexCoordOffsetEXT(GPVERTEXARRAYTEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribBindingEXT(GPVERTEXARRAYVERTEXATTRIBBINDINGEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
+//   (*fnptr)(vaobj, attribindex, bindingindex);
+// }
+// static void  glowVertexArrayVertexAttribDivisorEXT(GPVERTEXARRAYVERTEXATTRIBDIVISOREXT fnptr, GLuint  vaobj, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(vaobj, index, divisor);
+// }
+// static void  glowVertexArrayVertexAttribFormatEXT(GPVERTEXARRAYVERTEXATTRIBFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIFormatEXT(GPVERTEXARRAYVERTEXATTRIBIFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIOffsetEXT(GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribLFormatEXT(GPVERTEXARRAYVERTEXATTRIBLFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribLOffsetEXT(GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribOffsetEXT(GPVERTEXARRAYVERTEXATTRIBOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, normalized, stride, offset);
+// }
+// static void  glowVertexArrayVertexBindingDivisorEXT(GPVERTEXARRAYVERTEXBINDINGDIVISOREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
+//   (*fnptr)(vaobj, bindingindex, divisor);
 // }
 // static void  glowVertexArrayVertexBuffer(GPVERTEXARRAYVERTEXBUFFER fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
 //   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
 // }
 // static void  glowVertexArrayVertexBuffers(GPVERTEXARRAYVERTEXBUFFERS fnptr, GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(vaobj, first, count, buffers, offsets, strides);
+// }
+// static void  glowVertexArrayVertexOffsetEXT(GPVERTEXARRAYVERTEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
 // }
 // static void  glowVertexAttrib1d(GPVERTEXATTRIB1D fnptr, GLuint  index, GLdouble  x) {
 //   (*fnptr)(index, x);
@@ -2786,8 +4920,14 @@ package gl
 // static void  glowVertexAttribDivisor(GPVERTEXATTRIBDIVISOR fnptr, GLuint  index, GLuint  divisor) {
 //   (*fnptr)(index, divisor);
 // }
+// static void  glowVertexAttribDivisorARB(GPVERTEXATTRIBDIVISORARB fnptr, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(index, divisor);
+// }
 // static void  glowVertexAttribFormat(GPVERTEXATTRIBFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexAttribFormatNV(GPVERTEXATTRIBFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride) {
+//   (*fnptr)(index, size, type, normalized, stride);
 // }
 // static void  glowVertexAttribI1i(GPVERTEXATTRIBI1I fnptr, GLuint  index, GLint  x) {
 //   (*fnptr)(index, x);
@@ -2852,6 +4992,9 @@ package gl
 // static void  glowVertexAttribIFormat(GPVERTEXATTRIBIFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexAttribIFormatNV(GPVERTEXATTRIBIFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
+// }
 // static void  glowVertexAttribIPointer(GPVERTEXATTRIBIPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
 // }
@@ -2861,10 +5004,22 @@ package gl
 // static void  glowVertexAttribL1dv(GPVERTEXATTRIBL1DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL1i64NV(GPVERTEXATTRIBL1I64NV fnptr, GLuint  index, GLint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
+// static void  glowVertexAttribL1i64vNV(GPVERTEXATTRIBL1I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL1ui64ARB(GPVERTEXATTRIBL1UI64ARB fnptr, GLuint  index, GLuint64EXT  x) {
 //   (*fnptr)(index, x);
 // }
+// static void  glowVertexAttribL1ui64NV(GPVERTEXATTRIBL1UI64NV fnptr, GLuint  index, GLuint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
 // static void  glowVertexAttribL1ui64vARB(GPVERTEXATTRIBL1UI64VARB fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL1ui64vNV(GPVERTEXATTRIBL1UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL2d(GPVERTEXATTRIBL2D fnptr, GLuint  index, GLdouble  x, GLdouble  y) {
@@ -2873,10 +5028,34 @@ package gl
 // static void  glowVertexAttribL2dv(GPVERTEXATTRIBL2DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL2i64NV(GPVERTEXATTRIBL2I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2i64vNV(GPVERTEXATTRIBL2I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL2ui64NV(GPVERTEXATTRIBL2UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2ui64vNV(GPVERTEXATTRIBL2UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL3d(GPVERTEXATTRIBL3D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z) {
 //   (*fnptr)(index, x, y, z);
 // }
 // static void  glowVertexAttribL3dv(GPVERTEXATTRIBL3DV fnptr, GLuint  index, const GLdouble * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3i64NV(GPVERTEXATTRIBL3I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3i64vNV(GPVERTEXATTRIBL3I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3ui64NV(GPVERTEXATTRIBL3UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3ui64vNV(GPVERTEXATTRIBL3UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL4d(GPVERTEXATTRIBL4D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
@@ -2885,8 +5064,23 @@ package gl
 // static void  glowVertexAttribL4dv(GPVERTEXATTRIBL4DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL4i64NV(GPVERTEXATTRIBL4I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4i64vNV(GPVERTEXATTRIBL4I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL4ui64NV(GPVERTEXATTRIBL4UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4ui64vNV(GPVERTEXATTRIBL4UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribLFormat(GPVERTEXATTRIBLFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexAttribLFormatNV(GPVERTEXATTRIBLFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
 // }
 // static void  glowVertexAttribLPointer(GPVERTEXATTRIBLPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
@@ -2921,6 +5115,9 @@ package gl
 // static void  glowVertexBindingDivisor(GPVERTEXBINDINGDIVISOR fnptr, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(bindingindex, divisor);
 // }
+// static void  glowVertexFormatNV(GPVERTEXFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
 // static void  glowViewport(GPVIEWPORT fnptr, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(x, y, width, height);
 // }
@@ -2933,8 +5130,23 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
+//   (*fnptr)(resultPath, numPaths, paths, weights);
+// }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
 // }
 import "C"
 import (
@@ -2943,10 +5155,12 @@ import (
 )
 
 const (
+	ACCUM_ADJACENT_PAIRS_NV                                    = 0x90AD
 	ACTIVE_ATOMIC_COUNTER_BUFFERS                              = 0x92D9
 	ACTIVE_ATTRIBUTES                                          = 0x8B89
 	ACTIVE_ATTRIBUTE_MAX_LENGTH                                = 0x8B8A
 	ACTIVE_PROGRAM                                             = 0x8259
+	ACTIVE_PROGRAM_EXT                                         = 0x8B8D
 	ACTIVE_RESOURCES                                           = 0x92F5
 	ACTIVE_SUBROUTINES                                         = 0x8DE5
 	ACTIVE_SUBROUTINE_MAX_LENGTH                               = 0x8E48
@@ -2959,10 +5173,15 @@ const (
 	ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH                       = 0x8A35
 	ACTIVE_UNIFORM_MAX_LENGTH                                  = 0x8B87
 	ACTIVE_VARIABLES                                           = 0x9305
+	ADJACENT_PAIRS_NV                                          = 0x90AE
+	AFFINE_2D_NV                                               = 0x9092
+	AFFINE_3D_NV                                               = 0x9094
 	ALIASED_LINE_WIDTH_RANGE                                   = 0x846E
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
+	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALPHA                                                      = 0x1906
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	AND                                                        = 0x1501
@@ -2970,6 +5189,7 @@ const (
 	AND_REVERSE                                                = 0x1502
 	ANY_SAMPLES_PASSED                                         = 0x8C2F
 	ANY_SAMPLES_PASSED_CONSERVATIVE                            = 0x8D6A
+	ARC_TO_NV                                                  = 0xFE
 	ARRAY_BUFFER                                               = 0x8892
 	ARRAY_BUFFER_BINDING                                       = 0x8894
 	ARRAY_SIZE                                                 = 0x92FB
@@ -2990,43 +5210,56 @@ const (
 	ATOMIC_COUNTER_BUFFER_SIZE                                 = 0x92C3
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	AUTO_GENERATE_MIPMAP                                       = 0x8295
 	BACK                                                       = 0x0405
 	BACK_LEFT                                                  = 0x0402
 	BACK_RIGHT                                                 = 0x0403
+	BEVEL_NV                                                   = 0x90A6
 	BGR                                                        = 0x80E0
 	BGRA                                                       = 0x80E1
 	BGRA_INTEGER                                               = 0x8D9B
 	BGR_INTEGER                                                = 0x8D9A
 	BLEND                                                      = 0x0BE2
+	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
+	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
 	BLEND_DST_RGB                                              = 0x80C8
 	BLEND_EQUATION                                             = 0x8009
 	BLEND_EQUATION_ALPHA                                       = 0x883D
 	BLEND_EQUATION_RGB                                         = 0x8009
+	BLEND_OVERLAP_NV                                           = 0x9281
+	BLEND_PREMULTIPLIED_SRC_NV                                 = 0x9280
 	BLEND_SRC                                                  = 0x0BE1
 	BLEND_SRC_ALPHA                                            = 0x80CB
 	BLEND_SRC_RGB                                              = 0x80C9
 	BLOCK_INDEX                                                = 0x92FD
 	BLUE                                                       = 0x1905
 	BLUE_INTEGER                                               = 0x8D96
+	BLUE_NV                                                    = 0x1905
+	BOLD_BIT_NV                                                = 0x01
 	BOOL                                                       = 0x8B56
 	BOOL_VEC2                                                  = 0x8B57
 	BOOL_VEC3                                                  = 0x8B58
 	BOOL_VEC4                                                  = 0x8B59
+	BOUNDING_BOX_NV                                            = 0x908D
+	BOUNDING_BOX_OF_BOUNDING_BOXES_NV                          = 0x909C
 	BUFFER                                                     = 0x82E0
 	BUFFER_ACCESS                                              = 0x88BB
 	BUFFER_ACCESS_FLAGS                                        = 0x911F
 	BUFFER_BINDING                                             = 0x9302
 	BUFFER_DATA_SIZE                                           = 0x9303
+	BUFFER_GPU_ADDRESS_NV                                      = 0x8F1D
 	BUFFER_IMMUTABLE_STORAGE                                   = 0x821F
 	BUFFER_KHR                                                 = 0x82E0
 	BUFFER_MAPPED                                              = 0x88BC
 	BUFFER_MAP_LENGTH                                          = 0x9120
 	BUFFER_MAP_OFFSET                                          = 0x9121
 	BUFFER_MAP_POINTER                                         = 0x88BD
+	BUFFER_OBJECT_EXT                                          = 0x9151
 	BUFFER_SIZE                                                = 0x8764
 	BUFFER_STORAGE_FLAGS                                       = 0x8220
 	BUFFER_UPDATE_BARRIER_BIT                                  = 0x00000200
@@ -3035,8 +5268,12 @@ const (
 	BYTE                                                       = 0x1400
 	CAVEAT_SUPPORT                                             = 0x82B8
 	CCW                                                        = 0x0901
+	CIRCULAR_CCW_ARC_TO_NV                                     = 0xF8
+	CIRCULAR_CW_ARC_TO_NV                                      = 0xFA
+	CIRCULAR_TANGENT_ARC_TO_NV                                 = 0xFC
 	CLAMP_READ_COLOR                                           = 0x891C
 	CLAMP_TO_BORDER                                            = 0x812D
+	CLAMP_TO_BORDER_ARB                                        = 0x812D
 	CLAMP_TO_EDGE                                              = 0x812F
 	CLEAR                                                      = 0x1500
 	CLEAR_BUFFER                                               = 0x82B4
@@ -3055,7 +5292,14 @@ const (
 	CLIP_DISTANCE6                                             = 0x3006
 	CLIP_DISTANCE7                                             = 0x3007
 	CLIP_ORIGIN                                                = 0x935C
+	CLOSE_PATH_NV                                              = 0x00
 	COLOR                                                      = 0x1800
+	COLORBURN_KHR                                              = 0x929A
+	COLORBURN_NV                                               = 0x929A
+	COLORDODGE_KHR                                             = 0x9299
+	COLORDODGE_NV                                              = 0x9299
+	COLOR_ARRAY_ADDRESS_NV                                     = 0x8F23
+	COLOR_ARRAY_LENGTH_NV                                      = 0x8F2D
 	COLOR_ATTACHMENT0                                          = 0x8CE0
 	COLOR_ATTACHMENT1                                          = 0x8CE1
 	COLOR_ATTACHMENT10                                         = 0x8CEA
@@ -3064,8 +5308,24 @@ const (
 	COLOR_ATTACHMENT13                                         = 0x8CED
 	COLOR_ATTACHMENT14                                         = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT5                                          = 0x8CE5
 	COLOR_ATTACHMENT6                                          = 0x8CE6
@@ -3078,11 +5338,14 @@ const (
 	COLOR_ENCODING                                             = 0x8296
 	COLOR_LOGIC_OP                                             = 0x0BF2
 	COLOR_RENDERABLE                                           = 0x8286
+	COLOR_SAMPLES_NV                                           = 0x8E20
 	COLOR_WRITEMASK                                            = 0x0C23
 	COMMAND_BARRIER_BIT                                        = 0x00000040
 	COMPARE_REF_TO_TEXTURE                                     = 0x884E
 	COMPATIBLE_SUBROUTINES                                     = 0x8E4B
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_R11_EAC                                         = 0x9270
 	COMPRESSED_RED                                             = 0x8225
 	COMPRESSED_RED_RGTC1                                       = 0x8DBB
@@ -3109,10 +5372,14 @@ const (
 	COMPRESSED_RGBA_ASTC_8x8_KHR                               = 0x93B7
 	COMPRESSED_RGBA_BPTC_UNORM                                 = 0x8E8C
 	COMPRESSED_RGBA_BPTC_UNORM_ARB                             = 0x8E8C
+	COMPRESSED_RGBA_S3TC_DXT1_EXT                              = 0x83F1
+	COMPRESSED_RGBA_S3TC_DXT3_EXT                              = 0x83F2
+	COMPRESSED_RGBA_S3TC_DXT5_EXT                              = 0x83F3
 	COMPRESSED_RGB_BPTC_SIGNED_FLOAT                           = 0x8E8E
 	COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB                       = 0x8E8E
 	COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT                         = 0x8E8F
 	COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB                     = 0x8E8F
+	COMPRESSED_RGB_S3TC_DXT1_EXT                               = 0x83F0
 	COMPRESSED_RG_RGTC2                                        = 0x8DBD
 	COMPRESSED_SIGNED_R11_EAC                                  = 0x9271
 	COMPRESSED_SIGNED_RED_RGTC1                                = 0x8DBC
@@ -3148,6 +5415,18 @@ const (
 	COMPUTE_TEXTURE                                            = 0x82A0
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
+	CONIC_CURVE_TO_NV                                          = 0x1A
+	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSTANT_ALPHA                                             = 0x8003
 	CONSTANT_COLOR                                             = 0x8001
 	CONTEXT_COMPATIBILITY_PROFILE_BIT                          = 0x00000002
@@ -3156,6 +5435,7 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
 	CONTEXT_LOST_KHR                                           = 0x0507
@@ -3166,18 +5446,30 @@ const (
 	CONTEXT_RELEASE_BEHAVIOR_KHR                               = 0x82FB
 	CONTEXT_ROBUST_ACCESS                                      = 0x90F3
 	CONTEXT_ROBUST_ACCESS_KHR                                  = 0x90F3
+	CONTRAST_NV                                                = 0x92A1
+	CONVEX_HULL_NV                                             = 0x908B
 	COPY                                                       = 0x1503
 	COPY_INVERTED                                              = 0x150C
 	COPY_READ_BUFFER                                           = 0x8F36
 	COPY_READ_BUFFER_BINDING                                   = 0x8F36
 	COPY_WRITE_BUFFER                                          = 0x8F37
 	COPY_WRITE_BUFFER_BINDING                                  = 0x8F37
+	COUNTER_RANGE_AMD                                          = 0x8BC1
+	COUNTER_TYPE_AMD                                           = 0x8BC0
+	COUNT_DOWN_NV                                              = 0x9089
+	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
+	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CULL_FACE                                                  = 0x0B44
 	CULL_FACE_MODE                                             = 0x0B45
 	CURRENT_PROGRAM                                            = 0x8B8D
 	CURRENT_QUERY                                              = 0x8865
 	CURRENT_VERTEX_ATTRIB                                      = 0x8626
 	CW                                                         = 0x0900
+	DARKEN_KHR                                                 = 0x9297
+	DARKEN_NV                                                  = 0x9297
 	DEBUG_CALLBACK_FUNCTION                                    = 0x8244
 	DEBUG_CALLBACK_FUNCTION_ARB                                = 0x8244
 	DEBUG_CALLBACK_FUNCTION_KHR                                = 0x8244
@@ -3250,6 +5542,7 @@ const (
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR                              = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_ARB                          = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_KHR                          = 0x824E
+	DECODE_EXT                                                 = 0x8A49
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DELETE_STATUS                                              = 0x8B80
@@ -3269,11 +5562,15 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
 	DEPTH_STENCIL_TEXTURE_MODE                                 = 0x90EA
 	DEPTH_TEST                                                 = 0x0B71
 	DEPTH_WRITEMASK                                            = 0x0B72
+	DIFFERENCE_KHR                                             = 0x929E
+	DIFFERENCE_NV                                              = 0x929E
+	DISJOINT_NV                                                = 0x9283
 	DISPATCH_INDIRECT_BUFFER                                   = 0x90EE
 	DISPATCH_INDIRECT_BUFFER_BINDING                           = 0x90EF
 	DITHER                                                     = 0x0BD0
@@ -3292,6 +5589,9 @@ const (
 	DOUBLE_VEC2                                                = 0x8FFC
 	DOUBLE_VEC3                                                = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER1                                               = 0x8826
@@ -3309,30 +5609,62 @@ const (
 	DRAW_BUFFER7                                               = 0x882C
 	DRAW_BUFFER8                                               = 0x882D
 	DRAW_BUFFER9                                               = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
+	DRAW_INDIRECT_ADDRESS_NV                                   = 0x8F41
 	DRAW_INDIRECT_BUFFER                                       = 0x8F3F
 	DRAW_INDIRECT_BUFFER_BINDING                               = 0x8F43
+	DRAW_INDIRECT_LENGTH_NV                                    = 0x8F42
+	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DST_ALPHA                                                  = 0x0304
+	DST_ATOP_NV                                                = 0x928F
 	DST_COLOR                                                  = 0x0306
+	DST_IN_NV                                                  = 0x928B
+	DST_NV                                                     = 0x9287
+	DST_OUT_NV                                                 = 0x928D
+	DST_OVER_NV                                                = 0x9289
+	DUP_FIRST_CUBIC_CURVE_TO_NV                                = 0xF2
+	DUP_LAST_CUBIC_CURVE_TO_NV                                 = 0xF4
 	DYNAMIC_COPY                                               = 0x88EA
 	DYNAMIC_DRAW                                               = 0x88E8
 	DYNAMIC_READ                                               = 0x88E9
 	DYNAMIC_STORAGE_BIT                                        = 0x0100
+	EDGE_FLAG_ARRAY_ADDRESS_NV                                 = 0x8F26
+	EDGE_FLAG_ARRAY_LENGTH_NV                                  = 0x8F30
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
+	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_BARRIER_BIT                                  = 0x00000002
 	ELEMENT_ARRAY_BUFFER                                       = 0x8893
 	ELEMENT_ARRAY_BUFFER_BINDING                               = 0x8895
+	ELEMENT_ARRAY_LENGTH_NV                                    = 0x8F33
+	ELEMENT_ARRAY_UNIFIED_NV                                   = 0x8F1F
 	EQUAL                                                      = 0x0202
 	EQUIV                                                      = 0x1509
+	EXCLUSION_KHR                                              = 0x92A0
+	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXTENSIONS                                                 = 0x1F03
+	FACTOR_MAX_AMD                                             = 0x901D
+	FACTOR_MIN_AMD                                             = 0x901C
 	FALSE                                                      = 0
 	FASTEST                                                    = 0x1101
+	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
+	FIRST_TO_REST_NV                                           = 0x90AF
 	FIRST_VERTEX_CONVENTION                                    = 0x8E4D
 	FIXED                                                      = 0x140C
 	FIXED_ONLY                                                 = 0x891D
 	FLOAT                                                      = 0x1406
+	FLOAT16_NV                                                 = 0x8FF8
+	FLOAT16_VEC2_NV                                            = 0x8FF9
+	FLOAT16_VEC3_NV                                            = 0x8FFA
+	FLOAT16_VEC4_NV                                            = 0x8FFB
 	FLOAT_32_UNSIGNED_INT_24_8_REV                             = 0x8DAD
 	FLOAT_MAT2                                                 = 0x8B5A
 	FLOAT_MAT2x3                                               = 0x8B65
@@ -3346,12 +5678,37 @@ const (
 	FLOAT_VEC2                                                 = 0x8B50
 	FLOAT_VEC3                                                 = 0x8B51
 	FLOAT_VEC4                                                 = 0x8B52
+	FOG_COORD_ARRAY_ADDRESS_NV                                 = 0x8F28
+	FOG_COORD_ARRAY_LENGTH_NV                                  = 0x8F32
+	FONT_ASCENDER_BIT_NV                                       = 0x00200000
+	FONT_DESCENDER_BIT_NV                                      = 0x00400000
+	FONT_GLYPHS_AVAILABLE_NV                                   = 0x9368
+	FONT_HAS_KERNING_BIT_NV                                    = 0x10000000
+	FONT_HEIGHT_BIT_NV                                         = 0x00800000
+	FONT_MAX_ADVANCE_HEIGHT_BIT_NV                             = 0x02000000
+	FONT_MAX_ADVANCE_WIDTH_BIT_NV                              = 0x01000000
+	FONT_NUM_GLYPH_INDICES_BIT_NV                              = 0x20000000
+	FONT_TARGET_UNAVAILABLE_NV                                 = 0x9369
+	FONT_UNAVAILABLE_NV                                        = 0x936A
+	FONT_UNDERLINE_POSITION_BIT_NV                             = 0x04000000
+	FONT_UNDERLINE_THICKNESS_BIT_NV                            = 0x08000000
+	FONT_UNINTELLIGIBLE_NV                                     = 0x936B
+	FONT_UNITS_PER_EM_BIT_NV                                   = 0x00100000
+	FONT_X_MAX_BOUNDS_BIT_NV                                   = 0x00040000
+	FONT_X_MIN_BOUNDS_BIT_NV                                   = 0x00010000
+	FONT_Y_MAX_BOUNDS_BIT_NV                                   = 0x00080000
+	FONT_Y_MIN_BOUNDS_BIT_NV                                   = 0x00020000
 	FRACTIONAL_EVEN                                            = 0x8E7C
 	FRACTIONAL_ODD                                             = 0x8E7B
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
+	FRAGMENT_INPUT_NV                                          = 0x936D
 	FRAGMENT_INTERPOLATION_OFFSET_BITS                         = 0x8E5D
 	FRAGMENT_SHADER                                            = 0x8B30
 	FRAGMENT_SHADER_BIT                                        = 0x00000002
+	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -3364,13 +5721,16 @@ const (
 	FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE                          = 0x8216
 	FRAMEBUFFER_ATTACHMENT_GREEN_SIZE                          = 0x8213
 	FRAMEBUFFER_ATTACHMENT_LAYERED                             = 0x8DA7
+	FRAMEBUFFER_ATTACHMENT_LAYERED_ARB                         = 0x8DA7
 	FRAMEBUFFER_ATTACHMENT_OBJECT_NAME                         = 0x8CD1
 	FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE                         = 0x8CD0
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
 	FRAMEBUFFER_BLEND                                          = 0x828B
@@ -3383,18 +5743,26 @@ const (
 	FRAMEBUFFER_DEFAULT_WIDTH                                  = 0x9310
 	FRAMEBUFFER_INCOMPLETE_ATTACHMENT                          = 0x8CD6
 	FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER                         = 0x8CDB
+	FRAMEBUFFER_INCOMPLETE_LAYER_COUNT_ARB                     = 0x8DA9
 	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS                       = 0x8DA8
+	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS_ARB                   = 0x8DA8
 	FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT                  = 0x8CD7
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE                         = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_UNDEFINED                                      = 0x8219
 	FRAMEBUFFER_UNSUPPORTED                                    = 0x8CDD
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_SUPPORT                                               = 0x82B7
@@ -3402,8 +5770,11 @@ const (
 	FUNC_REVERSE_SUBTRACT                                      = 0x800B
 	FUNC_SUBTRACT                                              = 0x800A
 	GEOMETRY_INPUT_TYPE                                        = 0x8917
+	GEOMETRY_INPUT_TYPE_ARB                                    = 0x8DDB
 	GEOMETRY_OUTPUT_TYPE                                       = 0x8918
+	GEOMETRY_OUTPUT_TYPE_ARB                                   = 0x8DDC
 	GEOMETRY_SHADER                                            = 0x8DD9
+	GEOMETRY_SHADER_ARB                                        = 0x8DD9
 	GEOMETRY_SHADER_BIT                                        = 0x00000004
 	GEOMETRY_SHADER_INVOCATIONS                                = 0x887F
 	GEOMETRY_SHADER_PRIMITIVES_EMITTED_ARB                     = 0x82F3
@@ -3411,18 +5782,42 @@ const (
 	GEOMETRY_SUBROUTINE_UNIFORM                                = 0x92F1
 	GEOMETRY_TEXTURE                                           = 0x829E
 	GEOMETRY_VERTICES_OUT                                      = 0x8916
+	GEOMETRY_VERTICES_OUT_ARB                                  = 0x8DDA
 	GEQUAL                                                     = 0x0206
 	GET_TEXTURE_IMAGE_FORMAT                                   = 0x8291
 	GET_TEXTURE_IMAGE_TYPE                                     = 0x8292
+	GLYPH_HAS_KERNING_BIT_NV                                   = 0x100
+	GLYPH_HEIGHT_BIT_NV                                        = 0x02
+	GLYPH_HORIZONTAL_BEARING_ADVANCE_BIT_NV                    = 0x10
+	GLYPH_HORIZONTAL_BEARING_X_BIT_NV                          = 0x04
+	GLYPH_HORIZONTAL_BEARING_Y_BIT_NV                          = 0x08
+	GLYPH_VERTICAL_BEARING_ADVANCE_BIT_NV                      = 0x80
+	GLYPH_VERTICAL_BEARING_X_BIT_NV                            = 0x20
+	GLYPH_VERTICAL_BEARING_Y_BIT_NV                            = 0x40
+	GLYPH_WIDTH_BIT_NV                                         = 0x01
+	GPU_ADDRESS_NV                                             = 0x8F34
 	GREATER                                                    = 0x0204
 	GREEN                                                      = 0x1904
 	GREEN_INTEGER                                              = 0x8D95
+	GREEN_NV                                                   = 0x1904
 	GUILTY_CONTEXT_RESET                                       = 0x8253
 	GUILTY_CONTEXT_RESET_ARB                                   = 0x8253
 	GUILTY_CONTEXT_RESET_KHR                                   = 0x8253
 	HALF_FLOAT                                                 = 0x140B
+	HARDLIGHT_KHR                                              = 0x929B
+	HARDLIGHT_NV                                               = 0x929B
+	HARDMIX_NV                                                 = 0x92A9
 	HIGH_FLOAT                                                 = 0x8DF2
 	HIGH_INT                                                   = 0x8DF5
+	HORIZONTAL_LINE_TO_NV                                      = 0x06
+	HSL_COLOR_KHR                                              = 0x92AF
+	HSL_COLOR_NV                                               = 0x92AF
+	HSL_HUE_KHR                                                = 0x92AD
+	HSL_HUE_NV                                                 = 0x92AD
+	HSL_LUMINOSITY_KHR                                         = 0x92B0
+	HSL_LUMINOSITY_NV                                          = 0x92B0
+	HSL_SATURATION_KHR                                         = 0x92AE
+	HSL_SATURATION_NV                                          = 0x92AE
 	IMAGE_1D                                                   = 0x904C
 	IMAGE_1D_ARRAY                                             = 0x9052
 	IMAGE_2D                                                   = 0x904D
@@ -3460,13 +5855,32 @@ const (
 	IMAGE_TEXEL_SIZE                                           = 0x82A7
 	IMPLEMENTATION_COLOR_READ_FORMAT                           = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
+	INDEX_ARRAY_ADDRESS_NV                                     = 0x8F24
+	INDEX_ARRAY_LENGTH_NV                                      = 0x8F2E
 	INFO_LOG_LENGTH                                            = 0x8B84
 	INNOCENT_CONTEXT_RESET                                     = 0x8254
 	INNOCENT_CONTEXT_RESET_ARB                                 = 0x8254
 	INNOCENT_CONTEXT_RESET_KHR                                 = 0x8254
 	INT                                                        = 0x1404
+	INT16_NV                                                   = 0x8FE4
+	INT16_VEC2_NV                                              = 0x8FE5
+	INT16_VEC3_NV                                              = 0x8FE6
+	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
+	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
+	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
+	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
+	INT64_VEC4_NV                                              = 0x8FEB
+	INT8_NV                                                    = 0x8FE0
+	INT8_VEC2_NV                                               = 0x8FE1
+	INT8_VEC3_NV                                               = 0x8FE2
+	INT8_VEC4_NV                                               = 0x8FE3
 	INTERLEAVED_ATTRIBS                                        = 0x8C8C
 	INTERNALFORMAT_ALPHA_SIZE                                  = 0x8274
 	INTERNALFORMAT_ALPHA_TYPE                                  = 0x827B
@@ -3516,27 +5930,41 @@ const (
 	INVALID_OPERATION                                          = 0x0502
 	INVALID_VALUE                                              = 0x0501
 	INVERT                                                     = 0x150A
+	INVERT_OVG_NV                                              = 0x92B4
+	INVERT_RGB_NV                                              = 0x92A3
 	ISOLINES                                                   = 0x8E7A
 	IS_PER_PATCH                                               = 0x92E7
 	IS_ROW_MAJOR                                               = 0x9300
+	ITALIC_BIT_NV                                              = 0x02
 	KEEP                                                       = 0x1E00
+	LARGE_CCW_ARC_TO_NV                                        = 0x16
+	LARGE_CW_ARC_TO_NV                                         = 0x18
 	LAST_VERTEX_CONVENTION                                     = 0x8E4E
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LESS                                                       = 0x0201
+	LIGHTEN_KHR                                                = 0x9298
+	LIGHTEN_NV                                                 = 0x9298
 	LINE                                                       = 0x1B01
 	LINEAR                                                     = 0x2601
+	LINEARBURN_NV                                              = 0x92A5
+	LINEARDODGE_NV                                             = 0x92A4
+	LINEARLIGHT_NV                                             = 0x92A7
 	LINEAR_MIPMAP_LINEAR                                       = 0x2703
 	LINEAR_MIPMAP_NEAREST                                      = 0x2701
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
+	LINES_ADJACENCY_ARB                                        = 0x000A
 	LINE_LOOP                                                  = 0x0002
 	LINE_SMOOTH                                                = 0x0B20
 	LINE_SMOOTH_HINT                                           = 0x0C52
 	LINE_STRIP                                                 = 0x0003
 	LINE_STRIP_ADJACENCY                                       = 0x000B
+	LINE_STRIP_ADJACENCY_ARB                                   = 0x000B
+	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -3636,12 +6064,17 @@ const (
 	MAX_GEOMETRY_INPUT_COMPONENTS                              = 0x9123
 	MAX_GEOMETRY_OUTPUT_COMPONENTS                             = 0x9124
 	MAX_GEOMETRY_OUTPUT_VERTICES                               = 0x8DE0
+	MAX_GEOMETRY_OUTPUT_VERTICES_ARB                           = 0x8DE0
 	MAX_GEOMETRY_SHADER_INVOCATIONS                            = 0x8E5A
 	MAX_GEOMETRY_SHADER_STORAGE_BLOCKS                         = 0x90D7
 	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS                           = 0x8C29
+	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS_ARB                       = 0x8C29
 	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS                       = 0x8DE1
+	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS_ARB                   = 0x8DE1
 	MAX_GEOMETRY_UNIFORM_BLOCKS                                = 0x8A2C
 	MAX_GEOMETRY_UNIFORM_COMPONENTS                            = 0x8DDF
+	MAX_GEOMETRY_UNIFORM_COMPONENTS_ARB                        = 0x8DDF
+	MAX_GEOMETRY_VARYING_COMPONENTS_ARB                        = 0x8DDD
 	MAX_HEIGHT                                                 = 0x827F
 	MAX_IMAGE_SAMPLES                                          = 0x906D
 	MAX_IMAGE_UNITS                                            = 0x8F38
@@ -3649,6 +6082,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_MULTISAMPLE_COVERAGE_MODES_NV                          = 0x8E11
 	MAX_NAME_LENGTH                                            = 0x92F6
 	MAX_NUM_ACTIVE_VARIABLES                                   = 0x92F7
 	MAX_NUM_COMPATIBLE_SUBROUTINES                             = 0x92F8
@@ -3657,16 +6091,21 @@ const (
 	MAX_PROGRAM_TEXTURE_GATHER_COMPONENTS_ARB                  = 0x8F9F
 	MAX_PROGRAM_TEXTURE_GATHER_OFFSET                          = 0x8E5F
 	MAX_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5F
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RENDERBUFFER_SIZE                                      = 0x84E8
 	MAX_SAMPLES                                                = 0x8D57
 	MAX_SAMPLE_MASK_WORDS                                      = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
+	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SPARSE_3D_TEXTURE_SIZE_ARB                             = 0x9199
 	MAX_SPARSE_ARRAY_TEXTURE_LAYERS_ARB                        = 0x919A
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -3691,8 +6130,10 @@ const (
 	MAX_TESS_GEN_LEVEL                                         = 0x8E7E
 	MAX_TESS_PATCH_COMPONENTS                                  = 0x8E84
 	MAX_TEXTURE_BUFFER_SIZE                                    = 0x8C2B
+	MAX_TEXTURE_BUFFER_SIZE_ARB                                = 0x8C2B
 	MAX_TEXTURE_IMAGE_UNITS                                    = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TRANSFORM_FEEDBACK_BUFFERS                             = 0x8E70
 	MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS              = 0x8C8A
@@ -3717,13 +6158,18 @@ const (
 	MAX_VERTEX_UNIFORM_BLOCKS                                  = 0x8A2B
 	MAX_VERTEX_UNIFORM_COMPONENTS                              = 0x8B4A
 	MAX_VERTEX_UNIFORM_VECTORS                                 = 0x8DFB
+	MAX_VERTEX_VARYING_COMPONENTS_ARB                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
 	MINOR_VERSION                                              = 0x821C
+	MINUS_CLAMPED_NV                                           = 0x92B3
+	MINUS_NV                                                   = 0x929F
 	MIN_FRAGMENT_INTERPOLATION_OFFSET                          = 0x8E5B
 	MIN_MAP_BUFFER_ALIGNMENT                                   = 0x90BC
 	MIN_PROGRAM_TEXEL_OFFSET                                   = 0x8904
@@ -3731,11 +6177,25 @@ const (
 	MIN_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5E
 	MIN_SAMPLE_SHADING_VALUE                                   = 0x8C37
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
+	MIRRORED_REPEAT_ARB                                        = 0x8370
 	MIRROR_CLAMP_TO_EDGE                                       = 0x8743
+	MITER_REVERT_NV                                            = 0x90A7
+	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
+	MOVE_TO_CONTINUES_NV                                       = 0x90B6
+	MOVE_TO_NV                                                 = 0x02
+	MOVE_TO_RESETS_NV                                          = 0x90B5
+	MULTIPLY_KHR                                               = 0x9294
+	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
+	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	NAMED_STRING_LENGTH_ARB                                    = 0x8DE9
 	NAMED_STRING_TYPE_ARB                                      = 0x8DEA
 	NAME_LENGTH                                                = 0x92F9
@@ -3748,7 +6208,10 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
+	NORMAL_ARRAY_ADDRESS_NV                                    = 0x8F22
+	NORMAL_ARRAY_LENGTH_NV                                     = 0x8F2C
 	NOTEQUAL                                                   = 0x0205
 	NO_ERROR                                                   = 0
 	NO_RESET_NOTIFICATION                                      = 0x8261
@@ -3761,7 +6224,10 @@ const (
 	NUM_PROGRAM_BINARY_FORMATS                                 = 0x87FE
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_TYPE                                                = 0x9112
 	OFFSET                                                     = 0x92FC
 	ONE                                                        = 1
@@ -3777,6 +6243,8 @@ const (
 	OR_INVERTED                                                = 0x150D
 	OR_REVERSE                                                 = 0x150B
 	OUT_OF_MEMORY                                              = 0x0505
+	OVERLAY_KHR                                                = 0x9296
+	OVERLAY_NV                                                 = 0x9296
 	PACK_ALIGNMENT                                             = 0x0D05
 	PACK_COMPRESSED_BLOCK_DEPTH                                = 0x912D
 	PACK_COMPRESSED_BLOCK_HEIGHT                               = 0x912C
@@ -3795,11 +6263,90 @@ const (
 	PATCH_DEFAULT_INNER_LEVEL                                  = 0x8E73
 	PATCH_DEFAULT_OUTER_LEVEL                                  = 0x8E74
 	PATCH_VERTICES                                             = 0x8E72
+	PATH_CLIENT_LENGTH_NV                                      = 0x907F
+	PATH_COMMAND_COUNT_NV                                      = 0x909D
+	PATH_COMPUTED_LENGTH_NV                                    = 0x90A0
+	PATH_COORD_COUNT_NV                                        = 0x909E
+	PATH_COVER_DEPTH_FUNC_NV                                   = 0x90BF
+	PATH_DASH_ARRAY_COUNT_NV                                   = 0x909F
+	PATH_DASH_CAPS_NV                                          = 0x907B
+	PATH_DASH_OFFSET_NV                                        = 0x907E
+	PATH_DASH_OFFSET_RESET_NV                                  = 0x90B4
+	PATH_END_CAPS_NV                                           = 0x9076
+	PATH_ERROR_POSITION_NV                                     = 0x90AB
+	PATH_FILL_BOUNDING_BOX_NV                                  = 0x90A1
+	PATH_FILL_COVER_MODE_NV                                    = 0x9082
+	PATH_FILL_MASK_NV                                          = 0x9081
+	PATH_FILL_MODE_NV                                          = 0x9080
+	PATH_FORMAT_PS_NV                                          = 0x9071
+	PATH_FORMAT_SVG_NV                                         = 0x9070
+	PATH_GEN_COEFF_NV                                          = 0x90B1
+	PATH_GEN_COMPONENTS_NV                                     = 0x90B3
+	PATH_GEN_MODE_NV                                           = 0x90B0
+	PATH_INITIAL_DASH_CAP_NV                                   = 0x907C
+	PATH_INITIAL_END_CAP_NV                                    = 0x9077
+	PATH_JOIN_STYLE_NV                                         = 0x9079
+	PATH_MAX_MODELVIEW_STACK_DEPTH_NV                          = 0x0D36
+	PATH_MAX_PROJECTION_STACK_DEPTH_NV                         = 0x0D38
+	PATH_MITER_LIMIT_NV                                        = 0x907A
+	PATH_MODELVIEW_MATRIX_NV                                   = 0x0BA6
+	PATH_MODELVIEW_NV                                          = 0x1700
+	PATH_MODELVIEW_STACK_DEPTH_NV                              = 0x0BA3
+	PATH_OBJECT_BOUNDING_BOX_NV                                = 0x908A
+	PATH_PROJECTION_MATRIX_NV                                  = 0x0BA7
+	PATH_PROJECTION_NV                                         = 0x1701
+	PATH_PROJECTION_STACK_DEPTH_NV                             = 0x0BA4
+	PATH_STENCIL_DEPTH_OFFSET_FACTOR_NV                        = 0x90BD
+	PATH_STENCIL_DEPTH_OFFSET_UNITS_NV                         = 0x90BE
+	PATH_STENCIL_FUNC_NV                                       = 0x90B7
+	PATH_STENCIL_REF_NV                                        = 0x90B8
+	PATH_STENCIL_VALUE_MASK_NV                                 = 0x90B9
+	PATH_STROKE_BOUNDING_BOX_NV                                = 0x90A2
+	PATH_STROKE_COVER_MODE_NV                                  = 0x9083
+	PATH_STROKE_MASK_NV                                        = 0x9084
+	PATH_STROKE_WIDTH_NV                                       = 0x9075
+	PATH_TERMINAL_DASH_CAP_NV                                  = 0x907D
+	PATH_TERMINAL_END_CAP_NV                                   = 0x9078
+	PATH_TRANSPOSE_MODELVIEW_MATRIX_NV                         = 0x84E3
+	PATH_TRANSPOSE_PROJECTION_MATRIX_NV                        = 0x84E4
+	PERCENTAGE_AMD                                             = 0x8BC3
+	PERFMON_RESULT_AMD                                         = 0x8BC6
+	PERFMON_RESULT_AVAILABLE_AMD                               = 0x8BC4
+	PERFMON_RESULT_SIZE_AMD                                    = 0x8BC5
+	PERFQUERY_COUNTER_DATA_BOOL32_INTEL                        = 0x94FC
+	PERFQUERY_COUNTER_DATA_DOUBLE_INTEL                        = 0x94FB
+	PERFQUERY_COUNTER_DATA_FLOAT_INTEL                         = 0x94FA
+	PERFQUERY_COUNTER_DATA_UINT32_INTEL                        = 0x94F8
+	PERFQUERY_COUNTER_DATA_UINT64_INTEL                        = 0x94F9
+	PERFQUERY_COUNTER_DESC_LENGTH_MAX_INTEL                    = 0x94FF
+	PERFQUERY_COUNTER_DURATION_NORM_INTEL                      = 0x94F1
+	PERFQUERY_COUNTER_DURATION_RAW_INTEL                       = 0x94F2
+	PERFQUERY_COUNTER_EVENT_INTEL                              = 0x94F0
+	PERFQUERY_COUNTER_NAME_LENGTH_MAX_INTEL                    = 0x94FE
+	PERFQUERY_COUNTER_RAW_INTEL                                = 0x94F4
+	PERFQUERY_COUNTER_THROUGHPUT_INTEL                         = 0x94F3
+	PERFQUERY_COUNTER_TIMESTAMP_INTEL                          = 0x94F5
+	PERFQUERY_DONOT_FLUSH_INTEL                                = 0x83F9
+	PERFQUERY_FLUSH_INTEL                                      = 0x83FA
+	PERFQUERY_GLOBAL_CONTEXT_INTEL                             = 0x00000001
+	PERFQUERY_GPA_EXTENDED_COUNTERS_INTEL                      = 0x9500
+	PERFQUERY_QUERY_NAME_LENGTH_MAX_INTEL                      = 0x94FD
+	PERFQUERY_SINGLE_CONTEXT_INTEL                             = 0x00000000
+	PERFQUERY_WAIT_INTEL                                       = 0x83FB
+	PINLIGHT_NV                                                = 0x92A8
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_PACK_BUFFER                                          = 0x88EB
+	PIXEL_PACK_BUFFER_ARB                                      = 0x88EB
 	PIXEL_PACK_BUFFER_BINDING                                  = 0x88ED
+	PIXEL_PACK_BUFFER_BINDING_ARB                              = 0x88ED
 	PIXEL_UNPACK_BUFFER                                        = 0x88EC
+	PIXEL_UNPACK_BUFFER_ARB                                    = 0x88EC
 	PIXEL_UNPACK_BUFFER_BINDING                                = 0x88EF
+	PIXEL_UNPACK_BUFFER_BINDING_ARB                            = 0x88EF
+	PLUS_CLAMPED_ALPHA_NV                                      = 0x92B2
+	PLUS_CLAMPED_NV                                            = 0x92B1
+	PLUS_DARKER_NV                                             = 0x9292
+	PLUS_NV                                                    = 0x9291
 	POINT                                                      = 0x1B00
 	POINTS                                                     = 0x0000
 	POINT_FADE_THRESHOLD_SIZE                                  = 0x8128
@@ -3808,6 +6355,9 @@ const (
 	POINT_SIZE_RANGE                                           = 0x0B12
 	POINT_SPRITE_COORD_ORIGIN                                  = 0x8CA0
 	POLYGON_MODE                                               = 0x0B40
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FILL                                        = 0x8037
 	POLYGON_OFFSET_LINE                                        = 0x2A02
@@ -3817,20 +6367,33 @@ const (
 	POLYGON_SMOOTH_HINT                                        = 0x0C53
 	PRIMITIVES_GENERATED                                       = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
 	PRIMITIVE_RESTART_INDEX                                    = 0x8F9E
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_INPUT                                              = 0x92E3
 	PROGRAM_KHR                                                = 0x82E2
+	PROGRAM_MATRIX_EXT                                         = 0x8E2D
+	PROGRAM_MATRIX_STACK_DEPTH_EXT                             = 0x8E2F
+	PROGRAM_OBJECT_EXT                                         = 0x8B40
 	PROGRAM_OUTPUT                                             = 0x92E4
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
+	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
+	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
+	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
 	PROGRAM_SEPARABLE                                          = 0x8258
+	PROGRAM_SEPARABLE_EXT                                      = 0x8258
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROXY_TEXTURE_1D                                           = 0x8063
 	PROXY_TEXTURE_1D_ARRAY                                     = 0x8C19
@@ -3843,6 +6406,7 @@ const (
 	PROXY_TEXTURE_CUBE_MAP_ARRAY                               = 0x900B
 	PROXY_TEXTURE_CUBE_MAP_ARRAY_ARB                           = 0x900B
 	PROXY_TEXTURE_RECTANGLE                                    = 0x84F7
+	QUADRATIC_CURVE_TO_NV                                      = 0x0A
 	QUADS                                                      = 0x0007
 	QUADS_FOLLOW_PROVOKING_VERTEX_CONVENTION                   = 0x8E4C
 	QUERY                                                      = 0x82E3
@@ -3851,18 +6415,23 @@ const (
 	QUERY_BUFFER_BINDING                                       = 0x9193
 	QUERY_BY_REGION_NO_WAIT                                    = 0x8E16
 	QUERY_BY_REGION_NO_WAIT_INVERTED                           = 0x8E1A
+	QUERY_BY_REGION_NO_WAIT_NV                                 = 0x8E16
 	QUERY_BY_REGION_WAIT                                       = 0x8E15
 	QUERY_BY_REGION_WAIT_INVERTED                              = 0x8E19
+	QUERY_BY_REGION_WAIT_NV                                    = 0x8E15
 	QUERY_COUNTER_BITS                                         = 0x8864
 	QUERY_KHR                                                  = 0x82E3
 	QUERY_NO_WAIT                                              = 0x8E14
 	QUERY_NO_WAIT_INVERTED                                     = 0x8E18
+	QUERY_NO_WAIT_NV                                           = 0x8E14
+	QUERY_OBJECT_EXT                                           = 0x9153
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
 	QUERY_RESULT_NO_WAIT                                       = 0x9194
 	QUERY_TARGET                                               = 0x82EA
 	QUERY_WAIT                                                 = 0x8E13
 	QUERY_WAIT_INVERTED                                        = 0x8E17
+	QUERY_WAIT_NV                                              = 0x8E13
 	R11F_G11F_B10F                                             = 0x8C3A
 	R16                                                        = 0x822A
 	R16F                                                       = 0x822D
@@ -3878,6 +6447,9 @@ const (
 	R8UI                                                       = 0x8232
 	R8_SNORM                                                   = 0x8F94
 	RASTERIZER_DISCARD                                         = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -3886,18 +6458,41 @@ const (
 	READ_PIXELS_FORMAT                                         = 0x828D
 	READ_PIXELS_TYPE                                           = 0x828E
 	READ_WRITE                                                 = 0x88BA
+	RECT_NV                                                    = 0xF6
 	RED                                                        = 0x1903
 	RED_INTEGER                                                = 0x8D94
+	RED_NV                                                     = 0x1903
 	REFERENCED_BY_COMPUTE_SHADER                               = 0x930B
 	REFERENCED_BY_FRAGMENT_SHADER                              = 0x930A
 	REFERENCED_BY_GEOMETRY_SHADER                              = 0x9309
 	REFERENCED_BY_TESS_CONTROL_SHADER                          = 0x9307
 	REFERENCED_BY_TESS_EVALUATION_SHADER                       = 0x9308
 	REFERENCED_BY_VERTEX_SHADER                                = 0x9306
+	RELATIVE_ARC_TO_NV                                         = 0xFF
+	RELATIVE_CONIC_CURVE_TO_NV                                 = 0x1B
+	RELATIVE_CUBIC_CURVE_TO_NV                                 = 0x0D
+	RELATIVE_HORIZONTAL_LINE_TO_NV                             = 0x07
+	RELATIVE_LARGE_CCW_ARC_TO_NV                               = 0x17
+	RELATIVE_LARGE_CW_ARC_TO_NV                                = 0x19
+	RELATIVE_LINE_TO_NV                                        = 0x05
+	RELATIVE_MOVE_TO_NV                                        = 0x03
+	RELATIVE_QUADRATIC_CURVE_TO_NV                             = 0x0B
+	RELATIVE_RECT_NV                                           = 0xF7
+	RELATIVE_ROUNDED_RECT2_NV                                  = 0xEB
+	RELATIVE_ROUNDED_RECT4_NV                                  = 0xED
+	RELATIVE_ROUNDED_RECT8_NV                                  = 0xEF
+	RELATIVE_ROUNDED_RECT_NV                                   = 0xE9
+	RELATIVE_SMALL_CCW_ARC_TO_NV                               = 0x13
+	RELATIVE_SMALL_CW_ARC_TO_NV                                = 0x15
+	RELATIVE_SMOOTH_CUBIC_CURVE_TO_NV                          = 0x11
+	RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV                      = 0x0F
+	RELATIVE_VERTICAL_LINE_TO_NV                               = 0x09
 	RENDERBUFFER                                               = 0x8D41
 	RENDERBUFFER_ALPHA_SIZE                                    = 0x8D53
 	RENDERBUFFER_BINDING                                       = 0x8CA7
 	RENDERBUFFER_BLUE_SIZE                                     = 0x8D52
+	RENDERBUFFER_COLOR_SAMPLES_NV                              = 0x8E10
+	RENDERBUFFER_COVERAGE_SAMPLES_NV                           = 0x8CAB
 	RENDERBUFFER_DEPTH_SIZE                                    = 0x8D54
 	RENDERBUFFER_GREEN_SIZE                                    = 0x8D51
 	RENDERBUFFER_HEIGHT                                        = 0x8D43
@@ -3912,6 +6507,7 @@ const (
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
 	RESET_NOTIFICATION_STRATEGY_ARB                            = 0x8256
 	RESET_NOTIFICATION_STRATEGY_KHR                            = 0x8256
+	RESTART_PATH_NV                                            = 0xF0
 	RG                                                         = 0x8227
 	RG16                                                       = 0x822C
 	RG16F                                                      = 0x822F
@@ -3964,9 +6560,16 @@ const (
 	RGBA8UI                                                    = 0x8D7C
 	RGBA8_SNORM                                                = 0x8F97
 	RGBA_INTEGER                                               = 0x8D99
+	RGB_422_APPLE                                              = 0x8A1F
 	RGB_INTEGER                                                = 0x8D98
+	RGB_RAW_422_APPLE                                          = 0x8A51
 	RG_INTEGER                                                 = 0x8228
 	RIGHT                                                      = 0x0407
+	ROUNDED_RECT2_NV                                           = 0xEA
+	ROUNDED_RECT4_NV                                           = 0xEC
+	ROUNDED_RECT8_NV                                           = 0xEE
+	ROUNDED_RECT_NV                                            = 0xE8
+	ROUND_NV                                                   = 0x90A4
 	SAMPLER                                                    = 0x82E6
 	SAMPLER_1D                                                 = 0x8B5D
 	SAMPLER_1D_ARRAY                                           = 0x8DC0
@@ -3998,24 +6601,40 @@ const (
 	SAMPLE_COVERAGE                                            = 0x80A0
 	SAMPLE_COVERAGE_INVERT                                     = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_VALUE                                          = 0x8E52
 	SAMPLE_POSITION                                            = 0x8E50
 	SAMPLE_SHADING                                             = 0x8C36
 	SAMPLE_SHADING_ARB                                         = 0x8C36
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
+	SCREEN_KHR                                                 = 0x9295
+	SCREEN_NV                                                  = 0x9295
+	SECONDARY_COLOR_ARRAY_ADDRESS_NV                           = 0x8F27
+	SECONDARY_COLOR_ARRAY_LENGTH_NV                            = 0x8F31
 	SEPARATE_ATTRIBS                                           = 0x8C8D
 	SET                                                        = 0x150F
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
+	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
 	SHADER_IMAGE_ACCESS_BARRIER_BIT                            = 0x00000020
 	SHADER_IMAGE_ATOMIC                                        = 0x82A6
 	SHADER_IMAGE_LOAD                                          = 0x82A4
 	SHADER_IMAGE_STORE                                         = 0x82A5
 	SHADER_INCLUDE_ARB                                         = 0x8DAE
 	SHADER_KHR                                                 = 0x82E1
+	SHADER_OBJECT_EXT                                          = 0x8B48
 	SHADER_SOURCE_LENGTH                                       = 0x8B88
 	SHADER_STORAGE_BARRIER_BIT                                 = 0x00002000
 	SHADER_STORAGE_BLOCK                                       = 0x92E6
@@ -4026,6 +6645,7 @@ const (
 	SHADER_STORAGE_BUFFER_START                                = 0x90D4
 	SHADER_TYPE                                                = 0x8B4F
 	SHADING_LANGUAGE_VERSION                                   = 0x8B8C
+	SHARED_EDGE_NV                                             = 0xC0
 	SHORT                                                      = 0x1402
 	SIGNALED                                                   = 0x9119
 	SIGNED_NORMALIZED                                          = 0x8F9C
@@ -4033,18 +6653,35 @@ const (
 	SIMULTANEOUS_TEXTURE_AND_DEPTH_WRITE                       = 0x82AE
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_TEST                      = 0x82AD
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_WRITE                     = 0x82AF
+	SKIP_DECODE_EXT                                            = 0x8A4A
+	SKIP_MISSING_GLYPH_NV                                      = 0x90A9
+	SMALL_CCW_ARC_TO_NV                                        = 0x12
+	SMALL_CW_ARC_TO_NV                                         = 0x14
+	SMOOTH_CUBIC_CURVE_TO_NV                                   = 0x10
 	SMOOTH_LINE_WIDTH_GRANULARITY                              = 0x0B23
 	SMOOTH_LINE_WIDTH_RANGE                                    = 0x0B22
 	SMOOTH_POINT_SIZE_GRANULARITY                              = 0x0B13
 	SMOOTH_POINT_SIZE_RANGE                                    = 0x0B12
+	SMOOTH_QUADRATIC_CURVE_TO_NV                               = 0x0E
+	SM_COUNT_NV                                                = 0x933B
+	SOFTLIGHT_KHR                                              = 0x929C
+	SOFTLIGHT_NV                                               = 0x929C
 	SPARSE_BUFFER_PAGE_SIZE_ARB                                = 0x82F8
 	SPARSE_STORAGE_BIT_ARB                                     = 0x0400
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
+	SQUARE_NV                                                  = 0x90A3
 	SRC1_ALPHA                                                 = 0x8589
 	SRC1_COLOR                                                 = 0x88F9
 	SRC_ALPHA                                                  = 0x0302
 	SRC_ALPHA_SATURATE                                         = 0x0308
+	SRC_ATOP_NV                                                = 0x928E
 	SRC_COLOR                                                  = 0x0300
+	SRC_IN_NV                                                  = 0x928A
+	SRC_NV                                                     = 0x9286
+	SRC_OUT_NV                                                 = 0x928C
+	SRC_OVER_NV                                                = 0x9288
 	SRGB                                                       = 0x8C40
 	SRGB8                                                      = 0x8C41
 	SRGB8_ALPHA8                                               = 0x8C43
@@ -4056,6 +6693,8 @@ const (
 	STACK_OVERFLOW_KHR                                         = 0x0503
 	STACK_UNDERFLOW                                            = 0x0504
 	STACK_UNDERFLOW_KHR                                        = 0x0504
+	STANDARD_FONT_FORMAT_NV                                    = 0x936C
+	STANDARD_FONT_NAME_NV                                      = 0x9072
 	STATIC_COPY                                                = 0x88E6
 	STATIC_DRAW                                                = 0x88E4
 	STATIC_READ                                                = 0x88E5
@@ -4081,7 +6720,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_VALUE_MASK                                         = 0x0B93
 	STENCIL_WRITEMASK                                          = 0x0B98
@@ -4090,6 +6731,10 @@ const (
 	STREAM_DRAW                                                = 0x88E0
 	STREAM_READ                                                = 0x88E1
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SYNC_CL_EVENT_ARB                                          = 0x8240
 	SYNC_CL_EVENT_COMPLETE_ARB                                 = 0x8241
 	SYNC_CONDITION                                             = 0x9113
@@ -4098,6 +6743,8 @@ const (
 	SYNC_FLUSH_COMMANDS_BIT                                    = 0x00000001
 	SYNC_GPU_COMMANDS_COMPLETE                                 = 0x9117
 	SYNC_STATUS                                                = 0x9114
+	SYSTEM_FONT_NAME_NV                                        = 0x9073
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
 	TESS_CONTROL_SHADER                                        = 0x8E88
 	TESS_CONTROL_SHADER_BIT                                    = 0x00000008
@@ -4158,7 +6805,6 @@ const (
 	TEXTURE_ALPHA_SIZE                                         = 0x805F
 	TEXTURE_ALPHA_TYPE                                         = 0x8C13
 	TEXTURE_BASE_LEVEL                                         = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_2D                                         = 0x8069
@@ -4167,6 +6813,7 @@ const (
 	TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY                       = 0x9105
 	TEXTURE_BINDING_3D                                         = 0x806A
 	TEXTURE_BINDING_BUFFER                                     = 0x8C2C
+	TEXTURE_BINDING_BUFFER_ARB                                 = 0x8C2C
 	TEXTURE_BINDING_CUBE_MAP                                   = 0x8514
 	TEXTURE_BINDING_CUBE_MAP_ARRAY                             = 0x900A
 	TEXTURE_BINDING_CUBE_MAP_ARRAY_ARB                         = 0x900A
@@ -4175,7 +6822,10 @@ const (
 	TEXTURE_BLUE_TYPE                                          = 0x8C12
 	TEXTURE_BORDER_COLOR                                       = 0x1004
 	TEXTURE_BUFFER                                             = 0x8C2A
+	TEXTURE_BUFFER_ARB                                         = 0x8C2A
 	TEXTURE_BUFFER_DATA_STORE_BINDING                          = 0x8C2D
+	TEXTURE_BUFFER_DATA_STORE_BINDING_ARB                      = 0x8C2D
+	TEXTURE_BUFFER_FORMAT_ARB                                  = 0x8C2E
 	TEXTURE_BUFFER_OFFSET                                      = 0x919D
 	TEXTURE_BUFFER_OFFSET_ALIGNMENT                            = 0x919F
 	TEXTURE_BUFFER_SIZE                                        = 0x919E
@@ -4187,6 +6837,8 @@ const (
 	TEXTURE_COMPRESSED_BLOCK_WIDTH                             = 0x82B1
 	TEXTURE_COMPRESSED_IMAGE_SIZE                              = 0x86A0
 	TEXTURE_COMPRESSION_HINT                                   = 0x84EF
+	TEXTURE_COORD_ARRAY_ADDRESS_NV                             = 0x8F25
+	TEXTURE_COORD_ARRAY_LENGTH_NV                              = 0x8F2F
 	TEXTURE_CUBE_MAP                                           = 0x8513
 	TEXTURE_CUBE_MAP_ARRAY                                     = 0x9009
 	TEXTURE_CUBE_MAP_ARRAY_ARB                                 = 0x9009
@@ -4214,17 +6866,21 @@ const (
 	TEXTURE_INTERNAL_FORMAT                                    = 0x1003
 	TEXTURE_LOD_BIAS                                           = 0x8501
 	TEXTURE_MAG_FILTER                                         = 0x2800
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_LEVEL                                          = 0x813D
 	TEXTURE_MAX_LOD                                            = 0x813B
 	TEXTURE_MIN_FILTER                                         = 0x2801
 	TEXTURE_MIN_LOD                                            = 0x813A
 	TEXTURE_RECTANGLE                                          = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
 	TEXTURE_SAMPLES                                            = 0x9106
 	TEXTURE_SHADOW                                             = 0x82A1
 	TEXTURE_SHARED_SIZE                                        = 0x8C3F
 	TEXTURE_SPARSE_ARB                                         = 0x91A6
+	TEXTURE_SRGB_DECODE_EXT                                    = 0x8A48
 	TEXTURE_STENCIL_SIZE                                       = 0x88F1
 	TEXTURE_SWIZZLE_A                                          = 0x8E45
 	TEXTURE_SWIZZLE_B                                          = 0x8E44
@@ -4268,15 +6924,27 @@ const (
 	TRANSFORM_FEEDBACK_VARYING                                 = 0x92F4
 	TRANSFORM_FEEDBACK_VARYINGS                                = 0x8C83
 	TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH                      = 0x8C76
+	TRANSLATE_2D_NV                                            = 0x9090
+	TRANSLATE_3D_NV                                            = 0x9091
+	TRANSLATE_X_NV                                             = 0x908E
+	TRANSLATE_Y_NV                                             = 0x908F
+	TRANSPOSE_AFFINE_2D_NV                                     = 0x9096
+	TRANSPOSE_AFFINE_3D_NV                                     = 0x9098
+	TRANSPOSE_PROGRAM_MATRIX_EXT                               = 0x8E2E
 	TRIANGLES                                                  = 0x0004
 	TRIANGLES_ADJACENCY                                        = 0x000C
+	TRIANGLES_ADJACENCY_ARB                                    = 0x000C
 	TRIANGLE_FAN                                               = 0x0006
 	TRIANGLE_STRIP                                             = 0x0005
 	TRIANGLE_STRIP_ADJACENCY                                   = 0x000D
+	TRIANGLE_STRIP_ADJACENCY_ARB                               = 0x000D
+	TRIANGULAR_NV                                              = 0x90A5
 	TRUE                                                       = 1
 	TYPE                                                       = 0x92FA
+	UNCORRELATED_NV                                            = 0x9282
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -4294,10 +6962,13 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -4324,7 +6995,23 @@ const (
 	UNSIGNED_BYTE_2_3_3_REV                                    = 0x8362
 	UNSIGNED_BYTE_3_3_2                                        = 0x8032
 	UNSIGNED_INT                                               = 0x1405
+	UNSIGNED_INT16_NV                                          = 0x8FF0
+	UNSIGNED_INT16_VEC2_NV                                     = 0x8FF1
+	UNSIGNED_INT16_VEC3_NV                                     = 0x8FF2
+	UNSIGNED_INT16_VEC4_NV                                     = 0x8FF3
+	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
+	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
+	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
+	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
+	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
+	UNSIGNED_INT8_NV                                           = 0x8FEC
+	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
+	UNSIGNED_INT8_VEC3_NV                                      = 0x8FEE
+	UNSIGNED_INT8_VEC4_NV                                      = 0x8FEF
 	UNSIGNED_INT_10F_11F_11F_REV                               = 0x8C3B
 	UNSIGNED_INT_10_10_10_2                                    = 0x8036
 	UNSIGNED_INT_24_8                                          = 0x84FA
@@ -4367,23 +7054,35 @@ const (
 	UNSIGNED_SHORT_5_5_5_1                                     = 0x8034
 	UNSIGNED_SHORT_5_6_5                                       = 0x8363
 	UNSIGNED_SHORT_5_6_5_REV                                   = 0x8364
+	UNSIGNED_SHORT_8_8_APPLE                                   = 0x85BA
+	UNSIGNED_SHORT_8_8_REV_APPLE                               = 0x85BB
 	UPPER_LEFT                                                 = 0x8CA2
+	USE_MISSING_GLYPH_NV                                       = 0x90AA
+	UTF16_NV                                                   = 0x909B
+	UTF8_NV                                                    = 0x909A
 	VALIDATE_STATUS                                            = 0x8B83
 	VENDOR                                                     = 0x1F00
 	VERSION                                                    = 0x1F02
 	VERTEX_ARRAY                                               = 0x8074
+	VERTEX_ARRAY_ADDRESS_NV                                    = 0x8F21
 	VERTEX_ARRAY_BINDING                                       = 0x85B5
 	VERTEX_ARRAY_KHR                                           = 0x8074
+	VERTEX_ARRAY_LENGTH_NV                                     = 0x8F2B
+	VERTEX_ARRAY_OBJECT_EXT                                    = 0x9154
+	VERTEX_ATTRIB_ARRAY_ADDRESS_NV                             = 0x8F20
 	VERTEX_ATTRIB_ARRAY_BARRIER_BIT                            = 0x00000001
 	VERTEX_ATTRIB_ARRAY_BUFFER_BINDING                         = 0x889F
 	VERTEX_ATTRIB_ARRAY_DIVISOR                                = 0x88FE
+	VERTEX_ATTRIB_ARRAY_DIVISOR_ARB                            = 0x88FE
 	VERTEX_ATTRIB_ARRAY_ENABLED                                = 0x8622
 	VERTEX_ATTRIB_ARRAY_INTEGER                                = 0x88FD
+	VERTEX_ATTRIB_ARRAY_LENGTH_NV                              = 0x8F2A
 	VERTEX_ATTRIB_ARRAY_NORMALIZED                             = 0x886A
 	VERTEX_ATTRIB_ARRAY_POINTER                                = 0x8645
 	VERTEX_ATTRIB_ARRAY_SIZE                                   = 0x8623
 	VERTEX_ATTRIB_ARRAY_STRIDE                                 = 0x8624
 	VERTEX_ATTRIB_ARRAY_TYPE                                   = 0x8625
+	VERTEX_ATTRIB_ARRAY_UNIFIED_NV                             = 0x8F1E
 	VERTEX_ATTRIB_BINDING                                      = 0x82D4
 	VERTEX_ATTRIB_RELATIVE_OFFSET                              = 0x82D5
 	VERTEX_BINDING_DIVISOR                                     = 0x82D6
@@ -4392,15 +7091,33 @@ const (
 	VERTEX_PROGRAM_POINT_SIZE                                  = 0x8642
 	VERTEX_SHADER                                              = 0x8B31
 	VERTEX_SHADER_BIT                                          = 0x00000001
+	VERTEX_SHADER_BIT_EXT                                      = 0x00000001
 	VERTEX_SHADER_INVOCATIONS_ARB                              = 0x82F0
 	VERTEX_SUBROUTINE                                          = 0x92E8
 	VERTEX_SUBROUTINE_UNIFORM                                  = 0x92EE
 	VERTEX_TEXTURE                                             = 0x829B
+	VERTICAL_LINE_TO_NV                                        = 0x08
 	VERTICES_SUBMITTED_ARB                                     = 0x82EE
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -4422,723 +7139,1284 @@ const (
 	VIRTUAL_PAGE_SIZE_X_ARB                                    = 0x9195
 	VIRTUAL_PAGE_SIZE_Y_ARB                                    = 0x9196
 	VIRTUAL_PAGE_SIZE_Z_ARB                                    = 0x9197
+	VIVIDLIGHT_NV                                              = 0x92A6
 	WAIT_FAILED                                                = 0x911D
+	WARPS_PER_SM_NV                                            = 0x933A
+	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRITE_ONLY                                                 = 0x88B9
 	XOR                                                        = 0x1506
+	XOR_NV                                                     = 0x1506
 	ZERO                                                       = 0
 	ZERO_TO_ONE                                                = 0x935F
 )
 
 var (
-	gpActiveShaderProgram                         C.GPACTIVESHADERPROGRAM
-	gpActiveTexture                               C.GPACTIVETEXTURE
-	gpAttachShader                                C.GPATTACHSHADER
-	gpBeginConditionalRender                      C.GPBEGINCONDITIONALRENDER
-	gpBeginQuery                                  C.GPBEGINQUERY
-	gpBeginQueryIndexed                           C.GPBEGINQUERYINDEXED
-	gpBeginTransformFeedback                      C.GPBEGINTRANSFORMFEEDBACK
-	gpBindAttribLocation                          C.GPBINDATTRIBLOCATION
-	gpBindBuffer                                  C.GPBINDBUFFER
-	gpBindBufferBase                              C.GPBINDBUFFERBASE
-	gpBindBufferRange                             C.GPBINDBUFFERRANGE
-	gpBindBuffersBase                             C.GPBINDBUFFERSBASE
-	gpBindBuffersRange                            C.GPBINDBUFFERSRANGE
-	gpBindFragDataLocation                        C.GPBINDFRAGDATALOCATION
-	gpBindFragDataLocationIndexed                 C.GPBINDFRAGDATALOCATIONINDEXED
-	gpBindFramebuffer                             C.GPBINDFRAMEBUFFER
-	gpBindImageTexture                            C.GPBINDIMAGETEXTURE
-	gpBindImageTextures                           C.GPBINDIMAGETEXTURES
-	gpBindProgramPipeline                         C.GPBINDPROGRAMPIPELINE
-	gpBindRenderbuffer                            C.GPBINDRENDERBUFFER
-	gpBindSampler                                 C.GPBINDSAMPLER
-	gpBindSamplers                                C.GPBINDSAMPLERS
-	gpBindTexture                                 C.GPBINDTEXTURE
-	gpBindTextureUnit                             C.GPBINDTEXTUREUNIT
-	gpBindTextures                                C.GPBINDTEXTURES
-	gpBindTransformFeedback                       C.GPBINDTRANSFORMFEEDBACK
-	gpBindVertexArray                             C.GPBINDVERTEXARRAY
-	gpBindVertexBuffer                            C.GPBINDVERTEXBUFFER
-	gpBindVertexBuffers                           C.GPBINDVERTEXBUFFERS
-	gpBlendColor                                  C.GPBLENDCOLOR
-	gpBlendEquation                               C.GPBLENDEQUATION
-	gpBlendEquationSeparate                       C.GPBLENDEQUATIONSEPARATE
-	gpBlendEquationSeparatei                      C.GPBLENDEQUATIONSEPARATEI
-	gpBlendEquationSeparateiARB                   C.GPBLENDEQUATIONSEPARATEIARB
-	gpBlendEquationi                              C.GPBLENDEQUATIONI
-	gpBlendEquationiARB                           C.GPBLENDEQUATIONIARB
-	gpBlendFunc                                   C.GPBLENDFUNC
-	gpBlendFuncSeparate                           C.GPBLENDFUNCSEPARATE
-	gpBlendFuncSeparatei                          C.GPBLENDFUNCSEPARATEI
-	gpBlendFuncSeparateiARB                       C.GPBLENDFUNCSEPARATEIARB
-	gpBlendFunci                                  C.GPBLENDFUNCI
-	gpBlendFunciARB                               C.GPBLENDFUNCIARB
-	gpBlitFramebuffer                             C.GPBLITFRAMEBUFFER
-	gpBlitNamedFramebuffer                        C.GPBLITNAMEDFRAMEBUFFER
-	gpBufferData                                  C.GPBUFFERDATA
-	gpBufferPageCommitmentARB                     C.GPBUFFERPAGECOMMITMENTARB
-	gpBufferStorage                               C.GPBUFFERSTORAGE
-	gpBufferSubData                               C.GPBUFFERSUBDATA
-	gpCheckFramebufferStatus                      C.GPCHECKFRAMEBUFFERSTATUS
-	gpCheckNamedFramebufferStatus                 C.GPCHECKNAMEDFRAMEBUFFERSTATUS
-	gpClampColor                                  C.GPCLAMPCOLOR
-	gpClear                                       C.GPCLEAR
-	gpClearBufferData                             C.GPCLEARBUFFERDATA
-	gpClearBufferSubData                          C.GPCLEARBUFFERSUBDATA
-	gpClearBufferfi                               C.GPCLEARBUFFERFI
-	gpClearBufferfv                               C.GPCLEARBUFFERFV
-	gpClearBufferiv                               C.GPCLEARBUFFERIV
-	gpClearBufferuiv                              C.GPCLEARBUFFERUIV
-	gpClearColor                                  C.GPCLEARCOLOR
-	gpClearDepth                                  C.GPCLEARDEPTH
-	gpClearDepthf                                 C.GPCLEARDEPTHF
-	gpClearNamedBufferData                        C.GPCLEARNAMEDBUFFERDATA
-	gpClearNamedBufferSubData                     C.GPCLEARNAMEDBUFFERSUBDATA
-	gpClearNamedFramebufferfi                     C.GPCLEARNAMEDFRAMEBUFFERFI
-	gpClearNamedFramebufferfv                     C.GPCLEARNAMEDFRAMEBUFFERFV
-	gpClearNamedFramebufferiv                     C.GPCLEARNAMEDFRAMEBUFFERIV
-	gpClearNamedFramebufferuiv                    C.GPCLEARNAMEDFRAMEBUFFERUIV
-	gpClearStencil                                C.GPCLEARSTENCIL
-	gpClearTexImage                               C.GPCLEARTEXIMAGE
-	gpClearTexSubImage                            C.GPCLEARTEXSUBIMAGE
-	gpClientWaitSync                              C.GPCLIENTWAITSYNC
-	gpClipControl                                 C.GPCLIPCONTROL
-	gpColorMask                                   C.GPCOLORMASK
-	gpColorMaski                                  C.GPCOLORMASKI
-	gpCompileShader                               C.GPCOMPILESHADER
-	gpCompileShaderIncludeARB                     C.GPCOMPILESHADERINCLUDEARB
-	gpCompressedTexImage1D                        C.GPCOMPRESSEDTEXIMAGE1D
-	gpCompressedTexImage2D                        C.GPCOMPRESSEDTEXIMAGE2D
-	gpCompressedTexImage3D                        C.GPCOMPRESSEDTEXIMAGE3D
-	gpCompressedTexSubImage1D                     C.GPCOMPRESSEDTEXSUBIMAGE1D
-	gpCompressedTexSubImage2D                     C.GPCOMPRESSEDTEXSUBIMAGE2D
-	gpCompressedTexSubImage3D                     C.GPCOMPRESSEDTEXSUBIMAGE3D
-	gpCompressedTextureSubImage1D                 C.GPCOMPRESSEDTEXTURESUBIMAGE1D
-	gpCompressedTextureSubImage2D                 C.GPCOMPRESSEDTEXTURESUBIMAGE2D
-	gpCompressedTextureSubImage3D                 C.GPCOMPRESSEDTEXTURESUBIMAGE3D
-	gpCopyBufferSubData                           C.GPCOPYBUFFERSUBDATA
-	gpCopyImageSubData                            C.GPCOPYIMAGESUBDATA
-	gpCopyNamedBufferSubData                      C.GPCOPYNAMEDBUFFERSUBDATA
-	gpCopyTexImage1D                              C.GPCOPYTEXIMAGE1D
-	gpCopyTexImage2D                              C.GPCOPYTEXIMAGE2D
-	gpCopyTexSubImage1D                           C.GPCOPYTEXSUBIMAGE1D
-	gpCopyTexSubImage2D                           C.GPCOPYTEXSUBIMAGE2D
-	gpCopyTexSubImage3D                           C.GPCOPYTEXSUBIMAGE3D
-	gpCopyTextureSubImage1D                       C.GPCOPYTEXTURESUBIMAGE1D
-	gpCopyTextureSubImage2D                       C.GPCOPYTEXTURESUBIMAGE2D
-	gpCopyTextureSubImage3D                       C.GPCOPYTEXTURESUBIMAGE3D
-	gpCreateBuffers                               C.GPCREATEBUFFERS
-	gpCreateFramebuffers                          C.GPCREATEFRAMEBUFFERS
-	gpCreateProgram                               C.GPCREATEPROGRAM
-	gpCreateProgramPipelines                      C.GPCREATEPROGRAMPIPELINES
-	gpCreateQueries                               C.GPCREATEQUERIES
-	gpCreateRenderbuffers                         C.GPCREATERENDERBUFFERS
-	gpCreateSamplers                              C.GPCREATESAMPLERS
-	gpCreateShader                                C.GPCREATESHADER
-	gpCreateShaderProgramv                        C.GPCREATESHADERPROGRAMV
-	gpCreateSyncFromCLeventARB                    C.GPCREATESYNCFROMCLEVENTARB
-	gpCreateTextures                              C.GPCREATETEXTURES
-	gpCreateTransformFeedbacks                    C.GPCREATETRANSFORMFEEDBACKS
-	gpCreateVertexArrays                          C.GPCREATEVERTEXARRAYS
-	gpCullFace                                    C.GPCULLFACE
-	gpDebugMessageCallback                        C.GPDEBUGMESSAGECALLBACK
-	gpDebugMessageCallbackARB                     C.GPDEBUGMESSAGECALLBACKARB
-	gpDebugMessageCallbackKHR                     C.GPDEBUGMESSAGECALLBACKKHR
-	gpDebugMessageControl                         C.GPDEBUGMESSAGECONTROL
-	gpDebugMessageControlARB                      C.GPDEBUGMESSAGECONTROLARB
-	gpDebugMessageControlKHR                      C.GPDEBUGMESSAGECONTROLKHR
-	gpDebugMessageInsert                          C.GPDEBUGMESSAGEINSERT
-	gpDebugMessageInsertARB                       C.GPDEBUGMESSAGEINSERTARB
-	gpDebugMessageInsertKHR                       C.GPDEBUGMESSAGEINSERTKHR
-	gpDeleteBuffers                               C.GPDELETEBUFFERS
-	gpDeleteFramebuffers                          C.GPDELETEFRAMEBUFFERS
-	gpDeleteNamedStringARB                        C.GPDELETENAMEDSTRINGARB
-	gpDeleteProgram                               C.GPDELETEPROGRAM
-	gpDeleteProgramPipelines                      C.GPDELETEPROGRAMPIPELINES
-	gpDeleteQueries                               C.GPDELETEQUERIES
-	gpDeleteRenderbuffers                         C.GPDELETERENDERBUFFERS
-	gpDeleteSamplers                              C.GPDELETESAMPLERS
-	gpDeleteShader                                C.GPDELETESHADER
-	gpDeleteSync                                  C.GPDELETESYNC
-	gpDeleteTextures                              C.GPDELETETEXTURES
-	gpDeleteTransformFeedbacks                    C.GPDELETETRANSFORMFEEDBACKS
-	gpDeleteVertexArrays                          C.GPDELETEVERTEXARRAYS
-	gpDepthFunc                                   C.GPDEPTHFUNC
-	gpDepthMask                                   C.GPDEPTHMASK
-	gpDepthRange                                  C.GPDEPTHRANGE
-	gpDepthRangeArrayv                            C.GPDEPTHRANGEARRAYV
-	gpDepthRangeIndexed                           C.GPDEPTHRANGEINDEXED
-	gpDepthRangef                                 C.GPDEPTHRANGEF
-	gpDetachShader                                C.GPDETACHSHADER
-	gpDisable                                     C.GPDISABLE
-	gpDisableVertexArrayAttrib                    C.GPDISABLEVERTEXARRAYATTRIB
-	gpDisableVertexAttribArray                    C.GPDISABLEVERTEXATTRIBARRAY
-	gpDisablei                                    C.GPDISABLEI
-	gpDispatchCompute                             C.GPDISPATCHCOMPUTE
-	gpDispatchComputeGroupSizeARB                 C.GPDISPATCHCOMPUTEGROUPSIZEARB
-	gpDispatchComputeIndirect                     C.GPDISPATCHCOMPUTEINDIRECT
-	gpDrawArrays                                  C.GPDRAWARRAYS
-	gpDrawArraysIndirect                          C.GPDRAWARRAYSINDIRECT
-	gpDrawArraysInstanced                         C.GPDRAWARRAYSINSTANCED
-	gpDrawArraysInstancedBaseInstance             C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
-	gpDrawBuffer                                  C.GPDRAWBUFFER
-	gpDrawBuffers                                 C.GPDRAWBUFFERS
-	gpDrawElements                                C.GPDRAWELEMENTS
-	gpDrawElementsBaseVertex                      C.GPDRAWELEMENTSBASEVERTEX
-	gpDrawElementsIndirect                        C.GPDRAWELEMENTSINDIRECT
-	gpDrawElementsInstanced                       C.GPDRAWELEMENTSINSTANCED
-	gpDrawElementsInstancedBaseInstance           C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
-	gpDrawElementsInstancedBaseVertex             C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
-	gpDrawElementsInstancedBaseVertexBaseInstance C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
-	gpDrawRangeElements                           C.GPDRAWRANGEELEMENTS
-	gpDrawRangeElementsBaseVertex                 C.GPDRAWRANGEELEMENTSBASEVERTEX
-	gpDrawTransformFeedback                       C.GPDRAWTRANSFORMFEEDBACK
-	gpDrawTransformFeedbackInstanced              C.GPDRAWTRANSFORMFEEDBACKINSTANCED
-	gpDrawTransformFeedbackStream                 C.GPDRAWTRANSFORMFEEDBACKSTREAM
-	gpDrawTransformFeedbackStreamInstanced        C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
-	gpEnable                                      C.GPENABLE
-	gpEnableVertexArrayAttrib                     C.GPENABLEVERTEXARRAYATTRIB
-	gpEnableVertexAttribArray                     C.GPENABLEVERTEXATTRIBARRAY
-	gpEnablei                                     C.GPENABLEI
-	gpEndConditionalRender                        C.GPENDCONDITIONALRENDER
-	gpEndQuery                                    C.GPENDQUERY
-	gpEndQueryIndexed                             C.GPENDQUERYINDEXED
-	gpEndTransformFeedback                        C.GPENDTRANSFORMFEEDBACK
-	gpFenceSync                                   C.GPFENCESYNC
-	gpFinish                                      C.GPFINISH
-	gpFlush                                       C.GPFLUSH
-	gpFlushMappedBufferRange                      C.GPFLUSHMAPPEDBUFFERRANGE
-	gpFlushMappedNamedBufferRange                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
-	gpFramebufferParameteri                       C.GPFRAMEBUFFERPARAMETERI
-	gpFramebufferRenderbuffer                     C.GPFRAMEBUFFERRENDERBUFFER
-	gpFramebufferTexture                          C.GPFRAMEBUFFERTEXTURE
-	gpFramebufferTexture1D                        C.GPFRAMEBUFFERTEXTURE1D
-	gpFramebufferTexture2D                        C.GPFRAMEBUFFERTEXTURE2D
-	gpFramebufferTexture3D                        C.GPFRAMEBUFFERTEXTURE3D
-	gpFramebufferTextureLayer                     C.GPFRAMEBUFFERTEXTURELAYER
-	gpFrontFace                                   C.GPFRONTFACE
-	gpGenBuffers                                  C.GPGENBUFFERS
-	gpGenFramebuffers                             C.GPGENFRAMEBUFFERS
-	gpGenProgramPipelines                         C.GPGENPROGRAMPIPELINES
-	gpGenQueries                                  C.GPGENQUERIES
-	gpGenRenderbuffers                            C.GPGENRENDERBUFFERS
-	gpGenSamplers                                 C.GPGENSAMPLERS
-	gpGenTextures                                 C.GPGENTEXTURES
-	gpGenTransformFeedbacks                       C.GPGENTRANSFORMFEEDBACKS
-	gpGenVertexArrays                             C.GPGENVERTEXARRAYS
-	gpGenerateMipmap                              C.GPGENERATEMIPMAP
-	gpGenerateTextureMipmap                       C.GPGENERATETEXTUREMIPMAP
-	gpGetActiveAtomicCounterBufferiv              C.GPGETACTIVEATOMICCOUNTERBUFFERIV
-	gpGetActiveAttrib                             C.GPGETACTIVEATTRIB
-	gpGetActiveSubroutineName                     C.GPGETACTIVESUBROUTINENAME
-	gpGetActiveSubroutineUniformName              C.GPGETACTIVESUBROUTINEUNIFORMNAME
-	gpGetActiveSubroutineUniformiv                C.GPGETACTIVESUBROUTINEUNIFORMIV
-	gpGetActiveUniform                            C.GPGETACTIVEUNIFORM
-	gpGetActiveUniformBlockName                   C.GPGETACTIVEUNIFORMBLOCKNAME
-	gpGetActiveUniformBlockiv                     C.GPGETACTIVEUNIFORMBLOCKIV
-	gpGetActiveUniformName                        C.GPGETACTIVEUNIFORMNAME
-	gpGetActiveUniformsiv                         C.GPGETACTIVEUNIFORMSIV
-	gpGetAttachedShaders                          C.GPGETATTACHEDSHADERS
-	gpGetAttribLocation                           C.GPGETATTRIBLOCATION
-	gpGetBooleani_v                               C.GPGETBOOLEANI_V
-	gpGetBooleanv                                 C.GPGETBOOLEANV
-	gpGetBufferParameteri64v                      C.GPGETBUFFERPARAMETERI64V
-	gpGetBufferParameteriv                        C.GPGETBUFFERPARAMETERIV
-	gpGetBufferPointerv                           C.GPGETBUFFERPOINTERV
-	gpGetBufferSubData                            C.GPGETBUFFERSUBDATA
-	gpGetCompressedTexImage                       C.GPGETCOMPRESSEDTEXIMAGE
-	gpGetCompressedTextureImage                   C.GPGETCOMPRESSEDTEXTUREIMAGE
-	gpGetCompressedTextureSubImage                C.GPGETCOMPRESSEDTEXTURESUBIMAGE
-	gpGetDebugMessageLog                          C.GPGETDEBUGMESSAGELOG
-	gpGetDebugMessageLogARB                       C.GPGETDEBUGMESSAGELOGARB
-	gpGetDebugMessageLogKHR                       C.GPGETDEBUGMESSAGELOGKHR
-	gpGetDoublei_v                                C.GPGETDOUBLEI_V
-	gpGetDoublev                                  C.GPGETDOUBLEV
-	gpGetError                                    C.GPGETERROR
-	gpGetFloati_v                                 C.GPGETFLOATI_V
-	gpGetFloatv                                   C.GPGETFLOATV
-	gpGetFragDataIndex                            C.GPGETFRAGDATAINDEX
-	gpGetFragDataLocation                         C.GPGETFRAGDATALOCATION
-	gpGetFramebufferAttachmentParameteriv         C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetFramebufferParameteriv                   C.GPGETFRAMEBUFFERPARAMETERIV
-	gpGetGraphicsResetStatus                      C.GPGETGRAPHICSRESETSTATUS
-	gpGetGraphicsResetStatusARB                   C.GPGETGRAPHICSRESETSTATUSARB
-	gpGetGraphicsResetStatusKHR                   C.GPGETGRAPHICSRESETSTATUSKHR
-	gpGetImageHandleARB                           C.GPGETIMAGEHANDLEARB
-	gpGetInteger64i_v                             C.GPGETINTEGER64I_V
-	gpGetInteger64v                               C.GPGETINTEGER64V
-	gpGetIntegeri_v                               C.GPGETINTEGERI_V
-	gpGetIntegerv                                 C.GPGETINTEGERV
-	gpGetInternalformati64v                       C.GPGETINTERNALFORMATI64V
-	gpGetInternalformativ                         C.GPGETINTERNALFORMATIV
-	gpGetMultisamplefv                            C.GPGETMULTISAMPLEFV
-	gpGetNamedBufferParameteri64v                 C.GPGETNAMEDBUFFERPARAMETERI64V
-	gpGetNamedBufferParameteriv                   C.GPGETNAMEDBUFFERPARAMETERIV
-	gpGetNamedBufferPointerv                      C.GPGETNAMEDBUFFERPOINTERV
-	gpGetNamedBufferSubData                       C.GPGETNAMEDBUFFERSUBDATA
-	gpGetNamedFramebufferAttachmentParameteriv    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetNamedFramebufferParameteriv              C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
-	gpGetNamedRenderbufferParameteriv             C.GPGETNAMEDRENDERBUFFERPARAMETERIV
-	gpGetNamedStringARB                           C.GPGETNAMEDSTRINGARB
-	gpGetNamedStringivARB                         C.GPGETNAMEDSTRINGIVARB
-	gpGetObjectLabel                              C.GPGETOBJECTLABEL
-	gpGetObjectLabelKHR                           C.GPGETOBJECTLABELKHR
-	gpGetObjectPtrLabel                           C.GPGETOBJECTPTRLABEL
-	gpGetObjectPtrLabelKHR                        C.GPGETOBJECTPTRLABELKHR
-	gpGetPointerv                                 C.GPGETPOINTERV
-	gpGetPointervKHR                              C.GPGETPOINTERVKHR
-	gpGetProgramBinary                            C.GPGETPROGRAMBINARY
-	gpGetProgramInfoLog                           C.GPGETPROGRAMINFOLOG
-	gpGetProgramInterfaceiv                       C.GPGETPROGRAMINTERFACEIV
-	gpGetProgramPipelineInfoLog                   C.GPGETPROGRAMPIPELINEINFOLOG
-	gpGetProgramPipelineiv                        C.GPGETPROGRAMPIPELINEIV
-	gpGetProgramResourceIndex                     C.GPGETPROGRAMRESOURCEINDEX
-	gpGetProgramResourceLocation                  C.GPGETPROGRAMRESOURCELOCATION
-	gpGetProgramResourceLocationIndex             C.GPGETPROGRAMRESOURCELOCATIONINDEX
-	gpGetProgramResourceName                      C.GPGETPROGRAMRESOURCENAME
-	gpGetProgramResourceiv                        C.GPGETPROGRAMRESOURCEIV
-	gpGetProgramStageiv                           C.GPGETPROGRAMSTAGEIV
-	gpGetProgramiv                                C.GPGETPROGRAMIV
-	gpGetQueryIndexediv                           C.GPGETQUERYINDEXEDIV
-	gpGetQueryObjecti64v                          C.GPGETQUERYOBJECTI64V
-	gpGetQueryObjectiv                            C.GPGETQUERYOBJECTIV
-	gpGetQueryObjectui64v                         C.GPGETQUERYOBJECTUI64V
-	gpGetQueryObjectuiv                           C.GPGETQUERYOBJECTUIV
-	gpGetQueryiv                                  C.GPGETQUERYIV
-	gpGetRenderbufferParameteriv                  C.GPGETRENDERBUFFERPARAMETERIV
-	gpGetSamplerParameterIiv                      C.GPGETSAMPLERPARAMETERIIV
-	gpGetSamplerParameterIuiv                     C.GPGETSAMPLERPARAMETERIUIV
-	gpGetSamplerParameterfv                       C.GPGETSAMPLERPARAMETERFV
-	gpGetSamplerParameteriv                       C.GPGETSAMPLERPARAMETERIV
-	gpGetShaderInfoLog                            C.GPGETSHADERINFOLOG
-	gpGetShaderPrecisionFormat                    C.GPGETSHADERPRECISIONFORMAT
-	gpGetShaderSource                             C.GPGETSHADERSOURCE
-	gpGetShaderiv                                 C.GPGETSHADERIV
-	gpGetString                                   C.GPGETSTRING
-	gpGetStringi                                  C.GPGETSTRINGI
-	gpGetSubroutineIndex                          C.GPGETSUBROUTINEINDEX
-	gpGetSubroutineUniformLocation                C.GPGETSUBROUTINEUNIFORMLOCATION
-	gpGetSynciv                                   C.GPGETSYNCIV
-	gpGetTexImage                                 C.GPGETTEXIMAGE
-	gpGetTexLevelParameterfv                      C.GPGETTEXLEVELPARAMETERFV
-	gpGetTexLevelParameteriv                      C.GPGETTEXLEVELPARAMETERIV
-	gpGetTexParameterIiv                          C.GPGETTEXPARAMETERIIV
-	gpGetTexParameterIuiv                         C.GPGETTEXPARAMETERIUIV
-	gpGetTexParameterfv                           C.GPGETTEXPARAMETERFV
-	gpGetTexParameteriv                           C.GPGETTEXPARAMETERIV
-	gpGetTextureHandleARB                         C.GPGETTEXTUREHANDLEARB
-	gpGetTextureImage                             C.GPGETTEXTUREIMAGE
-	gpGetTextureLevelParameterfv                  C.GPGETTEXTURELEVELPARAMETERFV
-	gpGetTextureLevelParameteriv                  C.GPGETTEXTURELEVELPARAMETERIV
-	gpGetTextureParameterIiv                      C.GPGETTEXTUREPARAMETERIIV
-	gpGetTextureParameterIuiv                     C.GPGETTEXTUREPARAMETERIUIV
-	gpGetTextureParameterfv                       C.GPGETTEXTUREPARAMETERFV
-	gpGetTextureParameteriv                       C.GPGETTEXTUREPARAMETERIV
-	gpGetTextureSamplerHandleARB                  C.GPGETTEXTURESAMPLERHANDLEARB
-	gpGetTextureSubImage                          C.GPGETTEXTURESUBIMAGE
-	gpGetTransformFeedbackVarying                 C.GPGETTRANSFORMFEEDBACKVARYING
-	gpGetTransformFeedbacki64_v                   C.GPGETTRANSFORMFEEDBACKI64_V
-	gpGetTransformFeedbacki_v                     C.GPGETTRANSFORMFEEDBACKI_V
-	gpGetTransformFeedbackiv                      C.GPGETTRANSFORMFEEDBACKIV
-	gpGetUniformBlockIndex                        C.GPGETUNIFORMBLOCKINDEX
-	gpGetUniformIndices                           C.GPGETUNIFORMINDICES
-	gpGetUniformLocation                          C.GPGETUNIFORMLOCATION
-	gpGetUniformSubroutineuiv                     C.GPGETUNIFORMSUBROUTINEUIV
-	gpGetUniformdv                                C.GPGETUNIFORMDV
-	gpGetUniformfv                                C.GPGETUNIFORMFV
-	gpGetUniformiv                                C.GPGETUNIFORMIV
-	gpGetUniformuiv                               C.GPGETUNIFORMUIV
-	gpGetVertexArrayIndexed64iv                   C.GPGETVERTEXARRAYINDEXED64IV
-	gpGetVertexArrayIndexediv                     C.GPGETVERTEXARRAYINDEXEDIV
-	gpGetVertexArrayiv                            C.GPGETVERTEXARRAYIV
-	gpGetVertexAttribIiv                          C.GPGETVERTEXATTRIBIIV
-	gpGetVertexAttribIuiv                         C.GPGETVERTEXATTRIBIUIV
-	gpGetVertexAttribLdv                          C.GPGETVERTEXATTRIBLDV
-	gpGetVertexAttribLui64vARB                    C.GPGETVERTEXATTRIBLUI64VARB
-	gpGetVertexAttribPointerv                     C.GPGETVERTEXATTRIBPOINTERV
-	gpGetVertexAttribdv                           C.GPGETVERTEXATTRIBDV
-	gpGetVertexAttribfv                           C.GPGETVERTEXATTRIBFV
-	gpGetVertexAttribiv                           C.GPGETVERTEXATTRIBIV
-	gpGetnCompressedTexImageARB                   C.GPGETNCOMPRESSEDTEXIMAGEARB
-	gpGetnTexImageARB                             C.GPGETNTEXIMAGEARB
-	gpGetnUniformdvARB                            C.GPGETNUNIFORMDVARB
-	gpGetnUniformfv                               C.GPGETNUNIFORMFV
-	gpGetnUniformfvARB                            C.GPGETNUNIFORMFVARB
-	gpGetnUniformfvKHR                            C.GPGETNUNIFORMFVKHR
-	gpGetnUniformiv                               C.GPGETNUNIFORMIV
-	gpGetnUniformivARB                            C.GPGETNUNIFORMIVARB
-	gpGetnUniformivKHR                            C.GPGETNUNIFORMIVKHR
-	gpGetnUniformuiv                              C.GPGETNUNIFORMUIV
-	gpGetnUniformuivARB                           C.GPGETNUNIFORMUIVARB
-	gpGetnUniformuivKHR                           C.GPGETNUNIFORMUIVKHR
-	gpHint                                        C.GPHINT
-	gpInvalidateBufferData                        C.GPINVALIDATEBUFFERDATA
-	gpInvalidateBufferSubData                     C.GPINVALIDATEBUFFERSUBDATA
-	gpInvalidateFramebuffer                       C.GPINVALIDATEFRAMEBUFFER
-	gpInvalidateNamedFramebufferData              C.GPINVALIDATENAMEDFRAMEBUFFERDATA
-	gpInvalidateNamedFramebufferSubData           C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
-	gpInvalidateSubFramebuffer                    C.GPINVALIDATESUBFRAMEBUFFER
-	gpInvalidateTexImage                          C.GPINVALIDATETEXIMAGE
-	gpInvalidateTexSubImage                       C.GPINVALIDATETEXSUBIMAGE
-	gpIsBuffer                                    C.GPISBUFFER
-	gpIsEnabled                                   C.GPISENABLED
-	gpIsEnabledi                                  C.GPISENABLEDI
-	gpIsFramebuffer                               C.GPISFRAMEBUFFER
-	gpIsImageHandleResidentARB                    C.GPISIMAGEHANDLERESIDENTARB
-	gpIsNamedStringARB                            C.GPISNAMEDSTRINGARB
-	gpIsProgram                                   C.GPISPROGRAM
-	gpIsProgramPipeline                           C.GPISPROGRAMPIPELINE
-	gpIsQuery                                     C.GPISQUERY
-	gpIsRenderbuffer                              C.GPISRENDERBUFFER
-	gpIsSampler                                   C.GPISSAMPLER
-	gpIsShader                                    C.GPISSHADER
-	gpIsSync                                      C.GPISSYNC
-	gpIsTexture                                   C.GPISTEXTURE
-	gpIsTextureHandleResidentARB                  C.GPISTEXTUREHANDLERESIDENTARB
-	gpIsTransformFeedback                         C.GPISTRANSFORMFEEDBACK
-	gpIsVertexArray                               C.GPISVERTEXARRAY
-	gpLineWidth                                   C.GPLINEWIDTH
-	gpLinkProgram                                 C.GPLINKPROGRAM
-	gpLogicOp                                     C.GPLOGICOP
-	gpMakeImageHandleNonResidentARB               C.GPMAKEIMAGEHANDLENONRESIDENTARB
-	gpMakeImageHandleResidentARB                  C.GPMAKEIMAGEHANDLERESIDENTARB
-	gpMakeTextureHandleNonResidentARB             C.GPMAKETEXTUREHANDLENONRESIDENTARB
-	gpMakeTextureHandleResidentARB                C.GPMAKETEXTUREHANDLERESIDENTARB
-	gpMapBuffer                                   C.GPMAPBUFFER
-	gpMapBufferRange                              C.GPMAPBUFFERRANGE
-	gpMapNamedBuffer                              C.GPMAPNAMEDBUFFER
-	gpMapNamedBufferRange                         C.GPMAPNAMEDBUFFERRANGE
-	gpMemoryBarrier                               C.GPMEMORYBARRIER
-	gpMemoryBarrierByRegion                       C.GPMEMORYBARRIERBYREGION
-	gpMinSampleShading                            C.GPMINSAMPLESHADING
-	gpMinSampleShadingARB                         C.GPMINSAMPLESHADINGARB
-	gpMultiDrawArrays                             C.GPMULTIDRAWARRAYS
-	gpMultiDrawArraysIndirect                     C.GPMULTIDRAWARRAYSINDIRECT
-	gpMultiDrawArraysIndirectCountARB             C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
-	gpMultiDrawElements                           C.GPMULTIDRAWELEMENTS
-	gpMultiDrawElementsBaseVertex                 C.GPMULTIDRAWELEMENTSBASEVERTEX
-	gpMultiDrawElementsIndirect                   C.GPMULTIDRAWELEMENTSINDIRECT
-	gpMultiDrawElementsIndirectCountARB           C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
-	gpNamedBufferData                             C.GPNAMEDBUFFERDATA
-	gpNamedBufferPageCommitmentARB                C.GPNAMEDBUFFERPAGECOMMITMENTARB
-	gpNamedBufferPageCommitmentEXT                C.GPNAMEDBUFFERPAGECOMMITMENTEXT
-	gpNamedBufferStorage                          C.GPNAMEDBUFFERSTORAGE
-	gpNamedBufferSubData                          C.GPNAMEDBUFFERSUBDATA
-	gpNamedFramebufferDrawBuffer                  C.GPNAMEDFRAMEBUFFERDRAWBUFFER
-	gpNamedFramebufferDrawBuffers                 C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
-	gpNamedFramebufferParameteri                  C.GPNAMEDFRAMEBUFFERPARAMETERI
-	gpNamedFramebufferReadBuffer                  C.GPNAMEDFRAMEBUFFERREADBUFFER
-	gpNamedFramebufferRenderbuffer                C.GPNAMEDFRAMEBUFFERRENDERBUFFER
-	gpNamedFramebufferTexture                     C.GPNAMEDFRAMEBUFFERTEXTURE
-	gpNamedFramebufferTextureLayer                C.GPNAMEDFRAMEBUFFERTEXTURELAYER
-	gpNamedRenderbufferStorage                    C.GPNAMEDRENDERBUFFERSTORAGE
-	gpNamedRenderbufferStorageMultisample         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
-	gpNamedStringARB                              C.GPNAMEDSTRINGARB
-	gpObjectLabel                                 C.GPOBJECTLABEL
-	gpObjectLabelKHR                              C.GPOBJECTLABELKHR
-	gpObjectPtrLabel                              C.GPOBJECTPTRLABEL
-	gpObjectPtrLabelKHR                           C.GPOBJECTPTRLABELKHR
-	gpPatchParameterfv                            C.GPPATCHPARAMETERFV
-	gpPatchParameteri                             C.GPPATCHPARAMETERI
-	gpPauseTransformFeedback                      C.GPPAUSETRANSFORMFEEDBACK
-	gpPixelStoref                                 C.GPPIXELSTOREF
-	gpPixelStorei                                 C.GPPIXELSTOREI
-	gpPointParameterf                             C.GPPOINTPARAMETERF
-	gpPointParameterfv                            C.GPPOINTPARAMETERFV
-	gpPointParameteri                             C.GPPOINTPARAMETERI
-	gpPointParameteriv                            C.GPPOINTPARAMETERIV
-	gpPointSize                                   C.GPPOINTSIZE
-	gpPolygonMode                                 C.GPPOLYGONMODE
-	gpPolygonOffset                               C.GPPOLYGONOFFSET
-	gpPopDebugGroup                               C.GPPOPDEBUGGROUP
-	gpPopDebugGroupKHR                            C.GPPOPDEBUGGROUPKHR
-	gpPrimitiveRestartIndex                       C.GPPRIMITIVERESTARTINDEX
-	gpProgramBinary                               C.GPPROGRAMBINARY
-	gpProgramParameteri                           C.GPPROGRAMPARAMETERI
-	gpProgramUniform1d                            C.GPPROGRAMUNIFORM1D
-	gpProgramUniform1dv                           C.GPPROGRAMUNIFORM1DV
-	gpProgramUniform1f                            C.GPPROGRAMUNIFORM1F
-	gpProgramUniform1fv                           C.GPPROGRAMUNIFORM1FV
-	gpProgramUniform1i                            C.GPPROGRAMUNIFORM1I
-	gpProgramUniform1iv                           C.GPPROGRAMUNIFORM1IV
-	gpProgramUniform1ui                           C.GPPROGRAMUNIFORM1UI
-	gpProgramUniform1uiv                          C.GPPROGRAMUNIFORM1UIV
-	gpProgramUniform2d                            C.GPPROGRAMUNIFORM2D
-	gpProgramUniform2dv                           C.GPPROGRAMUNIFORM2DV
-	gpProgramUniform2f                            C.GPPROGRAMUNIFORM2F
-	gpProgramUniform2fv                           C.GPPROGRAMUNIFORM2FV
-	gpProgramUniform2i                            C.GPPROGRAMUNIFORM2I
-	gpProgramUniform2iv                           C.GPPROGRAMUNIFORM2IV
-	gpProgramUniform2ui                           C.GPPROGRAMUNIFORM2UI
-	gpProgramUniform2uiv                          C.GPPROGRAMUNIFORM2UIV
-	gpProgramUniform3d                            C.GPPROGRAMUNIFORM3D
-	gpProgramUniform3dv                           C.GPPROGRAMUNIFORM3DV
-	gpProgramUniform3f                            C.GPPROGRAMUNIFORM3F
-	gpProgramUniform3fv                           C.GPPROGRAMUNIFORM3FV
-	gpProgramUniform3i                            C.GPPROGRAMUNIFORM3I
-	gpProgramUniform3iv                           C.GPPROGRAMUNIFORM3IV
-	gpProgramUniform3ui                           C.GPPROGRAMUNIFORM3UI
-	gpProgramUniform3uiv                          C.GPPROGRAMUNIFORM3UIV
-	gpProgramUniform4d                            C.GPPROGRAMUNIFORM4D
-	gpProgramUniform4dv                           C.GPPROGRAMUNIFORM4DV
-	gpProgramUniform4f                            C.GPPROGRAMUNIFORM4F
-	gpProgramUniform4fv                           C.GPPROGRAMUNIFORM4FV
-	gpProgramUniform4i                            C.GPPROGRAMUNIFORM4I
-	gpProgramUniform4iv                           C.GPPROGRAMUNIFORM4IV
-	gpProgramUniform4ui                           C.GPPROGRAMUNIFORM4UI
-	gpProgramUniform4uiv                          C.GPPROGRAMUNIFORM4UIV
-	gpProgramUniformHandleui64ARB                 C.GPPROGRAMUNIFORMHANDLEUI64ARB
-	gpProgramUniformHandleui64vARB                C.GPPROGRAMUNIFORMHANDLEUI64VARB
-	gpProgramUniformMatrix2dv                     C.GPPROGRAMUNIFORMMATRIX2DV
-	gpProgramUniformMatrix2fv                     C.GPPROGRAMUNIFORMMATRIX2FV
-	gpProgramUniformMatrix2x3dv                   C.GPPROGRAMUNIFORMMATRIX2X3DV
-	gpProgramUniformMatrix2x3fv                   C.GPPROGRAMUNIFORMMATRIX2X3FV
-	gpProgramUniformMatrix2x4dv                   C.GPPROGRAMUNIFORMMATRIX2X4DV
-	gpProgramUniformMatrix2x4fv                   C.GPPROGRAMUNIFORMMATRIX2X4FV
-	gpProgramUniformMatrix3dv                     C.GPPROGRAMUNIFORMMATRIX3DV
-	gpProgramUniformMatrix3fv                     C.GPPROGRAMUNIFORMMATRIX3FV
-	gpProgramUniformMatrix3x2dv                   C.GPPROGRAMUNIFORMMATRIX3X2DV
-	gpProgramUniformMatrix3x2fv                   C.GPPROGRAMUNIFORMMATRIX3X2FV
-	gpProgramUniformMatrix3x4dv                   C.GPPROGRAMUNIFORMMATRIX3X4DV
-	gpProgramUniformMatrix3x4fv                   C.GPPROGRAMUNIFORMMATRIX3X4FV
-	gpProgramUniformMatrix4dv                     C.GPPROGRAMUNIFORMMATRIX4DV
-	gpProgramUniformMatrix4fv                     C.GPPROGRAMUNIFORMMATRIX4FV
-	gpProgramUniformMatrix4x2dv                   C.GPPROGRAMUNIFORMMATRIX4X2DV
-	gpProgramUniformMatrix4x2fv                   C.GPPROGRAMUNIFORMMATRIX4X2FV
-	gpProgramUniformMatrix4x3dv                   C.GPPROGRAMUNIFORMMATRIX4X3DV
-	gpProgramUniformMatrix4x3fv                   C.GPPROGRAMUNIFORMMATRIX4X3FV
-	gpProvokingVertex                             C.GPPROVOKINGVERTEX
-	gpPushDebugGroup                              C.GPPUSHDEBUGGROUP
-	gpPushDebugGroupKHR                           C.GPPUSHDEBUGGROUPKHR
-	gpQueryCounter                                C.GPQUERYCOUNTER
-	gpReadBuffer                                  C.GPREADBUFFER
-	gpReadPixels                                  C.GPREADPIXELS
-	gpReadnPixels                                 C.GPREADNPIXELS
-	gpReadnPixelsARB                              C.GPREADNPIXELSARB
-	gpReadnPixelsKHR                              C.GPREADNPIXELSKHR
-	gpReleaseShaderCompiler                       C.GPRELEASESHADERCOMPILER
-	gpRenderbufferStorage                         C.GPRENDERBUFFERSTORAGE
-	gpRenderbufferStorageMultisample              C.GPRENDERBUFFERSTORAGEMULTISAMPLE
-	gpResumeTransformFeedback                     C.GPRESUMETRANSFORMFEEDBACK
-	gpSampleCoverage                              C.GPSAMPLECOVERAGE
-	gpSampleMaski                                 C.GPSAMPLEMASKI
-	gpSamplerParameterIiv                         C.GPSAMPLERPARAMETERIIV
-	gpSamplerParameterIuiv                        C.GPSAMPLERPARAMETERIUIV
-	gpSamplerParameterf                           C.GPSAMPLERPARAMETERF
-	gpSamplerParameterfv                          C.GPSAMPLERPARAMETERFV
-	gpSamplerParameteri                           C.GPSAMPLERPARAMETERI
-	gpSamplerParameteriv                          C.GPSAMPLERPARAMETERIV
-	gpScissor                                     C.GPSCISSOR
-	gpScissorArrayv                               C.GPSCISSORARRAYV
-	gpScissorIndexed                              C.GPSCISSORINDEXED
-	gpScissorIndexedv                             C.GPSCISSORINDEXEDV
-	gpShaderBinary                                C.GPSHADERBINARY
-	gpShaderSource                                C.GPSHADERSOURCE
-	gpShaderStorageBlockBinding                   C.GPSHADERSTORAGEBLOCKBINDING
-	gpStencilFunc                                 C.GPSTENCILFUNC
-	gpStencilFuncSeparate                         C.GPSTENCILFUNCSEPARATE
-	gpStencilMask                                 C.GPSTENCILMASK
-	gpStencilMaskSeparate                         C.GPSTENCILMASKSEPARATE
-	gpStencilOp                                   C.GPSTENCILOP
-	gpStencilOpSeparate                           C.GPSTENCILOPSEPARATE
-	gpTexBuffer                                   C.GPTEXBUFFER
-	gpTexBufferRange                              C.GPTEXBUFFERRANGE
-	gpTexImage1D                                  C.GPTEXIMAGE1D
-	gpTexImage2D                                  C.GPTEXIMAGE2D
-	gpTexImage2DMultisample                       C.GPTEXIMAGE2DMULTISAMPLE
-	gpTexImage3D                                  C.GPTEXIMAGE3D
-	gpTexImage3DMultisample                       C.GPTEXIMAGE3DMULTISAMPLE
-	gpTexPageCommitmentARB                        C.GPTEXPAGECOMMITMENTARB
-	gpTexParameterIiv                             C.GPTEXPARAMETERIIV
-	gpTexParameterIuiv                            C.GPTEXPARAMETERIUIV
-	gpTexParameterf                               C.GPTEXPARAMETERF
-	gpTexParameterfv                              C.GPTEXPARAMETERFV
-	gpTexParameteri                               C.GPTEXPARAMETERI
-	gpTexParameteriv                              C.GPTEXPARAMETERIV
-	gpTexStorage1D                                C.GPTEXSTORAGE1D
-	gpTexStorage2D                                C.GPTEXSTORAGE2D
-	gpTexStorage2DMultisample                     C.GPTEXSTORAGE2DMULTISAMPLE
-	gpTexStorage3D                                C.GPTEXSTORAGE3D
-	gpTexStorage3DMultisample                     C.GPTEXSTORAGE3DMULTISAMPLE
-	gpTexSubImage1D                               C.GPTEXSUBIMAGE1D
-	gpTexSubImage2D                               C.GPTEXSUBIMAGE2D
-	gpTexSubImage3D                               C.GPTEXSUBIMAGE3D
-	gpTextureBarrier                              C.GPTEXTUREBARRIER
-	gpTextureBuffer                               C.GPTEXTUREBUFFER
-	gpTextureBufferRange                          C.GPTEXTUREBUFFERRANGE
-	gpTextureParameterIiv                         C.GPTEXTUREPARAMETERIIV
-	gpTextureParameterIuiv                        C.GPTEXTUREPARAMETERIUIV
-	gpTextureParameterf                           C.GPTEXTUREPARAMETERF
-	gpTextureParameterfv                          C.GPTEXTUREPARAMETERFV
-	gpTextureParameteri                           C.GPTEXTUREPARAMETERI
-	gpTextureParameteriv                          C.GPTEXTUREPARAMETERIV
-	gpTextureStorage1D                            C.GPTEXTURESTORAGE1D
-	gpTextureStorage2D                            C.GPTEXTURESTORAGE2D
-	gpTextureStorage2DMultisample                 C.GPTEXTURESTORAGE2DMULTISAMPLE
-	gpTextureStorage3D                            C.GPTEXTURESTORAGE3D
-	gpTextureStorage3DMultisample                 C.GPTEXTURESTORAGE3DMULTISAMPLE
-	gpTextureSubImage1D                           C.GPTEXTURESUBIMAGE1D
-	gpTextureSubImage2D                           C.GPTEXTURESUBIMAGE2D
-	gpTextureSubImage3D                           C.GPTEXTURESUBIMAGE3D
-	gpTextureView                                 C.GPTEXTUREVIEW
-	gpTransformFeedbackBufferBase                 C.GPTRANSFORMFEEDBACKBUFFERBASE
-	gpTransformFeedbackBufferRange                C.GPTRANSFORMFEEDBACKBUFFERRANGE
-	gpTransformFeedbackVaryings                   C.GPTRANSFORMFEEDBACKVARYINGS
-	gpUniform1d                                   C.GPUNIFORM1D
-	gpUniform1dv                                  C.GPUNIFORM1DV
-	gpUniform1f                                   C.GPUNIFORM1F
-	gpUniform1fv                                  C.GPUNIFORM1FV
-	gpUniform1i                                   C.GPUNIFORM1I
-	gpUniform1iv                                  C.GPUNIFORM1IV
-	gpUniform1ui                                  C.GPUNIFORM1UI
-	gpUniform1uiv                                 C.GPUNIFORM1UIV
-	gpUniform2d                                   C.GPUNIFORM2D
-	gpUniform2dv                                  C.GPUNIFORM2DV
-	gpUniform2f                                   C.GPUNIFORM2F
-	gpUniform2fv                                  C.GPUNIFORM2FV
-	gpUniform2i                                   C.GPUNIFORM2I
-	gpUniform2iv                                  C.GPUNIFORM2IV
-	gpUniform2ui                                  C.GPUNIFORM2UI
-	gpUniform2uiv                                 C.GPUNIFORM2UIV
-	gpUniform3d                                   C.GPUNIFORM3D
-	gpUniform3dv                                  C.GPUNIFORM3DV
-	gpUniform3f                                   C.GPUNIFORM3F
-	gpUniform3fv                                  C.GPUNIFORM3FV
-	gpUniform3i                                   C.GPUNIFORM3I
-	gpUniform3iv                                  C.GPUNIFORM3IV
-	gpUniform3ui                                  C.GPUNIFORM3UI
-	gpUniform3uiv                                 C.GPUNIFORM3UIV
-	gpUniform4d                                   C.GPUNIFORM4D
-	gpUniform4dv                                  C.GPUNIFORM4DV
-	gpUniform4f                                   C.GPUNIFORM4F
-	gpUniform4fv                                  C.GPUNIFORM4FV
-	gpUniform4i                                   C.GPUNIFORM4I
-	gpUniform4iv                                  C.GPUNIFORM4IV
-	gpUniform4ui                                  C.GPUNIFORM4UI
-	gpUniform4uiv                                 C.GPUNIFORM4UIV
-	gpUniformBlockBinding                         C.GPUNIFORMBLOCKBINDING
-	gpUniformHandleui64ARB                        C.GPUNIFORMHANDLEUI64ARB
-	gpUniformHandleui64vARB                       C.GPUNIFORMHANDLEUI64VARB
-	gpUniformMatrix2dv                            C.GPUNIFORMMATRIX2DV
-	gpUniformMatrix2fv                            C.GPUNIFORMMATRIX2FV
-	gpUniformMatrix2x3dv                          C.GPUNIFORMMATRIX2X3DV
-	gpUniformMatrix2x3fv                          C.GPUNIFORMMATRIX2X3FV
-	gpUniformMatrix2x4dv                          C.GPUNIFORMMATRIX2X4DV
-	gpUniformMatrix2x4fv                          C.GPUNIFORMMATRIX2X4FV
-	gpUniformMatrix3dv                            C.GPUNIFORMMATRIX3DV
-	gpUniformMatrix3fv                            C.GPUNIFORMMATRIX3FV
-	gpUniformMatrix3x2dv                          C.GPUNIFORMMATRIX3X2DV
-	gpUniformMatrix3x2fv                          C.GPUNIFORMMATRIX3X2FV
-	gpUniformMatrix3x4dv                          C.GPUNIFORMMATRIX3X4DV
-	gpUniformMatrix3x4fv                          C.GPUNIFORMMATRIX3X4FV
-	gpUniformMatrix4dv                            C.GPUNIFORMMATRIX4DV
-	gpUniformMatrix4fv                            C.GPUNIFORMMATRIX4FV
-	gpUniformMatrix4x2dv                          C.GPUNIFORMMATRIX4X2DV
-	gpUniformMatrix4x2fv                          C.GPUNIFORMMATRIX4X2FV
-	gpUniformMatrix4x3dv                          C.GPUNIFORMMATRIX4X3DV
-	gpUniformMatrix4x3fv                          C.GPUNIFORMMATRIX4X3FV
-	gpUniformSubroutinesuiv                       C.GPUNIFORMSUBROUTINESUIV
-	gpUnmapBuffer                                 C.GPUNMAPBUFFER
-	gpUnmapNamedBuffer                            C.GPUNMAPNAMEDBUFFER
-	gpUseProgram                                  C.GPUSEPROGRAM
-	gpUseProgramStages                            C.GPUSEPROGRAMSTAGES
-	gpValidateProgram                             C.GPVALIDATEPROGRAM
-	gpValidateProgramPipeline                     C.GPVALIDATEPROGRAMPIPELINE
-	gpVertexArrayAttribBinding                    C.GPVERTEXARRAYATTRIBBINDING
-	gpVertexArrayAttribFormat                     C.GPVERTEXARRAYATTRIBFORMAT
-	gpVertexArrayAttribIFormat                    C.GPVERTEXARRAYATTRIBIFORMAT
-	gpVertexArrayAttribLFormat                    C.GPVERTEXARRAYATTRIBLFORMAT
-	gpVertexArrayBindingDivisor                   C.GPVERTEXARRAYBINDINGDIVISOR
-	gpVertexArrayElementBuffer                    C.GPVERTEXARRAYELEMENTBUFFER
-	gpVertexArrayVertexBuffer                     C.GPVERTEXARRAYVERTEXBUFFER
-	gpVertexArrayVertexBuffers                    C.GPVERTEXARRAYVERTEXBUFFERS
-	gpVertexAttrib1d                              C.GPVERTEXATTRIB1D
-	gpVertexAttrib1dv                             C.GPVERTEXATTRIB1DV
-	gpVertexAttrib1f                              C.GPVERTEXATTRIB1F
-	gpVertexAttrib1fv                             C.GPVERTEXATTRIB1FV
-	gpVertexAttrib1s                              C.GPVERTEXATTRIB1S
-	gpVertexAttrib1sv                             C.GPVERTEXATTRIB1SV
-	gpVertexAttrib2d                              C.GPVERTEXATTRIB2D
-	gpVertexAttrib2dv                             C.GPVERTEXATTRIB2DV
-	gpVertexAttrib2f                              C.GPVERTEXATTRIB2F
-	gpVertexAttrib2fv                             C.GPVERTEXATTRIB2FV
-	gpVertexAttrib2s                              C.GPVERTEXATTRIB2S
-	gpVertexAttrib2sv                             C.GPVERTEXATTRIB2SV
-	gpVertexAttrib3d                              C.GPVERTEXATTRIB3D
-	gpVertexAttrib3dv                             C.GPVERTEXATTRIB3DV
-	gpVertexAttrib3f                              C.GPVERTEXATTRIB3F
-	gpVertexAttrib3fv                             C.GPVERTEXATTRIB3FV
-	gpVertexAttrib3s                              C.GPVERTEXATTRIB3S
-	gpVertexAttrib3sv                             C.GPVERTEXATTRIB3SV
-	gpVertexAttrib4Nbv                            C.GPVERTEXATTRIB4NBV
-	gpVertexAttrib4Niv                            C.GPVERTEXATTRIB4NIV
-	gpVertexAttrib4Nsv                            C.GPVERTEXATTRIB4NSV
-	gpVertexAttrib4Nub                            C.GPVERTEXATTRIB4NUB
-	gpVertexAttrib4Nubv                           C.GPVERTEXATTRIB4NUBV
-	gpVertexAttrib4Nuiv                           C.GPVERTEXATTRIB4NUIV
-	gpVertexAttrib4Nusv                           C.GPVERTEXATTRIB4NUSV
-	gpVertexAttrib4bv                             C.GPVERTEXATTRIB4BV
-	gpVertexAttrib4d                              C.GPVERTEXATTRIB4D
-	gpVertexAttrib4dv                             C.GPVERTEXATTRIB4DV
-	gpVertexAttrib4f                              C.GPVERTEXATTRIB4F
-	gpVertexAttrib4fv                             C.GPVERTEXATTRIB4FV
-	gpVertexAttrib4iv                             C.GPVERTEXATTRIB4IV
-	gpVertexAttrib4s                              C.GPVERTEXATTRIB4S
-	gpVertexAttrib4sv                             C.GPVERTEXATTRIB4SV
-	gpVertexAttrib4ubv                            C.GPVERTEXATTRIB4UBV
-	gpVertexAttrib4uiv                            C.GPVERTEXATTRIB4UIV
-	gpVertexAttrib4usv                            C.GPVERTEXATTRIB4USV
-	gpVertexAttribBinding                         C.GPVERTEXATTRIBBINDING
-	gpVertexAttribDivisor                         C.GPVERTEXATTRIBDIVISOR
-	gpVertexAttribFormat                          C.GPVERTEXATTRIBFORMAT
-	gpVertexAttribI1i                             C.GPVERTEXATTRIBI1I
-	gpVertexAttribI1iv                            C.GPVERTEXATTRIBI1IV
-	gpVertexAttribI1ui                            C.GPVERTEXATTRIBI1UI
-	gpVertexAttribI1uiv                           C.GPVERTEXATTRIBI1UIV
-	gpVertexAttribI2i                             C.GPVERTEXATTRIBI2I
-	gpVertexAttribI2iv                            C.GPVERTEXATTRIBI2IV
-	gpVertexAttribI2ui                            C.GPVERTEXATTRIBI2UI
-	gpVertexAttribI2uiv                           C.GPVERTEXATTRIBI2UIV
-	gpVertexAttribI3i                             C.GPVERTEXATTRIBI3I
-	gpVertexAttribI3iv                            C.GPVERTEXATTRIBI3IV
-	gpVertexAttribI3ui                            C.GPVERTEXATTRIBI3UI
-	gpVertexAttribI3uiv                           C.GPVERTEXATTRIBI3UIV
-	gpVertexAttribI4bv                            C.GPVERTEXATTRIBI4BV
-	gpVertexAttribI4i                             C.GPVERTEXATTRIBI4I
-	gpVertexAttribI4iv                            C.GPVERTEXATTRIBI4IV
-	gpVertexAttribI4sv                            C.GPVERTEXATTRIBI4SV
-	gpVertexAttribI4ubv                           C.GPVERTEXATTRIBI4UBV
-	gpVertexAttribI4ui                            C.GPVERTEXATTRIBI4UI
-	gpVertexAttribI4uiv                           C.GPVERTEXATTRIBI4UIV
-	gpVertexAttribI4usv                           C.GPVERTEXATTRIBI4USV
-	gpVertexAttribIFormat                         C.GPVERTEXATTRIBIFORMAT
-	gpVertexAttribIPointer                        C.GPVERTEXATTRIBIPOINTER
-	gpVertexAttribL1d                             C.GPVERTEXATTRIBL1D
-	gpVertexAttribL1dv                            C.GPVERTEXATTRIBL1DV
-	gpVertexAttribL1ui64ARB                       C.GPVERTEXATTRIBL1UI64ARB
-	gpVertexAttribL1ui64vARB                      C.GPVERTEXATTRIBL1UI64VARB
-	gpVertexAttribL2d                             C.GPVERTEXATTRIBL2D
-	gpVertexAttribL2dv                            C.GPVERTEXATTRIBL2DV
-	gpVertexAttribL3d                             C.GPVERTEXATTRIBL3D
-	gpVertexAttribL3dv                            C.GPVERTEXATTRIBL3DV
-	gpVertexAttribL4d                             C.GPVERTEXATTRIBL4D
-	gpVertexAttribL4dv                            C.GPVERTEXATTRIBL4DV
-	gpVertexAttribLFormat                         C.GPVERTEXATTRIBLFORMAT
-	gpVertexAttribLPointer                        C.GPVERTEXATTRIBLPOINTER
-	gpVertexAttribP1ui                            C.GPVERTEXATTRIBP1UI
-	gpVertexAttribP1uiv                           C.GPVERTEXATTRIBP1UIV
-	gpVertexAttribP2ui                            C.GPVERTEXATTRIBP2UI
-	gpVertexAttribP2uiv                           C.GPVERTEXATTRIBP2UIV
-	gpVertexAttribP3ui                            C.GPVERTEXATTRIBP3UI
-	gpVertexAttribP3uiv                           C.GPVERTEXATTRIBP3UIV
-	gpVertexAttribP4ui                            C.GPVERTEXATTRIBP4UI
-	gpVertexAttribP4uiv                           C.GPVERTEXATTRIBP4UIV
-	gpVertexAttribPointer                         C.GPVERTEXATTRIBPOINTER
-	gpVertexBindingDivisor                        C.GPVERTEXBINDINGDIVISOR
-	gpViewport                                    C.GPVIEWPORT
-	gpViewportArrayv                              C.GPVIEWPORTARRAYV
-	gpViewportIndexedf                            C.GPVIEWPORTINDEXEDF
-	gpViewportIndexedfv                           C.GPVIEWPORTINDEXEDFV
-	gpWaitSync                                    C.GPWAITSYNC
+	gpActiveProgramEXT                               C.GPACTIVEPROGRAMEXT
+	gpActiveShaderProgram                            C.GPACTIVESHADERPROGRAM
+	gpActiveShaderProgramEXT                         C.GPACTIVESHADERPROGRAMEXT
+	gpActiveTexture                                  C.GPACTIVETEXTURE
+	gpApplyFramebufferAttachmentCMAAINTEL            C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
+	gpAttachShader                                   C.GPATTACHSHADER
+	gpBeginConditionalRender                         C.GPBEGINCONDITIONALRENDER
+	gpBeginConditionalRenderNV                       C.GPBEGINCONDITIONALRENDERNV
+	gpBeginPerfMonitorAMD                            C.GPBEGINPERFMONITORAMD
+	gpBeginPerfQueryINTEL                            C.GPBEGINPERFQUERYINTEL
+	gpBeginQuery                                     C.GPBEGINQUERY
+	gpBeginQueryIndexed                              C.GPBEGINQUERYINDEXED
+	gpBeginTransformFeedback                         C.GPBEGINTRANSFORMFEEDBACK
+	gpBindAttribLocation                             C.GPBINDATTRIBLOCATION
+	gpBindBuffer                                     C.GPBINDBUFFER
+	gpBindBufferBase                                 C.GPBINDBUFFERBASE
+	gpBindBufferRange                                C.GPBINDBUFFERRANGE
+	gpBindBuffersBase                                C.GPBINDBUFFERSBASE
+	gpBindBuffersRange                               C.GPBINDBUFFERSRANGE
+	gpBindFragDataLocation                           C.GPBINDFRAGDATALOCATION
+	gpBindFragDataLocationIndexed                    C.GPBINDFRAGDATALOCATIONINDEXED
+	gpBindFramebuffer                                C.GPBINDFRAMEBUFFER
+	gpBindImageTexture                               C.GPBINDIMAGETEXTURE
+	gpBindImageTextures                              C.GPBINDIMAGETEXTURES
+	gpBindMultiTextureEXT                            C.GPBINDMULTITEXTUREEXT
+	gpBindProgramPipeline                            C.GPBINDPROGRAMPIPELINE
+	gpBindProgramPipelineEXT                         C.GPBINDPROGRAMPIPELINEEXT
+	gpBindRenderbuffer                               C.GPBINDRENDERBUFFER
+	gpBindSampler                                    C.GPBINDSAMPLER
+	gpBindSamplers                                   C.GPBINDSAMPLERS
+	gpBindTexture                                    C.GPBINDTEXTURE
+	gpBindTextureUnit                                C.GPBINDTEXTUREUNIT
+	gpBindTextures                                   C.GPBINDTEXTURES
+	gpBindTransformFeedback                          C.GPBINDTRANSFORMFEEDBACK
+	gpBindVertexArray                                C.GPBINDVERTEXARRAY
+	gpBindVertexBuffer                               C.GPBINDVERTEXBUFFER
+	gpBindVertexBuffers                              C.GPBINDVERTEXBUFFERS
+	gpBlendBarrierKHR                                C.GPBLENDBARRIERKHR
+	gpBlendBarrierNV                                 C.GPBLENDBARRIERNV
+	gpBlendColor                                     C.GPBLENDCOLOR
+	gpBlendEquation                                  C.GPBLENDEQUATION
+	gpBlendEquationSeparate                          C.GPBLENDEQUATIONSEPARATE
+	gpBlendEquationSeparatei                         C.GPBLENDEQUATIONSEPARATEI
+	gpBlendEquationSeparateiARB                      C.GPBLENDEQUATIONSEPARATEIARB
+	gpBlendEquationi                                 C.GPBLENDEQUATIONI
+	gpBlendEquationiARB                              C.GPBLENDEQUATIONIARB
+	gpBlendFunc                                      C.GPBLENDFUNC
+	gpBlendFuncSeparate                              C.GPBLENDFUNCSEPARATE
+	gpBlendFuncSeparatei                             C.GPBLENDFUNCSEPARATEI
+	gpBlendFuncSeparateiARB                          C.GPBLENDFUNCSEPARATEIARB
+	gpBlendFunci                                     C.GPBLENDFUNCI
+	gpBlendFunciARB                                  C.GPBLENDFUNCIARB
+	gpBlendParameteriNV                              C.GPBLENDPARAMETERINV
+	gpBlitFramebuffer                                C.GPBLITFRAMEBUFFER
+	gpBlitNamedFramebuffer                           C.GPBLITNAMEDFRAMEBUFFER
+	gpBufferAddressRangeNV                           C.GPBUFFERADDRESSRANGENV
+	gpBufferData                                     C.GPBUFFERDATA
+	gpBufferPageCommitmentARB                        C.GPBUFFERPAGECOMMITMENTARB
+	gpBufferStorage                                  C.GPBUFFERSTORAGE
+	gpBufferSubData                                  C.GPBUFFERSUBDATA
+	gpCallCommandListNV                              C.GPCALLCOMMANDLISTNV
+	gpCheckFramebufferStatus                         C.GPCHECKFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatus                    C.GPCHECKNAMEDFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatusEXT                 C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT
+	gpClampColor                                     C.GPCLAMPCOLOR
+	gpClear                                          C.GPCLEAR
+	gpClearBufferData                                C.GPCLEARBUFFERDATA
+	gpClearBufferSubData                             C.GPCLEARBUFFERSUBDATA
+	gpClearBufferfi                                  C.GPCLEARBUFFERFI
+	gpClearBufferfv                                  C.GPCLEARBUFFERFV
+	gpClearBufferiv                                  C.GPCLEARBUFFERIV
+	gpClearBufferuiv                                 C.GPCLEARBUFFERUIV
+	gpClearColor                                     C.GPCLEARCOLOR
+	gpClearDepth                                     C.GPCLEARDEPTH
+	gpClearDepthf                                    C.GPCLEARDEPTHF
+	gpClearNamedBufferData                           C.GPCLEARNAMEDBUFFERDATA
+	gpClearNamedBufferDataEXT                        C.GPCLEARNAMEDBUFFERDATAEXT
+	gpClearNamedBufferSubData                        C.GPCLEARNAMEDBUFFERSUBDATA
+	gpClearNamedBufferSubDataEXT                     C.GPCLEARNAMEDBUFFERSUBDATAEXT
+	gpClearNamedFramebufferfi                        C.GPCLEARNAMEDFRAMEBUFFERFI
+	gpClearNamedFramebufferfv                        C.GPCLEARNAMEDFRAMEBUFFERFV
+	gpClearNamedFramebufferiv                        C.GPCLEARNAMEDFRAMEBUFFERIV
+	gpClearNamedFramebufferuiv                       C.GPCLEARNAMEDFRAMEBUFFERUIV
+	gpClearStencil                                   C.GPCLEARSTENCIL
+	gpClearTexImage                                  C.GPCLEARTEXIMAGE
+	gpClearTexSubImage                               C.GPCLEARTEXSUBIMAGE
+	gpClientAttribDefaultEXT                         C.GPCLIENTATTRIBDEFAULTEXT
+	gpClientWaitSync                                 C.GPCLIENTWAITSYNC
+	gpClipControl                                    C.GPCLIPCONTROL
+	gpColorFormatNV                                  C.GPCOLORFORMATNV
+	gpColorMask                                      C.GPCOLORMASK
+	gpColorMaski                                     C.GPCOLORMASKI
+	gpCommandListSegmentsNV                          C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                           C.GPCOMPILECOMMANDLISTNV
+	gpCompileShader                                  C.GPCOMPILESHADER
+	gpCompileShaderIncludeARB                        C.GPCOMPILESHADERINCLUDEARB
+	gpCompressedMultiTexImage1DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE1DEXT
+	gpCompressedMultiTexImage2DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE2DEXT
+	gpCompressedMultiTexImage3DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE3DEXT
+	gpCompressedMultiTexSubImage1DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT
+	gpCompressedMultiTexSubImage2DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT
+	gpCompressedMultiTexSubImage3DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT
+	gpCompressedTexImage1D                           C.GPCOMPRESSEDTEXIMAGE1D
+	gpCompressedTexImage2D                           C.GPCOMPRESSEDTEXIMAGE2D
+	gpCompressedTexImage3D                           C.GPCOMPRESSEDTEXIMAGE3D
+	gpCompressedTexSubImage1D                        C.GPCOMPRESSEDTEXSUBIMAGE1D
+	gpCompressedTexSubImage2D                        C.GPCOMPRESSEDTEXSUBIMAGE2D
+	gpCompressedTexSubImage3D                        C.GPCOMPRESSEDTEXSUBIMAGE3D
+	gpCompressedTextureImage1DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE1DEXT
+	gpCompressedTextureImage2DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE2DEXT
+	gpCompressedTextureImage3DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE3DEXT
+	gpCompressedTextureSubImage1D                    C.GPCOMPRESSEDTEXTURESUBIMAGE1D
+	gpCompressedTextureSubImage1DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT
+	gpCompressedTextureSubImage2D                    C.GPCOMPRESSEDTEXTURESUBIMAGE2D
+	gpCompressedTextureSubImage2DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
+	gpCompressedTextureSubImage3D                    C.GPCOMPRESSEDTEXTURESUBIMAGE3D
+	gpCompressedTextureSubImage3DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                 C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                 C.GPCONSERVATIVERASTERPARAMETERINV
+	gpCopyBufferSubData                              C.GPCOPYBUFFERSUBDATA
+	gpCopyImageSubData                               C.GPCOPYIMAGESUBDATA
+	gpCopyMultiTexImage1DEXT                         C.GPCOPYMULTITEXIMAGE1DEXT
+	gpCopyMultiTexImage2DEXT                         C.GPCOPYMULTITEXIMAGE2DEXT
+	gpCopyMultiTexSubImage1DEXT                      C.GPCOPYMULTITEXSUBIMAGE1DEXT
+	gpCopyMultiTexSubImage2DEXT                      C.GPCOPYMULTITEXSUBIMAGE2DEXT
+	gpCopyMultiTexSubImage3DEXT                      C.GPCOPYMULTITEXSUBIMAGE3DEXT
+	gpCopyNamedBufferSubData                         C.GPCOPYNAMEDBUFFERSUBDATA
+	gpCopyPathNV                                     C.GPCOPYPATHNV
+	gpCopyTexImage1D                                 C.GPCOPYTEXIMAGE1D
+	gpCopyTexImage2D                                 C.GPCOPYTEXIMAGE2D
+	gpCopyTexSubImage1D                              C.GPCOPYTEXSUBIMAGE1D
+	gpCopyTexSubImage2D                              C.GPCOPYTEXSUBIMAGE2D
+	gpCopyTexSubImage3D                              C.GPCOPYTEXSUBIMAGE3D
+	gpCopyTextureImage1DEXT                          C.GPCOPYTEXTUREIMAGE1DEXT
+	gpCopyTextureImage2DEXT                          C.GPCOPYTEXTUREIMAGE2DEXT
+	gpCopyTextureSubImage1D                          C.GPCOPYTEXTURESUBIMAGE1D
+	gpCopyTextureSubImage1DEXT                       C.GPCOPYTEXTURESUBIMAGE1DEXT
+	gpCopyTextureSubImage2D                          C.GPCOPYTEXTURESUBIMAGE2D
+	gpCopyTextureSubImage2DEXT                       C.GPCOPYTEXTURESUBIMAGE2DEXT
+	gpCopyTextureSubImage3D                          C.GPCOPYTEXTURESUBIMAGE3D
+	gpCopyTextureSubImage3DEXT                       C.GPCOPYTEXTURESUBIMAGE3DEXT
+	gpCoverFillPathInstancedNV                       C.GPCOVERFILLPATHINSTANCEDNV
+	gpCoverFillPathNV                                C.GPCOVERFILLPATHNV
+	gpCoverStrokePathInstancedNV                     C.GPCOVERSTROKEPATHINSTANCEDNV
+	gpCoverStrokePathNV                              C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                           C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                      C.GPCOVERAGEMODULATIONTABLENV
+	gpCreateBuffers                                  C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                           C.GPCREATECOMMANDLISTSNV
+	gpCreateFramebuffers                             C.GPCREATEFRAMEBUFFERS
+	gpCreatePerfQueryINTEL                           C.GPCREATEPERFQUERYINTEL
+	gpCreateProgram                                  C.GPCREATEPROGRAM
+	gpCreateProgramPipelines                         C.GPCREATEPROGRAMPIPELINES
+	gpCreateQueries                                  C.GPCREATEQUERIES
+	gpCreateRenderbuffers                            C.GPCREATERENDERBUFFERS
+	gpCreateSamplers                                 C.GPCREATESAMPLERS
+	gpCreateShader                                   C.GPCREATESHADER
+	gpCreateShaderProgramEXT                         C.GPCREATESHADERPROGRAMEXT
+	gpCreateShaderProgramv                           C.GPCREATESHADERPROGRAMV
+	gpCreateShaderProgramvEXT                        C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                 C.GPCREATESTATESNV
+	gpCreateSyncFromCLeventARB                       C.GPCREATESYNCFROMCLEVENTARB
+	gpCreateTextures                                 C.GPCREATETEXTURES
+	gpCreateTransformFeedbacks                       C.GPCREATETRANSFORMFEEDBACKS
+	gpCreateVertexArrays                             C.GPCREATEVERTEXARRAYS
+	gpCullFace                                       C.GPCULLFACE
+	gpDebugMessageCallback                           C.GPDEBUGMESSAGECALLBACK
+	gpDebugMessageCallbackARB                        C.GPDEBUGMESSAGECALLBACKARB
+	gpDebugMessageCallbackKHR                        C.GPDEBUGMESSAGECALLBACKKHR
+	gpDebugMessageControl                            C.GPDEBUGMESSAGECONTROL
+	gpDebugMessageControlARB                         C.GPDEBUGMESSAGECONTROLARB
+	gpDebugMessageControlKHR                         C.GPDEBUGMESSAGECONTROLKHR
+	gpDebugMessageInsert                             C.GPDEBUGMESSAGEINSERT
+	gpDebugMessageInsertARB                          C.GPDEBUGMESSAGEINSERTARB
+	gpDebugMessageInsertKHR                          C.GPDEBUGMESSAGEINSERTKHR
+	gpDeleteBuffers                                  C.GPDELETEBUFFERS
+	gpDeleteCommandListsNV                           C.GPDELETECOMMANDLISTSNV
+	gpDeleteFramebuffers                             C.GPDELETEFRAMEBUFFERS
+	gpDeleteNamedStringARB                           C.GPDELETENAMEDSTRINGARB
+	gpDeletePathsNV                                  C.GPDELETEPATHSNV
+	gpDeletePerfMonitorsAMD                          C.GPDELETEPERFMONITORSAMD
+	gpDeletePerfQueryINTEL                           C.GPDELETEPERFQUERYINTEL
+	gpDeleteProgram                                  C.GPDELETEPROGRAM
+	gpDeleteProgramPipelines                         C.GPDELETEPROGRAMPIPELINES
+	gpDeleteProgramPipelinesEXT                      C.GPDELETEPROGRAMPIPELINESEXT
+	gpDeleteQueries                                  C.GPDELETEQUERIES
+	gpDeleteRenderbuffers                            C.GPDELETERENDERBUFFERS
+	gpDeleteSamplers                                 C.GPDELETESAMPLERS
+	gpDeleteShader                                   C.GPDELETESHADER
+	gpDeleteStatesNV                                 C.GPDELETESTATESNV
+	gpDeleteSync                                     C.GPDELETESYNC
+	gpDeleteTextures                                 C.GPDELETETEXTURES
+	gpDeleteTransformFeedbacks                       C.GPDELETETRANSFORMFEEDBACKS
+	gpDeleteVertexArrays                             C.GPDELETEVERTEXARRAYS
+	gpDepthFunc                                      C.GPDEPTHFUNC
+	gpDepthMask                                      C.GPDEPTHMASK
+	gpDepthRange                                     C.GPDEPTHRANGE
+	gpDepthRangeArrayv                               C.GPDEPTHRANGEARRAYV
+	gpDepthRangeIndexed                              C.GPDEPTHRANGEINDEXED
+	gpDepthRangef                                    C.GPDEPTHRANGEF
+	gpDetachShader                                   C.GPDETACHSHADER
+	gpDisable                                        C.GPDISABLE
+	gpDisableClientStateIndexedEXT                   C.GPDISABLECLIENTSTATEINDEXEDEXT
+	gpDisableClientStateiEXT                         C.GPDISABLECLIENTSTATEIEXT
+	gpDisableIndexedEXT                              C.GPDISABLEINDEXEDEXT
+	gpDisableVertexArrayAttrib                       C.GPDISABLEVERTEXARRAYATTRIB
+	gpDisableVertexArrayAttribEXT                    C.GPDISABLEVERTEXARRAYATTRIBEXT
+	gpDisableVertexArrayEXT                          C.GPDISABLEVERTEXARRAYEXT
+	gpDisableVertexAttribArray                       C.GPDISABLEVERTEXATTRIBARRAY
+	gpDisablei                                       C.GPDISABLEI
+	gpDispatchCompute                                C.GPDISPATCHCOMPUTE
+	gpDispatchComputeGroupSizeARB                    C.GPDISPATCHCOMPUTEGROUPSIZEARB
+	gpDispatchComputeIndirect                        C.GPDISPATCHCOMPUTEINDIRECT
+	gpDrawArrays                                     C.GPDRAWARRAYS
+	gpDrawArraysIndirect                             C.GPDRAWARRAYSINDIRECT
+	gpDrawArraysInstanced                            C.GPDRAWARRAYSINSTANCED
+	gpDrawArraysInstancedARB                         C.GPDRAWARRAYSINSTANCEDARB
+	gpDrawArraysInstancedBaseInstance                C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
+	gpDrawArraysInstancedEXT                         C.GPDRAWARRAYSINSTANCEDEXT
+	gpDrawBuffer                                     C.GPDRAWBUFFER
+	gpDrawBuffers                                    C.GPDRAWBUFFERS
+	gpDrawCommandsAddressNV                          C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                 C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                    C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                           C.GPDRAWCOMMANDSSTATESNV
+	gpDrawElements                                   C.GPDRAWELEMENTS
+	gpDrawElementsBaseVertex                         C.GPDRAWELEMENTSBASEVERTEX
+	gpDrawElementsIndirect                           C.GPDRAWELEMENTSINDIRECT
+	gpDrawElementsInstanced                          C.GPDRAWELEMENTSINSTANCED
+	gpDrawElementsInstancedARB                       C.GPDRAWELEMENTSINSTANCEDARB
+	gpDrawElementsInstancedBaseInstance              C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
+	gpDrawElementsInstancedBaseVertex                C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
+	gpDrawElementsInstancedBaseVertexBaseInstance    C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
+	gpDrawElementsInstancedEXT                       C.GPDRAWELEMENTSINSTANCEDEXT
+	gpDrawRangeElements                              C.GPDRAWRANGEELEMENTS
+	gpDrawRangeElementsBaseVertex                    C.GPDRAWRANGEELEMENTSBASEVERTEX
+	gpDrawTransformFeedback                          C.GPDRAWTRANSFORMFEEDBACK
+	gpDrawTransformFeedbackInstanced                 C.GPDRAWTRANSFORMFEEDBACKINSTANCED
+	gpDrawTransformFeedbackStream                    C.GPDRAWTRANSFORMFEEDBACKSTREAM
+	gpDrawTransformFeedbackStreamInstanced           C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                  C.GPDRAWVKIMAGENV
+	gpEdgeFlagFormatNV                               C.GPEDGEFLAGFORMATNV
+	gpEnable                                         C.GPENABLE
+	gpEnableClientStateIndexedEXT                    C.GPENABLECLIENTSTATEINDEXEDEXT
+	gpEnableClientStateiEXT                          C.GPENABLECLIENTSTATEIEXT
+	gpEnableIndexedEXT                               C.GPENABLEINDEXEDEXT
+	gpEnableVertexArrayAttrib                        C.GPENABLEVERTEXARRAYATTRIB
+	gpEnableVertexArrayAttribEXT                     C.GPENABLEVERTEXARRAYATTRIBEXT
+	gpEnableVertexArrayEXT                           C.GPENABLEVERTEXARRAYEXT
+	gpEnableVertexAttribArray                        C.GPENABLEVERTEXATTRIBARRAY
+	gpEnablei                                        C.GPENABLEI
+	gpEndConditionalRender                           C.GPENDCONDITIONALRENDER
+	gpEndConditionalRenderNV                         C.GPENDCONDITIONALRENDERNV
+	gpEndPerfMonitorAMD                              C.GPENDPERFMONITORAMD
+	gpEndPerfQueryINTEL                              C.GPENDPERFQUERYINTEL
+	gpEndQuery                                       C.GPENDQUERY
+	gpEndQueryIndexed                                C.GPENDQUERYINDEXED
+	gpEndTransformFeedback                           C.GPENDTRANSFORMFEEDBACK
+	gpEvaluateDepthValuesARB                         C.GPEVALUATEDEPTHVALUESARB
+	gpFenceSync                                      C.GPFENCESYNC
+	gpFinish                                         C.GPFINISH
+	gpFlush                                          C.GPFLUSH
+	gpFlushMappedBufferRange                         C.GPFLUSHMAPPEDBUFFERRANGE
+	gpFlushMappedNamedBufferRange                    C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
+	gpFlushMappedNamedBufferRangeEXT                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT
+	gpFogCoordFormatNV                               C.GPFOGCOORDFORMATNV
+	gpFragmentCoverageColorNV                        C.GPFRAGMENTCOVERAGECOLORNV
+	gpFramebufferDrawBufferEXT                       C.GPFRAMEBUFFERDRAWBUFFEREXT
+	gpFramebufferDrawBuffersEXT                      C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                     C.GPFRAMEBUFFERFETCHBARRIEREXT
+	gpFramebufferParameteri                          C.GPFRAMEBUFFERPARAMETERI
+	gpFramebufferReadBufferEXT                       C.GPFRAMEBUFFERREADBUFFEREXT
+	gpFramebufferRenderbuffer                        C.GPFRAMEBUFFERRENDERBUFFER
+	gpFramebufferSampleLocationsfvARB                C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                 C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferTexture                             C.GPFRAMEBUFFERTEXTURE
+	gpFramebufferTexture1D                           C.GPFRAMEBUFFERTEXTURE1D
+	gpFramebufferTexture2D                           C.GPFRAMEBUFFERTEXTURE2D
+	gpFramebufferTexture3D                           C.GPFRAMEBUFFERTEXTURE3D
+	gpFramebufferTextureARB                          C.GPFRAMEBUFFERTEXTUREARB
+	gpFramebufferTextureFaceARB                      C.GPFRAMEBUFFERTEXTUREFACEARB
+	gpFramebufferTextureLayer                        C.GPFRAMEBUFFERTEXTURELAYER
+	gpFramebufferTextureLayerARB                     C.GPFRAMEBUFFERTEXTURELAYERARB
+	gpFramebufferTextureMultiviewOVR                 C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
+	gpFrontFace                                      C.GPFRONTFACE
+	gpGenBuffers                                     C.GPGENBUFFERS
+	gpGenFramebuffers                                C.GPGENFRAMEBUFFERS
+	gpGenPathsNV                                     C.GPGENPATHSNV
+	gpGenPerfMonitorsAMD                             C.GPGENPERFMONITORSAMD
+	gpGenProgramPipelines                            C.GPGENPROGRAMPIPELINES
+	gpGenProgramPipelinesEXT                         C.GPGENPROGRAMPIPELINESEXT
+	gpGenQueries                                     C.GPGENQUERIES
+	gpGenRenderbuffers                               C.GPGENRENDERBUFFERS
+	gpGenSamplers                                    C.GPGENSAMPLERS
+	gpGenTextures                                    C.GPGENTEXTURES
+	gpGenTransformFeedbacks                          C.GPGENTRANSFORMFEEDBACKS
+	gpGenVertexArrays                                C.GPGENVERTEXARRAYS
+	gpGenerateMipmap                                 C.GPGENERATEMIPMAP
+	gpGenerateMultiTexMipmapEXT                      C.GPGENERATEMULTITEXMIPMAPEXT
+	gpGenerateTextureMipmap                          C.GPGENERATETEXTUREMIPMAP
+	gpGenerateTextureMipmapEXT                       C.GPGENERATETEXTUREMIPMAPEXT
+	gpGetActiveAtomicCounterBufferiv                 C.GPGETACTIVEATOMICCOUNTERBUFFERIV
+	gpGetActiveAttrib                                C.GPGETACTIVEATTRIB
+	gpGetActiveSubroutineName                        C.GPGETACTIVESUBROUTINENAME
+	gpGetActiveSubroutineUniformName                 C.GPGETACTIVESUBROUTINEUNIFORMNAME
+	gpGetActiveSubroutineUniformiv                   C.GPGETACTIVESUBROUTINEUNIFORMIV
+	gpGetActiveUniform                               C.GPGETACTIVEUNIFORM
+	gpGetActiveUniformBlockName                      C.GPGETACTIVEUNIFORMBLOCKNAME
+	gpGetActiveUniformBlockiv                        C.GPGETACTIVEUNIFORMBLOCKIV
+	gpGetActiveUniformName                           C.GPGETACTIVEUNIFORMNAME
+	gpGetActiveUniformsiv                            C.GPGETACTIVEUNIFORMSIV
+	gpGetAttachedShaders                             C.GPGETATTACHEDSHADERS
+	gpGetAttribLocation                              C.GPGETATTRIBLOCATION
+	gpGetBooleanIndexedvEXT                          C.GPGETBOOLEANINDEXEDVEXT
+	gpGetBooleani_v                                  C.GPGETBOOLEANI_V
+	gpGetBooleanv                                    C.GPGETBOOLEANV
+	gpGetBufferParameteri64v                         C.GPGETBUFFERPARAMETERI64V
+	gpGetBufferParameteriv                           C.GPGETBUFFERPARAMETERIV
+	gpGetBufferParameterui64vNV                      C.GPGETBUFFERPARAMETERUI64VNV
+	gpGetBufferPointerv                              C.GPGETBUFFERPOINTERV
+	gpGetBufferSubData                               C.GPGETBUFFERSUBDATA
+	gpGetCommandHeaderNV                             C.GPGETCOMMANDHEADERNV
+	gpGetCompressedMultiTexImageEXT                  C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
+	gpGetCompressedTexImage                          C.GPGETCOMPRESSEDTEXIMAGE
+	gpGetCompressedTextureImage                      C.GPGETCOMPRESSEDTEXTUREIMAGE
+	gpGetCompressedTextureImageEXT                   C.GPGETCOMPRESSEDTEXTUREIMAGEEXT
+	gpGetCompressedTextureSubImage                   C.GPGETCOMPRESSEDTEXTURESUBIMAGE
+	gpGetCoverageModulationTableNV                   C.GPGETCOVERAGEMODULATIONTABLENV
+	gpGetDebugMessageLog                             C.GPGETDEBUGMESSAGELOG
+	gpGetDebugMessageLogARB                          C.GPGETDEBUGMESSAGELOGARB
+	gpGetDebugMessageLogKHR                          C.GPGETDEBUGMESSAGELOGKHR
+	gpGetDoubleIndexedvEXT                           C.GPGETDOUBLEINDEXEDVEXT
+	gpGetDoublei_v                                   C.GPGETDOUBLEI_V
+	gpGetDoublei_vEXT                                C.GPGETDOUBLEI_VEXT
+	gpGetDoublev                                     C.GPGETDOUBLEV
+	gpGetError                                       C.GPGETERROR
+	gpGetFirstPerfQueryIdINTEL                       C.GPGETFIRSTPERFQUERYIDINTEL
+	gpGetFloatIndexedvEXT                            C.GPGETFLOATINDEXEDVEXT
+	gpGetFloati_v                                    C.GPGETFLOATI_V
+	gpGetFloati_vEXT                                 C.GPGETFLOATI_VEXT
+	gpGetFloatv                                      C.GPGETFLOATV
+	gpGetFragDataIndex                               C.GPGETFRAGDATAINDEX
+	gpGetFragDataLocation                            C.GPGETFRAGDATALOCATION
+	gpGetFramebufferAttachmentParameteriv            C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetFramebufferParameteriv                      C.GPGETFRAMEBUFFERPARAMETERIV
+	gpGetFramebufferParameterivEXT                   C.GPGETFRAMEBUFFERPARAMETERIVEXT
+	gpGetGraphicsResetStatus                         C.GPGETGRAPHICSRESETSTATUS
+	gpGetGraphicsResetStatusARB                      C.GPGETGRAPHICSRESETSTATUSARB
+	gpGetGraphicsResetStatusKHR                      C.GPGETGRAPHICSRESETSTATUSKHR
+	gpGetImageHandleARB                              C.GPGETIMAGEHANDLEARB
+	gpGetImageHandleNV                               C.GPGETIMAGEHANDLENV
+	gpGetInteger64i_v                                C.GPGETINTEGER64I_V
+	gpGetInteger64v                                  C.GPGETINTEGER64V
+	gpGetIntegerIndexedvEXT                          C.GPGETINTEGERINDEXEDVEXT
+	gpGetIntegeri_v                                  C.GPGETINTEGERI_V
+	gpGetIntegerui64i_vNV                            C.GPGETINTEGERUI64I_VNV
+	gpGetIntegerui64vNV                              C.GPGETINTEGERUI64VNV
+	gpGetIntegerv                                    C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                    C.GPGETINTERNALFORMATSAMPLEIVNV
+	gpGetInternalformati64v                          C.GPGETINTERNALFORMATI64V
+	gpGetInternalformativ                            C.GPGETINTERNALFORMATIV
+	gpGetMultiTexEnvfvEXT                            C.GPGETMULTITEXENVFVEXT
+	gpGetMultiTexEnvivEXT                            C.GPGETMULTITEXENVIVEXT
+	gpGetMultiTexGendvEXT                            C.GPGETMULTITEXGENDVEXT
+	gpGetMultiTexGenfvEXT                            C.GPGETMULTITEXGENFVEXT
+	gpGetMultiTexGenivEXT                            C.GPGETMULTITEXGENIVEXT
+	gpGetMultiTexImageEXT                            C.GPGETMULTITEXIMAGEEXT
+	gpGetMultiTexLevelParameterfvEXT                 C.GPGETMULTITEXLEVELPARAMETERFVEXT
+	gpGetMultiTexLevelParameterivEXT                 C.GPGETMULTITEXLEVELPARAMETERIVEXT
+	gpGetMultiTexParameterIivEXT                     C.GPGETMULTITEXPARAMETERIIVEXT
+	gpGetMultiTexParameterIuivEXT                    C.GPGETMULTITEXPARAMETERIUIVEXT
+	gpGetMultiTexParameterfvEXT                      C.GPGETMULTITEXPARAMETERFVEXT
+	gpGetMultiTexParameterivEXT                      C.GPGETMULTITEXPARAMETERIVEXT
+	gpGetMultisamplefv                               C.GPGETMULTISAMPLEFV
+	gpGetNamedBufferParameteri64v                    C.GPGETNAMEDBUFFERPARAMETERI64V
+	gpGetNamedBufferParameteriv                      C.GPGETNAMEDBUFFERPARAMETERIV
+	gpGetNamedBufferParameterivEXT                   C.GPGETNAMEDBUFFERPARAMETERIVEXT
+	gpGetNamedBufferParameterui64vNV                 C.GPGETNAMEDBUFFERPARAMETERUI64VNV
+	gpGetNamedBufferPointerv                         C.GPGETNAMEDBUFFERPOINTERV
+	gpGetNamedBufferPointervEXT                      C.GPGETNAMEDBUFFERPOINTERVEXT
+	gpGetNamedBufferSubData                          C.GPGETNAMEDBUFFERSUBDATA
+	gpGetNamedBufferSubDataEXT                       C.GPGETNAMEDBUFFERSUBDATAEXT
+	gpGetNamedFramebufferAttachmentParameteriv       C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetNamedFramebufferAttachmentParameterivEXT    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameteriv                 C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
+	gpGetNamedFramebufferParameterivEXT              C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
+	gpGetNamedProgramLocalParameterIivEXT            C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
+	gpGetNamedProgramLocalParameterIuivEXT           C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT
+	gpGetNamedProgramLocalParameterdvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT
+	gpGetNamedProgramLocalParameterfvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT
+	gpGetNamedProgramStringEXT                       C.GPGETNAMEDPROGRAMSTRINGEXT
+	gpGetNamedProgramivEXT                           C.GPGETNAMEDPROGRAMIVEXT
+	gpGetNamedRenderbufferParameteriv                C.GPGETNAMEDRENDERBUFFERPARAMETERIV
+	gpGetNamedRenderbufferParameterivEXT             C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT
+	gpGetNamedStringARB                              C.GPGETNAMEDSTRINGARB
+	gpGetNamedStringivARB                            C.GPGETNAMEDSTRINGIVARB
+	gpGetNextPerfQueryIdINTEL                        C.GPGETNEXTPERFQUERYIDINTEL
+	gpGetObjectLabel                                 C.GPGETOBJECTLABEL
+	gpGetObjectLabelEXT                              C.GPGETOBJECTLABELEXT
+	gpGetObjectLabelKHR                              C.GPGETOBJECTLABELKHR
+	gpGetObjectPtrLabel                              C.GPGETOBJECTPTRLABEL
+	gpGetObjectPtrLabelKHR                           C.GPGETOBJECTPTRLABELKHR
+	gpGetPathCommandsNV                              C.GPGETPATHCOMMANDSNV
+	gpGetPathCoordsNV                                C.GPGETPATHCOORDSNV
+	gpGetPathDashArrayNV                             C.GPGETPATHDASHARRAYNV
+	gpGetPathLengthNV                                C.GPGETPATHLENGTHNV
+	gpGetPathMetricRangeNV                           C.GPGETPATHMETRICRANGENV
+	gpGetPathMetricsNV                               C.GPGETPATHMETRICSNV
+	gpGetPathParameterfvNV                           C.GPGETPATHPARAMETERFVNV
+	gpGetPathParameterivNV                           C.GPGETPATHPARAMETERIVNV
+	gpGetPathSpacingNV                               C.GPGETPATHSPACINGNV
+	gpGetPerfCounterInfoINTEL                        C.GPGETPERFCOUNTERINFOINTEL
+	gpGetPerfMonitorCounterDataAMD                   C.GPGETPERFMONITORCOUNTERDATAAMD
+	gpGetPerfMonitorCounterInfoAMD                   C.GPGETPERFMONITORCOUNTERINFOAMD
+	gpGetPerfMonitorCounterStringAMD                 C.GPGETPERFMONITORCOUNTERSTRINGAMD
+	gpGetPerfMonitorCountersAMD                      C.GPGETPERFMONITORCOUNTERSAMD
+	gpGetPerfMonitorGroupStringAMD                   C.GPGETPERFMONITORGROUPSTRINGAMD
+	gpGetPerfMonitorGroupsAMD                        C.GPGETPERFMONITORGROUPSAMD
+	gpGetPerfQueryDataINTEL                          C.GPGETPERFQUERYDATAINTEL
+	gpGetPerfQueryIdByNameINTEL                      C.GPGETPERFQUERYIDBYNAMEINTEL
+	gpGetPerfQueryInfoINTEL                          C.GPGETPERFQUERYINFOINTEL
+	gpGetPointerIndexedvEXT                          C.GPGETPOINTERINDEXEDVEXT
+	gpGetPointeri_vEXT                               C.GPGETPOINTERI_VEXT
+	gpGetPointerv                                    C.GPGETPOINTERV
+	gpGetPointervKHR                                 C.GPGETPOINTERVKHR
+	gpGetProgramBinary                               C.GPGETPROGRAMBINARY
+	gpGetProgramInfoLog                              C.GPGETPROGRAMINFOLOG
+	gpGetProgramInterfaceiv                          C.GPGETPROGRAMINTERFACEIV
+	gpGetProgramPipelineInfoLog                      C.GPGETPROGRAMPIPELINEINFOLOG
+	gpGetProgramPipelineInfoLogEXT                   C.GPGETPROGRAMPIPELINEINFOLOGEXT
+	gpGetProgramPipelineiv                           C.GPGETPROGRAMPIPELINEIV
+	gpGetProgramPipelineivEXT                        C.GPGETPROGRAMPIPELINEIVEXT
+	gpGetProgramResourceIndex                        C.GPGETPROGRAMRESOURCEINDEX
+	gpGetProgramResourceLocation                     C.GPGETPROGRAMRESOURCELOCATION
+	gpGetProgramResourceLocationIndex                C.GPGETPROGRAMRESOURCELOCATIONINDEX
+	gpGetProgramResourceName                         C.GPGETPROGRAMRESOURCENAME
+	gpGetProgramResourcefvNV                         C.GPGETPROGRAMRESOURCEFVNV
+	gpGetProgramResourceiv                           C.GPGETPROGRAMRESOURCEIV
+	gpGetProgramStageiv                              C.GPGETPROGRAMSTAGEIV
+	gpGetProgramiv                                   C.GPGETPROGRAMIV
+	gpGetQueryBufferObjecti64v                       C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                         C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                      C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                        C.GPGETQUERYBUFFEROBJECTUIV
+	gpGetQueryIndexediv                              C.GPGETQUERYINDEXEDIV
+	gpGetQueryObjecti64v                             C.GPGETQUERYOBJECTI64V
+	gpGetQueryObjectiv                               C.GPGETQUERYOBJECTIV
+	gpGetQueryObjectui64v                            C.GPGETQUERYOBJECTUI64V
+	gpGetQueryObjectuiv                              C.GPGETQUERYOBJECTUIV
+	gpGetQueryiv                                     C.GPGETQUERYIV
+	gpGetRenderbufferParameteriv                     C.GPGETRENDERBUFFERPARAMETERIV
+	gpGetSamplerParameterIiv                         C.GPGETSAMPLERPARAMETERIIV
+	gpGetSamplerParameterIuiv                        C.GPGETSAMPLERPARAMETERIUIV
+	gpGetSamplerParameterfv                          C.GPGETSAMPLERPARAMETERFV
+	gpGetSamplerParameteriv                          C.GPGETSAMPLERPARAMETERIV
+	gpGetShaderInfoLog                               C.GPGETSHADERINFOLOG
+	gpGetShaderPrecisionFormat                       C.GPGETSHADERPRECISIONFORMAT
+	gpGetShaderSource                                C.GPGETSHADERSOURCE
+	gpGetShaderiv                                    C.GPGETSHADERIV
+	gpGetStageIndexNV                                C.GPGETSTAGEINDEXNV
+	gpGetString                                      C.GPGETSTRING
+	gpGetStringi                                     C.GPGETSTRINGI
+	gpGetSubroutineIndex                             C.GPGETSUBROUTINEINDEX
+	gpGetSubroutineUniformLocation                   C.GPGETSUBROUTINEUNIFORMLOCATION
+	gpGetSynciv                                      C.GPGETSYNCIV
+	gpGetTexImage                                    C.GPGETTEXIMAGE
+	gpGetTexLevelParameterfv                         C.GPGETTEXLEVELPARAMETERFV
+	gpGetTexLevelParameteriv                         C.GPGETTEXLEVELPARAMETERIV
+	gpGetTexParameterIiv                             C.GPGETTEXPARAMETERIIV
+	gpGetTexParameterIuiv                            C.GPGETTEXPARAMETERIUIV
+	gpGetTexParameterfv                              C.GPGETTEXPARAMETERFV
+	gpGetTexParameteriv                              C.GPGETTEXPARAMETERIV
+	gpGetTextureHandleARB                            C.GPGETTEXTUREHANDLEARB
+	gpGetTextureHandleNV                             C.GPGETTEXTUREHANDLENV
+	gpGetTextureImage                                C.GPGETTEXTUREIMAGE
+	gpGetTextureImageEXT                             C.GPGETTEXTUREIMAGEEXT
+	gpGetTextureLevelParameterfv                     C.GPGETTEXTURELEVELPARAMETERFV
+	gpGetTextureLevelParameterfvEXT                  C.GPGETTEXTURELEVELPARAMETERFVEXT
+	gpGetTextureLevelParameteriv                     C.GPGETTEXTURELEVELPARAMETERIV
+	gpGetTextureLevelParameterivEXT                  C.GPGETTEXTURELEVELPARAMETERIVEXT
+	gpGetTextureParameterIiv                         C.GPGETTEXTUREPARAMETERIIV
+	gpGetTextureParameterIivEXT                      C.GPGETTEXTUREPARAMETERIIVEXT
+	gpGetTextureParameterIuiv                        C.GPGETTEXTUREPARAMETERIUIV
+	gpGetTextureParameterIuivEXT                     C.GPGETTEXTUREPARAMETERIUIVEXT
+	gpGetTextureParameterfv                          C.GPGETTEXTUREPARAMETERFV
+	gpGetTextureParameterfvEXT                       C.GPGETTEXTUREPARAMETERFVEXT
+	gpGetTextureParameteriv                          C.GPGETTEXTUREPARAMETERIV
+	gpGetTextureParameterivEXT                       C.GPGETTEXTUREPARAMETERIVEXT
+	gpGetTextureSamplerHandleARB                     C.GPGETTEXTURESAMPLERHANDLEARB
+	gpGetTextureSamplerHandleNV                      C.GPGETTEXTURESAMPLERHANDLENV
+	gpGetTextureSubImage                             C.GPGETTEXTURESUBIMAGE
+	gpGetTransformFeedbackVarying                    C.GPGETTRANSFORMFEEDBACKVARYING
+	gpGetTransformFeedbacki64_v                      C.GPGETTRANSFORMFEEDBACKI64_V
+	gpGetTransformFeedbacki_v                        C.GPGETTRANSFORMFEEDBACKI_V
+	gpGetTransformFeedbackiv                         C.GPGETTRANSFORMFEEDBACKIV
+	gpGetUniformBlockIndex                           C.GPGETUNIFORMBLOCKINDEX
+	gpGetUniformIndices                              C.GPGETUNIFORMINDICES
+	gpGetUniformLocation                             C.GPGETUNIFORMLOCATION
+	gpGetUniformSubroutineuiv                        C.GPGETUNIFORMSUBROUTINEUIV
+	gpGetUniformdv                                   C.GPGETUNIFORMDV
+	gpGetUniformfv                                   C.GPGETUNIFORMFV
+	gpGetUniformi64vARB                              C.GPGETUNIFORMI64VARB
+	gpGetUniformi64vNV                               C.GPGETUNIFORMI64VNV
+	gpGetUniformiv                                   C.GPGETUNIFORMIV
+	gpGetUniformui64vARB                             C.GPGETUNIFORMUI64VARB
+	gpGetUniformui64vNV                              C.GPGETUNIFORMUI64VNV
+	gpGetUniformuiv                                  C.GPGETUNIFORMUIV
+	gpGetVertexArrayIndexed64iv                      C.GPGETVERTEXARRAYINDEXED64IV
+	gpGetVertexArrayIndexediv                        C.GPGETVERTEXARRAYINDEXEDIV
+	gpGetVertexArrayIntegeri_vEXT                    C.GPGETVERTEXARRAYINTEGERI_VEXT
+	gpGetVertexArrayIntegervEXT                      C.GPGETVERTEXARRAYINTEGERVEXT
+	gpGetVertexArrayPointeri_vEXT                    C.GPGETVERTEXARRAYPOINTERI_VEXT
+	gpGetVertexArrayPointervEXT                      C.GPGETVERTEXARRAYPOINTERVEXT
+	gpGetVertexArrayiv                               C.GPGETVERTEXARRAYIV
+	gpGetVertexAttribIiv                             C.GPGETVERTEXATTRIBIIV
+	gpGetVertexAttribIuiv                            C.GPGETVERTEXATTRIBIUIV
+	gpGetVertexAttribLdv                             C.GPGETVERTEXATTRIBLDV
+	gpGetVertexAttribLi64vNV                         C.GPGETVERTEXATTRIBLI64VNV
+	gpGetVertexAttribLui64vARB                       C.GPGETVERTEXATTRIBLUI64VARB
+	gpGetVertexAttribLui64vNV                        C.GPGETVERTEXATTRIBLUI64VNV
+	gpGetVertexAttribPointerv                        C.GPGETVERTEXATTRIBPOINTERV
+	gpGetVertexAttribdv                              C.GPGETVERTEXATTRIBDV
+	gpGetVertexAttribfv                              C.GPGETVERTEXATTRIBFV
+	gpGetVertexAttribiv                              C.GPGETVERTEXATTRIBIV
+	gpGetVkProcAddrNV                                C.GPGETVKPROCADDRNV
+	gpGetnCompressedTexImageARB                      C.GPGETNCOMPRESSEDTEXIMAGEARB
+	gpGetnTexImageARB                                C.GPGETNTEXIMAGEARB
+	gpGetnUniformdvARB                               C.GPGETNUNIFORMDVARB
+	gpGetnUniformfv                                  C.GPGETNUNIFORMFV
+	gpGetnUniformfvARB                               C.GPGETNUNIFORMFVARB
+	gpGetnUniformfvKHR                               C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                             C.GPGETNUNIFORMI64VARB
+	gpGetnUniformiv                                  C.GPGETNUNIFORMIV
+	gpGetnUniformivARB                               C.GPGETNUNIFORMIVARB
+	gpGetnUniformivKHR                               C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                            C.GPGETNUNIFORMUI64VARB
+	gpGetnUniformuiv                                 C.GPGETNUNIFORMUIV
+	gpGetnUniformuivARB                              C.GPGETNUNIFORMUIVARB
+	gpGetnUniformuivKHR                              C.GPGETNUNIFORMUIVKHR
+	gpHint                                           C.GPHINT
+	gpIndexFormatNV                                  C.GPINDEXFORMATNV
+	gpInsertEventMarkerEXT                           C.GPINSERTEVENTMARKEREXT
+	gpInterpolatePathsNV                             C.GPINTERPOLATEPATHSNV
+	gpInvalidateBufferData                           C.GPINVALIDATEBUFFERDATA
+	gpInvalidateBufferSubData                        C.GPINVALIDATEBUFFERSUBDATA
+	gpInvalidateFramebuffer                          C.GPINVALIDATEFRAMEBUFFER
+	gpInvalidateNamedFramebufferData                 C.GPINVALIDATENAMEDFRAMEBUFFERDATA
+	gpInvalidateNamedFramebufferSubData              C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
+	gpInvalidateSubFramebuffer                       C.GPINVALIDATESUBFRAMEBUFFER
+	gpInvalidateTexImage                             C.GPINVALIDATETEXIMAGE
+	gpInvalidateTexSubImage                          C.GPINVALIDATETEXSUBIMAGE
+	gpIsBuffer                                       C.GPISBUFFER
+	gpIsBufferResidentNV                             C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                C.GPISCOMMANDLISTNV
+	gpIsEnabled                                      C.GPISENABLED
+	gpIsEnabledIndexedEXT                            C.GPISENABLEDINDEXEDEXT
+	gpIsEnabledi                                     C.GPISENABLEDI
+	gpIsFramebuffer                                  C.GPISFRAMEBUFFER
+	gpIsImageHandleResidentARB                       C.GPISIMAGEHANDLERESIDENTARB
+	gpIsImageHandleResidentNV                        C.GPISIMAGEHANDLERESIDENTNV
+	gpIsNamedBufferResidentNV                        C.GPISNAMEDBUFFERRESIDENTNV
+	gpIsNamedStringARB                               C.GPISNAMEDSTRINGARB
+	gpIsPathNV                                       C.GPISPATHNV
+	gpIsPointInFillPathNV                            C.GPISPOINTINFILLPATHNV
+	gpIsPointInStrokePathNV                          C.GPISPOINTINSTROKEPATHNV
+	gpIsProgram                                      C.GPISPROGRAM
+	gpIsProgramPipeline                              C.GPISPROGRAMPIPELINE
+	gpIsProgramPipelineEXT                           C.GPISPROGRAMPIPELINEEXT
+	gpIsQuery                                        C.GPISQUERY
+	gpIsRenderbuffer                                 C.GPISRENDERBUFFER
+	gpIsSampler                                      C.GPISSAMPLER
+	gpIsShader                                       C.GPISSHADER
+	gpIsStateNV                                      C.GPISSTATENV
+	gpIsSync                                         C.GPISSYNC
+	gpIsTexture                                      C.GPISTEXTURE
+	gpIsTextureHandleResidentARB                     C.GPISTEXTUREHANDLERESIDENTARB
+	gpIsTextureHandleResidentNV                      C.GPISTEXTUREHANDLERESIDENTNV
+	gpIsTransformFeedback                            C.GPISTRANSFORMFEEDBACK
+	gpIsVertexArray                                  C.GPISVERTEXARRAY
+	gpLabelObjectEXT                                 C.GPLABELOBJECTEXT
+	gpLineWidth                                      C.GPLINEWIDTH
+	gpLinkProgram                                    C.GPLINKPROGRAM
+	gpListDrawCommandsStatesClientNV                 C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
+	gpLogicOp                                        C.GPLOGICOP
+	gpMakeBufferNonResidentNV                        C.GPMAKEBUFFERNONRESIDENTNV
+	gpMakeBufferResidentNV                           C.GPMAKEBUFFERRESIDENTNV
+	gpMakeImageHandleNonResidentARB                  C.GPMAKEIMAGEHANDLENONRESIDENTARB
+	gpMakeImageHandleNonResidentNV                   C.GPMAKEIMAGEHANDLENONRESIDENTNV
+	gpMakeImageHandleResidentARB                     C.GPMAKEIMAGEHANDLERESIDENTARB
+	gpMakeImageHandleResidentNV                      C.GPMAKEIMAGEHANDLERESIDENTNV
+	gpMakeNamedBufferNonResidentNV                   C.GPMAKENAMEDBUFFERNONRESIDENTNV
+	gpMakeNamedBufferResidentNV                      C.GPMAKENAMEDBUFFERRESIDENTNV
+	gpMakeTextureHandleNonResidentARB                C.GPMAKETEXTUREHANDLENONRESIDENTARB
+	gpMakeTextureHandleNonResidentNV                 C.GPMAKETEXTUREHANDLENONRESIDENTNV
+	gpMakeTextureHandleResidentARB                   C.GPMAKETEXTUREHANDLERESIDENTARB
+	gpMakeTextureHandleResidentNV                    C.GPMAKETEXTUREHANDLERESIDENTNV
+	gpMapBuffer                                      C.GPMAPBUFFER
+	gpMapBufferRange                                 C.GPMAPBUFFERRANGE
+	gpMapNamedBuffer                                 C.GPMAPNAMEDBUFFER
+	gpMapNamedBufferEXT                              C.GPMAPNAMEDBUFFEREXT
+	gpMapNamedBufferRange                            C.GPMAPNAMEDBUFFERRANGE
+	gpMapNamedBufferRangeEXT                         C.GPMAPNAMEDBUFFERRANGEEXT
+	gpMatrixFrustumEXT                               C.GPMATRIXFRUSTUMEXT
+	gpMatrixLoad3x2fNV                               C.GPMATRIXLOAD3X2FNV
+	gpMatrixLoad3x3fNV                               C.GPMATRIXLOAD3X3FNV
+	gpMatrixLoadIdentityEXT                          C.GPMATRIXLOADIDENTITYEXT
+	gpMatrixLoadTranspose3x3fNV                      C.GPMATRIXLOADTRANSPOSE3X3FNV
+	gpMatrixLoadTransposedEXT                        C.GPMATRIXLOADTRANSPOSEDEXT
+	gpMatrixLoadTransposefEXT                        C.GPMATRIXLOADTRANSPOSEFEXT
+	gpMatrixLoaddEXT                                 C.GPMATRIXLOADDEXT
+	gpMatrixLoadfEXT                                 C.GPMATRIXLOADFEXT
+	gpMatrixMult3x2fNV                               C.GPMATRIXMULT3X2FNV
+	gpMatrixMult3x3fNV                               C.GPMATRIXMULT3X3FNV
+	gpMatrixMultTranspose3x3fNV                      C.GPMATRIXMULTTRANSPOSE3X3FNV
+	gpMatrixMultTransposedEXT                        C.GPMATRIXMULTTRANSPOSEDEXT
+	gpMatrixMultTransposefEXT                        C.GPMATRIXMULTTRANSPOSEFEXT
+	gpMatrixMultdEXT                                 C.GPMATRIXMULTDEXT
+	gpMatrixMultfEXT                                 C.GPMATRIXMULTFEXT
+	gpMatrixOrthoEXT                                 C.GPMATRIXORTHOEXT
+	gpMatrixPopEXT                                   C.GPMATRIXPOPEXT
+	gpMatrixPushEXT                                  C.GPMATRIXPUSHEXT
+	gpMatrixRotatedEXT                               C.GPMATRIXROTATEDEXT
+	gpMatrixRotatefEXT                               C.GPMATRIXROTATEFEXT
+	gpMatrixScaledEXT                                C.GPMATRIXSCALEDEXT
+	gpMatrixScalefEXT                                C.GPMATRIXSCALEFEXT
+	gpMatrixTranslatedEXT                            C.GPMATRIXTRANSLATEDEXT
+	gpMatrixTranslatefEXT                            C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                    C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                    C.GPMAXSHADERCOMPILERTHREADSKHR
+	gpMemoryBarrier                                  C.GPMEMORYBARRIER
+	gpMemoryBarrierByRegion                          C.GPMEMORYBARRIERBYREGION
+	gpMinSampleShading                               C.GPMINSAMPLESHADING
+	gpMinSampleShadingARB                            C.GPMINSAMPLESHADINGARB
+	gpMultiDrawArrays                                C.GPMULTIDRAWARRAYS
+	gpMultiDrawArraysIndirect                        C.GPMULTIDRAWARRAYSINDIRECT
+	gpMultiDrawArraysIndirectBindlessCountNV         C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawArraysIndirectBindlessNV              C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV
+	gpMultiDrawArraysIndirectCountARB                C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
+	gpMultiDrawElements                              C.GPMULTIDRAWELEMENTS
+	gpMultiDrawElementsBaseVertex                    C.GPMULTIDRAWELEMENTSBASEVERTEX
+	gpMultiDrawElementsIndirect                      C.GPMULTIDRAWELEMENTSINDIRECT
+	gpMultiDrawElementsIndirectBindlessCountNV       C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawElementsIndirectBindlessNV            C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV
+	gpMultiDrawElementsIndirectCountARB              C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
+	gpMultiTexBufferEXT                              C.GPMULTITEXBUFFEREXT
+	gpMultiTexCoordPointerEXT                        C.GPMULTITEXCOORDPOINTEREXT
+	gpMultiTexEnvfEXT                                C.GPMULTITEXENVFEXT
+	gpMultiTexEnvfvEXT                               C.GPMULTITEXENVFVEXT
+	gpMultiTexEnviEXT                                C.GPMULTITEXENVIEXT
+	gpMultiTexEnvivEXT                               C.GPMULTITEXENVIVEXT
+	gpMultiTexGendEXT                                C.GPMULTITEXGENDEXT
+	gpMultiTexGendvEXT                               C.GPMULTITEXGENDVEXT
+	gpMultiTexGenfEXT                                C.GPMULTITEXGENFEXT
+	gpMultiTexGenfvEXT                               C.GPMULTITEXGENFVEXT
+	gpMultiTexGeniEXT                                C.GPMULTITEXGENIEXT
+	gpMultiTexGenivEXT                               C.GPMULTITEXGENIVEXT
+	gpMultiTexImage1DEXT                             C.GPMULTITEXIMAGE1DEXT
+	gpMultiTexImage2DEXT                             C.GPMULTITEXIMAGE2DEXT
+	gpMultiTexImage3DEXT                             C.GPMULTITEXIMAGE3DEXT
+	gpMultiTexParameterIivEXT                        C.GPMULTITEXPARAMETERIIVEXT
+	gpMultiTexParameterIuivEXT                       C.GPMULTITEXPARAMETERIUIVEXT
+	gpMultiTexParameterfEXT                          C.GPMULTITEXPARAMETERFEXT
+	gpMultiTexParameterfvEXT                         C.GPMULTITEXPARAMETERFVEXT
+	gpMultiTexParameteriEXT                          C.GPMULTITEXPARAMETERIEXT
+	gpMultiTexParameterivEXT                         C.GPMULTITEXPARAMETERIVEXT
+	gpMultiTexRenderbufferEXT                        C.GPMULTITEXRENDERBUFFEREXT
+	gpMultiTexSubImage1DEXT                          C.GPMULTITEXSUBIMAGE1DEXT
+	gpMultiTexSubImage2DEXT                          C.GPMULTITEXSUBIMAGE2DEXT
+	gpMultiTexSubImage3DEXT                          C.GPMULTITEXSUBIMAGE3DEXT
+	gpNamedBufferData                                C.GPNAMEDBUFFERDATA
+	gpNamedBufferDataEXT                             C.GPNAMEDBUFFERDATAEXT
+	gpNamedBufferPageCommitmentARB                   C.GPNAMEDBUFFERPAGECOMMITMENTARB
+	gpNamedBufferPageCommitmentEXT                   C.GPNAMEDBUFFERPAGECOMMITMENTEXT
+	gpNamedBufferStorage                             C.GPNAMEDBUFFERSTORAGE
+	gpNamedBufferStorageEXT                          C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferSubData                             C.GPNAMEDBUFFERSUBDATA
+	gpNamedBufferSubDataEXT                          C.GPNAMEDBUFFERSUBDATAEXT
+	gpNamedCopyBufferSubDataEXT                      C.GPNAMEDCOPYBUFFERSUBDATAEXT
+	gpNamedFramebufferDrawBuffer                     C.GPNAMEDFRAMEBUFFERDRAWBUFFER
+	gpNamedFramebufferDrawBuffers                    C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
+	gpNamedFramebufferParameteri                     C.GPNAMEDFRAMEBUFFERPARAMETERI
+	gpNamedFramebufferParameteriEXT                  C.GPNAMEDFRAMEBUFFERPARAMETERIEXT
+	gpNamedFramebufferReadBuffer                     C.GPNAMEDFRAMEBUFFERREADBUFFER
+	gpNamedFramebufferRenderbuffer                   C.GPNAMEDFRAMEBUFFERRENDERBUFFER
+	gpNamedFramebufferRenderbufferEXT                C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB           C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV            C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferTexture                        C.GPNAMEDFRAMEBUFFERTEXTURE
+	gpNamedFramebufferTexture1DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
+	gpNamedFramebufferTexture2DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
+	gpNamedFramebufferTexture3DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT
+	gpNamedFramebufferTextureEXT                     C.GPNAMEDFRAMEBUFFERTEXTUREEXT
+	gpNamedFramebufferTextureFaceEXT                 C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT
+	gpNamedFramebufferTextureLayer                   C.GPNAMEDFRAMEBUFFERTEXTURELAYER
+	gpNamedFramebufferTextureLayerEXT                C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT
+	gpNamedProgramLocalParameter4dEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT
+	gpNamedProgramLocalParameter4dvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT
+	gpNamedProgramLocalParameter4fEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT
+	gpNamedProgramLocalParameter4fvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT
+	gpNamedProgramLocalParameterI4iEXT               C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT
+	gpNamedProgramLocalParameterI4ivEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT
+	gpNamedProgramLocalParameterI4uiEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT
+	gpNamedProgramLocalParameterI4uivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT
+	gpNamedProgramLocalParameters4fvEXT              C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT
+	gpNamedProgramLocalParametersI4ivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT
+	gpNamedProgramLocalParametersI4uivEXT            C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT
+	gpNamedProgramStringEXT                          C.GPNAMEDPROGRAMSTRINGEXT
+	gpNamedRenderbufferStorage                       C.GPNAMEDRENDERBUFFERSTORAGE
+	gpNamedRenderbufferStorageEXT                    C.GPNAMEDRENDERBUFFERSTORAGEEXT
+	gpNamedRenderbufferStorageMultisample            C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
+	gpNamedRenderbufferStorageMultisampleCoverageEXT C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT
+	gpNamedRenderbufferStorageMultisampleEXT         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT
+	gpNamedStringARB                                 C.GPNAMEDSTRINGARB
+	gpNormalFormatNV                                 C.GPNORMALFORMATNV
+	gpObjectLabel                                    C.GPOBJECTLABEL
+	gpObjectLabelKHR                                 C.GPOBJECTLABELKHR
+	gpObjectPtrLabel                                 C.GPOBJECTPTRLABEL
+	gpObjectPtrLabelKHR                              C.GPOBJECTPTRLABELKHR
+	gpPatchParameterfv                               C.GPPATCHPARAMETERFV
+	gpPatchParameteri                                C.GPPATCHPARAMETERI
+	gpPathCommandsNV                                 C.GPPATHCOMMANDSNV
+	gpPathCoordsNV                                   C.GPPATHCOORDSNV
+	gpPathCoverDepthFuncNV                           C.GPPATHCOVERDEPTHFUNCNV
+	gpPathDashArrayNV                                C.GPPATHDASHARRAYNV
+	gpPathGlyphIndexArrayNV                          C.GPPATHGLYPHINDEXARRAYNV
+	gpPathGlyphIndexRangeNV                          C.GPPATHGLYPHINDEXRANGENV
+	gpPathGlyphRangeNV                               C.GPPATHGLYPHRANGENV
+	gpPathGlyphsNV                                   C.GPPATHGLYPHSNV
+	gpPathMemoryGlyphIndexArrayNV                    C.GPPATHMEMORYGLYPHINDEXARRAYNV
+	gpPathParameterfNV                               C.GPPATHPARAMETERFNV
+	gpPathParameterfvNV                              C.GPPATHPARAMETERFVNV
+	gpPathParameteriNV                               C.GPPATHPARAMETERINV
+	gpPathParameterivNV                              C.GPPATHPARAMETERIVNV
+	gpPathStencilDepthOffsetNV                       C.GPPATHSTENCILDEPTHOFFSETNV
+	gpPathStencilFuncNV                              C.GPPATHSTENCILFUNCNV
+	gpPathStringNV                                   C.GPPATHSTRINGNV
+	gpPathSubCommandsNV                              C.GPPATHSUBCOMMANDSNV
+	gpPathSubCoordsNV                                C.GPPATHSUBCOORDSNV
+	gpPauseTransformFeedback                         C.GPPAUSETRANSFORMFEEDBACK
+	gpPixelStoref                                    C.GPPIXELSTOREF
+	gpPixelStorei                                    C.GPPIXELSTOREI
+	gpPointAlongPathNV                               C.GPPOINTALONGPATHNV
+	gpPointParameterf                                C.GPPOINTPARAMETERF
+	gpPointParameterfv                               C.GPPOINTPARAMETERFV
+	gpPointParameteri                                C.GPPOINTPARAMETERI
+	gpPointParameteriv                               C.GPPOINTPARAMETERIV
+	gpPointSize                                      C.GPPOINTSIZE
+	gpPolygonMode                                    C.GPPOLYGONMODE
+	gpPolygonOffset                                  C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                             C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                          C.GPPOLYGONOFFSETCLAMPEXT
+	gpPopDebugGroup                                  C.GPPOPDEBUGGROUP
+	gpPopDebugGroupKHR                               C.GPPOPDEBUGGROUPKHR
+	gpPopGroupMarkerEXT                              C.GPPOPGROUPMARKEREXT
+	gpPrimitiveBoundingBoxARB                        C.GPPRIMITIVEBOUNDINGBOXARB
+	gpPrimitiveRestartIndex                          C.GPPRIMITIVERESTARTINDEX
+	gpProgramBinary                                  C.GPPROGRAMBINARY
+	gpProgramParameteri                              C.GPPROGRAMPARAMETERI
+	gpProgramParameteriARB                           C.GPPROGRAMPARAMETERIARB
+	gpProgramParameteriEXT                           C.GPPROGRAMPARAMETERIEXT
+	gpProgramPathFragmentInputGenNV                  C.GPPROGRAMPATHFRAGMENTINPUTGENNV
+	gpProgramUniform1d                               C.GPPROGRAMUNIFORM1D
+	gpProgramUniform1dEXT                            C.GPPROGRAMUNIFORM1DEXT
+	gpProgramUniform1dv                              C.GPPROGRAMUNIFORM1DV
+	gpProgramUniform1dvEXT                           C.GPPROGRAMUNIFORM1DVEXT
+	gpProgramUniform1f                               C.GPPROGRAMUNIFORM1F
+	gpProgramUniform1fEXT                            C.GPPROGRAMUNIFORM1FEXT
+	gpProgramUniform1fv                              C.GPPROGRAMUNIFORM1FV
+	gpProgramUniform1fvEXT                           C.GPPROGRAMUNIFORM1FVEXT
+	gpProgramUniform1i                               C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                          C.GPPROGRAMUNIFORM1I64ARB
+	gpProgramUniform1i64NV                           C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                         C.GPPROGRAMUNIFORM1I64VARB
+	gpProgramUniform1i64vNV                          C.GPPROGRAMUNIFORM1I64VNV
+	gpProgramUniform1iEXT                            C.GPPROGRAMUNIFORM1IEXT
+	gpProgramUniform1iv                              C.GPPROGRAMUNIFORM1IV
+	gpProgramUniform1ivEXT                           C.GPPROGRAMUNIFORM1IVEXT
+	gpProgramUniform1ui                              C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                         C.GPPROGRAMUNIFORM1UI64ARB
+	gpProgramUniform1ui64NV                          C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                        C.GPPROGRAMUNIFORM1UI64VARB
+	gpProgramUniform1ui64vNV                         C.GPPROGRAMUNIFORM1UI64VNV
+	gpProgramUniform1uiEXT                           C.GPPROGRAMUNIFORM1UIEXT
+	gpProgramUniform1uiv                             C.GPPROGRAMUNIFORM1UIV
+	gpProgramUniform1uivEXT                          C.GPPROGRAMUNIFORM1UIVEXT
+	gpProgramUniform2d                               C.GPPROGRAMUNIFORM2D
+	gpProgramUniform2dEXT                            C.GPPROGRAMUNIFORM2DEXT
+	gpProgramUniform2dv                              C.GPPROGRAMUNIFORM2DV
+	gpProgramUniform2dvEXT                           C.GPPROGRAMUNIFORM2DVEXT
+	gpProgramUniform2f                               C.GPPROGRAMUNIFORM2F
+	gpProgramUniform2fEXT                            C.GPPROGRAMUNIFORM2FEXT
+	gpProgramUniform2fv                              C.GPPROGRAMUNIFORM2FV
+	gpProgramUniform2fvEXT                           C.GPPROGRAMUNIFORM2FVEXT
+	gpProgramUniform2i                               C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                          C.GPPROGRAMUNIFORM2I64ARB
+	gpProgramUniform2i64NV                           C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                         C.GPPROGRAMUNIFORM2I64VARB
+	gpProgramUniform2i64vNV                          C.GPPROGRAMUNIFORM2I64VNV
+	gpProgramUniform2iEXT                            C.GPPROGRAMUNIFORM2IEXT
+	gpProgramUniform2iv                              C.GPPROGRAMUNIFORM2IV
+	gpProgramUniform2ivEXT                           C.GPPROGRAMUNIFORM2IVEXT
+	gpProgramUniform2ui                              C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                         C.GPPROGRAMUNIFORM2UI64ARB
+	gpProgramUniform2ui64NV                          C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                        C.GPPROGRAMUNIFORM2UI64VARB
+	gpProgramUniform2ui64vNV                         C.GPPROGRAMUNIFORM2UI64VNV
+	gpProgramUniform2uiEXT                           C.GPPROGRAMUNIFORM2UIEXT
+	gpProgramUniform2uiv                             C.GPPROGRAMUNIFORM2UIV
+	gpProgramUniform2uivEXT                          C.GPPROGRAMUNIFORM2UIVEXT
+	gpProgramUniform3d                               C.GPPROGRAMUNIFORM3D
+	gpProgramUniform3dEXT                            C.GPPROGRAMUNIFORM3DEXT
+	gpProgramUniform3dv                              C.GPPROGRAMUNIFORM3DV
+	gpProgramUniform3dvEXT                           C.GPPROGRAMUNIFORM3DVEXT
+	gpProgramUniform3f                               C.GPPROGRAMUNIFORM3F
+	gpProgramUniform3fEXT                            C.GPPROGRAMUNIFORM3FEXT
+	gpProgramUniform3fv                              C.GPPROGRAMUNIFORM3FV
+	gpProgramUniform3fvEXT                           C.GPPROGRAMUNIFORM3FVEXT
+	gpProgramUniform3i                               C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                          C.GPPROGRAMUNIFORM3I64ARB
+	gpProgramUniform3i64NV                           C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                         C.GPPROGRAMUNIFORM3I64VARB
+	gpProgramUniform3i64vNV                          C.GPPROGRAMUNIFORM3I64VNV
+	gpProgramUniform3iEXT                            C.GPPROGRAMUNIFORM3IEXT
+	gpProgramUniform3iv                              C.GPPROGRAMUNIFORM3IV
+	gpProgramUniform3ivEXT                           C.GPPROGRAMUNIFORM3IVEXT
+	gpProgramUniform3ui                              C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                         C.GPPROGRAMUNIFORM3UI64ARB
+	gpProgramUniform3ui64NV                          C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                        C.GPPROGRAMUNIFORM3UI64VARB
+	gpProgramUniform3ui64vNV                         C.GPPROGRAMUNIFORM3UI64VNV
+	gpProgramUniform3uiEXT                           C.GPPROGRAMUNIFORM3UIEXT
+	gpProgramUniform3uiv                             C.GPPROGRAMUNIFORM3UIV
+	gpProgramUniform3uivEXT                          C.GPPROGRAMUNIFORM3UIVEXT
+	gpProgramUniform4d                               C.GPPROGRAMUNIFORM4D
+	gpProgramUniform4dEXT                            C.GPPROGRAMUNIFORM4DEXT
+	gpProgramUniform4dv                              C.GPPROGRAMUNIFORM4DV
+	gpProgramUniform4dvEXT                           C.GPPROGRAMUNIFORM4DVEXT
+	gpProgramUniform4f                               C.GPPROGRAMUNIFORM4F
+	gpProgramUniform4fEXT                            C.GPPROGRAMUNIFORM4FEXT
+	gpProgramUniform4fv                              C.GPPROGRAMUNIFORM4FV
+	gpProgramUniform4fvEXT                           C.GPPROGRAMUNIFORM4FVEXT
+	gpProgramUniform4i                               C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                          C.GPPROGRAMUNIFORM4I64ARB
+	gpProgramUniform4i64NV                           C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                         C.GPPROGRAMUNIFORM4I64VARB
+	gpProgramUniform4i64vNV                          C.GPPROGRAMUNIFORM4I64VNV
+	gpProgramUniform4iEXT                            C.GPPROGRAMUNIFORM4IEXT
+	gpProgramUniform4iv                              C.GPPROGRAMUNIFORM4IV
+	gpProgramUniform4ivEXT                           C.GPPROGRAMUNIFORM4IVEXT
+	gpProgramUniform4ui                              C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                         C.GPPROGRAMUNIFORM4UI64ARB
+	gpProgramUniform4ui64NV                          C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                        C.GPPROGRAMUNIFORM4UI64VARB
+	gpProgramUniform4ui64vNV                         C.GPPROGRAMUNIFORM4UI64VNV
+	gpProgramUniform4uiEXT                           C.GPPROGRAMUNIFORM4UIEXT
+	gpProgramUniform4uiv                             C.GPPROGRAMUNIFORM4UIV
+	gpProgramUniform4uivEXT                          C.GPPROGRAMUNIFORM4UIVEXT
+	gpProgramUniformHandleui64ARB                    C.GPPROGRAMUNIFORMHANDLEUI64ARB
+	gpProgramUniformHandleui64NV                     C.GPPROGRAMUNIFORMHANDLEUI64NV
+	gpProgramUniformHandleui64vARB                   C.GPPROGRAMUNIFORMHANDLEUI64VARB
+	gpProgramUniformHandleui64vNV                    C.GPPROGRAMUNIFORMHANDLEUI64VNV
+	gpProgramUniformMatrix2dv                        C.GPPROGRAMUNIFORMMATRIX2DV
+	gpProgramUniformMatrix2dvEXT                     C.GPPROGRAMUNIFORMMATRIX2DVEXT
+	gpProgramUniformMatrix2fv                        C.GPPROGRAMUNIFORMMATRIX2FV
+	gpProgramUniformMatrix2fvEXT                     C.GPPROGRAMUNIFORMMATRIX2FVEXT
+	gpProgramUniformMatrix2x3dv                      C.GPPROGRAMUNIFORMMATRIX2X3DV
+	gpProgramUniformMatrix2x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3DVEXT
+	gpProgramUniformMatrix2x3fv                      C.GPPROGRAMUNIFORMMATRIX2X3FV
+	gpProgramUniformMatrix2x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3FVEXT
+	gpProgramUniformMatrix2x4dv                      C.GPPROGRAMUNIFORMMATRIX2X4DV
+	gpProgramUniformMatrix2x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4DVEXT
+	gpProgramUniformMatrix2x4fv                      C.GPPROGRAMUNIFORMMATRIX2X4FV
+	gpProgramUniformMatrix2x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4FVEXT
+	gpProgramUniformMatrix3dv                        C.GPPROGRAMUNIFORMMATRIX3DV
+	gpProgramUniformMatrix3dvEXT                     C.GPPROGRAMUNIFORMMATRIX3DVEXT
+	gpProgramUniformMatrix3fv                        C.GPPROGRAMUNIFORMMATRIX3FV
+	gpProgramUniformMatrix3fvEXT                     C.GPPROGRAMUNIFORMMATRIX3FVEXT
+	gpProgramUniformMatrix3x2dv                      C.GPPROGRAMUNIFORMMATRIX3X2DV
+	gpProgramUniformMatrix3x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2DVEXT
+	gpProgramUniformMatrix3x2fv                      C.GPPROGRAMUNIFORMMATRIX3X2FV
+	gpProgramUniformMatrix3x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2FVEXT
+	gpProgramUniformMatrix3x4dv                      C.GPPROGRAMUNIFORMMATRIX3X4DV
+	gpProgramUniformMatrix3x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4DVEXT
+	gpProgramUniformMatrix3x4fv                      C.GPPROGRAMUNIFORMMATRIX3X4FV
+	gpProgramUniformMatrix3x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4FVEXT
+	gpProgramUniformMatrix4dv                        C.GPPROGRAMUNIFORMMATRIX4DV
+	gpProgramUniformMatrix4dvEXT                     C.GPPROGRAMUNIFORMMATRIX4DVEXT
+	gpProgramUniformMatrix4fv                        C.GPPROGRAMUNIFORMMATRIX4FV
+	gpProgramUniformMatrix4fvEXT                     C.GPPROGRAMUNIFORMMATRIX4FVEXT
+	gpProgramUniformMatrix4x2dv                      C.GPPROGRAMUNIFORMMATRIX4X2DV
+	gpProgramUniformMatrix4x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2DVEXT
+	gpProgramUniformMatrix4x2fv                      C.GPPROGRAMUNIFORMMATRIX4X2FV
+	gpProgramUniformMatrix4x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2FVEXT
+	gpProgramUniformMatrix4x3dv                      C.GPPROGRAMUNIFORMMATRIX4X3DV
+	gpProgramUniformMatrix4x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3DVEXT
+	gpProgramUniformMatrix4x3fv                      C.GPPROGRAMUNIFORMMATRIX4X3FV
+	gpProgramUniformMatrix4x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3FVEXT
+	gpProgramUniformui64NV                           C.GPPROGRAMUNIFORMUI64NV
+	gpProgramUniformui64vNV                          C.GPPROGRAMUNIFORMUI64VNV
+	gpProvokingVertex                                C.GPPROVOKINGVERTEX
+	gpPushClientAttribDefaultEXT                     C.GPPUSHCLIENTATTRIBDEFAULTEXT
+	gpPushDebugGroup                                 C.GPPUSHDEBUGGROUP
+	gpPushDebugGroupKHR                              C.GPPUSHDEBUGGROUPKHR
+	gpPushGroupMarkerEXT                             C.GPPUSHGROUPMARKEREXT
+	gpQueryCounter                                   C.GPQUERYCOUNTER
+	gpRasterSamplesEXT                               C.GPRASTERSAMPLESEXT
+	gpReadBuffer                                     C.GPREADBUFFER
+	gpReadPixels                                     C.GPREADPIXELS
+	gpReadnPixels                                    C.GPREADNPIXELS
+	gpReadnPixelsARB                                 C.GPREADNPIXELSARB
+	gpReadnPixelsKHR                                 C.GPREADNPIXELSKHR
+	gpReleaseShaderCompiler                          C.GPRELEASESHADERCOMPILER
+	gpRenderbufferStorage                            C.GPRENDERBUFFERSTORAGE
+	gpRenderbufferStorageMultisample                 C.GPRENDERBUFFERSTORAGEMULTISAMPLE
+	gpRenderbufferStorageMultisampleCoverageNV       C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV
+	gpResolveDepthValuesNV                           C.GPRESOLVEDEPTHVALUESNV
+	gpResumeTransformFeedback                        C.GPRESUMETRANSFORMFEEDBACK
+	gpSampleCoverage                                 C.GPSAMPLECOVERAGE
+	gpSampleMaski                                    C.GPSAMPLEMASKI
+	gpSamplerParameterIiv                            C.GPSAMPLERPARAMETERIIV
+	gpSamplerParameterIuiv                           C.GPSAMPLERPARAMETERIUIV
+	gpSamplerParameterf                              C.GPSAMPLERPARAMETERF
+	gpSamplerParameterfv                             C.GPSAMPLERPARAMETERFV
+	gpSamplerParameteri                              C.GPSAMPLERPARAMETERI
+	gpSamplerParameteriv                             C.GPSAMPLERPARAMETERIV
+	gpScissor                                        C.GPSCISSOR
+	gpScissorArrayv                                  C.GPSCISSORARRAYV
+	gpScissorIndexed                                 C.GPSCISSORINDEXED
+	gpScissorIndexedv                                C.GPSCISSORINDEXEDV
+	gpSecondaryColorFormatNV                         C.GPSECONDARYCOLORFORMATNV
+	gpSelectPerfMonitorCountersAMD                   C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpShaderBinary                                   C.GPSHADERBINARY
+	gpShaderSource                                   C.GPSHADERSOURCE
+	gpShaderStorageBlockBinding                      C.GPSHADERSTORAGEBLOCKBINDING
+	gpSignalVkFenceNV                                C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                            C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                            C.GPSPECIALIZESHADERARB
+	gpStateCaptureNV                                 C.GPSTATECAPTURENV
+	gpStencilFillPathInstancedNV                     C.GPSTENCILFILLPATHINSTANCEDNV
+	gpStencilFillPathNV                              C.GPSTENCILFILLPATHNV
+	gpStencilFunc                                    C.GPSTENCILFUNC
+	gpStencilFuncSeparate                            C.GPSTENCILFUNCSEPARATE
+	gpStencilMask                                    C.GPSTENCILMASK
+	gpStencilMaskSeparate                            C.GPSTENCILMASKSEPARATE
+	gpStencilOp                                      C.GPSTENCILOP
+	gpStencilOpSeparate                              C.GPSTENCILOPSEPARATE
+	gpStencilStrokePathInstancedNV                   C.GPSTENCILSTROKEPATHINSTANCEDNV
+	gpStencilStrokePathNV                            C.GPSTENCILSTROKEPATHNV
+	gpStencilThenCoverFillPathInstancedNV            C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV
+	gpStencilThenCoverFillPathNV                     C.GPSTENCILTHENCOVERFILLPATHNV
+	gpStencilThenCoverStrokePathInstancedNV          C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV
+	gpStencilThenCoverStrokePathNV                   C.GPSTENCILTHENCOVERSTROKEPATHNV
+	gpSubpixelPrecisionBiasNV                        C.GPSUBPIXELPRECISIONBIASNV
+	gpTexBuffer                                      C.GPTEXBUFFER
+	gpTexBufferARB                                   C.GPTEXBUFFERARB
+	gpTexBufferRange                                 C.GPTEXBUFFERRANGE
+	gpTexCoordFormatNV                               C.GPTEXCOORDFORMATNV
+	gpTexImage1D                                     C.GPTEXIMAGE1D
+	gpTexImage2D                                     C.GPTEXIMAGE2D
+	gpTexImage2DMultisample                          C.GPTEXIMAGE2DMULTISAMPLE
+	gpTexImage3D                                     C.GPTEXIMAGE3D
+	gpTexImage3DMultisample                          C.GPTEXIMAGE3DMULTISAMPLE
+	gpTexPageCommitmentARB                           C.GPTEXPAGECOMMITMENTARB
+	gpTexParameterIiv                                C.GPTEXPARAMETERIIV
+	gpTexParameterIuiv                               C.GPTEXPARAMETERIUIV
+	gpTexParameterf                                  C.GPTEXPARAMETERF
+	gpTexParameterfv                                 C.GPTEXPARAMETERFV
+	gpTexParameteri                                  C.GPTEXPARAMETERI
+	gpTexParameteriv                                 C.GPTEXPARAMETERIV
+	gpTexStorage1D                                   C.GPTEXSTORAGE1D
+	gpTexStorage2D                                   C.GPTEXSTORAGE2D
+	gpTexStorage2DMultisample                        C.GPTEXSTORAGE2DMULTISAMPLE
+	gpTexStorage3D                                   C.GPTEXSTORAGE3D
+	gpTexStorage3DMultisample                        C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexSubImage1D                                  C.GPTEXSUBIMAGE1D
+	gpTexSubImage2D                                  C.GPTEXSUBIMAGE2D
+	gpTexSubImage3D                                  C.GPTEXSUBIMAGE3D
+	gpTextureBarrier                                 C.GPTEXTUREBARRIER
+	gpTextureBarrierNV                               C.GPTEXTUREBARRIERNV
+	gpTextureBuffer                                  C.GPTEXTUREBUFFER
+	gpTextureBufferEXT                               C.GPTEXTUREBUFFEREXT
+	gpTextureBufferRange                             C.GPTEXTUREBUFFERRANGE
+	gpTextureBufferRangeEXT                          C.GPTEXTUREBUFFERRANGEEXT
+	gpTextureImage1DEXT                              C.GPTEXTUREIMAGE1DEXT
+	gpTextureImage2DEXT                              C.GPTEXTUREIMAGE2DEXT
+	gpTextureImage3DEXT                              C.GPTEXTUREIMAGE3DEXT
+	gpTexturePageCommitmentEXT                       C.GPTEXTUREPAGECOMMITMENTEXT
+	gpTextureParameterIiv                            C.GPTEXTUREPARAMETERIIV
+	gpTextureParameterIivEXT                         C.GPTEXTUREPARAMETERIIVEXT
+	gpTextureParameterIuiv                           C.GPTEXTUREPARAMETERIUIV
+	gpTextureParameterIuivEXT                        C.GPTEXTUREPARAMETERIUIVEXT
+	gpTextureParameterf                              C.GPTEXTUREPARAMETERF
+	gpTextureParameterfEXT                           C.GPTEXTUREPARAMETERFEXT
+	gpTextureParameterfv                             C.GPTEXTUREPARAMETERFV
+	gpTextureParameterfvEXT                          C.GPTEXTUREPARAMETERFVEXT
+	gpTextureParameteri                              C.GPTEXTUREPARAMETERI
+	gpTextureParameteriEXT                           C.GPTEXTUREPARAMETERIEXT
+	gpTextureParameteriv                             C.GPTEXTUREPARAMETERIV
+	gpTextureParameterivEXT                          C.GPTEXTUREPARAMETERIVEXT
+	gpTextureRenderbufferEXT                         C.GPTEXTURERENDERBUFFEREXT
+	gpTextureStorage1D                               C.GPTEXTURESTORAGE1D
+	gpTextureStorage1DEXT                            C.GPTEXTURESTORAGE1DEXT
+	gpTextureStorage2D                               C.GPTEXTURESTORAGE2D
+	gpTextureStorage2DEXT                            C.GPTEXTURESTORAGE2DEXT
+	gpTextureStorage2DMultisample                    C.GPTEXTURESTORAGE2DMULTISAMPLE
+	gpTextureStorage2DMultisampleEXT                 C.GPTEXTURESTORAGE2DMULTISAMPLEEXT
+	gpTextureStorage3D                               C.GPTEXTURESTORAGE3D
+	gpTextureStorage3DEXT                            C.GPTEXTURESTORAGE3DEXT
+	gpTextureStorage3DMultisample                    C.GPTEXTURESTORAGE3DMULTISAMPLE
+	gpTextureStorage3DMultisampleEXT                 C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureSubImage1D                              C.GPTEXTURESUBIMAGE1D
+	gpTextureSubImage1DEXT                           C.GPTEXTURESUBIMAGE1DEXT
+	gpTextureSubImage2D                              C.GPTEXTURESUBIMAGE2D
+	gpTextureSubImage2DEXT                           C.GPTEXTURESUBIMAGE2DEXT
+	gpTextureSubImage3D                              C.GPTEXTURESUBIMAGE3D
+	gpTextureSubImage3DEXT                           C.GPTEXTURESUBIMAGE3DEXT
+	gpTextureView                                    C.GPTEXTUREVIEW
+	gpTransformFeedbackBufferBase                    C.GPTRANSFORMFEEDBACKBUFFERBASE
+	gpTransformFeedbackBufferRange                   C.GPTRANSFORMFEEDBACKBUFFERRANGE
+	gpTransformFeedbackVaryings                      C.GPTRANSFORMFEEDBACKVARYINGS
+	gpTransformPathNV                                C.GPTRANSFORMPATHNV
+	gpUniform1d                                      C.GPUNIFORM1D
+	gpUniform1dv                                     C.GPUNIFORM1DV
+	gpUniform1f                                      C.GPUNIFORM1F
+	gpUniform1fv                                     C.GPUNIFORM1FV
+	gpUniform1i                                      C.GPUNIFORM1I
+	gpUniform1i64ARB                                 C.GPUNIFORM1I64ARB
+	gpUniform1i64NV                                  C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                C.GPUNIFORM1I64VARB
+	gpUniform1i64vNV                                 C.GPUNIFORM1I64VNV
+	gpUniform1iv                                     C.GPUNIFORM1IV
+	gpUniform1ui                                     C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                C.GPUNIFORM1UI64ARB
+	gpUniform1ui64NV                                 C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                               C.GPUNIFORM1UI64VARB
+	gpUniform1ui64vNV                                C.GPUNIFORM1UI64VNV
+	gpUniform1uiv                                    C.GPUNIFORM1UIV
+	gpUniform2d                                      C.GPUNIFORM2D
+	gpUniform2dv                                     C.GPUNIFORM2DV
+	gpUniform2f                                      C.GPUNIFORM2F
+	gpUniform2fv                                     C.GPUNIFORM2FV
+	gpUniform2i                                      C.GPUNIFORM2I
+	gpUniform2i64ARB                                 C.GPUNIFORM2I64ARB
+	gpUniform2i64NV                                  C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                C.GPUNIFORM2I64VARB
+	gpUniform2i64vNV                                 C.GPUNIFORM2I64VNV
+	gpUniform2iv                                     C.GPUNIFORM2IV
+	gpUniform2ui                                     C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                C.GPUNIFORM2UI64ARB
+	gpUniform2ui64NV                                 C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                               C.GPUNIFORM2UI64VARB
+	gpUniform2ui64vNV                                C.GPUNIFORM2UI64VNV
+	gpUniform2uiv                                    C.GPUNIFORM2UIV
+	gpUniform3d                                      C.GPUNIFORM3D
+	gpUniform3dv                                     C.GPUNIFORM3DV
+	gpUniform3f                                      C.GPUNIFORM3F
+	gpUniform3fv                                     C.GPUNIFORM3FV
+	gpUniform3i                                      C.GPUNIFORM3I
+	gpUniform3i64ARB                                 C.GPUNIFORM3I64ARB
+	gpUniform3i64NV                                  C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                C.GPUNIFORM3I64VARB
+	gpUniform3i64vNV                                 C.GPUNIFORM3I64VNV
+	gpUniform3iv                                     C.GPUNIFORM3IV
+	gpUniform3ui                                     C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                C.GPUNIFORM3UI64ARB
+	gpUniform3ui64NV                                 C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                               C.GPUNIFORM3UI64VARB
+	gpUniform3ui64vNV                                C.GPUNIFORM3UI64VNV
+	gpUniform3uiv                                    C.GPUNIFORM3UIV
+	gpUniform4d                                      C.GPUNIFORM4D
+	gpUniform4dv                                     C.GPUNIFORM4DV
+	gpUniform4f                                      C.GPUNIFORM4F
+	gpUniform4fv                                     C.GPUNIFORM4FV
+	gpUniform4i                                      C.GPUNIFORM4I
+	gpUniform4i64ARB                                 C.GPUNIFORM4I64ARB
+	gpUniform4i64NV                                  C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                C.GPUNIFORM4I64VARB
+	gpUniform4i64vNV                                 C.GPUNIFORM4I64VNV
+	gpUniform4iv                                     C.GPUNIFORM4IV
+	gpUniform4ui                                     C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                C.GPUNIFORM4UI64ARB
+	gpUniform4ui64NV                                 C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                               C.GPUNIFORM4UI64VARB
+	gpUniform4ui64vNV                                C.GPUNIFORM4UI64VNV
+	gpUniform4uiv                                    C.GPUNIFORM4UIV
+	gpUniformBlockBinding                            C.GPUNIFORMBLOCKBINDING
+	gpUniformHandleui64ARB                           C.GPUNIFORMHANDLEUI64ARB
+	gpUniformHandleui64NV                            C.GPUNIFORMHANDLEUI64NV
+	gpUniformHandleui64vARB                          C.GPUNIFORMHANDLEUI64VARB
+	gpUniformHandleui64vNV                           C.GPUNIFORMHANDLEUI64VNV
+	gpUniformMatrix2dv                               C.GPUNIFORMMATRIX2DV
+	gpUniformMatrix2fv                               C.GPUNIFORMMATRIX2FV
+	gpUniformMatrix2x3dv                             C.GPUNIFORMMATRIX2X3DV
+	gpUniformMatrix2x3fv                             C.GPUNIFORMMATRIX2X3FV
+	gpUniformMatrix2x4dv                             C.GPUNIFORMMATRIX2X4DV
+	gpUniformMatrix2x4fv                             C.GPUNIFORMMATRIX2X4FV
+	gpUniformMatrix3dv                               C.GPUNIFORMMATRIX3DV
+	gpUniformMatrix3fv                               C.GPUNIFORMMATRIX3FV
+	gpUniformMatrix3x2dv                             C.GPUNIFORMMATRIX3X2DV
+	gpUniformMatrix3x2fv                             C.GPUNIFORMMATRIX3X2FV
+	gpUniformMatrix3x4dv                             C.GPUNIFORMMATRIX3X4DV
+	gpUniformMatrix3x4fv                             C.GPUNIFORMMATRIX3X4FV
+	gpUniformMatrix4dv                               C.GPUNIFORMMATRIX4DV
+	gpUniformMatrix4fv                               C.GPUNIFORMMATRIX4FV
+	gpUniformMatrix4x2dv                             C.GPUNIFORMMATRIX4X2DV
+	gpUniformMatrix4x2fv                             C.GPUNIFORMMATRIX4X2FV
+	gpUniformMatrix4x3dv                             C.GPUNIFORMMATRIX4X3DV
+	gpUniformMatrix4x3fv                             C.GPUNIFORMMATRIX4X3FV
+	gpUniformSubroutinesuiv                          C.GPUNIFORMSUBROUTINESUIV
+	gpUniformui64NV                                  C.GPUNIFORMUI64NV
+	gpUniformui64vNV                                 C.GPUNIFORMUI64VNV
+	gpUnmapBuffer                                    C.GPUNMAPBUFFER
+	gpUnmapNamedBuffer                               C.GPUNMAPNAMEDBUFFER
+	gpUnmapNamedBufferEXT                            C.GPUNMAPNAMEDBUFFEREXT
+	gpUseProgram                                     C.GPUSEPROGRAM
+	gpUseProgramStages                               C.GPUSEPROGRAMSTAGES
+	gpUseProgramStagesEXT                            C.GPUSEPROGRAMSTAGESEXT
+	gpUseShaderProgramEXT                            C.GPUSESHADERPROGRAMEXT
+	gpValidateProgram                                C.GPVALIDATEPROGRAM
+	gpValidateProgramPipeline                        C.GPVALIDATEPROGRAMPIPELINE
+	gpValidateProgramPipelineEXT                     C.GPVALIDATEPROGRAMPIPELINEEXT
+	gpVertexArrayAttribBinding                       C.GPVERTEXARRAYATTRIBBINDING
+	gpVertexArrayAttribFormat                        C.GPVERTEXARRAYATTRIBFORMAT
+	gpVertexArrayAttribIFormat                       C.GPVERTEXARRAYATTRIBIFORMAT
+	gpVertexArrayAttribLFormat                       C.GPVERTEXARRAYATTRIBLFORMAT
+	gpVertexArrayBindVertexBufferEXT                 C.GPVERTEXARRAYBINDVERTEXBUFFEREXT
+	gpVertexArrayBindingDivisor                      C.GPVERTEXARRAYBINDINGDIVISOR
+	gpVertexArrayColorOffsetEXT                      C.GPVERTEXARRAYCOLOROFFSETEXT
+	gpVertexArrayEdgeFlagOffsetEXT                   C.GPVERTEXARRAYEDGEFLAGOFFSETEXT
+	gpVertexArrayElementBuffer                       C.GPVERTEXARRAYELEMENTBUFFER
+	gpVertexArrayFogCoordOffsetEXT                   C.GPVERTEXARRAYFOGCOORDOFFSETEXT
+	gpVertexArrayIndexOffsetEXT                      C.GPVERTEXARRAYINDEXOFFSETEXT
+	gpVertexArrayMultiTexCoordOffsetEXT              C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT
+	gpVertexArrayNormalOffsetEXT                     C.GPVERTEXARRAYNORMALOFFSETEXT
+	gpVertexArraySecondaryColorOffsetEXT             C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT
+	gpVertexArrayTexCoordOffsetEXT                   C.GPVERTEXARRAYTEXCOORDOFFSETEXT
+	gpVertexArrayVertexAttribBindingEXT              C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT
+	gpVertexArrayVertexAttribDivisorEXT              C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT
+	gpVertexArrayVertexAttribFormatEXT               C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT
+	gpVertexArrayVertexAttribIFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT
+	gpVertexArrayVertexAttribIOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT
+	gpVertexArrayVertexAttribLFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT
+	gpVertexArrayVertexAttribLOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT
+	gpVertexArrayVertexAttribOffsetEXT               C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT
+	gpVertexArrayVertexBindingDivisorEXT             C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT
+	gpVertexArrayVertexBuffer                        C.GPVERTEXARRAYVERTEXBUFFER
+	gpVertexArrayVertexBuffers                       C.GPVERTEXARRAYVERTEXBUFFERS
+	gpVertexArrayVertexOffsetEXT                     C.GPVERTEXARRAYVERTEXOFFSETEXT
+	gpVertexAttrib1d                                 C.GPVERTEXATTRIB1D
+	gpVertexAttrib1dv                                C.GPVERTEXATTRIB1DV
+	gpVertexAttrib1f                                 C.GPVERTEXATTRIB1F
+	gpVertexAttrib1fv                                C.GPVERTEXATTRIB1FV
+	gpVertexAttrib1s                                 C.GPVERTEXATTRIB1S
+	gpVertexAttrib1sv                                C.GPVERTEXATTRIB1SV
+	gpVertexAttrib2d                                 C.GPVERTEXATTRIB2D
+	gpVertexAttrib2dv                                C.GPVERTEXATTRIB2DV
+	gpVertexAttrib2f                                 C.GPVERTEXATTRIB2F
+	gpVertexAttrib2fv                                C.GPVERTEXATTRIB2FV
+	gpVertexAttrib2s                                 C.GPVERTEXATTRIB2S
+	gpVertexAttrib2sv                                C.GPVERTEXATTRIB2SV
+	gpVertexAttrib3d                                 C.GPVERTEXATTRIB3D
+	gpVertexAttrib3dv                                C.GPVERTEXATTRIB3DV
+	gpVertexAttrib3f                                 C.GPVERTEXATTRIB3F
+	gpVertexAttrib3fv                                C.GPVERTEXATTRIB3FV
+	gpVertexAttrib3s                                 C.GPVERTEXATTRIB3S
+	gpVertexAttrib3sv                                C.GPVERTEXATTRIB3SV
+	gpVertexAttrib4Nbv                               C.GPVERTEXATTRIB4NBV
+	gpVertexAttrib4Niv                               C.GPVERTEXATTRIB4NIV
+	gpVertexAttrib4Nsv                               C.GPVERTEXATTRIB4NSV
+	gpVertexAttrib4Nub                               C.GPVERTEXATTRIB4NUB
+	gpVertexAttrib4Nubv                              C.GPVERTEXATTRIB4NUBV
+	gpVertexAttrib4Nuiv                              C.GPVERTEXATTRIB4NUIV
+	gpVertexAttrib4Nusv                              C.GPVERTEXATTRIB4NUSV
+	gpVertexAttrib4bv                                C.GPVERTEXATTRIB4BV
+	gpVertexAttrib4d                                 C.GPVERTEXATTRIB4D
+	gpVertexAttrib4dv                                C.GPVERTEXATTRIB4DV
+	gpVertexAttrib4f                                 C.GPVERTEXATTRIB4F
+	gpVertexAttrib4fv                                C.GPVERTEXATTRIB4FV
+	gpVertexAttrib4iv                                C.GPVERTEXATTRIB4IV
+	gpVertexAttrib4s                                 C.GPVERTEXATTRIB4S
+	gpVertexAttrib4sv                                C.GPVERTEXATTRIB4SV
+	gpVertexAttrib4ubv                               C.GPVERTEXATTRIB4UBV
+	gpVertexAttrib4uiv                               C.GPVERTEXATTRIB4UIV
+	gpVertexAttrib4usv                               C.GPVERTEXATTRIB4USV
+	gpVertexAttribBinding                            C.GPVERTEXATTRIBBINDING
+	gpVertexAttribDivisor                            C.GPVERTEXATTRIBDIVISOR
+	gpVertexAttribDivisorARB                         C.GPVERTEXATTRIBDIVISORARB
+	gpVertexAttribFormat                             C.GPVERTEXATTRIBFORMAT
+	gpVertexAttribFormatNV                           C.GPVERTEXATTRIBFORMATNV
+	gpVertexAttribI1i                                C.GPVERTEXATTRIBI1I
+	gpVertexAttribI1iv                               C.GPVERTEXATTRIBI1IV
+	gpVertexAttribI1ui                               C.GPVERTEXATTRIBI1UI
+	gpVertexAttribI1uiv                              C.GPVERTEXATTRIBI1UIV
+	gpVertexAttribI2i                                C.GPVERTEXATTRIBI2I
+	gpVertexAttribI2iv                               C.GPVERTEXATTRIBI2IV
+	gpVertexAttribI2ui                               C.GPVERTEXATTRIBI2UI
+	gpVertexAttribI2uiv                              C.GPVERTEXATTRIBI2UIV
+	gpVertexAttribI3i                                C.GPVERTEXATTRIBI3I
+	gpVertexAttribI3iv                               C.GPVERTEXATTRIBI3IV
+	gpVertexAttribI3ui                               C.GPVERTEXATTRIBI3UI
+	gpVertexAttribI3uiv                              C.GPVERTEXATTRIBI3UIV
+	gpVertexAttribI4bv                               C.GPVERTEXATTRIBI4BV
+	gpVertexAttribI4i                                C.GPVERTEXATTRIBI4I
+	gpVertexAttribI4iv                               C.GPVERTEXATTRIBI4IV
+	gpVertexAttribI4sv                               C.GPVERTEXATTRIBI4SV
+	gpVertexAttribI4ubv                              C.GPVERTEXATTRIBI4UBV
+	gpVertexAttribI4ui                               C.GPVERTEXATTRIBI4UI
+	gpVertexAttribI4uiv                              C.GPVERTEXATTRIBI4UIV
+	gpVertexAttribI4usv                              C.GPVERTEXATTRIBI4USV
+	gpVertexAttribIFormat                            C.GPVERTEXATTRIBIFORMAT
+	gpVertexAttribIFormatNV                          C.GPVERTEXATTRIBIFORMATNV
+	gpVertexAttribIPointer                           C.GPVERTEXATTRIBIPOINTER
+	gpVertexAttribL1d                                C.GPVERTEXATTRIBL1D
+	gpVertexAttribL1dv                               C.GPVERTEXATTRIBL1DV
+	gpVertexAttribL1i64NV                            C.GPVERTEXATTRIBL1I64NV
+	gpVertexAttribL1i64vNV                           C.GPVERTEXATTRIBL1I64VNV
+	gpVertexAttribL1ui64ARB                          C.GPVERTEXATTRIBL1UI64ARB
+	gpVertexAttribL1ui64NV                           C.GPVERTEXATTRIBL1UI64NV
+	gpVertexAttribL1ui64vARB                         C.GPVERTEXATTRIBL1UI64VARB
+	gpVertexAttribL1ui64vNV                          C.GPVERTEXATTRIBL1UI64VNV
+	gpVertexAttribL2d                                C.GPVERTEXATTRIBL2D
+	gpVertexAttribL2dv                               C.GPVERTEXATTRIBL2DV
+	gpVertexAttribL2i64NV                            C.GPVERTEXATTRIBL2I64NV
+	gpVertexAttribL2i64vNV                           C.GPVERTEXATTRIBL2I64VNV
+	gpVertexAttribL2ui64NV                           C.GPVERTEXATTRIBL2UI64NV
+	gpVertexAttribL2ui64vNV                          C.GPVERTEXATTRIBL2UI64VNV
+	gpVertexAttribL3d                                C.GPVERTEXATTRIBL3D
+	gpVertexAttribL3dv                               C.GPVERTEXATTRIBL3DV
+	gpVertexAttribL3i64NV                            C.GPVERTEXATTRIBL3I64NV
+	gpVertexAttribL3i64vNV                           C.GPVERTEXATTRIBL3I64VNV
+	gpVertexAttribL3ui64NV                           C.GPVERTEXATTRIBL3UI64NV
+	gpVertexAttribL3ui64vNV                          C.GPVERTEXATTRIBL3UI64VNV
+	gpVertexAttribL4d                                C.GPVERTEXATTRIBL4D
+	gpVertexAttribL4dv                               C.GPVERTEXATTRIBL4DV
+	gpVertexAttribL4i64NV                            C.GPVERTEXATTRIBL4I64NV
+	gpVertexAttribL4i64vNV                           C.GPVERTEXATTRIBL4I64VNV
+	gpVertexAttribL4ui64NV                           C.GPVERTEXATTRIBL4UI64NV
+	gpVertexAttribL4ui64vNV                          C.GPVERTEXATTRIBL4UI64VNV
+	gpVertexAttribLFormat                            C.GPVERTEXATTRIBLFORMAT
+	gpVertexAttribLFormatNV                          C.GPVERTEXATTRIBLFORMATNV
+	gpVertexAttribLPointer                           C.GPVERTEXATTRIBLPOINTER
+	gpVertexAttribP1ui                               C.GPVERTEXATTRIBP1UI
+	gpVertexAttribP1uiv                              C.GPVERTEXATTRIBP1UIV
+	gpVertexAttribP2ui                               C.GPVERTEXATTRIBP2UI
+	gpVertexAttribP2uiv                              C.GPVERTEXATTRIBP2UIV
+	gpVertexAttribP3ui                               C.GPVERTEXATTRIBP3UI
+	gpVertexAttribP3uiv                              C.GPVERTEXATTRIBP3UIV
+	gpVertexAttribP4ui                               C.GPVERTEXATTRIBP4UI
+	gpVertexAttribP4uiv                              C.GPVERTEXATTRIBP4UIV
+	gpVertexAttribPointer                            C.GPVERTEXATTRIBPOINTER
+	gpVertexBindingDivisor                           C.GPVERTEXBINDINGDIVISOR
+	gpVertexFormatNV                                 C.GPVERTEXFORMATNV
+	gpViewport                                       C.GPVIEWPORT
+	gpViewportArrayv                                 C.GPVIEWPORTARRAYV
+	gpViewportIndexedf                               C.GPVIEWPORTINDEXEDF
+	gpViewportIndexedfv                              C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                       C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                              C.GPVIEWPORTSWIZZLENV
+	gpWaitSync                                       C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                              C.GPWAITVKSEMAPHORENV
+	gpWeightPathsNV                                  C.GPWEIGHTPATHSNV
+	gpWindowRectanglesEXT                            C.GPWINDOWRECTANGLESEXT
 )
 
 // Helper functions
@@ -5148,15 +8426,24 @@ func boolToInt(b bool) int {
 	}
 	return 0
 }
+func ActiveProgramEXT(program uint32) {
+	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
+}
 
 // set the active program object for a program pipeline object
 func ActiveShaderProgram(pipeline uint32, program uint32) {
 	C.glowActiveShaderProgram(gpActiveShaderProgram, (C.GLuint)(pipeline), (C.GLuint)(program))
 }
+func ActiveShaderProgramEXT(pipeline uint32, program uint32) {
+	C.glowActiveShaderProgramEXT(gpActiveShaderProgramEXT, (C.GLuint)(pipeline), (C.GLuint)(program))
+}
 
 // select active texture unit
 func ActiveTexture(texture uint32) {
 	C.glowActiveTexture(gpActiveTexture, (C.GLenum)(texture))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 
 // Attaches a shader object to a program object
@@ -5167,6 +8454,15 @@ func AttachShader(program uint32, shader uint32) {
 // start conditional rendering
 func BeginConditionalRender(id uint32, mode uint32) {
 	C.glowBeginConditionalRender(gpBeginConditionalRender, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginConditionalRenderNV(id uint32, mode uint32) {
+	C.glowBeginConditionalRenderNV(gpBeginConditionalRenderNV, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginPerfMonitorAMD(monitor uint32) {
+	C.glowBeginPerfMonitorAMD(gpBeginPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func BeginPerfQueryINTEL(queryHandle uint32) {
+	C.glowBeginPerfQueryINTEL(gpBeginPerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // delimit the boundaries of a query object
@@ -5236,10 +8532,16 @@ func BindImageTexture(unit uint32, texture uint32, level int32, layered bool, la
 func BindImageTextures(first uint32, count int32, textures *uint32) {
 	C.glowBindImageTextures(gpBindImageTextures, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(textures)))
 }
+func BindMultiTextureEXT(texunit uint32, target uint32, texture uint32) {
+	C.glowBindMultiTextureEXT(gpBindMultiTextureEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(texture))
+}
 
 // bind a program pipeline to the current context
 func BindProgramPipeline(pipeline uint32) {
 	C.glowBindProgramPipeline(gpBindProgramPipeline, (C.GLuint)(pipeline))
+}
+func BindProgramPipelineEXT(pipeline uint32) {
+	C.glowBindProgramPipelineEXT(gpBindProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 
 // bind a renderbuffer to a renderbuffer target
@@ -5291,6 +8593,12 @@ func BindVertexBuffer(bindingindex uint32, buffer uint32, offset int, stride int
 func BindVertexBuffers(first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowBindVertexBuffers(gpBindVertexBuffers, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
 }
+func BlendBarrierKHR() {
+	C.glowBlendBarrierKHR(gpBlendBarrierKHR)
+}
+func BlendBarrierNV() {
+	C.glowBlendBarrierNV(gpBlendBarrierNV)
+}
 
 // set the blend color
 func BlendColor(red float32, green float32, blue float32, alpha float32) {
@@ -5340,6 +8648,9 @@ func BlendFunci(buf uint32, src uint32, dst uint32) {
 func BlendFunciARB(buf uint32, src uint32, dst uint32) {
 	C.glowBlendFunciARB(gpBlendFunciARB, (C.GLuint)(buf), (C.GLenum)(src), (C.GLenum)(dst))
 }
+func BlendParameteriNV(pname uint32, value int32) {
+	C.glowBlendParameteriNV(gpBlendParameteriNV, (C.GLenum)(pname), (C.GLint)(value))
+}
 
 // copy a block of pixels from one framebuffer object to another
 func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
@@ -5350,13 +8661,16 @@ func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 i
 func BlitNamedFramebuffer(readFramebuffer uint32, drawFramebuffer uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
 	C.glowBlitNamedFramebuffer(gpBlitNamedFramebuffer, (C.GLuint)(readFramebuffer), (C.GLuint)(drawFramebuffer), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
 }
+func BufferAddressRangeNV(pname uint32, index uint32, address uint64, length int) {
+	C.glowBufferAddressRangeNV(gpBufferAddressRangeNV, (C.GLenum)(pname), (C.GLuint)(index), (C.GLuint64EXT)(address), (C.GLsizeiptr)(length))
+}
 
 // creates and initializes a buffer object's data     store
 func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferData(gpBufferData, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
@@ -5368,6 +8682,9 @@ func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubData(gpBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
+}
 
 // check the completeness status of a framebuffer
 func CheckFramebufferStatus(target uint32) uint32 {
@@ -5378,6 +8695,10 @@ func CheckFramebufferStatus(target uint32) uint32 {
 // check the completeness status of a framebuffer
 func CheckNamedFramebufferStatus(framebuffer uint32, target uint32) uint32 {
 	ret := C.glowCheckNamedFramebufferStatus(gpCheckNamedFramebufferStatus, (C.GLuint)(framebuffer), (C.GLenum)(target))
+	return (uint32)(ret)
+}
+func CheckNamedFramebufferStatusEXT(framebuffer uint32, target uint32) uint32 {
+	ret := C.glowCheckNamedFramebufferStatusEXT(gpCheckNamedFramebufferStatusEXT, (C.GLuint)(framebuffer), (C.GLenum)(target))
 	return (uint32)(ret)
 }
 
@@ -5422,6 +8743,8 @@ func ClearColor(red float32, green float32, blue float32, alpha float32) {
 func ClearDepth(depth float64) {
 	C.glowClearDepth(gpClearDepth, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -5430,13 +8753,19 @@ func ClearDepthf(d float32) {
 func ClearNamedBufferData(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferData(gpClearNamedBufferData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferDataEXT(gpClearNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -5462,9 +8791,12 @@ func ClearTexImage(texture uint32, level int32, format uint32, xtype uint32, dat
 func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearTexSubImage(gpClearTexSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClientAttribDefaultEXT(mask uint32) {
+	C.glowClientAttribDefaultEXT(gpClientAttribDefaultEXT, (C.GLbitfield)(mask))
+}
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -5473,11 +8805,20 @@ func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
 func ClipControl(origin uint32, depth uint32) {
 	C.glowClipControl(gpClipControl, (C.GLenum)(origin), (C.GLenum)(depth))
 }
+func ColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowColorFormatNV(gpColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func ColorMask(red bool, green bool, blue bool, alpha bool) {
 	C.glowColorMask(gpColorMask, (C.GLboolean)(boolToInt(red)), (C.GLboolean)(boolToInt(green)), (C.GLboolean)(boolToInt(blue)), (C.GLboolean)(boolToInt(alpha)))
 }
 func ColorMaski(index uint32, r bool, g bool, b bool, a bool) {
 	C.glowColorMaski(gpColorMaski, (C.GLuint)(index), (C.GLboolean)(boolToInt(r)), (C.GLboolean)(boolToInt(g)), (C.GLboolean)(boolToInt(b)), (C.GLboolean)(boolToInt(a)))
+}
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
 }
 
 // Compiles a shader object
@@ -5486,6 +8827,24 @@ func CompileShader(shader uint32) {
 }
 func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
+}
+func CompressedMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage1DEXT(gpCompressedMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage2DEXT(gpCompressedMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage3DEXT(gpCompressedMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage1DEXT(gpCompressedMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage2DEXT(gpCompressedMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage3DEXT(gpCompressedMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a one-dimensional texture image in a compressed format
@@ -5517,20 +8876,44 @@ func CompressedTexSubImage2D(target uint32, level int32, xoffset int32, yoffset 
 func CompressedTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTexSubImage3D(gpCompressedTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage1DEXT(gpCompressedTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage2DEXT(gpCompressedTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage3DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage3DEXT(gpCompressedTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a one-dimensional texture subimage in a compressed     format
 func CompressedTextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage1D(gpCompressedTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage1DEXT(gpCompressedTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a two-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage2D(gpCompressedTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage2DEXT(gpCompressedTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a three-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3D(gpCompressedTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
@@ -5542,10 +8925,28 @@ func CopyBufferSubData(readTarget uint32, writeTarget uint32, readOffset int, wr
 func CopyImageSubData(srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
 	C.glowCopyImageSubData(gpCopyImageSubData, (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
 }
+func CopyMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyMultiTexImage1DEXT(gpCopyMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyMultiTexImage2DEXT(gpCopyMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
+func CopyMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyMultiTexSubImage1DEXT(gpCopyMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage2DEXT(gpCopyMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage3DEXT(gpCopyMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func CopyPathNV(resultPath uint32, srcPath uint32) {
+	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
 }
 
 // copy pixels into a 1D texture image
@@ -5572,30 +8973,69 @@ func CopyTexSubImage2D(target uint32, level int32, xoffset int32, yoffset int32,
 func CopyTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTexSubImage3D(gpCopyTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyTextureImage1DEXT(gpCopyTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyTextureImage2DEXT(gpCopyTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
 
 // copy a one-dimensional texture subimage
 func CopyTextureSubImage1D(texture uint32, level int32, xoffset int32, x int32, y int32, width int32) {
 	C.glowCopyTextureSubImage1D(gpCopyTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyTextureSubImage1DEXT(gpCopyTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
 }
 
 // copy a two-dimensional texture subimage
 func CopyTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage2D(gpCopyTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage2DEXT(gpCopyTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy a three-dimensional texture subimage
 func CopyTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage3D(gpCopyTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage3DEXT(gpCopyTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverFillPathInstancedNV(gpCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverFillPathNV(path uint32, coverMode uint32) {
+	C.glowCoverFillPathNV(gpCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverStrokePathInstancedNV(gpCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverStrokePathNV(path uint32, coverMode uint32) {
+	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
+	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
 }
 
 // Creates a program object
@@ -5629,15 +9069,26 @@ func CreateShader(xtype uint32) uint32 {
 	ret := C.glowCreateShader(gpCreateShader, (C.GLenum)(xtype))
 	return (uint32)(ret)
 }
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
+	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
+	return (uint32)(ret)
+}
 
 // create a stand-alone program from an array of null-terminated source code strings
 func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
+	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
+	return (uint32)(ret)
+}
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -5700,6 +9151,9 @@ func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint
 func DeleteBuffers(n int32, buffers *uint32) {
 	C.glowDeleteBuffers(gpDeleteBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // delete framebuffer objects
 func DeleteFramebuffers(n int32, framebuffers *uint32) {
@@ -5707,6 +9161,15 @@ func DeleteFramebuffers(n int32, framebuffers *uint32) {
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+}
+func DeletePathsNV(path uint32, xrange int32) {
+	C.glowDeletePathsNV(gpDeletePathsNV, (C.GLuint)(path), (C.GLsizei)(xrange))
+}
+func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowDeletePerfMonitorsAMD(gpDeletePerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
+func DeletePerfQueryINTEL(queryHandle uint32) {
+	C.glowDeletePerfQueryINTEL(gpDeletePerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // Deletes a program object
@@ -5717,6 +9180,9 @@ func DeleteProgram(program uint32) {
 // delete program pipeline objects
 func DeleteProgramPipelines(n int32, pipelines *uint32) {
 	C.glowDeleteProgramPipelines(gpDeleteProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func DeleteProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowDeleteProgramPipelinesEXT(gpDeleteProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // delete named query objects
@@ -5738,9 +9204,12 @@ func DeleteSamplers(count int32, samplers *uint32) {
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -5781,6 +9250,8 @@ func DepthRangeArrayv(first uint32, count int32, v *float64) {
 func DepthRangeIndexed(index uint32, n float64, f float64) {
 	C.glowDepthRangeIndexed(gpDepthRangeIndexed, (C.GLuint)(index), (C.GLdouble)(n), (C.GLdouble)(f))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -5792,10 +9263,25 @@ func DetachShader(program uint32, shader uint32) {
 func Disable(cap uint32) {
 	C.glowDisable(gpDisable, (C.GLenum)(cap))
 }
+func DisableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowDisableClientStateIndexedEXT(gpDisableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableClientStateiEXT(array uint32, index uint32) {
+	C.glowDisableClientStateiEXT(gpDisableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableIndexedEXT(target uint32, index uint32) {
+	C.glowDisableIndexedEXT(gpDisableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func DisableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowDisableVertexArrayAttrib(gpDisableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowDisableVertexArrayAttribEXT(gpDisableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowDisableVertexArrayEXT(gpDisableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -5833,10 +9319,16 @@ func DrawArraysIndirect(mode uint32, indirect unsafe.Pointer) {
 func DrawArraysInstanced(mode uint32, first int32, count int32, instancecount int32) {
 	C.glowDrawArraysInstanced(gpDrawArraysInstanced, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount))
 }
+func DrawArraysInstancedARB(mode uint32, first int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedARB(gpDrawArraysInstancedARB, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a range of elements with offset applied to instanced attributes
 func DrawArraysInstancedBaseInstance(mode uint32, first int32, count int32, instancecount int32, baseinstance uint32) {
 	C.glowDrawArraysInstancedBaseInstance(gpDrawArraysInstancedBaseInstance, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount), (C.GLuint)(baseinstance))
+}
+func DrawArraysInstancedEXT(mode uint32, start int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedEXT(gpDrawArraysInstancedEXT, (C.GLenum)(mode), (C.GLint)(start), (C.GLsizei)(count), (C.GLsizei)(primcount))
 }
 
 // specify which color buffers are to be drawn into
@@ -5847,6 +9339,18 @@ func DrawBuffer(buf uint32) {
 // Specifies a list of color buffers to be drawn     into
 func DrawBuffers(n int32, bufs *uint32) {
 	C.glowDrawBuffers(gpDrawBuffers, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 
 // render primitives from array data
@@ -5868,6 +9372,9 @@ func DrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer) {
 func DrawElementsInstanced(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32) {
 	C.glowDrawElementsInstanced(gpDrawElementsInstanced, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount))
 }
+func DrawElementsInstancedARB(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedARB(gpDrawElementsInstancedARB, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a set of elements with offset applied to instanced attributes
 func DrawElementsInstancedBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, baseinstance uint32) {
@@ -5882,6 +9389,9 @@ func DrawElementsInstancedBaseVertex(mode uint32, count int32, xtype uint32, ind
 // render multiple instances of a set of primitives from array data with a per-element offset
 func DrawElementsInstancedBaseVertexBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, basevertex int32, baseinstance uint32) {
 	C.glowDrawElementsInstancedBaseVertexBaseInstance(gpDrawElementsInstancedBaseVertexBaseInstance, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount), (C.GLint)(basevertex), (C.GLuint)(baseinstance))
+}
+func DrawElementsInstancedEXT(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedEXT(gpDrawElementsInstancedEXT, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
 }
 
 // render primitives from array data
@@ -5913,15 +9423,36 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
 }
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
+}
+func EdgeFlagFormatNV(stride int32) {
+	C.glowEdgeFlagFormatNV(gpEdgeFlagFormatNV, (C.GLsizei)(stride))
+}
 
 // enable or disable server-side GL capabilities
 func Enable(cap uint32) {
 	C.glowEnable(gpEnable, (C.GLenum)(cap))
 }
+func EnableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowEnableClientStateIndexedEXT(gpEnableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableClientStateiEXT(array uint32, index uint32) {
+	C.glowEnableClientStateiEXT(gpEnableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableIndexedEXT(target uint32, index uint32) {
+	C.glowEnableIndexedEXT(gpEnableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func EnableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowEnableVertexArrayAttrib(gpEnableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowEnableVertexArrayAttribEXT(gpEnableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowEnableVertexArrayEXT(gpEnableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -5934,6 +9465,15 @@ func Enablei(target uint32, index uint32) {
 func EndConditionalRender() {
 	C.glowEndConditionalRender(gpEndConditionalRender)
 }
+func EndConditionalRenderNV() {
+	C.glowEndConditionalRenderNV(gpEndConditionalRenderNV)
+}
+func EndPerfMonitorAMD(monitor uint32) {
+	C.glowEndPerfMonitorAMD(gpEndPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func EndPerfQueryINTEL(queryHandle uint32) {
+	C.glowEndPerfQueryINTEL(gpEndPerfQueryINTEL, (C.GLuint)(queryHandle))
+}
 func EndQuery(target uint32) {
 	C.glowEndQuery(gpEndQuery, (C.GLenum)(target))
 }
@@ -5943,11 +9483,14 @@ func EndQueryIndexed(target uint32, index uint32) {
 func EndTransformFeedback() {
 	C.glowEndTransformFeedback(gpEndTransformFeedback)
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -5966,18 +9509,45 @@ func FlushMappedBufferRange(target uint32, offset int, length int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FogCoordFormatNV(xtype uint32, stride int32) {
+	C.glowFogCoordFormatNV(gpFogCoordFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
+func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferDrawBufferEXT(gpFramebufferDrawBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
+func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
+	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
 }
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
 	C.glowFramebufferParameteri(gpFramebufferParameteri, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
 }
+func FramebufferReadBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferReadBufferEXT(gpFramebufferReadBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
 
 // attach a renderbuffer as a logical buffer of a framebuffer object
 func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbuffer(gpFramebufferRenderbuffer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
@@ -5987,16 +9557,30 @@ func FramebufferTexture(target uint32, attachment uint32, texture uint32, level 
 func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1D(gpFramebufferTexture1D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
 func FramebufferTexture3D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
 	C.glowFramebufferTexture3D(gpFramebufferTexture3D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
 }
+func FramebufferTextureARB(target uint32, attachment uint32, texture uint32, level int32) {
+	C.glowFramebufferTextureARB(gpFramebufferTextureARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func FramebufferTextureFaceARB(target uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowFramebufferTextureFaceARB(gpFramebufferTextureFaceARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
+}
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func FramebufferTextureLayer(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayer(gpFramebufferTextureLayer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowFramebufferTextureLayerARB(gpFramebufferTextureLayerARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 
 // define front- and back-facing polygons
@@ -6013,10 +9597,20 @@ func GenBuffers(n int32, buffers *uint32) {
 func GenFramebuffers(n int32, framebuffers *uint32) {
 	C.glowGenFramebuffers(gpGenFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
 }
+func GenPathsNV(xrange int32) uint32 {
+	ret := C.glowGenPathsNV(gpGenPathsNV, (C.GLsizei)(xrange))
+	return (uint32)(ret)
+}
+func GenPerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowGenPerfMonitorsAMD(gpGenPerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
 
 // reserve program pipeline object names
 func GenProgramPipelines(n int32, pipelines *uint32) {
 	C.glowGenProgramPipelines(gpGenProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func GenProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowGenProgramPipelinesEXT(gpGenProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // generate query object names
@@ -6053,10 +9647,16 @@ func GenVertexArrays(n int32, arrays *uint32) {
 func GenerateMipmap(target uint32) {
 	C.glowGenerateMipmap(gpGenerateMipmap, (C.GLenum)(target))
 }
+func GenerateMultiTexMipmapEXT(texunit uint32, target uint32) {
+	C.glowGenerateMultiTexMipmapEXT(gpGenerateMultiTexMipmapEXT, (C.GLenum)(texunit), (C.GLenum)(target))
+}
 
 // generate mipmaps for a specified texture object
 func GenerateTextureMipmap(texture uint32) {
 	C.glowGenerateTextureMipmap(gpGenerateTextureMipmap, (C.GLuint)(texture))
+}
+func GenerateTextureMipmapEXT(texture uint32, target uint32) {
+	C.glowGenerateTextureMipmapEXT(gpGenerateTextureMipmapEXT, (C.GLuint)(texture), (C.GLenum)(target))
 }
 
 // retrieve information about the set of active atomic counter buffers for a program
@@ -6091,6 +9691,8 @@ func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6115,6 +9717,9 @@ func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
+func GetBooleanIndexedvEXT(target uint32, index uint32, data *bool) {
+	C.glowGetBooleanIndexedvEXT(gpGetBooleanIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
+}
 func GetBooleani_v(target uint32, index uint32, data *bool) {
 	C.glowGetBooleani_v(gpGetBooleani_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
 }
@@ -6131,6 +9736,9 @@ func GetBufferParameteri64v(target uint32, pname uint32, params *int64) {
 func GetBufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetBufferParameteriv(gpGetBufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetBufferParameterui64vNV(target uint32, pname uint32, params *uint64) {
+	C.glowGetBufferParameterui64vNV(gpGetBufferParameterui64vNV, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
@@ -6140,6 +9748,13 @@ func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
 // returns a subset of a buffer object's data store
 func GetBufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetBufferSubData(gpGetBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
+func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
 
 // return a compressed texture image
@@ -6151,10 +9766,16 @@ func GetCompressedTexImage(target uint32, level int32, img unsafe.Pointer) {
 func GetCompressedTextureImage(texture uint32, level int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureImage(gpGetCompressedTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLsizei)(bufSize), pixels)
 }
+func GetCompressedTextureImageEXT(texture uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedTextureImageEXT(gpGetCompressedTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(lod), img)
+}
 
 // retrieve a sub-region of a compressed texture image from a     compressed texture object
 func GetCompressedTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureSubImage(gpGetCompressedTextureSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(bufSize), pixels)
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -6170,8 +9791,14 @@ func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
+func GetDoubleIndexedvEXT(target uint32, index uint32, data *float64) {
+	C.glowGetDoubleIndexedvEXT(gpGetDoubleIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
 func GetDoublei_v(target uint32, index uint32, data *float64) {
 	C.glowGetDoublei_v(gpGetDoublei_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
+func GetDoublei_vEXT(pname uint32, index uint32, params *float64) {
+	C.glowGetDoublei_vEXT(gpGetDoublei_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
 }
 func GetDoublev(pname uint32, data *float64) {
 	C.glowGetDoublev(gpGetDoublev, (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(data)))
@@ -6182,8 +9809,17 @@ func GetError() uint32 {
 	ret := C.glowGetError(gpGetError)
 	return (uint32)(ret)
 }
+func GetFirstPerfQueryIdINTEL(queryId *uint32) {
+	C.glowGetFirstPerfQueryIdINTEL(gpGetFirstPerfQueryIdINTEL, (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetFloatIndexedvEXT(target uint32, index uint32, data *float32) {
+	C.glowGetFloatIndexedvEXT(gpGetFloatIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
 func GetFloati_v(target uint32, index uint32, data *float32) {
 	C.glowGetFloati_v(gpGetFloati_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
+func GetFloati_vEXT(pname uint32, index uint32, params *float32) {
+	C.glowGetFloati_vEXT(gpGetFloati_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetFloatv(pname uint32, data *float32) {
 	C.glowGetFloatv(gpGetFloatv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(data)))
@@ -6201,14 +9837,17 @@ func GetFragDataLocation(program uint32, name *uint8) int32 {
 	return (int32)(ret)
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetFramebufferParameterivEXT(gpGetFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // check if the rendering context has not been lost due to software or hardware issues
@@ -6228,23 +9867,77 @@ func GetImageHandleARB(texture uint32, level int32, layered bool, layer int32, f
 	ret := C.glowGetImageHandleARB(gpGetImageHandleARB, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
 	return (uint64)(ret)
 }
+func GetImageHandleNV(texture uint32, level int32, layered bool, layer int32, format uint32) uint64 {
+	ret := C.glowGetImageHandleNV(gpGetImageHandleNV, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
+	return (uint64)(ret)
+}
 func GetInteger64i_v(target uint32, index uint32, data *int64) {
 	C.glowGetInteger64i_v(gpGetInteger64i_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint64)(unsafe.Pointer(data)))
 }
 func GetInteger64v(pname uint32, data *int64) {
 	C.glowGetInteger64v(gpGetInteger64v, (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(data)))
 }
+func GetIntegerIndexedvEXT(target uint32, index uint32, data *int32) {
+	C.glowGetIntegerIndexedvEXT(gpGetIntegerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
 func GetIntegeri_v(target uint32, index uint32, data *int32) {
 	C.glowGetIntegeri_v(gpGetIntegeri_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
+func GetIntegerui64i_vNV(value uint32, index uint32, result *uint64) {
+	C.glowGetIntegerui64i_vNV(gpGetIntegerui64i_vNV, (C.GLenum)(value), (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(result)))
+}
+func GetIntegerui64vNV(value uint32, result *uint64) {
+	C.glowGetIntegerui64vNV(gpGetIntegerui64vNV, (C.GLenum)(value), (*C.GLuint64EXT)(unsafe.Pointer(result)))
 }
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexEnvfvEXT(gpGetMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexEnvivEXT(gpGetMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowGetMultiTexGendvEXT(gpGetMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexGenfvEXT(gpGetMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexGenivEXT(gpGetMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexImageEXT(texunit uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetMultiTexImageEXT(gpGetMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func GetMultiTexLevelParameterfvEXT(texunit uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetMultiTexLevelParameterfvEXT(gpGetMultiTexLevelParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexLevelParameterivEXT(texunit uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetMultiTexLevelParameterivEXT(gpGetMultiTexLevelParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterIivEXT(gpGetMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetMultiTexParameterIuivEXT(gpGetMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexParameterfvEXT(gpGetMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterivEXT(gpGetMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // retrieve the location of a sample
@@ -6261,30 +9954,69 @@ func GetNamedBufferParameteri64v(buffer uint32, pname uint32, params *int64) {
 func GetNamedBufferParameteriv(buffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedBufferParameteriv(gpGetNamedBufferParameteriv, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedBufferParameterivEXT(buffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedBufferParameterivEXT(gpGetNamedBufferParameterivEXT, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedBufferParameterui64vNV(buffer uint32, pname uint32, params *uint64) {
+	C.glowGetNamedBufferParameterui64vNV(gpGetNamedBufferParameterui64vNV, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetNamedBufferPointerv(buffer uint32, pname uint32, params *unsafe.Pointer) {
 	C.glowGetNamedBufferPointerv(gpGetNamedBufferPointerv, (C.GLuint)(buffer), (C.GLenum)(pname), params)
 }
+func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Pointer) {
+	C.glowGetNamedBufferPointervEXT(gpGetNamedBufferPointervEXT, (C.GLuint)(buffer), (C.GLenum)(pname), params)
+}
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 
 // retrieve information about attachments of a framebuffer object
 func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameteriv(gpGetNamedFramebufferAttachmentParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a framebuffer object
 func GetNamedFramebufferParameteriv(framebuffer uint32, pname uint32, param *int32) {
 	C.glowGetNamedFramebufferParameteriv(gpGetNamedFramebufferParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
 }
+func GetNamedFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferParameterivEXT(gpGetNamedFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowGetNamedProgramLocalParameterIivEXT(gpGetNamedProgramLocalParameterIivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIuivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowGetNamedProgramLocalParameterIuivEXT(gpGetNamedProgramLocalParameterIuivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterdvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowGetNamedProgramLocalParameterdvEXT(gpGetNamedProgramLocalParameterdvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterfvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowGetNamedProgramLocalParameterfvEXT(gpGetNamedProgramLocalParameterfvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetNamedProgramStringEXT(program uint32, target uint32, pname uint32, xstring unsafe.Pointer) {
+	C.glowGetNamedProgramStringEXT(gpGetNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), xstring)
+}
+func GetNamedProgramivEXT(program uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetNamedProgramivEXT(gpGetNamedProgramivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a renderbuffer object
 func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameteriv(gpGetNamedRenderbufferParameteriv, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedRenderbufferParameterivEXT(renderbuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedRenderbufferParameterivEXT(gpGetNamedRenderbufferParameterivEXT, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
@@ -6292,10 +10024,16 @@ func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int
 func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
+	C.glowGetNextPerfQueryIdINTEL(gpGetNextPerfQueryIdINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(nextQueryId)))
+}
 
 // retrieve the label of a named object identified within a namespace
 func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
+	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
@@ -6307,6 +10045,70 @@ func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *
 }
 func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetPathCommandsNV(path uint32, commands *uint8) {
+	C.glowGetPathCommandsNV(gpGetPathCommandsNV, (C.GLuint)(path), (*C.GLubyte)(unsafe.Pointer(commands)))
+}
+func GetPathCoordsNV(path uint32, coords *float32) {
+	C.glowGetPathCoordsNV(gpGetPathCoordsNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(coords)))
+}
+func GetPathDashArrayNV(path uint32, dashArray *float32) {
+	C.glowGetPathDashArrayNV(gpGetPathDashArrayNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func GetPathLengthNV(path uint32, startSegment int32, numSegments int32) float32 {
+	ret := C.glowGetPathLengthNV(gpGetPathLengthNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments))
+	return (float32)(ret)
+}
+func GetPathMetricRangeNV(metricQueryMask uint32, firstPathName uint32, numPaths int32, stride int32, metrics *float32) {
+	C.glowGetPathMetricRangeNV(gpGetPathMetricRangeNV, (C.GLbitfield)(metricQueryMask), (C.GLuint)(firstPathName), (C.GLsizei)(numPaths), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathMetricsNV(metricQueryMask uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, stride int32, metrics *float32) {
+	C.glowGetPathMetricsNV(gpGetPathMetricsNV, (C.GLbitfield)(metricQueryMask), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowGetPathParameterfvNV(gpGetPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func GetPathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowGetPathParameterivNV(gpGetPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func GetPathSpacingNV(pathListMode uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, advanceScale float32, kerningScale float32, transformType uint32, returnedSpacing *float32) {
+	C.glowGetPathSpacingNV(gpGetPathSpacingNV, (C.GLenum)(pathListMode), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLfloat)(advanceScale), (C.GLfloat)(kerningScale), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(returnedSpacing)))
+}
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
+}
+func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
+	C.glowGetPerfMonitorCounterDataAMD(gpGetPerfMonitorCounterDataAMD, (C.GLuint)(monitor), (C.GLenum)(pname), (C.GLsizei)(dataSize), (*C.GLuint)(unsafe.Pointer(data)), (*C.GLint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
+	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
+}
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
+	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
+}
+func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
+	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
+}
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
+	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
+}
+func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
+	C.glowGetPerfMonitorGroupsAMD(gpGetPerfMonitorGroupsAMD, (*C.GLint)(unsafe.Pointer(numGroups)), (C.GLsizei)(groupsSize), (*C.GLuint)(unsafe.Pointer(groups)))
+}
+func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
+	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
+	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
+}
+func GetPointerIndexedvEXT(target uint32, index uint32, data *unsafe.Pointer) {
+	C.glowGetPointerIndexedvEXT(gpGetPointerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), data)
+}
+func GetPointeri_vEXT(pname uint32, index uint32, params *unsafe.Pointer) {
+	C.glowGetPointeri_vEXT(gpGetPointeri_vEXT, (C.GLenum)(pname), (C.GLuint)(index), params)
 }
 
 // return the address of the specified pointer
@@ -6334,8 +10136,14 @@ func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32
 func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
+	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
+}
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
 	C.glowGetProgramPipelineiv(gpGetProgramPipelineiv, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
+	C.glowGetProgramPipelineivEXT(gpGetProgramPipelineivEXT, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // query the index of a named resource within a program
@@ -6360,6 +10168,9 @@ func GetProgramResourceLocationIndex(program uint32, programInterface uint32, na
 func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
+func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
+	C.glowGetProgramResourcefvNV(gpGetProgramResourcefvNV, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLfloat)(unsafe.Pointer(params)))
+}
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
 	C.glowGetProgramResourceiv(gpGetProgramResourceiv, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6370,6 +10181,18 @@ func GetProgramStageiv(program uint32, shadertype uint32, pname uint32, values *
 // Returns a parameter from a program object
 func GetProgramiv(program uint32, pname uint32, params *int32) {
 	C.glowGetProgramiv(gpGetProgramiv, (C.GLuint)(program), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
 }
 
 // return parameters of an indexed query object target
@@ -6385,6 +10208,8 @@ func GetQueryObjectiv(id uint32, pname uint32, params *int32) {
 func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64v(gpGetQueryObjectui64v, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -6394,7 +10219,7 @@ func GetQueryiv(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryiv(gpGetQueryiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6430,6 +10255,10 @@ func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8)
 func GetShaderiv(shader uint32, pname uint32, params *int32) {
 	C.glowGetShaderiv(gpGetShaderiv, (C.GLuint)(shader), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -6454,7 +10283,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 
@@ -6484,31 +10313,60 @@ func GetTextureHandleARB(texture uint32) uint64 {
 	ret := C.glowGetTextureHandleARB(gpGetTextureHandleARB, (C.GLuint)(texture))
 	return (uint64)(ret)
 }
+func GetTextureHandleNV(texture uint32) uint64 {
+	ret := C.glowGetTextureHandleNV(gpGetTextureHandleNV, (C.GLuint)(texture))
+	return (uint64)(ret)
+}
 
 // return a texture image
 func GetTextureImage(texture uint32, level int32, format uint32, xtype uint32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetTextureImage(gpGetTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), pixels)
 }
+func GetTextureImageEXT(texture uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetTextureImageEXT(gpGetTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 func GetTextureLevelParameterfv(texture uint32, level int32, pname uint32, params *float32) {
 	C.glowGetTextureLevelParameterfv(gpGetTextureLevelParameterfv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureLevelParameterfvEXT(texture uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetTextureLevelParameterfvEXT(gpGetTextureLevelParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureLevelParameteriv(texture uint32, level int32, pname uint32, params *int32) {
 	C.glowGetTextureLevelParameteriv(gpGetTextureLevelParameteriv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureLevelParameterivEXT(texture uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetTextureLevelParameterivEXT(gpGetTextureLevelParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameterIiv(gpGetTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetTextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterIivEXT(gpGetTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetTextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowGetTextureParameterIuiv(gpGetTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetTextureParameterIuivEXT(gpGetTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterfv(texture uint32, pname uint32, params *float32) {
 	C.glowGetTextureParameterfv(gpGetTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetTextureParameterfvEXT(gpGetTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureParameteriv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameteriv(gpGetTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterivEXT(gpGetTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureSamplerHandleARB(texture uint32, sampler uint32) uint64 {
 	ret := C.glowGetTextureSamplerHandleARB(gpGetTextureSamplerHandleARB, (C.GLuint)(texture), (C.GLuint)(sampler))
+	return (uint64)(ret)
+}
+func GetTextureSamplerHandleNV(texture uint32, sampler uint32) uint64 {
+	ret := C.glowGetTextureSamplerHandleNV(gpGetTextureSamplerHandleNV, (C.GLuint)(texture), (C.GLuint)(sampler))
 	return (uint64)(ret)
 }
 
@@ -6560,10 +10418,22 @@ func GetUniformdv(program uint32, location int32, params *float64) {
 func GetUniformfv(program uint32, location int32, params *float32) {
 	C.glowGetUniformfv(gpGetUniformfv, (C.GLuint)(program), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func GetUniformi64vNV(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 
 // Returns the value of a uniform variable
 func GetUniformiv(program uint32, location int32, params *int32) {
 	C.glowGetUniformiv(gpGetUniformiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func GetUniformui64vNV(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 func GetUniformuiv(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuiv(gpGetUniformuiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
@@ -6573,6 +10443,18 @@ func GetVertexArrayIndexed64iv(vaobj uint32, index uint32, pname uint32, param *
 }
 func GetVertexArrayIndexediv(vaobj uint32, index uint32, pname uint32, param *int32) {
 	C.glowGetVertexArrayIndexediv(gpGetVertexArrayIndexediv, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegeri_vEXT(vaobj uint32, index uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegeri_vEXT(gpGetVertexArrayIntegeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegervEXT(vaobj uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegervEXT(gpGetVertexArrayIntegervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayPointeri_vEXT(vaobj uint32, index uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointeri_vEXT(gpGetVertexArrayPointeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), param)
+}
+func GetVertexArrayPointervEXT(vaobj uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointervEXT(gpGetVertexArrayPointervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), param)
 }
 
 // retrieve parameters of a vertex array object
@@ -6594,8 +10476,14 @@ func GetVertexAttribIuiv(index uint32, pname uint32, params *uint32) {
 func GetVertexAttribLdv(index uint32, pname uint32, params *float64) {
 	C.glowGetVertexAttribLdv(gpGetVertexAttribLdv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
 }
+func GetVertexAttribLi64vNV(index uint32, pname uint32, params *int64) {
+	C.glowGetVertexAttribLi64vNV(gpGetVertexAttribLi64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 func GetVertexAttribLui64vARB(index uint32, pname uint32, params *uint64) {
 	C.glowGetVertexAttribLui64vARB(gpGetVertexAttribLui64vARB, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
+func GetVertexAttribLui64vNV(index uint32, pname uint32, params *uint64) {
+	C.glowGetVertexAttribLui64vNV(gpGetVertexAttribLui64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 
 // return the address of the specified generic vertex attribute pointer
@@ -6617,6 +10505,10 @@ func GetVertexAttribfv(index uint32, pname uint32, params *float32) {
 func GetVertexAttribiv(index uint32, pname uint32, params *int32) {
 	C.glowGetVertexAttribiv(gpGetVertexAttribiv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
+}
 func GetnCompressedTexImageARB(target uint32, lod int32, bufSize int32, img unsafe.Pointer) {
 	C.glowGetnCompressedTexImageARB(gpGetnCompressedTexImageARB, (C.GLenum)(target), (C.GLint)(lod), (C.GLsizei)(bufSize), img)
 }
@@ -6635,6 +10527,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6643,6 +10538,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -6657,6 +10555,15 @@ func GetnUniformuivKHR(program uint32, location int32, bufSize int32, params *ui
 // specify implementation-specific hints
 func Hint(target uint32, mode uint32) {
 	C.glowHint(gpHint, (C.GLenum)(target), (C.GLenum)(mode))
+}
+func IndexFormatNV(xtype uint32, stride int32) {
+	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func InsertEventMarkerEXT(length int32, marker *uint8) {
+	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
+func InterpolatePathsNV(resultPath uint32, pathA uint32, pathB uint32, weight float32) {
+	C.glowInterpolatePathsNV(gpInterpolatePathsNV, (C.GLuint)(resultPath), (C.GLuint)(pathA), (C.GLuint)(pathB), (C.GLfloat)(weight))
 }
 
 // invalidate the content of a buffer object's data store
@@ -6704,8 +10611,20 @@ func IsBuffer(buffer uint32) bool {
 	ret := C.glowIsBuffer(gpIsBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func IsBufferResidentNV(target uint32) bool {
+	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
+	return ret == TRUE
+}
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
+	return ret == TRUE
+}
+func IsEnabledIndexedEXT(target uint32, index uint32) bool {
+	ret := C.glowIsEnabledIndexedEXT(gpIsEnabledIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
 	return ret == TRUE
 }
 func IsEnabledi(target uint32, index uint32) bool {
@@ -6722,8 +10641,28 @@ func IsImageHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsImageHandleResidentARB(gpIsImageHandleResidentARB, (C.GLuint64)(handle))
 	return ret == TRUE
 }
+func IsImageHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsImageHandleResidentNV(gpIsImageHandleResidentNV, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsNamedBufferResidentNV(buffer uint32) bool {
+	ret := C.glowIsNamedBufferResidentNV(gpIsNamedBufferResidentNV, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+	return ret == TRUE
+}
+func IsPathNV(path uint32) bool {
+	ret := C.glowIsPathNV(gpIsPathNV, (C.GLuint)(path))
+	return ret == TRUE
+}
+func IsPointInFillPathNV(path uint32, mask uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInFillPathNV(gpIsPointInFillPathNV, (C.GLuint)(path), (C.GLuint)(mask), (C.GLfloat)(x), (C.GLfloat)(y))
+	return ret == TRUE
+}
+func IsPointInStrokePathNV(path uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInStrokePathNV(gpIsPointInStrokePathNV, (C.GLuint)(path), (C.GLfloat)(x), (C.GLfloat)(y))
 	return ret == TRUE
 }
 
@@ -6736,6 +10675,10 @@ func IsProgram(program uint32) bool {
 // determine if a name corresponds to a program pipeline object
 func IsProgramPipeline(pipeline uint32) bool {
 	ret := C.glowIsProgramPipeline(gpIsProgramPipeline, (C.GLuint)(pipeline))
+	return ret == TRUE
+}
+func IsProgramPipelineEXT(pipeline uint32) bool {
+	ret := C.glowIsProgramPipelineEXT(gpIsProgramPipelineEXT, (C.GLuint)(pipeline))
 	return ret == TRUE
 }
 
@@ -6762,9 +10705,13 @@ func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -6776,6 +10723,10 @@ func IsTexture(texture uint32) bool {
 }
 func IsTextureHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsTextureHandleResidentARB(gpIsTextureHandleResidentARB, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsTextureHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsTextureHandleResidentNV(gpIsTextureHandleResidentNV, (C.GLuint64)(handle))
 	return ret == TRUE
 }
 
@@ -6790,6 +10741,9 @@ func IsVertexArray(array uint32) bool {
 	ret := C.glowIsVertexArray(gpIsVertexArray, (C.GLuint)(array))
 	return ret == TRUE
 }
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
+	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
+}
 
 // specify the width of rasterized lines
 func LineWidth(width float32) {
@@ -6800,22 +10754,49 @@ func LineWidth(width float32) {
 func LinkProgram(program uint32) {
 	C.glowLinkProgram(gpLinkProgram, (C.GLuint)(program))
 }
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 
 // specify a logical pixel operation for rendering
 func LogicOp(opcode uint32) {
 	C.glowLogicOp(gpLogicOp, (C.GLenum)(opcode))
 }
+func MakeBufferNonResidentNV(target uint32) {
+	C.glowMakeBufferNonResidentNV(gpMakeBufferNonResidentNV, (C.GLenum)(target))
+}
+func MakeBufferResidentNV(target uint32, access uint32) {
+	C.glowMakeBufferResidentNV(gpMakeBufferResidentNV, (C.GLenum)(target), (C.GLenum)(access))
+}
 func MakeImageHandleNonResidentARB(handle uint64) {
 	C.glowMakeImageHandleNonResidentARB(gpMakeImageHandleNonResidentARB, (C.GLuint64)(handle))
+}
+func MakeImageHandleNonResidentNV(handle uint64) {
+	C.glowMakeImageHandleNonResidentNV(gpMakeImageHandleNonResidentNV, (C.GLuint64)(handle))
 }
 func MakeImageHandleResidentARB(handle uint64, access uint32) {
 	C.glowMakeImageHandleResidentARB(gpMakeImageHandleResidentARB, (C.GLuint64)(handle), (C.GLenum)(access))
 }
+func MakeImageHandleResidentNV(handle uint64, access uint32) {
+	C.glowMakeImageHandleResidentNV(gpMakeImageHandleResidentNV, (C.GLuint64)(handle), (C.GLenum)(access))
+}
+func MakeNamedBufferNonResidentNV(buffer uint32) {
+	C.glowMakeNamedBufferNonResidentNV(gpMakeNamedBufferNonResidentNV, (C.GLuint)(buffer))
+}
+func MakeNamedBufferResidentNV(buffer uint32, access uint32) {
+	C.glowMakeNamedBufferResidentNV(gpMakeNamedBufferResidentNV, (C.GLuint)(buffer), (C.GLenum)(access))
+}
 func MakeTextureHandleNonResidentARB(handle uint64) {
 	C.glowMakeTextureHandleNonResidentARB(gpMakeTextureHandleNonResidentARB, (C.GLuint64)(handle))
 }
+func MakeTextureHandleNonResidentNV(handle uint64) {
+	C.glowMakeTextureHandleNonResidentNV(gpMakeTextureHandleNonResidentNV, (C.GLuint64)(handle))
+}
 func MakeTextureHandleResidentARB(handle uint64) {
 	C.glowMakeTextureHandleResidentARB(gpMakeTextureHandleResidentARB, (C.GLuint64)(handle))
+}
+func MakeTextureHandleResidentNV(handle uint64) {
+	C.glowMakeTextureHandleResidentNV(gpMakeTextureHandleResidentNV, (C.GLuint64)(handle))
 }
 
 // map all of a buffer object's data store into the client's address space
@@ -6835,11 +10816,100 @@ func MapNamedBuffer(buffer uint32, access uint32) unsafe.Pointer {
 	ret := C.glowMapNamedBuffer(gpMapNamedBuffer, (C.GLuint)(buffer), (C.GLenum)(access))
 	return (unsafe.Pointer)(ret)
 }
+func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferEXT(gpMapNamedBufferEXT, (C.GLuint)(buffer), (C.GLenum)(access))
+	return (unsafe.Pointer)(ret)
+}
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
+}
+func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRangeEXT(gpMapNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
+	return (unsafe.Pointer)(ret)
+}
+func MatrixFrustumEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixFrustumEXT(gpMatrixFrustumEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixLoad3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x2fNV(gpMatrixLoad3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoad3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x3fNV(gpMatrixLoad3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadIdentityEXT(mode uint32) {
+	C.glowMatrixLoadIdentityEXT(gpMatrixLoadIdentityEXT, (C.GLenum)(mode))
+}
+func MatrixLoadTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoadTranspose3x3fNV(gpMatrixLoadTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixLoadTransposedEXT(gpMatrixLoadTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadTransposefEXT(gpMatrixLoadTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoaddEXT(mode uint32, m *float64) {
+	C.glowMatrixLoaddEXT(gpMatrixLoaddEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadfEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadfEXT(gpMatrixLoadfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x2fNV(gpMatrixMult3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x3fNV(gpMatrixMult3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMultTranspose3x3fNV(gpMatrixMultTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixMultTransposedEXT(gpMatrixMultTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixMultTransposefEXT(gpMatrixMultTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultdEXT(mode uint32, m *float64) {
+	C.glowMatrixMultdEXT(gpMatrixMultdEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultfEXT(mode uint32, m *float32) {
+	C.glowMatrixMultfEXT(gpMatrixMultfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixOrthoEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixOrthoEXT(gpMatrixOrthoEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixPopEXT(mode uint32) {
+	C.glowMatrixPopEXT(gpMatrixPopEXT, (C.GLenum)(mode))
+}
+func MatrixPushEXT(mode uint32) {
+	C.glowMatrixPushEXT(gpMatrixPushEXT, (C.GLenum)(mode))
+}
+func MatrixRotatedEXT(mode uint32, angle float64, x float64, y float64, z float64) {
+	C.glowMatrixRotatedEXT(gpMatrixRotatedEXT, (C.GLenum)(mode), (C.GLdouble)(angle), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixRotatefEXT(mode uint32, angle float32, x float32, y float32, z float32) {
+	C.glowMatrixRotatefEXT(gpMatrixRotatefEXT, (C.GLenum)(mode), (C.GLfloat)(angle), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixScaledEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixScaledEXT(gpMatrixScaledEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixScalefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixScalefEXT(gpMatrixScalefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixTranslatedEXT(gpMatrixTranslatedEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
 }
 
 // defines a barrier ordering memory transactions
@@ -6867,8 +10937,14 @@ func MultiDrawArrays(mode uint32, first *int32, count *int32, drawcount int32) {
 func MultiDrawArraysIndirect(mode uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawArraysIndirect(gpMultiDrawArraysIndirect, (C.GLenum)(mode), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessCountNV(gpMultiDrawArraysIndirectBindlessCountNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 
 // render multiple sets of primitives by specifying indices of array data elements
@@ -6885,29 +10961,122 @@ func MultiDrawElementsBaseVertex(mode uint32, count *int32, xtype uint32, indice
 func MultiDrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawElementsIndirect(gpMultiDrawElementsIndirect, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessCountNV(gpMultiDrawElementsIndirectBindlessCountNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+}
+func MultiTexBufferEXT(texunit uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowMultiTexBufferEXT(gpMultiTexBufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
+func MultiTexCoordPointerEXT(texunit uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
+	C.glowMultiTexCoordPointerEXT(gpMultiTexCoordPointerEXT, (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
+}
+func MultiTexEnvfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexEnvfEXT(gpMultiTexEnvfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexEnvfvEXT(gpMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexEnviEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexEnviEXT(gpMultiTexEnviEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexEnvivEXT(gpMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexGendEXT(texunit uint32, coord uint32, pname uint32, param float64) {
+	C.glowMultiTexGendEXT(gpMultiTexGendEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLdouble)(param))
+}
+func MultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowMultiTexGendvEXT(gpMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func MultiTexGenfEXT(texunit uint32, coord uint32, pname uint32, param float32) {
+	C.glowMultiTexGenfEXT(gpMultiTexGenfEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowMultiTexGenfvEXT(gpMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexGeniEXT(texunit uint32, coord uint32, pname uint32, param int32) {
+	C.glowMultiTexGeniEXT(gpMultiTexGeniEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowMultiTexGenivEXT(gpMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage1DEXT(gpMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage2DEXT(gpMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage3DEXT(gpMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterIivEXT(gpMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowMultiTexParameterIuivEXT(gpMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexParameterfEXT(gpMultiTexParameterfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexParameterfvEXT(gpMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexParameteriEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexParameteriEXT(gpMultiTexParameteriEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterivEXT(gpMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexRenderbufferEXT(texunit uint32, target uint32, renderbuffer uint32) {
+	C.glowMultiTexRenderbufferEXT(gpMultiTexRenderbufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(renderbuffer))
+}
+func MultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage1DEXT(gpMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage2DEXT(gpMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
+}
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
+}
+func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedCopyBufferSubDataEXT(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowNamedCopyBufferSubDataEXT(gpNamedCopyBufferSubDataEXT, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 
 // specify which color buffers are to be drawn into
@@ -6924,6 +11093,9 @@ func NamedFramebufferDrawBuffers(framebuffer uint32, n int32, bufs *uint32) {
 func NamedFramebufferParameteri(framebuffer uint32, pname uint32, param int32) {
 	C.glowNamedFramebufferParameteri(gpNamedFramebufferParameteri, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
 }
+func NamedFramebufferParameteriEXT(framebuffer uint32, pname uint32, param int32) {
+	C.glowNamedFramebufferParameteriEXT(gpNamedFramebufferParameteriEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // select a color buffer source for pixels
 func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
@@ -6934,26 +11106,101 @@ func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
 func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbuffer(gpNamedFramebufferRenderbuffer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
+	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture1DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture1DEXT(gpNamedFramebufferTexture1DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture2DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture2DEXT(gpNamedFramebufferTexture2DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture3DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
+	C.glowNamedFramebufferTexture3DEXT(gpNamedFramebufferTexture3DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
+}
+func NamedFramebufferTextureEXT(framebuffer uint32, attachment uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTextureEXT(gpNamedFramebufferTextureEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTextureFaceEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowNamedFramebufferTextureFaceEXT(gpNamedFramebufferTextureFaceEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
 }
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func NamedFramebufferTextureLayer(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowNamedFramebufferTextureLayer(gpNamedFramebufferTextureLayer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
 }
+func NamedFramebufferTextureLayerEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowNamedFramebufferTextureLayerEXT(gpNamedFramebufferTextureLayerEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func NamedProgramLocalParameter4dEXT(program uint32, target uint32, index uint32, x float64, y float64, z float64, w float64) {
+	C.glowNamedProgramLocalParameter4dEXT(gpNamedProgramLocalParameter4dEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
+func NamedProgramLocalParameter4dvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowNamedProgramLocalParameter4dvEXT(gpNamedProgramLocalParameter4dvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameter4fEXT(program uint32, target uint32, index uint32, x float32, y float32, z float32, w float32) {
+	C.glowNamedProgramLocalParameter4fEXT(gpNamedProgramLocalParameter4fEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z), (C.GLfloat)(w))
+}
+func NamedProgramLocalParameter4fvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowNamedProgramLocalParameter4fvEXT(gpNamedProgramLocalParameter4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4iEXT(program uint32, target uint32, index uint32, x int32, y int32, z int32, w int32) {
+	C.glowNamedProgramLocalParameterI4iEXT(gpNamedProgramLocalParameterI4iEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLint)(x), (C.GLint)(y), (C.GLint)(z), (C.GLint)(w))
+}
+func NamedProgramLocalParameterI4ivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowNamedProgramLocalParameterI4ivEXT(gpNamedProgramLocalParameterI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4uiEXT(program uint32, target uint32, index uint32, x uint32, y uint32, z uint32, w uint32) {
+	C.glowNamedProgramLocalParameterI4uiEXT(gpNamedProgramLocalParameterI4uiEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(x), (C.GLuint)(y), (C.GLuint)(z), (C.GLuint)(w))
+}
+func NamedProgramLocalParameterI4uivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowNamedProgramLocalParameterI4uivEXT(gpNamedProgramLocalParameterI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameters4fvEXT(program uint32, target uint32, index uint32, count int32, params *float32) {
+	C.glowNamedProgramLocalParameters4fvEXT(gpNamedProgramLocalParameters4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4ivEXT(program uint32, target uint32, index uint32, count int32, params *int32) {
+	C.glowNamedProgramLocalParametersI4ivEXT(gpNamedProgramLocalParametersI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4uivEXT(program uint32, target uint32, index uint32, count int32, params *uint32) {
+	C.glowNamedProgramLocalParametersI4uivEXT(gpNamedProgramLocalParametersI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramStringEXT(program uint32, target uint32, format uint32, len int32, xstring unsafe.Pointer) {
+	C.glowNamedProgramStringEXT(gpNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(format), (C.GLsizei)(len), xstring)
+}
 
 // establish data storage, format and dimensions of a     renderbuffer object's image
 func NamedRenderbufferStorage(renderbuffer uint32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorage(gpNamedRenderbufferStorage, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageEXT(renderbuffer uint32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageEXT(gpNamedRenderbufferStorageEXT, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func NamedRenderbufferStorageMultisample(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisample(gpNamedRenderbufferStorageMultisample, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func NamedRenderbufferStorageMultisampleCoverageEXT(renderbuffer uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleCoverageEXT(gpNamedRenderbufferStorageMultisampleCoverageEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageMultisampleEXT(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleEXT(gpNamedRenderbufferStorageMultisampleEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
+}
+func NormalFormatNV(xtype uint32, stride int32) {
+	C.glowNormalFormatNV(gpNormalFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // label a named object identified within a namespace
@@ -6974,8 +11221,67 @@ func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathCommandsNV(path uint32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCommandsNV(gpPathCommandsNV, (C.GLuint)(path), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoordsNV(path uint32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCoordsNV(gpPathCoordsNV, (C.GLuint)(path), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoverDepthFuncNV(xfunc uint32) {
+	C.glowPathCoverDepthFuncNV(gpPathCoverDepthFuncNV, (C.GLenum)(xfunc))
+}
+func PathDashArrayNV(path uint32, dashCount int32, dashArray *float32) {
+	C.glowPathDashArrayNV(gpPathDashArrayNV, (C.GLuint)(path), (C.GLsizei)(dashCount), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func PathGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathGlyphIndexArrayNV(gpPathGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathGlyphIndexRangeNV(fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, pathParameterTemplate uint32, emScale float32, baseAndCount *uint32) uint32 {
+	ret := C.glowPathGlyphIndexRangeNV(gpPathGlyphIndexRangeNV, (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale), (*C.GLuint)(unsafe.Pointer(baseAndCount)))
+	return (uint32)(ret)
+}
+func PathGlyphRangeNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyph uint32, numGlyphs int32, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphRangeNV(gpPathGlyphRangeNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyph), (C.GLsizei)(numGlyphs), (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathGlyphsNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, numGlyphs int32, xtype uint32, charcodes unsafe.Pointer, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphsNV(gpPathGlyphsNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLsizei)(numGlyphs), (C.GLenum)(xtype), charcodes, (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathMemoryGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontSize int, fontData unsafe.Pointer, faceIndex int32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathMemoryGlyphIndexArrayNV(gpPathMemoryGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), (C.GLsizeiptr)(fontSize), fontData, (C.GLsizei)(faceIndex), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathParameterfNV(path uint32, pname uint32, value float32) {
+	C.glowPathParameterfNV(gpPathParameterfNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func PathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowPathParameterfvNV(gpPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func PathParameteriNV(path uint32, pname uint32, value int32) {
+	C.glowPathParameteriNV(gpPathParameteriNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowPathParameterivNV(gpPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func PathStencilDepthOffsetNV(factor float32, units float32) {
+	C.glowPathStencilDepthOffsetNV(gpPathStencilDepthOffsetNV, (C.GLfloat)(factor), (C.GLfloat)(units))
+}
+func PathStencilFuncNV(xfunc uint32, ref int32, mask uint32) {
+	C.glowPathStencilFuncNV(gpPathStencilFuncNV, (C.GLenum)(xfunc), (C.GLint)(ref), (C.GLuint)(mask))
+}
+func PathStringNV(path uint32, format uint32, length int32, pathString unsafe.Pointer) {
+	C.glowPathStringNV(gpPathStringNV, (C.GLuint)(path), (C.GLenum)(format), (C.GLsizei)(length), pathString)
+}
+func PathSubCommandsNV(path uint32, commandStart int32, commandsToDelete int32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCommandsNV(gpPathSubCommandsNV, (C.GLuint)(path), (C.GLsizei)(commandStart), (C.GLsizei)(commandsToDelete), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathSubCoordsNV(path uint32, coordStart int32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCoordsNV(gpPathSubCoordsNV, (C.GLuint)(path), (C.GLsizei)(coordStart), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
 }
 
 // pause transform feedback operations
@@ -6985,8 +11291,14 @@ func PauseTransformFeedback() {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
+}
+func PointAlongPathNV(path uint32, startSegment int32, numSegments int32, distance float32, x *float32, y *float32, tangentX *float32, tangentY *float32) bool {
+	ret := C.glowPointAlongPathNV(gpPointAlongPathNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments), (C.GLfloat)(distance), (*C.GLfloat)(unsafe.Pointer(x)), (*C.GLfloat)(unsafe.Pointer(y)), (*C.GLfloat)(unsafe.Pointer(tangentX)), (*C.GLfloat)(unsafe.Pointer(tangentY)))
+	return ret == TRUE
 }
 func PointParameterf(pname uint32, param float32) {
 	C.glowPointParameterf(gpPointParameterf, (C.GLenum)(pname), (C.GLfloat)(param))
@@ -7015,6 +11327,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 
 // pop the active debug group
 func PopDebugGroup() {
@@ -7022,6 +11340,12 @@ func PopDebugGroup() {
 }
 func PopDebugGroupKHR() {
 	C.glowPopDebugGroupKHR(gpPopDebugGroupKHR)
+}
+func PopGroupMarkerEXT() {
+	C.glowPopGroupMarkerEXT(gpPopGroupMarkerEXT)
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -7033,235 +11357,507 @@ func PrimitiveRestartIndex(index uint32) {
 func ProgramBinary(program uint32, binaryFormat uint32, binary unsafe.Pointer, length int32) {
 	C.glowProgramBinary(gpProgramBinary, (C.GLuint)(program), (C.GLenum)(binaryFormat), binary, (C.GLsizei)(length))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriARB(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriARB(gpProgramParameteriARB, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriEXT(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriEXT(gpProgramParameteriEXT, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramPathFragmentInputGenNV(program uint32, location int32, genMode uint32, components int32, coeffs *float32) {
+	C.glowProgramPathFragmentInputGenNV(gpProgramPathFragmentInputGenNV, (C.GLuint)(program), (C.GLint)(location), (C.GLenum)(genMode), (C.GLint)(components), (*C.GLfloat)(unsafe.Pointer(coeffs)))
 }
 func ProgramUniform1d(program uint32, location int32, v0 float64) {
 	C.glowProgramUniform1d(gpProgramUniform1d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0))
 }
+func ProgramUniform1dEXT(program uint32, location int32, x float64) {
+	C.glowProgramUniform1dEXT(gpProgramUniform1dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x))
+}
 func ProgramUniform1dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform1dv(gpProgramUniform1dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform1dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform1dvEXT(gpProgramUniform1dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1f(program uint32, location int32, v0 float32) {
 	C.glowProgramUniform1f(gpProgramUniform1f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
 }
+func ProgramUniform1fEXT(program uint32, location int32, v0 float32) {
+	C.glowProgramUniform1fEXT(gpProgramUniform1fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform1fv(gpProgramUniform1fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform1fvEXT(gpProgramUniform1fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
+func ProgramUniform1i64NV(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1iEXT(program uint32, location int32, v0 int32) {
+	C.glowProgramUniform1iEXT(gpProgramUniform1iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform1iv(gpProgramUniform1iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform1ivEXT(gpProgramUniform1ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
+func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1uiEXT(program uint32, location int32, v0 uint32) {
+	C.glowProgramUniform1uiEXT(gpProgramUniform1uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform1uiv(gpProgramUniform1uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform1uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform1uivEXT(gpProgramUniform1uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform2d(program uint32, location int32, v0 float64, v1 float64) {
 	C.glowProgramUniform2d(gpProgramUniform2d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1))
 }
+func ProgramUniform2dEXT(program uint32, location int32, x float64, y float64) {
+	C.glowProgramUniform2dEXT(gpProgramUniform2dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y))
+}
 func ProgramUniform2dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform2dv(gpProgramUniform2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform2dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform2dvEXT(gpProgramUniform2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2f(program uint32, location int32, v0 float32, v1 float32) {
 	C.glowProgramUniform2f(gpProgramUniform2f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
 }
+func ProgramUniform2fEXT(program uint32, location int32, v0 float32, v1 float32) {
+	C.glowProgramUniform2fEXT(gpProgramUniform2fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform2fv(gpProgramUniform2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform2fvEXT(gpProgramUniform2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2iEXT(program uint32, location int32, v0 int32, v1 int32) {
+	C.glowProgramUniform2iEXT(gpProgramUniform2iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform2iv(gpProgramUniform2iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform2ivEXT(gpProgramUniform2ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2uiEXT(program uint32, location int32, v0 uint32, v1 uint32) {
+	C.glowProgramUniform2uiEXT(gpProgramUniform2uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform2uiv(gpProgramUniform2uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform2uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform2uivEXT(gpProgramUniform2uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform3d(program uint32, location int32, v0 float64, v1 float64, v2 float64) {
 	C.glowProgramUniform3d(gpProgramUniform3d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2))
 }
+func ProgramUniform3dEXT(program uint32, location int32, x float64, y float64, z float64) {
+	C.glowProgramUniform3dEXT(gpProgramUniform3dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
 func ProgramUniform3dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform3dv(gpProgramUniform3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform3dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform3dvEXT(gpProgramUniform3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3f(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
 	C.glowProgramUniform3f(gpProgramUniform3f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
 }
+func ProgramUniform3fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
+	C.glowProgramUniform3fEXT(gpProgramUniform3fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform3fv(gpProgramUniform3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform3fvEXT(gpProgramUniform3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
+	C.glowProgramUniform3iEXT(gpProgramUniform3iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform3iv(gpProgramUniform3iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform3ivEXT(gpProgramUniform3ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
+	C.glowProgramUniform3uiEXT(gpProgramUniform3uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform3uiv(gpProgramUniform3uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform3uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform3uivEXT(gpProgramUniform3uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform4d(program uint32, location int32, v0 float64, v1 float64, v2 float64, v3 float64) {
 	C.glowProgramUniform4d(gpProgramUniform4d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2), (C.GLdouble)(v3))
 }
+func ProgramUniform4dEXT(program uint32, location int32, x float64, y float64, z float64, w float64) {
+	C.glowProgramUniform4dEXT(gpProgramUniform4dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
 func ProgramUniform4dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform4dv(gpProgramUniform4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform4dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform4dvEXT(gpProgramUniform4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4f(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
 	C.glowProgramUniform4f(gpProgramUniform4f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
 }
+func ProgramUniform4fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
+	C.glowProgramUniform4fEXT(gpProgramUniform4fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform4fv(gpProgramUniform4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform4fvEXT(gpProgramUniform4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
+	C.glowProgramUniform4iEXT(gpProgramUniform4iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform4iv(gpProgramUniform4iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform4ivEXT(gpProgramUniform4ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
+	C.glowProgramUniform4uiEXT(gpProgramUniform4uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform4uiv(gpProgramUniform4uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform4uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform4uivEXT(gpProgramUniform4uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniformHandleui64ARB(program uint32, location int32, value uint64) {
 	C.glowProgramUniformHandleui64ARB(gpProgramUniformHandleui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
+}
+func ProgramUniformHandleui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformHandleui64NV(gpProgramUniformHandleui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
 }
 func ProgramUniformHandleui64vARB(program uint32, location int32, count int32, values *uint64) {
 	C.glowProgramUniformHandleui64vARB(gpProgramUniformHandleui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
 }
+func ProgramUniformHandleui64vNV(program uint32, location int32, count int32, values *uint64) {
+	C.glowProgramUniformHandleui64vNV(gpProgramUniformHandleui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
+}
 func ProgramUniformMatrix2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2dv(gpProgramUniformMatrix2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2dvEXT(gpProgramUniformMatrix2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2fv(gpProgramUniformMatrix2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2fvEXT(gpProgramUniformMatrix2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x3dv(gpProgramUniformMatrix2x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x3dvEXT(gpProgramUniformMatrix2x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x3fv(gpProgramUniformMatrix2x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x3fvEXT(gpProgramUniformMatrix2x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x4dv(gpProgramUniformMatrix2x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x4dvEXT(gpProgramUniformMatrix2x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x4fv(gpProgramUniformMatrix2x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x4fvEXT(gpProgramUniformMatrix2x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3dv(gpProgramUniformMatrix3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3dvEXT(gpProgramUniformMatrix3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3fv(gpProgramUniformMatrix3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3fvEXT(gpProgramUniformMatrix3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x2dv(gpProgramUniformMatrix3x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x2dvEXT(gpProgramUniformMatrix3x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x2fv(gpProgramUniformMatrix3x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x2fvEXT(gpProgramUniformMatrix3x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x4dv(gpProgramUniformMatrix3x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x4dvEXT(gpProgramUniformMatrix3x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x4fv(gpProgramUniformMatrix3x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x4fvEXT(gpProgramUniformMatrix3x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4dv(gpProgramUniformMatrix4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4dvEXT(gpProgramUniformMatrix4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4fv(gpProgramUniformMatrix4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4fvEXT(gpProgramUniformMatrix4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x2dv(gpProgramUniformMatrix4x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x2dvEXT(gpProgramUniformMatrix4x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x2fv(gpProgramUniformMatrix4x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x2fvEXT(gpProgramUniformMatrix4x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x3dv(gpProgramUniformMatrix4x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x3dvEXT(gpProgramUniformMatrix4x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x3fv(gpProgramUniformMatrix4x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x3fvEXT(gpProgramUniformMatrix4x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniformui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformui64NV(gpProgramUniformui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func ProgramUniformui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniformui64vNV(gpProgramUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // specifiy the vertex to be used as the source of data for flat shaded varyings
 func ProvokingVertex(mode uint32) {
 	C.glowProvokingVertex(gpProvokingVertex, (C.GLenum)(mode))
+}
+func PushClientAttribDefaultEXT(mask uint32) {
+	C.glowPushClientAttribDefaultEXT(gpPushClientAttribDefaultEXT, (C.GLbitfield)(mask))
 }
 
 // push a named debug group into the command stream
@@ -7271,10 +11867,16 @@ func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
+func PushGroupMarkerEXT(length int32, marker *uint8) {
+	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
 
 // record the GL time into a query object after all previous commands have reached the GL server but have not yet necessarily executed.
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
+}
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
 
 // select a color buffer source for pixels
@@ -7311,6 +11913,12 @@ func RenderbufferStorage(target uint32, internalformat uint32, width int32, heig
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func RenderbufferStorageMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowRenderbufferStorageMultisample(gpRenderbufferStorageMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func RenderbufferStorageMultisampleCoverageNV(target uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowRenderbufferStorageMultisampleCoverageNV(gpRenderbufferStorageMultisampleCoverageNV, (C.GLenum)(target), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
 }
 
 // resume transform feedback operations
@@ -7361,6 +11969,12 @@ func ScissorIndexed(index uint32, left int32, bottom int32, width int32, height 
 func ScissorIndexedv(index uint32, v *int32) {
 	C.glowScissorIndexedv(gpScissorIndexedv, (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(v)))
 }
+func SecondaryColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowSecondaryColorFormatNV(gpSecondaryColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
+	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
+}
 
 // load pre-compiled shader binaries
 func ShaderBinary(count int32, shaders *uint32, binaryformat uint32, binary unsafe.Pointer, length int32) {
@@ -7375,6 +11989,24 @@ func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 // change an active shader storage block binding
 func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storageBlockBinding uint32) {
 	C.glowShaderStorageBlockBinding(gpShaderStorageBlockBinding, (C.GLuint)(program), (C.GLuint)(storageBlockIndex), (C.GLuint)(storageBlockBinding))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
+}
+func StencilFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilFillPathInstancedNV(gpStencilFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilFillPathNV(path uint32, fillMode uint32, mask uint32) {
+	C.glowStencilFillPathNV(gpStencilFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask))
 }
 
 // set front and back function and reference value for stencil testing
@@ -7406,15 +12038,42 @@ func StencilOp(fail uint32, zfail uint32, zpass uint32) {
 func StencilOpSeparate(face uint32, sfail uint32, dpfail uint32, dppass uint32) {
 	C.glowStencilOpSeparate(gpStencilOpSeparate, (C.GLenum)(face), (C.GLenum)(sfail), (C.GLenum)(dpfail), (C.GLenum)(dppass))
 }
+func StencilStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilStrokePathInstancedNV(gpStencilStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilStrokePathNV(path uint32, reference int32, mask uint32) {
+	C.glowStencilStrokePathNV(gpStencilStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask))
+}
+func StencilThenCoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverFillPathInstancedNV(gpStencilThenCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverFillPathNV(path uint32, fillMode uint32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverFillPathNV(gpStencilThenCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func StencilThenCoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverStrokePathInstancedNV(gpStencilThenCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverStrokePathNV(path uint32, reference int32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverStrokePathNV(gpStencilThenCoverStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TexBuffer(target uint32, internalformat uint32, buffer uint32) {
 	C.glowTexBuffer(gpTexBuffer, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TexBufferARB(target uint32, internalformat uint32, buffer uint32) {
+	C.glowTexBufferARB(gpTexBufferARB, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
 func TexBufferRange(target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTexBufferRange(gpTexBufferRange, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TexCoordFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowTexCoordFormatNV(gpTexCoordFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // specify a one-dimensional texture image
@@ -7441,8 +12100,8 @@ func TexImage3D(target uint32, level int32, internalformat int32, width int32, h
 func TexImage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexImage3DMultisample(gpTexImage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -7507,73 +12166,139 @@ func TexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zof
 func TextureBarrier() {
 	C.glowTextureBarrier(gpTextureBarrier)
 }
+func TextureBarrierNV() {
+	C.glowTextureBarrierNV(gpTextureBarrierNV)
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TextureBuffer(texture uint32, internalformat uint32, buffer uint32) {
 	C.glowTextureBuffer(gpTextureBuffer, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowTextureBufferEXT(gpTextureBufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureImage1DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage1DEXT(gpTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage2DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage2DEXT(gpTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage3DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage3DEXT(gpTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func TextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterIivEXT(gpTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func TextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowTextureParameterIuiv(gpTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func TextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowTextureParameterIuivEXT(gpTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
 func TextureParameterf(texture uint32, pname uint32, param float32) {
 	C.glowTextureParameterf(gpTextureParameterf, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLfloat)(param))
 }
+func TextureParameterfEXT(texture uint32, target uint32, pname uint32, param float32) {
+	C.glowTextureParameterfEXT(gpTextureParameterfEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
 func TextureParameterfv(texture uint32, pname uint32, param *float32) {
 	C.glowTextureParameterfv(gpTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(param)))
+}
+func TextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowTextureParameterfvEXT(gpTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func TextureParameteri(texture uint32, pname uint32, param int32) {
 	C.glowTextureParameteri(gpTextureParameteri, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLint)(param))
 }
+func TextureParameteriEXT(texture uint32, target uint32, pname uint32, param int32) {
+	C.glowTextureParameteriEXT(gpTextureParameteriEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
 func TextureParameteriv(texture uint32, pname uint32, param *int32) {
 	C.glowTextureParameteriv(gpTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func TextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterivEXT(gpTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func TextureRenderbufferEXT(texture uint32, target uint32, renderbuffer uint32) {
+	C.glowTextureRenderbufferEXT(gpTextureRenderbufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLuint)(renderbuffer))
 }
 
 // simultaneously specify storage for all levels of a one-dimensional texture
 func TextureStorage1D(texture uint32, levels int32, internalformat uint32, width int32) {
 	C.glowTextureStorage1D(gpTextureStorage1D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
 }
+func TextureStorage1DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32) {
+	C.glowTextureStorage1DEXT(gpTextureStorage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
+}
 
 // simultaneously specify storage for all levels of a two-dimensional or one-dimensional array texture
 func TextureStorage2D(texture uint32, levels int32, internalformat uint32, width int32, height int32) {
 	C.glowTextureStorage2D(gpTextureStorage2D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func TextureStorage2DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32) {
+	C.glowTextureStorage2DEXT(gpTextureStorage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // specify storage for a two-dimensional multisample texture
 func TextureStorage2DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
 	C.glowTextureStorage2DMultisample(gpTextureStorage2DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage2DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
+	C.glowTextureStorage2DMultisampleEXT(gpTextureStorage2DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // simultaneously specify storage for all levels of a three-dimensional, two-dimensional array or cube-map array texture
 func TextureStorage3D(texture uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
 	C.glowTextureStorage3D(gpTextureStorage3D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func TextureStorage3DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
+	C.glowTextureStorage3DEXT(gpTextureStorage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
 }
 
 // specify storage for a two-dimensional multisample array texture
 func TextureStorage3DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisample(gpTextureStorage3DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
+	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // specify a one-dimensional texture subimage
 func TextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage1D(gpTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage1DEXT(gpTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // specify a two-dimensional texture subimage
 func TextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage2D(gpTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func TextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage2DEXT(gpTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 
 // specify a three-dimensional texture subimage
 func TextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage3D(gpTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage3DEXT(gpTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // initialize a texture as a data alias of another texture's data store
@@ -7587,13 +12312,16 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 
 // specify values to record in transform feedback buffers
 func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
+}
+func TransformPathNV(resultPath uint32, srcPath uint32, transformType uint32, transformValues *float32) {
+	C.glowTransformPathNV(gpTransformPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
 }
 func Uniform1d(location int32, x float64) {
 	C.glowUniform1d(gpUniform1d, (C.GLint)(location), (C.GLdouble)(x))
@@ -7616,6 +12344,18 @@ func Uniform1fv(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
+func Uniform1i64NV(location int32, x int64) {
+	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform1i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform1iv(location int32, count int32, value *int32) {
@@ -7625,6 +12365,18 @@ func Uniform1iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
+}
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
+func Uniform1ui64NV(location int32, x uint64) {
+	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform1ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7652,6 +12404,18 @@ func Uniform2fv(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func Uniform2i64NV(location int32, x int64, y int64) {
+	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform2i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform2iv(location int32, count int32, value *int32) {
@@ -7661,6 +12425,18 @@ func Uniform2iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func Uniform2ui64NV(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform2ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7688,6 +12464,18 @@ func Uniform3fv(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func Uniform3i64NV(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform3i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform3iv(location int32, count int32, value *int32) {
@@ -7697,6 +12485,18 @@ func Uniform3iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform3ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7724,6 +12524,18 @@ func Uniform4fv(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform4i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform4iv(location int32, count int32, value *int32) {
@@ -7733,6 +12545,18 @@ func Uniform4iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform4ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7747,8 +12571,14 @@ func UniformBlockBinding(program uint32, uniformBlockIndex uint32, uniformBlockB
 func UniformHandleui64ARB(location int32, value uint64) {
 	C.glowUniformHandleui64ARB(gpUniformHandleui64ARB, (C.GLint)(location), (C.GLuint64)(value))
 }
+func UniformHandleui64NV(location int32, value uint64) {
+	C.glowUniformHandleui64NV(gpUniformHandleui64NV, (C.GLint)(location), (C.GLuint64)(value))
+}
 func UniformHandleui64vARB(location int32, count int32, value *uint64) {
 	C.glowUniformHandleui64vARB(gpUniformHandleui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func UniformHandleui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformHandleui64vNV(gpUniformHandleui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func UniformMatrix2dv(location int32, count int32, transpose bool, value *float64) {
 	C.glowUniformMatrix2dv(gpUniformMatrix2dv, (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
@@ -7825,6 +12655,12 @@ func UniformMatrix4x3fv(location int32, count int32, transpose bool, value *floa
 func UniformSubroutinesuiv(shadertype uint32, count int32, indices *uint32) {
 	C.glowUniformSubroutinesuiv(gpUniformSubroutinesuiv, (C.GLenum)(shadertype), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(indices)))
 }
+func Uniformui64NV(location int32, value uint64) {
+	C.glowUniformui64NV(gpUniformui64NV, (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func Uniformui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformui64vNV(gpUniformui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // release the mapping of a buffer object's data store into the client's address space
 func UnmapBuffer(target uint32) bool {
@@ -7837,6 +12673,10 @@ func UnmapNamedBuffer(buffer uint32) bool {
 	ret := C.glowUnmapNamedBuffer(gpUnmapNamedBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func UnmapNamedBufferEXT(buffer uint32) bool {
+	ret := C.glowUnmapNamedBufferEXT(gpUnmapNamedBufferEXT, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 
 // Installs a program object as part of current rendering state
 func UseProgram(program uint32) {
@@ -7847,6 +12687,12 @@ func UseProgram(program uint32) {
 func UseProgramStages(pipeline uint32, stages uint32, program uint32) {
 	C.glowUseProgramStages(gpUseProgramStages, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
 }
+func UseProgramStagesEXT(pipeline uint32, stages uint32, program uint32) {
+	C.glowUseProgramStagesEXT(gpUseProgramStagesEXT, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
+}
+func UseShaderProgramEXT(xtype uint32, program uint32) {
+	C.glowUseShaderProgramEXT(gpUseShaderProgramEXT, (C.GLenum)(xtype), (C.GLuint)(program))
+}
 
 // Validates a program object
 func ValidateProgram(program uint32) {
@@ -7856,6 +12702,9 @@ func ValidateProgram(program uint32) {
 // validate a program pipeline object against current GL state
 func ValidateProgramPipeline(pipeline uint32) {
 	C.glowValidateProgramPipeline(gpValidateProgramPipeline, (C.GLuint)(pipeline))
+}
+func ValidateProgramPipelineEXT(pipeline uint32) {
+	C.glowValidateProgramPipelineEXT(gpValidateProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 func VertexArrayAttribBinding(vaobj uint32, attribindex uint32, bindingindex uint32) {
 	C.glowVertexArrayAttribBinding(gpVertexArrayAttribBinding, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
@@ -7871,15 +12720,69 @@ func VertexArrayAttribIFormat(vaobj uint32, attribindex uint32, size int32, xtyp
 func VertexArrayAttribLFormat(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexArrayAttribLFormat(gpVertexArrayAttribLFormat, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexArrayBindVertexBufferEXT(vaobj uint32, bindingindex uint32, buffer uint32, offset int, stride int32) {
+	C.glowVertexArrayBindVertexBufferEXT(gpVertexArrayBindVertexBufferEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(stride))
+}
 
 // modify the rate at which generic vertex attributes     advance
 func VertexArrayBindingDivisor(vaobj uint32, bindingindex uint32, divisor uint32) {
 	C.glowVertexArrayBindingDivisor(gpVertexArrayBindingDivisor, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexArrayColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayColorOffsetEXT(gpVertexArrayColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayEdgeFlagOffsetEXT(vaobj uint32, buffer uint32, stride int32, offset int) {
+	C.glowVertexArrayEdgeFlagOffsetEXT(gpVertexArrayEdgeFlagOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
 
 // configures element array buffer binding of a vertex array object
 func VertexArrayElementBuffer(vaobj uint32, buffer uint32) {
 	C.glowVertexArrayElementBuffer(gpVertexArrayElementBuffer, (C.GLuint)(vaobj), (C.GLuint)(buffer))
+}
+func VertexArrayFogCoordOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayFogCoordOffsetEXT(gpVertexArrayFogCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayIndexOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayIndexOffsetEXT(gpVertexArrayIndexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayMultiTexCoordOffsetEXT(vaobj uint32, buffer uint32, texunit uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayMultiTexCoordOffsetEXT(gpVertexArrayMultiTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayNormalOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayNormalOffsetEXT(gpVertexArrayNormalOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArraySecondaryColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArraySecondaryColorOffsetEXT(gpVertexArraySecondaryColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayTexCoordOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayTexCoordOffsetEXT(gpVertexArrayTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribBindingEXT(vaobj uint32, attribindex uint32, bindingindex uint32) {
+	C.glowVertexArrayVertexAttribBindingEXT(gpVertexArrayVertexAttribBindingEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
+}
+func VertexArrayVertexAttribDivisorEXT(vaobj uint32, index uint32, divisor uint32) {
+	C.glowVertexArrayVertexAttribDivisorEXT(gpVertexArrayVertexAttribDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLuint)(divisor))
+}
+func VertexArrayVertexAttribFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribFormatEXT(gpVertexArrayVertexAttribFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribIFormatEXT(gpVertexArrayVertexAttribIFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribIOffsetEXT(gpVertexArrayVertexAttribIOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribLFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribLFormatEXT(gpVertexArrayVertexAttribLFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribLOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribLOffsetEXT(gpVertexArrayVertexAttribLOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, normalized bool, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribOffsetEXT(gpVertexArrayVertexAttribOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexBindingDivisorEXT(vaobj uint32, bindingindex uint32, divisor uint32) {
+	C.glowVertexArrayVertexBindingDivisorEXT(gpVertexArrayVertexBindingDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
 
 // bind a buffer to a vertex buffer bind point
@@ -7890,6 +12793,9 @@ func VertexArrayVertexBuffer(vaobj uint32, bindingindex uint32, buffer uint32, o
 // attach multiple buffer objects to a vertex array object
 func VertexArrayVertexBuffers(vaobj uint32, first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowVertexArrayVertexBuffers(gpVertexArrayVertexBuffers, (C.GLuint)(vaobj), (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
+}
+func VertexArrayVertexOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexOffsetEXT(gpVertexArrayVertexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
 }
 func VertexAttrib1d(index uint32, x float64) {
 	C.glowVertexAttrib1d(gpVertexAttrib1d, (C.GLuint)(index), (C.GLdouble)(x))
@@ -8009,10 +12915,16 @@ func VertexAttribBinding(attribindex uint32, bindingindex uint32) {
 func VertexAttribDivisor(index uint32, divisor uint32) {
 	C.glowVertexAttribDivisor(gpVertexAttribDivisor, (C.GLuint)(index), (C.GLuint)(divisor))
 }
+func VertexAttribDivisorARB(index uint32, divisor uint32) {
+	C.glowVertexAttribDivisorARB(gpVertexAttribDivisorARB, (C.GLuint)(index), (C.GLuint)(divisor))
+}
 
 // specify the organization of vertex arrays
 func VertexAttribFormat(attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
 	C.glowVertexAttribFormat(gpVertexAttribFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexAttribFormatNV(index uint32, size int32, xtype uint32, normalized bool, stride int32) {
+	C.glowVertexAttribFormatNV(gpVertexAttribFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride))
 }
 func VertexAttribI1i(index uint32, x int32) {
 	C.glowVertexAttribI1i(gpVertexAttribI1i, (C.GLuint)(index), (C.GLint)(x))
@@ -8077,6 +12989,9 @@ func VertexAttribI4usv(index uint32, v *uint16) {
 func VertexAttribIFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribIFormat(gpVertexAttribIFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexAttribIFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribIFormatNV(gpVertexAttribIFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func VertexAttribIPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribIPointer(gpVertexAttribIPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
 }
@@ -8086,11 +13001,23 @@ func VertexAttribL1d(index uint32, x float64) {
 func VertexAttribL1dv(index uint32, v *float64) {
 	C.glowVertexAttribL1dv(gpVertexAttribL1dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL1i64NV(index uint32, x int64) {
+	C.glowVertexAttribL1i64NV(gpVertexAttribL1i64NV, (C.GLuint)(index), (C.GLint64EXT)(x))
+}
+func VertexAttribL1i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL1i64vNV(gpVertexAttribL1i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL1ui64ARB(index uint32, x uint64) {
 	C.glowVertexAttribL1ui64ARB(gpVertexAttribL1ui64ARB, (C.GLuint)(index), (C.GLuint64EXT)(x))
 }
+func VertexAttribL1ui64NV(index uint32, x uint64) {
+	C.glowVertexAttribL1ui64NV(gpVertexAttribL1ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x))
+}
 func VertexAttribL1ui64vARB(index uint32, v *uint64) {
 	C.glowVertexAttribL1ui64vARB(gpVertexAttribL1ui64vARB, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL1ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL1ui64vNV(gpVertexAttribL1ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL2d(index uint32, x float64, y float64) {
 	C.glowVertexAttribL2d(gpVertexAttribL2d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y))
@@ -8098,11 +13025,35 @@ func VertexAttribL2d(index uint32, x float64, y float64) {
 func VertexAttribL2dv(index uint32, v *float64) {
 	C.glowVertexAttribL2dv(gpVertexAttribL2dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL2i64NV(index uint32, x int64, y int64) {
+	C.glowVertexAttribL2i64NV(gpVertexAttribL2i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func VertexAttribL2i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL2i64vNV(gpVertexAttribL2i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL2ui64NV(index uint32, x uint64, y uint64) {
+	C.glowVertexAttribL2ui64NV(gpVertexAttribL2ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func VertexAttribL2ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL2ui64vNV(gpVertexAttribL2ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL3d(index uint32, x float64, y float64, z float64) {
 	C.glowVertexAttribL3d(gpVertexAttribL3d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
 }
 func VertexAttribL3dv(index uint32, v *float64) {
 	C.glowVertexAttribL3dv(gpVertexAttribL3dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
+}
+func VertexAttribL3i64NV(index uint32, x int64, y int64, z int64) {
+	C.glowVertexAttribL3i64NV(gpVertexAttribL3i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func VertexAttribL3i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL3i64vNV(gpVertexAttribL3i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL3ui64NV(index uint32, x uint64, y uint64, z uint64) {
+	C.glowVertexAttribL3ui64NV(gpVertexAttribL3ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func VertexAttribL3ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL3ui64vNV(gpVertexAttribL3ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 	C.glowVertexAttribL4d(gpVertexAttribL4d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
@@ -8110,8 +13061,23 @@ func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 func VertexAttribL4dv(index uint32, v *float64) {
 	C.glowVertexAttribL4dv(gpVertexAttribL4dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL4i64NV(index uint32, x int64, y int64, z int64, w int64) {
+	C.glowVertexAttribL4i64NV(gpVertexAttribL4i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func VertexAttribL4i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL4i64vNV(gpVertexAttribL4i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL4ui64NV(index uint32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowVertexAttribL4ui64NV(gpVertexAttribL4ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func VertexAttribL4ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL4ui64vNV(gpVertexAttribL4ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribLFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribLFormat(gpVertexAttribLFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexAttribLFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribLFormatNV(gpVertexAttribLFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 func VertexAttribLPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribLPointer(gpVertexAttribLPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
@@ -8150,6 +13116,9 @@ func VertexAttribPointer(index uint32, size int32, xtype uint32, normalized bool
 func VertexBindingDivisor(bindingindex uint32, divisor uint32) {
 	C.glowVertexBindingDivisor(gpVertexBindingDivisor, (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowVertexFormatNV(gpVertexFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 
 // set the viewport
 func Viewport(x int32, y int32, width int32, height int32) {
@@ -8164,10 +13133,25 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
+	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
+}
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
 }
 
 // Init initializes the OpenGL bindings by loading the function pointers (for
@@ -8197,14 +13181,17 @@ func Init() error {
 // function pointer loading function. For more cases Init should be used
 // instead.
 func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
+	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
 	if gpActiveShaderProgram == nil {
 		return errors.New("glActiveShaderProgram")
 	}
+	gpActiveShaderProgramEXT = (C.GPACTIVESHADERPROGRAMEXT)(getProcAddr("glActiveShaderProgramEXT"))
 	gpActiveTexture = (C.GPACTIVETEXTURE)(getProcAddr("glActiveTexture"))
 	if gpActiveTexture == nil {
 		return errors.New("glActiveTexture")
 	}
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpAttachShader = (C.GPATTACHSHADER)(getProcAddr("glAttachShader"))
 	if gpAttachShader == nil {
 		return errors.New("glAttachShader")
@@ -8213,6 +13200,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBeginConditionalRender == nil {
 		return errors.New("glBeginConditionalRender")
 	}
+	gpBeginConditionalRenderNV = (C.GPBEGINCONDITIONALRENDERNV)(getProcAddr("glBeginConditionalRenderNV"))
+	gpBeginPerfMonitorAMD = (C.GPBEGINPERFMONITORAMD)(getProcAddr("glBeginPerfMonitorAMD"))
+	gpBeginPerfQueryINTEL = (C.GPBEGINPERFQUERYINTEL)(getProcAddr("glBeginPerfQueryINTEL"))
 	gpBeginQuery = (C.GPBEGINQUERY)(getProcAddr("glBeginQuery"))
 	if gpBeginQuery == nil {
 		return errors.New("glBeginQuery")
@@ -8260,10 +13250,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glBindImageTexture")
 	}
 	gpBindImageTextures = (C.GPBINDIMAGETEXTURES)(getProcAddr("glBindImageTextures"))
+	gpBindMultiTextureEXT = (C.GPBINDMULTITEXTUREEXT)(getProcAddr("glBindMultiTextureEXT"))
 	gpBindProgramPipeline = (C.GPBINDPROGRAMPIPELINE)(getProcAddr("glBindProgramPipeline"))
 	if gpBindProgramPipeline == nil {
 		return errors.New("glBindProgramPipeline")
 	}
+	gpBindProgramPipelineEXT = (C.GPBINDPROGRAMPIPELINEEXT)(getProcAddr("glBindProgramPipelineEXT"))
 	gpBindRenderbuffer = (C.GPBINDRENDERBUFFER)(getProcAddr("glBindRenderbuffer"))
 	if gpBindRenderbuffer == nil {
 		return errors.New("glBindRenderbuffer")
@@ -8289,6 +13281,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpBindVertexBuffer = (C.GPBINDVERTEXBUFFER)(getProcAddr("glBindVertexBuffer"))
 	gpBindVertexBuffers = (C.GPBINDVERTEXBUFFERS)(getProcAddr("glBindVertexBuffers"))
+	gpBlendBarrierKHR = (C.GPBLENDBARRIERKHR)(getProcAddr("glBlendBarrierKHR"))
+	gpBlendBarrierNV = (C.GPBLENDBARRIERNV)(getProcAddr("glBlendBarrierNV"))
 	gpBlendColor = (C.GPBLENDCOLOR)(getProcAddr("glBlendColor"))
 	if gpBlendColor == nil {
 		return errors.New("glBlendColor")
@@ -8329,11 +13323,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glBlendFunci")
 	}
 	gpBlendFunciARB = (C.GPBLENDFUNCIARB)(getProcAddr("glBlendFunciARB"))
+	gpBlendParameteriNV = (C.GPBLENDPARAMETERINV)(getProcAddr("glBlendParameteriNV"))
 	gpBlitFramebuffer = (C.GPBLITFRAMEBUFFER)(getProcAddr("glBlitFramebuffer"))
 	if gpBlitFramebuffer == nil {
 		return errors.New("glBlitFramebuffer")
 	}
 	gpBlitNamedFramebuffer = (C.GPBLITNAMEDFRAMEBUFFER)(getProcAddr("glBlitNamedFramebuffer"))
+	gpBufferAddressRangeNV = (C.GPBUFFERADDRESSRANGENV)(getProcAddr("glBufferAddressRangeNV"))
 	gpBufferData = (C.GPBUFFERDATA)(getProcAddr("glBufferData"))
 	if gpBufferData == nil {
 		return errors.New("glBufferData")
@@ -8344,11 +13340,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCheckFramebufferStatus = (C.GPCHECKFRAMEBUFFERSTATUS)(getProcAddr("glCheckFramebufferStatus"))
 	if gpCheckFramebufferStatus == nil {
 		return errors.New("glCheckFramebufferStatus")
 	}
 	gpCheckNamedFramebufferStatus = (C.GPCHECKNAMEDFRAMEBUFFERSTATUS)(getProcAddr("glCheckNamedFramebufferStatus"))
+	gpCheckNamedFramebufferStatusEXT = (C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(getProcAddr("glCheckNamedFramebufferStatusEXT"))
 	gpClampColor = (C.GPCLAMPCOLOR)(getProcAddr("glClampColor"))
 	if gpClampColor == nil {
 		return errors.New("glClampColor")
@@ -8388,7 +13386,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glClearDepthf")
 	}
 	gpClearNamedBufferData = (C.GPCLEARNAMEDBUFFERDATA)(getProcAddr("glClearNamedBufferData"))
+	gpClearNamedBufferDataEXT = (C.GPCLEARNAMEDBUFFERDATAEXT)(getProcAddr("glClearNamedBufferDataEXT"))
 	gpClearNamedBufferSubData = (C.GPCLEARNAMEDBUFFERSUBDATA)(getProcAddr("glClearNamedBufferSubData"))
+	gpClearNamedBufferSubDataEXT = (C.GPCLEARNAMEDBUFFERSUBDATAEXT)(getProcAddr("glClearNamedBufferSubDataEXT"))
 	gpClearNamedFramebufferfi = (C.GPCLEARNAMEDFRAMEBUFFERFI)(getProcAddr("glClearNamedFramebufferfi"))
 	gpClearNamedFramebufferfv = (C.GPCLEARNAMEDFRAMEBUFFERFV)(getProcAddr("glClearNamedFramebufferfv"))
 	gpClearNamedFramebufferiv = (C.GPCLEARNAMEDFRAMEBUFFERIV)(getProcAddr("glClearNamedFramebufferiv"))
@@ -8399,11 +13399,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpClearTexImage = (C.GPCLEARTEXIMAGE)(getProcAddr("glClearTexImage"))
 	gpClearTexSubImage = (C.GPCLEARTEXSUBIMAGE)(getProcAddr("glClearTexSubImage"))
+	gpClientAttribDefaultEXT = (C.GPCLIENTATTRIBDEFAULTEXT)(getProcAddr("glClientAttribDefaultEXT"))
 	gpClientWaitSync = (C.GPCLIENTWAITSYNC)(getProcAddr("glClientWaitSync"))
 	if gpClientWaitSync == nil {
 		return errors.New("glClientWaitSync")
 	}
 	gpClipControl = (C.GPCLIPCONTROL)(getProcAddr("glClipControl"))
+	gpColorFormatNV = (C.GPCOLORFORMATNV)(getProcAddr("glColorFormatNV"))
 	gpColorMask = (C.GPCOLORMASK)(getProcAddr("glColorMask"))
 	if gpColorMask == nil {
 		return errors.New("glColorMask")
@@ -8412,11 +13414,19 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpColorMaski == nil {
 		return errors.New("glColorMaski")
 	}
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
 	}
 	gpCompileShaderIncludeARB = (C.GPCOMPILESHADERINCLUDEARB)(getProcAddr("glCompileShaderIncludeARB"))
+	gpCompressedMultiTexImage1DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE1DEXT)(getProcAddr("glCompressedMultiTexImage1DEXT"))
+	gpCompressedMultiTexImage2DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE2DEXT)(getProcAddr("glCompressedMultiTexImage2DEXT"))
+	gpCompressedMultiTexImage3DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE3DEXT)(getProcAddr("glCompressedMultiTexImage3DEXT"))
+	gpCompressedMultiTexSubImage1DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCompressedMultiTexSubImage1DEXT"))
+	gpCompressedMultiTexSubImage2DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCompressedMultiTexSubImage2DEXT"))
+	gpCompressedMultiTexSubImage3DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCompressedMultiTexSubImage3DEXT"))
 	gpCompressedTexImage1D = (C.GPCOMPRESSEDTEXIMAGE1D)(getProcAddr("glCompressedTexImage1D"))
 	if gpCompressedTexImage1D == nil {
 		return errors.New("glCompressedTexImage1D")
@@ -8441,15 +13451,29 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCompressedTexSubImage3D == nil {
 		return errors.New("glCompressedTexSubImage3D")
 	}
+	gpCompressedTextureImage1DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE1DEXT)(getProcAddr("glCompressedTextureImage1DEXT"))
+	gpCompressedTextureImage2DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE2DEXT)(getProcAddr("glCompressedTextureImage2DEXT"))
+	gpCompressedTextureImage3DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE3DEXT)(getProcAddr("glCompressedTextureImage3DEXT"))
 	gpCompressedTextureSubImage1D = (C.GPCOMPRESSEDTEXTURESUBIMAGE1D)(getProcAddr("glCompressedTextureSubImage1D"))
+	gpCompressedTextureSubImage1DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(getProcAddr("glCompressedTextureSubImage1DEXT"))
 	gpCompressedTextureSubImage2D = (C.GPCOMPRESSEDTEXTURESUBIMAGE2D)(getProcAddr("glCompressedTextureSubImage2D"))
+	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
+	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpCopyBufferSubData = (C.GPCOPYBUFFERSUBDATA)(getProcAddr("glCopyBufferSubData"))
 	if gpCopyBufferSubData == nil {
 		return errors.New("glCopyBufferSubData")
 	}
 	gpCopyImageSubData = (C.GPCOPYIMAGESUBDATA)(getProcAddr("glCopyImageSubData"))
+	gpCopyMultiTexImage1DEXT = (C.GPCOPYMULTITEXIMAGE1DEXT)(getProcAddr("glCopyMultiTexImage1DEXT"))
+	gpCopyMultiTexImage2DEXT = (C.GPCOPYMULTITEXIMAGE2DEXT)(getProcAddr("glCopyMultiTexImage2DEXT"))
+	gpCopyMultiTexSubImage1DEXT = (C.GPCOPYMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCopyMultiTexSubImage1DEXT"))
+	gpCopyMultiTexSubImage2DEXT = (C.GPCOPYMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCopyMultiTexSubImage2DEXT"))
+	gpCopyMultiTexSubImage3DEXT = (C.GPCOPYMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCopyMultiTexSubImage3DEXT"))
 	gpCopyNamedBufferSubData = (C.GPCOPYNAMEDBUFFERSUBDATA)(getProcAddr("glCopyNamedBufferSubData"))
+	gpCopyPathNV = (C.GPCOPYPATHNV)(getProcAddr("glCopyPathNV"))
 	gpCopyTexImage1D = (C.GPCOPYTEXIMAGE1D)(getProcAddr("glCopyTexImage1D"))
 	if gpCopyTexImage1D == nil {
 		return errors.New("glCopyTexImage1D")
@@ -8470,11 +13494,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCopyTexSubImage3D == nil {
 		return errors.New("glCopyTexSubImage3D")
 	}
+	gpCopyTextureImage1DEXT = (C.GPCOPYTEXTUREIMAGE1DEXT)(getProcAddr("glCopyTextureImage1DEXT"))
+	gpCopyTextureImage2DEXT = (C.GPCOPYTEXTUREIMAGE2DEXT)(getProcAddr("glCopyTextureImage2DEXT"))
 	gpCopyTextureSubImage1D = (C.GPCOPYTEXTURESUBIMAGE1D)(getProcAddr("glCopyTextureSubImage1D"))
+	gpCopyTextureSubImage1DEXT = (C.GPCOPYTEXTURESUBIMAGE1DEXT)(getProcAddr("glCopyTextureSubImage1DEXT"))
 	gpCopyTextureSubImage2D = (C.GPCOPYTEXTURESUBIMAGE2D)(getProcAddr("glCopyTextureSubImage2D"))
+	gpCopyTextureSubImage2DEXT = (C.GPCOPYTEXTURESUBIMAGE2DEXT)(getProcAddr("glCopyTextureSubImage2DEXT"))
 	gpCopyTextureSubImage3D = (C.GPCOPYTEXTURESUBIMAGE3D)(getProcAddr("glCopyTextureSubImage3D"))
+	gpCopyTextureSubImage3DEXT = (C.GPCOPYTEXTURESUBIMAGE3DEXT)(getProcAddr("glCopyTextureSubImage3DEXT"))
+	gpCoverFillPathInstancedNV = (C.GPCOVERFILLPATHINSTANCEDNV)(getProcAddr("glCoverFillPathInstancedNV"))
+	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
+	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
+	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
+	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
 		return errors.New("glCreateProgram")
@@ -8487,10 +13524,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCreateShader == nil {
 		return errors.New("glCreateShader")
 	}
+	gpCreateShaderProgramEXT = (C.GPCREATESHADERPROGRAMEXT)(getProcAddr("glCreateShaderProgramEXT"))
 	gpCreateShaderProgramv = (C.GPCREATESHADERPROGRAMV)(getProcAddr("glCreateShaderProgramv"))
 	if gpCreateShaderProgramv == nil {
 		return errors.New("glCreateShaderProgramv")
 	}
+	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	gpCreateTransformFeedbacks = (C.GPCREATETRANSFORMFEEDBACKS)(getProcAddr("glCreateTransformFeedbacks"))
@@ -8512,11 +13552,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteBuffers == nil {
 		return errors.New("glDeleteBuffers")
 	}
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFramebuffers = (C.GPDELETEFRAMEBUFFERS)(getProcAddr("glDeleteFramebuffers"))
 	if gpDeleteFramebuffers == nil {
 		return errors.New("glDeleteFramebuffers")
 	}
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
+	gpDeletePathsNV = (C.GPDELETEPATHSNV)(getProcAddr("glDeletePathsNV"))
+	gpDeletePerfMonitorsAMD = (C.GPDELETEPERFMONITORSAMD)(getProcAddr("glDeletePerfMonitorsAMD"))
+	gpDeletePerfQueryINTEL = (C.GPDELETEPERFQUERYINTEL)(getProcAddr("glDeletePerfQueryINTEL"))
 	gpDeleteProgram = (C.GPDELETEPROGRAM)(getProcAddr("glDeleteProgram"))
 	if gpDeleteProgram == nil {
 		return errors.New("glDeleteProgram")
@@ -8525,6 +13569,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteProgramPipelines == nil {
 		return errors.New("glDeleteProgramPipelines")
 	}
+	gpDeleteProgramPipelinesEXT = (C.GPDELETEPROGRAMPIPELINESEXT)(getProcAddr("glDeleteProgramPipelinesEXT"))
 	gpDeleteQueries = (C.GPDELETEQUERIES)(getProcAddr("glDeleteQueries"))
 	if gpDeleteQueries == nil {
 		return errors.New("glDeleteQueries")
@@ -8541,6 +13586,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	if gpDeleteSync == nil {
 		return errors.New("glDeleteSync")
@@ -8589,7 +13635,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDisable == nil {
 		return errors.New("glDisable")
 	}
+	gpDisableClientStateIndexedEXT = (C.GPDISABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glDisableClientStateIndexedEXT"))
+	gpDisableClientStateiEXT = (C.GPDISABLECLIENTSTATEIEXT)(getProcAddr("glDisableClientStateiEXT"))
+	gpDisableIndexedEXT = (C.GPDISABLEINDEXEDEXT)(getProcAddr("glDisableIndexedEXT"))
 	gpDisableVertexArrayAttrib = (C.GPDISABLEVERTEXARRAYATTRIB)(getProcAddr("glDisableVertexArrayAttrib"))
+	gpDisableVertexArrayAttribEXT = (C.GPDISABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glDisableVertexArrayAttribEXT"))
+	gpDisableVertexArrayEXT = (C.GPDISABLEVERTEXARRAYEXT)(getProcAddr("glDisableVertexArrayEXT"))
 	gpDisableVertexAttribArray = (C.GPDISABLEVERTEXATTRIBARRAY)(getProcAddr("glDisableVertexAttribArray"))
 	if gpDisableVertexAttribArray == nil {
 		return errors.New("glDisableVertexAttribArray")
@@ -8613,10 +13664,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawArraysInstanced == nil {
 		return errors.New("glDrawArraysInstanced")
 	}
+	gpDrawArraysInstancedARB = (C.GPDRAWARRAYSINSTANCEDARB)(getProcAddr("glDrawArraysInstancedARB"))
 	gpDrawArraysInstancedBaseInstance = (C.GPDRAWARRAYSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawArraysInstancedBaseInstance"))
 	if gpDrawArraysInstancedBaseInstance == nil {
 		return errors.New("glDrawArraysInstancedBaseInstance")
 	}
+	gpDrawArraysInstancedEXT = (C.GPDRAWARRAYSINSTANCEDEXT)(getProcAddr("glDrawArraysInstancedEXT"))
 	gpDrawBuffer = (C.GPDRAWBUFFER)(getProcAddr("glDrawBuffer"))
 	if gpDrawBuffer == nil {
 		return errors.New("glDrawBuffer")
@@ -8625,6 +13678,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawBuffers == nil {
 		return errors.New("glDrawBuffers")
 	}
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
 	if gpDrawElements == nil {
 		return errors.New("glDrawElements")
@@ -8641,6 +13698,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawElementsInstanced == nil {
 		return errors.New("glDrawElementsInstanced")
 	}
+	gpDrawElementsInstancedARB = (C.GPDRAWELEMENTSINSTANCEDARB)(getProcAddr("glDrawElementsInstancedARB"))
 	gpDrawElementsInstancedBaseInstance = (C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawElementsInstancedBaseInstance"))
 	if gpDrawElementsInstancedBaseInstance == nil {
 		return errors.New("glDrawElementsInstancedBaseInstance")
@@ -8653,6 +13711,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawElementsInstancedBaseVertexBaseInstance == nil {
 		return errors.New("glDrawElementsInstancedBaseVertexBaseInstance")
 	}
+	gpDrawElementsInstancedEXT = (C.GPDRAWELEMENTSINSTANCEDEXT)(getProcAddr("glDrawElementsInstancedEXT"))
 	gpDrawRangeElements = (C.GPDRAWRANGEELEMENTS)(getProcAddr("glDrawRangeElements"))
 	if gpDrawRangeElements == nil {
 		return errors.New("glDrawRangeElements")
@@ -8677,11 +13736,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawTransformFeedbackStreamInstanced == nil {
 		return errors.New("glDrawTransformFeedbackStreamInstanced")
 	}
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
+	gpEdgeFlagFormatNV = (C.GPEDGEFLAGFORMATNV)(getProcAddr("glEdgeFlagFormatNV"))
 	gpEnable = (C.GPENABLE)(getProcAddr("glEnable"))
 	if gpEnable == nil {
 		return errors.New("glEnable")
 	}
+	gpEnableClientStateIndexedEXT = (C.GPENABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glEnableClientStateIndexedEXT"))
+	gpEnableClientStateiEXT = (C.GPENABLECLIENTSTATEIEXT)(getProcAddr("glEnableClientStateiEXT"))
+	gpEnableIndexedEXT = (C.GPENABLEINDEXEDEXT)(getProcAddr("glEnableIndexedEXT"))
 	gpEnableVertexArrayAttrib = (C.GPENABLEVERTEXARRAYATTRIB)(getProcAddr("glEnableVertexArrayAttrib"))
+	gpEnableVertexArrayAttribEXT = (C.GPENABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glEnableVertexArrayAttribEXT"))
+	gpEnableVertexArrayEXT = (C.GPENABLEVERTEXARRAYEXT)(getProcAddr("glEnableVertexArrayEXT"))
 	gpEnableVertexAttribArray = (C.GPENABLEVERTEXATTRIBARRAY)(getProcAddr("glEnableVertexAttribArray"))
 	if gpEnableVertexAttribArray == nil {
 		return errors.New("glEnableVertexAttribArray")
@@ -8694,6 +13760,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEndConditionalRender == nil {
 		return errors.New("glEndConditionalRender")
 	}
+	gpEndConditionalRenderNV = (C.GPENDCONDITIONALRENDERNV)(getProcAddr("glEndConditionalRenderNV"))
+	gpEndPerfMonitorAMD = (C.GPENDPERFMONITORAMD)(getProcAddr("glEndPerfMonitorAMD"))
+	gpEndPerfQueryINTEL = (C.GPENDPERFQUERYINTEL)(getProcAddr("glEndPerfQueryINTEL"))
 	gpEndQuery = (C.GPENDQUERY)(getProcAddr("glEndQuery"))
 	if gpEndQuery == nil {
 		return errors.New("glEndQuery")
@@ -8706,6 +13775,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEndTransformFeedback == nil {
 		return errors.New("glEndTransformFeedback")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpFenceSync = (C.GPFENCESYNC)(getProcAddr("glFenceSync"))
 	if gpFenceSync == nil {
 		return errors.New("glFenceSync")
@@ -8723,11 +13793,20 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glFlushMappedBufferRange")
 	}
 	gpFlushMappedNamedBufferRange = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGE)(getProcAddr("glFlushMappedNamedBufferRange"))
+	gpFlushMappedNamedBufferRangeEXT = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(getProcAddr("glFlushMappedNamedBufferRangeEXT"))
+	gpFogCoordFormatNV = (C.GPFOGCOORDFORMATNV)(getProcAddr("glFogCoordFormatNV"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
+	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
+	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
+	gpFramebufferReadBufferEXT = (C.GPFRAMEBUFFERREADBUFFEREXT)(getProcAddr("glFramebufferReadBufferEXT"))
 	gpFramebufferRenderbuffer = (C.GPFRAMEBUFFERRENDERBUFFER)(getProcAddr("glFramebufferRenderbuffer"))
 	if gpFramebufferRenderbuffer == nil {
 		return errors.New("glFramebufferRenderbuffer")
 	}
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	if gpFramebufferTexture == nil {
 		return errors.New("glFramebufferTexture")
@@ -8744,10 +13823,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpFramebufferTexture3D == nil {
 		return errors.New("glFramebufferTexture3D")
 	}
+	gpFramebufferTextureARB = (C.GPFRAMEBUFFERTEXTUREARB)(getProcAddr("glFramebufferTextureARB"))
+	gpFramebufferTextureFaceARB = (C.GPFRAMEBUFFERTEXTUREFACEARB)(getProcAddr("glFramebufferTextureFaceARB"))
 	gpFramebufferTextureLayer = (C.GPFRAMEBUFFERTEXTURELAYER)(getProcAddr("glFramebufferTextureLayer"))
 	if gpFramebufferTextureLayer == nil {
 		return errors.New("glFramebufferTextureLayer")
 	}
+	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
 		return errors.New("glFrontFace")
@@ -8760,10 +13843,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenFramebuffers == nil {
 		return errors.New("glGenFramebuffers")
 	}
+	gpGenPathsNV = (C.GPGENPATHSNV)(getProcAddr("glGenPathsNV"))
+	gpGenPerfMonitorsAMD = (C.GPGENPERFMONITORSAMD)(getProcAddr("glGenPerfMonitorsAMD"))
 	gpGenProgramPipelines = (C.GPGENPROGRAMPIPELINES)(getProcAddr("glGenProgramPipelines"))
 	if gpGenProgramPipelines == nil {
 		return errors.New("glGenProgramPipelines")
 	}
+	gpGenProgramPipelinesEXT = (C.GPGENPROGRAMPIPELINESEXT)(getProcAddr("glGenProgramPipelinesEXT"))
 	gpGenQueries = (C.GPGENQUERIES)(getProcAddr("glGenQueries"))
 	if gpGenQueries == nil {
 		return errors.New("glGenQueries")
@@ -8792,7 +13878,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenerateMipmap == nil {
 		return errors.New("glGenerateMipmap")
 	}
+	gpGenerateMultiTexMipmapEXT = (C.GPGENERATEMULTITEXMIPMAPEXT)(getProcAddr("glGenerateMultiTexMipmapEXT"))
 	gpGenerateTextureMipmap = (C.GPGENERATETEXTUREMIPMAP)(getProcAddr("glGenerateTextureMipmap"))
+	gpGenerateTextureMipmapEXT = (C.GPGENERATETEXTUREMIPMAPEXT)(getProcAddr("glGenerateTextureMipmapEXT"))
 	gpGetActiveAtomicCounterBufferiv = (C.GPGETACTIVEATOMICCOUNTERBUFFERIV)(getProcAddr("glGetActiveAtomicCounterBufferiv"))
 	if gpGetActiveAtomicCounterBufferiv == nil {
 		return errors.New("glGetActiveAtomicCounterBufferiv")
@@ -8841,6 +13929,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetAttribLocation == nil {
 		return errors.New("glGetAttribLocation")
 	}
+	gpGetBooleanIndexedvEXT = (C.GPGETBOOLEANINDEXEDVEXT)(getProcAddr("glGetBooleanIndexedvEXT"))
 	gpGetBooleani_v = (C.GPGETBOOLEANI_V)(getProcAddr("glGetBooleani_v"))
 	if gpGetBooleani_v == nil {
 		return errors.New("glGetBooleani_v")
@@ -8857,6 +13946,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetBufferParameteriv == nil {
 		return errors.New("glGetBufferParameteriv")
 	}
+	gpGetBufferParameterui64vNV = (C.GPGETBUFFERPARAMETERUI64VNV)(getProcAddr("glGetBufferParameterui64vNV"))
 	gpGetBufferPointerv = (C.GPGETBUFFERPOINTERV)(getProcAddr("glGetBufferPointerv"))
 	if gpGetBufferPointerv == nil {
 		return errors.New("glGetBufferPointerv")
@@ -8865,19 +13955,25 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetBufferSubData == nil {
 		return errors.New("glGetBufferSubData")
 	}
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
+	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
 		return errors.New("glGetCompressedTexImage")
 	}
 	gpGetCompressedTextureImage = (C.GPGETCOMPRESSEDTEXTUREIMAGE)(getProcAddr("glGetCompressedTextureImage"))
+	gpGetCompressedTextureImageEXT = (C.GPGETCOMPRESSEDTEXTUREIMAGEEXT)(getProcAddr("glGetCompressedTextureImageEXT"))
 	gpGetCompressedTextureSubImage = (C.GPGETCOMPRESSEDTEXTURESUBIMAGE)(getProcAddr("glGetCompressedTextureSubImage"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	gpGetDebugMessageLogARB = (C.GPGETDEBUGMESSAGELOGARB)(getProcAddr("glGetDebugMessageLogARB"))
 	gpGetDebugMessageLogKHR = (C.GPGETDEBUGMESSAGELOGKHR)(getProcAddr("glGetDebugMessageLogKHR"))
+	gpGetDoubleIndexedvEXT = (C.GPGETDOUBLEINDEXEDVEXT)(getProcAddr("glGetDoubleIndexedvEXT"))
 	gpGetDoublei_v = (C.GPGETDOUBLEI_V)(getProcAddr("glGetDoublei_v"))
 	if gpGetDoublei_v == nil {
 		return errors.New("glGetDoublei_v")
 	}
+	gpGetDoublei_vEXT = (C.GPGETDOUBLEI_VEXT)(getProcAddr("glGetDoublei_vEXT"))
 	gpGetDoublev = (C.GPGETDOUBLEV)(getProcAddr("glGetDoublev"))
 	if gpGetDoublev == nil {
 		return errors.New("glGetDoublev")
@@ -8886,10 +13982,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetError == nil {
 		return errors.New("glGetError")
 	}
+	gpGetFirstPerfQueryIdINTEL = (C.GPGETFIRSTPERFQUERYIDINTEL)(getProcAddr("glGetFirstPerfQueryIdINTEL"))
+	gpGetFloatIndexedvEXT = (C.GPGETFLOATINDEXEDVEXT)(getProcAddr("glGetFloatIndexedvEXT"))
 	gpGetFloati_v = (C.GPGETFLOATI_V)(getProcAddr("glGetFloati_v"))
 	if gpGetFloati_v == nil {
 		return errors.New("glGetFloati_v")
 	}
+	gpGetFloati_vEXT = (C.GPGETFLOATI_VEXT)(getProcAddr("glGetFloati_vEXT"))
 	gpGetFloatv = (C.GPGETFLOATV)(getProcAddr("glGetFloatv"))
 	if gpGetFloatv == nil {
 		return errors.New("glGetFloatv")
@@ -8907,10 +14006,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetFramebufferAttachmentParameteriv")
 	}
 	gpGetFramebufferParameteriv = (C.GPGETFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetFramebufferParameteriv"))
+	gpGetFramebufferParameterivEXT = (C.GPGETFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetFramebufferParameterivEXT"))
 	gpGetGraphicsResetStatus = (C.GPGETGRAPHICSRESETSTATUS)(getProcAddr("glGetGraphicsResetStatus"))
 	gpGetGraphicsResetStatusARB = (C.GPGETGRAPHICSRESETSTATUSARB)(getProcAddr("glGetGraphicsResetStatusARB"))
 	gpGetGraphicsResetStatusKHR = (C.GPGETGRAPHICSRESETSTATUSKHR)(getProcAddr("glGetGraphicsResetStatusKHR"))
 	gpGetImageHandleARB = (C.GPGETIMAGEHANDLEARB)(getProcAddr("glGetImageHandleARB"))
+	gpGetImageHandleNV = (C.GPGETIMAGEHANDLENV)(getProcAddr("glGetImageHandleNV"))
 	gpGetInteger64i_v = (C.GPGETINTEGER64I_V)(getProcAddr("glGetInteger64i_v"))
 	if gpGetInteger64i_v == nil {
 		return errors.New("glGetInteger64i_v")
@@ -8919,36 +14020,88 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetInteger64v == nil {
 		return errors.New("glGetInteger64v")
 	}
+	gpGetIntegerIndexedvEXT = (C.GPGETINTEGERINDEXEDVEXT)(getProcAddr("glGetIntegerIndexedvEXT"))
 	gpGetIntegeri_v = (C.GPGETINTEGERI_V)(getProcAddr("glGetIntegeri_v"))
 	if gpGetIntegeri_v == nil {
 		return errors.New("glGetIntegeri_v")
 	}
+	gpGetIntegerui64i_vNV = (C.GPGETINTEGERUI64I_VNV)(getProcAddr("glGetIntegerui64i_vNV"))
+	gpGetIntegerui64vNV = (C.GPGETINTEGERUI64VNV)(getProcAddr("glGetIntegerui64vNV"))
 	gpGetIntegerv = (C.GPGETINTEGERV)(getProcAddr("glGetIntegerv"))
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	gpGetInternalformativ = (C.GPGETINTERNALFORMATIV)(getProcAddr("glGetInternalformativ"))
 	if gpGetInternalformativ == nil {
 		return errors.New("glGetInternalformativ")
 	}
+	gpGetMultiTexEnvfvEXT = (C.GPGETMULTITEXENVFVEXT)(getProcAddr("glGetMultiTexEnvfvEXT"))
+	gpGetMultiTexEnvivEXT = (C.GPGETMULTITEXENVIVEXT)(getProcAddr("glGetMultiTexEnvivEXT"))
+	gpGetMultiTexGendvEXT = (C.GPGETMULTITEXGENDVEXT)(getProcAddr("glGetMultiTexGendvEXT"))
+	gpGetMultiTexGenfvEXT = (C.GPGETMULTITEXGENFVEXT)(getProcAddr("glGetMultiTexGenfvEXT"))
+	gpGetMultiTexGenivEXT = (C.GPGETMULTITEXGENIVEXT)(getProcAddr("glGetMultiTexGenivEXT"))
+	gpGetMultiTexImageEXT = (C.GPGETMULTITEXIMAGEEXT)(getProcAddr("glGetMultiTexImageEXT"))
+	gpGetMultiTexLevelParameterfvEXT = (C.GPGETMULTITEXLEVELPARAMETERFVEXT)(getProcAddr("glGetMultiTexLevelParameterfvEXT"))
+	gpGetMultiTexLevelParameterivEXT = (C.GPGETMULTITEXLEVELPARAMETERIVEXT)(getProcAddr("glGetMultiTexLevelParameterivEXT"))
+	gpGetMultiTexParameterIivEXT = (C.GPGETMULTITEXPARAMETERIIVEXT)(getProcAddr("glGetMultiTexParameterIivEXT"))
+	gpGetMultiTexParameterIuivEXT = (C.GPGETMULTITEXPARAMETERIUIVEXT)(getProcAddr("glGetMultiTexParameterIuivEXT"))
+	gpGetMultiTexParameterfvEXT = (C.GPGETMULTITEXPARAMETERFVEXT)(getProcAddr("glGetMultiTexParameterfvEXT"))
+	gpGetMultiTexParameterivEXT = (C.GPGETMULTITEXPARAMETERIVEXT)(getProcAddr("glGetMultiTexParameterivEXT"))
 	gpGetMultisamplefv = (C.GPGETMULTISAMPLEFV)(getProcAddr("glGetMultisamplefv"))
 	if gpGetMultisamplefv == nil {
 		return errors.New("glGetMultisamplefv")
 	}
 	gpGetNamedBufferParameteri64v = (C.GPGETNAMEDBUFFERPARAMETERI64V)(getProcAddr("glGetNamedBufferParameteri64v"))
 	gpGetNamedBufferParameteriv = (C.GPGETNAMEDBUFFERPARAMETERIV)(getProcAddr("glGetNamedBufferParameteriv"))
+	gpGetNamedBufferParameterivEXT = (C.GPGETNAMEDBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedBufferParameterivEXT"))
+	gpGetNamedBufferParameterui64vNV = (C.GPGETNAMEDBUFFERPARAMETERUI64VNV)(getProcAddr("glGetNamedBufferParameterui64vNV"))
 	gpGetNamedBufferPointerv = (C.GPGETNAMEDBUFFERPOINTERV)(getProcAddr("glGetNamedBufferPointerv"))
+	gpGetNamedBufferPointervEXT = (C.GPGETNAMEDBUFFERPOINTERVEXT)(getProcAddr("glGetNamedBufferPointervEXT"))
 	gpGetNamedBufferSubData = (C.GPGETNAMEDBUFFERSUBDATA)(getProcAddr("glGetNamedBufferSubData"))
+	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
+	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
+	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
+	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
+	gpGetNamedProgramLocalParameterIuivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIuivEXT"))
+	gpGetNamedProgramLocalParameterdvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(getProcAddr("glGetNamedProgramLocalParameterdvEXT"))
+	gpGetNamedProgramLocalParameterfvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(getProcAddr("glGetNamedProgramLocalParameterfvEXT"))
+	gpGetNamedProgramStringEXT = (C.GPGETNAMEDPROGRAMSTRINGEXT)(getProcAddr("glGetNamedProgramStringEXT"))
+	gpGetNamedProgramivEXT = (C.GPGETNAMEDPROGRAMIVEXT)(getProcAddr("glGetNamedProgramivEXT"))
 	gpGetNamedRenderbufferParameteriv = (C.GPGETNAMEDRENDERBUFFERPARAMETERIV)(getProcAddr("glGetNamedRenderbufferParameteriv"))
+	gpGetNamedRenderbufferParameterivEXT = (C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedRenderbufferParameterivEXT"))
 	gpGetNamedStringARB = (C.GPGETNAMEDSTRINGARB)(getProcAddr("glGetNamedStringARB"))
 	gpGetNamedStringivARB = (C.GPGETNAMEDSTRINGIVARB)(getProcAddr("glGetNamedStringivARB"))
+	gpGetNextPerfQueryIdINTEL = (C.GPGETNEXTPERFQUERYIDINTEL)(getProcAddr("glGetNextPerfQueryIdINTEL"))
 	gpGetObjectLabel = (C.GPGETOBJECTLABEL)(getProcAddr("glGetObjectLabel"))
+	gpGetObjectLabelEXT = (C.GPGETOBJECTLABELEXT)(getProcAddr("glGetObjectLabelEXT"))
 	gpGetObjectLabelKHR = (C.GPGETOBJECTLABELKHR)(getProcAddr("glGetObjectLabelKHR"))
 	gpGetObjectPtrLabel = (C.GPGETOBJECTPTRLABEL)(getProcAddr("glGetObjectPtrLabel"))
 	gpGetObjectPtrLabelKHR = (C.GPGETOBJECTPTRLABELKHR)(getProcAddr("glGetObjectPtrLabelKHR"))
+	gpGetPathCommandsNV = (C.GPGETPATHCOMMANDSNV)(getProcAddr("glGetPathCommandsNV"))
+	gpGetPathCoordsNV = (C.GPGETPATHCOORDSNV)(getProcAddr("glGetPathCoordsNV"))
+	gpGetPathDashArrayNV = (C.GPGETPATHDASHARRAYNV)(getProcAddr("glGetPathDashArrayNV"))
+	gpGetPathLengthNV = (C.GPGETPATHLENGTHNV)(getProcAddr("glGetPathLengthNV"))
+	gpGetPathMetricRangeNV = (C.GPGETPATHMETRICRANGENV)(getProcAddr("glGetPathMetricRangeNV"))
+	gpGetPathMetricsNV = (C.GPGETPATHMETRICSNV)(getProcAddr("glGetPathMetricsNV"))
+	gpGetPathParameterfvNV = (C.GPGETPATHPARAMETERFVNV)(getProcAddr("glGetPathParameterfvNV"))
+	gpGetPathParameterivNV = (C.GPGETPATHPARAMETERIVNV)(getProcAddr("glGetPathParameterivNV"))
+	gpGetPathSpacingNV = (C.GPGETPATHSPACINGNV)(getProcAddr("glGetPathSpacingNV"))
+	gpGetPerfCounterInfoINTEL = (C.GPGETPERFCOUNTERINFOINTEL)(getProcAddr("glGetPerfCounterInfoINTEL"))
+	gpGetPerfMonitorCounterDataAMD = (C.GPGETPERFMONITORCOUNTERDATAAMD)(getProcAddr("glGetPerfMonitorCounterDataAMD"))
+	gpGetPerfMonitorCounterInfoAMD = (C.GPGETPERFMONITORCOUNTERINFOAMD)(getProcAddr("glGetPerfMonitorCounterInfoAMD"))
+	gpGetPerfMonitorCounterStringAMD = (C.GPGETPERFMONITORCOUNTERSTRINGAMD)(getProcAddr("glGetPerfMonitorCounterStringAMD"))
+	gpGetPerfMonitorCountersAMD = (C.GPGETPERFMONITORCOUNTERSAMD)(getProcAddr("glGetPerfMonitorCountersAMD"))
+	gpGetPerfMonitorGroupStringAMD = (C.GPGETPERFMONITORGROUPSTRINGAMD)(getProcAddr("glGetPerfMonitorGroupStringAMD"))
+	gpGetPerfMonitorGroupsAMD = (C.GPGETPERFMONITORGROUPSAMD)(getProcAddr("glGetPerfMonitorGroupsAMD"))
+	gpGetPerfQueryDataINTEL = (C.GPGETPERFQUERYDATAINTEL)(getProcAddr("glGetPerfQueryDataINTEL"))
+	gpGetPerfQueryIdByNameINTEL = (C.GPGETPERFQUERYIDBYNAMEINTEL)(getProcAddr("glGetPerfQueryIdByNameINTEL"))
+	gpGetPerfQueryInfoINTEL = (C.GPGETPERFQUERYINFOINTEL)(getProcAddr("glGetPerfQueryInfoINTEL"))
+	gpGetPointerIndexedvEXT = (C.GPGETPOINTERINDEXEDVEXT)(getProcAddr("glGetPointerIndexedvEXT"))
+	gpGetPointeri_vEXT = (C.GPGETPOINTERI_VEXT)(getProcAddr("glGetPointeri_vEXT"))
 	gpGetPointerv = (C.GPGETPOINTERV)(getProcAddr("glGetPointerv"))
 	gpGetPointervKHR = (C.GPGETPOINTERVKHR)(getProcAddr("glGetPointervKHR"))
 	gpGetProgramBinary = (C.GPGETPROGRAMBINARY)(getProcAddr("glGetProgramBinary"))
@@ -8964,14 +14117,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetProgramPipelineInfoLog == nil {
 		return errors.New("glGetProgramPipelineInfoLog")
 	}
+	gpGetProgramPipelineInfoLogEXT = (C.GPGETPROGRAMPIPELINEINFOLOGEXT)(getProcAddr("glGetProgramPipelineInfoLogEXT"))
 	gpGetProgramPipelineiv = (C.GPGETPROGRAMPIPELINEIV)(getProcAddr("glGetProgramPipelineiv"))
 	if gpGetProgramPipelineiv == nil {
 		return errors.New("glGetProgramPipelineiv")
 	}
+	gpGetProgramPipelineivEXT = (C.GPGETPROGRAMPIPELINEIVEXT)(getProcAddr("glGetProgramPipelineivEXT"))
 	gpGetProgramResourceIndex = (C.GPGETPROGRAMRESOURCEINDEX)(getProcAddr("glGetProgramResourceIndex"))
 	gpGetProgramResourceLocation = (C.GPGETPROGRAMRESOURCELOCATION)(getProcAddr("glGetProgramResourceLocation"))
 	gpGetProgramResourceLocationIndex = (C.GPGETPROGRAMRESOURCELOCATIONINDEX)(getProcAddr("glGetProgramResourceLocationIndex"))
 	gpGetProgramResourceName = (C.GPGETPROGRAMRESOURCENAME)(getProcAddr("glGetProgramResourceName"))
+	gpGetProgramResourcefvNV = (C.GPGETPROGRAMRESOURCEFVNV)(getProcAddr("glGetProgramResourcefvNV"))
 	gpGetProgramResourceiv = (C.GPGETPROGRAMRESOURCEIV)(getProcAddr("glGetProgramResourceiv"))
 	gpGetProgramStageiv = (C.GPGETPROGRAMSTAGEIV)(getProcAddr("glGetProgramStageiv"))
 	if gpGetProgramStageiv == nil {
@@ -8981,6 +14137,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetProgramiv == nil {
 		return errors.New("glGetProgramiv")
 	}
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	if gpGetQueryIndexediv == nil {
 		return errors.New("glGetQueryIndexediv")
@@ -9041,6 +14201,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetShaderiv == nil {
 		return errors.New("glGetShaderiv")
 	}
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -9090,14 +14251,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetTexParameteriv")
 	}
 	gpGetTextureHandleARB = (C.GPGETTEXTUREHANDLEARB)(getProcAddr("glGetTextureHandleARB"))
+	gpGetTextureHandleNV = (C.GPGETTEXTUREHANDLENV)(getProcAddr("glGetTextureHandleNV"))
 	gpGetTextureImage = (C.GPGETTEXTUREIMAGE)(getProcAddr("glGetTextureImage"))
+	gpGetTextureImageEXT = (C.GPGETTEXTUREIMAGEEXT)(getProcAddr("glGetTextureImageEXT"))
 	gpGetTextureLevelParameterfv = (C.GPGETTEXTURELEVELPARAMETERFV)(getProcAddr("glGetTextureLevelParameterfv"))
+	gpGetTextureLevelParameterfvEXT = (C.GPGETTEXTURELEVELPARAMETERFVEXT)(getProcAddr("glGetTextureLevelParameterfvEXT"))
 	gpGetTextureLevelParameteriv = (C.GPGETTEXTURELEVELPARAMETERIV)(getProcAddr("glGetTextureLevelParameteriv"))
+	gpGetTextureLevelParameterivEXT = (C.GPGETTEXTURELEVELPARAMETERIVEXT)(getProcAddr("glGetTextureLevelParameterivEXT"))
 	gpGetTextureParameterIiv = (C.GPGETTEXTUREPARAMETERIIV)(getProcAddr("glGetTextureParameterIiv"))
+	gpGetTextureParameterIivEXT = (C.GPGETTEXTUREPARAMETERIIVEXT)(getProcAddr("glGetTextureParameterIivEXT"))
 	gpGetTextureParameterIuiv = (C.GPGETTEXTUREPARAMETERIUIV)(getProcAddr("glGetTextureParameterIuiv"))
+	gpGetTextureParameterIuivEXT = (C.GPGETTEXTUREPARAMETERIUIVEXT)(getProcAddr("glGetTextureParameterIuivEXT"))
 	gpGetTextureParameterfv = (C.GPGETTEXTUREPARAMETERFV)(getProcAddr("glGetTextureParameterfv"))
+	gpGetTextureParameterfvEXT = (C.GPGETTEXTUREPARAMETERFVEXT)(getProcAddr("glGetTextureParameterfvEXT"))
 	gpGetTextureParameteriv = (C.GPGETTEXTUREPARAMETERIV)(getProcAddr("glGetTextureParameteriv"))
+	gpGetTextureParameterivEXT = (C.GPGETTEXTUREPARAMETERIVEXT)(getProcAddr("glGetTextureParameterivEXT"))
 	gpGetTextureSamplerHandleARB = (C.GPGETTEXTURESAMPLERHANDLEARB)(getProcAddr("glGetTextureSamplerHandleARB"))
+	gpGetTextureSamplerHandleNV = (C.GPGETTEXTURESAMPLERHANDLENV)(getProcAddr("glGetTextureSamplerHandleNV"))
 	gpGetTextureSubImage = (C.GPGETTEXTURESUBIMAGE)(getProcAddr("glGetTextureSubImage"))
 	gpGetTransformFeedbackVarying = (C.GPGETTRANSFORMFEEDBACKVARYING)(getProcAddr("glGetTransformFeedbackVarying"))
 	if gpGetTransformFeedbackVarying == nil {
@@ -9130,16 +14300,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetUniformfv == nil {
 		return errors.New("glGetUniformfv")
 	}
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
+	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
+	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
 	}
 	gpGetVertexArrayIndexed64iv = (C.GPGETVERTEXARRAYINDEXED64IV)(getProcAddr("glGetVertexArrayIndexed64iv"))
 	gpGetVertexArrayIndexediv = (C.GPGETVERTEXARRAYINDEXEDIV)(getProcAddr("glGetVertexArrayIndexediv"))
+	gpGetVertexArrayIntegeri_vEXT = (C.GPGETVERTEXARRAYINTEGERI_VEXT)(getProcAddr("glGetVertexArrayIntegeri_vEXT"))
+	gpGetVertexArrayIntegervEXT = (C.GPGETVERTEXARRAYINTEGERVEXT)(getProcAddr("glGetVertexArrayIntegervEXT"))
+	gpGetVertexArrayPointeri_vEXT = (C.GPGETVERTEXARRAYPOINTERI_VEXT)(getProcAddr("glGetVertexArrayPointeri_vEXT"))
+	gpGetVertexArrayPointervEXT = (C.GPGETVERTEXARRAYPOINTERVEXT)(getProcAddr("glGetVertexArrayPointervEXT"))
 	gpGetVertexArrayiv = (C.GPGETVERTEXARRAYIV)(getProcAddr("glGetVertexArrayiv"))
 	gpGetVertexAttribIiv = (C.GPGETVERTEXATTRIBIIV)(getProcAddr("glGetVertexAttribIiv"))
 	if gpGetVertexAttribIiv == nil {
@@ -9153,7 +14331,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetVertexAttribLdv == nil {
 		return errors.New("glGetVertexAttribLdv")
 	}
+	gpGetVertexAttribLi64vNV = (C.GPGETVERTEXATTRIBLI64VNV)(getProcAddr("glGetVertexAttribLi64vNV"))
 	gpGetVertexAttribLui64vARB = (C.GPGETVERTEXATTRIBLUI64VARB)(getProcAddr("glGetVertexAttribLui64vARB"))
+	gpGetVertexAttribLui64vNV = (C.GPGETVERTEXATTRIBLUI64VNV)(getProcAddr("glGetVertexAttribLui64vNV"))
 	gpGetVertexAttribPointerv = (C.GPGETVERTEXATTRIBPOINTERV)(getProcAddr("glGetVertexAttribPointerv"))
 	if gpGetVertexAttribPointerv == nil {
 		return errors.New("glGetVertexAttribPointerv")
@@ -9170,15 +14350,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetVertexAttribiv == nil {
 		return errors.New("glGetVertexAttribiv")
 	}
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnCompressedTexImageARB = (C.GPGETNCOMPRESSEDTEXIMAGEARB)(getProcAddr("glGetnCompressedTexImageARB"))
 	gpGetnTexImageARB = (C.GPGETNTEXIMAGEARB)(getProcAddr("glGetnTexImageARB"))
 	gpGetnUniformdvARB = (C.GPGETNUNIFORMDVARB)(getProcAddr("glGetnUniformdvARB"))
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	gpGetnUniformuivARB = (C.GPGETNUNIFORMUIVARB)(getProcAddr("glGetnUniformuivARB"))
 	gpGetnUniformuivKHR = (C.GPGETNUNIFORMUIVKHR)(getProcAddr("glGetnUniformuivKHR"))
@@ -9186,6 +14369,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpHint == nil {
 		return errors.New("glHint")
 	}
+	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
+	gpInsertEventMarkerEXT = (C.GPINSERTEVENTMARKEREXT)(getProcAddr("glInsertEventMarkerEXT"))
+	gpInterpolatePathsNV = (C.GPINTERPOLATEPATHSNV)(getProcAddr("glInterpolatePathsNV"))
 	gpInvalidateBufferData = (C.GPINVALIDATEBUFFERDATA)(getProcAddr("glInvalidateBufferData"))
 	gpInvalidateBufferSubData = (C.GPINVALIDATEBUFFERSUBDATA)(getProcAddr("glInvalidateBufferSubData"))
 	gpInvalidateFramebuffer = (C.GPINVALIDATEFRAMEBUFFER)(getProcAddr("glInvalidateFramebuffer"))
@@ -9198,10 +14384,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsBuffer == nil {
 		return errors.New("glIsBuffer")
 	}
+	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
 	}
+	gpIsEnabledIndexedEXT = (C.GPISENABLEDINDEXEDEXT)(getProcAddr("glIsEnabledIndexedEXT"))
 	gpIsEnabledi = (C.GPISENABLEDI)(getProcAddr("glIsEnabledi"))
 	if gpIsEnabledi == nil {
 		return errors.New("glIsEnabledi")
@@ -9211,7 +14400,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsFramebuffer")
 	}
 	gpIsImageHandleResidentARB = (C.GPISIMAGEHANDLERESIDENTARB)(getProcAddr("glIsImageHandleResidentARB"))
+	gpIsImageHandleResidentNV = (C.GPISIMAGEHANDLERESIDENTNV)(getProcAddr("glIsImageHandleResidentNV"))
+	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
+	gpIsPathNV = (C.GPISPATHNV)(getProcAddr("glIsPathNV"))
+	gpIsPointInFillPathNV = (C.GPISPOINTINFILLPATHNV)(getProcAddr("glIsPointInFillPathNV"))
+	gpIsPointInStrokePathNV = (C.GPISPOINTINSTROKEPATHNV)(getProcAddr("glIsPointInStrokePathNV"))
 	gpIsProgram = (C.GPISPROGRAM)(getProcAddr("glIsProgram"))
 	if gpIsProgram == nil {
 		return errors.New("glIsProgram")
@@ -9220,6 +14414,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsProgramPipeline == nil {
 		return errors.New("glIsProgramPipeline")
 	}
+	gpIsProgramPipelineEXT = (C.GPISPROGRAMPIPELINEEXT)(getProcAddr("glIsProgramPipelineEXT"))
 	gpIsQuery = (C.GPISQUERY)(getProcAddr("glIsQuery"))
 	if gpIsQuery == nil {
 		return errors.New("glIsQuery")
@@ -9236,6 +14431,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	if gpIsSync == nil {
 		return errors.New("glIsSync")
@@ -9245,6 +14441,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsTexture")
 	}
 	gpIsTextureHandleResidentARB = (C.GPISTEXTUREHANDLERESIDENTARB)(getProcAddr("glIsTextureHandleResidentARB"))
+	gpIsTextureHandleResidentNV = (C.GPISTEXTUREHANDLERESIDENTNV)(getProcAddr("glIsTextureHandleResidentNV"))
 	gpIsTransformFeedback = (C.GPISTRANSFORMFEEDBACK)(getProcAddr("glIsTransformFeedback"))
 	if gpIsTransformFeedback == nil {
 		return errors.New("glIsTransformFeedback")
@@ -9253,6 +14450,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsVertexArray == nil {
 		return errors.New("glIsVertexArray")
 	}
+	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLineWidth = (C.GPLINEWIDTH)(getProcAddr("glLineWidth"))
 	if gpLineWidth == nil {
 		return errors.New("glLineWidth")
@@ -9261,14 +14459,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpLinkProgram == nil {
 		return errors.New("glLinkProgram")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpLogicOp = (C.GPLOGICOP)(getProcAddr("glLogicOp"))
 	if gpLogicOp == nil {
 		return errors.New("glLogicOp")
 	}
+	gpMakeBufferNonResidentNV = (C.GPMAKEBUFFERNONRESIDENTNV)(getProcAddr("glMakeBufferNonResidentNV"))
+	gpMakeBufferResidentNV = (C.GPMAKEBUFFERRESIDENTNV)(getProcAddr("glMakeBufferResidentNV"))
 	gpMakeImageHandleNonResidentARB = (C.GPMAKEIMAGEHANDLENONRESIDENTARB)(getProcAddr("glMakeImageHandleNonResidentARB"))
+	gpMakeImageHandleNonResidentNV = (C.GPMAKEIMAGEHANDLENONRESIDENTNV)(getProcAddr("glMakeImageHandleNonResidentNV"))
 	gpMakeImageHandleResidentARB = (C.GPMAKEIMAGEHANDLERESIDENTARB)(getProcAddr("glMakeImageHandleResidentARB"))
+	gpMakeImageHandleResidentNV = (C.GPMAKEIMAGEHANDLERESIDENTNV)(getProcAddr("glMakeImageHandleResidentNV"))
+	gpMakeNamedBufferNonResidentNV = (C.GPMAKENAMEDBUFFERNONRESIDENTNV)(getProcAddr("glMakeNamedBufferNonResidentNV"))
+	gpMakeNamedBufferResidentNV = (C.GPMAKENAMEDBUFFERRESIDENTNV)(getProcAddr("glMakeNamedBufferResidentNV"))
 	gpMakeTextureHandleNonResidentARB = (C.GPMAKETEXTUREHANDLENONRESIDENTARB)(getProcAddr("glMakeTextureHandleNonResidentARB"))
+	gpMakeTextureHandleNonResidentNV = (C.GPMAKETEXTUREHANDLENONRESIDENTNV)(getProcAddr("glMakeTextureHandleNonResidentNV"))
 	gpMakeTextureHandleResidentARB = (C.GPMAKETEXTUREHANDLERESIDENTARB)(getProcAddr("glMakeTextureHandleResidentARB"))
+	gpMakeTextureHandleResidentNV = (C.GPMAKETEXTUREHANDLERESIDENTNV)(getProcAddr("glMakeTextureHandleResidentNV"))
 	gpMapBuffer = (C.GPMAPBUFFER)(getProcAddr("glMapBuffer"))
 	if gpMapBuffer == nil {
 		return errors.New("glMapBuffer")
@@ -9278,7 +14485,36 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMapBufferRange")
 	}
 	gpMapNamedBuffer = (C.GPMAPNAMEDBUFFER)(getProcAddr("glMapNamedBuffer"))
+	gpMapNamedBufferEXT = (C.GPMAPNAMEDBUFFEREXT)(getProcAddr("glMapNamedBufferEXT"))
 	gpMapNamedBufferRange = (C.GPMAPNAMEDBUFFERRANGE)(getProcAddr("glMapNamedBufferRange"))
+	gpMapNamedBufferRangeEXT = (C.GPMAPNAMEDBUFFERRANGEEXT)(getProcAddr("glMapNamedBufferRangeEXT"))
+	gpMatrixFrustumEXT = (C.GPMATRIXFRUSTUMEXT)(getProcAddr("glMatrixFrustumEXT"))
+	gpMatrixLoad3x2fNV = (C.GPMATRIXLOAD3X2FNV)(getProcAddr("glMatrixLoad3x2fNV"))
+	gpMatrixLoad3x3fNV = (C.GPMATRIXLOAD3X3FNV)(getProcAddr("glMatrixLoad3x3fNV"))
+	gpMatrixLoadIdentityEXT = (C.GPMATRIXLOADIDENTITYEXT)(getProcAddr("glMatrixLoadIdentityEXT"))
+	gpMatrixLoadTranspose3x3fNV = (C.GPMATRIXLOADTRANSPOSE3X3FNV)(getProcAddr("glMatrixLoadTranspose3x3fNV"))
+	gpMatrixLoadTransposedEXT = (C.GPMATRIXLOADTRANSPOSEDEXT)(getProcAddr("glMatrixLoadTransposedEXT"))
+	gpMatrixLoadTransposefEXT = (C.GPMATRIXLOADTRANSPOSEFEXT)(getProcAddr("glMatrixLoadTransposefEXT"))
+	gpMatrixLoaddEXT = (C.GPMATRIXLOADDEXT)(getProcAddr("glMatrixLoaddEXT"))
+	gpMatrixLoadfEXT = (C.GPMATRIXLOADFEXT)(getProcAddr("glMatrixLoadfEXT"))
+	gpMatrixMult3x2fNV = (C.GPMATRIXMULT3X2FNV)(getProcAddr("glMatrixMult3x2fNV"))
+	gpMatrixMult3x3fNV = (C.GPMATRIXMULT3X3FNV)(getProcAddr("glMatrixMult3x3fNV"))
+	gpMatrixMultTranspose3x3fNV = (C.GPMATRIXMULTTRANSPOSE3X3FNV)(getProcAddr("glMatrixMultTranspose3x3fNV"))
+	gpMatrixMultTransposedEXT = (C.GPMATRIXMULTTRANSPOSEDEXT)(getProcAddr("glMatrixMultTransposedEXT"))
+	gpMatrixMultTransposefEXT = (C.GPMATRIXMULTTRANSPOSEFEXT)(getProcAddr("glMatrixMultTransposefEXT"))
+	gpMatrixMultdEXT = (C.GPMATRIXMULTDEXT)(getProcAddr("glMatrixMultdEXT"))
+	gpMatrixMultfEXT = (C.GPMATRIXMULTFEXT)(getProcAddr("glMatrixMultfEXT"))
+	gpMatrixOrthoEXT = (C.GPMATRIXORTHOEXT)(getProcAddr("glMatrixOrthoEXT"))
+	gpMatrixPopEXT = (C.GPMATRIXPOPEXT)(getProcAddr("glMatrixPopEXT"))
+	gpMatrixPushEXT = (C.GPMATRIXPUSHEXT)(getProcAddr("glMatrixPushEXT"))
+	gpMatrixRotatedEXT = (C.GPMATRIXROTATEDEXT)(getProcAddr("glMatrixRotatedEXT"))
+	gpMatrixRotatefEXT = (C.GPMATRIXROTATEFEXT)(getProcAddr("glMatrixRotatefEXT"))
+	gpMatrixScaledEXT = (C.GPMATRIXSCALEDEXT)(getProcAddr("glMatrixScaledEXT"))
+	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
+	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
+	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	if gpMemoryBarrier == nil {
 		return errors.New("glMemoryBarrier")
@@ -9294,6 +14530,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMultiDrawArrays")
 	}
 	gpMultiDrawArraysIndirect = (C.GPMULTIDRAWARRAYSINDIRECT)(getProcAddr("glMultiDrawArraysIndirect"))
+	gpMultiDrawArraysIndirectBindlessCountNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawArraysIndirectBindlessCountNV"))
+	gpMultiDrawArraysIndirectBindlessNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawArraysIndirectBindlessNV"))
 	gpMultiDrawArraysIndirectCountARB = (C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawArraysIndirectCountARB"))
 	gpMultiDrawElements = (C.GPMULTIDRAWELEMENTS)(getProcAddr("glMultiDrawElements"))
 	if gpMultiDrawElements == nil {
@@ -9304,22 +14542,79 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMultiDrawElementsBaseVertex")
 	}
 	gpMultiDrawElementsIndirect = (C.GPMULTIDRAWELEMENTSINDIRECT)(getProcAddr("glMultiDrawElementsIndirect"))
+	gpMultiDrawElementsIndirectBindlessCountNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawElementsIndirectBindlessCountNV"))
+	gpMultiDrawElementsIndirectBindlessNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawElementsIndirectBindlessNV"))
 	gpMultiDrawElementsIndirectCountARB = (C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawElementsIndirectCountARB"))
+	gpMultiTexBufferEXT = (C.GPMULTITEXBUFFEREXT)(getProcAddr("glMultiTexBufferEXT"))
+	gpMultiTexCoordPointerEXT = (C.GPMULTITEXCOORDPOINTEREXT)(getProcAddr("glMultiTexCoordPointerEXT"))
+	gpMultiTexEnvfEXT = (C.GPMULTITEXENVFEXT)(getProcAddr("glMultiTexEnvfEXT"))
+	gpMultiTexEnvfvEXT = (C.GPMULTITEXENVFVEXT)(getProcAddr("glMultiTexEnvfvEXT"))
+	gpMultiTexEnviEXT = (C.GPMULTITEXENVIEXT)(getProcAddr("glMultiTexEnviEXT"))
+	gpMultiTexEnvivEXT = (C.GPMULTITEXENVIVEXT)(getProcAddr("glMultiTexEnvivEXT"))
+	gpMultiTexGendEXT = (C.GPMULTITEXGENDEXT)(getProcAddr("glMultiTexGendEXT"))
+	gpMultiTexGendvEXT = (C.GPMULTITEXGENDVEXT)(getProcAddr("glMultiTexGendvEXT"))
+	gpMultiTexGenfEXT = (C.GPMULTITEXGENFEXT)(getProcAddr("glMultiTexGenfEXT"))
+	gpMultiTexGenfvEXT = (C.GPMULTITEXGENFVEXT)(getProcAddr("glMultiTexGenfvEXT"))
+	gpMultiTexGeniEXT = (C.GPMULTITEXGENIEXT)(getProcAddr("glMultiTexGeniEXT"))
+	gpMultiTexGenivEXT = (C.GPMULTITEXGENIVEXT)(getProcAddr("glMultiTexGenivEXT"))
+	gpMultiTexImage1DEXT = (C.GPMULTITEXIMAGE1DEXT)(getProcAddr("glMultiTexImage1DEXT"))
+	gpMultiTexImage2DEXT = (C.GPMULTITEXIMAGE2DEXT)(getProcAddr("glMultiTexImage2DEXT"))
+	gpMultiTexImage3DEXT = (C.GPMULTITEXIMAGE3DEXT)(getProcAddr("glMultiTexImage3DEXT"))
+	gpMultiTexParameterIivEXT = (C.GPMULTITEXPARAMETERIIVEXT)(getProcAddr("glMultiTexParameterIivEXT"))
+	gpMultiTexParameterIuivEXT = (C.GPMULTITEXPARAMETERIUIVEXT)(getProcAddr("glMultiTexParameterIuivEXT"))
+	gpMultiTexParameterfEXT = (C.GPMULTITEXPARAMETERFEXT)(getProcAddr("glMultiTexParameterfEXT"))
+	gpMultiTexParameterfvEXT = (C.GPMULTITEXPARAMETERFVEXT)(getProcAddr("glMultiTexParameterfvEXT"))
+	gpMultiTexParameteriEXT = (C.GPMULTITEXPARAMETERIEXT)(getProcAddr("glMultiTexParameteriEXT"))
+	gpMultiTexParameterivEXT = (C.GPMULTITEXPARAMETERIVEXT)(getProcAddr("glMultiTexParameterivEXT"))
+	gpMultiTexRenderbufferEXT = (C.GPMULTITEXRENDERBUFFEREXT)(getProcAddr("glMultiTexRenderbufferEXT"))
+	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
+	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
+	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
+	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
+	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
+	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
+	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
 	gpNamedFramebufferDrawBuffer = (C.GPNAMEDFRAMEBUFFERDRAWBUFFER)(getProcAddr("glNamedFramebufferDrawBuffer"))
 	gpNamedFramebufferDrawBuffers = (C.GPNAMEDFRAMEBUFFERDRAWBUFFERS)(getProcAddr("glNamedFramebufferDrawBuffers"))
 	gpNamedFramebufferParameteri = (C.GPNAMEDFRAMEBUFFERPARAMETERI)(getProcAddr("glNamedFramebufferParameteri"))
+	gpNamedFramebufferParameteriEXT = (C.GPNAMEDFRAMEBUFFERPARAMETERIEXT)(getProcAddr("glNamedFramebufferParameteriEXT"))
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	gpNamedFramebufferRenderbuffer = (C.GPNAMEDFRAMEBUFFERRENDERBUFFER)(getProcAddr("glNamedFramebufferRenderbuffer"))
+	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
+	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
+	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
+	gpNamedFramebufferTexture3DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(getProcAddr("glNamedFramebufferTexture3DEXT"))
+	gpNamedFramebufferTextureEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREEXT)(getProcAddr("glNamedFramebufferTextureEXT"))
+	gpNamedFramebufferTextureFaceEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(getProcAddr("glNamedFramebufferTextureFaceEXT"))
 	gpNamedFramebufferTextureLayer = (C.GPNAMEDFRAMEBUFFERTEXTURELAYER)(getProcAddr("glNamedFramebufferTextureLayer"))
+	gpNamedFramebufferTextureLayerEXT = (C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glNamedFramebufferTextureLayerEXT"))
+	gpNamedProgramLocalParameter4dEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(getProcAddr("glNamedProgramLocalParameter4dEXT"))
+	gpNamedProgramLocalParameter4dvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(getProcAddr("glNamedProgramLocalParameter4dvEXT"))
+	gpNamedProgramLocalParameter4fEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(getProcAddr("glNamedProgramLocalParameter4fEXT"))
+	gpNamedProgramLocalParameter4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(getProcAddr("glNamedProgramLocalParameter4fvEXT"))
+	gpNamedProgramLocalParameterI4iEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(getProcAddr("glNamedProgramLocalParameterI4iEXT"))
+	gpNamedProgramLocalParameterI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(getProcAddr("glNamedProgramLocalParameterI4ivEXT"))
+	gpNamedProgramLocalParameterI4uiEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(getProcAddr("glNamedProgramLocalParameterI4uiEXT"))
+	gpNamedProgramLocalParameterI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(getProcAddr("glNamedProgramLocalParameterI4uivEXT"))
+	gpNamedProgramLocalParameters4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(getProcAddr("glNamedProgramLocalParameters4fvEXT"))
+	gpNamedProgramLocalParametersI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(getProcAddr("glNamedProgramLocalParametersI4ivEXT"))
+	gpNamedProgramLocalParametersI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(getProcAddr("glNamedProgramLocalParametersI4uivEXT"))
+	gpNamedProgramStringEXT = (C.GPNAMEDPROGRAMSTRINGEXT)(getProcAddr("glNamedProgramStringEXT"))
 	gpNamedRenderbufferStorage = (C.GPNAMEDRENDERBUFFERSTORAGE)(getProcAddr("glNamedRenderbufferStorage"))
+	gpNamedRenderbufferStorageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEEXT)(getProcAddr("glNamedRenderbufferStorageEXT"))
 	gpNamedRenderbufferStorageMultisample = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(getProcAddr("glNamedRenderbufferStorageMultisample"))
+	gpNamedRenderbufferStorageMultisampleCoverageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleCoverageEXT"))
+	gpNamedRenderbufferStorageMultisampleEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleEXT"))
 	gpNamedStringARB = (C.GPNAMEDSTRINGARB)(getProcAddr("glNamedStringARB"))
+	gpNormalFormatNV = (C.GPNORMALFORMATNV)(getProcAddr("glNormalFormatNV"))
 	gpObjectLabel = (C.GPOBJECTLABEL)(getProcAddr("glObjectLabel"))
 	gpObjectLabelKHR = (C.GPOBJECTLABELKHR)(getProcAddr("glObjectLabelKHR"))
 	gpObjectPtrLabel = (C.GPOBJECTPTRLABEL)(getProcAddr("glObjectPtrLabel"))
@@ -9332,6 +14627,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPatchParameteri == nil {
 		return errors.New("glPatchParameteri")
 	}
+	gpPathCommandsNV = (C.GPPATHCOMMANDSNV)(getProcAddr("glPathCommandsNV"))
+	gpPathCoordsNV = (C.GPPATHCOORDSNV)(getProcAddr("glPathCoordsNV"))
+	gpPathCoverDepthFuncNV = (C.GPPATHCOVERDEPTHFUNCNV)(getProcAddr("glPathCoverDepthFuncNV"))
+	gpPathDashArrayNV = (C.GPPATHDASHARRAYNV)(getProcAddr("glPathDashArrayNV"))
+	gpPathGlyphIndexArrayNV = (C.GPPATHGLYPHINDEXARRAYNV)(getProcAddr("glPathGlyphIndexArrayNV"))
+	gpPathGlyphIndexRangeNV = (C.GPPATHGLYPHINDEXRANGENV)(getProcAddr("glPathGlyphIndexRangeNV"))
+	gpPathGlyphRangeNV = (C.GPPATHGLYPHRANGENV)(getProcAddr("glPathGlyphRangeNV"))
+	gpPathGlyphsNV = (C.GPPATHGLYPHSNV)(getProcAddr("glPathGlyphsNV"))
+	gpPathMemoryGlyphIndexArrayNV = (C.GPPATHMEMORYGLYPHINDEXARRAYNV)(getProcAddr("glPathMemoryGlyphIndexArrayNV"))
+	gpPathParameterfNV = (C.GPPATHPARAMETERFNV)(getProcAddr("glPathParameterfNV"))
+	gpPathParameterfvNV = (C.GPPATHPARAMETERFVNV)(getProcAddr("glPathParameterfvNV"))
+	gpPathParameteriNV = (C.GPPATHPARAMETERINV)(getProcAddr("glPathParameteriNV"))
+	gpPathParameterivNV = (C.GPPATHPARAMETERIVNV)(getProcAddr("glPathParameterivNV"))
+	gpPathStencilDepthOffsetNV = (C.GPPATHSTENCILDEPTHOFFSETNV)(getProcAddr("glPathStencilDepthOffsetNV"))
+	gpPathStencilFuncNV = (C.GPPATHSTENCILFUNCNV)(getProcAddr("glPathStencilFuncNV"))
+	gpPathStringNV = (C.GPPATHSTRINGNV)(getProcAddr("glPathStringNV"))
+	gpPathSubCommandsNV = (C.GPPATHSUBCOMMANDSNV)(getProcAddr("glPathSubCommandsNV"))
+	gpPathSubCoordsNV = (C.GPPATHSUBCOORDSNV)(getProcAddr("glPathSubCoordsNV"))
 	gpPauseTransformFeedback = (C.GPPAUSETRANSFORMFEEDBACK)(getProcAddr("glPauseTransformFeedback"))
 	if gpPauseTransformFeedback == nil {
 		return errors.New("glPauseTransformFeedback")
@@ -9344,6 +14657,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPixelStorei == nil {
 		return errors.New("glPixelStorei")
 	}
+	gpPointAlongPathNV = (C.GPPOINTALONGPATHNV)(getProcAddr("glPointAlongPathNV"))
 	gpPointParameterf = (C.GPPOINTPARAMETERF)(getProcAddr("glPointParameterf"))
 	if gpPointParameterf == nil {
 		return errors.New("glPointParameterf")
@@ -9372,8 +14686,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPopDebugGroup = (C.GPPOPDEBUGGROUP)(getProcAddr("glPopDebugGroup"))
 	gpPopDebugGroupKHR = (C.GPPOPDEBUGGROUPKHR)(getProcAddr("glPopDebugGroupKHR"))
+	gpPopGroupMarkerEXT = (C.GPPOPGROUPMARKEREXT)(getProcAddr("glPopGroupMarkerEXT"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	if gpPrimitiveRestartIndex == nil {
 		return errors.New("glPrimitiveRestartIndex")
@@ -9386,218 +14704,310 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramParameteri == nil {
 		return errors.New("glProgramParameteri")
 	}
+	gpProgramParameteriARB = (C.GPPROGRAMPARAMETERIARB)(getProcAddr("glProgramParameteriARB"))
+	gpProgramParameteriEXT = (C.GPPROGRAMPARAMETERIEXT)(getProcAddr("glProgramParameteriEXT"))
+	gpProgramPathFragmentInputGenNV = (C.GPPROGRAMPATHFRAGMENTINPUTGENNV)(getProcAddr("glProgramPathFragmentInputGenNV"))
 	gpProgramUniform1d = (C.GPPROGRAMUNIFORM1D)(getProcAddr("glProgramUniform1d"))
 	if gpProgramUniform1d == nil {
 		return errors.New("glProgramUniform1d")
 	}
+	gpProgramUniform1dEXT = (C.GPPROGRAMUNIFORM1DEXT)(getProcAddr("glProgramUniform1dEXT"))
 	gpProgramUniform1dv = (C.GPPROGRAMUNIFORM1DV)(getProcAddr("glProgramUniform1dv"))
 	if gpProgramUniform1dv == nil {
 		return errors.New("glProgramUniform1dv")
 	}
+	gpProgramUniform1dvEXT = (C.GPPROGRAMUNIFORM1DVEXT)(getProcAddr("glProgramUniform1dvEXT"))
 	gpProgramUniform1f = (C.GPPROGRAMUNIFORM1F)(getProcAddr("glProgramUniform1f"))
 	if gpProgramUniform1f == nil {
 		return errors.New("glProgramUniform1f")
 	}
+	gpProgramUniform1fEXT = (C.GPPROGRAMUNIFORM1FEXT)(getProcAddr("glProgramUniform1fEXT"))
 	gpProgramUniform1fv = (C.GPPROGRAMUNIFORM1FV)(getProcAddr("glProgramUniform1fv"))
 	if gpProgramUniform1fv == nil {
 		return errors.New("glProgramUniform1fv")
 	}
+	gpProgramUniform1fvEXT = (C.GPPROGRAMUNIFORM1FVEXT)(getProcAddr("glProgramUniform1fvEXT"))
 	gpProgramUniform1i = (C.GPPROGRAMUNIFORM1I)(getProcAddr("glProgramUniform1i"))
 	if gpProgramUniform1i == nil {
 		return errors.New("glProgramUniform1i")
 	}
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
+	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
+	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
+	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
 	if gpProgramUniform1iv == nil {
 		return errors.New("glProgramUniform1iv")
 	}
+	gpProgramUniform1ivEXT = (C.GPPROGRAMUNIFORM1IVEXT)(getProcAddr("glProgramUniform1ivEXT"))
 	gpProgramUniform1ui = (C.GPPROGRAMUNIFORM1UI)(getProcAddr("glProgramUniform1ui"))
 	if gpProgramUniform1ui == nil {
 		return errors.New("glProgramUniform1ui")
 	}
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
+	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
+	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
+	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
 	if gpProgramUniform1uiv == nil {
 		return errors.New("glProgramUniform1uiv")
 	}
+	gpProgramUniform1uivEXT = (C.GPPROGRAMUNIFORM1UIVEXT)(getProcAddr("glProgramUniform1uivEXT"))
 	gpProgramUniform2d = (C.GPPROGRAMUNIFORM2D)(getProcAddr("glProgramUniform2d"))
 	if gpProgramUniform2d == nil {
 		return errors.New("glProgramUniform2d")
 	}
+	gpProgramUniform2dEXT = (C.GPPROGRAMUNIFORM2DEXT)(getProcAddr("glProgramUniform2dEXT"))
 	gpProgramUniform2dv = (C.GPPROGRAMUNIFORM2DV)(getProcAddr("glProgramUniform2dv"))
 	if gpProgramUniform2dv == nil {
 		return errors.New("glProgramUniform2dv")
 	}
+	gpProgramUniform2dvEXT = (C.GPPROGRAMUNIFORM2DVEXT)(getProcAddr("glProgramUniform2dvEXT"))
 	gpProgramUniform2f = (C.GPPROGRAMUNIFORM2F)(getProcAddr("glProgramUniform2f"))
 	if gpProgramUniform2f == nil {
 		return errors.New("glProgramUniform2f")
 	}
+	gpProgramUniform2fEXT = (C.GPPROGRAMUNIFORM2FEXT)(getProcAddr("glProgramUniform2fEXT"))
 	gpProgramUniform2fv = (C.GPPROGRAMUNIFORM2FV)(getProcAddr("glProgramUniform2fv"))
 	if gpProgramUniform2fv == nil {
 		return errors.New("glProgramUniform2fv")
 	}
+	gpProgramUniform2fvEXT = (C.GPPROGRAMUNIFORM2FVEXT)(getProcAddr("glProgramUniform2fvEXT"))
 	gpProgramUniform2i = (C.GPPROGRAMUNIFORM2I)(getProcAddr("glProgramUniform2i"))
 	if gpProgramUniform2i == nil {
 		return errors.New("glProgramUniform2i")
 	}
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
+	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
+	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
+	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
 	if gpProgramUniform2iv == nil {
 		return errors.New("glProgramUniform2iv")
 	}
+	gpProgramUniform2ivEXT = (C.GPPROGRAMUNIFORM2IVEXT)(getProcAddr("glProgramUniform2ivEXT"))
 	gpProgramUniform2ui = (C.GPPROGRAMUNIFORM2UI)(getProcAddr("glProgramUniform2ui"))
 	if gpProgramUniform2ui == nil {
 		return errors.New("glProgramUniform2ui")
 	}
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
+	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
+	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
+	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
 	if gpProgramUniform2uiv == nil {
 		return errors.New("glProgramUniform2uiv")
 	}
+	gpProgramUniform2uivEXT = (C.GPPROGRAMUNIFORM2UIVEXT)(getProcAddr("glProgramUniform2uivEXT"))
 	gpProgramUniform3d = (C.GPPROGRAMUNIFORM3D)(getProcAddr("glProgramUniform3d"))
 	if gpProgramUniform3d == nil {
 		return errors.New("glProgramUniform3d")
 	}
+	gpProgramUniform3dEXT = (C.GPPROGRAMUNIFORM3DEXT)(getProcAddr("glProgramUniform3dEXT"))
 	gpProgramUniform3dv = (C.GPPROGRAMUNIFORM3DV)(getProcAddr("glProgramUniform3dv"))
 	if gpProgramUniform3dv == nil {
 		return errors.New("glProgramUniform3dv")
 	}
+	gpProgramUniform3dvEXT = (C.GPPROGRAMUNIFORM3DVEXT)(getProcAddr("glProgramUniform3dvEXT"))
 	gpProgramUniform3f = (C.GPPROGRAMUNIFORM3F)(getProcAddr("glProgramUniform3f"))
 	if gpProgramUniform3f == nil {
 		return errors.New("glProgramUniform3f")
 	}
+	gpProgramUniform3fEXT = (C.GPPROGRAMUNIFORM3FEXT)(getProcAddr("glProgramUniform3fEXT"))
 	gpProgramUniform3fv = (C.GPPROGRAMUNIFORM3FV)(getProcAddr("glProgramUniform3fv"))
 	if gpProgramUniform3fv == nil {
 		return errors.New("glProgramUniform3fv")
 	}
+	gpProgramUniform3fvEXT = (C.GPPROGRAMUNIFORM3FVEXT)(getProcAddr("glProgramUniform3fvEXT"))
 	gpProgramUniform3i = (C.GPPROGRAMUNIFORM3I)(getProcAddr("glProgramUniform3i"))
 	if gpProgramUniform3i == nil {
 		return errors.New("glProgramUniform3i")
 	}
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
+	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
+	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
+	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
 	if gpProgramUniform3iv == nil {
 		return errors.New("glProgramUniform3iv")
 	}
+	gpProgramUniform3ivEXT = (C.GPPROGRAMUNIFORM3IVEXT)(getProcAddr("glProgramUniform3ivEXT"))
 	gpProgramUniform3ui = (C.GPPROGRAMUNIFORM3UI)(getProcAddr("glProgramUniform3ui"))
 	if gpProgramUniform3ui == nil {
 		return errors.New("glProgramUniform3ui")
 	}
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
+	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
+	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
+	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
 	if gpProgramUniform3uiv == nil {
 		return errors.New("glProgramUniform3uiv")
 	}
+	gpProgramUniform3uivEXT = (C.GPPROGRAMUNIFORM3UIVEXT)(getProcAddr("glProgramUniform3uivEXT"))
 	gpProgramUniform4d = (C.GPPROGRAMUNIFORM4D)(getProcAddr("glProgramUniform4d"))
 	if gpProgramUniform4d == nil {
 		return errors.New("glProgramUniform4d")
 	}
+	gpProgramUniform4dEXT = (C.GPPROGRAMUNIFORM4DEXT)(getProcAddr("glProgramUniform4dEXT"))
 	gpProgramUniform4dv = (C.GPPROGRAMUNIFORM4DV)(getProcAddr("glProgramUniform4dv"))
 	if gpProgramUniform4dv == nil {
 		return errors.New("glProgramUniform4dv")
 	}
+	gpProgramUniform4dvEXT = (C.GPPROGRAMUNIFORM4DVEXT)(getProcAddr("glProgramUniform4dvEXT"))
 	gpProgramUniform4f = (C.GPPROGRAMUNIFORM4F)(getProcAddr("glProgramUniform4f"))
 	if gpProgramUniform4f == nil {
 		return errors.New("glProgramUniform4f")
 	}
+	gpProgramUniform4fEXT = (C.GPPROGRAMUNIFORM4FEXT)(getProcAddr("glProgramUniform4fEXT"))
 	gpProgramUniform4fv = (C.GPPROGRAMUNIFORM4FV)(getProcAddr("glProgramUniform4fv"))
 	if gpProgramUniform4fv == nil {
 		return errors.New("glProgramUniform4fv")
 	}
+	gpProgramUniform4fvEXT = (C.GPPROGRAMUNIFORM4FVEXT)(getProcAddr("glProgramUniform4fvEXT"))
 	gpProgramUniform4i = (C.GPPROGRAMUNIFORM4I)(getProcAddr("glProgramUniform4i"))
 	if gpProgramUniform4i == nil {
 		return errors.New("glProgramUniform4i")
 	}
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
+	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
+	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
+	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
 	if gpProgramUniform4iv == nil {
 		return errors.New("glProgramUniform4iv")
 	}
+	gpProgramUniform4ivEXT = (C.GPPROGRAMUNIFORM4IVEXT)(getProcAddr("glProgramUniform4ivEXT"))
 	gpProgramUniform4ui = (C.GPPROGRAMUNIFORM4UI)(getProcAddr("glProgramUniform4ui"))
 	if gpProgramUniform4ui == nil {
 		return errors.New("glProgramUniform4ui")
 	}
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
+	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
+	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
+	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
 	if gpProgramUniform4uiv == nil {
 		return errors.New("glProgramUniform4uiv")
 	}
+	gpProgramUniform4uivEXT = (C.GPPROGRAMUNIFORM4UIVEXT)(getProcAddr("glProgramUniform4uivEXT"))
 	gpProgramUniformHandleui64ARB = (C.GPPROGRAMUNIFORMHANDLEUI64ARB)(getProcAddr("glProgramUniformHandleui64ARB"))
+	gpProgramUniformHandleui64NV = (C.GPPROGRAMUNIFORMHANDLEUI64NV)(getProcAddr("glProgramUniformHandleui64NV"))
 	gpProgramUniformHandleui64vARB = (C.GPPROGRAMUNIFORMHANDLEUI64VARB)(getProcAddr("glProgramUniformHandleui64vARB"))
+	gpProgramUniformHandleui64vNV = (C.GPPROGRAMUNIFORMHANDLEUI64VNV)(getProcAddr("glProgramUniformHandleui64vNV"))
 	gpProgramUniformMatrix2dv = (C.GPPROGRAMUNIFORMMATRIX2DV)(getProcAddr("glProgramUniformMatrix2dv"))
 	if gpProgramUniformMatrix2dv == nil {
 		return errors.New("glProgramUniformMatrix2dv")
 	}
+	gpProgramUniformMatrix2dvEXT = (C.GPPROGRAMUNIFORMMATRIX2DVEXT)(getProcAddr("glProgramUniformMatrix2dvEXT"))
 	gpProgramUniformMatrix2fv = (C.GPPROGRAMUNIFORMMATRIX2FV)(getProcAddr("glProgramUniformMatrix2fv"))
 	if gpProgramUniformMatrix2fv == nil {
 		return errors.New("glProgramUniformMatrix2fv")
 	}
+	gpProgramUniformMatrix2fvEXT = (C.GPPROGRAMUNIFORMMATRIX2FVEXT)(getProcAddr("glProgramUniformMatrix2fvEXT"))
 	gpProgramUniformMatrix2x3dv = (C.GPPROGRAMUNIFORMMATRIX2X3DV)(getProcAddr("glProgramUniformMatrix2x3dv"))
 	if gpProgramUniformMatrix2x3dv == nil {
 		return errors.New("glProgramUniformMatrix2x3dv")
 	}
+	gpProgramUniformMatrix2x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3DVEXT)(getProcAddr("glProgramUniformMatrix2x3dvEXT"))
 	gpProgramUniformMatrix2x3fv = (C.GPPROGRAMUNIFORMMATRIX2X3FV)(getProcAddr("glProgramUniformMatrix2x3fv"))
 	if gpProgramUniformMatrix2x3fv == nil {
 		return errors.New("glProgramUniformMatrix2x3fv")
 	}
+	gpProgramUniformMatrix2x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3FVEXT)(getProcAddr("glProgramUniformMatrix2x3fvEXT"))
 	gpProgramUniformMatrix2x4dv = (C.GPPROGRAMUNIFORMMATRIX2X4DV)(getProcAddr("glProgramUniformMatrix2x4dv"))
 	if gpProgramUniformMatrix2x4dv == nil {
 		return errors.New("glProgramUniformMatrix2x4dv")
 	}
+	gpProgramUniformMatrix2x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4DVEXT)(getProcAddr("glProgramUniformMatrix2x4dvEXT"))
 	gpProgramUniformMatrix2x4fv = (C.GPPROGRAMUNIFORMMATRIX2X4FV)(getProcAddr("glProgramUniformMatrix2x4fv"))
 	if gpProgramUniformMatrix2x4fv == nil {
 		return errors.New("glProgramUniformMatrix2x4fv")
 	}
+	gpProgramUniformMatrix2x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4FVEXT)(getProcAddr("glProgramUniformMatrix2x4fvEXT"))
 	gpProgramUniformMatrix3dv = (C.GPPROGRAMUNIFORMMATRIX3DV)(getProcAddr("glProgramUniformMatrix3dv"))
 	if gpProgramUniformMatrix3dv == nil {
 		return errors.New("glProgramUniformMatrix3dv")
 	}
+	gpProgramUniformMatrix3dvEXT = (C.GPPROGRAMUNIFORMMATRIX3DVEXT)(getProcAddr("glProgramUniformMatrix3dvEXT"))
 	gpProgramUniformMatrix3fv = (C.GPPROGRAMUNIFORMMATRIX3FV)(getProcAddr("glProgramUniformMatrix3fv"))
 	if gpProgramUniformMatrix3fv == nil {
 		return errors.New("glProgramUniformMatrix3fv")
 	}
+	gpProgramUniformMatrix3fvEXT = (C.GPPROGRAMUNIFORMMATRIX3FVEXT)(getProcAddr("glProgramUniformMatrix3fvEXT"))
 	gpProgramUniformMatrix3x2dv = (C.GPPROGRAMUNIFORMMATRIX3X2DV)(getProcAddr("glProgramUniformMatrix3x2dv"))
 	if gpProgramUniformMatrix3x2dv == nil {
 		return errors.New("glProgramUniformMatrix3x2dv")
 	}
+	gpProgramUniformMatrix3x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2DVEXT)(getProcAddr("glProgramUniformMatrix3x2dvEXT"))
 	gpProgramUniformMatrix3x2fv = (C.GPPROGRAMUNIFORMMATRIX3X2FV)(getProcAddr("glProgramUniformMatrix3x2fv"))
 	if gpProgramUniformMatrix3x2fv == nil {
 		return errors.New("glProgramUniformMatrix3x2fv")
 	}
+	gpProgramUniformMatrix3x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2FVEXT)(getProcAddr("glProgramUniformMatrix3x2fvEXT"))
 	gpProgramUniformMatrix3x4dv = (C.GPPROGRAMUNIFORMMATRIX3X4DV)(getProcAddr("glProgramUniformMatrix3x4dv"))
 	if gpProgramUniformMatrix3x4dv == nil {
 		return errors.New("glProgramUniformMatrix3x4dv")
 	}
+	gpProgramUniformMatrix3x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4DVEXT)(getProcAddr("glProgramUniformMatrix3x4dvEXT"))
 	gpProgramUniformMatrix3x4fv = (C.GPPROGRAMUNIFORMMATRIX3X4FV)(getProcAddr("glProgramUniformMatrix3x4fv"))
 	if gpProgramUniformMatrix3x4fv == nil {
 		return errors.New("glProgramUniformMatrix3x4fv")
 	}
+	gpProgramUniformMatrix3x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4FVEXT)(getProcAddr("glProgramUniformMatrix3x4fvEXT"))
 	gpProgramUniformMatrix4dv = (C.GPPROGRAMUNIFORMMATRIX4DV)(getProcAddr("glProgramUniformMatrix4dv"))
 	if gpProgramUniformMatrix4dv == nil {
 		return errors.New("glProgramUniformMatrix4dv")
 	}
+	gpProgramUniformMatrix4dvEXT = (C.GPPROGRAMUNIFORMMATRIX4DVEXT)(getProcAddr("glProgramUniformMatrix4dvEXT"))
 	gpProgramUniformMatrix4fv = (C.GPPROGRAMUNIFORMMATRIX4FV)(getProcAddr("glProgramUniformMatrix4fv"))
 	if gpProgramUniformMatrix4fv == nil {
 		return errors.New("glProgramUniformMatrix4fv")
 	}
+	gpProgramUniformMatrix4fvEXT = (C.GPPROGRAMUNIFORMMATRIX4FVEXT)(getProcAddr("glProgramUniformMatrix4fvEXT"))
 	gpProgramUniformMatrix4x2dv = (C.GPPROGRAMUNIFORMMATRIX4X2DV)(getProcAddr("glProgramUniformMatrix4x2dv"))
 	if gpProgramUniformMatrix4x2dv == nil {
 		return errors.New("glProgramUniformMatrix4x2dv")
 	}
+	gpProgramUniformMatrix4x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2DVEXT)(getProcAddr("glProgramUniformMatrix4x2dvEXT"))
 	gpProgramUniformMatrix4x2fv = (C.GPPROGRAMUNIFORMMATRIX4X2FV)(getProcAddr("glProgramUniformMatrix4x2fv"))
 	if gpProgramUniformMatrix4x2fv == nil {
 		return errors.New("glProgramUniformMatrix4x2fv")
 	}
+	gpProgramUniformMatrix4x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2FVEXT)(getProcAddr("glProgramUniformMatrix4x2fvEXT"))
 	gpProgramUniformMatrix4x3dv = (C.GPPROGRAMUNIFORMMATRIX4X3DV)(getProcAddr("glProgramUniformMatrix4x3dv"))
 	if gpProgramUniformMatrix4x3dv == nil {
 		return errors.New("glProgramUniformMatrix4x3dv")
 	}
+	gpProgramUniformMatrix4x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3DVEXT)(getProcAddr("glProgramUniformMatrix4x3dvEXT"))
 	gpProgramUniformMatrix4x3fv = (C.GPPROGRAMUNIFORMMATRIX4X3FV)(getProcAddr("glProgramUniformMatrix4x3fv"))
 	if gpProgramUniformMatrix4x3fv == nil {
 		return errors.New("glProgramUniformMatrix4x3fv")
 	}
+	gpProgramUniformMatrix4x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3FVEXT)(getProcAddr("glProgramUniformMatrix4x3fvEXT"))
+	gpProgramUniformui64NV = (C.GPPROGRAMUNIFORMUI64NV)(getProcAddr("glProgramUniformui64NV"))
+	gpProgramUniformui64vNV = (C.GPPROGRAMUNIFORMUI64VNV)(getProcAddr("glProgramUniformui64vNV"))
 	gpProvokingVertex = (C.GPPROVOKINGVERTEX)(getProcAddr("glProvokingVertex"))
 	if gpProvokingVertex == nil {
 		return errors.New("glProvokingVertex")
 	}
+	gpPushClientAttribDefaultEXT = (C.GPPUSHCLIENTATTRIBDEFAULTEXT)(getProcAddr("glPushClientAttribDefaultEXT"))
 	gpPushDebugGroup = (C.GPPUSHDEBUGGROUP)(getProcAddr("glPushDebugGroup"))
 	gpPushDebugGroupKHR = (C.GPPUSHDEBUGGROUPKHR)(getProcAddr("glPushDebugGroupKHR"))
+	gpPushGroupMarkerEXT = (C.GPPUSHGROUPMARKEREXT)(getProcAddr("glPushGroupMarkerEXT"))
 	gpQueryCounter = (C.GPQUERYCOUNTER)(getProcAddr("glQueryCounter"))
 	if gpQueryCounter == nil {
 		return errors.New("glQueryCounter")
 	}
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -9621,6 +15031,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpRenderbufferStorageMultisample == nil {
 		return errors.New("glRenderbufferStorageMultisample")
 	}
+	gpRenderbufferStorageMultisampleCoverageNV = (C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(getProcAddr("glRenderbufferStorageMultisampleCoverageNV"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	if gpResumeTransformFeedback == nil {
 		return errors.New("glResumeTransformFeedback")
@@ -9673,6 +15085,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpScissorIndexedv == nil {
 		return errors.New("glScissorIndexedv")
 	}
+	gpSecondaryColorFormatNV = (C.GPSECONDARYCOLORFORMATNV)(getProcAddr("glSecondaryColorFormatNV"))
+	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
 	gpShaderBinary = (C.GPSHADERBINARY)(getProcAddr("glShaderBinary"))
 	if gpShaderBinary == nil {
 		return errors.New("glShaderBinary")
@@ -9682,6 +15096,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glShaderSource")
 	}
 	gpShaderStorageBlockBinding = (C.GPSHADERSTORAGEBLOCKBINDING)(getProcAddr("glShaderStorageBlockBinding"))
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
+	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
+	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
 	gpStencilFunc = (C.GPSTENCILFUNC)(getProcAddr("glStencilFunc"))
 	if gpStencilFunc == nil {
 		return errors.New("glStencilFunc")
@@ -9706,11 +15126,20 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpStencilOpSeparate == nil {
 		return errors.New("glStencilOpSeparate")
 	}
+	gpStencilStrokePathInstancedNV = (C.GPSTENCILSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilStrokePathInstancedNV"))
+	gpStencilStrokePathNV = (C.GPSTENCILSTROKEPATHNV)(getProcAddr("glStencilStrokePathNV"))
+	gpStencilThenCoverFillPathInstancedNV = (C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverFillPathInstancedNV"))
+	gpStencilThenCoverFillPathNV = (C.GPSTENCILTHENCOVERFILLPATHNV)(getProcAddr("glStencilThenCoverFillPathNV"))
+	gpStencilThenCoverStrokePathInstancedNV = (C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverStrokePathInstancedNV"))
+	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpTexBuffer = (C.GPTEXBUFFER)(getProcAddr("glTexBuffer"))
 	if gpTexBuffer == nil {
 		return errors.New("glTexBuffer")
 	}
+	gpTexBufferARB = (C.GPTEXBUFFERARB)(getProcAddr("glTexBufferARB"))
 	gpTexBufferRange = (C.GPTEXBUFFERRANGE)(getProcAddr("glTexBufferRange"))
+	gpTexCoordFormatNV = (C.GPTEXCOORDFORMATNV)(getProcAddr("glTexCoordFormatNV"))
 	gpTexImage1D = (C.GPTEXIMAGE1D)(getProcAddr("glTexImage1D"))
 	if gpTexImage1D == nil {
 		return errors.New("glTexImage1D")
@@ -9783,22 +15212,44 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glTexSubImage3D")
 	}
 	gpTextureBarrier = (C.GPTEXTUREBARRIER)(getProcAddr("glTextureBarrier"))
+	gpTextureBarrierNV = (C.GPTEXTUREBARRIERNV)(getProcAddr("glTextureBarrierNV"))
 	gpTextureBuffer = (C.GPTEXTUREBUFFER)(getProcAddr("glTextureBuffer"))
+	gpTextureBufferEXT = (C.GPTEXTUREBUFFEREXT)(getProcAddr("glTextureBufferEXT"))
 	gpTextureBufferRange = (C.GPTEXTUREBUFFERRANGE)(getProcAddr("glTextureBufferRange"))
+	gpTextureBufferRangeEXT = (C.GPTEXTUREBUFFERRANGEEXT)(getProcAddr("glTextureBufferRangeEXT"))
+	gpTextureImage1DEXT = (C.GPTEXTUREIMAGE1DEXT)(getProcAddr("glTextureImage1DEXT"))
+	gpTextureImage2DEXT = (C.GPTEXTUREIMAGE2DEXT)(getProcAddr("glTextureImage2DEXT"))
+	gpTextureImage3DEXT = (C.GPTEXTUREIMAGE3DEXT)(getProcAddr("glTextureImage3DEXT"))
+	gpTexturePageCommitmentEXT = (C.GPTEXTUREPAGECOMMITMENTEXT)(getProcAddr("glTexturePageCommitmentEXT"))
 	gpTextureParameterIiv = (C.GPTEXTUREPARAMETERIIV)(getProcAddr("glTextureParameterIiv"))
+	gpTextureParameterIivEXT = (C.GPTEXTUREPARAMETERIIVEXT)(getProcAddr("glTextureParameterIivEXT"))
 	gpTextureParameterIuiv = (C.GPTEXTUREPARAMETERIUIV)(getProcAddr("glTextureParameterIuiv"))
+	gpTextureParameterIuivEXT = (C.GPTEXTUREPARAMETERIUIVEXT)(getProcAddr("glTextureParameterIuivEXT"))
 	gpTextureParameterf = (C.GPTEXTUREPARAMETERF)(getProcAddr("glTextureParameterf"))
+	gpTextureParameterfEXT = (C.GPTEXTUREPARAMETERFEXT)(getProcAddr("glTextureParameterfEXT"))
 	gpTextureParameterfv = (C.GPTEXTUREPARAMETERFV)(getProcAddr("glTextureParameterfv"))
+	gpTextureParameterfvEXT = (C.GPTEXTUREPARAMETERFVEXT)(getProcAddr("glTextureParameterfvEXT"))
 	gpTextureParameteri = (C.GPTEXTUREPARAMETERI)(getProcAddr("glTextureParameteri"))
+	gpTextureParameteriEXT = (C.GPTEXTUREPARAMETERIEXT)(getProcAddr("glTextureParameteriEXT"))
 	gpTextureParameteriv = (C.GPTEXTUREPARAMETERIV)(getProcAddr("glTextureParameteriv"))
+	gpTextureParameterivEXT = (C.GPTEXTUREPARAMETERIVEXT)(getProcAddr("glTextureParameterivEXT"))
+	gpTextureRenderbufferEXT = (C.GPTEXTURERENDERBUFFEREXT)(getProcAddr("glTextureRenderbufferEXT"))
 	gpTextureStorage1D = (C.GPTEXTURESTORAGE1D)(getProcAddr("glTextureStorage1D"))
+	gpTextureStorage1DEXT = (C.GPTEXTURESTORAGE1DEXT)(getProcAddr("glTextureStorage1DEXT"))
 	gpTextureStorage2D = (C.GPTEXTURESTORAGE2D)(getProcAddr("glTextureStorage2D"))
+	gpTextureStorage2DEXT = (C.GPTEXTURESTORAGE2DEXT)(getProcAddr("glTextureStorage2DEXT"))
 	gpTextureStorage2DMultisample = (C.GPTEXTURESTORAGE2DMULTISAMPLE)(getProcAddr("glTextureStorage2DMultisample"))
+	gpTextureStorage2DMultisampleEXT = (C.GPTEXTURESTORAGE2DMULTISAMPLEEXT)(getProcAddr("glTextureStorage2DMultisampleEXT"))
 	gpTextureStorage3D = (C.GPTEXTURESTORAGE3D)(getProcAddr("glTextureStorage3D"))
+	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
+	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
+	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
 	gpTextureSubImage2D = (C.GPTEXTURESUBIMAGE2D)(getProcAddr("glTextureSubImage2D"))
+	gpTextureSubImage2DEXT = (C.GPTEXTURESUBIMAGE2DEXT)(getProcAddr("glTextureSubImage2DEXT"))
 	gpTextureSubImage3D = (C.GPTEXTURESUBIMAGE3D)(getProcAddr("glTextureSubImage3D"))
+	gpTextureSubImage3DEXT = (C.GPTEXTURESUBIMAGE3DEXT)(getProcAddr("glTextureSubImage3DEXT"))
 	gpTextureView = (C.GPTEXTUREVIEW)(getProcAddr("glTextureView"))
 	gpTransformFeedbackBufferBase = (C.GPTRANSFORMFEEDBACKBUFFERBASE)(getProcAddr("glTransformFeedbackBufferBase"))
 	gpTransformFeedbackBufferRange = (C.GPTRANSFORMFEEDBACKBUFFERRANGE)(getProcAddr("glTransformFeedbackBufferRange"))
@@ -9806,6 +15257,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpTransformFeedbackVaryings == nil {
 		return errors.New("glTransformFeedbackVaryings")
 	}
+	gpTransformPathNV = (C.GPTRANSFORMPATHNV)(getProcAddr("glTransformPathNV"))
 	gpUniform1d = (C.GPUNIFORM1D)(getProcAddr("glUniform1d"))
 	if gpUniform1d == nil {
 		return errors.New("glUniform1d")
@@ -9826,6 +15278,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
+	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
+	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
 	if gpUniform1iv == nil {
 		return errors.New("glUniform1iv")
@@ -9834,6 +15290,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
+	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
+	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
 	if gpUniform1uiv == nil {
 		return errors.New("glUniform1uiv")
@@ -9858,6 +15318,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
+	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
+	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
 	if gpUniform2iv == nil {
 		return errors.New("glUniform2iv")
@@ -9866,6 +15330,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
+	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
+	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
 	if gpUniform2uiv == nil {
 		return errors.New("glUniform2uiv")
@@ -9890,6 +15358,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
+	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
+	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
 	if gpUniform3iv == nil {
 		return errors.New("glUniform3iv")
@@ -9898,6 +15370,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
+	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
+	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
 	if gpUniform3uiv == nil {
 		return errors.New("glUniform3uiv")
@@ -9922,6 +15398,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
+	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
+	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
 	if gpUniform4iv == nil {
 		return errors.New("glUniform4iv")
@@ -9930,6 +15410,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
+	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
+	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
 	if gpUniform4uiv == nil {
 		return errors.New("glUniform4uiv")
@@ -9939,7 +15423,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glUniformBlockBinding")
 	}
 	gpUniformHandleui64ARB = (C.GPUNIFORMHANDLEUI64ARB)(getProcAddr("glUniformHandleui64ARB"))
+	gpUniformHandleui64NV = (C.GPUNIFORMHANDLEUI64NV)(getProcAddr("glUniformHandleui64NV"))
 	gpUniformHandleui64vARB = (C.GPUNIFORMHANDLEUI64VARB)(getProcAddr("glUniformHandleui64vARB"))
+	gpUniformHandleui64vNV = (C.GPUNIFORMHANDLEUI64VNV)(getProcAddr("glUniformHandleui64vNV"))
 	gpUniformMatrix2dv = (C.GPUNIFORMMATRIX2DV)(getProcAddr("glUniformMatrix2dv"))
 	if gpUniformMatrix2dv == nil {
 		return errors.New("glUniformMatrix2dv")
@@ -10016,11 +15502,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniformSubroutinesuiv == nil {
 		return errors.New("glUniformSubroutinesuiv")
 	}
+	gpUniformui64NV = (C.GPUNIFORMUI64NV)(getProcAddr("glUniformui64NV"))
+	gpUniformui64vNV = (C.GPUNIFORMUI64VNV)(getProcAddr("glUniformui64vNV"))
 	gpUnmapBuffer = (C.GPUNMAPBUFFER)(getProcAddr("glUnmapBuffer"))
 	if gpUnmapBuffer == nil {
 		return errors.New("glUnmapBuffer")
 	}
 	gpUnmapNamedBuffer = (C.GPUNMAPNAMEDBUFFER)(getProcAddr("glUnmapNamedBuffer"))
+	gpUnmapNamedBufferEXT = (C.GPUNMAPNAMEDBUFFEREXT)(getProcAddr("glUnmapNamedBufferEXT"))
 	gpUseProgram = (C.GPUSEPROGRAM)(getProcAddr("glUseProgram"))
 	if gpUseProgram == nil {
 		return errors.New("glUseProgram")
@@ -10029,6 +15518,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUseProgramStages == nil {
 		return errors.New("glUseProgramStages")
 	}
+	gpUseProgramStagesEXT = (C.GPUSEPROGRAMSTAGESEXT)(getProcAddr("glUseProgramStagesEXT"))
+	gpUseShaderProgramEXT = (C.GPUSESHADERPROGRAMEXT)(getProcAddr("glUseShaderProgramEXT"))
 	gpValidateProgram = (C.GPVALIDATEPROGRAM)(getProcAddr("glValidateProgram"))
 	if gpValidateProgram == nil {
 		return errors.New("glValidateProgram")
@@ -10037,14 +15528,34 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpValidateProgramPipeline == nil {
 		return errors.New("glValidateProgramPipeline")
 	}
+	gpValidateProgramPipelineEXT = (C.GPVALIDATEPROGRAMPIPELINEEXT)(getProcAddr("glValidateProgramPipelineEXT"))
 	gpVertexArrayAttribBinding = (C.GPVERTEXARRAYATTRIBBINDING)(getProcAddr("glVertexArrayAttribBinding"))
 	gpVertexArrayAttribFormat = (C.GPVERTEXARRAYATTRIBFORMAT)(getProcAddr("glVertexArrayAttribFormat"))
 	gpVertexArrayAttribIFormat = (C.GPVERTEXARRAYATTRIBIFORMAT)(getProcAddr("glVertexArrayAttribIFormat"))
 	gpVertexArrayAttribLFormat = (C.GPVERTEXARRAYATTRIBLFORMAT)(getProcAddr("glVertexArrayAttribLFormat"))
+	gpVertexArrayBindVertexBufferEXT = (C.GPVERTEXARRAYBINDVERTEXBUFFEREXT)(getProcAddr("glVertexArrayBindVertexBufferEXT"))
 	gpVertexArrayBindingDivisor = (C.GPVERTEXARRAYBINDINGDIVISOR)(getProcAddr("glVertexArrayBindingDivisor"))
+	gpVertexArrayColorOffsetEXT = (C.GPVERTEXARRAYCOLOROFFSETEXT)(getProcAddr("glVertexArrayColorOffsetEXT"))
+	gpVertexArrayEdgeFlagOffsetEXT = (C.GPVERTEXARRAYEDGEFLAGOFFSETEXT)(getProcAddr("glVertexArrayEdgeFlagOffsetEXT"))
 	gpVertexArrayElementBuffer = (C.GPVERTEXARRAYELEMENTBUFFER)(getProcAddr("glVertexArrayElementBuffer"))
+	gpVertexArrayFogCoordOffsetEXT = (C.GPVERTEXARRAYFOGCOORDOFFSETEXT)(getProcAddr("glVertexArrayFogCoordOffsetEXT"))
+	gpVertexArrayIndexOffsetEXT = (C.GPVERTEXARRAYINDEXOFFSETEXT)(getProcAddr("glVertexArrayIndexOffsetEXT"))
+	gpVertexArrayMultiTexCoordOffsetEXT = (C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayMultiTexCoordOffsetEXT"))
+	gpVertexArrayNormalOffsetEXT = (C.GPVERTEXARRAYNORMALOFFSETEXT)(getProcAddr("glVertexArrayNormalOffsetEXT"))
+	gpVertexArraySecondaryColorOffsetEXT = (C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(getProcAddr("glVertexArraySecondaryColorOffsetEXT"))
+	gpVertexArrayTexCoordOffsetEXT = (C.GPVERTEXARRAYTEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayTexCoordOffsetEXT"))
+	gpVertexArrayVertexAttribBindingEXT = (C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(getProcAddr("glVertexArrayVertexAttribBindingEXT"))
+	gpVertexArrayVertexAttribDivisorEXT = (C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(getProcAddr("glVertexArrayVertexAttribDivisorEXT"))
+	gpVertexArrayVertexAttribFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(getProcAddr("glVertexArrayVertexAttribFormatEXT"))
+	gpVertexArrayVertexAttribIFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(getProcAddr("glVertexArrayVertexAttribIFormatEXT"))
+	gpVertexArrayVertexAttribIOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribIOffsetEXT"))
+	gpVertexArrayVertexAttribLFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(getProcAddr("glVertexArrayVertexAttribLFormatEXT"))
+	gpVertexArrayVertexAttribLOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribLOffsetEXT"))
+	gpVertexArrayVertexAttribOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribOffsetEXT"))
+	gpVertexArrayVertexBindingDivisorEXT = (C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(getProcAddr("glVertexArrayVertexBindingDivisorEXT"))
 	gpVertexArrayVertexBuffer = (C.GPVERTEXARRAYVERTEXBUFFER)(getProcAddr("glVertexArrayVertexBuffer"))
 	gpVertexArrayVertexBuffers = (C.GPVERTEXARRAYVERTEXBUFFERS)(getProcAddr("glVertexArrayVertexBuffers"))
+	gpVertexArrayVertexOffsetEXT = (C.GPVERTEXARRAYVERTEXOFFSETEXT)(getProcAddr("glVertexArrayVertexOffsetEXT"))
 	gpVertexAttrib1d = (C.GPVERTEXATTRIB1D)(getProcAddr("glVertexAttrib1d"))
 	if gpVertexAttrib1d == nil {
 		return errors.New("glVertexAttrib1d")
@@ -10194,7 +15705,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribDivisor == nil {
 		return errors.New("glVertexAttribDivisor")
 	}
+	gpVertexAttribDivisorARB = (C.GPVERTEXATTRIBDIVISORARB)(getProcAddr("glVertexAttribDivisorARB"))
 	gpVertexAttribFormat = (C.GPVERTEXATTRIBFORMAT)(getProcAddr("glVertexAttribFormat"))
+	gpVertexAttribFormatNV = (C.GPVERTEXATTRIBFORMATNV)(getProcAddr("glVertexAttribFormatNV"))
 	gpVertexAttribI1i = (C.GPVERTEXATTRIBI1I)(getProcAddr("glVertexAttribI1i"))
 	if gpVertexAttribI1i == nil {
 		return errors.New("glVertexAttribI1i")
@@ -10276,6 +15789,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glVertexAttribI4usv")
 	}
 	gpVertexAttribIFormat = (C.GPVERTEXATTRIBIFORMAT)(getProcAddr("glVertexAttribIFormat"))
+	gpVertexAttribIFormatNV = (C.GPVERTEXATTRIBIFORMATNV)(getProcAddr("glVertexAttribIFormatNV"))
 	gpVertexAttribIPointer = (C.GPVERTEXATTRIBIPOINTER)(getProcAddr("glVertexAttribIPointer"))
 	if gpVertexAttribIPointer == nil {
 		return errors.New("glVertexAttribIPointer")
@@ -10288,8 +15802,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL1dv == nil {
 		return errors.New("glVertexAttribL1dv")
 	}
+	gpVertexAttribL1i64NV = (C.GPVERTEXATTRIBL1I64NV)(getProcAddr("glVertexAttribL1i64NV"))
+	gpVertexAttribL1i64vNV = (C.GPVERTEXATTRIBL1I64VNV)(getProcAddr("glVertexAttribL1i64vNV"))
 	gpVertexAttribL1ui64ARB = (C.GPVERTEXATTRIBL1UI64ARB)(getProcAddr("glVertexAttribL1ui64ARB"))
+	gpVertexAttribL1ui64NV = (C.GPVERTEXATTRIBL1UI64NV)(getProcAddr("glVertexAttribL1ui64NV"))
 	gpVertexAttribL1ui64vARB = (C.GPVERTEXATTRIBL1UI64VARB)(getProcAddr("glVertexAttribL1ui64vARB"))
+	gpVertexAttribL1ui64vNV = (C.GPVERTEXATTRIBL1UI64VNV)(getProcAddr("glVertexAttribL1ui64vNV"))
 	gpVertexAttribL2d = (C.GPVERTEXATTRIBL2D)(getProcAddr("glVertexAttribL2d"))
 	if gpVertexAttribL2d == nil {
 		return errors.New("glVertexAttribL2d")
@@ -10298,6 +15816,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL2dv == nil {
 		return errors.New("glVertexAttribL2dv")
 	}
+	gpVertexAttribL2i64NV = (C.GPVERTEXATTRIBL2I64NV)(getProcAddr("glVertexAttribL2i64NV"))
+	gpVertexAttribL2i64vNV = (C.GPVERTEXATTRIBL2I64VNV)(getProcAddr("glVertexAttribL2i64vNV"))
+	gpVertexAttribL2ui64NV = (C.GPVERTEXATTRIBL2UI64NV)(getProcAddr("glVertexAttribL2ui64NV"))
+	gpVertexAttribL2ui64vNV = (C.GPVERTEXATTRIBL2UI64VNV)(getProcAddr("glVertexAttribL2ui64vNV"))
 	gpVertexAttribL3d = (C.GPVERTEXATTRIBL3D)(getProcAddr("glVertexAttribL3d"))
 	if gpVertexAttribL3d == nil {
 		return errors.New("glVertexAttribL3d")
@@ -10306,6 +15828,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL3dv == nil {
 		return errors.New("glVertexAttribL3dv")
 	}
+	gpVertexAttribL3i64NV = (C.GPVERTEXATTRIBL3I64NV)(getProcAddr("glVertexAttribL3i64NV"))
+	gpVertexAttribL3i64vNV = (C.GPVERTEXATTRIBL3I64VNV)(getProcAddr("glVertexAttribL3i64vNV"))
+	gpVertexAttribL3ui64NV = (C.GPVERTEXATTRIBL3UI64NV)(getProcAddr("glVertexAttribL3ui64NV"))
+	gpVertexAttribL3ui64vNV = (C.GPVERTEXATTRIBL3UI64VNV)(getProcAddr("glVertexAttribL3ui64vNV"))
 	gpVertexAttribL4d = (C.GPVERTEXATTRIBL4D)(getProcAddr("glVertexAttribL4d"))
 	if gpVertexAttribL4d == nil {
 		return errors.New("glVertexAttribL4d")
@@ -10314,7 +15840,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL4dv == nil {
 		return errors.New("glVertexAttribL4dv")
 	}
+	gpVertexAttribL4i64NV = (C.GPVERTEXATTRIBL4I64NV)(getProcAddr("glVertexAttribL4i64NV"))
+	gpVertexAttribL4i64vNV = (C.GPVERTEXATTRIBL4I64VNV)(getProcAddr("glVertexAttribL4i64vNV"))
+	gpVertexAttribL4ui64NV = (C.GPVERTEXATTRIBL4UI64NV)(getProcAddr("glVertexAttribL4ui64NV"))
+	gpVertexAttribL4ui64vNV = (C.GPVERTEXATTRIBL4UI64VNV)(getProcAddr("glVertexAttribL4ui64vNV"))
 	gpVertexAttribLFormat = (C.GPVERTEXATTRIBLFORMAT)(getProcAddr("glVertexAttribLFormat"))
+	gpVertexAttribLFormatNV = (C.GPVERTEXATTRIBLFORMATNV)(getProcAddr("glVertexAttribLFormatNV"))
 	gpVertexAttribLPointer = (C.GPVERTEXATTRIBLPOINTER)(getProcAddr("glVertexAttribLPointer"))
 	if gpVertexAttribLPointer == nil {
 		return errors.New("glVertexAttribLPointer")
@@ -10356,6 +15887,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glVertexAttribPointer")
 	}
 	gpVertexBindingDivisor = (C.GPVERTEXBINDINGDIVISOR)(getProcAddr("glVertexBindingDivisor"))
+	gpVertexFormatNV = (C.GPVERTEXFORMATNV)(getProcAddr("glVertexFormatNV"))
 	gpViewport = (C.GPVIEWPORT)(getProcAddr("glViewport"))
 	if gpViewport == nil {
 		return errors.New("glViewport")
@@ -10372,9 +15904,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpViewportIndexedfv == nil {
 		return errors.New("glViewportIndexedfv")
 	}
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
+	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	return nil
 }

--- a/v4.2-core/gl/procaddr.go
+++ b/v4.2-core/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcore42(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v4.3-compatibility/gl/package.go
+++ b/v4.3-compatibility/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -75,7 +73,6 @@ package gl
 // typedef unsigned int GLenum;
 // typedef unsigned char GLboolean;
 // typedef unsigned int GLbitfield;
-// typedef void GLvoid;
 // typedef signed char GLbyte;
 // typedef short GLshort;
 // typedef int GLint;
@@ -88,6 +85,7 @@ package gl
 // typedef float GLclampf;
 // typedef double GLdouble;
 // typedef double GLclampd;
+// typedef void *GLeglClientBufferEXT;
 // typedef char GLchar;
 // typedef char GLcharARB;
 // #ifdef __APPLE__
@@ -104,7 +102,7 @@ package gl
 // typedef ptrdiff_t GLsizeiptrARB;
 // typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
@@ -113,12 +111,14 @@ package gl
 // typedef void (APIENTRY *GLDEBUGPROCAMD)(GLuint id,GLenum category,GLenum severity,GLsizei length,const GLchar *message,void *userParam);
 // typedef unsigned short GLhalfNV;
 // typedef GLintptr GLvdpauSurfaceNV;
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcompatibility43(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcompatibility43(source, type, id, severity, length, message, userParam);
 // }
 // typedef void  (APIENTRYP GPACCUM)(GLenum  op, GLfloat  value);
 // typedef void  (APIENTRYP GPACCUMXOES)(GLenum  op, GLfixed  value);
+// typedef GLboolean  (APIENTRYP GPACQUIREKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key, GLuint  timeout);
 // typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
@@ -131,6 +131,8 @@ package gl
 // typedef void  (APIENTRYP GPALPHAFRAGMENTOP3ATI)(GLenum  op, GLuint  dst, GLuint  dstMod, GLuint  arg1, GLuint  arg1Rep, GLuint  arg1Mod, GLuint  arg2, GLuint  arg2Rep, GLuint  arg2Mod, GLuint  arg3, GLuint  arg3Rep, GLuint  arg3Mod);
 // typedef void  (APIENTRYP GPALPHAFUNC)(GLenum  func, GLfloat  ref);
 // typedef void  (APIENTRYP GPALPHAFUNCXOES)(GLenum  func, GLfixed  ref);
+// typedef void  (APIENTRYP GPALPHATOCOVERAGEDITHERCONTROLNV)(GLenum  mode);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPAPPLYTEXTUREEXT)(GLenum  mode);
 // typedef GLboolean  (APIENTRYP GPAREPROGRAMSRESIDENTNV)(GLsizei  n, const GLuint * programs, GLboolean * residences);
 // typedef GLboolean  (APIENTRYP GPARETEXTURESRESIDENT)(GLsizei  n, const GLuint * textures, GLboolean * residences);
@@ -252,11 +254,14 @@ package gl
 // typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPBUFFERDATAARB)(GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERPARAMETERIAPPLE)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEEXTERNALEXT)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEMEMEXT)(GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPBUFFERSUBDATAARB)(GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLIST)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLISTS)(GLsizei  n, GLenum  type, const void * lists);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
@@ -286,9 +291,9 @@ package gl
 // typedef void  (APIENTRYP GPCLEARINDEX)(GLfloat  c);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
@@ -384,6 +389,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERIVNV)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERARB)(GLhandleARB  shaderObj);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
@@ -414,6 +421,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER2D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * image);
@@ -444,7 +453,7 @@ package gl
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  type);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
@@ -469,8 +478,12 @@ package gl
 // typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEMEMORYOBJECTSEXT)(GLsizei  n, GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef GLhandleARB  (APIENTRYP GPCREATEPROGRAMOBJECTARB)();
@@ -483,6 +496,7 @@ package gl
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -509,12 +523,14 @@ package gl
 // typedef void  (APIENTRYP GPDELETEASYNCMARKERSSGIX)(GLuint  marker, GLsizei  range);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
 // typedef void  (APIENTRYP GPDELETEBUFFERSARB)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFENCESAPPLE)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFENCESNV)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFRAGMENTSHADERATI)(GLuint  id);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERSEXT)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETELISTS)(GLuint  list, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEMEMORYOBJECTSEXT)(GLsizei  n, const GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
 // typedef void  (APIENTRYP GPDELETENAMESAMD)(GLenum  identifier, GLuint  num, const GLuint * names);
 // typedef void  (APIENTRYP GPDELETEOBJECTARB)(GLhandleARB  obj);
@@ -529,10 +545,13 @@ package gl
 // typedef void  (APIENTRYP GPDELETEPROGRAMSNV)(GLsizei  n, const GLuint * programs);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETEQUERIESARB)(GLsizei  n, const GLuint * ids);
+// typedef void  (APIENTRYP GPDELETEQUERYRESOURCETAGNV)(GLsizei  n, const GLint * tagIds);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERSEXT)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
+// typedef void  (APIENTRYP GPDELETESEMAPHORESEXT)(GLsizei  n, const GLuint * semaphores);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETEXTURESEXT)(GLsizei  n, const GLuint * textures);
@@ -582,6 +601,10 @@ package gl
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSARB)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSATI)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYAPPLE)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYATI)(GLenum  mode, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
@@ -606,6 +629,7 @@ package gl
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKNV)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
 // typedef void  (APIENTRYP GPEDGEFLAG)(GLboolean  flag);
 // typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPEDGEFLAGPOINTER)(GLsizei  stride, const void * pointer);
@@ -661,6 +685,7 @@ package gl
 // typedef void  (APIENTRYP GPEVALMESH2)(GLenum  mode, GLint  i1, GLint  i2, GLint  j1, GLint  j2);
 // typedef void  (APIENTRYP GPEVALPOINT1)(GLint  i);
 // typedef void  (APIENTRYP GPEVALPOINT2)(GLint  i, GLint  j);
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef void  (APIENTRYP GPEXECUTEPROGRAMNV)(GLenum  target, GLuint  id, const GLfloat * params);
 // typedef void  (APIENTRYP GPEXTRACTCOMPONENTEXT)(GLuint  res, GLuint  src, GLuint  num);
 // typedef void  (APIENTRYP GPFEEDBACKBUFFER)(GLsizei  size, GLenum  type, GLfloat * buffer);
@@ -676,7 +701,7 @@ package gl
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGEAPPLE)(GLenum  target, GLintptr  offset, GLsizeiptr  size);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHPIXELDATARANGENV)(GLenum  target);
 // typedef void  (APIENTRYP GPFLUSHRASTERSGIX)();
@@ -705,6 +730,7 @@ package gl
 // typedef void  (APIENTRYP GPFOGXOES)(GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPFOGXVOES)(GLenum  pname, const GLfixed * param);
 // typedef void  (APIENTRYP GPFRAGMENTCOLORMATERIALSGIX)(GLenum  face, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELISGIX)(GLenum  pname, GLint  param);
@@ -721,10 +747,14 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEZOOMSGIX)(GLint  factor);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFEREXT)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1DEXT)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -739,6 +769,7 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYEREXT)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFREEOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPFRUSTUM)(GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
@@ -763,9 +794,11 @@ package gl
 // typedef void  (APIENTRYP GPGENPROGRAMSNV)(GLsizei  n, GLuint * programs);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENQUERIESARB)(GLsizei  n, GLuint * ids);
+// typedef void  (APIENTRYP GPGENQUERYRESOURCETAGNV)(GLsizei  n, GLint * tagIds);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERSEXT)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
+// typedef void  (APIENTRYP GPGENSEMAPHORESEXT)(GLsizei  n, GLuint * semaphores);
 // typedef GLuint  (APIENTRYP GPGENSYMBOLSEXT)(GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components);
 // typedef void  (APIENTRYP GPGENTEXTURES)(GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPGENTEXTURESEXT)(GLsizei  n, GLuint * textures);
@@ -826,6 +859,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERFVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERIVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, GLfloat * params);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  level, void * img);
@@ -839,6 +873,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIVEXT)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERXVOES)(GLenum  target, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGAMD)(GLuint  count, GLsizei  bufsize, GLenum * categories, GLuint * severities, GLuint * ids, GLsizei * lengths, GLchar * message);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
@@ -868,6 +903,7 @@ package gl
 // typedef void  (APIENTRYP GPGETFRAGMENTMATERIALIVSGIX)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERFVAMD)(GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
@@ -894,6 +930,7 @@ package gl
 // typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -921,6 +958,7 @@ package gl
 // typedef void  (APIENTRYP GPGETMATERIALIV)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMATERIALXOES)(GLenum  face, GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPGETMATERIALXVOES)(GLenum  face, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMINMAX)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXEXT)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
@@ -947,10 +985,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
@@ -996,7 +1035,7 @@ package gl
 // typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
-// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
 // typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
 // typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
 // typedef void  (APIENTRYP GPGETPIXELMAPFV)(GLenum  map, GLfloat * values);
@@ -1045,6 +1084,10 @@ package gl
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVARB)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVNV)(GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64VEXT)(GLuint  id, GLenum  pname, GLint64 * params);
@@ -1062,6 +1105,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIUIV)(GLuint  sampler, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERFV)(GLuint  sampler, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIV)(GLuint  sampler, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTER)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTEREXT)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSHADERINFOLOG)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
@@ -1070,6 +1114,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERSOURCEARB)(GLhandleARB  obj, GLsizei  maxLength, GLsizei * length, GLcharARB * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETSHARPENTEXFUNCSGIS)(GLenum  target, GLfloat * points);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -1133,12 +1178,16 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFVARB)(GLhandleARB  programObj, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIVARB)(GLhandleARB  programObj, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIVEXT)(GLuint  program, GLint  location, GLuint * params);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEI_VEXT)(GLenum  target, GLuint  index, GLubyte * data);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEVEXT)(GLenum  pname, GLubyte * data);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTFVATI)(GLuint  id, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTIVATI)(GLuint  id, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -1184,6 +1233,7 @@ package gl
 // typedef void  (APIENTRYP GPGETVIDEOIVNV)(GLuint  video_slot, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVIDEOUI64VNV)(GLuint  video_slot, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVIDEOUIVNV)(GLuint  video_slot, GLenum  pname, GLuint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOLORTABLEARB)(GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNCONVOLUTIONFILTERARB)(GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * image);
@@ -1202,9 +1252,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
@@ -1225,6 +1277,12 @@ package gl
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERFVHP)(GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIHP)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIVHP)(GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPIMPORTMEMORYFDEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32HANDLEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32NAMEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, const void * name);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREFDEXT)(GLuint  semaphore, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32HANDLEEXT)(GLuint  semaphore, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32NAMEEXT)(GLuint  semaphore, GLenum  handleType, const void * name);
 // typedef GLsync  (APIENTRYP GPIMPORTSYNCEXT)(GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags);
 // typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPINDEXFUNCEXT)(GLenum  func, GLclampf  ref);
@@ -1263,6 +1321,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERARB)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
 // typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
@@ -1273,6 +1332,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISLIST)(GLuint  list);
+// typedef GLboolean  (APIENTRYP GPISMEMORYOBJECTEXT)(GLuint  memoryObject);
 // typedef GLboolean  (APIENTRYP GPISNAMEAMD)(GLenum  identifier, GLuint  name);
 // typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
@@ -1291,7 +1351,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFEREXT)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
+// typedef GLboolean  (APIENTRYP GPISSEMAPHOREEXT)(GLuint  semaphore);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREEXT)(GLuint  texture);
@@ -1303,6 +1365,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAYAPPLE)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXATTRIBENABLEDAPPLE)(GLuint  index, GLenum  pname);
+// typedef void  (APIENTRYP GPLGPUCOPYIMAGESUBDATANVX)(GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPLGPUINTERLOCKNVX)();
+// typedef void  (APIENTRYP GPLGPUNAMEDBUFFERSUBDATANVX)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLIGHTENVISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPLIGHTMODELF)(GLenum  pname, GLfloat  param);
@@ -1323,6 +1388,7 @@ package gl
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPLINKPROGRAMARB)(GLhandleARB  programObj);
 // typedef void  (APIENTRYP GPLISTBASE)(GLuint  base);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLISTPARAMETERFSGIX)(GLuint  list, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPLISTPARAMETERFVSGIX)(GLuint  list, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPLISTPARAMETERISGIX)(GLuint  list, GLenum  pname, GLint  param);
@@ -1371,7 +1437,7 @@ package gl
 // typedef void  (APIENTRYP GPMAPGRID2XOES)(GLint  n, GLfixed  u1, GLfixed  u2, GLfixed  v1, GLfixed  v2);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPMAPPARAMETERFVNV)(GLenum  target, GLenum  pname, const GLfloat * params);
@@ -1417,9 +1483,12 @@ package gl
 // typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIEREXT)(GLbitfield  barriers);
+// typedef void  (APIENTRYP GPMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPMINSAMPLESHADING)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINMAX)(GLenum  target, GLenum  internalformat, GLboolean  sink);
@@ -1438,7 +1507,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTAMD)(GLenum  mode, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTARRAYAPPLE)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
@@ -1447,7 +1516,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTAMD)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWRANGEELEMENTARRAYAPPLE)(GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWARRAYSIBM)(const GLenum * mode, const GLint * first, const GLsizei * count, GLsizei  primcount, GLint  modestride);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWELEMENTSIBM)(const GLenum * mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  primcount, GLint  modestride);
@@ -1572,13 +1641,26 @@ package gl
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPMULTICASTBARRIERNV)();
+// typedef void  (APIENTRYP GPMULTICASTBLITFRAMEBUFFERNV)(GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPMULTICASTBUFFERSUBDATANV)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPMULTICASTCOPYBUFFERSUBDATANV)(GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPMULTICASTCOPYIMAGESUBDATANV)(GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
+// typedef void  (APIENTRYP GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPMULTICASTWAITSYNCNV)(GLuint  signalGpu, GLbitfield  waitGpuMask);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXTERNALEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEMEMEXT)(GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
@@ -1588,6 +1670,9 @@ package gl
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -1731,6 +1816,8 @@ package gl
 // typedef GLint  (APIENTRYP GPPOLLINSTRUMENTSSGIX)(GLint * marker_p);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETEXT)(GLfloat  factor, GLfloat  bias);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETXOES)(GLfixed  factor, GLfixed  units);
 // typedef void  (APIENTRYP GPPOLYGONSTIPPLE)(const GLubyte * mask);
@@ -1743,6 +1830,7 @@ package gl
 // typedef void  (APIENTRYP GPPOPNAME)();
 // typedef void  (APIENTRYP GPPRESENTFRAMEDUALFILLNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLenum  target1, GLuint  fill1, GLenum  target2, GLuint  fill2, GLenum  target3, GLuint  fill3);
 // typedef void  (APIENTRYP GPPRESENTFRAMEKEYEDNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1);
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEXNV)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTNV)();
@@ -1800,13 +1888,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1820,13 +1912,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1840,13 +1936,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1860,13 +1960,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1927,6 +2031,8 @@ package gl
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
 // typedef GLbitfield  (APIENTRYP GPQUERYMATRIXXOES)(GLfixed * mantissa, GLint * exponent);
 // typedef void  (APIENTRYP GPQUERYOBJECTPARAMETERUIAMD)(GLenum  target, GLuint  id, GLenum  pname, GLuint  param);
+// typedef GLint  (APIENTRYP GPQUERYRESOURCENV)(GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer);
+// typedef void  (APIENTRYP GPQUERYRESOURCETAGNV)(GLint  tagId, const GLchar * tagString);
 // typedef void  (APIENTRYP GPRASTERPOS2D)(GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPRASTERPOS2DV)(const GLdouble * v);
 // typedef void  (APIENTRYP GPRASTERPOS2F)(GLfloat  x, GLfloat  y);
@@ -1957,6 +2063,7 @@ package gl
 // typedef void  (APIENTRYP GPRASTERPOS4SV)(const GLshort * v);
 // typedef void  (APIENTRYP GPRASTERPOS4XOES)(GLfixed  x, GLfixed  y, GLfixed  z, GLfixed  w);
 // typedef void  (APIENTRYP GPRASTERPOS4XVOES)(const GLfixed * coords);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
@@ -1974,7 +2081,9 @@ package gl
 // typedef void  (APIENTRYP GPRECTXOES)(GLfixed  x1, GLfixed  y1, GLfixed  x2, GLfixed  y2);
 // typedef void  (APIENTRYP GPRECTXVOES)(const GLfixed * v1, const GLfixed * v2);
 // typedef void  (APIENTRYP GPREFERENCEPLANESGIX)(const GLdouble * equation);
+// typedef GLboolean  (APIENTRYP GPRELEASEKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key);
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
+// typedef void  (APIENTRYP GPRENDERGPUMASKNV)(GLbitfield  mask);
 // typedef GLint  (APIENTRYP GPRENDERMODE)(GLenum  mode);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
@@ -2010,6 +2119,7 @@ package gl
 // typedef void  (APIENTRYP GPRESETMINMAX)(GLenum  target);
 // typedef void  (APIENTRYP GPRESETMINMAXEXT)(GLenum  target);
 // typedef void  (APIENTRYP GPRESIZEBUFFERSMESA)();
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACKNV)();
 // typedef void  (APIENTRYP GPROTATED)(GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
@@ -2017,7 +2127,6 @@ package gl
 // typedef void  (APIENTRYP GPROTATEXOES)(GLfixed  angle, GLfixed  x, GLfixed  y, GLfixed  z);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEARB)(GLfloat  value, GLboolean  invert);
-// typedef void  (APIENTRYP GPSAMPLECOVERAGEOES)(GLfixed  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEXOES)(GLclampx  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMAPATI)(GLuint  dst, GLuint  interp, GLenum  swizzle);
 // typedef void  (APIENTRYP GPSAMPLEMASKEXT)(GLclampf  value, GLboolean  invert);
@@ -2081,6 +2190,7 @@ package gl
 // typedef void  (APIENTRYP GPSECONDARYCOLORPOINTERLISTIBM)(GLint  size, GLenum  type, GLint  stride, const void ** pointer, GLint  ptrstride);
 // typedef void  (APIENTRYP GPSELECTBUFFER)(GLsizei  size, GLuint * buffer);
 // typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
+// typedef void  (APIENTRYP GPSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, const GLuint64 * params);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSETFENCEAPPLE)(GLuint  fence);
@@ -2098,11 +2208,16 @@ package gl
 // typedef void  (APIENTRYP GPSHADERSOURCEARB)(GLhandleARB  shaderObj, GLsizei  count, const GLcharARB ** string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
 // typedef void  (APIENTRYP GPSHARPENTEXFUNCSGIS)(GLenum  target, GLsizei  n, const GLfloat * points);
+// typedef void  (APIENTRYP GPSIGNALSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERIVSGIX)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPSTARTINSTRUMENTSSGIX)();
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
 // typedef void  (APIENTRYP GPSTENCILCLEARTAGEXT)(GLsizei  stencilTagBits, GLuint  stencilClearTag);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
@@ -2123,6 +2238,7 @@ package gl
 // typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
 // typedef void  (APIENTRYP GPSTOPINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPSTRINGMARKERGREMEDY)(GLsizei  len, const void * string);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPSWIZZLEEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // typedef void  (APIENTRYP GPSYNCTEXTUREINTEL)(GLuint  texture);
 // typedef void  (APIENTRYP GPTAGSAMPLEBUFFERSGIX)();
@@ -2256,7 +2372,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLint  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations);
 // typedef void  (APIENTRYP GPTEXIMAGE4DSGIS)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIVEXT)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
@@ -2273,6 +2389,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXSTORAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXSTORAGE3D)(GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXSTORAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM1DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXSTORAGESPARSEAMD)(GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1DEXT)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2285,7 +2406,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTURECOLORMASKSGIS)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
@@ -2298,7 +2419,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURELIGHTEXT)(GLenum  pname);
 // typedef void  (APIENTRYP GPTEXTUREMATERIALEXT)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPTEXTURENORMALEXT)(GLenum  mode);
-// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
@@ -2323,6 +2444,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM1DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXTURESTORAGESPARSEAMD)(GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2334,7 +2460,7 @@ package gl
 // typedef void  (APIENTRYP GPTRACKMATRIXNV)(GLenum  target, GLuint  address, GLenum  matrix, GLenum  transform);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKATTRIBSNV)(GLsizei  count, const GLint * attribs, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKSTREAMATTRIBSNV)(GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGSEXT)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
@@ -2350,13 +2476,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IARB)(GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIEXT)(GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2368,13 +2498,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IARB)(GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIEXT)(GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2386,13 +2520,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2404,13 +2542,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2837,7 +2979,11 @@ package gl
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
+// typedef void  (APIENTRYP GPWAITSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
 // typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
 // typedef void  (APIENTRYP GPWEIGHTPOINTERARB)(GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPWEIGHTBVARB)(GLint  size, const GLbyte * weights);
@@ -2904,12 +3050,16 @@ package gl
 // typedef void  (APIENTRYP GPWINDOWPOS4IVMESA)(const GLint * v);
 // typedef void  (APIENTRYP GPWINDOWPOS4SMESA)(GLshort  x, GLshort  y, GLshort  z, GLshort  w);
 // typedef void  (APIENTRYP GPWINDOWPOS4SVMESA)(const GLshort * v);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
 // typedef void  (APIENTRYP GPWRITEMASKEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // static void  glowAccum(GPACCUM fnptr, GLenum  op, GLfloat  value) {
 //   (*fnptr)(op, value);
 // }
 // static void  glowAccumxOES(GPACCUMXOES fnptr, GLenum  op, GLfixed  value) {
 //   (*fnptr)(op, value);
+// }
+// static GLboolean  glowAcquireKeyedMutexWin32EXT(GPACQUIREKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key, GLuint  timeout) {
+//   return (*fnptr)(memory, key, timeout);
 // }
 // static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
 //   (*fnptr)(program);
@@ -2946,6 +3096,12 @@ package gl
 // }
 // static void  glowAlphaFuncxOES(GPALPHAFUNCXOES fnptr, GLenum  func, GLfixed  ref) {
 //   (*fnptr)(func, ref);
+// }
+// static void  glowAlphaToCoverageDitherControlNV(GPALPHATOCOVERAGEDITHERCONTROLNV fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowApplyTextureEXT(GPAPPLYTEXTUREEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -3310,7 +3466,7 @@ package gl
 // static void  glowBufferDataARB(GPBUFFERDATAARB fnptr, GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferParameteriAPPLE(GPBUFFERPARAMETERIAPPLE fnptr, GLenum  target, GLenum  pname, GLint  param) {
@@ -3319,11 +3475,20 @@ package gl
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(target, size, data, flags);
 // }
+// static void  glowBufferStorageExternalEXT(GPBUFFERSTORAGEEXTERNALEXT fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(target, offset, size, clientBuffer, flags);
+// }
+// static void  glowBufferStorageMemEXT(GPBUFFERSTORAGEMEMEXT fnptr, GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, size, memory, offset);
+// }
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
 // static void  glowBufferSubDataARB(GPBUFFERSUBDATAARB fnptr, GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
 // }
 // static void  glowCallList(GPCALLLIST fnptr, GLuint  list) {
 //   (*fnptr)(list);
@@ -3412,14 +3577,14 @@ package gl
 // static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
 // static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -3706,6 +3871,12 @@ package gl
 // static void  glowCombinerStageParameterfvNV(GPCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, const GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
@@ -3795,6 +3966,12 @@ package gl
 // }
 // static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
 //   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowConvolutionFilter1D(GPCONVOLUTIONFILTER1D fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image) {
 //   (*fnptr)(target, internalformat, width, format, type, image);
@@ -3886,7 +4063,7 @@ package gl
 // static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
@@ -3961,11 +4138,23 @@ package gl
 // static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
 //   (*fnptr)(path, coverMode);
 // }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
+// }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreateMemoryObjectsEXT(GPCREATEMEMORYOBJECTSEXT fnptr, GLsizei  n, GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
 //   (*fnptr)(queryId, queryHandle);
@@ -4002,6 +4191,9 @@ package gl
 // }
 // static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -4081,6 +4273,9 @@ package gl
 // static void  glowDeleteBuffersARB(GPDELETEBUFFERSARB fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFencesAPPLE(GPDELETEFENCESAPPLE fnptr, GLsizei  n, const GLuint * fences) {
 //   (*fnptr)(n, fences);
 // }
@@ -4098,6 +4293,9 @@ package gl
 // }
 // static void  glowDeleteLists(GPDELETELISTS fnptr, GLuint  list, GLsizei  range) {
 //   (*fnptr)(list, range);
+// }
+// static void  glowDeleteMemoryObjectsEXT(GPDELETEMEMORYOBJECTSEXT fnptr, GLsizei  n, const GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
@@ -4141,6 +4339,9 @@ package gl
 // static void  glowDeleteQueriesARB(GPDELETEQUERIESARB fnptr, GLsizei  n, const GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowDeleteQueryResourceTagNV(GPDELETEQUERYRESOURCETAGNV fnptr, GLsizei  n, const GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowDeleteRenderbuffers(GPDELETERENDERBUFFERS fnptr, GLsizei  n, const GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4150,8 +4351,14 @@ package gl
 // static void  glowDeleteSamplers(GPDELETESAMPLERS fnptr, GLsizei  count, const GLuint * samplers) {
 //   (*fnptr)(count, samplers);
 // }
+// static void  glowDeleteSemaphoresEXT(GPDELETESEMAPHORESEXT fnptr, GLsizei  n, const GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
+// }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -4300,6 +4507,18 @@ package gl
 // static void  glowDrawBuffersATI(GPDRAWBUFFERSATI fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
 // }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
+// }
 // static void  glowDrawElementArrayAPPLE(GPDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, GLint  first, GLsizei  count) {
 //   (*fnptr)(mode, first, count);
 // }
@@ -4371,6 +4590,9 @@ package gl
 // }
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
+// }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
 // }
 // static void  glowEdgeFlag(GPEDGEFLAG fnptr, GLboolean  flag) {
 //   (*fnptr)(flag);
@@ -4537,6 +4759,9 @@ package gl
 // static void  glowEvalPoint2(GPEVALPOINT2 fnptr, GLint  i, GLint  j) {
 //   (*fnptr)(i, j);
 // }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowExecuteProgramNV(GPEXECUTEPROGRAMNV fnptr, GLenum  target, GLuint  id, const GLfloat * params) {
 //   (*fnptr)(target, id, params);
 // }
@@ -4582,7 +4807,7 @@ package gl
 // static void  glowFlushMappedBufferRangeAPPLE(GPFLUSHMAPPEDBUFFERRANGEAPPLE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, offset, size);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
 // }
 // static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
@@ -4669,6 +4894,9 @@ package gl
 // static void  glowFragmentColorMaterialSGIX(GPFRAGMENTCOLORMATERIALSGIX fnptr, GLenum  face, GLenum  mode) {
 //   (*fnptr)(face, mode);
 // }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
 // static void  glowFragmentLightModelfSGIX(GPFRAGMENTLIGHTMODELFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -4717,6 +4945,9 @@ package gl
 // static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(framebuffer, n, bufs);
 // }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
@@ -4728,6 +4959,15 @@ package gl
 // }
 // static void  glowFramebufferRenderbufferEXT(GPFRAMEBUFFERRENDERBUFFEREXT fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSamplePositionsfvAMD(GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(target, numsamples, pixelindex, values);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -4770,6 +5010,9 @@ package gl
 // }
 // static void  glowFramebufferTextureLayerEXT(GPFRAMEBUFFERTEXTURELAYEREXT fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFreeObjectBufferATI(GPFREEOBJECTBUFFERATI fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -4843,6 +5086,9 @@ package gl
 // static void  glowGenQueriesARB(GPGENQUERIESARB fnptr, GLsizei  n, GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowGenQueryResourceTagNV(GPGENQUERYRESOURCETAGNV fnptr, GLsizei  n, GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowGenRenderbuffers(GPGENRENDERBUFFERS fnptr, GLsizei  n, GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4851,6 +5097,9 @@ package gl
 // }
 // static void  glowGenSamplers(GPGENSAMPLERS fnptr, GLsizei  count, GLuint * samplers) {
 //   (*fnptr)(count, samplers);
+// }
+// static void  glowGenSemaphoresEXT(GPGENSEMAPHORESEXT fnptr, GLsizei  n, GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
 // }
 // static GLuint  glowGenSymbolsEXT(GPGENSYMBOLSEXT fnptr, GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components) {
 //   return (*fnptr)(datatype, storagetype, range, components);
@@ -5032,6 +5281,9 @@ package gl
 // static void  glowGetCombinerStageParameterfvNV(GPGETCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
 // static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
 //   (*fnptr)(texunit, target, lod, img);
 // }
@@ -5070,6 +5322,9 @@ package gl
 // }
 // static void  glowGetConvolutionParameterxvOES(GPGETCONVOLUTIONPARAMETERXVOES fnptr, GLenum  target, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -5158,6 +5413,9 @@ package gl
 // static void  glowGetFramebufferAttachmentParameterivEXT(GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLenum  target, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, attachment, pname, params);
 // }
+// static void  glowGetFramebufferParameterfvAMD(GPGETFRAMEBUFFERPARAMETERFVAMD fnptr, GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(target, pname, numsamples, pixelindex, size, values);
+// }
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
@@ -5235,6 +5493,9 @@ package gl
 // }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
@@ -5317,6 +5578,9 @@ package gl
 // static void  glowGetMaterialxvOES(GPGETMATERIALXVOES fnptr, GLenum  face, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(face, pname, params);
 // }
+// static void  glowGetMemoryObjectParameterivEXT(GPGETMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
+// }
 // static void  glowGetMinmax(GPGETMINMAX fnptr, GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values) {
 //   (*fnptr)(target, reset, format, type, values);
 // }
@@ -5395,7 +5659,7 @@ package gl
 // static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
@@ -5406,6 +5670,9 @@ package gl
 // }
 // static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
+// }
+// static void  glowGetNamedFramebufferParameterfvAMD(GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD fnptr, GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(framebuffer, pname, numsamples, pixelindex, size, values);
 // }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
@@ -5542,7 +5809,7 @@ package gl
 // static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
 //   (*fnptr)(numGroups, groupsSize, groups);
 // }
-// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten) {
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
 //   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
 // }
 // static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
@@ -5689,6 +5956,18 @@ package gl
 // static void  glowGetProgramivNV(GPGETPROGRAMIVNV fnptr, GLuint  id, GLenum  pname, GLint * params) {
 //   (*fnptr)(id, pname, params);
 // }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
 // }
@@ -5740,6 +6019,9 @@ package gl
 // static void  glowGetSamplerParameteriv(GPGETSAMPLERPARAMETERIV fnptr, GLuint  sampler, GLenum  pname, GLint * params) {
 //   (*fnptr)(sampler, pname, params);
 // }
+// static void  glowGetSemaphoreParameterui64vEXT(GPGETSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowGetSeparableFilter(GPGETSEPARABLEFILTER fnptr, GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span) {
 //   (*fnptr)(target, format, type, row, column, span);
 // }
@@ -5763,6 +6045,9 @@ package gl
 // }
 // static void  glowGetSharpenTexFuncSGIS(GPGETSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLfloat * points) {
 //   (*fnptr)(target, points);
+// }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
 // }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
@@ -5953,6 +6238,9 @@ package gl
 // static void  glowGetUniformfvARB(GPGETUNIFORMFVARB fnptr, GLhandleARB  programObj, GLint  location, GLfloat * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5962,6 +6250,9 @@ package gl
 // static void  glowGetUniformivARB(GPGETUNIFORMIVARB fnptr, GLhandleARB  programObj, GLint  location, GLint * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5970,6 +6261,12 @@ package gl
 // }
 // static void  glowGetUniformuivEXT(GPGETUNIFORMUIVEXT fnptr, GLuint  program, GLint  location, GLuint * params) {
 //   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUnsignedBytei_vEXT(GPGETUNSIGNEDBYTEI_VEXT fnptr, GLenum  target, GLuint  index, GLubyte * data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetUnsignedBytevEXT(GPGETUNSIGNEDBYTEVEXT fnptr, GLenum  pname, GLubyte * data) {
+//   (*fnptr)(pname, data);
 // }
 // static void  glowGetVariantArrayObjectfvATI(GPGETVARIANTARRAYOBJECTFVATI fnptr, GLuint  id, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(id, pname, params);
@@ -6106,6 +6403,9 @@ package gl
 // static void  glowGetVideouivNV(GPGETVIDEOUIVNV fnptr, GLuint  video_slot, GLenum  pname, GLuint * params) {
 //   (*fnptr)(video_slot, pname, params);
 // }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
+// }
 // static void  glowGetnColorTableARB(GPGETNCOLORTABLEARB fnptr, GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table) {
 //   (*fnptr)(target, format, type, bufSize, table);
 // }
@@ -6160,6 +6460,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -6167,6 +6470,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -6228,6 +6534,24 @@ package gl
 // }
 // static void  glowImageTransformParameterivHP(GPIMAGETRANSFORMPARAMETERIVHP fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowImportMemoryFdEXT(GPIMPORTMEMORYFDEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(memory, size, handleType, fd);
+// }
+// static void  glowImportMemoryWin32HandleEXT(GPIMPORTMEMORYWIN32HANDLEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, void * handle) {
+//   (*fnptr)(memory, size, handleType, handle);
+// }
+// static void  glowImportMemoryWin32NameEXT(GPIMPORTMEMORYWIN32NAMEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, const void * name) {
+//   (*fnptr)(memory, size, handleType, name);
+// }
+// static void  glowImportSemaphoreFdEXT(GPIMPORTSEMAPHOREFDEXT fnptr, GLuint  semaphore, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(semaphore, handleType, fd);
+// }
+// static void  glowImportSemaphoreWin32HandleEXT(GPIMPORTSEMAPHOREWIN32HANDLEEXT fnptr, GLuint  semaphore, GLenum  handleType, void * handle) {
+//   (*fnptr)(semaphore, handleType, handle);
+// }
+// static void  glowImportSemaphoreWin32NameEXT(GPIMPORTSEMAPHOREWIN32NAMEEXT fnptr, GLuint  semaphore, GLenum  handleType, const void * name) {
+//   (*fnptr)(semaphore, handleType, name);
 // }
 // static GLsync  glowImportSyncEXT(GPIMPORTSYNCEXT fnptr, GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags) {
 //   return (*fnptr)(external_sync_type, external_sync, flags);
@@ -6343,6 +6667,9 @@ package gl
 // static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
 // }
@@ -6372,6 +6699,9 @@ package gl
 // }
 // static GLboolean  glowIsList(GPISLIST fnptr, GLuint  list) {
 //   return (*fnptr)(list);
+// }
+// static GLboolean  glowIsMemoryObjectEXT(GPISMEMORYOBJECTEXT fnptr, GLuint  memoryObject) {
+//   return (*fnptr)(memoryObject);
 // }
 // static GLboolean  glowIsNameAMD(GPISNAMEAMD fnptr, GLenum  identifier, GLuint  name) {
 //   return (*fnptr)(identifier, name);
@@ -6427,8 +6757,14 @@ package gl
 // static GLboolean  glowIsSampler(GPISSAMPLER fnptr, GLuint  sampler) {
 //   return (*fnptr)(sampler);
 // }
+// static GLboolean  glowIsSemaphoreEXT(GPISSEMAPHOREEXT fnptr, GLuint  semaphore) {
+//   return (*fnptr)(semaphore);
+// }
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
+// }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
 // }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
@@ -6462,6 +6798,15 @@ package gl
 // }
 // static GLboolean  glowIsVertexAttribEnabledAPPLE(GPISVERTEXATTRIBENABLEDAPPLE fnptr, GLuint  index, GLenum  pname) {
 //   return (*fnptr)(index, pname);
+// }
+// static void  glowLGPUCopyImageSubDataNVX(GPLGPUCOPYIMAGESUBDATANVX fnptr, GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(sourceGpu, destinationGpuMask, srcName, srcTarget, srcLevel, srcX, srxY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, width, height, depth);
+// }
+// static void  glowLGPUInterlockNVX(GPLGPUINTERLOCKNVX fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowLGPUNamedBufferSubDataNVX(GPLGPUNAMEDBUFFERSUBDATANVX fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
 // }
 // static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(type, object, length, label);
@@ -6522,6 +6867,9 @@ package gl
 // }
 // static void  glowListBase(GPLISTBASE fnptr, GLuint  base) {
 //   (*fnptr)(base);
+// }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
 // }
 // static void  glowListParameterfSGIX(GPLISTPARAMETERFSGIX fnptr, GLuint  list, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(list, pname, param);
@@ -6667,7 +7015,7 @@ package gl
 // static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
 // }
 // static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
@@ -6805,6 +7153,12 @@ package gl
 // static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
 //   (*fnptr)(mode, x, y, z);
 // }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
 // }
@@ -6813,6 +7167,9 @@ package gl
 // }
 // static void  glowMemoryBarrierEXT(GPMEMORYBARRIEREXT fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
+// }
+// static void  glowMemoryObjectParameterivEXT(GPMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, const GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
 // }
 // static void  glowMinSampleShading(GPMINSAMPLESHADING fnptr, GLfloat  value) {
 //   (*fnptr)(value);
@@ -6868,7 +7225,7 @@ package gl
 // static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElementArrayAPPLE(GPMULTIDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -6895,7 +7252,7 @@ package gl
 // static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawRangeElementArrayAPPLE(GPMULTIDRAWRANGEELEMENTARRAYAPPLE fnptr, GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -7270,25 +7627,64 @@ package gl
 // static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMulticastBarrierNV(GPMULTICASTBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowMulticastBlitFramebufferNV(GPMULTICASTBLITFRAMEBUFFERNV fnptr, GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
+//   (*fnptr)(srcGpu, dstGpu, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+// }
+// static void  glowMulticastBufferSubDataNV(GPMULTICASTBUFFERSUBDATANV fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
+// }
+// static void  glowMulticastCopyBufferSubDataNV(GPMULTICASTCOPYBUFFERSUBDATANV fnptr, GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readGpu, writeGpuMask, readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowMulticastCopyImageSubDataNV(GPMULTICASTCOPYIMAGESUBDATANV fnptr, GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
+//   (*fnptr)(srcGpu, dstGpuMask, srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
+// }
+// static void  glowMulticastFramebufferSampleLocationsfvNV(GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(gpu, framebuffer, start, count, v);
+// }
+// static void  glowMulticastGetQueryObjecti64vNV(GPMULTICASTGETQUERYOBJECTI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectivNV(GPMULTICASTGETQUERYOBJECTIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectui64vNV(GPMULTICASTGETQUERYOBJECTUI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectuivNV(GPMULTICASTGETQUERYOBJECTUIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastWaitSyncNV(GPMULTICASTWAITSYNCNV fnptr, GLuint  signalGpu, GLbitfield  waitGpuMask) {
+//   (*fnptr)(signalGpu, waitGpuMask);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
 // static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
 // static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageExternalEXT(GPNAMEDBUFFERSTORAGEEXTERNALEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(buffer, offset, size, clientBuffer, flags);
+// }
+// static void  glowNamedBufferStorageMemEXT(GPNAMEDBUFFERSTORAGEMEMEXT fnptr, GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(buffer, size, memory, offset);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
@@ -7317,6 +7713,15 @@ package gl
 // }
 // static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSamplePositionsfvAMD(GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(framebuffer, numsamples, pixelindex, values);
 // }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
@@ -7747,6 +8152,12 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPolygonOffsetEXT(GPPOLYGONOFFSETEXT fnptr, GLfloat  factor, GLfloat  bias) {
 //   (*fnptr)(factor, bias);
 // }
@@ -7782,6 +8193,9 @@ package gl
 // }
 // static void  glowPresentFrameKeyedNV(GPPRESENTFRAMEKEYEDNV fnptr, GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1) {
 //   (*fnptr)(video_slot, minPresentTime, beginPresentTimeId, presentDurationId, type, target0, fill0, key0, target1, fill1, key1);
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -7954,8 +8368,14 @@ package gl
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7972,8 +8392,14 @@ package gl
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8014,8 +8440,14 @@ package gl
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8032,8 +8464,14 @@ package gl
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8074,8 +8512,14 @@ package gl
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8092,8 +8536,14 @@ package gl
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8134,8 +8584,14 @@ package gl
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8152,8 +8608,14 @@ package gl
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8335,6 +8797,12 @@ package gl
 // static void  glowQueryObjectParameteruiAMD(GPQUERYOBJECTPARAMETERUIAMD fnptr, GLenum  target, GLuint  id, GLenum  pname, GLuint  param) {
 //   (*fnptr)(target, id, pname, param);
 // }
+// static GLint  glowQueryResourceNV(GPQUERYRESOURCENV fnptr, GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer) {
+//   return (*fnptr)(queryType, tagId, bufSize, buffer);
+// }
+// static void  glowQueryResourceTagNV(GPQUERYRESOURCETAGNV fnptr, GLint  tagId, const GLchar * tagString) {
+//   (*fnptr)(tagId, tagString);
+// }
 // static void  glowRasterPos2d(GPRASTERPOS2D fnptr, GLdouble  x, GLdouble  y) {
 //   (*fnptr)(x, y);
 // }
@@ -8425,6 +8893,9 @@ package gl
 // static void  glowRasterPos4xvOES(GPRASTERPOS4XVOES fnptr, const GLfixed * coords) {
 //   (*fnptr)(coords);
 // }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
+// }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
 // }
@@ -8476,8 +8947,14 @@ package gl
 // static void  glowReferencePlaneSGIX(GPREFERENCEPLANESGIX fnptr, const GLdouble * equation) {
 //   (*fnptr)(equation);
 // }
+// static GLboolean  glowReleaseKeyedMutexWin32EXT(GPRELEASEKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key) {
+//   return (*fnptr)(memory, key);
+// }
 // static void  glowReleaseShaderCompiler(GPRELEASESHADERCOMPILER fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowRenderGpuMaskNV(GPRENDERGPUMASKNV fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static GLint  glowRenderMode(GPRENDERMODE fnptr, GLenum  mode) {
 //   return (*fnptr)(mode);
@@ -8584,6 +9061,9 @@ package gl
 // static void  glowResizeBuffersMESA(GPRESIZEBUFFERSMESA fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -8603,9 +9083,6 @@ package gl
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoverageARB(GPSAMPLECOVERAGEARB fnptr, GLfloat  value, GLboolean  invert) {
-//   (*fnptr)(value, invert);
-// }
-// static void  glowSampleCoverageOES(GPSAMPLECOVERAGEOES fnptr, GLfixed  value, GLboolean  invert) {
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoveragexOES(GPSAMPLECOVERAGEXOES fnptr, GLclampx  value, GLboolean  invert) {
@@ -8797,6 +9274,9 @@ package gl
 // static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
 //   (*fnptr)(monitor, enable, group, numCounters, counterList);
 // }
+// static void  glowSemaphoreParameterui64vEXT(GPSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, const GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowSeparableFilter2D(GPSEPARABLEFILTER2D fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column) {
 //   (*fnptr)(target, internalformat, width, height, format, type, row, column);
 // }
@@ -8848,6 +9328,18 @@ package gl
 // static void  glowSharpenTexFuncSGIS(GPSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLsizei  n, const GLfloat * points) {
 //   (*fnptr)(target, n, points);
 // }
+// static void  glowSignalSemaphoreEXT(GPSIGNALSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, dstLayouts);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
 // static void  glowSpriteParameterfSGIX(GPSPRITEPARAMETERFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -8862,6 +9354,9 @@ package gl
 // }
 // static void  glowStartInstrumentsSGIX(GPSTARTINSTRUMENTSSGIX fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
 // }
 // static void  glowStencilClearTagEXT(GPSTENCILCLEARTAGEXT fnptr, GLsizei  stencilTagBits, GLuint  stencilClearTag) {
 //   (*fnptr)(stencilTagBits, stencilClearTag);
@@ -8922,6 +9417,9 @@ package gl
 // }
 // static void  glowStringMarkerGREMEDY(GPSTRINGMARKERGREMEDY fnptr, GLsizei  len, const void * string) {
 //   (*fnptr)(len, string);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
 // }
 // static void  glowSwizzleEXT(GPSWIZZLEEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
@@ -9322,8 +9820,8 @@ package gl
 // static void  glowTexImage4DSGIS(GPTEXIMAGE4DSGIS fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, height, depth, size4d, border, format, type, pixels);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -9373,6 +9871,21 @@ package gl
 // static void  glowTexStorage3DMultisample(GPTEXSTORAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTexStorageMem1DEXT(GPTEXSTORAGEMEM1DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTexStorageMem2DEXT(GPTEXSTORAGEMEM2DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTexStorageMem2DMultisampleEXT(GPTEXSTORAGEMEM2DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTexStorageMem3DEXT(GPTEXSTORAGEMEM3DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTexStorageMem3DMultisampleEXT(GPTEXSTORAGEMEM3DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTexStorageSparseAMD(GPTEXSTORAGESPARSEAMD fnptr, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9409,7 +9922,7 @@ package gl
 // static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, target, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
 // }
 // static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
@@ -9448,8 +9961,8 @@ package gl
 // static void  glowTextureNormalEXT(GPTEXTURENORMALEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
 // }
-// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
@@ -9523,6 +10036,21 @@ package gl
 // static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorageMem1DEXT(GPTEXTURESTORAGEMEM1DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTextureStorageMem2DEXT(GPTEXTURESTORAGEMEM2DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTextureStorageMem2DMultisampleEXT(GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTextureStorageMem3DEXT(GPTEXTURESTORAGEMEM3DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTextureStorageMem3DMultisampleEXT(GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTextureStorageSparseAMD(GPTEXTURESTORAGESPARSEAMD fnptr, GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(texture, target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9556,7 +10084,7 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackStreamAttribsNV(GPTRANSFORMFEEDBACKSTREAMATTRIBSNV fnptr, GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode) {
@@ -9604,8 +10132,14 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9622,8 +10156,14 @@ package gl
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9658,8 +10198,14 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9676,8 +10222,14 @@ package gl
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9712,8 +10264,14 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9730,8 +10288,14 @@ package gl
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9766,8 +10330,14 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9784,8 +10354,14 @@ package gl
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -11065,8 +11641,20 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
+// static void  glowWaitSemaphoreEXT(GPWAITSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, srcLayouts);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
 // }
 // static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
 //   (*fnptr)(resultPath, numPaths, paths, weights);
@@ -11266,6 +11854,9 @@ package gl
 // static void  glowWindowPos4svMESA(GPWINDOWPOS4SVMESA fnptr, const GLshort * v) {
 //   (*fnptr)(v);
 // }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
+// }
 // static void  glowWriteMaskEXT(GPWRITEMASKEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
 // }
@@ -11357,6 +11948,7 @@ const (
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_BARRIER_BITS_EXT                                       = 0xFFFFFFFF
 	ALL_COMPLETED_NV                                           = 0x84F2
+	ALL_PIXELS_AMD                                             = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
 	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALL_STATIC_DATA_IBM                                        = 103060
@@ -11391,11 +11983,16 @@ const (
 	ALPHA_MAX_SGIX                                             = 0x8321
 	ALPHA_MIN_CLAMP_INGR                                       = 0x8563
 	ALPHA_MIN_SGIX                                             = 0x8320
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALPHA_SCALE                                                = 0x0D1C
 	ALPHA_SNORM                                                = 0x9010
 	ALPHA_TEST                                                 = 0x0BC0
 	ALPHA_TEST_FUNC                                            = 0x0BC1
 	ALPHA_TEST_REF                                             = 0x0BC2
+	ALPHA_TO_COVERAGE_DITHER_DEFAULT_NV                        = 0x934D
+	ALPHA_TO_COVERAGE_DITHER_DISABLE_NV                        = 0x934F
+	ALPHA_TO_COVERAGE_DITHER_ENABLE_NV                         = 0x934E
+	ALPHA_TO_COVERAGE_DITHER_MODE_NV                           = 0x92BF
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	ALWAYS_FAST_HINT_PGI                                       = 0x1A20C
@@ -11441,6 +12038,7 @@ const (
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
 	ATTENUATION_EXT                                            = 0x834D
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	ATTRIB_ARRAY_POINTER_NV                                    = 0x8645
 	ATTRIB_ARRAY_SIZE_NV                                       = 0x8623
 	ATTRIB_ARRAY_STRIDE_NV                                     = 0x8624
@@ -11483,6 +12081,7 @@ const (
 	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
 	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_COLOR_EXT                                            = 0x8005
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
@@ -11660,10 +12259,26 @@ const (
 	COLOR_ATTACHMENT14_EXT                                     = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
 	COLOR_ATTACHMENT15_EXT                                     = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT1_EXT                                      = 0x8CE1
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT2_EXT                                      = 0x8CE2
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT3_EXT                                      = 0x8CE3
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT4_EXT                                      = 0x8CE4
@@ -11767,6 +12382,8 @@ const (
 	COMPILE                                                    = 0x1300
 	COMPILE_AND_EXECUTE                                        = 0x1301
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_ALPHA                                           = 0x84E9
 	COMPRESSED_ALPHA_ARB                                       = 0x84E9
 	COMPRESSED_INTENSITY                                       = 0x84EC
@@ -11870,8 +12487,18 @@ const (
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	COMP_BIT_ATI                                               = 0x00000002
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
 	CONIC_CURVE_TO_NV                                          = 0x1A
 	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSERVE_MEMORY_HINT_PGI                                   = 0x1A1FD
 	CONSTANT                                                   = 0x8576
 	CONSTANT_ALPHA                                             = 0x8003
@@ -11893,6 +12520,7 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
 	CONTEXT_LOST_KHR                                           = 0x0507
@@ -11971,6 +12599,9 @@ const (
 	COUNTER_TYPE_AMD                                           = 0x8BC0
 	COUNT_DOWN_NV                                              = 0x9089
 	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
 	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CUBIC_EXT                                                  = 0x8334
 	CUBIC_HP                                                   = 0x815F
@@ -12020,6 +12651,7 @@ const (
 	CURRENT_VERTEX_WEIGHT_EXT                                  = 0x850B
 	CURRENT_WEIGHT_ARB                                         = 0x86A8
 	CW                                                         = 0x0900
+	D3D12_FENCE_VALUE_EXT                                      = 0x9595
 	DARKEN_KHR                                                 = 0x9297
 	DARKEN_NV                                                  = 0x9297
 	DATA_BUFFER_AMD                                            = 0x9151
@@ -12112,6 +12744,7 @@ const (
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DECR_WRAP_EXT                                              = 0x8508
+	DEDICATED_MEMORY_OBJECT_EXT                                = 0x9581
 	DEFORMATIONS_MASK_SGIX                                     = 0x8196
 	DELETE_STATUS                                              = 0x8B80
 	DEPENDENT_AR_TEXTURE_2D_NV                                 = 0x86E9
@@ -12153,6 +12786,7 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_SCALE                                                = 0x0D1E
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
@@ -12170,6 +12804,9 @@ const (
 	DETAIL_TEXTURE_FUNC_POINTS_SGIS                            = 0x809C
 	DETAIL_TEXTURE_LEVEL_SGIS                                  = 0x809A
 	DETAIL_TEXTURE_MODE_SGIS                                   = 0x809B
+	DEVICE_LUID_EXT                                            = 0x9599
+	DEVICE_NODE_MASK_EXT                                       = 0x959A
+	DEVICE_UUID_EXT                                            = 0x9597
 	DIFFERENCE_KHR                                             = 0x929E
 	DIFFERENCE_NV                                              = 0x929E
 	DIFFUSE                                                    = 0x1201
@@ -12232,6 +12869,9 @@ const (
 	DOUBLE_VEC3_EXT                                            = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
 	DOUBLE_VEC4_EXT                                            = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER0_ARB                                           = 0x8825
@@ -12281,6 +12921,9 @@ const (
 	DRAW_BUFFER9                                               = 0x882E
 	DRAW_BUFFER9_ARB                                           = 0x882E
 	DRAW_BUFFER9_ATI                                           = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
 	DRAW_FRAMEBUFFER_BINDING_EXT                               = 0x8CA6
@@ -12292,6 +12935,7 @@ const (
 	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DRAW_PIXELS_APPLE                                          = 0x8A0A
 	DRAW_PIXEL_TOKEN                                           = 0x0705
+	DRIVER_UUID_EXT                                            = 0x9598
 	DSDT8_MAG8_INTENSITY8_NV                                   = 0x870B
 	DSDT8_MAG8_NV                                              = 0x870A
 	DSDT8_NV                                                   = 0x8709
@@ -12352,7 +12996,9 @@ const (
 	EDGE_FLAG_ARRAY_POINTER_EXT                                = 0x8093
 	EDGE_FLAG_ARRAY_STRIDE                                     = 0x808C
 	EDGE_FLAG_ARRAY_STRIDE_EXT                                 = 0x808C
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
 	EIGHTH_BIT_ATI                                             = 0x00000020
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
 	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_APPLE                                        = 0x8A0C
 	ELEMENT_ARRAY_ATI                                          = 0x8768
@@ -12397,6 +13043,7 @@ const (
 	EVAL_VERTEX_ATTRIB9_NV                                     = 0x86CF
 	EXCLUSION_KHR                                              = 0x92A0
 	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXP                                                        = 0x0800
 	EXP2                                                       = 0x0801
 	EXPAND_NEGATE_NV                                           = 0x8539
@@ -12430,6 +13077,7 @@ const (
 	FIELD_UPPER_NV                                             = 0x9022
 	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
 	FILTER4_SGIS                                               = 0x8146
 	FIRST_TO_REST_NV                                           = 0x90AF
@@ -12441,6 +13089,15 @@ const (
 	FIXED_ONLY_ARB                                             = 0x891D
 	FLAT                                                       = 0x1D00
 	FLOAT                                                      = 0x1406
+	FLOAT16_MAT2_AMD                                           = 0x91C5
+	FLOAT16_MAT2x3_AMD                                         = 0x91C8
+	FLOAT16_MAT2x4_AMD                                         = 0x91C9
+	FLOAT16_MAT3_AMD                                           = 0x91C6
+	FLOAT16_MAT3x2_AMD                                         = 0x91CA
+	FLOAT16_MAT3x4_AMD                                         = 0x91CB
+	FLOAT16_MAT4_AMD                                           = 0x91C7
+	FLOAT16_MAT4x2_AMD                                         = 0x91CC
+	FLOAT16_MAT4x3_AMD                                         = 0x91CD
 	FLOAT16_NV                                                 = 0x8FF8
 	FLOAT16_VEC2_NV                                            = 0x8FF9
 	FLOAT16_VEC3_NV                                            = 0x8FFA
@@ -12546,6 +13203,8 @@ const (
 	FRAGMENT_COLOR_MATERIAL_FACE_SGIX                          = 0x8402
 	FRAGMENT_COLOR_MATERIAL_PARAMETER_SGIX                     = 0x8403
 	FRAGMENT_COLOR_MATERIAL_SGIX                               = 0x8401
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
 	FRAGMENT_DEPTH                                             = 0x8452
 	FRAGMENT_DEPTH_EXT                                         = 0x8452
 	FRAGMENT_INPUT_NV                                          = 0x936D
@@ -12577,6 +13236,7 @@ const (
 	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
 	FRAGMENT_SHADER_DERIVATIVE_HINT_ARB                        = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -12598,12 +13258,14 @@ const (
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_3D_ZOFFSET_EXT              = 0x8CD4
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE_EXT           = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER_EXT                   = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL_EXT                   = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BARRIER_BIT_EXT                                = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
@@ -12635,8 +13297,13 @@ const (
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_EXT                     = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER_EXT                     = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_SRGB_CAPABLE_EXT                               = 0x8DBA
 	FRAMEBUFFER_SRGB_EXT                                       = 0x8DB9
@@ -12649,6 +13316,7 @@ const (
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_RANGE_EXT                                             = 0x87E1
@@ -12728,6 +13396,14 @@ const (
 	HALF_FLOAT                                                 = 0x140B
 	HALF_FLOAT_ARB                                             = 0x140B
 	HALF_FLOAT_NV                                              = 0x140B
+	HANDLE_TYPE_D3D11_IMAGE_EXT                                = 0x958B
+	HANDLE_TYPE_D3D11_IMAGE_KMT_EXT                            = 0x958C
+	HANDLE_TYPE_D3D12_FENCE_EXT                                = 0x9594
+	HANDLE_TYPE_D3D12_RESOURCE_EXT                             = 0x958A
+	HANDLE_TYPE_D3D12_TILEPOOL_EXT                             = 0x9589
+	HANDLE_TYPE_OPAQUE_FD_EXT                                  = 0x9586
+	HANDLE_TYPE_OPAQUE_WIN32_EXT                               = 0x9587
+	HANDLE_TYPE_OPAQUE_WIN32_KMT_EXT                           = 0x9588
 	HARDLIGHT_KHR                                              = 0x929B
 	HARDLIGHT_NV                                               = 0x929B
 	HARDMIX_NV                                                 = 0x92A9
@@ -12835,6 +13511,7 @@ const (
 	IMPLEMENTATION_COLOR_READ_FORMAT_OES                       = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
 	IMPLEMENTATION_COLOR_READ_TYPE_OES                         = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
 	INCR_WRAP_EXT                                              = 0x8507
@@ -12879,9 +13556,13 @@ const (
 	INT16_VEC2_NV                                              = 0x8FE5
 	INT16_VEC3_NV                                              = 0x8FE6
 	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
 	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
 	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
 	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
 	INT64_VEC4_NV                                              = 0x8FEB
 	INT8_NV                                                    = 0x8FE0
 	INT8_VEC2_NV                                               = 0x8FE1
@@ -13020,13 +13701,23 @@ const (
 	LAST_VIDEO_CAPTURE_STATUS_NV                               = 0x9027
 	LAYER_NV                                                   = 0x8DAA
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
+	LAYOUT_COLOR_ATTACHMENT_EXT                                = 0x958E
 	LAYOUT_DEFAULT_INTEL                                       = 0
+	LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT              = 0x9531
+	LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT              = 0x9530
+	LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT                        = 0x958F
+	LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT                         = 0x9590
+	LAYOUT_GENERAL_EXT                                         = 0x958D
 	LAYOUT_LINEAR_CPU_CACHED_INTEL                             = 2
 	LAYOUT_LINEAR_INTEL                                        = 1
+	LAYOUT_SHADER_READ_ONLY_EXT                                = 0x9591
+	LAYOUT_TRANSFER_DST_EXT                                    = 0x9593
+	LAYOUT_TRANSFER_SRC_EXT                                    = 0x9592
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LERP_ATI                                                   = 0x8969
 	LESS                                                       = 0x0201
+	LGPU_SEPARATE_STORAGE_BIT_NVX                              = 0x0800
 	LIGHT0                                                     = 0x4000
 	LIGHT1                                                     = 0x4001
 	LIGHT2                                                     = 0x4002
@@ -13062,6 +13753,7 @@ const (
 	LINEAR_SHARPEN_ALPHA_SGIS                                  = 0x80AE
 	LINEAR_SHARPEN_COLOR_SGIS                                  = 0x80AF
 	LINEAR_SHARPEN_SGIS                                        = 0x80AD
+	LINEAR_TILING_EXT                                          = 0x9585
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
 	LINES_ADJACENCY_ARB                                        = 0x000A
@@ -13081,6 +13773,7 @@ const (
 	LINE_TOKEN                                                 = 0x0702
 	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -13107,6 +13800,7 @@ const (
 	LOW_INT                                                    = 0x8DF3
 	LO_BIAS_NV                                                 = 0x8715
 	LO_SCALE_NV                                                = 0x870F
+	LUID_SIZE_EXT                                              = 8
 	LUMINANCE                                                  = 0x1909
 	LUMINANCE12                                                = 0x8041
 	LUMINANCE12_ALPHA12                                        = 0x8047
@@ -13440,6 +14134,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_LGPU_GPUS_NVX                                          = 0x92BA
 	MAX_LIGHTS                                                 = 0x0D31
 	MAX_LIST_NESTING                                           = 0x0B31
 	MAX_MAP_TESSELLATION_NV                                    = 0x86D6
@@ -13504,6 +14199,7 @@ const (
 	MAX_PROGRAM_TEX_INSTRUCTIONS_ARB                           = 0x880C
 	MAX_PROGRAM_TOTAL_OUTPUT_COMPONENTS_NV                     = 0x8C28
 	MAX_PROJECTION_STACK_DEPTH                                 = 0x0D38
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RATIONAL_EVAL_ORDER_NV                                 = 0x86D7
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RECTANGLE_TEXTURE_SIZE_ARB                             = 0x84F8
@@ -13516,6 +14212,8 @@ const (
 	MAX_SAMPLE_MASK_WORDS_NV                                   = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
 	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SHININESS_NV                                           = 0x8504
@@ -13526,6 +14224,7 @@ const (
 	MAX_SPARSE_TEXTURE_SIZE_AMD                                = 0x9198
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
 	MAX_SPOT_EXPONENT_NV                                       = 0x8505
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -13560,6 +14259,7 @@ const (
 	MAX_TEXTURE_IMAGE_UNITS_NV                                 = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
 	MAX_TEXTURE_LOD_BIAS_EXT                                   = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_MAX_ANISOTROPY_EXT                             = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TEXTURE_STACK_DEPTH                                    = 0x0D39
@@ -13615,7 +14315,9 @@ const (
 	MAX_VERTEX_VARYING_COMPONENTS_EXT                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
@@ -13642,7 +14344,6 @@ const (
 	MIN_SAMPLE_SHADING_VALUE                                   = 0x8C37
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
 	MIN_SPARSE_LEVEL_AMD                                       = 0x919B
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
 	MIRRORED_REPEAT_ARB                                        = 0x8370
@@ -13655,6 +14356,8 @@ const (
 	MIRROR_CLAMP_TO_EDGE_EXT                                   = 0x8743
 	MITER_REVERT_NV                                            = 0x90A7
 	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
 	MODELVIEW                                                  = 0x1700
 	MODELVIEW0_ARB                                             = 0x1700
 	MODELVIEW0_EXT                                             = 0x1700
@@ -13706,9 +14409,12 @@ const (
 	MOVE_TO_RESETS_NV                                          = 0x90B5
 	MOV_ATI                                                    = 0x8961
 	MULT                                                       = 0x0103
+	MULTICAST_GPUS_NV                                          = 0x92BA
+	MULTICAST_PROGRAMMABLE_SAMPLE_LOCATION_NV                  = 0x9549
 	MULTIPLY_KHR                                               = 0x9294
 	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
 	MULTISAMPLE_3DFX                                           = 0x86B2
 	MULTISAMPLE_ARB                                            = 0x809D
 	MULTISAMPLE_BIT                                            = 0x20000000
@@ -13718,6 +14424,9 @@ const (
 	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
 	MULTISAMPLE_EXT                                            = 0x809D
 	MULTISAMPLE_FILTER_HINT_NV                                 = 0x8534
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	MULTISAMPLE_SGIS                                           = 0x809D
 	MUL_ATI                                                    = 0x8964
 	MVP_MATRIX_EXT                                             = 0x87E3
@@ -13748,6 +14457,7 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
 	NORMALIZE                                                  = 0x0BA1
 	NORMALIZED_RANGE_EXT                                       = 0x87E0
@@ -13781,6 +14491,7 @@ const (
 	NUM_COMPATIBLE_SUBROUTINES                                 = 0x8E4A
 	NUM_COMPRESSED_TEXTURE_FORMATS                             = 0x86A2
 	NUM_COMPRESSED_TEXTURE_FORMATS_ARB                         = 0x86A2
+	NUM_DEVICE_UUIDS_EXT                                       = 0x9596
 	NUM_EXTENSIONS                                             = 0x821D
 	NUM_FILL_STREAMS_NV                                        = 0x8E29
 	NUM_FRAGMENT_CONSTANTS_ATI                                 = 0x896F
@@ -13795,8 +14506,12 @@ const (
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
 	NUM_SHADING_LANGUAGE_VERSIONS                              = 0x82E9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
+	NUM_TILING_TYPES_EXT                                       = 0x9582
 	NUM_VIDEO_CAPTURE_STREAMS_NV                               = 0x9024
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_ACTIVE_ATTRIBUTES_ARB                               = 0x8B89
 	OBJECT_ACTIVE_ATTRIBUTE_MAX_LENGTH_ARB                     = 0x8B8A
 	OBJECT_ACTIVE_UNIFORMS_ARB                                 = 0x8B86
@@ -13873,6 +14588,7 @@ const (
 	OPERAND2_RGB_EXT                                           = 0x8592
 	OPERAND3_ALPHA_NV                                          = 0x859B
 	OPERAND3_RGB_NV                                            = 0x8593
+	OPTIMAL_TILING_EXT                                         = 0x9584
 	OP_ADD_EXT                                                 = 0x8787
 	OP_CLAMP_EXT                                               = 0x878E
 	OP_CROSS_PRODUCT_EXT                                       = 0x8797
@@ -13952,7 +14668,7 @@ const (
 	PACK_INVERT_MESA                                           = 0x8758
 	PACK_LSB_FIRST                                             = 0x0D01
 	PACK_RESAMPLE_OML                                          = 0x8984
-	PACK_RESAMPLE_SGIX                                         = 0x842C
+	PACK_RESAMPLE_SGIX                                         = 0x842E
 	PACK_ROW_BYTES_APPLE                                       = 0x8A15
 	PACK_ROW_LENGTH                                            = 0x0D02
 	PACK_SKIP_IMAGES                                           = 0x806B
@@ -14057,10 +14773,14 @@ const (
 	PERFQUERY_WAIT_INTEL                                       = 0x83FB
 	PERSPECTIVE_CORRECTION_HINT                                = 0x0C50
 	PERTURB_EXT                                                = 0x85AE
+	PER_GPU_STORAGE_BIT_NV                                     = 0x0800
+	PER_GPU_STORAGE_NV                                         = 0x9548
 	PER_STAGE_CONSTANTS_NV                                     = 0x8535
 	PHONG_HINT_WIN                                             = 0x80EB
 	PHONG_WIN                                                  = 0x80EA
 	PINLIGHT_NV                                                = 0x92A8
+	PIXELS_PER_SAMPLE_PATTERN_X_AMD                            = 0x91AE
+	PIXELS_PER_SAMPLE_PATTERN_Y_AMD                            = 0x91AF
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_BUFFER_BARRIER_BIT_EXT                               = 0x00000080
 	PIXEL_COUNTER_BITS_NV                                      = 0x8864
@@ -14166,6 +14886,9 @@ const (
 	POLYGON_BIT                                                = 0x00000008
 	POLYGON_MODE                                               = 0x0B40
 	POLYGON_OFFSET_BIAS_EXT                                    = 0x8039
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_EXT                                         = 0x8037
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FACTOR_EXT                                  = 0x8038
@@ -14236,6 +14959,7 @@ const (
 	PRIMITIVES_GENERATED_EXT                                   = 0x8C87
 	PRIMITIVES_GENERATED_NV                                    = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_ID_NV                                            = 0x8C7C
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
@@ -14243,11 +14967,16 @@ const (
 	PRIMITIVE_RESTART_INDEX_NV                                 = 0x8559
 	PRIMITIVE_RESTART_NV                                       = 0x8558
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_ADDRESS_REGISTERS_ARB                              = 0x88B0
 	PROGRAM_ALU_INSTRUCTIONS_ARB                               = 0x8805
 	PROGRAM_ATTRIBS_ARB                                        = 0x88AC
 	PROGRAM_ATTRIB_COMPONENTS_NV                               = 0x8906
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
+	PROGRAM_BINARY_FORMAT_MESA                                 = 0x875F
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_BINDING_ARB                                        = 0x8677
@@ -14280,6 +15009,7 @@ const (
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
 	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
 	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
 	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
@@ -14298,6 +15028,7 @@ const (
 	PROJECTION                                                 = 0x1701
 	PROJECTION_MATRIX                                          = 0x0BA7
 	PROJECTION_STACK_DEPTH                                     = 0x0BA4
+	PROTECTED_MEMORY_OBJECT_EXT                                = 0x959B
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROVOKING_VERTEX_EXT                                       = 0x8E4F
 	PROXY_COLOR_TABLE                                          = 0x80D3
@@ -14334,6 +15065,7 @@ const (
 	PROXY_TEXTURE_RECTANGLE_ARB                                = 0x84F7
 	PROXY_TEXTURE_RECTANGLE_NV                                 = 0x84F7
 	PURGEABLE_APPLE                                            = 0x8A1D
+	PURGED_CONTEXT_RESET_NV                                    = 0x92BB
 	Q                                                          = 0x2003
 	QUADRATIC_ATTENUATION                                      = 0x1209
 	QUADRATIC_CURVE_TO_NV                                      = 0x0A
@@ -14374,6 +15106,12 @@ const (
 	QUERY_NO_WAIT_NV                                           = 0x8E14
 	QUERY_OBJECT_AMD                                           = 0x9153
 	QUERY_OBJECT_EXT                                           = 0x9153
+	QUERY_RESOURCE_BUFFEROBJECT_NV                             = 0x9547
+	QUERY_RESOURCE_MEMTYPE_VIDMEM_NV                           = 0x9542
+	QUERY_RESOURCE_RENDERBUFFER_NV                             = 0x9546
+	QUERY_RESOURCE_SYS_RESERVED_NV                             = 0x9544
+	QUERY_RESOURCE_TEXTURE_NV                                  = 0x9545
+	QUERY_RESOURCE_TYPE_VIDMEM_ALLOC_NV                        = 0x9540
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_ARB                                           = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
@@ -14412,7 +15150,10 @@ const (
 	RASTERIZER_DISCARD                                         = 0x8C89
 	RASTERIZER_DISCARD_EXT                                     = 0x8C89
 	RASTERIZER_DISCARD_NV                                      = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
 	RASTER_POSITION_UNCLIPPED_IBM                              = 0x19262
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -14537,6 +15278,7 @@ const (
 	RENDERBUFFER_WIDTH                                         = 0x8D42
 	RENDERBUFFER_WIDTH_EXT                                     = 0x8D42
 	RENDERER                                                   = 0x1F01
+	RENDER_GPU_MASK_NV                                         = 0x9558
 	RENDER_MODE                                                = 0x0C40
 	REPEAT                                                     = 0x2901
 	REPLACE                                                    = 0x1E01
@@ -14555,9 +15297,9 @@ const (
 	RESAMPLE_DECIMATE_OML                                      = 0x8989
 	RESAMPLE_DECIMATE_SGIX                                     = 0x8430
 	RESAMPLE_REPLICATE_OML                                     = 0x8986
-	RESAMPLE_REPLICATE_SGIX                                    = 0x842E
+	RESAMPLE_REPLICATE_SGIX                                    = 0x8433
 	RESAMPLE_ZERO_FILL_OML                                     = 0x8987
-	RESAMPLE_ZERO_FILL_SGIX                                    = 0x842F
+	RESAMPLE_ZERO_FILL_SGIX                                    = 0x8434
 	RESCALE_NORMAL                                             = 0x803A
 	RESCALE_NORMAL_EXT                                         = 0x803A
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
@@ -14755,6 +15497,14 @@ const (
 	SAMPLE_COVERAGE_INVERT_ARB                                 = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
 	SAMPLE_COVERAGE_VALUE_ARB                                  = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_EXT                                            = 0x80A0
 	SAMPLE_MASK_INVERT_EXT                                     = 0x80AB
@@ -14781,6 +15531,7 @@ const (
 	SCALE_BY_TWO_NV                                            = 0x853E
 	SCISSOR_BIT                                                = 0x00080000
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
 	SCREEN_COORDINATES_REND                                    = 0x8490
 	SCREEN_KHR                                                 = 0x9295
@@ -14817,6 +15568,7 @@ const (
 	SET_AMD                                                    = 0x874A
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
 	SHADER_CONSISTENT_NV                                       = 0x86DD
 	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
@@ -14844,6 +15596,7 @@ const (
 	SHADING_LANGUAGE_VERSION_ARB                               = 0x8B8C
 	SHADOW_AMBIENT_SGIX                                        = 0x80BF
 	SHADOW_ATTENUATION_EXT                                     = 0x834E
+	SHARED_EDGE_NV                                             = 0xC0
 	SHARED_TEXTURE_PALETTE_EXT                                 = 0x81FB
 	SHARPEN_TEXTURE_FUNC_POINTS_SGIS                           = 0x80B0
 	SHININESS                                                  = 0x1601
@@ -14930,6 +15683,8 @@ const (
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
 	SPECULAR                                                   = 0x1202
 	SPHERE_MAP                                                 = 0x2402
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
 	SPOT_CUTOFF                                                = 0x1206
 	SPOT_DIRECTION                                             = 0x1204
 	SPOT_EXPONENT                                              = 0x1205
@@ -15016,7 +15771,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TAG_BITS_EXT                                       = 0x88F2
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_TEST_TWO_SIDE_EXT                                  = 0x8910
@@ -15038,11 +15795,15 @@ const (
 	STRICT_LIGHTING_HINT_PGI                                   = 0x1A217
 	STRICT_SCISSOR_HINT_PGI                                    = 0x1A218
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
 	SUBSAMPLE_DISTANCE_AMD                                     = 0x883F
 	SUBTRACT                                                   = 0x84E7
 	SUBTRACT_ARB                                               = 0x84E7
 	SUB_ATI                                                    = 0x8965
 	SUCCESS_NV                                                 = 0x902F
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SURFACE_MAPPED_NV                                          = 0x8700
 	SURFACE_REGISTERED_NV                                      = 0x86FD
 	SURFACE_STATE_NV                                           = 0x86EB
@@ -15080,6 +15841,7 @@ const (
 	TANGENT_ARRAY_POINTER_EXT                                  = 0x8442
 	TANGENT_ARRAY_STRIDE_EXT                                   = 0x843F
 	TANGENT_ARRAY_TYPE_EXT                                     = 0x843E
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESSELLATION_FACTOR_AMD                                    = 0x9005
 	TESSELLATION_MODE_AMD                                      = 0x9004
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
@@ -15199,7 +15961,6 @@ const (
 	TEXTURE_APPLICATION_MODE_EXT                               = 0x834F
 	TEXTURE_BASE_LEVEL                                         = 0x813C
 	TEXTURE_BASE_LEVEL_SGIS                                    = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_1D_ARRAY_EXT                               = 0x8C1C
@@ -15375,6 +16136,7 @@ const (
 	TEXTURE_MATERIAL_FACE_EXT                                  = 0x8351
 	TEXTURE_MATERIAL_PARAMETER_EXT                             = 0x8352
 	TEXTURE_MATRIX                                             = 0x0BA8
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_ANISOTROPY_EXT                                 = 0x84FE
 	TEXTURE_MAX_CLAMP_R_SGIX                                   = 0x836B
 	TEXTURE_MAX_CLAMP_S_SGIX                                   = 0x8369
@@ -15398,6 +16160,8 @@ const (
 	TEXTURE_RECTANGLE                                          = 0x84F5
 	TEXTURE_RECTANGLE_ARB                                      = 0x84F5
 	TEXTURE_RECTANGLE_NV                                       = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_SIZE_EXT                                       = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
@@ -15429,6 +16193,7 @@ const (
 	TEXTURE_SWIZZLE_RGBA_EXT                                   = 0x8E46
 	TEXTURE_SWIZZLE_R_EXT                                      = 0x8E42
 	TEXTURE_TARGET                                             = 0x1006
+	TEXTURE_TILING_EXT                                         = 0x9580
 	TEXTURE_TOO_LARGE_EXT                                      = 0x8065
 	TEXTURE_UNSIGNED_REMAP_MODE_NV                             = 0x888F
 	TEXTURE_UPDATE_BARRIER_BIT                                 = 0x00000100
@@ -15445,6 +16210,10 @@ const (
 	TEXTURE_WRAP_S                                             = 0x2802
 	TEXTURE_WRAP_T                                             = 0x2803
 	TEXT_FRAGMENT_SHADER_ATI                                   = 0x8200
+	TILE_RASTER_ORDER_FIXED_MESA                               = 0x8BB8
+	TILE_RASTER_ORDER_INCREASING_X_MESA                        = 0x8BB9
+	TILE_RASTER_ORDER_INCREASING_Y_MESA                        = 0x8BBA
+	TILING_TYPES_EXT                                           = 0x9583
 	TIMEOUT_EXPIRED                                            = 0x911B
 	TIMEOUT_IGNORED                                            = 0xFFFFFFFFFFFFFFFF
 	TIMESTAMP                                                  = 0x8E28
@@ -15533,6 +16302,7 @@ const (
 	UNDEFINED_APPLE                                            = 0x8A1C
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -15551,12 +16321,15 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
 	UNIFORM_BUFFER_BINDING_EXT                                 = 0x8DEF
 	UNIFORM_BUFFER_EXT                                         = 0x8DEE
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -15579,7 +16352,7 @@ const (
 	UNPACK_IMAGE_HEIGHT_EXT                                    = 0x806E
 	UNPACK_LSB_FIRST                                           = 0x0CF1
 	UNPACK_RESAMPLE_OML                                        = 0x8985
-	UNPACK_RESAMPLE_SGIX                                       = 0x842D
+	UNPACK_RESAMPLE_SGIX                                       = 0x842F
 	UNPACK_ROW_BYTES_APPLE                                     = 0x8A16
 	UNPACK_ROW_LENGTH                                          = 0x0CF2
 	UNPACK_SKIP_IMAGES                                         = 0x806D
@@ -15603,8 +16376,11 @@ const (
 	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
 	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
 	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
 	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
 	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
 	UNSIGNED_INT8_NV                                           = 0x8FEC
 	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
@@ -15696,6 +16472,7 @@ const (
 	USE_MISSING_GLYPH_NV                                       = 0x90AA
 	UTF16_NV                                                   = 0x909B
 	UTF8_NV                                                    = 0x909A
+	UUID_SIZE_EXT                                              = 16
 	V2F                                                        = 0x2A20
 	V3F                                                        = 0x2A21
 	VALIDATE_STATUS                                            = 0x8B83
@@ -15879,8 +16656,24 @@ const (
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BIT                                               = 0x00000800
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -15910,6 +16703,8 @@ const (
 	WAIT_FAILED                                                = 0x911D
 	WARPS_PER_SM_NV                                            = 0x933A
 	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
 	WEIGHT_ARRAY_ARB                                           = 0x86AD
 	WEIGHT_ARRAY_BUFFER_BINDING                                = 0x889E
 	WEIGHT_ARRAY_BUFFER_BINDING_ARB                            = 0x889E
@@ -15919,6 +16714,8 @@ const (
 	WEIGHT_ARRAY_TYPE_ARB                                      = 0x86A9
 	WEIGHT_SUM_UNITY_ARB                                       = 0x86A6
 	WIDE_LINE_HINT_PGI                                         = 0x1A222
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRAP_BORDER_SUN                                            = 0x81D4
 	WRITE_DISCARD_NV                                           = 0x88BE
 	WRITE_ONLY                                                 = 0x88B9
@@ -15955,6 +16752,7 @@ const (
 var (
 	gpAccum                                                  C.GPACCUM
 	gpAccumxOES                                              C.GPACCUMXOES
+	gpAcquireKeyedMutexWin32EXT                              C.GPACQUIREKEYEDMUTEXWIN32EXT
 	gpActiveProgramEXT                                       C.GPACTIVEPROGRAMEXT
 	gpActiveShaderProgram                                    C.GPACTIVESHADERPROGRAM
 	gpActiveShaderProgramEXT                                 C.GPACTIVESHADERPROGRAMEXT
@@ -15967,6 +16765,8 @@ var (
 	gpAlphaFragmentOp3ATI                                    C.GPALPHAFRAGMENTOP3ATI
 	gpAlphaFunc                                              C.GPALPHAFUNC
 	gpAlphaFuncxOES                                          C.GPALPHAFUNCXOES
+	gpAlphaToCoverageDitherControlNV                         C.GPALPHATOCOVERAGEDITHERCONTROLNV
+	gpApplyFramebufferAttachmentCMAAINTEL                    C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
 	gpApplyTextureEXT                                        C.GPAPPLYTEXTUREEXT
 	gpAreProgramsResidentNV                                  C.GPAREPROGRAMSRESIDENTNV
 	gpAreTexturesResident                                    C.GPARETEXTURESRESIDENT
@@ -16091,8 +16891,11 @@ var (
 	gpBufferPageCommitmentARB                                C.GPBUFFERPAGECOMMITMENTARB
 	gpBufferParameteriAPPLE                                  C.GPBUFFERPARAMETERIAPPLE
 	gpBufferStorage                                          C.GPBUFFERSTORAGE
+	gpBufferStorageExternalEXT                               C.GPBUFFERSTORAGEEXTERNALEXT
+	gpBufferStorageMemEXT                                    C.GPBUFFERSTORAGEMEMEXT
 	gpBufferSubData                                          C.GPBUFFERSUBDATA
 	gpBufferSubDataARB                                       C.GPBUFFERSUBDATAARB
+	gpCallCommandListNV                                      C.GPCALLCOMMANDLISTNV
 	gpCallList                                               C.GPCALLLIST
 	gpCallLists                                              C.GPCALLLISTS
 	gpCheckFramebufferStatus                                 C.GPCHECKFRAMEBUFFERSTATUS
@@ -16220,6 +17023,8 @@ var (
 	gpCombinerParameteriNV                                   C.GPCOMBINERPARAMETERINV
 	gpCombinerParameterivNV                                  C.GPCOMBINERPARAMETERIVNV
 	gpCombinerStageParameterfvNV                             C.GPCOMBINERSTAGEPARAMETERFVNV
+	gpCommandListSegmentsNV                                  C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                                   C.GPCOMPILECOMMANDLISTNV
 	gpCompileShader                                          C.GPCOMPILESHADER
 	gpCompileShaderARB                                       C.GPCOMPILESHADERARB
 	gpCompileShaderIncludeARB                                C.GPCOMPILESHADERINCLUDEARB
@@ -16250,6 +17055,8 @@ var (
 	gpCompressedTextureSubImage2DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
 	gpCompressedTextureSubImage3D                            C.GPCOMPRESSEDTEXTURESUBIMAGE3D
 	gpCompressedTextureSubImage3DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                         C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                         C.GPCONSERVATIVERASTERPARAMETERINV
 	gpConvolutionFilter1D                                    C.GPCONVOLUTIONFILTER1D
 	gpConvolutionFilter1DEXT                                 C.GPCONVOLUTIONFILTER1DEXT
 	gpConvolutionFilter2D                                    C.GPCONVOLUTIONFILTER2D
@@ -16305,8 +17112,12 @@ var (
 	gpCoverFillPathNV                                        C.GPCOVERFILLPATHNV
 	gpCoverStrokePathInstancedNV                             C.GPCOVERSTROKEPATHINSTANCEDNV
 	gpCoverStrokePathNV                                      C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                                   C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                              C.GPCOVERAGEMODULATIONTABLENV
 	gpCreateBuffers                                          C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                                   C.GPCREATECOMMANDLISTSNV
 	gpCreateFramebuffers                                     C.GPCREATEFRAMEBUFFERS
+	gpCreateMemoryObjectsEXT                                 C.GPCREATEMEMORYOBJECTSEXT
 	gpCreatePerfQueryINTEL                                   C.GPCREATEPERFQUERYINTEL
 	gpCreateProgram                                          C.GPCREATEPROGRAM
 	gpCreateProgramObjectARB                                 C.GPCREATEPROGRAMOBJECTARB
@@ -16319,6 +17130,7 @@ var (
 	gpCreateShaderProgramEXT                                 C.GPCREATESHADERPROGRAMEXT
 	gpCreateShaderProgramv                                   C.GPCREATESHADERPROGRAMV
 	gpCreateShaderProgramvEXT                                C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                         C.GPCREATESTATESNV
 	gpCreateSyncFromCLeventARB                               C.GPCREATESYNCFROMCLEVENTARB
 	gpCreateTextures                                         C.GPCREATETEXTURES
 	gpCreateTransformFeedbacks                               C.GPCREATETRANSFORMFEEDBACKS
@@ -16345,12 +17157,14 @@ var (
 	gpDeleteAsyncMarkersSGIX                                 C.GPDELETEASYNCMARKERSSGIX
 	gpDeleteBuffers                                          C.GPDELETEBUFFERS
 	gpDeleteBuffersARB                                       C.GPDELETEBUFFERSARB
+	gpDeleteCommandListsNV                                   C.GPDELETECOMMANDLISTSNV
 	gpDeleteFencesAPPLE                                      C.GPDELETEFENCESAPPLE
 	gpDeleteFencesNV                                         C.GPDELETEFENCESNV
 	gpDeleteFragmentShaderATI                                C.GPDELETEFRAGMENTSHADERATI
 	gpDeleteFramebuffers                                     C.GPDELETEFRAMEBUFFERS
 	gpDeleteFramebuffersEXT                                  C.GPDELETEFRAMEBUFFERSEXT
 	gpDeleteLists                                            C.GPDELETELISTS
+	gpDeleteMemoryObjectsEXT                                 C.GPDELETEMEMORYOBJECTSEXT
 	gpDeleteNamedStringARB                                   C.GPDELETENAMEDSTRINGARB
 	gpDeleteNamesAMD                                         C.GPDELETENAMESAMD
 	gpDeleteObjectARB                                        C.GPDELETEOBJECTARB
@@ -16365,10 +17179,13 @@ var (
 	gpDeleteProgramsNV                                       C.GPDELETEPROGRAMSNV
 	gpDeleteQueries                                          C.GPDELETEQUERIES
 	gpDeleteQueriesARB                                       C.GPDELETEQUERIESARB
+	gpDeleteQueryResourceTagNV                               C.GPDELETEQUERYRESOURCETAGNV
 	gpDeleteRenderbuffers                                    C.GPDELETERENDERBUFFERS
 	gpDeleteRenderbuffersEXT                                 C.GPDELETERENDERBUFFERSEXT
 	gpDeleteSamplers                                         C.GPDELETESAMPLERS
+	gpDeleteSemaphoresEXT                                    C.GPDELETESEMAPHORESEXT
 	gpDeleteShader                                           C.GPDELETESHADER
+	gpDeleteStatesNV                                         C.GPDELETESTATESNV
 	gpDeleteSync                                             C.GPDELETESYNC
 	gpDeleteTextures                                         C.GPDELETETEXTURES
 	gpDeleteTexturesEXT                                      C.GPDELETETEXTURESEXT
@@ -16418,6 +17235,10 @@ var (
 	gpDrawBuffers                                            C.GPDRAWBUFFERS
 	gpDrawBuffersARB                                         C.GPDRAWBUFFERSARB
 	gpDrawBuffersATI                                         C.GPDRAWBUFFERSATI
+	gpDrawCommandsAddressNV                                  C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                         C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                            C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                                   C.GPDRAWCOMMANDSSTATESNV
 	gpDrawElementArrayAPPLE                                  C.GPDRAWELEMENTARRAYAPPLE
 	gpDrawElementArrayATI                                    C.GPDRAWELEMENTARRAYATI
 	gpDrawElements                                           C.GPDRAWELEMENTS
@@ -16442,6 +17263,7 @@ var (
 	gpDrawTransformFeedbackNV                                C.GPDRAWTRANSFORMFEEDBACKNV
 	gpDrawTransformFeedbackStream                            C.GPDRAWTRANSFORMFEEDBACKSTREAM
 	gpDrawTransformFeedbackStreamInstanced                   C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                          C.GPDRAWVKIMAGENV
 	gpEdgeFlag                                               C.GPEDGEFLAG
 	gpEdgeFlagFormatNV                                       C.GPEDGEFLAGFORMATNV
 	gpEdgeFlagPointer                                        C.GPEDGEFLAGPOINTER
@@ -16497,6 +17319,7 @@ var (
 	gpEvalMesh2                                              C.GPEVALMESH2
 	gpEvalPoint1                                             C.GPEVALPOINT1
 	gpEvalPoint2                                             C.GPEVALPOINT2
+	gpEvaluateDepthValuesARB                                 C.GPEVALUATEDEPTHVALUESARB
 	gpExecuteProgramNV                                       C.GPEXECUTEPROGRAMNV
 	gpExtractComponentEXT                                    C.GPEXTRACTCOMPONENTEXT
 	gpFeedbackBuffer                                         C.GPFEEDBACKBUFFER
@@ -16541,6 +17364,7 @@ var (
 	gpFogxOES                                                C.GPFOGXOES
 	gpFogxvOES                                               C.GPFOGXVOES
 	gpFragmentColorMaterialSGIX                              C.GPFRAGMENTCOLORMATERIALSGIX
+	gpFragmentCoverageColorNV                                C.GPFRAGMENTCOVERAGECOLORNV
 	gpFragmentLightModelfSGIX                                C.GPFRAGMENTLIGHTMODELFSGIX
 	gpFragmentLightModelfvSGIX                               C.GPFRAGMENTLIGHTMODELFVSGIX
 	gpFragmentLightModeliSGIX                                C.GPFRAGMENTLIGHTMODELISGIX
@@ -16557,10 +17381,14 @@ var (
 	gpFrameZoomSGIX                                          C.GPFRAMEZOOMSGIX
 	gpFramebufferDrawBufferEXT                               C.GPFRAMEBUFFERDRAWBUFFEREXT
 	gpFramebufferDrawBuffersEXT                              C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                             C.GPFRAMEBUFFERFETCHBARRIEREXT
 	gpFramebufferParameteri                                  C.GPFRAMEBUFFERPARAMETERI
 	gpFramebufferReadBufferEXT                               C.GPFRAMEBUFFERREADBUFFEREXT
 	gpFramebufferRenderbuffer                                C.GPFRAMEBUFFERRENDERBUFFER
 	gpFramebufferRenderbufferEXT                             C.GPFRAMEBUFFERRENDERBUFFEREXT
+	gpFramebufferSampleLocationsfvARB                        C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                         C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferSamplePositionsfvAMD                        C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpFramebufferTexture                                     C.GPFRAMEBUFFERTEXTURE
 	gpFramebufferTexture1D                                   C.GPFRAMEBUFFERTEXTURE1D
 	gpFramebufferTexture1DEXT                                C.GPFRAMEBUFFERTEXTURE1DEXT
@@ -16575,6 +17403,7 @@ var (
 	gpFramebufferTextureLayer                                C.GPFRAMEBUFFERTEXTURELAYER
 	gpFramebufferTextureLayerARB                             C.GPFRAMEBUFFERTEXTURELAYERARB
 	gpFramebufferTextureLayerEXT                             C.GPFRAMEBUFFERTEXTURELAYEREXT
+	gpFramebufferTextureMultiviewOVR                         C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
 	gpFreeObjectBufferATI                                    C.GPFREEOBJECTBUFFERATI
 	gpFrontFace                                              C.GPFRONTFACE
 	gpFrustum                                                C.GPFRUSTUM
@@ -16599,9 +17428,11 @@ var (
 	gpGenProgramsNV                                          C.GPGENPROGRAMSNV
 	gpGenQueries                                             C.GPGENQUERIES
 	gpGenQueriesARB                                          C.GPGENQUERIESARB
+	gpGenQueryResourceTagNV                                  C.GPGENQUERYRESOURCETAGNV
 	gpGenRenderbuffers                                       C.GPGENRENDERBUFFERS
 	gpGenRenderbuffersEXT                                    C.GPGENRENDERBUFFERSEXT
 	gpGenSamplers                                            C.GPGENSAMPLERS
+	gpGenSemaphoresEXT                                       C.GPGENSEMAPHORESEXT
 	gpGenSymbolsEXT                                          C.GPGENSYMBOLSEXT
 	gpGenTextures                                            C.GPGENTEXTURES
 	gpGenTexturesEXT                                         C.GPGENTEXTURESEXT
@@ -16662,6 +17493,7 @@ var (
 	gpGetCombinerOutputParameterfvNV                         C.GPGETCOMBINEROUTPUTPARAMETERFVNV
 	gpGetCombinerOutputParameterivNV                         C.GPGETCOMBINEROUTPUTPARAMETERIVNV
 	gpGetCombinerStageParameterfvNV                          C.GPGETCOMBINERSTAGEPARAMETERFVNV
+	gpGetCommandHeaderNV                                     C.GPGETCOMMANDHEADERNV
 	gpGetCompressedMultiTexImageEXT                          C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
 	gpGetCompressedTexImage                                  C.GPGETCOMPRESSEDTEXIMAGE
 	gpGetCompressedTexImageARB                               C.GPGETCOMPRESSEDTEXIMAGEARB
@@ -16675,6 +17507,7 @@ var (
 	gpGetConvolutionParameteriv                              C.GPGETCONVOLUTIONPARAMETERIV
 	gpGetConvolutionParameterivEXT                           C.GPGETCONVOLUTIONPARAMETERIVEXT
 	gpGetConvolutionParameterxvOES                           C.GPGETCONVOLUTIONPARAMETERXVOES
+	gpGetCoverageModulationTableNV                           C.GPGETCOVERAGEMODULATIONTABLENV
 	gpGetDebugMessageLog                                     C.GPGETDEBUGMESSAGELOG
 	gpGetDebugMessageLogAMD                                  C.GPGETDEBUGMESSAGELOGAMD
 	gpGetDebugMessageLogARB                                  C.GPGETDEBUGMESSAGELOGARB
@@ -16704,6 +17537,7 @@ var (
 	gpGetFragmentMaterialivSGIX                              C.GPGETFRAGMENTMATERIALIVSGIX
 	gpGetFramebufferAttachmentParameteriv                    C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetFramebufferAttachmentParameterivEXT                 C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetFramebufferParameterfvAMD                           C.GPGETFRAMEBUFFERPARAMETERFVAMD
 	gpGetFramebufferParameteriv                              C.GPGETFRAMEBUFFERPARAMETERIV
 	gpGetFramebufferParameterivEXT                           C.GPGETFRAMEBUFFERPARAMETERIVEXT
 	gpGetGraphicsResetStatus                                 C.GPGETGRAPHICSRESETSTATUS
@@ -16730,6 +17564,7 @@ var (
 	gpGetIntegerui64i_vNV                                    C.GPGETINTEGERUI64I_VNV
 	gpGetIntegerui64vNV                                      C.GPGETINTEGERUI64VNV
 	gpGetIntegerv                                            C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                            C.GPGETINTERNALFORMATSAMPLEIVNV
 	gpGetInternalformati64v                                  C.GPGETINTERNALFORMATI64V
 	gpGetInternalformativ                                    C.GPGETINTERNALFORMATIV
 	gpGetInvariantBooleanvEXT                                C.GPGETINVARIANTBOOLEANVEXT
@@ -16757,6 +17592,7 @@ var (
 	gpGetMaterialiv                                          C.GPGETMATERIALIV
 	gpGetMaterialxOES                                        C.GPGETMATERIALXOES
 	gpGetMaterialxvOES                                       C.GPGETMATERIALXVOES
+	gpGetMemoryObjectParameterivEXT                          C.GPGETMEMORYOBJECTPARAMETERIVEXT
 	gpGetMinmax                                              C.GPGETMINMAX
 	gpGetMinmaxEXT                                           C.GPGETMINMAXEXT
 	gpGetMinmaxParameterfv                                   C.GPGETMINMAXPARAMETERFV
@@ -16787,6 +17623,7 @@ var (
 	gpGetNamedBufferSubDataEXT                               C.GPGETNAMEDBUFFERSUBDATAEXT
 	gpGetNamedFramebufferAttachmentParameteriv               C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetNamedFramebufferAttachmentParameterivEXT            C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameterfvAMD                      C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD
 	gpGetNamedFramebufferParameteriv                         C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
 	gpGetNamedFramebufferParameterivEXT                      C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
 	gpGetNamedProgramLocalParameterIivEXT                    C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
@@ -16881,6 +17718,10 @@ var (
 	gpGetProgramiv                                           C.GPGETPROGRAMIV
 	gpGetProgramivARB                                        C.GPGETPROGRAMIVARB
 	gpGetProgramivNV                                         C.GPGETPROGRAMIVNV
+	gpGetQueryBufferObjecti64v                               C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                                 C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                              C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                                C.GPGETQUERYBUFFEROBJECTUIV
 	gpGetQueryIndexediv                                      C.GPGETQUERYINDEXEDIV
 	gpGetQueryObjecti64v                                     C.GPGETQUERYOBJECTI64V
 	gpGetQueryObjecti64vEXT                                  C.GPGETQUERYOBJECTI64VEXT
@@ -16898,6 +17739,7 @@ var (
 	gpGetSamplerParameterIuiv                                C.GPGETSAMPLERPARAMETERIUIV
 	gpGetSamplerParameterfv                                  C.GPGETSAMPLERPARAMETERFV
 	gpGetSamplerParameteriv                                  C.GPGETSAMPLERPARAMETERIV
+	gpGetSemaphoreParameterui64vEXT                          C.GPGETSEMAPHOREPARAMETERUI64VEXT
 	gpGetSeparableFilter                                     C.GPGETSEPARABLEFILTER
 	gpGetSeparableFilterEXT                                  C.GPGETSEPARABLEFILTEREXT
 	gpGetShaderInfoLog                                       C.GPGETSHADERINFOLOG
@@ -16906,6 +17748,7 @@ var (
 	gpGetShaderSourceARB                                     C.GPGETSHADERSOURCEARB
 	gpGetShaderiv                                            C.GPGETSHADERIV
 	gpGetSharpenTexFuncSGIS                                  C.GPGETSHARPENTEXFUNCSGIS
+	gpGetStageIndexNV                                        C.GPGETSTAGEINDEXNV
 	gpGetString                                              C.GPGETSTRING
 	gpGetStringi                                             C.GPGETSTRINGI
 	gpGetSubroutineIndex                                     C.GPGETSUBROUTINEINDEX
@@ -16969,12 +17812,16 @@ var (
 	gpGetUniformdv                                           C.GPGETUNIFORMDV
 	gpGetUniformfv                                           C.GPGETUNIFORMFV
 	gpGetUniformfvARB                                        C.GPGETUNIFORMFVARB
+	gpGetUniformi64vARB                                      C.GPGETUNIFORMI64VARB
 	gpGetUniformi64vNV                                       C.GPGETUNIFORMI64VNV
 	gpGetUniformiv                                           C.GPGETUNIFORMIV
 	gpGetUniformivARB                                        C.GPGETUNIFORMIVARB
+	gpGetUniformui64vARB                                     C.GPGETUNIFORMUI64VARB
 	gpGetUniformui64vNV                                      C.GPGETUNIFORMUI64VNV
 	gpGetUniformuiv                                          C.GPGETUNIFORMUIV
 	gpGetUniformuivEXT                                       C.GPGETUNIFORMUIVEXT
+	gpGetUnsignedBytei_vEXT                                  C.GPGETUNSIGNEDBYTEI_VEXT
+	gpGetUnsignedBytevEXT                                    C.GPGETUNSIGNEDBYTEVEXT
 	gpGetVariantArrayObjectfvATI                             C.GPGETVARIANTARRAYOBJECTFVATI
 	gpGetVariantArrayObjectivATI                             C.GPGETVARIANTARRAYOBJECTIVATI
 	gpGetVariantBooleanvEXT                                  C.GPGETVARIANTBOOLEANVEXT
@@ -17020,6 +17867,7 @@ var (
 	gpGetVideoivNV                                           C.GPGETVIDEOIVNV
 	gpGetVideoui64vNV                                        C.GPGETVIDEOUI64VNV
 	gpGetVideouivNV                                          C.GPGETVIDEOUIVNV
+	gpGetVkProcAddrNV                                        C.GPGETVKPROCADDRNV
 	gpGetnColorTableARB                                      C.GPGETNCOLORTABLEARB
 	gpGetnCompressedTexImageARB                              C.GPGETNCOMPRESSEDTEXIMAGEARB
 	gpGetnConvolutionFilterARB                               C.GPGETNCONVOLUTIONFILTERARB
@@ -17038,9 +17886,11 @@ var (
 	gpGetnUniformfv                                          C.GPGETNUNIFORMFV
 	gpGetnUniformfvARB                                       C.GPGETNUNIFORMFVARB
 	gpGetnUniformfvKHR                                       C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                                     C.GPGETNUNIFORMI64VARB
 	gpGetnUniformiv                                          C.GPGETNUNIFORMIV
 	gpGetnUniformivARB                                       C.GPGETNUNIFORMIVARB
 	gpGetnUniformivKHR                                       C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                                    C.GPGETNUNIFORMUI64VARB
 	gpGetnUniformuiv                                         C.GPGETNUNIFORMUIV
 	gpGetnUniformuivARB                                      C.GPGETNUNIFORMUIVARB
 	gpGetnUniformuivKHR                                      C.GPGETNUNIFORMUIVKHR
@@ -17061,6 +17911,12 @@ var (
 	gpImageTransformParameterfvHP                            C.GPIMAGETRANSFORMPARAMETERFVHP
 	gpImageTransformParameteriHP                             C.GPIMAGETRANSFORMPARAMETERIHP
 	gpImageTransformParameterivHP                            C.GPIMAGETRANSFORMPARAMETERIVHP
+	gpImportMemoryFdEXT                                      C.GPIMPORTMEMORYFDEXT
+	gpImportMemoryWin32HandleEXT                             C.GPIMPORTMEMORYWIN32HANDLEEXT
+	gpImportMemoryWin32NameEXT                               C.GPIMPORTMEMORYWIN32NAMEEXT
+	gpImportSemaphoreFdEXT                                   C.GPIMPORTSEMAPHOREFDEXT
+	gpImportSemaphoreWin32HandleEXT                          C.GPIMPORTSEMAPHOREWIN32HANDLEEXT
+	gpImportSemaphoreWin32NameEXT                            C.GPIMPORTSEMAPHOREWIN32NAMEEXT
 	gpImportSyncEXT                                          C.GPIMPORTSYNCEXT
 	gpIndexFormatNV                                          C.GPINDEXFORMATNV
 	gpIndexFuncEXT                                           C.GPINDEXFUNCEXT
@@ -17099,6 +17955,7 @@ var (
 	gpIsBuffer                                               C.GPISBUFFER
 	gpIsBufferARB                                            C.GPISBUFFERARB
 	gpIsBufferResidentNV                                     C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                        C.GPISCOMMANDLISTNV
 	gpIsEnabled                                              C.GPISENABLED
 	gpIsEnabledIndexedEXT                                    C.GPISENABLEDINDEXEDEXT
 	gpIsEnabledi                                             C.GPISENABLEDI
@@ -17109,6 +17966,7 @@ var (
 	gpIsImageHandleResidentARB                               C.GPISIMAGEHANDLERESIDENTARB
 	gpIsImageHandleResidentNV                                C.GPISIMAGEHANDLERESIDENTNV
 	gpIsList                                                 C.GPISLIST
+	gpIsMemoryObjectEXT                                      C.GPISMEMORYOBJECTEXT
 	gpIsNameAMD                                              C.GPISNAMEAMD
 	gpIsNamedBufferResidentNV                                C.GPISNAMEDBUFFERRESIDENTNV
 	gpIsNamedStringARB                                       C.GPISNAMEDSTRINGARB
@@ -17127,7 +17985,9 @@ var (
 	gpIsRenderbuffer                                         C.GPISRENDERBUFFER
 	gpIsRenderbufferEXT                                      C.GPISRENDERBUFFEREXT
 	gpIsSampler                                              C.GPISSAMPLER
+	gpIsSemaphoreEXT                                         C.GPISSEMAPHOREEXT
 	gpIsShader                                               C.GPISSHADER
+	gpIsStateNV                                              C.GPISSTATENV
 	gpIsSync                                                 C.GPISSYNC
 	gpIsTexture                                              C.GPISTEXTURE
 	gpIsTextureEXT                                           C.GPISTEXTUREEXT
@@ -17139,6 +17999,9 @@ var (
 	gpIsVertexArray                                          C.GPISVERTEXARRAY
 	gpIsVertexArrayAPPLE                                     C.GPISVERTEXARRAYAPPLE
 	gpIsVertexAttribEnabledAPPLE                             C.GPISVERTEXATTRIBENABLEDAPPLE
+	gpLGPUCopyImageSubDataNVX                                C.GPLGPUCOPYIMAGESUBDATANVX
+	gpLGPUInterlockNVX                                       C.GPLGPUINTERLOCKNVX
+	gpLGPUNamedBufferSubDataNVX                              C.GPLGPUNAMEDBUFFERSUBDATANVX
 	gpLabelObjectEXT                                         C.GPLABELOBJECTEXT
 	gpLightEnviSGIX                                          C.GPLIGHTENVISGIX
 	gpLightModelf                                            C.GPLIGHTMODELF
@@ -17159,6 +18022,7 @@ var (
 	gpLinkProgram                                            C.GPLINKPROGRAM
 	gpLinkProgramARB                                         C.GPLINKPROGRAMARB
 	gpListBase                                               C.GPLISTBASE
+	gpListDrawCommandsStatesClientNV                         C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
 	gpListParameterfSGIX                                     C.GPLISTPARAMETERFSGIX
 	gpListParameterfvSGIX                                    C.GPLISTPARAMETERFVSGIX
 	gpListParameteriSGIX                                     C.GPLISTPARAMETERISGIX
@@ -17253,9 +18117,12 @@ var (
 	gpMatrixScalefEXT                                        C.GPMATRIXSCALEFEXT
 	gpMatrixTranslatedEXT                                    C.GPMATRIXTRANSLATEDEXT
 	gpMatrixTranslatefEXT                                    C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                            C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                            C.GPMAXSHADERCOMPILERTHREADSKHR
 	gpMemoryBarrier                                          C.GPMEMORYBARRIER
 	gpMemoryBarrierByRegion                                  C.GPMEMORYBARRIERBYREGION
 	gpMemoryBarrierEXT                                       C.GPMEMORYBARRIEREXT
+	gpMemoryObjectParameterivEXT                             C.GPMEMORYOBJECTPARAMETERIVEXT
 	gpMinSampleShading                                       C.GPMINSAMPLESHADING
 	gpMinSampleShadingARB                                    C.GPMINSAMPLESHADINGARB
 	gpMinmax                                                 C.GPMINMAX
@@ -17408,12 +18275,25 @@ var (
 	gpMultiTexSubImage1DEXT                                  C.GPMULTITEXSUBIMAGE1DEXT
 	gpMultiTexSubImage2DEXT                                  C.GPMULTITEXSUBIMAGE2DEXT
 	gpMultiTexSubImage3DEXT                                  C.GPMULTITEXSUBIMAGE3DEXT
+	gpMulticastBarrierNV                                     C.GPMULTICASTBARRIERNV
+	gpMulticastBlitFramebufferNV                             C.GPMULTICASTBLITFRAMEBUFFERNV
+	gpMulticastBufferSubDataNV                               C.GPMULTICASTBUFFERSUBDATANV
+	gpMulticastCopyBufferSubDataNV                           C.GPMULTICASTCOPYBUFFERSUBDATANV
+	gpMulticastCopyImageSubDataNV                            C.GPMULTICASTCOPYIMAGESUBDATANV
+	gpMulticastFramebufferSampleLocationsfvNV                C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpMulticastGetQueryObjecti64vNV                          C.GPMULTICASTGETQUERYOBJECTI64VNV
+	gpMulticastGetQueryObjectivNV                            C.GPMULTICASTGETQUERYOBJECTIVNV
+	gpMulticastGetQueryObjectui64vNV                         C.GPMULTICASTGETQUERYOBJECTUI64VNV
+	gpMulticastGetQueryObjectuivNV                           C.GPMULTICASTGETQUERYOBJECTUIVNV
+	gpMulticastWaitSyncNV                                    C.GPMULTICASTWAITSYNCNV
 	gpNamedBufferData                                        C.GPNAMEDBUFFERDATA
 	gpNamedBufferDataEXT                                     C.GPNAMEDBUFFERDATAEXT
 	gpNamedBufferPageCommitmentARB                           C.GPNAMEDBUFFERPAGECOMMITMENTARB
 	gpNamedBufferPageCommitmentEXT                           C.GPNAMEDBUFFERPAGECOMMITMENTEXT
 	gpNamedBufferStorage                                     C.GPNAMEDBUFFERSTORAGE
 	gpNamedBufferStorageEXT                                  C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferStorageExternalEXT                          C.GPNAMEDBUFFERSTORAGEEXTERNALEXT
+	gpNamedBufferStorageMemEXT                               C.GPNAMEDBUFFERSTORAGEMEMEXT
 	gpNamedBufferSubData                                     C.GPNAMEDBUFFERSUBDATA
 	gpNamedBufferSubDataEXT                                  C.GPNAMEDBUFFERSUBDATAEXT
 	gpNamedCopyBufferSubDataEXT                              C.GPNAMEDCOPYBUFFERSUBDATAEXT
@@ -17424,6 +18304,9 @@ var (
 	gpNamedFramebufferReadBuffer                             C.GPNAMEDFRAMEBUFFERREADBUFFER
 	gpNamedFramebufferRenderbuffer                           C.GPNAMEDFRAMEBUFFERRENDERBUFFER
 	gpNamedFramebufferRenderbufferEXT                        C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB                   C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV                    C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferSamplePositionsfvAMD                   C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpNamedFramebufferTexture                                C.GPNAMEDFRAMEBUFFERTEXTURE
 	gpNamedFramebufferTexture1DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
 	gpNamedFramebufferTexture2DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
@@ -17567,6 +18450,8 @@ var (
 	gpPollInstrumentsSGIX                                    C.GPPOLLINSTRUMENTSSGIX
 	gpPolygonMode                                            C.GPPOLYGONMODE
 	gpPolygonOffset                                          C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                                     C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                                  C.GPPOLYGONOFFSETCLAMPEXT
 	gpPolygonOffsetEXT                                       C.GPPOLYGONOFFSETEXT
 	gpPolygonOffsetxOES                                      C.GPPOLYGONOFFSETXOES
 	gpPolygonStipple                                         C.GPPOLYGONSTIPPLE
@@ -17579,6 +18464,7 @@ var (
 	gpPopName                                                C.GPPOPNAME
 	gpPresentFrameDualFillNV                                 C.GPPRESENTFRAMEDUALFILLNV
 	gpPresentFrameKeyedNV                                    C.GPPRESENTFRAMEKEYEDNV
+	gpPrimitiveBoundingBoxARB                                C.GPPRIMITIVEBOUNDINGBOXARB
 	gpPrimitiveRestartIndex                                  C.GPPRIMITIVERESTARTINDEX
 	gpPrimitiveRestartIndexNV                                C.GPPRIMITIVERESTARTINDEXNV
 	gpPrimitiveRestartNV                                     C.GPPRIMITIVERESTARTNV
@@ -17636,13 +18522,17 @@ var (
 	gpProgramUniform1fv                                      C.GPPROGRAMUNIFORM1FV
 	gpProgramUniform1fvEXT                                   C.GPPROGRAMUNIFORM1FVEXT
 	gpProgramUniform1i                                       C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                                  C.GPPROGRAMUNIFORM1I64ARB
 	gpProgramUniform1i64NV                                   C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                                 C.GPPROGRAMUNIFORM1I64VARB
 	gpProgramUniform1i64vNV                                  C.GPPROGRAMUNIFORM1I64VNV
 	gpProgramUniform1iEXT                                    C.GPPROGRAMUNIFORM1IEXT
 	gpProgramUniform1iv                                      C.GPPROGRAMUNIFORM1IV
 	gpProgramUniform1ivEXT                                   C.GPPROGRAMUNIFORM1IVEXT
 	gpProgramUniform1ui                                      C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                                 C.GPPROGRAMUNIFORM1UI64ARB
 	gpProgramUniform1ui64NV                                  C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                                C.GPPROGRAMUNIFORM1UI64VARB
 	gpProgramUniform1ui64vNV                                 C.GPPROGRAMUNIFORM1UI64VNV
 	gpProgramUniform1uiEXT                                   C.GPPROGRAMUNIFORM1UIEXT
 	gpProgramUniform1uiv                                     C.GPPROGRAMUNIFORM1UIV
@@ -17656,13 +18546,17 @@ var (
 	gpProgramUniform2fv                                      C.GPPROGRAMUNIFORM2FV
 	gpProgramUniform2fvEXT                                   C.GPPROGRAMUNIFORM2FVEXT
 	gpProgramUniform2i                                       C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                                  C.GPPROGRAMUNIFORM2I64ARB
 	gpProgramUniform2i64NV                                   C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                                 C.GPPROGRAMUNIFORM2I64VARB
 	gpProgramUniform2i64vNV                                  C.GPPROGRAMUNIFORM2I64VNV
 	gpProgramUniform2iEXT                                    C.GPPROGRAMUNIFORM2IEXT
 	gpProgramUniform2iv                                      C.GPPROGRAMUNIFORM2IV
 	gpProgramUniform2ivEXT                                   C.GPPROGRAMUNIFORM2IVEXT
 	gpProgramUniform2ui                                      C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                                 C.GPPROGRAMUNIFORM2UI64ARB
 	gpProgramUniform2ui64NV                                  C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                                C.GPPROGRAMUNIFORM2UI64VARB
 	gpProgramUniform2ui64vNV                                 C.GPPROGRAMUNIFORM2UI64VNV
 	gpProgramUniform2uiEXT                                   C.GPPROGRAMUNIFORM2UIEXT
 	gpProgramUniform2uiv                                     C.GPPROGRAMUNIFORM2UIV
@@ -17676,13 +18570,17 @@ var (
 	gpProgramUniform3fv                                      C.GPPROGRAMUNIFORM3FV
 	gpProgramUniform3fvEXT                                   C.GPPROGRAMUNIFORM3FVEXT
 	gpProgramUniform3i                                       C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                                  C.GPPROGRAMUNIFORM3I64ARB
 	gpProgramUniform3i64NV                                   C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                                 C.GPPROGRAMUNIFORM3I64VARB
 	gpProgramUniform3i64vNV                                  C.GPPROGRAMUNIFORM3I64VNV
 	gpProgramUniform3iEXT                                    C.GPPROGRAMUNIFORM3IEXT
 	gpProgramUniform3iv                                      C.GPPROGRAMUNIFORM3IV
 	gpProgramUniform3ivEXT                                   C.GPPROGRAMUNIFORM3IVEXT
 	gpProgramUniform3ui                                      C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                                 C.GPPROGRAMUNIFORM3UI64ARB
 	gpProgramUniform3ui64NV                                  C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                                C.GPPROGRAMUNIFORM3UI64VARB
 	gpProgramUniform3ui64vNV                                 C.GPPROGRAMUNIFORM3UI64VNV
 	gpProgramUniform3uiEXT                                   C.GPPROGRAMUNIFORM3UIEXT
 	gpProgramUniform3uiv                                     C.GPPROGRAMUNIFORM3UIV
@@ -17696,13 +18594,17 @@ var (
 	gpProgramUniform4fv                                      C.GPPROGRAMUNIFORM4FV
 	gpProgramUniform4fvEXT                                   C.GPPROGRAMUNIFORM4FVEXT
 	gpProgramUniform4i                                       C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                                  C.GPPROGRAMUNIFORM4I64ARB
 	gpProgramUniform4i64NV                                   C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                                 C.GPPROGRAMUNIFORM4I64VARB
 	gpProgramUniform4i64vNV                                  C.GPPROGRAMUNIFORM4I64VNV
 	gpProgramUniform4iEXT                                    C.GPPROGRAMUNIFORM4IEXT
 	gpProgramUniform4iv                                      C.GPPROGRAMUNIFORM4IV
 	gpProgramUniform4ivEXT                                   C.GPPROGRAMUNIFORM4IVEXT
 	gpProgramUniform4ui                                      C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                                 C.GPPROGRAMUNIFORM4UI64ARB
 	gpProgramUniform4ui64NV                                  C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                                C.GPPROGRAMUNIFORM4UI64VARB
 	gpProgramUniform4ui64vNV                                 C.GPPROGRAMUNIFORM4UI64VNV
 	gpProgramUniform4uiEXT                                   C.GPPROGRAMUNIFORM4UIEXT
 	gpProgramUniform4uiv                                     C.GPPROGRAMUNIFORM4UIV
@@ -17763,6 +18665,8 @@ var (
 	gpQueryCounter                                           C.GPQUERYCOUNTER
 	gpQueryMatrixxOES                                        C.GPQUERYMATRIXXOES
 	gpQueryObjectParameteruiAMD                              C.GPQUERYOBJECTPARAMETERUIAMD
+	gpQueryResourceNV                                        C.GPQUERYRESOURCENV
+	gpQueryResourceTagNV                                     C.GPQUERYRESOURCETAGNV
 	gpRasterPos2d                                            C.GPRASTERPOS2D
 	gpRasterPos2dv                                           C.GPRASTERPOS2DV
 	gpRasterPos2f                                            C.GPRASTERPOS2F
@@ -17793,6 +18697,7 @@ var (
 	gpRasterPos4sv                                           C.GPRASTERPOS4SV
 	gpRasterPos4xOES                                         C.GPRASTERPOS4XOES
 	gpRasterPos4xvOES                                        C.GPRASTERPOS4XVOES
+	gpRasterSamplesEXT                                       C.GPRASTERSAMPLESEXT
 	gpReadBuffer                                             C.GPREADBUFFER
 	gpReadInstrumentsSGIX                                    C.GPREADINSTRUMENTSSGIX
 	gpReadPixels                                             C.GPREADPIXELS
@@ -17810,7 +18715,9 @@ var (
 	gpRectxOES                                               C.GPRECTXOES
 	gpRectxvOES                                              C.GPRECTXVOES
 	gpReferencePlaneSGIX                                     C.GPREFERENCEPLANESGIX
+	gpReleaseKeyedMutexWin32EXT                              C.GPRELEASEKEYEDMUTEXWIN32EXT
 	gpReleaseShaderCompiler                                  C.GPRELEASESHADERCOMPILER
+	gpRenderGpuMaskNV                                        C.GPRENDERGPUMASKNV
 	gpRenderMode                                             C.GPRENDERMODE
 	gpRenderbufferStorage                                    C.GPRENDERBUFFERSTORAGE
 	gpRenderbufferStorageEXT                                 C.GPRENDERBUFFERSTORAGEEXT
@@ -17846,6 +18753,7 @@ var (
 	gpResetMinmax                                            C.GPRESETMINMAX
 	gpResetMinmaxEXT                                         C.GPRESETMINMAXEXT
 	gpResizeBuffersMESA                                      C.GPRESIZEBUFFERSMESA
+	gpResolveDepthValuesNV                                   C.GPRESOLVEDEPTHVALUESNV
 	gpResumeTransformFeedback                                C.GPRESUMETRANSFORMFEEDBACK
 	gpResumeTransformFeedbackNV                              C.GPRESUMETRANSFORMFEEDBACKNV
 	gpRotated                                                C.GPROTATED
@@ -17853,7 +18761,6 @@ var (
 	gpRotatexOES                                             C.GPROTATEXOES
 	gpSampleCoverage                                         C.GPSAMPLECOVERAGE
 	gpSampleCoverageARB                                      C.GPSAMPLECOVERAGEARB
-	gpSampleCoverageOES                                      C.GPSAMPLECOVERAGEOES
 	gpSampleCoveragexOES                                     C.GPSAMPLECOVERAGEXOES
 	gpSampleMapATI                                           C.GPSAMPLEMAPATI
 	gpSampleMaskEXT                                          C.GPSAMPLEMASKEXT
@@ -17917,6 +18824,7 @@ var (
 	gpSecondaryColorPointerListIBM                           C.GPSECONDARYCOLORPOINTERLISTIBM
 	gpSelectBuffer                                           C.GPSELECTBUFFER
 	gpSelectPerfMonitorCountersAMD                           C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpSemaphoreParameterui64vEXT                             C.GPSEMAPHOREPARAMETERUI64VEXT
 	gpSeparableFilter2D                                      C.GPSEPARABLEFILTER2D
 	gpSeparableFilter2DEXT                                   C.GPSEPARABLEFILTER2DEXT
 	gpSetFenceAPPLE                                          C.GPSETFENCEAPPLE
@@ -17934,11 +18842,16 @@ var (
 	gpShaderSourceARB                                        C.GPSHADERSOURCEARB
 	gpShaderStorageBlockBinding                              C.GPSHADERSTORAGEBLOCKBINDING
 	gpSharpenTexFuncSGIS                                     C.GPSHARPENTEXFUNCSGIS
+	gpSignalSemaphoreEXT                                     C.GPSIGNALSEMAPHOREEXT
+	gpSignalVkFenceNV                                        C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                                    C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                                    C.GPSPECIALIZESHADERARB
 	gpSpriteParameterfSGIX                                   C.GPSPRITEPARAMETERFSGIX
 	gpSpriteParameterfvSGIX                                  C.GPSPRITEPARAMETERFVSGIX
 	gpSpriteParameteriSGIX                                   C.GPSPRITEPARAMETERISGIX
 	gpSpriteParameterivSGIX                                  C.GPSPRITEPARAMETERIVSGIX
 	gpStartInstrumentsSGIX                                   C.GPSTARTINSTRUMENTSSGIX
+	gpStateCaptureNV                                         C.GPSTATECAPTURENV
 	gpStencilClearTagEXT                                     C.GPSTENCILCLEARTAGEXT
 	gpStencilFillPathInstancedNV                             C.GPSTENCILFILLPATHINSTANCEDNV
 	gpStencilFillPathNV                                      C.GPSTENCILFILLPATHNV
@@ -17959,6 +18872,7 @@ var (
 	gpStencilThenCoverStrokePathNV                           C.GPSTENCILTHENCOVERSTROKEPATHNV
 	gpStopInstrumentsSGIX                                    C.GPSTOPINSTRUMENTSSGIX
 	gpStringMarkerGREMEDY                                    C.GPSTRINGMARKERGREMEDY
+	gpSubpixelPrecisionBiasNV                                C.GPSUBPIXELPRECISIONBIASNV
 	gpSwizzleEXT                                             C.GPSWIZZLEEXT
 	gpSyncTextureINTEL                                       C.GPSYNCTEXTUREINTEL
 	gpTagSampleBufferSGIX                                    C.GPTAGSAMPLEBUFFERSGIX
@@ -18109,6 +19023,11 @@ var (
 	gpTexStorage2DMultisample                                C.GPTEXSTORAGE2DMULTISAMPLE
 	gpTexStorage3D                                           C.GPTEXSTORAGE3D
 	gpTexStorage3DMultisample                                C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexStorageMem1DEXT                                     C.GPTEXSTORAGEMEM1DEXT
+	gpTexStorageMem2DEXT                                     C.GPTEXSTORAGEMEM2DEXT
+	gpTexStorageMem2DMultisampleEXT                          C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT
+	gpTexStorageMem3DEXT                                     C.GPTEXSTORAGEMEM3DEXT
+	gpTexStorageMem3DMultisampleEXT                          C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT
 	gpTexStorageSparseAMD                                    C.GPTEXSTORAGESPARSEAMD
 	gpTexSubImage1D                                          C.GPTEXSUBIMAGE1D
 	gpTexSubImage1DEXT                                       C.GPTEXSUBIMAGE1DEXT
@@ -18159,6 +19078,11 @@ var (
 	gpTextureStorage3DEXT                                    C.GPTEXTURESTORAGE3DEXT
 	gpTextureStorage3DMultisample                            C.GPTEXTURESTORAGE3DMULTISAMPLE
 	gpTextureStorage3DMultisampleEXT                         C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureStorageMem1DEXT                                 C.GPTEXTURESTORAGEMEM1DEXT
+	gpTextureStorageMem2DEXT                                 C.GPTEXTURESTORAGEMEM2DEXT
+	gpTextureStorageMem2DMultisampleEXT                      C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT
+	gpTextureStorageMem3DEXT                                 C.GPTEXTURESTORAGEMEM3DEXT
+	gpTextureStorageMem3DMultisampleEXT                      C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT
 	gpTextureStorageSparseAMD                                C.GPTEXTURESTORAGESPARSEAMD
 	gpTextureSubImage1D                                      C.GPTEXTURESUBIMAGE1D
 	gpTextureSubImage1DEXT                                   C.GPTEXTURESUBIMAGE1DEXT
@@ -18186,13 +19110,17 @@ var (
 	gpUniform1fv                                             C.GPUNIFORM1FV
 	gpUniform1fvARB                                          C.GPUNIFORM1FVARB
 	gpUniform1i                                              C.GPUNIFORM1I
+	gpUniform1i64ARB                                         C.GPUNIFORM1I64ARB
 	gpUniform1i64NV                                          C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                        C.GPUNIFORM1I64VARB
 	gpUniform1i64vNV                                         C.GPUNIFORM1I64VNV
 	gpUniform1iARB                                           C.GPUNIFORM1IARB
 	gpUniform1iv                                             C.GPUNIFORM1IV
 	gpUniform1ivARB                                          C.GPUNIFORM1IVARB
 	gpUniform1ui                                             C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                        C.GPUNIFORM1UI64ARB
 	gpUniform1ui64NV                                         C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                                       C.GPUNIFORM1UI64VARB
 	gpUniform1ui64vNV                                        C.GPUNIFORM1UI64VNV
 	gpUniform1uiEXT                                          C.GPUNIFORM1UIEXT
 	gpUniform1uiv                                            C.GPUNIFORM1UIV
@@ -18204,13 +19132,17 @@ var (
 	gpUniform2fv                                             C.GPUNIFORM2FV
 	gpUniform2fvARB                                          C.GPUNIFORM2FVARB
 	gpUniform2i                                              C.GPUNIFORM2I
+	gpUniform2i64ARB                                         C.GPUNIFORM2I64ARB
 	gpUniform2i64NV                                          C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                        C.GPUNIFORM2I64VARB
 	gpUniform2i64vNV                                         C.GPUNIFORM2I64VNV
 	gpUniform2iARB                                           C.GPUNIFORM2IARB
 	gpUniform2iv                                             C.GPUNIFORM2IV
 	gpUniform2ivARB                                          C.GPUNIFORM2IVARB
 	gpUniform2ui                                             C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                        C.GPUNIFORM2UI64ARB
 	gpUniform2ui64NV                                         C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                                       C.GPUNIFORM2UI64VARB
 	gpUniform2ui64vNV                                        C.GPUNIFORM2UI64VNV
 	gpUniform2uiEXT                                          C.GPUNIFORM2UIEXT
 	gpUniform2uiv                                            C.GPUNIFORM2UIV
@@ -18222,13 +19154,17 @@ var (
 	gpUniform3fv                                             C.GPUNIFORM3FV
 	gpUniform3fvARB                                          C.GPUNIFORM3FVARB
 	gpUniform3i                                              C.GPUNIFORM3I
+	gpUniform3i64ARB                                         C.GPUNIFORM3I64ARB
 	gpUniform3i64NV                                          C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                        C.GPUNIFORM3I64VARB
 	gpUniform3i64vNV                                         C.GPUNIFORM3I64VNV
 	gpUniform3iARB                                           C.GPUNIFORM3IARB
 	gpUniform3iv                                             C.GPUNIFORM3IV
 	gpUniform3ivARB                                          C.GPUNIFORM3IVARB
 	gpUniform3ui                                             C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                        C.GPUNIFORM3UI64ARB
 	gpUniform3ui64NV                                         C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                                       C.GPUNIFORM3UI64VARB
 	gpUniform3ui64vNV                                        C.GPUNIFORM3UI64VNV
 	gpUniform3uiEXT                                          C.GPUNIFORM3UIEXT
 	gpUniform3uiv                                            C.GPUNIFORM3UIV
@@ -18240,13 +19176,17 @@ var (
 	gpUniform4fv                                             C.GPUNIFORM4FV
 	gpUniform4fvARB                                          C.GPUNIFORM4FVARB
 	gpUniform4i                                              C.GPUNIFORM4I
+	gpUniform4i64ARB                                         C.GPUNIFORM4I64ARB
 	gpUniform4i64NV                                          C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                        C.GPUNIFORM4I64VARB
 	gpUniform4i64vNV                                         C.GPUNIFORM4I64VNV
 	gpUniform4iARB                                           C.GPUNIFORM4IARB
 	gpUniform4iv                                             C.GPUNIFORM4IV
 	gpUniform4ivARB                                          C.GPUNIFORM4IVARB
 	gpUniform4ui                                             C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                        C.GPUNIFORM4UI64ARB
 	gpUniform4ui64NV                                         C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                                       C.GPUNIFORM4UI64VARB
 	gpUniform4ui64vNV                                        C.GPUNIFORM4UI64VNV
 	gpUniform4uiEXT                                          C.GPUNIFORM4UIEXT
 	gpUniform4uiv                                            C.GPUNIFORM4UIV
@@ -18673,7 +19613,11 @@ var (
 	gpViewportArrayv                                         C.GPVIEWPORTARRAYV
 	gpViewportIndexedf                                       C.GPVIEWPORTINDEXEDF
 	gpViewportIndexedfv                                      C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                               C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                                      C.GPVIEWPORTSWIZZLENV
+	gpWaitSemaphoreEXT                                       C.GPWAITSEMAPHOREEXT
 	gpWaitSync                                               C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                                      C.GPWAITVKSEMAPHORENV
 	gpWeightPathsNV                                          C.GPWEIGHTPATHSNV
 	gpWeightPointerARB                                       C.GPWEIGHTPOINTERARB
 	gpWeightbvARB                                            C.GPWEIGHTBVARB
@@ -18740,6 +19684,7 @@ var (
 	gpWindowPos4ivMESA                                       C.GPWINDOWPOS4IVMESA
 	gpWindowPos4sMESA                                        C.GPWINDOWPOS4SMESA
 	gpWindowPos4svMESA                                       C.GPWINDOWPOS4SVMESA
+	gpWindowRectanglesEXT                                    C.GPWINDOWRECTANGLESEXT
 	gpWriteMaskEXT                                           C.GPWRITEMASKEXT
 )
 
@@ -18757,6 +19702,10 @@ func Accum(op uint32, value float32) {
 }
 func AccumxOES(op uint32, value int32) {
 	C.glowAccumxOES(gpAccumxOES, (C.GLenum)(op), (C.GLfixed)(value))
+}
+func AcquireKeyedMutexWin32EXT(memory uint32, key uint64, timeout uint32) bool {
+	ret := C.glowAcquireKeyedMutexWin32EXT(gpAcquireKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key), (C.GLuint)(timeout))
+	return ret == TRUE
 }
 func ActiveProgramEXT(program uint32) {
 	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
@@ -18799,6 +19748,12 @@ func AlphaFunc(xfunc uint32, ref float32) {
 }
 func AlphaFuncxOES(xfunc uint32, ref int32) {
 	C.glowAlphaFuncxOES(gpAlphaFuncxOES, (C.GLenum)(xfunc), (C.GLfixed)(ref))
+}
+func AlphaToCoverageDitherControlNV(mode uint32) {
+	C.glowAlphaToCoverageDitherControlNV(gpAlphaToCoverageDitherControlNV, (C.GLenum)(mode))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 func ApplyTextureEXT(mode uint32) {
 	C.glowApplyTextureEXT(gpApplyTextureEXT, (C.GLenum)(mode))
@@ -19247,8 +20202,8 @@ func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 func BufferDataARB(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferDataARB(gpBufferDataARB, (C.GLenum)(target), (C.GLsizeiptrARB)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 	C.glowBufferParameteriAPPLE(gpBufferParameteriAPPLE, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
@@ -19258,6 +20213,12 @@ func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowBufferStorage(gpBufferStorage, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func BufferStorageExternalEXT(target uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowBufferStorageExternalEXT(gpBufferStorageExternalEXT, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func BufferStorageMemEXT(target uint32, size int, memory uint32, offset uint64) {
+	C.glowBufferStorageMemEXT(gpBufferStorageMemEXT, (C.GLenum)(target), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
@@ -19265,6 +20226,9 @@ func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 }
 func BufferSubDataARB(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubDataARB(gpBufferSubDataARB, (C.GLenum)(target), (C.GLintptrARB)(offset), (C.GLsizeiptrARB)(size), data)
+}
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
 }
 
 // execute a display list
@@ -19361,6 +20325,8 @@ func ClearDepth(depth float64) {
 func ClearDepthdNV(depth float64) {
 	C.glowClearDepthdNV(gpClearDepthdNV, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -19385,14 +20351,14 @@ func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32
 }
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
 func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -19434,7 +20400,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -19702,6 +20668,12 @@ func CombinerParameterivNV(pname uint32, params *int32) {
 func CombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowCombinerStageParameterfvNV(gpCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
+}
 
 // Compiles a shader object
 func CompileShader(shader uint32) {
@@ -19812,6 +20784,12 @@ func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yof
 func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // define a one-dimensional convolution filter
 func ConvolutionFilter1D(target uint32, internalformat uint32, width int32, format uint32, xtype uint32, image unsafe.Pointer) {
@@ -19920,8 +20898,8 @@ func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffs
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 func CopyPathNV(resultPath uint32, srcPath uint32) {
 	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
@@ -20013,15 +20991,27 @@ func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsaf
 func CoverStrokePathNV(path uint32, coverMode uint32) {
 	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
 }
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreateMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowCreateMemoryObjectsEXT(gpCreateMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
 	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
@@ -20080,9 +21070,12 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -20178,6 +21171,9 @@ func DeleteBuffers(n int32, buffers *uint32) {
 func DeleteBuffersARB(n int32, buffers *uint32) {
 	C.glowDeleteBuffersARB(gpDeleteBuffersARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 func DeleteFencesAPPLE(n int32, fences *uint32) {
 	C.glowDeleteFencesAPPLE(gpDeleteFencesAPPLE, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(fences)))
 }
@@ -20199,6 +21195,9 @@ func DeleteFramebuffersEXT(n int32, framebuffers *uint32) {
 // delete a contiguous group of display lists
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
+}
+func DeleteMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowDeleteMemoryObjectsEXT(gpDeleteMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
@@ -20248,6 +21247,9 @@ func DeleteQueries(n int32, ids *uint32) {
 func DeleteQueriesARB(n int32, ids *uint32) {
 	C.glowDeleteQueriesARB(gpDeleteQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func DeleteQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowDeleteQueryResourceTagNV(gpDeleteQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // delete renderbuffer objects
 func DeleteRenderbuffers(n int32, renderbuffers *uint32) {
@@ -20261,14 +21263,20 @@ func DeleteRenderbuffersEXT(n int32, renderbuffers *uint32) {
 func DeleteSamplers(count int32, samplers *uint32) {
 	C.glowDeleteSamplers(gpDeleteSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
 }
+func DeleteSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowDeleteSemaphoresEXT(gpDeleteSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
+}
 
 // Deletes a shader object
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -20330,6 +21338,8 @@ func DepthRangeIndexed(index uint32, n float64, f float64) {
 func DepthRangedNV(zNear float64, zFar float64) {
 	C.glowDepthRangedNV(gpDepthRangedNV, (C.GLdouble)(zNear), (C.GLdouble)(zFar))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -20451,6 +21461,18 @@ func DrawBuffersARB(n int32, bufs *uint32) {
 func DrawBuffersATI(n int32, bufs *uint32) {
 	C.glowDrawBuffersATI(gpDrawBuffersATI, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 func DrawElementArrayAPPLE(mode uint32, first int32, count int32) {
 	C.glowDrawElementArrayAPPLE(gpDrawElementArrayAPPLE, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count))
 }
@@ -20550,6 +21572,9 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 // render multiple instances of primitives using a count derived from a specifed stream of a transform feedback object
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
+}
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
 }
 
 // flag edges as either boundary or nonboundary
@@ -20728,6 +21753,9 @@ func EvalPoint1(i int32) {
 func EvalPoint2(i int32, j int32) {
 	C.glowEvalPoint2(gpEvalPoint2, (C.GLint)(i), (C.GLint)(j))
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 func ExecuteProgramNV(target uint32, id uint32, params *float32) {
 	C.glowExecuteProgramNV(gpExecuteProgramNV, (C.GLenum)(target), (C.GLuint)(id), (*C.GLfloat)(unsafe.Pointer(params)))
 }
@@ -20744,9 +21772,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -20787,8 +21815,8 @@ func FlushMappedBufferRangeAPPLE(target uint32, offset int, size int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
 }
 func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
 	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
@@ -20876,6 +21904,9 @@ func FogxvOES(pname uint32, param *int32) {
 func FragmentColorMaterialSGIX(face uint32, mode uint32) {
 	C.glowFragmentColorMaterialSGIX(gpFragmentColorMaterialSGIX, (C.GLenum)(face), (C.GLenum)(mode))
 }
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
 func FragmentLightModelfSGIX(pname uint32, param float32) {
 	C.glowFragmentLightModelfSGIX(gpFragmentLightModelfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -20924,6 +21955,9 @@ func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
 func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
 	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
+}
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
@@ -20940,6 +21974,15 @@ func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarge
 func FramebufferRenderbufferEXT(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbufferEXT(gpFramebufferRenderbufferEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSamplePositionsfvAMD(target uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowFramebufferSamplePositionsfvAMD(gpFramebufferSamplePositionsfvAMD, (C.GLenum)(target), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
 func FramebufferTexture(target uint32, attachment uint32, texture uint32, level int32) {
@@ -20951,6 +21994,8 @@ func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, te
 func FramebufferTexture1DEXT(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1DEXT(gpFramebufferTexture1DEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
@@ -20985,6 +22030,9 @@ func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32
 }
 func FramebufferTextureLayerEXT(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayerEXT(gpFramebufferTextureLayerEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 func FreeObjectBufferATI(buffer uint32) {
 	C.glowFreeObjectBufferATI(gpFreeObjectBufferATI, (C.GLuint)(buffer))
@@ -21076,6 +22124,9 @@ func GenQueries(n int32, ids *uint32) {
 func GenQueriesARB(n int32, ids *uint32) {
 	C.glowGenQueriesARB(gpGenQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func GenQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowGenQueryResourceTagNV(gpGenQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // generate renderbuffer object names
 func GenRenderbuffers(n int32, renderbuffers *uint32) {
@@ -21088,6 +22139,9 @@ func GenRenderbuffersEXT(n int32, renderbuffers *uint32) {
 // generate sampler object names
 func GenSamplers(count int32, samplers *uint32) {
 	C.glowGenSamplers(gpGenSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
+}
+func GenSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowGenSemaphoresEXT(gpGenSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
 }
 func GenSymbolsEXT(datatype uint32, storagetype uint32, xrange uint32, components uint32) uint32 {
 	ret := C.glowGenSymbolsEXT(gpGenSymbolsEXT, (C.GLenum)(datatype), (C.GLenum)(storagetype), (C.GLenum)(xrange), (C.GLuint)(components))
@@ -21179,6 +22233,8 @@ func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, leng
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21315,6 +22371,10 @@ func GetCombinerOutputParameterivNV(stage uint32, portion uint32, pname uint32, 
 func GetCombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowGetCombinerStageParameterfvNV(gpGetCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
 func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
 	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
@@ -21361,6 +22421,9 @@ func GetConvolutionParameterivEXT(target uint32, pname uint32, params *int32) {
 }
 func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 	C.glowGetConvolutionParameterxvOES(gpGetConvolutionParameterxvOES, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -21460,15 +22523,18 @@ func GetFragmentMaterialivSGIX(face uint32, pname uint32, params *int32) {
 	C.glowGetFragmentMaterialivSGIX(gpGetFragmentMaterialivSGIX, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetFramebufferAttachmentParameterivEXT(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameterivEXT(gpGetFramebufferAttachmentParameterivEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetFramebufferParameterfvAMD(target uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetFramebufferParameterfvAMD(gpGetFramebufferParameterfvAMD, (C.GLenum)(target), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21558,9 +22624,14 @@ func GetIntegerui64vNV(value uint32, result *uint64) {
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21638,6 +22709,9 @@ func GetMaterialxOES(face uint32, pname uint32, param int32) {
 }
 func GetMaterialxvOES(face uint32, pname uint32, params *int32) {
 	C.glowGetMaterialxvOES(gpGetMaterialxvOES, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetMemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowGetMemoryObjectParameterivEXT(gpGetMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // get minimum and maximum pixel values
@@ -21729,8 +22803,8 @@ func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Point
 }
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -21742,6 +22816,9 @@ func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uin
 }
 func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedFramebufferParameterfvAMD(framebuffer uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetNamedFramebufferParameterfvAMD(gpGetNamedFramebufferParameterfvAMD, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 
 // query a named parameter of a framebuffer object
@@ -22057,6 +23134,18 @@ func GetProgramivARB(target uint32, pname uint32, params *int32) {
 func GetProgramivNV(id uint32, pname uint32, params *int32) {
 	C.glowGetProgramivNV(gpGetProgramivNV, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
 
 // return parameters of an indexed query object target
 func GetQueryIndexediv(target uint32, index uint32, pname uint32, params *int32) {
@@ -22080,6 +23169,8 @@ func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 func GetQueryObjectui64vEXT(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64vEXT(gpGetQueryObjectui64vEXT, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -22095,7 +23186,7 @@ func GetQueryivARB(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryivARB(gpGetQueryivARB, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -22113,6 +23204,9 @@ func GetSamplerParameterfv(sampler uint32, pname uint32, params *float32) {
 }
 func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 	C.glowGetSamplerParameteriv(gpGetSamplerParameteriv, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetSemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowGetSemaphoreParameterui64vEXT(gpGetSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 
 // get separable convolution filter kernel images
@@ -22148,6 +23242,10 @@ func GetShaderiv(shader uint32, pname uint32, params *int32) {
 func GetSharpenTexFuncSGIS(target uint32, points *float32) {
 	C.glowGetSharpenTexFuncSGIS(gpGetSharpenTexFuncSGIS, (C.GLenum)(target), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -22172,7 +23270,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -22376,6 +23474,9 @@ func GetUniformfv(program uint32, location int32, params *float32) {
 func GetUniformfvARB(programObj uintptr, location int32, params *float32) {
 	C.glowGetUniformfvARB(gpGetUniformfvARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetUniformi64vNV(program uint32, location int32, params *int64) {
 	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
 }
@@ -22387,6 +23488,9 @@ func GetUniformiv(program uint32, location int32, params *int32) {
 func GetUniformivARB(programObj uintptr, location int32, params *int32) {
 	C.glowGetUniformivARB(gpGetUniformivARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 func GetUniformui64vNV(program uint32, location int32, params *uint64) {
 	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
@@ -22395,6 +23499,12 @@ func GetUniformuiv(program uint32, location int32, params *uint32) {
 }
 func GetUniformuivEXT(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuivEXT(gpGetUniformuivEXT, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetUnsignedBytei_vEXT(target uint32, index uint32, data *uint8) {
+	C.glowGetUnsignedBytei_vEXT(gpGetUnsignedBytei_vEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLubyte)(unsafe.Pointer(data)))
+}
+func GetUnsignedBytevEXT(pname uint32, data *uint8) {
+	C.glowGetUnsignedBytevEXT(gpGetUnsignedBytevEXT, (C.GLenum)(pname), (*C.GLubyte)(unsafe.Pointer(data)))
 }
 func GetVariantArrayObjectfvATI(id uint32, pname uint32, params *float32) {
 	C.glowGetVariantArrayObjectfvATI(gpGetVariantArrayObjectfvATI, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
@@ -22548,6 +23658,10 @@ func GetVideoui64vNV(video_slot uint32, pname uint32, params *uint64) {
 func GetVideouivNV(video_slot uint32, pname uint32, params *uint32) {
 	C.glowGetVideouivNV(gpGetVideouivNV, (C.GLuint)(video_slot), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
+}
 func GetnColorTableARB(target uint32, format uint32, xtype uint32, bufSize int32, table unsafe.Pointer) {
 	C.glowGetnColorTableARB(gpGetnColorTableARB, (C.GLenum)(target), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), table)
 }
@@ -22602,6 +23716,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -22610,6 +23727,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -22675,9 +23795,27 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportMemoryFdEXT(memory uint32, size uint64, handleType uint32, fd int32) {
+	C.glowImportMemoryFdEXT(gpImportMemoryFdEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportMemoryWin32HandleEXT(memory uint32, size uint64, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportMemoryWin32HandleEXT(gpImportMemoryWin32HandleEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), handle)
+}
+func ImportMemoryWin32NameEXT(memory uint32, size uint64, handleType uint32, name unsafe.Pointer) {
+	C.glowImportMemoryWin32NameEXT(gpImportMemoryWin32NameEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), name)
+}
+func ImportSemaphoreFdEXT(semaphore uint32, handleType uint32, fd int32) {
+	C.glowImportSemaphoreFdEXT(gpImportSemaphoreFdEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportSemaphoreWin32HandleEXT(semaphore uint32, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportSemaphoreWin32HandleEXT(gpImportSemaphoreWin32HandleEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), handle)
+}
+func ImportSemaphoreWin32NameEXT(semaphore uint32, handleType uint32, name unsafe.Pointer) {
+	C.glowImportSemaphoreWin32NameEXT(gpImportSemaphoreWin32NameEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), name)
+}
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -22820,6 +23958,10 @@ func IsBufferResidentNV(target uint32) bool {
 	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
 	return ret == TRUE
 }
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
 	return ret == TRUE
@@ -22862,6 +24004,10 @@ func IsImageHandleResidentNV(handle uint64) bool {
 // determine if a name corresponds to a display list
 func IsList(list uint32) bool {
 	ret := C.glowIsList(gpIsList, (C.GLuint)(list))
+	return ret == TRUE
+}
+func IsMemoryObjectEXT(memoryObject uint32) bool {
+	ret := C.glowIsMemoryObjectEXT(gpIsMemoryObjectEXT, (C.GLuint)(memoryObject))
 	return ret == TRUE
 }
 func IsNameAMD(identifier uint32, name uint32) bool {
@@ -22946,15 +24092,23 @@ func IsSampler(sampler uint32) bool {
 	ret := C.glowIsSampler(gpIsSampler, (C.GLuint)(sampler))
 	return ret == TRUE
 }
+func IsSemaphoreEXT(semaphore uint32) bool {
+	ret := C.glowIsSemaphoreEXT(gpIsSemaphoreEXT, (C.GLuint)(semaphore))
+	return ret == TRUE
+}
 
 // Determines if a name corresponds to a shader object
 func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -23003,6 +24157,15 @@ func IsVertexArrayAPPLE(array uint32) bool {
 func IsVertexAttribEnabledAPPLE(index uint32, pname uint32) bool {
 	ret := C.glowIsVertexAttribEnabledAPPLE(gpIsVertexAttribEnabledAPPLE, (C.GLuint)(index), (C.GLenum)(pname))
 	return ret == TRUE
+}
+func LGPUCopyImageSubDataNVX(sourceGpu uint32, destinationGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srxY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, width int32, height int32, depth int32) {
+	C.glowLGPUCopyImageSubDataNVX(gpLGPUCopyImageSubDataNVX, (C.GLuint)(sourceGpu), (C.GLbitfield)(destinationGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srxY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func LGPUInterlockNVX() {
+	C.glowLGPUInterlockNVX(gpLGPUInterlockNVX)
+}
+func LGPUNamedBufferSubDataNVX(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowLGPUNamedBufferSubDataNVX(gpLGPUNamedBufferSubDataNVX, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
@@ -23071,6 +24234,9 @@ func LinkProgramARB(programObj uintptr) {
 // set the display-list base for
 func ListBase(base uint32) {
 	C.glowListBase(gpListBase, (C.GLuint)(base))
+}
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 func ListParameterfSGIX(list uint32, pname uint32, param float32) {
 	C.glowListParameterfSGIX(gpListParameterfSGIX, (C.GLuint)(list), (C.GLenum)(pname), (C.GLfloat)(param))
@@ -23235,8 +24401,8 @@ func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
 }
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
 }
 func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
@@ -23379,6 +24545,12 @@ func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
 func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
 	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
 }
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
+}
 
 // defines a barrier ordering memory transactions
 func MemoryBarrier(barriers uint32) {
@@ -23389,6 +24561,9 @@ func MemoryBarrierByRegion(barriers uint32) {
 }
 func MemoryBarrierEXT(barriers uint32) {
 	C.glowMemoryBarrierEXT(gpMemoryBarrierEXT, (C.GLbitfield)(barriers))
+}
+func MemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowMemoryObjectParameterivEXT(gpMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // specifies minimum rate at which sample shaing takes place
@@ -23452,8 +24627,8 @@ func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer
 func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawElementArrayAPPLE(mode uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawElementArrayAPPLE(gpMultiDrawElementArrayAPPLE, (C.GLenum)(mode), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -23485,8 +24660,8 @@ func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirec
 func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawRangeElementArrayAPPLE(mode uint32, start uint32, end uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawRangeElementArrayAPPLE(gpMultiDrawRangeElementArrayAPPLE, (C.GLenum)(mode), (C.GLuint)(start), (C.GLuint)(end), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -23860,32 +25035,71 @@ func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset i
 func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func MulticastBarrierNV() {
+	C.glowMulticastBarrierNV(gpMulticastBarrierNV)
+}
+func MulticastBlitFramebufferNV(srcGpu uint32, dstGpu uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
+	C.glowMulticastBlitFramebufferNV(gpMulticastBlitFramebufferNV, (C.GLuint)(srcGpu), (C.GLuint)(dstGpu), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
+}
+func MulticastBufferSubDataNV(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowMulticastBufferSubDataNV(gpMulticastBufferSubDataNV, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func MulticastCopyBufferSubDataNV(readGpu uint32, writeGpuMask uint32, readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowMulticastCopyBufferSubDataNV(gpMulticastCopyBufferSubDataNV, (C.GLuint)(readGpu), (C.GLbitfield)(writeGpuMask), (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func MulticastCopyImageSubDataNV(srcGpu uint32, dstGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
+	C.glowMulticastCopyImageSubDataNV(gpMulticastCopyImageSubDataNV, (C.GLuint)(srcGpu), (C.GLbitfield)(dstGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
+}
+func MulticastFramebufferSampleLocationsfvNV(gpu uint32, framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowMulticastFramebufferSampleLocationsfvNV(gpMulticastFramebufferSampleLocationsfvNV, (C.GLuint)(gpu), (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func MulticastGetQueryObjecti64vNV(gpu uint32, id uint32, pname uint32, params *int64) {
+	C.glowMulticastGetQueryObjecti64vNV(gpMulticastGetQueryObjecti64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectivNV(gpu uint32, id uint32, pname uint32, params *int32) {
+	C.glowMulticastGetQueryObjectivNV(gpMulticastGetQueryObjectivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectui64vNV(gpu uint32, id uint32, pname uint32, params *uint64) {
+	C.glowMulticastGetQueryObjectui64vNV(gpMulticastGetQueryObjectui64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectuivNV(gpu uint32, id uint32, pname uint32, params *uint32) {
+	C.glowMulticastGetQueryObjectuivNV(gpMulticastGetQueryObjectuivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MulticastWaitSyncNV(signalGpu uint32, waitGpuMask uint32) {
+	C.glowMulticastWaitSyncNV(gpMulticastWaitSyncNV, (C.GLuint)(signalGpu), (C.GLbitfield)(waitGpuMask))
+}
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
 func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func NamedBufferStorageExternalEXT(buffer uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowNamedBufferStorageExternalEXT(gpNamedBufferStorageExternalEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func NamedBufferStorageMemEXT(buffer uint32, size int, memory uint32, offset uint64) {
+	C.glowNamedBufferStorageMemEXT(gpNamedBufferStorageMemEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -23923,6 +25137,15 @@ func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderb
 }
 func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSamplePositionsfvAMD(framebuffer uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowNamedFramebufferSamplePositionsfvAMD(gpNamedFramebufferSamplePositionsfvAMD, (C.GLuint)(framebuffer), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
@@ -24173,6 +25396,8 @@ func PassThroughxOES(token int32) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -24268,6 +25493,8 @@ func PixelMapx(xmap uint32, size int32, values *int32) {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
 }
@@ -24390,6 +25617,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 func PolygonOffsetEXT(factor float32, bias float32) {
 	C.glowPolygonOffsetEXT(gpPolygonOffsetEXT, (C.GLfloat)(factor), (C.GLfloat)(bias))
 }
@@ -24429,6 +25662,9 @@ func PresentFrameDualFillNV(video_slot uint32, minPresentTime uint64, beginPrese
 }
 func PresentFrameKeyedNV(video_slot uint32, minPresentTime uint64, beginPresentTimeId uint32, presentDurationId uint32, xtype uint32, target0 uint32, fill0 uint32, key0 uint32, target1 uint32, fill1 uint32, key1 uint32) {
 	C.glowPresentFrameKeyedNV(gpPresentFrameKeyedNV, (C.GLuint)(video_slot), (C.GLuint64EXT)(minPresentTime), (C.GLuint)(beginPresentTimeId), (C.GLuint)(presentDurationId), (C.GLenum)(xtype), (C.GLenum)(target0), (C.GLuint)(fill0), (C.GLuint)(key0), (C.GLenum)(target1), (C.GLuint)(fill1), (C.GLuint)(key1))
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -24556,6 +25792,8 @@ func ProgramParameter4fNV(target uint32, index uint32, x float32, y float32, z f
 func ProgramParameter4fvNV(target uint32, index uint32, v *float32) {
 	C.glowProgramParameter4fvNV(gpProgramParameter4fvNV, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -24613,8 +25851,14 @@ func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
 func ProgramUniform1i64NV(program uint32, location int32, x int64) {
 	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24635,8 +25879,14 @@ func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
 func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
 	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24685,8 +25935,14 @@ func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
 	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24707,8 +25963,14 @@ func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
 	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24757,8 +26019,14 @@ func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
 	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24779,8 +26047,14 @@ func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
 	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24829,8 +26103,14 @@ func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
 	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24851,8 +26131,14 @@ func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -25062,12 +26348,21 @@ func PushName(name uint32) {
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
 }
+
+// return the values of the current matrix
 func QueryMatrixxOES(mantissa *int32, exponent *int32) uint32 {
 	ret := C.glowQueryMatrixxOES(gpQueryMatrixxOES, (*C.GLfixed)(unsafe.Pointer(mantissa)), (*C.GLint)(unsafe.Pointer(exponent)))
 	return (uint32)(ret)
 }
 func QueryObjectParameteruiAMD(target uint32, id uint32, pname uint32, param uint32) {
 	C.glowQueryObjectParameteruiAMD(gpQueryObjectParameteruiAMD, (C.GLenum)(target), (C.GLuint)(id), (C.GLenum)(pname), (C.GLuint)(param))
+}
+func QueryResourceNV(queryType uint32, tagId int32, bufSize uint32, buffer *int32) int32 {
+	ret := C.glowQueryResourceNV(gpQueryResourceNV, (C.GLenum)(queryType), (C.GLint)(tagId), (C.GLuint)(bufSize), (*C.GLint)(unsafe.Pointer(buffer)))
+	return (int32)(ret)
+}
+func QueryResourceTagNV(tagId int32, tagString *uint8) {
+	C.glowQueryResourceTagNV(gpQueryResourceTagNV, (C.GLint)(tagId), (*C.GLchar)(unsafe.Pointer(tagString)))
 }
 func RasterPos2d(x float64, y float64) {
 	C.glowRasterPos2d(gpRasterPos2d, (C.GLdouble)(x), (C.GLdouble)(y))
@@ -25159,6 +26454,9 @@ func RasterPos4xOES(x int32, y int32, z int32, w int32) {
 func RasterPos4xvOES(coords *int32) {
 	C.glowRasterPos4xvOES(gpRasterPos4xvOES, (*C.GLfixed)(unsafe.Pointer(coords)))
 }
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // select a color buffer source for pixels
 func ReadBuffer(src uint32) {
@@ -25216,10 +26514,17 @@ func RectxvOES(v1 *int32, v2 *int32) {
 func ReferencePlaneSGIX(equation *float64) {
 	C.glowReferencePlaneSGIX(gpReferencePlaneSGIX, (*C.GLdouble)(unsafe.Pointer(equation)))
 }
+func ReleaseKeyedMutexWin32EXT(memory uint32, key uint64) bool {
+	ret := C.glowReleaseKeyedMutexWin32EXT(gpReleaseKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key))
+	return ret == TRUE
+}
 
 // release resources consumed by the implementation's shader compiler
 func ReleaseShaderCompiler() {
 	C.glowReleaseShaderCompiler(gpReleaseShaderCompiler)
+}
+func RenderGpuMaskNV(mask uint32) {
+	C.glowRenderGpuMaskNV(gpRenderGpuMaskNV, (C.GLbitfield)(mask))
 }
 
 // set rasterization mode
@@ -25337,6 +26642,9 @@ func ResetMinmaxEXT(target uint32) {
 func ResizeBuffersMESA() {
 	C.glowResizeBuffersMESA(gpResizeBuffersMESA)
 }
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
+}
 
 // resume transform feedback operations
 func ResumeTransformFeedback() {
@@ -25361,9 +26669,6 @@ func SampleCoverage(value float32, invert bool) {
 }
 func SampleCoverageARB(value float32, invert bool) {
 	C.glowSampleCoverageARB(gpSampleCoverageARB, (C.GLfloat)(value), (C.GLboolean)(boolToInt(invert)))
-}
-func SampleCoverageOES(value int32, invert bool) {
-	C.glowSampleCoverageOES(gpSampleCoverageOES, (C.GLfixed)(value), (C.GLboolean)(boolToInt(invert)))
 }
 func SampleCoveragexOES(value int32, invert bool) {
 	C.glowSampleCoveragexOES(gpSampleCoveragexOES, (C.GLclampx)(value), (C.GLboolean)(boolToInt(invert)))
@@ -25564,6 +26869,9 @@ func SelectBuffer(size int32, buffer *uint32) {
 func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
 	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
 }
+func SemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowSemaphoreParameterui64vEXT(gpSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 
 // define a separable two-dimensional convolution filter
 func SeparableFilter2D(target uint32, internalformat uint32, width int32, height int32, format uint32, xtype uint32, row unsafe.Pointer, column unsafe.Pointer) {
@@ -25625,6 +26933,18 @@ func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storage
 func SharpenTexFuncSGIS(target uint32, n int32, points *float32) {
 	C.glowSharpenTexFuncSGIS(gpSharpenTexFuncSGIS, (C.GLenum)(target), (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func SignalSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, dstLayouts *uint32) {
+	C.glowSignalSemaphoreEXT(gpSignalSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(dstLayouts)))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
 func SpriteParameterfSGIX(pname uint32, param float32) {
 	C.glowSpriteParameterfSGIX(gpSpriteParameterfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -25639,6 +26959,9 @@ func SpriteParameterivSGIX(pname uint32, params *int32) {
 }
 func StartInstrumentsSGIX() {
 	C.glowStartInstrumentsSGIX(gpStartInstrumentsSGIX)
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
 }
 func StencilClearTagEXT(stencilTagBits int32, stencilClearTag uint32) {
 	C.glowStencilClearTagEXT(gpStencilClearTagEXT, (C.GLsizei)(stencilTagBits), (C.GLuint)(stencilClearTag))
@@ -25711,6 +27034,9 @@ func StopInstrumentsSGIX(marker int32) {
 }
 func StringMarkerGREMEDY(len int32, xstring unsafe.Pointer) {
 	C.glowStringMarkerGREMEDY(gpStringMarkerGREMEDY, (C.GLsizei)(len), xstring)
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
 }
 func SwizzleEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowSwizzleEXT(gpSwizzleEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
@@ -26130,8 +27456,8 @@ func TexImage3DMultisampleCoverageNV(target uint32, coverageSamples int32, color
 func TexImage4DSGIS(target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, size4d int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTexImage4DSGIS(gpTexImage4DSGIS, (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(size4d), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -26191,6 +27517,21 @@ func TexStorage3D(target uint32, levels int32, internalformat uint32, width int3
 func TexStorage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexStorage3DMultisample(gpTexStorage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TexStorageMem1DEXT(target uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem1DEXT(gpTexStorageMem1DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DEXT(gpTexStorageMem2DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DMultisampleEXT(gpTexStorageMem2DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DEXT(gpTexStorageMem3DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DMultisampleEXT(gpTexStorageMem3DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TexStorageSparseAMD(target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTexStorageSparseAMD(gpTexStorageSparseAMD, (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -26239,8 +27580,8 @@ func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buff
 }
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
@@ -26278,8 +27619,8 @@ func TextureMaterialEXT(face uint32, mode uint32) {
 func TextureNormalEXT(mode uint32) {
 	C.glowTextureNormalEXT(gpTextureNormalEXT, (C.GLenum)(mode))
 }
-func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -26363,6 +27704,21 @@ func TextureStorage3DMultisample(texture uint32, samples int32, internalformat u
 func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorageMem1DEXT(texture uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem1DEXT(gpTextureStorageMem1DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DEXT(gpTextureStorageMem2DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DMultisampleEXT(gpTextureStorageMem2DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DEXT(gpTextureStorageMem3DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DMultisampleEXT(gpTextureStorageMem3DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TextureStorageSparseAMD(texture uint32, target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTextureStorageSparseAMD(gpTextureStorageSparseAMD, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -26408,8 +27764,8 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TransformFeedbackStreamAttribsNV(count int32, attribs *int32, nbuffers int32, bufstreams *int32, bufferMode uint32) {
 	C.glowTransformFeedbackStreamAttribsNV(gpTransformFeedbackStreamAttribsNV, (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(attribs)), (C.GLsizei)(nbuffers), (*C.GLint)(unsafe.Pointer(bufstreams)), (C.GLenum)(bufferMode))
@@ -26464,8 +27820,14 @@ func Uniform1fvARB(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
 func Uniform1i64NV(location int32, x int64) {
 	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform1i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26486,8 +27848,14 @@ func Uniform1ivARB(location int32, count int32, value *int32) {
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
 }
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
 func Uniform1ui64NV(location int32, x uint64) {
 	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform1ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26530,8 +27898,14 @@ func Uniform2fvARB(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func Uniform2i64NV(location int32, x int64, y int64) {
 	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform2i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26552,8 +27926,14 @@ func Uniform2ivARB(location int32, count int32, value *int32) {
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func Uniform2ui64NV(location int32, x uint64, y uint64) {
 	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform2ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26596,8 +27976,14 @@ func Uniform3fvARB(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func Uniform3i64NV(location int32, x int64, y int64, z int64) {
 	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform3i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26618,8 +28004,14 @@ func Uniform3ivARB(location int32, count int32, value *int32) {
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
 	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform3ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26662,8 +28054,14 @@ func Uniform4fvARB(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
 	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform4i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26684,8 +28082,14 @@ func Uniform4ivARB(location int32, count int32, value *int32) {
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform4ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -28031,10 +29435,22 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
+func WaitSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, srcLayouts *uint32) {
+	C.glowWaitSemaphoreEXT(gpWaitSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(srcLayouts)))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
 	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
@@ -28234,6 +29650,9 @@ func WindowPos4sMESA(x int16, y int16, z int16, w int16) {
 func WindowPos4svMESA(v *int16) {
 	C.glowWindowPos4svMESA(gpWindowPos4svMESA, (*C.GLshort)(unsafe.Pointer(v)))
 }
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
+}
 func WriteMaskEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowWriteMaskEXT(gpWriteMaskEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
 }
@@ -28270,6 +29689,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAccum")
 	}
 	gpAccumxOES = (C.GPACCUMXOES)(getProcAddr("glAccumxOES"))
+	gpAcquireKeyedMutexWin32EXT = (C.GPACQUIREKEYEDMUTEXWIN32EXT)(getProcAddr("glAcquireKeyedMutexWin32EXT"))
 	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
 	if gpActiveShaderProgram == nil {
@@ -28291,6 +29711,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAlphaFunc")
 	}
 	gpAlphaFuncxOES = (C.GPALPHAFUNCXOES)(getProcAddr("glAlphaFuncxOES"))
+	gpAlphaToCoverageDitherControlNV = (C.GPALPHATOCOVERAGEDITHERCONTROLNV)(getProcAddr("glAlphaToCoverageDitherControlNV"))
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpApplyTextureEXT = (C.GPAPPLYTEXTUREEXT)(getProcAddr("glApplyTextureEXT"))
 	gpAreProgramsResidentNV = (C.GPAREPROGRAMSRESIDENTNV)(getProcAddr("glAreProgramsResidentNV"))
 	gpAreTexturesResident = (C.GPARETEXTURESRESIDENT)(getProcAddr("glAreTexturesResident"))
@@ -28520,11 +29942,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpBufferPageCommitmentARB = (C.GPBUFFERPAGECOMMITMENTARB)(getProcAddr("glBufferPageCommitmentARB"))
 	gpBufferParameteriAPPLE = (C.GPBUFFERPARAMETERIAPPLE)(getProcAddr("glBufferParameteriAPPLE"))
 	gpBufferStorage = (C.GPBUFFERSTORAGE)(getProcAddr("glBufferStorage"))
+	gpBufferStorageExternalEXT = (C.GPBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glBufferStorageExternalEXT"))
+	gpBufferStorageMemEXT = (C.GPBUFFERSTORAGEMEMEXT)(getProcAddr("glBufferStorageMemEXT"))
 	gpBufferSubData = (C.GPBUFFERSUBDATA)(getProcAddr("glBufferSubData"))
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
 	gpBufferSubDataARB = (C.GPBUFFERSUBDATAARB)(getProcAddr("glBufferSubDataARB"))
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCallList = (C.GPCALLLIST)(getProcAddr("glCallList"))
 	if gpCallList == nil {
 		return errors.New("glCallList")
@@ -28832,6 +30257,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCombinerParameteriNV = (C.GPCOMBINERPARAMETERINV)(getProcAddr("glCombinerParameteriNV"))
 	gpCombinerParameterivNV = (C.GPCOMBINERPARAMETERIVNV)(getProcAddr("glCombinerParameterivNV"))
 	gpCombinerStageParameterfvNV = (C.GPCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glCombinerStageParameterfvNV"))
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
@@ -28883,6 +30310,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
 	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpConvolutionFilter1D = (C.GPCONVOLUTIONFILTER1D)(getProcAddr("glConvolutionFilter1D"))
 	gpConvolutionFilter1DEXT = (C.GPCONVOLUTIONFILTER1DEXT)(getProcAddr("glConvolutionFilter1DEXT"))
 	gpConvolutionFilter2D = (C.GPCONVOLUTIONFILTER2D)(getProcAddr("glConvolutionFilter2D"))
@@ -28962,8 +30391,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
 	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
 	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
+	gpCreateMemoryObjectsEXT = (C.GPCREATEMEMORYOBJECTSEXT)(getProcAddr("glCreateMemoryObjectsEXT"))
 	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
@@ -28985,6 +30418,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glCreateShaderProgramv")
 	}
 	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	gpCreateTransformFeedbacks = (C.GPCREATETRANSFORMFEEDBACKS)(getProcAddr("glCreateTransformFeedbacks"))
@@ -29026,6 +30460,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteBuffers")
 	}
 	gpDeleteBuffersARB = (C.GPDELETEBUFFERSARB)(getProcAddr("glDeleteBuffersARB"))
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFencesAPPLE = (C.GPDELETEFENCESAPPLE)(getProcAddr("glDeleteFencesAPPLE"))
 	gpDeleteFencesNV = (C.GPDELETEFENCESNV)(getProcAddr("glDeleteFencesNV"))
 	gpDeleteFragmentShaderATI = (C.GPDELETEFRAGMENTSHADERATI)(getProcAddr("glDeleteFragmentShaderATI"))
@@ -29038,6 +30473,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteLists == nil {
 		return errors.New("glDeleteLists")
 	}
+	gpDeleteMemoryObjectsEXT = (C.GPDELETEMEMORYOBJECTSEXT)(getProcAddr("glDeleteMemoryObjectsEXT"))
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
 	gpDeleteNamesAMD = (C.GPDELETENAMESAMD)(getProcAddr("glDeleteNamesAMD"))
 	gpDeleteObjectARB = (C.GPDELETEOBJECTARB)(getProcAddr("glDeleteObjectARB"))
@@ -29061,6 +30497,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteQueries")
 	}
 	gpDeleteQueriesARB = (C.GPDELETEQUERIESARB)(getProcAddr("glDeleteQueriesARB"))
+	gpDeleteQueryResourceTagNV = (C.GPDELETEQUERYRESOURCETAGNV)(getProcAddr("glDeleteQueryResourceTagNV"))
 	gpDeleteRenderbuffers = (C.GPDELETERENDERBUFFERS)(getProcAddr("glDeleteRenderbuffers"))
 	if gpDeleteRenderbuffers == nil {
 		return errors.New("glDeleteRenderbuffers")
@@ -29070,10 +30507,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteSamplers == nil {
 		return errors.New("glDeleteSamplers")
 	}
+	gpDeleteSemaphoresEXT = (C.GPDELETESEMAPHORESEXT)(getProcAddr("glDeleteSemaphoresEXT"))
 	gpDeleteShader = (C.GPDELETESHADER)(getProcAddr("glDeleteShader"))
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	if gpDeleteSync == nil {
 		return errors.New("glDeleteSync")
@@ -29192,6 +30631,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpDrawBuffersARB = (C.GPDRAWBUFFERSARB)(getProcAddr("glDrawBuffersARB"))
 	gpDrawBuffersATI = (C.GPDRAWBUFFERSATI)(getProcAddr("glDrawBuffersATI"))
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElementArrayAPPLE = (C.GPDRAWELEMENTARRAYAPPLE)(getProcAddr("glDrawElementArrayAPPLE"))
 	gpDrawElementArrayATI = (C.GPDRAWELEMENTARRAYATI)(getProcAddr("glDrawElementArrayATI"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
@@ -29258,6 +30701,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawTransformFeedbackStreamInstanced == nil {
 		return errors.New("glDrawTransformFeedbackStreamInstanced")
 	}
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
 	gpEdgeFlag = (C.GPEDGEFLAG)(getProcAddr("glEdgeFlag"))
 	if gpEdgeFlag == nil {
 		return errors.New("glEdgeFlag")
@@ -29388,6 +30832,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEvalPoint2 == nil {
 		return errors.New("glEvalPoint2")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpExecuteProgramNV = (C.GPEXECUTEPROGRAMNV)(getProcAddr("glExecuteProgramNV"))
 	gpExtractComponentEXT = (C.GPEXTRACTCOMPONENTEXT)(getProcAddr("glExtractComponentEXT"))
 	gpFeedbackBuffer = (C.GPFEEDBACKBUFFER)(getProcAddr("glFeedbackBuffer"))
@@ -29474,6 +30919,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFogxOES = (C.GPFOGXOES)(getProcAddr("glFogxOES"))
 	gpFogxvOES = (C.GPFOGXVOES)(getProcAddr("glFogxvOES"))
 	gpFragmentColorMaterialSGIX = (C.GPFRAGMENTCOLORMATERIALSGIX)(getProcAddr("glFragmentColorMaterialSGIX"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
 	gpFragmentLightModelfSGIX = (C.GPFRAGMENTLIGHTMODELFSGIX)(getProcAddr("glFragmentLightModelfSGIX"))
 	gpFragmentLightModelfvSGIX = (C.GPFRAGMENTLIGHTMODELFVSGIX)(getProcAddr("glFragmentLightModelfvSGIX"))
 	gpFragmentLightModeliSGIX = (C.GPFRAGMENTLIGHTMODELISGIX)(getProcAddr("glFragmentLightModeliSGIX"))
@@ -29490,6 +30936,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFrameZoomSGIX = (C.GPFRAMEZOOMSGIX)(getProcAddr("glFrameZoomSGIX"))
 	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
 	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
 	if gpFramebufferParameteri == nil {
 		return errors.New("glFramebufferParameteri")
@@ -29500,6 +30947,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glFramebufferRenderbuffer")
 	}
 	gpFramebufferRenderbufferEXT = (C.GPFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glFramebufferRenderbufferEXT"))
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
+	gpFramebufferSamplePositionsfvAMD = (C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glFramebufferSamplePositionsfvAMD"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	if gpFramebufferTexture == nil {
 		return errors.New("glFramebufferTexture")
@@ -29529,6 +30979,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
 	gpFramebufferTextureLayerEXT = (C.GPFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glFramebufferTextureLayerEXT"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFreeObjectBufferATI = (C.GPFREEOBJECTBUFFERATI)(getProcAddr("glFreeObjectBufferATI"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
@@ -29574,6 +31025,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGenQueries")
 	}
 	gpGenQueriesARB = (C.GPGENQUERIESARB)(getProcAddr("glGenQueriesARB"))
+	gpGenQueryResourceTagNV = (C.GPGENQUERYRESOURCETAGNV)(getProcAddr("glGenQueryResourceTagNV"))
 	gpGenRenderbuffers = (C.GPGENRENDERBUFFERS)(getProcAddr("glGenRenderbuffers"))
 	if gpGenRenderbuffers == nil {
 		return errors.New("glGenRenderbuffers")
@@ -29583,6 +31035,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenSamplers == nil {
 		return errors.New("glGenSamplers")
 	}
+	gpGenSemaphoresEXT = (C.GPGENSEMAPHORESEXT)(getProcAddr("glGenSemaphoresEXT"))
 	gpGenSymbolsEXT = (C.GPGENSYMBOLSEXT)(getProcAddr("glGenSymbolsEXT"))
 	gpGenTextures = (C.GPGENTEXTURES)(getProcAddr("glGenTextures"))
 	if gpGenTextures == nil {
@@ -29712,6 +31165,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetCombinerOutputParameterfvNV = (C.GPGETCOMBINEROUTPUTPARAMETERFVNV)(getProcAddr("glGetCombinerOutputParameterfvNV"))
 	gpGetCombinerOutputParameterivNV = (C.GPGETCOMBINEROUTPUTPARAMETERIVNV)(getProcAddr("glGetCombinerOutputParameterivNV"))
 	gpGetCombinerStageParameterfvNV = (C.GPGETCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glGetCombinerStageParameterfvNV"))
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
 	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
@@ -29728,6 +31182,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetConvolutionParameteriv = (C.GPGETCONVOLUTIONPARAMETERIV)(getProcAddr("glGetConvolutionParameteriv"))
 	gpGetConvolutionParameterivEXT = (C.GPGETCONVOLUTIONPARAMETERIVEXT)(getProcAddr("glGetConvolutionParameterivEXT"))
 	gpGetConvolutionParameterxvOES = (C.GPGETCONVOLUTIONPARAMETERXVOES)(getProcAddr("glGetConvolutionParameterxvOES"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	if gpGetDebugMessageLog == nil {
 		return errors.New("glGetDebugMessageLog")
@@ -29784,6 +31239,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetFramebufferAttachmentParameteriv")
 	}
 	gpGetFramebufferAttachmentParameterivEXT = (C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetFramebufferAttachmentParameterivEXT"))
+	gpGetFramebufferParameterfvAMD = (C.GPGETFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetFramebufferParameterfvAMD"))
 	gpGetFramebufferParameteriv = (C.GPGETFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetFramebufferParameteriv"))
 	if gpGetFramebufferParameteriv == nil {
 		return errors.New("glGetFramebufferParameteriv")
@@ -29825,6 +31281,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	if gpGetInternalformati64v == nil {
 		return errors.New("glGetInternalformati64v")
@@ -29879,6 +31336,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetMaterialxOES = (C.GPGETMATERIALXOES)(getProcAddr("glGetMaterialxOES"))
 	gpGetMaterialxvOES = (C.GPGETMATERIALXVOES)(getProcAddr("glGetMaterialxvOES"))
+	gpGetMemoryObjectParameterivEXT = (C.GPGETMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glGetMemoryObjectParameterivEXT"))
 	gpGetMinmax = (C.GPGETMINMAX)(getProcAddr("glGetMinmax"))
 	gpGetMinmaxEXT = (C.GPGETMINMAXEXT)(getProcAddr("glGetMinmaxEXT"))
 	gpGetMinmaxParameterfv = (C.GPGETMINMAXPARAMETERFV)(getProcAddr("glGetMinmaxParameterfv"))
@@ -29912,6 +31370,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
 	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
+	gpGetNamedFramebufferParameterfvAMD = (C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetNamedFramebufferParameterfvAMD"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
 	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
 	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
@@ -30063,6 +31522,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetProgramivARB = (C.GPGETPROGRAMIVARB)(getProcAddr("glGetProgramivARB"))
 	gpGetProgramivNV = (C.GPGETPROGRAMIVNV)(getProcAddr("glGetProgramivNV"))
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	if gpGetQueryIndexediv == nil {
 		return errors.New("glGetQueryIndexediv")
@@ -30113,6 +31576,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetSamplerParameteriv == nil {
 		return errors.New("glGetSamplerParameteriv")
 	}
+	gpGetSemaphoreParameterui64vEXT = (C.GPGETSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glGetSemaphoreParameterui64vEXT"))
 	gpGetSeparableFilter = (C.GPGETSEPARABLEFILTER)(getProcAddr("glGetSeparableFilter"))
 	gpGetSeparableFilterEXT = (C.GPGETSEPARABLEFILTEREXT)(getProcAddr("glGetSeparableFilterEXT"))
 	gpGetShaderInfoLog = (C.GPGETSHADERINFOLOG)(getProcAddr("glGetShaderInfoLog"))
@@ -30133,6 +31597,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetShaderiv")
 	}
 	gpGetSharpenTexFuncSGIS = (C.GPGETSHARPENTEXFUNCSGIS)(getProcAddr("glGetSharpenTexFuncSGIS"))
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -30268,18 +31733,22 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetUniformfv")
 	}
 	gpGetUniformfvARB = (C.GPGETUNIFORMFVARB)(getProcAddr("glGetUniformfvARB"))
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
 	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
 	gpGetUniformivARB = (C.GPGETUNIFORMIVARB)(getProcAddr("glGetUniformivARB"))
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
 	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
 	}
 	gpGetUniformuivEXT = (C.GPGETUNIFORMUIVEXT)(getProcAddr("glGetUniformuivEXT"))
+	gpGetUnsignedBytei_vEXT = (C.GPGETUNSIGNEDBYTEI_VEXT)(getProcAddr("glGetUnsignedBytei_vEXT"))
+	gpGetUnsignedBytevEXT = (C.GPGETUNSIGNEDBYTEVEXT)(getProcAddr("glGetUnsignedBytevEXT"))
 	gpGetVariantArrayObjectfvATI = (C.GPGETVARIANTARRAYOBJECTFVATI)(getProcAddr("glGetVariantArrayObjectfvATI"))
 	gpGetVariantArrayObjectivATI = (C.GPGETVARIANTARRAYOBJECTIVATI)(getProcAddr("glGetVariantArrayObjectivATI"))
 	gpGetVariantBooleanvEXT = (C.GPGETVARIANTBOOLEANVEXT)(getProcAddr("glGetVariantBooleanvEXT"))
@@ -30346,6 +31815,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetVideoivNV = (C.GPGETVIDEOIVNV)(getProcAddr("glGetVideoivNV"))
 	gpGetVideoui64vNV = (C.GPGETVIDEOUI64VNV)(getProcAddr("glGetVideoui64vNV"))
 	gpGetVideouivNV = (C.GPGETVIDEOUIVNV)(getProcAddr("glGetVideouivNV"))
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnColorTableARB = (C.GPGETNCOLORTABLEARB)(getProcAddr("glGetnColorTableARB"))
 	gpGetnCompressedTexImageARB = (C.GPGETNCOMPRESSEDTEXIMAGEARB)(getProcAddr("glGetnCompressedTexImageARB"))
 	gpGetnConvolutionFilterARB = (C.GPGETNCONVOLUTIONFILTERARB)(getProcAddr("glGetnConvolutionFilterARB"))
@@ -30364,9 +31834,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	gpGetnUniformuivARB = (C.GPGETNUNIFORMUIVARB)(getProcAddr("glGetnUniformuivARB"))
 	gpGetnUniformuivKHR = (C.GPGETNUNIFORMUIVKHR)(getProcAddr("glGetnUniformuivKHR"))
@@ -30390,6 +31862,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpImageTransformParameterfvHP = (C.GPIMAGETRANSFORMPARAMETERFVHP)(getProcAddr("glImageTransformParameterfvHP"))
 	gpImageTransformParameteriHP = (C.GPIMAGETRANSFORMPARAMETERIHP)(getProcAddr("glImageTransformParameteriHP"))
 	gpImageTransformParameterivHP = (C.GPIMAGETRANSFORMPARAMETERIVHP)(getProcAddr("glImageTransformParameterivHP"))
+	gpImportMemoryFdEXT = (C.GPIMPORTMEMORYFDEXT)(getProcAddr("glImportMemoryFdEXT"))
+	gpImportMemoryWin32HandleEXT = (C.GPIMPORTMEMORYWIN32HANDLEEXT)(getProcAddr("glImportMemoryWin32HandleEXT"))
+	gpImportMemoryWin32NameEXT = (C.GPIMPORTMEMORYWIN32NAMEEXT)(getProcAddr("glImportMemoryWin32NameEXT"))
+	gpImportSemaphoreFdEXT = (C.GPIMPORTSEMAPHOREFDEXT)(getProcAddr("glImportSemaphoreFdEXT"))
+	gpImportSemaphoreWin32HandleEXT = (C.GPIMPORTSEMAPHOREWIN32HANDLEEXT)(getProcAddr("glImportSemaphoreWin32HandleEXT"))
+	gpImportSemaphoreWin32NameEXT = (C.GPIMPORTSEMAPHOREWIN32NAMEEXT)(getProcAddr("glImportSemaphoreWin32NameEXT"))
 	gpImportSyncEXT = (C.GPIMPORTSYNCEXT)(getProcAddr("glImportSyncEXT"))
 	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
 	gpIndexFuncEXT = (C.GPINDEXFUNCEXT)(getProcAddr("glIndexFuncEXT"))
@@ -30491,6 +31969,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsBufferARB = (C.GPISBUFFERARB)(getProcAddr("glIsBufferARB"))
 	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
@@ -30513,6 +31992,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsList == nil {
 		return errors.New("glIsList")
 	}
+	gpIsMemoryObjectEXT = (C.GPISMEMORYOBJECTEXT)(getProcAddr("glIsMemoryObjectEXT"))
 	gpIsNameAMD = (C.GPISNAMEAMD)(getProcAddr("glIsNameAMD"))
 	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
@@ -30546,10 +32026,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsSampler == nil {
 		return errors.New("glIsSampler")
 	}
+	gpIsSemaphoreEXT = (C.GPISSEMAPHOREEXT)(getProcAddr("glIsSemaphoreEXT"))
 	gpIsShader = (C.GPISSHADER)(getProcAddr("glIsShader"))
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	if gpIsSync == nil {
 		return errors.New("glIsSync")
@@ -30573,6 +32055,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsVertexArrayAPPLE = (C.GPISVERTEXARRAYAPPLE)(getProcAddr("glIsVertexArrayAPPLE"))
 	gpIsVertexAttribEnabledAPPLE = (C.GPISVERTEXATTRIBENABLEDAPPLE)(getProcAddr("glIsVertexAttribEnabledAPPLE"))
+	gpLGPUCopyImageSubDataNVX = (C.GPLGPUCOPYIMAGESUBDATANVX)(getProcAddr("glLGPUCopyImageSubDataNVX"))
+	gpLGPUInterlockNVX = (C.GPLGPUINTERLOCKNVX)(getProcAddr("glLGPUInterlockNVX"))
+	gpLGPUNamedBufferSubDataNVX = (C.GPLGPUNAMEDBUFFERSUBDATANVX)(getProcAddr("glLGPUNamedBufferSubDataNVX"))
 	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLightEnviSGIX = (C.GPLIGHTENVISGIX)(getProcAddr("glLightEnviSGIX"))
 	gpLightModelf = (C.GPLIGHTMODELF)(getProcAddr("glLightModelf"))
@@ -30629,6 +32114,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpListBase == nil {
 		return errors.New("glListBase")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpListParameterfSGIX = (C.GPLISTPARAMETERFSGIX)(getProcAddr("glListParameterfSGIX"))
 	gpListParameterfvSGIX = (C.GPLISTPARAMETERFVSGIX)(getProcAddr("glListParameterfvSGIX"))
 	gpListParameteriSGIX = (C.GPLISTPARAMETERISGIX)(getProcAddr("glListParameteriSGIX"))
@@ -30789,12 +32275,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
 	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
 	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	if gpMemoryBarrier == nil {
 		return errors.New("glMemoryBarrier")
 	}
 	gpMemoryBarrierByRegion = (C.GPMEMORYBARRIERBYREGION)(getProcAddr("glMemoryBarrierByRegion"))
 	gpMemoryBarrierEXT = (C.GPMEMORYBARRIEREXT)(getProcAddr("glMemoryBarrierEXT"))
+	gpMemoryObjectParameterivEXT = (C.GPMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glMemoryObjectParameterivEXT"))
 	gpMinSampleShading = (C.GPMINSAMPLESHADING)(getProcAddr("glMinSampleShading"))
 	if gpMinSampleShading == nil {
 		return errors.New("glMinSampleShading")
@@ -31097,12 +32586,25 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
 	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
 	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
+	gpMulticastBarrierNV = (C.GPMULTICASTBARRIERNV)(getProcAddr("glMulticastBarrierNV"))
+	gpMulticastBlitFramebufferNV = (C.GPMULTICASTBLITFRAMEBUFFERNV)(getProcAddr("glMulticastBlitFramebufferNV"))
+	gpMulticastBufferSubDataNV = (C.GPMULTICASTBUFFERSUBDATANV)(getProcAddr("glMulticastBufferSubDataNV"))
+	gpMulticastCopyBufferSubDataNV = (C.GPMULTICASTCOPYBUFFERSUBDATANV)(getProcAddr("glMulticastCopyBufferSubDataNV"))
+	gpMulticastCopyImageSubDataNV = (C.GPMULTICASTCOPYIMAGESUBDATANV)(getProcAddr("glMulticastCopyImageSubDataNV"))
+	gpMulticastFramebufferSampleLocationsfvNV = (C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glMulticastFramebufferSampleLocationsfvNV"))
+	gpMulticastGetQueryObjecti64vNV = (C.GPMULTICASTGETQUERYOBJECTI64VNV)(getProcAddr("glMulticastGetQueryObjecti64vNV"))
+	gpMulticastGetQueryObjectivNV = (C.GPMULTICASTGETQUERYOBJECTIVNV)(getProcAddr("glMulticastGetQueryObjectivNV"))
+	gpMulticastGetQueryObjectui64vNV = (C.GPMULTICASTGETQUERYOBJECTUI64VNV)(getProcAddr("glMulticastGetQueryObjectui64vNV"))
+	gpMulticastGetQueryObjectuivNV = (C.GPMULTICASTGETQUERYOBJECTUIVNV)(getProcAddr("glMulticastGetQueryObjectuivNV"))
+	gpMulticastWaitSyncNV = (C.GPMULTICASTWAITSYNCNV)(getProcAddr("glMulticastWaitSyncNV"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
 	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
 	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
+	gpNamedBufferStorageExternalEXT = (C.GPNAMEDBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glNamedBufferStorageExternalEXT"))
+	gpNamedBufferStorageMemEXT = (C.GPNAMEDBUFFERSTORAGEMEMEXT)(getProcAddr("glNamedBufferStorageMemEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
 	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
 	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
@@ -31113,6 +32615,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	gpNamedFramebufferRenderbuffer = (C.GPNAMEDFRAMEBUFFERRENDERBUFFER)(getProcAddr("glNamedFramebufferRenderbuffer"))
 	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
+	gpNamedFramebufferSamplePositionsfvAMD = (C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glNamedFramebufferSamplePositionsfvAMD"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
 	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
 	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
@@ -31364,6 +32869,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPolygonOffsetEXT = (C.GPPOLYGONOFFSETEXT)(getProcAddr("glPolygonOffsetEXT"))
 	gpPolygonOffsetxOES = (C.GPPOLYGONOFFSETXOES)(getProcAddr("glPolygonOffsetxOES"))
 	gpPolygonStipple = (C.GPPOLYGONSTIPPLE)(getProcAddr("glPolygonStipple"))
@@ -31394,6 +32901,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpPresentFrameDualFillNV = (C.GPPRESENTFRAMEDUALFILLNV)(getProcAddr("glPresentFrameDualFillNV"))
 	gpPresentFrameKeyedNV = (C.GPPRESENTFRAMEKEYEDNV)(getProcAddr("glPresentFrameKeyedNV"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	if gpPrimitiveRestartIndex == nil {
 		return errors.New("glPrimitiveRestartIndex")
@@ -31478,7 +32986,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform1i == nil {
 		return errors.New("glProgramUniform1i")
 	}
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
 	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
 	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
 	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
@@ -31490,7 +33000,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform1ui == nil {
 		return errors.New("glProgramUniform1ui")
 	}
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
 	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
 	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
 	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
@@ -31522,7 +33034,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform2i == nil {
 		return errors.New("glProgramUniform2i")
 	}
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
 	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
 	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
 	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
@@ -31534,7 +33048,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform2ui == nil {
 		return errors.New("glProgramUniform2ui")
 	}
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
 	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
 	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
 	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
@@ -31566,7 +33082,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform3i == nil {
 		return errors.New("glProgramUniform3i")
 	}
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
 	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
 	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
 	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
@@ -31578,7 +33096,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform3ui == nil {
 		return errors.New("glProgramUniform3ui")
 	}
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
 	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
 	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
 	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
@@ -31610,7 +33130,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform4i == nil {
 		return errors.New("glProgramUniform4i")
 	}
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
 	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
 	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
 	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
@@ -31622,7 +33144,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform4ui == nil {
 		return errors.New("glProgramUniform4ui")
 	}
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
 	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
 	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
 	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
@@ -31761,6 +33285,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpQueryMatrixxOES = (C.GPQUERYMATRIXXOES)(getProcAddr("glQueryMatrixxOES"))
 	gpQueryObjectParameteruiAMD = (C.GPQUERYOBJECTPARAMETERUIAMD)(getProcAddr("glQueryObjectParameteruiAMD"))
+	gpQueryResourceNV = (C.GPQUERYRESOURCENV)(getProcAddr("glQueryResourceNV"))
+	gpQueryResourceTagNV = (C.GPQUERYRESOURCETAGNV)(getProcAddr("glQueryResourceTagNV"))
 	gpRasterPos2d = (C.GPRASTERPOS2D)(getProcAddr("glRasterPos2d"))
 	if gpRasterPos2d == nil {
 		return errors.New("glRasterPos2d")
@@ -31863,6 +33389,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpRasterPos4xOES = (C.GPRASTERPOS4XOES)(getProcAddr("glRasterPos4xOES"))
 	gpRasterPos4xvOES = (C.GPRASTERPOS4XVOES)(getProcAddr("glRasterPos4xvOES"))
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -31910,10 +33437,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpRectxOES = (C.GPRECTXOES)(getProcAddr("glRectxOES"))
 	gpRectxvOES = (C.GPRECTXVOES)(getProcAddr("glRectxvOES"))
 	gpReferencePlaneSGIX = (C.GPREFERENCEPLANESGIX)(getProcAddr("glReferencePlaneSGIX"))
+	gpReleaseKeyedMutexWin32EXT = (C.GPRELEASEKEYEDMUTEXWIN32EXT)(getProcAddr("glReleaseKeyedMutexWin32EXT"))
 	gpReleaseShaderCompiler = (C.GPRELEASESHADERCOMPILER)(getProcAddr("glReleaseShaderCompiler"))
 	if gpReleaseShaderCompiler == nil {
 		return errors.New("glReleaseShaderCompiler")
 	}
+	gpRenderGpuMaskNV = (C.GPRENDERGPUMASKNV)(getProcAddr("glRenderGpuMaskNV"))
 	gpRenderMode = (C.GPRENDERMODE)(getProcAddr("glRenderMode"))
 	if gpRenderMode == nil {
 		return errors.New("glRenderMode")
@@ -31958,6 +33487,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpResetMinmax = (C.GPRESETMINMAX)(getProcAddr("glResetMinmax"))
 	gpResetMinmaxEXT = (C.GPRESETMINMAXEXT)(getProcAddr("glResetMinmaxEXT"))
 	gpResizeBuffersMESA = (C.GPRESIZEBUFFERSMESA)(getProcAddr("glResizeBuffersMESA"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	if gpResumeTransformFeedback == nil {
 		return errors.New("glResumeTransformFeedback")
@@ -31977,7 +33507,6 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSampleCoverage")
 	}
 	gpSampleCoverageARB = (C.GPSAMPLECOVERAGEARB)(getProcAddr("glSampleCoverageARB"))
-	gpSampleCoverageOES = (C.GPSAMPLECOVERAGEOES)(getProcAddr("glSampleCoverageOES"))
 	gpSampleCoveragexOES = (C.GPSAMPLECOVERAGEXOES)(getProcAddr("glSampleCoveragexOES"))
 	gpSampleMapATI = (C.GPSAMPLEMAPATI)(getProcAddr("glSampleMapATI"))
 	gpSampleMaskEXT = (C.GPSAMPLEMASKEXT)(getProcAddr("glSampleMaskEXT"))
@@ -32140,6 +33669,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSelectBuffer")
 	}
 	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
+	gpSemaphoreParameterui64vEXT = (C.GPSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glSemaphoreParameterui64vEXT"))
 	gpSeparableFilter2D = (C.GPSEPARABLEFILTER2D)(getProcAddr("glSeparableFilter2D"))
 	gpSeparableFilter2DEXT = (C.GPSEPARABLEFILTER2DEXT)(getProcAddr("glSeparableFilter2DEXT"))
 	gpSetFenceAPPLE = (C.GPSETFENCEAPPLE)(getProcAddr("glSetFenceAPPLE"))
@@ -32169,11 +33699,16 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glShaderStorageBlockBinding")
 	}
 	gpSharpenTexFuncSGIS = (C.GPSHARPENTEXFUNCSGIS)(getProcAddr("glSharpenTexFuncSGIS"))
+	gpSignalSemaphoreEXT = (C.GPSIGNALSEMAPHOREEXT)(getProcAddr("glSignalSemaphoreEXT"))
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
 	gpSpriteParameterfSGIX = (C.GPSPRITEPARAMETERFSGIX)(getProcAddr("glSpriteParameterfSGIX"))
 	gpSpriteParameterfvSGIX = (C.GPSPRITEPARAMETERFVSGIX)(getProcAddr("glSpriteParameterfvSGIX"))
 	gpSpriteParameteriSGIX = (C.GPSPRITEPARAMETERISGIX)(getProcAddr("glSpriteParameteriSGIX"))
 	gpSpriteParameterivSGIX = (C.GPSPRITEPARAMETERIVSGIX)(getProcAddr("glSpriteParameterivSGIX"))
 	gpStartInstrumentsSGIX = (C.GPSTARTINSTRUMENTSSGIX)(getProcAddr("glStartInstrumentsSGIX"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
 	gpStencilClearTagEXT = (C.GPSTENCILCLEARTAGEXT)(getProcAddr("glStencilClearTagEXT"))
 	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
 	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
@@ -32212,6 +33747,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
 	gpStopInstrumentsSGIX = (C.GPSTOPINSTRUMENTSSGIX)(getProcAddr("glStopInstrumentsSGIX"))
 	gpStringMarkerGREMEDY = (C.GPSTRINGMARKERGREMEDY)(getProcAddr("glStringMarkerGREMEDY"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpSwizzleEXT = (C.GPSWIZZLEEXT)(getProcAddr("glSwizzleEXT"))
 	gpSyncTextureINTEL = (C.GPSYNCTEXTUREINTEL)(getProcAddr("glSyncTextureINTEL"))
 	gpTagSampleBufferSGIX = (C.GPTAGSAMPLEBUFFERSGIX)(getProcAddr("glTagSampleBufferSGIX"))
@@ -32569,6 +34105,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpTexStorage3DMultisample == nil {
 		return errors.New("glTexStorage3DMultisample")
 	}
+	gpTexStorageMem1DEXT = (C.GPTEXSTORAGEMEM1DEXT)(getProcAddr("glTexStorageMem1DEXT"))
+	gpTexStorageMem2DEXT = (C.GPTEXSTORAGEMEM2DEXT)(getProcAddr("glTexStorageMem2DEXT"))
+	gpTexStorageMem2DMultisampleEXT = (C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem2DMultisampleEXT"))
+	gpTexStorageMem3DEXT = (C.GPTEXSTORAGEMEM3DEXT)(getProcAddr("glTexStorageMem3DEXT"))
+	gpTexStorageMem3DMultisampleEXT = (C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem3DMultisampleEXT"))
 	gpTexStorageSparseAMD = (C.GPTEXSTORAGESPARSEAMD)(getProcAddr("glTexStorageSparseAMD"))
 	gpTexSubImage1D = (C.GPTEXSUBIMAGE1D)(getProcAddr("glTexSubImage1D"))
 	if gpTexSubImage1D == nil {
@@ -32628,6 +34169,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
 	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
+	gpTextureStorageMem1DEXT = (C.GPTEXTURESTORAGEMEM1DEXT)(getProcAddr("glTextureStorageMem1DEXT"))
+	gpTextureStorageMem2DEXT = (C.GPTEXTURESTORAGEMEM2DEXT)(getProcAddr("glTextureStorageMem2DEXT"))
+	gpTextureStorageMem2DMultisampleEXT = (C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem2DMultisampleEXT"))
+	gpTextureStorageMem3DEXT = (C.GPTEXTURESTORAGEMEM3DEXT)(getProcAddr("glTextureStorageMem3DEXT"))
+	gpTextureStorageMem3DMultisampleEXT = (C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem3DMultisampleEXT"))
 	gpTextureStorageSparseAMD = (C.GPTEXTURESTORAGESPARSEAMD)(getProcAddr("glTextureStorageSparseAMD"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
 	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
@@ -32682,7 +34228,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
 	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
 	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iARB = (C.GPUNIFORM1IARB)(getProcAddr("glUniform1iARB"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
@@ -32694,7 +34242,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
 	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
 	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiEXT = (C.GPUNIFORM1UIEXT)(getProcAddr("glUniform1uiEXT"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
@@ -32724,7 +34274,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
 	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
 	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iARB = (C.GPUNIFORM2IARB)(getProcAddr("glUniform2iARB"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
@@ -32736,7 +34288,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
 	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
 	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiEXT = (C.GPUNIFORM2UIEXT)(getProcAddr("glUniform2uiEXT"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
@@ -32766,7 +34320,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
 	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
 	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iARB = (C.GPUNIFORM3IARB)(getProcAddr("glUniform3iARB"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
@@ -32778,7 +34334,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
 	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
 	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiEXT = (C.GPUNIFORM3UIEXT)(getProcAddr("glUniform3uiEXT"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
@@ -32808,7 +34366,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
 	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
 	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iARB = (C.GPUNIFORM4IARB)(getProcAddr("glUniform4iARB"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
@@ -32820,7 +34380,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
 	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
 	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiEXT = (C.GPUNIFORM4UIEXT)(getProcAddr("glUniform4uiEXT"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
@@ -33673,10 +35235,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpViewportIndexedfv == nil {
 		return errors.New("glViewportIndexedfv")
 	}
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
+	gpWaitSemaphoreEXT = (C.GPWAITSEMAPHOREEXT)(getProcAddr("glWaitSemaphoreEXT"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
 	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
 	gpWeightPointerARB = (C.GPWEIGHTPOINTERARB)(getProcAddr("glWeightPointerARB"))
 	gpWeightbvARB = (C.GPWEIGHTBVARB)(getProcAddr("glWeightbvARB"))
@@ -33791,6 +35357,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpWindowPos4ivMESA = (C.GPWINDOWPOS4IVMESA)(getProcAddr("glWindowPos4ivMESA"))
 	gpWindowPos4sMESA = (C.GPWINDOWPOS4SMESA)(getProcAddr("glWindowPos4sMESA"))
 	gpWindowPos4svMESA = (C.GPWINDOWPOS4SVMESA)(getProcAddr("glWindowPos4svMESA"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	gpWriteMaskEXT = (C.GPWRITEMASKEXT)(getProcAddr("glWriteMaskEXT"))
 	return nil
 }

--- a/v4.3-compatibility/gl/procaddr.go
+++ b/v4.3-compatibility/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcompatibility43(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v4.3-core/gl/package.go
+++ b/v4.3-core/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -89,21 +87,29 @@ package gl
 // typedef ptrdiff_t GLsizeiptr;
 // typedef int64_t GLint64;
 // typedef uint64_t GLuint64;
+// typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCARB)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCKHR)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcore43(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcore43(source, type, id, severity, length, message, userParam);
 // }
+// typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
+// typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVETEXTURE)(GLenum  texture);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPATTACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPBEGINCONDITIONALRENDER)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINCONDITIONALRENDERNV)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPBEGINPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPBEGINQUERY)(GLenum  target, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINQUERYINDEXED)(GLenum  target, GLuint  index, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINTRANSFORMFEEDBACK)(GLenum  primitiveMode);
@@ -118,7 +124,9 @@ package gl
 // typedef void  (APIENTRYP GPBINDFRAMEBUFFER)(GLenum  target, GLuint  framebuffer);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURE)(GLuint  unit, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  access, GLenum  format);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURES)(GLuint  first, GLsizei  count, const GLuint * textures);
+// typedef void  (APIENTRYP GPBINDMULTITEXTUREEXT)(GLenum  texunit, GLenum  target, GLuint  texture);
 // typedef void  (APIENTRYP GPBINDPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPBINDPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPBINDRENDERBUFFER)(GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPBINDSAMPLER)(GLuint  unit, GLuint  sampler);
 // typedef void  (APIENTRYP GPBINDSAMPLERS)(GLuint  first, GLsizei  count, const GLuint * samplers);
@@ -129,6 +137,8 @@ package gl
 // typedef void  (APIENTRYP GPBINDVERTEXARRAY)(GLuint  array);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFER)(GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFERS)(GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPBLENDBARRIERKHR)();
+// typedef void  (APIENTRYP GPBLENDBARRIERNV)();
 // typedef void  (APIENTRYP GPBLENDCOLOR)(GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha);
 // typedef void  (APIENTRYP GPBLENDEQUATION)(GLenum  mode);
 // typedef void  (APIENTRYP GPBLENDEQUATIONSEPARATE)(GLenum  modeRGB, GLenum  modeAlpha);
@@ -142,14 +152,18 @@ package gl
 // typedef void  (APIENTRYP GPBLENDFUNCSEPARATEIARB)(GLuint  buf, GLenum  srcRGB, GLenum  dstRGB, GLenum  srcAlpha, GLenum  dstAlpha);
 // typedef void  (APIENTRYP GPBLENDFUNCI)(GLuint  buf, GLenum  src, GLenum  dst);
 // typedef void  (APIENTRYP GPBLENDFUNCIARB)(GLuint  buf, GLenum  src, GLenum  dst);
+// typedef void  (APIENTRYP GPBLENDPARAMETERINV)(GLenum  pname, GLint  value);
 // typedef void  (APIENTRYP GPBLITFRAMEBUFFER)(GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
 // typedef void  (APIENTRYP GPBLITNAMEDFRAMEBUFFER)(GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
 // typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUS)(GLuint  framebuffer, GLenum  target);
+// typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(GLuint  framebuffer, GLenum  target);
 // typedef void  (APIENTRYP GPCLAMPCOLOR)(GLenum  target, GLenum  clamp);
 // typedef void  (APIENTRYP GPCLEAR)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPCLEARBUFFERDATA)(GLenum  target, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
@@ -162,49 +176,91 @@ package gl
 // typedef void  (APIENTRYP GPCLEARDEPTH)(GLdouble  depth);
 // typedef void  (APIENTRYP GPCLEARDEPTHF)(GLfloat  d);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
 // typedef void  (APIENTRYP GPCLEARSTENCIL)(GLint  s);
 // typedef void  (APIENTRYP GPCLEARTEXIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARTEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef GLenum  (APIENTRYP GPCLIENTWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
 // typedef void  (APIENTRYP GPCLIPCONTROL)(GLenum  origin, GLenum  depth);
+// typedef void  (APIENTRYP GPCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPCOLORMASK)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPCOLORMASKI)(GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE3D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOPYBUFFERSUBDATA)(GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYIMAGESUBDATA)(GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef void  (APIENTRYP GPCREATEPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPCREATEQUERIES)(GLenum  target, GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPCREATERENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPCREATESAMPLERS)(GLsizei  n, GLuint * samplers);
 // typedef GLuint  (APIENTRYP GPCREATESHADER)(GLenum  type);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -220,14 +276,20 @@ package gl
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTARB)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTKHR)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef void  (APIENTRYP GPDELETEPATHSNV)(GLuint  path, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
+// typedef void  (APIENTRYP GPDELETEPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPDELETEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINES)(GLsizei  n, const GLuint * pipelines);
+// typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINESEXT)(GLsizei  n, const GLuint * pipelines);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETRANSFORMFEEDBACKS)(GLsizei  n, const GLuint * ids);
@@ -240,7 +302,12 @@ package gl
 // typedef void  (APIENTRYP GPDEPTHRANGEF)(GLfloat  n, GLfloat  f);
 // typedef void  (APIENTRYP GPDETACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPDISABLE)(GLenum  cap);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPDISABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISPATCHCOMPUTE)(GLuint  num_groups_x, GLuint  num_groups_y, GLuint  num_groups_z);
@@ -249,46 +316,81 @@ package gl
 // typedef void  (APIENTRYP GPDRAWARRAYS)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCED)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDARB)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDBASEINSTANCE)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDEXT)(GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWBUFFER)(GLenum  buf);
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWELEMENTSBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCED)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDARB)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDEXT)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTS)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTSBASEVERTEX)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACK)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKINSTANCED)(GLenum  mode, GLuint  id, GLsizei  instancecount);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
+// typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPENABLE)(GLenum  cap);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPENABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPENABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDCONDITIONALRENDER)();
+// typedef void  (APIENTRYP GPENDCONDITIONALRENDERNV)();
+// typedef void  (APIENTRYP GPENDPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPENDPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPENDQUERY)(GLenum  target);
 // typedef void  (APIENTRYP GPENDQUERYINDEXED)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDTRANSFORMFEEDBACK)();
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef GLsync  (APIENTRYP GPFENCESYNC)(GLenum  condition, GLbitfield  flags);
 // typedef void  (APIENTRYP GPFINISH)();
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFOGCOORDFORMATNV)(GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE2D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE3D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREFACEARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPGENBUFFERS)(GLsizei  n, GLuint * buffers);
 // typedef void  (APIENTRYP GPGENFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef GLuint  (APIENTRYP GPGENPATHSNV)(GLsizei  range);
+// typedef void  (APIENTRYP GPGENPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
 // typedef void  (APIENTRYP GPGENPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
+// typedef void  (APIENTRYP GPGENPROGRAMPIPELINESEXT)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
@@ -296,7 +398,9 @@ package gl
 // typedef void  (APIENTRYP GPGENTRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENVERTEXARRAYS)(GLsizei  n, GLuint * arrays);
 // typedef void  (APIENTRYP GPGENERATEMIPMAP)(GLenum  target);
+// typedef void  (APIENTRYP GPGENERATEMULTITEXMIPMAPEXT)(GLenum  texunit, GLenum  target);
 // typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAP)(GLuint  texture);
+// typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAPEXT)(GLuint  texture, GLenum  target);
 // typedef void  (APIENTRYP GPGETACTIVEATOMICCOUNTERBUFFERIV)(GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETACTIVEATTRIB)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLint * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETACTIVESUBROUTINENAME)(GLuint  program, GLenum  shadertype, GLuint  index, GLsizei  bufsize, GLsizei * length, GLchar * name);
@@ -309,65 +413,137 @@ package gl
 // typedef void  (APIENTRYP GPGETACTIVEUNIFORMSIV)(GLuint  program, GLsizei  uniformCount, const GLuint * uniformIndices, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETATTACHEDSHADERS)(GLuint  program, GLsizei  maxCount, GLsizei * count, GLuint * shaders);
 // typedef GLint  (APIENTRYP GPGETATTRIBLOCATION)(GLuint  program, const GLchar * name);
+// typedef void  (APIENTRYP GPGETBOOLEANINDEXEDVEXT)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANI_V)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANV)(GLenum  pname, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERI64V)(GLenum  target, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETBUFFERPARAMETERUI64VNV)(GLenum  target, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETBUFFERPOINTERV)(GLenum  target, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGE)(GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGKHR)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
+// typedef void  (APIENTRYP GPGETDOUBLEINDEXEDVEXT)(GLenum  target, GLuint  index, GLdouble * data);
 // typedef void  (APIENTRYP GPGETDOUBLEI_V)(GLenum  target, GLuint  index, GLdouble * data);
+// typedef void  (APIENTRYP GPGETDOUBLEI_VEXT)(GLenum  pname, GLuint  index, GLdouble * params);
 // typedef void  (APIENTRYP GPGETDOUBLEV)(GLenum  pname, GLdouble * data);
 // typedef GLenum  (APIENTRYP GPGETERROR)();
+// typedef void  (APIENTRYP GPGETFIRSTPERFQUERYIDINTEL)(GLuint * queryId);
+// typedef void  (APIENTRYP GPGETFLOATINDEXEDVEXT)(GLenum  target, GLuint  index, GLfloat * data);
 // typedef void  (APIENTRYP GPGETFLOATI_V)(GLenum  target, GLuint  index, GLfloat * data);
+// typedef void  (APIENTRYP GPGETFLOATI_VEXT)(GLenum  pname, GLuint  index, GLfloat * params);
 // typedef void  (APIENTRYP GPGETFLOATV)(GLenum  pname, GLfloat * data);
 // typedef GLint  (APIENTRYP GPGETFRAGDATAINDEX)(GLuint  program, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETFRAGDATALOCATION)(GLuint  program, const GLchar * name);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSARB)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSKHR)();
 // typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLEARB)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
+// typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLENV)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
 // typedef void  (APIENTRYP GPGETINTEGER64I_V)(GLenum  target, GLuint  index, GLint64 * data);
 // typedef void  (APIENTRYP GPGETINTEGER64V)(GLenum  pname, GLint64 * data);
+// typedef void  (APIENTRYP GPGETINTEGERINDEXEDVEXT)(GLenum  target, GLuint  index, GLint * data);
 // typedef void  (APIENTRYP GPGETINTEGERI_V)(GLenum  target, GLuint  index, GLint * data);
+// typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
+// typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMULTISAMPLEFV)(GLenum  pname, GLuint  index, GLfloat * val);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERI64V)(GLuint  buffer, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIV)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIVEXT)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  pname, void * string);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMIVEXT)(GLuint  program, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIV)(GLuint  renderbuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(GLuint  renderbuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGARB)(GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGIVARB)(GLint  namelen, const GLchar * name, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNEXTPERFQUERYIDINTEL)(GLuint  queryId, GLuint * nextQueryId);
 // typedef void  (APIENTRYP GPGETOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETOBJECTLABELEXT)(GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABEL)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABELKHR)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETPATHCOMMANDSNV)(GLuint  path, GLubyte * commands);
+// typedef void  (APIENTRYP GPGETPATHCOORDSNV)(GLuint  path, GLfloat * coords);
+// typedef void  (APIENTRYP GPGETPATHDASHARRAYNV)(GLuint  path, GLfloat * dashArray);
+// typedef GLfloat  (APIENTRYP GPGETPATHLENGTHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments);
+// typedef void  (APIENTRYP GPGETPATHMETRICRANGENV)(GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHMETRICSNV)(GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, GLfloat * value);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, GLint * value);
+// typedef void  (APIENTRYP GPGETPATHSPACINGNV)(GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing);
+// typedef void  (APIENTRYP GPGETPERFCOUNTERINFOINTEL)(GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERDATAAMD)(GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERINFOAMD)(GLuint  group, GLuint  counter, GLenum  pname, void * data);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSTRINGAMD)(GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
+// typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
+// typedef void  (APIENTRYP GPGETPOINTERINDEXEDVEXT)(GLenum  target, GLuint  index, void ** data);
+// typedef void  (APIENTRYP GPGETPOINTERI_VEXT)(GLenum  pname, GLuint  index, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERV)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERVKHR)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPROGRAMBINARY)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLenum * binaryFormat, void * binary);
 // typedef void  (APIENTRYP GPGETPROGRAMINFOLOG)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMINTERFACEIV)(GLuint  program, GLenum  programInterface, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOG)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOGEXT)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIV)(GLuint  pipeline, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIVEXT)(GLuint  pipeline, GLenum  pname, GLint * params);
 // typedef GLuint  (APIENTRYP GPGETPROGRAMRESOURCEINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATION)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATIONINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCENAME)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name);
+// typedef void  (APIENTRYP GPGETPROGRAMRESOURCEFVNV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCEIV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMSTAGEIV)(GLuint  program, GLenum  shadertype, GLenum  pname, GLint * values);
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTIV)(GLuint  id, GLenum  pname, GLint * params);
@@ -383,6 +559,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERPRECISIONFORMAT)(GLenum  shadertype, GLenum  precisiontype, GLint * range, GLint * precision);
 // typedef void  (APIENTRYP GPGETSHADERSOURCE)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -396,14 +573,23 @@ package gl
 // typedef void  (APIENTRYP GPGETTEXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLEARB)(GLuint  texture);
+// typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLENV)(GLuint  texture);
 // typedef void  (APIENTRYP GPGETTEXTUREIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFV)(GLuint  texture, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIV)(GLuint  texture, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLEARB)(GLuint  texture, GLuint  sampler);
+// typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLENV)(GLuint  texture, GLuint  sampler);
 // typedef void  (APIENTRYP GPGETTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKVARYING)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLsizei * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKI64_V)(GLuint  xfb, GLenum  pname, GLuint  index, GLint64 * param);
@@ -415,32 +601,48 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMSUBROUTINEUIV)(GLenum  shadertype, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXED64IV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint64 * param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXEDIV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERVEXT)(GLuint  vaobj, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, void ** param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERVEXT)(GLuint  vaobj, GLenum  pname, void ** param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYIV)(GLuint  vaobj, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIIV)(GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIUIV)(GLuint  index, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLDV)(GLuint  index, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLI64VNV)(GLuint  index, GLenum  pname, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VARB)(GLuint  index, GLenum  pname, GLuint64EXT * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VNV)(GLuint  index, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBPOINTERV)(GLuint  index, GLenum  pname, void ** pointer);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBDV)(GLuint  index, GLenum  pname, GLdouble * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBFV)(GLuint  index, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIV)(GLuint  index, GLenum  pname, GLint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNTEXIMAGEARB)(GLenum  target, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNUNIFORMDVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLdouble * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPHINT)(GLenum  target, GLenum  mode);
+// typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPINSERTEVENTMARKEREXT)(GLsizei  length, const GLchar * marker);
+// typedef void  (APIENTRYP GPINTERPOLATEPATHSNV)(GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERDATA)(GLuint  buffer);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPINVALIDATEFRAMEBUFFER)(GLenum  target, GLsizei  numAttachments, const GLenum * attachments);
@@ -450,68 +652,196 @@ package gl
 // typedef void  (APIENTRYP GPINVALIDATETEXIMAGE)(GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPINVALIDATETEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
+// typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISFRAMEBUFFER)(GLuint  framebuffer);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef GLboolean  (APIENTRYP GPISPATHNV)(GLuint  path);
+// typedef GLboolean  (APIENTRYP GPISPOINTINFILLPATHNV)(GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y);
+// typedef GLboolean  (APIENTRYP GPISPOINTINSTROKEPATHNV)(GLuint  path, GLfloat  x, GLfloat  y);
 // typedef GLboolean  (APIENTRYP GPISPROGRAM)(GLuint  program);
 // typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef GLboolean  (APIENTRYP GPISQUERY)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISTRANSFORMFEEDBACK)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
+// typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLINEWIDTH)(GLfloat  width);
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLOGICOP)(GLenum  opcode);
+// typedef void  (APIENTRYP GPMAKEBUFFERNONRESIDENTNV)(GLenum  target);
+// typedef void  (APIENTRYP GPMAKEBUFFERRESIDENTNV)(GLenum  target, GLenum  access);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTARB)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTNV)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERNONRESIDENTNV)(GLuint  buffer);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERRESIDENTNV)(GLuint  buffer, GLenum  access);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef void * (APIENTRYP GPMAPBUFFER)(GLenum  target, GLenum  access);
 // typedef void * (APIENTRYP GPMAPBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void  (APIENTRYP GPMATRIXFRUSTUMEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADIDENTITYEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXORTHOEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXPOPEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXPUSHEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXROTATEDEXT)(GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXROTATEFEXT)(GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMINSAMPLESHADING)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYS)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTITEXBUFFEREXT)(GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPMULTITEXCOORDPOINTEREXT)(GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
+// typedef void  (APIENTRYP GPMULTITEXENVFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXENVIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXGENDEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param);
+// typedef void  (APIENTRYP GPMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params);
+// typedef void  (APIENTRYP GPMULTITEXGENFEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXGENIEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXRENDERBUFFEREXT)(GLenum  texunit, GLenum  target, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFERS)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERI)(GLuint  framebuffer, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERIEXT)(GLuint  framebuffer, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYER)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLdouble * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGE)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEEXT)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDSTRINGARB)(GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string);
+// typedef void  (APIENTRYP GPNORMALFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABEL)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABELKHR)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPPATCHPARAMETERFV)(GLenum  pname, const GLfloat * values);
 // typedef void  (APIENTRYP GPPATCHPARAMETERI)(GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHCOMMANDSNV)(GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOORDSNV)(GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOVERDEPTHFUNCNV)(GLenum  func);
+// typedef void  (APIENTRYP GPPATHDASHARRAYNV)(GLuint  path, GLsizei  dashCount, const GLfloat * dashArray);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXRANGENV)(GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount);
+// typedef void  (APIENTRYP GPPATHGLYPHRANGENV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHGLYPHSNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHMEMORYGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHPARAMETERFNV)(GLuint  path, GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, const GLfloat * value);
+// typedef void  (APIENTRYP GPPATHPARAMETERINV)(GLuint  path, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, const GLint * value);
+// typedef void  (APIENTRYP GPPATHSTENCILDEPTHOFFSETNV)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPATHSTENCILFUNCNV)(GLenum  func, GLint  ref, GLuint  mask);
+// typedef void  (APIENTRYP GPPATHSTRINGNV)(GLuint  path, GLenum  format, GLsizei  length, const void * pathString);
+// typedef void  (APIENTRYP GPPATHSUBCOMMANDSNV)(GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHSUBCOORDSNV)(GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords);
 // typedef void  (APIENTRYP GPPAUSETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPPIXELSTOREF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPIXELSTOREI)(GLenum  pname, GLint  param);
+// typedef GLboolean  (APIENTRYP GPPOINTALONGPATHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY);
 // typedef void  (APIENTRYP GPPOINTPARAMETERF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPOINTPARAMETERFV)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPPOINTPARAMETERI)(GLenum  pname, GLint  param);
@@ -519,67 +849,163 @@ package gl
 // typedef void  (APIENTRYP GPPOINTSIZE)(GLfloat  size);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOPDEBUGGROUP)();
 // typedef void  (APIENTRYP GPPOPDEBUGGROUPKHR)();
+// typedef void  (APIENTRYP GPPOPGROUPMARKEREXT)();
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPROGRAMBINARY)(GLuint  program, GLenum  binaryFormat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPPROGRAMPARAMETERI)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIARB)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIEXT)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPATHFRAGMENTINPUTGENNV)(GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1D)(GLuint  program, GLint  location, GLdouble  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DEXT)(GLuint  program, GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1F)(GLuint  program, GLint  location, GLfloat  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FEXT)(GLuint  program, GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64ARB)(GLuint  program, GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64NV)(GLuint  program, GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64NV)(GLuint  program, GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROVOKINGVERTEX)(GLenum  mode);
+// typedef void  (APIENTRYP GPPUSHCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUP)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUPKHR)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
+// typedef void  (APIENTRYP GPPUSHGROUPMARKEREXT)(GLsizei  length, const GLchar * marker);
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPREADNPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, GLsizei  bufSize, void * data);
@@ -588,6 +1014,8 @@ package gl
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMASKI)(GLuint  maskNumber, GLbitfield  mask);
@@ -601,23 +1029,40 @@ package gl
 // typedef void  (APIENTRYP GPSCISSORARRAYV)(GLuint  first, GLsizei  count, const GLint * v);
 // typedef void  (APIENTRYP GPSCISSORINDEXED)(GLuint  index, GLint  left, GLint  bottom, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPSCISSORINDEXEDV)(GLuint  index, const GLint * v);
+// typedef void  (APIENTRYP GPSECONDARYCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
 // typedef void  (APIENTRYP GPSHADERBINARY)(GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPSHADERSOURCE)(GLuint  shader, GLsizei  count, const GLchar *const* string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNC)(GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNCSEPARATE)(GLenum  face, GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASK)(GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASKSEPARATE)(GLenum  face, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILOP)(GLenum  fail, GLenum  zfail, GLenum  zpass);
 // typedef void  (APIENTRYP GPSTENCILOPSEPARATE)(GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPTEXBUFFER)(GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXBUFFERARB)(GLenum  target, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXBUFFERRANGE)(GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXCOORDFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPTEXIMAGE1D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE2D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERF)(GLenum  target, GLenum  pname, GLfloat  param);
@@ -633,61 +1078,118 @@ package gl
 // typedef void  (APIENTRYP GPTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREBARRIER)();
+// typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERF)(GLuint  texture, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, const GLfloat * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERI)(GLuint  texture, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, const GLint * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTURERENDERBUFFEREXT)(GLuint  texture, GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE1D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE1DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREVIEW)(GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
+// typedef void  (APIENTRYP GPTRANSFORMPATHNV)(GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPUNIFORM1D)(GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPUNIFORM1DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM1F)(GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM2D)(GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPUNIFORM2DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM2F)(GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM3D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPUNIFORM3DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM3F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM4D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPUNIFORM4DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM4F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORMBLOCKBINDING)(GLuint  program, GLuint  uniformBlockIndex, GLuint  uniformBlockBinding);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64ARB)(GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64NV)(GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VNV)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
@@ -707,20 +1209,45 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMSUBROUTINESUIV)(GLenum  shadertype, GLsizei  count, const GLuint * indices);
+// typedef void  (APIENTRYP GPUNIFORMUI64NV)(GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPUNIFORMUI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef GLboolean  (APIENTRYP GPUNMAPBUFFER)(GLenum  target);
 // typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFEREXT)(GLuint  buffer);
 // typedef void  (APIENTRYP GPUSEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPUSEPROGRAMSTAGES)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSEPROGRAMSTAGESEXT)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSESHADERPROGRAMEXT)(GLenum  type, GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBBINDING)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBIFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBLFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYBINDVERTEXBUFFEREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYBINDINGDIVISOR)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYEDGEFLAGOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXARRAYELEMENTBUFFER)(GLuint  vaobj, GLuint  buffer);
+// typedef void  (APIENTRYP GPVERTEXARRAYFOGCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYINDEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYNORMALOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYTEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(GLuint  vaobj, GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFER)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFERS)(GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1DV)(GLuint  index, const GLdouble * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1F)(GLuint  index, GLfloat  x);
@@ -759,7 +1286,9 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIB4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBBINDING)(GLuint  attribindex, GLuint  bindingindex);
 // typedef void  (APIENTRYP GPVERTEXATTRIBDIVISOR)(GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXATTRIBDIVISORARB)(GLuint  index, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXATTRIBFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1I)(GLuint  index, GLint  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1IV)(GLuint  index, const GLint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1UI)(GLuint  index, GLuint  x);
@@ -781,18 +1310,36 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4UIV)(GLuint  index, const GLuint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBIFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64NV)(GLuint  index, GLint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64VNV)(GLuint  index, const GLint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64ARB)(GLuint  index, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64NV)(GLuint  index, GLuint64EXT  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VARB)(GLuint  index, const GLuint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2D)(GLuint  index, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBLFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UI)(GLuint  index, GLenum  type, GLboolean  normalized, GLuint  value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
@@ -804,22 +1351,46 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBP4UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBPOINTER)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXBINDINGDIVISOR)(GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVIEWPORT)(GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
+// static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
+//   (*fnptr)(program);
+// }
 // static void  glowActiveShaderProgram(GPACTIVESHADERPROGRAM fnptr, GLuint  pipeline, GLuint  program) {
+//   (*fnptr)(pipeline, program);
+// }
+// static void  glowActiveShaderProgramEXT(GPACTIVESHADERPROGRAMEXT fnptr, GLuint  pipeline, GLuint  program) {
 //   (*fnptr)(pipeline, program);
 // }
 // static void  glowActiveTexture(GPACTIVETEXTURE fnptr, GLenum  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowAttachShader(GPATTACHSHADER fnptr, GLuint  program, GLuint  shader) {
 //   (*fnptr)(program, shader);
 // }
 // static void  glowBeginConditionalRender(GPBEGINCONDITIONALRENDER fnptr, GLuint  id, GLenum  mode) {
 //   (*fnptr)(id, mode);
+// }
+// static void  glowBeginConditionalRenderNV(GPBEGINCONDITIONALRENDERNV fnptr, GLuint  id, GLenum  mode) {
+//   (*fnptr)(id, mode);
+// }
+// static void  glowBeginPerfMonitorAMD(GPBEGINPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowBeginPerfQueryINTEL(GPBEGINPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
 // }
 // static void  glowBeginQuery(GPBEGINQUERY fnptr, GLenum  target, GLuint  id) {
 //   (*fnptr)(target, id);
@@ -863,7 +1434,13 @@ package gl
 // static void  glowBindImageTextures(GPBINDIMAGETEXTURES fnptr, GLuint  first, GLsizei  count, const GLuint * textures) {
 //   (*fnptr)(first, count, textures);
 // }
+// static void  glowBindMultiTextureEXT(GPBINDMULTITEXTUREEXT fnptr, GLenum  texunit, GLenum  target, GLuint  texture) {
+//   (*fnptr)(texunit, target, texture);
+// }
 // static void  glowBindProgramPipeline(GPBINDPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowBindProgramPipelineEXT(GPBINDPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowBindRenderbuffer(GPBINDRENDERBUFFER fnptr, GLenum  target, GLuint  renderbuffer) {
@@ -895,6 +1472,12 @@ package gl
 // }
 // static void  glowBindVertexBuffers(GPBINDVERTEXBUFFERS fnptr, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(first, count, buffers, offsets, strides);
+// }
+// static void  glowBlendBarrierKHR(GPBLENDBARRIERKHR fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowBlendBarrierNV(GPBLENDBARRIERNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowBlendColor(GPBLENDCOLOR fnptr, GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
@@ -935,16 +1518,22 @@ package gl
 // static void  glowBlendFunciARB(GPBLENDFUNCIARB fnptr, GLuint  buf, GLenum  src, GLenum  dst) {
 //   (*fnptr)(buf, src, dst);
 // }
+// static void  glowBlendParameteriNV(GPBLENDPARAMETERINV fnptr, GLenum  pname, GLint  value) {
+//   (*fnptr)(pname, value);
+// }
 // static void  glowBlitFramebuffer(GPBLITFRAMEBUFFER fnptr, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
 // static void  glowBlitNamedFramebuffer(GPBLITNAMEDFRAMEBUFFER fnptr, GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
+// static void  glowBufferAddressRangeNV(GPBUFFERADDRESSRANGENV fnptr, GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length) {
+//   (*fnptr)(pname, index, address, length);
+// }
 // static void  glowBufferData(GPBUFFERDATA fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
@@ -953,10 +1542,16 @@ package gl
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static GLenum  glowCheckFramebufferStatus(GPCHECKFRAMEBUFFERSTATUS fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLenum  glowCheckNamedFramebufferStatus(GPCHECKNAMEDFRAMEBUFFERSTATUS fnptr, GLuint  framebuffer, GLenum  target) {
+//   return (*fnptr)(framebuffer, target);
+// }
+// static GLenum  glowCheckNamedFramebufferStatusEXT(GPCHECKNAMEDFRAMEBUFFERSTATUSEXT fnptr, GLuint  framebuffer, GLenum  target) {
 //   return (*fnptr)(framebuffer, target);
 // }
 // static void  glowClampColor(GPCLAMPCOLOR fnptr, GLenum  target, GLenum  clamp) {
@@ -995,11 +1590,17 @@ package gl
 // static void  glowClearNamedBufferData(GPCLEARNAMEDBUFFERDATA fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, format, type, data);
+// }
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
+// }
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -1019,11 +1620,17 @@ package gl
 // static void  glowClearTexSubImage(GPCLEARTEXSUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data);
 // }
+// static void  glowClientAttribDefaultEXT(GPCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
+// }
 // static GLenum  glowClientWaitSync(GPCLIENTWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   return (*fnptr)(sync, flags, timeout);
 // }
 // static void  glowClipControl(GPCLIPCONTROL fnptr, GLenum  origin, GLenum  depth) {
 //   (*fnptr)(origin, depth);
+// }
+// static void  glowColorFormatNV(GPCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
 // }
 // static void  glowColorMask(GPCOLORMASK fnptr, GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
@@ -1031,11 +1638,35 @@ package gl
 // static void  glowColorMaski(GPCOLORMASKI fnptr, GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a) {
 //   (*fnptr)(index, r, g, b, a);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
 // static void  glowCompileShaderIncludeARB(GPCOMPILESHADERINCLUDEARB fnptr, GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length) {
 //   (*fnptr)(shader, count, path, length);
+// }
+// static void  glowCompressedMultiTexImage1DEXT(GPCOMPRESSEDMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage2DEXT(GPCOMPRESSEDMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage3DEXT(GPCOMPRESSEDMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage1DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage2DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage3DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
 // }
 // static void  glowCompressedTexImage1D(GPCOMPRESSEDTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, internalformat, width, border, imageSize, data);
@@ -1055,14 +1686,38 @@ package gl
 // static void  glowCompressedTexSubImage3D(GPCOMPRESSEDTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
 // }
+// static void  glowCompressedTextureImage1DEXT(GPCOMPRESSEDTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage2DEXT(GPCOMPRESSEDTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage3DEXT(GPCOMPRESSEDTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage1D(GPCOMPRESSEDTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, width, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage1DEXT(GPCOMPRESSEDTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, imageSize, bits);
 // }
 // static void  glowCompressedTextureSubImage2D(GPCOMPRESSEDTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, imageSize, data);
 // }
+// static void  glowCompressedTextureSubImage2DEXT(GPCOMPRESSEDTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage3D(GPCOMPRESSEDTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowCopyBufferSubData(GPCOPYBUFFERSUBDATA fnptr, GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readTarget, writeTarget, readOffset, writeOffset, size);
@@ -1070,8 +1725,26 @@ package gl
 // static void  glowCopyImageSubData(GPCOPYIMAGESUBDATA fnptr, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
 //   (*fnptr)(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyMultiTexImage1DEXT(GPCOPYMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyMultiTexImage2DEXT(GPCOPYMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, height, border);
+// }
+// static void  glowCopyMultiTexSubImage1DEXT(GPCOPYMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texunit, target, level, xoffset, x, y, width);
+// }
+// static void  glowCopyMultiTexSubImage2DEXT(GPCOPYMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, x, y, width, height);
+// }
+// static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
+//   (*fnptr)(resultPath, srcPath);
 // }
 // static void  glowCopyTexImage1D(GPCOPYTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
 //   (*fnptr)(target, level, internalformat, x, y, width, border);
@@ -1088,20 +1761,59 @@ package gl
 // static void  glowCopyTexSubImage3D(GPCOPYTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureImage1DEXT(GPCOPYTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyTextureImage2DEXT(GPCOPYTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, height, border);
+// }
 // static void  glowCopyTextureSubImage1D(GPCOPYTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
 //   (*fnptr)(texture, level, xoffset, x, y, width);
+// }
+// static void  glowCopyTextureSubImage1DEXT(GPCOPYTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texture, target, level, xoffset, x, y, width);
 // }
 // static void  glowCopyTextureSubImage2D(GPCOPYTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureSubImage2DEXT(GPCOPYTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, x, y, width, height);
+// }
 // static void  glowCopyTextureSubImage3D(GPCOPYTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyTextureSubImage3DEXT(GPCOPYTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCoverFillPathInstancedNV(GPCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverFillPathNV(GPCOVERFILLPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverStrokePathInstancedNV(GPCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
 // }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
+//   (*fnptr)(queryId, queryHandle);
 // }
 // static GLuint  glowCreateProgram(GPCREATEPROGRAM fnptr) {
 //   return (*fnptr)();
@@ -1121,8 +1833,17 @@ package gl
 // static GLuint  glowCreateShader(GPCREATESHADER fnptr, GLenum  type) {
 //   return (*fnptr)(type);
 // }
+// static GLuint  glowCreateShaderProgramEXT(GPCREATESHADERPROGRAMEXT fnptr, GLenum  type, const GLchar * string) {
+//   return (*fnptr)(type, string);
+// }
 // static GLuint  glowCreateShaderProgramv(GPCREATESHADERPROGRAMV fnptr, GLenum  type, GLsizei  count, const GLchar *const* strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
+//   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -1169,16 +1890,31 @@ package gl
 // static void  glowDeleteBuffers(GPDELETEBUFFERS fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFramebuffers(GPDELETEFRAMEBUFFERS fnptr, GLsizei  n, const GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
 // }
+// static void  glowDeletePathsNV(GPDELETEPATHSNV fnptr, GLuint  path, GLsizei  range) {
+//   (*fnptr)(path, range);
+// }
+// static void  glowDeletePerfMonitorsAMD(GPDELETEPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
+// static void  glowDeletePerfQueryINTEL(GPDELETEPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowDeleteProgram(GPDELETEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowDeleteProgramPipelines(GPDELETEPROGRAMPIPELINES fnptr, GLsizei  n, const GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowDeleteProgramPipelinesEXT(GPDELETEPROGRAMPIPELINESEXT fnptr, GLsizei  n, const GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowDeleteQueries(GPDELETEQUERIES fnptr, GLsizei  n, const GLuint * ids) {
@@ -1192,6 +1928,9 @@ package gl
 // }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -1229,8 +1968,23 @@ package gl
 // static void  glowDisable(GPDISABLE fnptr, GLenum  cap) {
 //   (*fnptr)(cap);
 // }
+// static void  glowDisableClientStateIndexedEXT(GPDISABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableClientStateiEXT(GPDISABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableIndexedEXT(GPDISABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowDisableVertexArrayAttrib(GPDISABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayAttribEXT(GPDISABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayEXT(GPDISABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowDisableVertexAttribArray(GPDISABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1256,14 +2010,32 @@ package gl
 // static void  glowDrawArraysInstanced(GPDRAWARRAYSINSTANCED fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount) {
 //   (*fnptr)(mode, first, count, instancecount);
 // }
+// static void  glowDrawArraysInstancedARB(GPDRAWARRAYSINSTANCEDARB fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, first, count, primcount);
+// }
 // static void  glowDrawArraysInstancedBaseInstance(GPDRAWARRAYSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, first, count, instancecount, baseinstance);
+// }
+// static void  glowDrawArraysInstancedEXT(GPDRAWARRAYSINSTANCEDEXT fnptr, GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, start, count, primcount);
 // }
 // static void  glowDrawBuffer(GPDRAWBUFFER fnptr, GLenum  buf) {
 //   (*fnptr)(buf);
 // }
 // static void  glowDrawBuffers(GPDRAWBUFFERS fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
+// }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
 // }
 // static void  glowDrawElements(GPDRAWELEMENTS fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, count, type, indices);
@@ -1277,6 +2049,9 @@ package gl
 // static void  glowDrawElementsInstanced(GPDRAWELEMENTSINSTANCED fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount) {
 //   (*fnptr)(mode, count, type, indices, instancecount);
 // }
+// static void  glowDrawElementsInstancedARB(GPDRAWELEMENTSINSTANCEDARB fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
+// }
 // static void  glowDrawElementsInstancedBaseInstance(GPDRAWELEMENTSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, baseinstance);
 // }
@@ -1285,6 +2060,9 @@ package gl
 // }
 // static void  glowDrawElementsInstancedBaseVertexBaseInstance(GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, basevertex, baseinstance);
+// }
+// static void  glowDrawElementsInstancedEXT(GPDRAWELEMENTSINSTANCEDEXT fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
 // }
 // static void  glowDrawRangeElements(GPDRAWRANGEELEMENTS fnptr, GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, start, end, count, type, indices);
@@ -1304,11 +2082,32 @@ package gl
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
 // }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
+// }
+// static void  glowEdgeFlagFormatNV(GPEDGEFLAGFORMATNV fnptr, GLsizei  stride) {
+//   (*fnptr)(stride);
+// }
 // static void  glowEnable(GPENABLE fnptr, GLenum  cap) {
 //   (*fnptr)(cap);
 // }
+// static void  glowEnableClientStateIndexedEXT(GPENABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableClientStateiEXT(GPENABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableIndexedEXT(GPENABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowEnableVertexArrayAttrib(GPENABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayAttribEXT(GPENABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayEXT(GPENABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowEnableVertexAttribArray(GPENABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1319,6 +2118,15 @@ package gl
 // static void  glowEndConditionalRender(GPENDCONDITIONALRENDER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowEndConditionalRenderNV(GPENDCONDITIONALRENDERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowEndPerfMonitorAMD(GPENDPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowEndPerfQueryINTEL(GPENDPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowEndQuery(GPENDQUERY fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
@@ -1326,6 +2134,9 @@ package gl
 //   (*fnptr)(target, index);
 // }
 // static void  glowEndTransformFeedback(GPENDTRANSFORMFEEDBACK fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
 //   (*fnptr)();
 // }
 // static GLsync  glowFenceSync(GPFENCESYNC fnptr, GLenum  condition, GLbitfield  flags) {
@@ -1340,14 +2151,41 @@ package gl
 // static void  glowFlushMappedBufferRange(GPFLUSHMAPPEDBUFFERRANGE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(target, offset, length);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
+//   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFogCoordFormatNV(GPFOGCOORDFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
+// static void  glowFramebufferDrawBufferEXT(GPFRAMEBUFFERDRAWBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
+// static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
+//   (*fnptr)(framebuffer, n, bufs);
+// }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
+// static void  glowFramebufferReadBufferEXT(GPFRAMEBUFFERREADBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
 // static void  glowFramebufferRenderbuffer(GPFRAMEBUFFERRENDERBUFFER fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -1361,8 +2199,20 @@ package gl
 // static void  glowFramebufferTexture3D(GPFRAMEBUFFERTEXTURE3D fnptr, GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
 //   (*fnptr)(target, attachment, textarget, texture, level, zoffset);
 // }
+// static void  glowFramebufferTextureARB(GPFRAMEBUFFERTEXTUREARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(target, attachment, texture, level);
+// }
+// static void  glowFramebufferTextureFaceARB(GPFRAMEBUFFERTEXTUREFACEARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(target, attachment, texture, level, face);
+// }
 // static void  glowFramebufferTextureLayer(GPFRAMEBUFFERTEXTURELAYER fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureLayerARB(GPFRAMEBUFFERTEXTURELAYERARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFrontFace(GPFRONTFACE fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -1373,7 +2223,16 @@ package gl
 // static void  glowGenFramebuffers(GPGENFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
+// static GLuint  glowGenPathsNV(GPGENPATHSNV fnptr, GLsizei  range) {
+//   return (*fnptr)(range);
+// }
+// static void  glowGenPerfMonitorsAMD(GPGENPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
 // static void  glowGenProgramPipelines(GPGENPROGRAMPIPELINES fnptr, GLsizei  n, GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowGenProgramPipelinesEXT(GPGENPROGRAMPIPELINESEXT fnptr, GLsizei  n, GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowGenQueries(GPGENQUERIES fnptr, GLsizei  n, GLuint * ids) {
@@ -1397,8 +2256,14 @@ package gl
 // static void  glowGenerateMipmap(GPGENERATEMIPMAP fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
+// static void  glowGenerateMultiTexMipmapEXT(GPGENERATEMULTITEXMIPMAPEXT fnptr, GLenum  texunit, GLenum  target) {
+//   (*fnptr)(texunit, target);
+// }
 // static void  glowGenerateTextureMipmap(GPGENERATETEXTUREMIPMAP fnptr, GLuint  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowGenerateTextureMipmapEXT(GPGENERATETEXTUREMIPMAPEXT fnptr, GLuint  texture, GLenum  target) {
+//   (*fnptr)(texture, target);
 // }
 // static void  glowGetActiveAtomicCounterBufferiv(GPGETACTIVEATOMICCOUNTERBUFFERIV fnptr, GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, bufferIndex, pname, params);
@@ -1436,6 +2301,9 @@ package gl
 // static GLint  glowGetAttribLocation(GPGETATTRIBLOCATION fnptr, GLuint  program, const GLchar * name) {
 //   return (*fnptr)(program, name);
 // }
+// static void  glowGetBooleanIndexedvEXT(GPGETBOOLEANINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLboolean * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetBooleani_v(GPGETBOOLEANI_V fnptr, GLenum  target, GLuint  index, GLboolean * data) {
 //   (*fnptr)(target, index, data);
 // }
@@ -1448,11 +2316,20 @@ package gl
 // static void  glowGetBufferParameteriv(GPGETBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetBufferParameterui64vNV(GPGETBUFFERPARAMETERUI64VNV fnptr, GLenum  target, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(target, pname, params);
+// }
 // static void  glowGetBufferPointerv(GPGETBUFFERPOINTERV fnptr, GLenum  target, GLenum  pname, void ** params) {
 //   (*fnptr)(target, pname, params);
 // }
 // static void  glowGetBufferSubData(GPGETBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
+// static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texunit, target, lod, img);
 // }
 // static void  glowGetCompressedTexImage(GPGETCOMPRESSEDTEXIMAGE fnptr, GLenum  target, GLint  level, void * img) {
 //   (*fnptr)(target, level, img);
@@ -1460,8 +2337,14 @@ package gl
 // static void  glowGetCompressedTextureImage(GPGETCOMPRESSEDTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, bufSize, pixels);
 // }
+// static void  glowGetCompressedTextureImageEXT(GPGETCOMPRESSEDTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texture, target, lod, img);
+// }
 // static void  glowGetCompressedTextureSubImage(GPGETCOMPRESSEDTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -1472,8 +2355,14 @@ package gl
 // static GLuint  glowGetDebugMessageLogKHR(GPGETDEBUGMESSAGELOGKHR fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
 // }
+// static void  glowGetDoubleIndexedvEXT(GPGETDOUBLEINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLdouble * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetDoublei_v(GPGETDOUBLEI_V fnptr, GLenum  target, GLuint  index, GLdouble * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetDoublei_vEXT(GPGETDOUBLEI_VEXT fnptr, GLenum  pname, GLuint  index, GLdouble * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetDoublev(GPGETDOUBLEV fnptr, GLenum  pname, GLdouble * data) {
 //   (*fnptr)(pname, data);
@@ -1481,8 +2370,17 @@ package gl
 // static GLenum  glowGetError(GPGETERROR fnptr) {
 //   return (*fnptr)();
 // }
+// static void  glowGetFirstPerfQueryIdINTEL(GPGETFIRSTPERFQUERYIDINTEL fnptr, GLuint * queryId) {
+//   (*fnptr)(queryId);
+// }
+// static void  glowGetFloatIndexedvEXT(GPGETFLOATINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLfloat * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetFloati_v(GPGETFLOATI_V fnptr, GLenum  target, GLuint  index, GLfloat * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetFloati_vEXT(GPGETFLOATI_VEXT fnptr, GLenum  pname, GLuint  index, GLfloat * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetFloatv(GPGETFLOATV fnptr, GLenum  pname, GLfloat * data) {
 //   (*fnptr)(pname, data);
@@ -1499,6 +2397,9 @@ package gl
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetFramebufferParameterivEXT(GPGETFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
 // static GLenum  glowGetGraphicsResetStatus(GPGETGRAPHICSRESETSTATUS fnptr) {
 //   return (*fnptr)();
 // }
@@ -1511,23 +2412,74 @@ package gl
 // static GLuint64  glowGetImageHandleARB(GPGETIMAGEHANDLEARB fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
 //   return (*fnptr)(texture, level, layered, layer, format);
 // }
+// static GLuint64  glowGetImageHandleNV(GPGETIMAGEHANDLENV fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
+//   return (*fnptr)(texture, level, layered, layer, format);
+// }
 // static void  glowGetInteger64i_v(GPGETINTEGER64I_V fnptr, GLenum  target, GLuint  index, GLint64 * data) {
 //   (*fnptr)(target, index, data);
 // }
 // static void  glowGetInteger64v(GPGETINTEGER64V fnptr, GLenum  pname, GLint64 * data) {
 //   (*fnptr)(pname, data);
 // }
+// static void  glowGetIntegerIndexedvEXT(GPGETINTEGERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLint * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetIntegeri_v(GPGETINTEGERI_V fnptr, GLenum  target, GLuint  index, GLint * data) {
 //   (*fnptr)(target, index, data);
 // }
+// static void  glowGetIntegerui64i_vNV(GPGETINTEGERUI64I_VNV fnptr, GLenum  value, GLuint  index, GLuint64EXT * result) {
+//   (*fnptr)(value, index, result);
+// }
+// static void  glowGetIntegerui64vNV(GPGETINTEGERUI64VNV fnptr, GLenum  value, GLuint64EXT * result) {
+//   (*fnptr)(value, result);
+// }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
 // }
 // static void  glowGetInternalformativ(GPGETINTERNALFORMATIV fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
+// }
+// static void  glowGetMultiTexEnvfvEXT(GPGETMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexEnvivEXT(GPGETMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexGendvEXT(GPGETMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenfvEXT(GPGETMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenivEXT(GPGETMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexImageEXT(GPGETMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texunit, target, level, format, type, pixels);
+// }
+// static void  glowGetMultiTexLevelParameterfvEXT(GPGETMULTITEXLEVELPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexLevelParameterivEXT(GPGETMULTITEXLEVELPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexParameterIivEXT(GPGETMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterIuivEXT(GPGETMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterfvEXT(GPGETMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterivEXT(GPGETMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
 // }
 // static void  glowGetMultisamplefv(GPGETMULTISAMPLEFV fnptr, GLenum  pname, GLuint  index, GLfloat * val) {
 //   (*fnptr)(pname, index, val);
@@ -1538,19 +2490,58 @@ package gl
 // static void  glowGetNamedBufferParameteriv(GPGETNAMEDBUFFERPARAMETERIV fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(buffer, pname, params);
 // }
+// static void  glowGetNamedBufferParameterivEXT(GPGETNAMEDBUFFERPARAMETERIVEXT fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferParameterui64vNV(GPGETNAMEDBUFFERPARAMETERUI64VNV fnptr, GLuint  buffer, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
 // static void  glowGetNamedBufferPointerv(GPGETNAMEDBUFFERPOINTERV fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedFramebufferAttachmentParameteriv(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
 // }
+// static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, attachment, pname, params);
+// }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowGetNamedFramebufferParameterivEXT(GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIuivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterdvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterfvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramStringEXT(GPGETNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, void * string) {
+//   (*fnptr)(program, target, pname, string);
+// }
+// static void  glowGetNamedProgramivEXT(GPGETNAMEDPROGRAMIVEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(program, target, pname, params);
+// }
 // static void  glowGetNamedRenderbufferParameteriv(GPGETNAMEDRENDERBUFFERPARAMETERIV fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(renderbuffer, pname, params);
+// }
+// static void  glowGetNamedRenderbufferParameterivEXT(GPGETNAMEDRENDERBUFFERPARAMETERIVEXT fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(renderbuffer, pname, params);
 // }
 // static void  glowGetNamedStringARB(GPGETNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string) {
@@ -1559,8 +2550,14 @@ package gl
 // static void  glowGetNamedStringivARB(GPGETNAMEDSTRINGIVARB fnptr, GLint  namelen, const GLchar * name, GLenum  pname, GLint * params) {
 //   (*fnptr)(namelen, name, pname, params);
 // }
+// static void  glowGetNextPerfQueryIdINTEL(GPGETNEXTPERFQUERYIDINTEL fnptr, GLuint  queryId, GLuint * nextQueryId) {
+//   (*fnptr)(queryId, nextQueryId);
+// }
 // static void  glowGetObjectLabel(GPGETOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
+// }
+// static void  glowGetObjectLabelEXT(GPGETOBJECTLABELEXT fnptr, GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label) {
+//   (*fnptr)(type, object, bufSize, length, label);
 // }
 // static void  glowGetObjectLabelKHR(GPGETOBJECTLABELKHR fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
@@ -1570,6 +2567,69 @@ package gl
 // }
 // static void  glowGetObjectPtrLabelKHR(GPGETOBJECTPTRLABELKHR fnptr, const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(ptr, bufSize, length, label);
+// }
+// static void  glowGetPathCommandsNV(GPGETPATHCOMMANDSNV fnptr, GLuint  path, GLubyte * commands) {
+//   (*fnptr)(path, commands);
+// }
+// static void  glowGetPathCoordsNV(GPGETPATHCOORDSNV fnptr, GLuint  path, GLfloat * coords) {
+//   (*fnptr)(path, coords);
+// }
+// static void  glowGetPathDashArrayNV(GPGETPATHDASHARRAYNV fnptr, GLuint  path, GLfloat * dashArray) {
+//   (*fnptr)(path, dashArray);
+// }
+// static GLfloat  glowGetPathLengthNV(GPGETPATHLENGTHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments) {
+//   return (*fnptr)(path, startSegment, numSegments);
+// }
+// static void  glowGetPathMetricRangeNV(GPGETPATHMETRICRANGENV fnptr, GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, firstPathName, numPaths, stride, metrics);
+// }
+// static void  glowGetPathMetricsNV(GPGETPATHMETRICSNV fnptr, GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, numPaths, pathNameType, paths, pathBase, stride, metrics);
+// }
+// static void  glowGetPathParameterfvNV(GPGETPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathParameterivNV(GPGETPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathSpacingNV(GPGETPATHSPACINGNV fnptr, GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing) {
+//   (*fnptr)(pathListMode, numPaths, pathNameType, paths, pathBase, advanceScale, kerningScale, transformType, returnedSpacing);
+// }
+// static void  glowGetPerfCounterInfoINTEL(GPGETPERFCOUNTERINFOINTEL fnptr, GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue) {
+//   (*fnptr)(queryId, counterId, counterNameLength, counterName, counterDescLength, counterDesc, counterOffset, counterDataSize, counterTypeEnum, counterDataTypeEnum, rawCounterMaxValue);
+// }
+// static void  glowGetPerfMonitorCounterDataAMD(GPGETPERFMONITORCOUNTERDATAAMD fnptr, GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten) {
+//   (*fnptr)(monitor, pname, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfMonitorCounterInfoAMD(GPGETPERFMONITORCOUNTERINFOAMD fnptr, GLuint  group, GLuint  counter, GLenum  pname, void * data) {
+//   (*fnptr)(group, counter, pname, data);
+// }
+// static void  glowGetPerfMonitorCounterStringAMD(GPGETPERFMONITORCOUNTERSTRINGAMD fnptr, GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString) {
+//   (*fnptr)(group, counter, bufSize, length, counterString);
+// }
+// static void  glowGetPerfMonitorCountersAMD(GPGETPERFMONITORCOUNTERSAMD fnptr, GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters) {
+//   (*fnptr)(group, numCounters, maxActiveCounters, counterSize, counters);
+// }
+// static void  glowGetPerfMonitorGroupStringAMD(GPGETPERFMONITORGROUPSTRINGAMD fnptr, GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString) {
+//   (*fnptr)(group, bufSize, length, groupString);
+// }
+// static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
+//   (*fnptr)(numGroups, groupsSize, groups);
+// }
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
+//   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
+//   (*fnptr)(queryName, queryId);
+// }
+// static void  glowGetPerfQueryInfoINTEL(GPGETPERFQUERYINFOINTEL fnptr, GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask) {
+//   (*fnptr)(queryId, queryNameLength, queryName, dataSize, noCounters, noInstances, capsMask);
+// }
+// static void  glowGetPointerIndexedvEXT(GPGETPOINTERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, void ** data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetPointeri_vEXT(GPGETPOINTERI_VEXT fnptr, GLenum  pname, GLuint  index, void ** params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetPointerv(GPGETPOINTERV fnptr, GLenum  pname, void ** params) {
 //   (*fnptr)(pname, params);
@@ -1589,7 +2649,13 @@ package gl
 // static void  glowGetProgramPipelineInfoLog(GPGETPROGRAMPIPELINEINFOLOG fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
 //   (*fnptr)(pipeline, bufSize, length, infoLog);
 // }
+// static void  glowGetProgramPipelineInfoLogEXT(GPGETPROGRAMPIPELINEINFOLOGEXT fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
+//   (*fnptr)(pipeline, bufSize, length, infoLog);
+// }
 // static void  glowGetProgramPipelineiv(GPGETPROGRAMPIPELINEIV fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
+//   (*fnptr)(pipeline, pname, params);
+// }
+// static void  glowGetProgramPipelineivEXT(GPGETPROGRAMPIPELINEIVEXT fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
 //   (*fnptr)(pipeline, pname, params);
 // }
 // static GLuint  glowGetProgramResourceIndex(GPGETPROGRAMRESOURCEINDEX fnptr, GLuint  program, GLenum  programInterface, const GLchar * name) {
@@ -1604,6 +2670,9 @@ package gl
 // static void  glowGetProgramResourceName(GPGETPROGRAMRESOURCENAME fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name) {
 //   (*fnptr)(program, programInterface, index, bufSize, length, name);
 // }
+// static void  glowGetProgramResourcefvNV(GPGETPROGRAMRESOURCEFVNV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params) {
+//   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
+// }
 // static void  glowGetProgramResourceiv(GPGETPROGRAMRESOURCEIV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params) {
 //   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
 // }
@@ -1612,6 +2681,18 @@ package gl
 // }
 // static void  glowGetProgramiv(GPGETPROGRAMIV fnptr, GLuint  program, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, pname, params);
+// }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
 // }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
@@ -1658,6 +2739,9 @@ package gl
 // static void  glowGetShaderiv(GPGETSHADERIV fnptr, GLuint  shader, GLenum  pname, GLint * params) {
 //   (*fnptr)(shader, pname, params);
 // }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
+// }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
 // }
@@ -1697,28 +2781,55 @@ package gl
 // static GLuint64  glowGetTextureHandleARB(GPGETTEXTUREHANDLEARB fnptr, GLuint  texture) {
 //   return (*fnptr)(texture);
 // }
+// static GLuint64  glowGetTextureHandleNV(GPGETTEXTUREHANDLENV fnptr, GLuint  texture) {
+//   return (*fnptr)(texture);
+// }
 // static void  glowGetTextureImage(GPGETTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, format, type, bufSize, pixels);
+// }
+// static void  glowGetTextureImageEXT(GPGETTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texture, target, level, format, type, pixels);
 // }
 // static void  glowGetTextureLevelParameterfv(GPGETTEXTURELEVELPARAMETERFV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, level, pname, params);
 // }
+// static void  glowGetTextureLevelParameterfvEXT(GPGETTEXTURELEVELPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, level, pname, params);
+// }
 // static void  glowGetTextureLevelParameteriv(GPGETTEXTURELEVELPARAMETERIV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, level, pname, params);
+// }
+// static void  glowGetTextureLevelParameterivEXT(GPGETTEXTURELEVELPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, level, pname, params);
 // }
 // static void  glowGetTextureParameterIiv(GPGETTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterIivEXT(GPGETTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameterIuiv(GPGETTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowGetTextureParameterIuivEXT(GPGETTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowGetTextureParameterfv(GPGETTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterfvEXT(GPGETTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameteriv(GPGETTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterivEXT(GPGETTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static GLuint64  glowGetTextureSamplerHandleARB(GPGETTEXTURESAMPLERHANDLEARB fnptr, GLuint  texture, GLuint  sampler) {
+//   return (*fnptr)(texture, sampler);
+// }
+// static GLuint64  glowGetTextureSamplerHandleNV(GPGETTEXTURESAMPLERHANDLENV fnptr, GLuint  texture, GLuint  sampler) {
 //   return (*fnptr)(texture, sampler);
 // }
 // static void  glowGetTextureSubImage(GPGETTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
@@ -1754,7 +2865,19 @@ package gl
 // static void  glowGetUniformfv(GPGETUNIFORMFV fnptr, GLuint  program, GLint  location, GLfloat * params) {
 //   (*fnptr)(program, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformiv(GPGETUNIFORMIV fnptr, GLuint  program, GLint  location, GLint * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
 // static void  glowGetUniformuiv(GPGETUNIFORMUIV fnptr, GLuint  program, GLint  location, GLuint * params) {
@@ -1765,6 +2888,18 @@ package gl
 // }
 // static void  glowGetVertexArrayIndexediv(GPGETVERTEXARRAYINDEXEDIV fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegeri_vEXT(GPGETVERTEXARRAYINTEGERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegervEXT(GPGETVERTEXARRAYINTEGERVEXT fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, pname, param);
+// }
+// static void  glowGetVertexArrayPointeri_vEXT(GPGETVERTEXARRAYPOINTERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayPointervEXT(GPGETVERTEXARRAYPOINTERVEXT fnptr, GLuint  vaobj, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, pname, param);
 // }
 // static void  glowGetVertexArrayiv(GPGETVERTEXARRAYIV fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, pname, param);
@@ -1778,7 +2913,13 @@ package gl
 // static void  glowGetVertexAttribLdv(GPGETVERTEXATTRIBLDV fnptr, GLuint  index, GLenum  pname, GLdouble * params) {
 //   (*fnptr)(index, pname, params);
 // }
+// static void  glowGetVertexAttribLi64vNV(GPGETVERTEXATTRIBLI64VNV fnptr, GLuint  index, GLenum  pname, GLint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
 // static void  glowGetVertexAttribLui64vARB(GPGETVERTEXATTRIBLUI64VARB fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
+// static void  glowGetVertexAttribLui64vNV(GPGETVERTEXATTRIBLUI64VNV fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
 //   (*fnptr)(index, pname, params);
 // }
 // static void  glowGetVertexAttribPointerv(GPGETVERTEXATTRIBPOINTERV fnptr, GLuint  index, GLenum  pname, void ** pointer) {
@@ -1792,6 +2933,9 @@ package gl
 // }
 // static void  glowGetVertexAttribiv(GPGETVERTEXATTRIBIV fnptr, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(index, pname, params);
+// }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
 // }
 // static void  glowGetnCompressedTexImageARB(GPGETNCOMPRESSEDTEXIMAGEARB fnptr, GLenum  target, GLint  lod, GLsizei  bufSize, void * img) {
 //   (*fnptr)(target, lod, bufSize, img);
@@ -1811,6 +2955,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -1818,6 +2965,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -1831,6 +2981,15 @@ package gl
 // }
 // static void  glowHint(GPHINT fnptr, GLenum  target, GLenum  mode) {
 //   (*fnptr)(target, mode);
+// }
+// static void  glowIndexFormatNV(GPINDEXFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
+// static void  glowInsertEventMarkerEXT(GPINSERTEVENTMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
+// static void  glowInterpolatePathsNV(GPINTERPOLATEPATHSNV fnptr, GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight) {
+//   (*fnptr)(resultPath, pathA, pathB, weight);
 // }
 // static void  glowInvalidateBufferData(GPINVALIDATEBUFFERDATA fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -1859,8 +3018,17 @@ package gl
 // static GLboolean  glowIsBuffer(GPISBUFFER fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
+// static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
+//   return (*fnptr)(target);
+// }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
+// }
+// static GLboolean  glowIsEnabledIndexedEXT(GPISENABLEDINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   return (*fnptr)(target, index);
 // }
 // static GLboolean  glowIsEnabledi(GPISENABLEDI fnptr, GLenum  target, GLuint  index) {
 //   return (*fnptr)(target, index);
@@ -1871,13 +3039,31 @@ package gl
 // static GLboolean  glowIsImageHandleResidentARB(GPISIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsImageHandleResidentNV(GPISIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
+// static GLboolean  glowIsNamedBufferResidentNV(GPISNAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
 // static GLboolean  glowIsNamedStringARB(GPISNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   return (*fnptr)(namelen, name);
+// }
+// static GLboolean  glowIsPathNV(GPISPATHNV fnptr, GLuint  path) {
+//   return (*fnptr)(path);
+// }
+// static GLboolean  glowIsPointInFillPathNV(GPISPOINTINFILLPATHNV fnptr, GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, mask, x, y);
+// }
+// static GLboolean  glowIsPointInStrokePathNV(GPISPOINTINSTROKEPATHNV fnptr, GLuint  path, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, x, y);
 // }
 // static GLboolean  glowIsProgram(GPISPROGRAM fnptr, GLuint  program) {
 //   return (*fnptr)(program);
 // }
 // static GLboolean  glowIsProgramPipeline(GPISPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   return (*fnptr)(pipeline);
+// }
+// static GLboolean  glowIsProgramPipelineEXT(GPISPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   return (*fnptr)(pipeline);
 // }
 // static GLboolean  glowIsQuery(GPISQUERY fnptr, GLuint  id) {
@@ -1892,6 +3078,9 @@ package gl
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
 // }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
+// }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
 // }
@@ -1901,11 +3090,17 @@ package gl
 // static GLboolean  glowIsTextureHandleResidentARB(GPISTEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsTextureHandleResidentNV(GPISTEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
 // static GLboolean  glowIsTransformFeedback(GPISTRANSFORMFEEDBACK fnptr, GLuint  id) {
 //   return (*fnptr)(id);
 // }
 // static GLboolean  glowIsVertexArray(GPISVERTEXARRAY fnptr, GLuint  array) {
 //   return (*fnptr)(array);
+// }
+// static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
+//   (*fnptr)(type, object, length, label);
 // }
 // static void  glowLineWidth(GPLINEWIDTH fnptr, GLfloat  width) {
 //   (*fnptr)(width);
@@ -1913,19 +3108,46 @@ package gl
 // static void  glowLinkProgram(GPLINKPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
+// }
 // static void  glowLogicOp(GPLOGICOP fnptr, GLenum  opcode) {
 //   (*fnptr)(opcode);
 // }
+// static void  glowMakeBufferNonResidentNV(GPMAKEBUFFERNONRESIDENTNV fnptr, GLenum  target) {
+//   (*fnptr)(target);
+// }
+// static void  glowMakeBufferResidentNV(GPMAKEBUFFERRESIDENTNV fnptr, GLenum  target, GLenum  access) {
+//   (*fnptr)(target, access);
+// }
 // static void  glowMakeImageHandleNonResidentARB(GPMAKEIMAGEHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeImageHandleNonResidentNV(GPMAKEIMAGEHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void  glowMakeImageHandleResidentARB(GPMAKEIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle, GLenum  access) {
 //   (*fnptr)(handle, access);
 // }
+// static void  glowMakeImageHandleResidentNV(GPMAKEIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle, GLenum  access) {
+//   (*fnptr)(handle, access);
+// }
+// static void  glowMakeNamedBufferNonResidentNV(GPMAKENAMEDBUFFERNONRESIDENTNV fnptr, GLuint  buffer) {
+//   (*fnptr)(buffer);
+// }
+// static void  glowMakeNamedBufferResidentNV(GPMAKENAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer, GLenum  access) {
+//   (*fnptr)(buffer, access);
+// }
 // static void  glowMakeTextureHandleNonResidentARB(GPMAKETEXTUREHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
+// static void  glowMakeTextureHandleNonResidentNV(GPMAKETEXTUREHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
 // static void  glowMakeTextureHandleResidentARB(GPMAKETEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeTextureHandleResidentNV(GPMAKETEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void * glowMapBuffer(GPMAPBUFFER fnptr, GLenum  target, GLenum  access) {
@@ -1937,8 +3159,95 @@ package gl
 // static void * glowMapNamedBuffer(GPMAPNAMEDBUFFER fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
+//   return (*fnptr)(buffer, access);
+// }
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
+//   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void  glowMatrixFrustumEXT(GPMATRIXFRUSTUMEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixLoad3x2fNV(GPMATRIXLOAD3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoad3x3fNV(GPMATRIXLOAD3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadIdentityEXT(GPMATRIXLOADIDENTITYEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixLoadTranspose3x3fNV(GPMATRIXLOADTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadTransposedEXT(GPMATRIXLOADTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadTransposefEXT(GPMATRIXLOADTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoaddEXT(GPMATRIXLOADDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadfEXT(GPMATRIXLOADFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMult3x2fNV(GPMATRIXMULT3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMult3x3fNV(GPMATRIXMULT3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTranspose3x3fNV(GPMATRIXMULTTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTransposedEXT(GPMATRIXMULTTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultTransposefEXT(GPMATRIXMULTTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultdEXT(GPMATRIXMULTDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultfEXT(GPMATRIXMULTFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixOrthoEXT(GPMATRIXORTHOEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixPopEXT(GPMATRIXPOPEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixPushEXT(GPMATRIXPUSHEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixRotatedEXT(GPMATRIXROTATEDEXT fnptr, GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixRotatefEXT(GPMATRIXROTATEFEXT fnptr, GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixScaledEXT(GPMATRIXSCALEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixScalefEXT(GPMATRIXSCALEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatedEXT(GPMATRIXTRANSLATEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
 // }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
@@ -1958,7 +3267,13 @@ package gl
 // static void  glowMultiDrawArraysIndirect(GPMULTIDRAWARRAYSINDIRECT fnptr, GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectBindlessCountNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElements(GPMULTIDRAWELEMENTS fnptr, GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount) {
@@ -1970,23 +3285,116 @@ package gl
 // static void  glowMultiDrawElementsIndirect(GPMULTIDRAWELEMENTSINDIRECT fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectBindlessCountNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMultiTexBufferEXT(GPMULTITEXBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texunit, target, internalformat, buffer);
+// }
+// static void  glowMultiTexCoordPointerEXT(GPMULTITEXCOORDPOINTEREXT fnptr, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
+//   (*fnptr)(texunit, size, type, stride, pointer);
+// }
+// static void  glowMultiTexEnvfEXT(GPMULTITEXENVFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvfvEXT(GPMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexEnviEXT(GPMULTITEXENVIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvivEXT(GPMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexGendEXT(GPMULTITEXGENDEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGendvEXT(GPMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGenfEXT(GPMULTITEXGENFEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenfvEXT(GPMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGeniEXT(GPMULTITEXGENIEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenivEXT(GPMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexImage1DEXT(GPMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage2DEXT(GPMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage3DEXT(GPMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowMultiTexParameterIivEXT(GPMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterIuivEXT(GPMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterfEXT(GPMULTITEXPARAMETERFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterfvEXT(GPMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameteriEXT(GPMULTITEXPARAMETERIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterivEXT(GPMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexRenderbufferEXT(GPMULTITEXRENDERBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texunit, target, renderbuffer);
+// }
+// static void  glowMultiTexSubImage1DEXT(GPMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage2DEXT(GPMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
+//   (*fnptr)(buffer, size, data, usage);
+// }
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
+//   (*fnptr)(buffer, size, data, flags);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedCopyBufferSubDataEXT(GPNAMEDCOPYBUFFERSUBDATAEXT fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowNamedFramebufferDrawBuffer(GPNAMEDFRAMEBUFFERDRAWBUFFER fnptr, GLuint  framebuffer, GLenum  buf) {
 //   (*fnptr)(framebuffer, buf);
@@ -1997,26 +3405,104 @@ package gl
 // static void  glowNamedFramebufferParameteri(GPNAMEDFRAMEBUFFERPARAMETERI fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowNamedFramebufferParameteriEXT(GPNAMEDFRAMEBUFFERPARAMETERIEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
+//   (*fnptr)(framebuffer, pname, param);
+// }
 // static void  glowNamedFramebufferReadBuffer(GPNAMEDFRAMEBUFFERREADBUFFER fnptr, GLuint  framebuffer, GLenum  src) {
 //   (*fnptr)(framebuffer, src);
 // }
 // static void  glowNamedFramebufferRenderbuffer(GPNAMEDFRAMEBUFFERRENDERBUFFER fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
 // }
+// static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
+//   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTexture1DEXT(GPNAMEDFRAMEBUFFERTEXTURE1DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture2DEXT(GPNAMEDFRAMEBUFFERTEXTURE2DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture3DEXT(GPNAMEDFRAMEBUFFERTEXTURE3DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level, zoffset);
+// }
+// static void  glowNamedFramebufferTextureEXT(GPNAMEDFRAMEBUFFERTEXTUREEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTextureFaceEXT(GPNAMEDFRAMEBUFFERTEXTUREFACEEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(framebuffer, attachment, texture, level, face);
 // }
 // static void  glowNamedFramebufferTextureLayer(GPNAMEDFRAMEBUFFERTEXTURELAYER fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(framebuffer, attachment, texture, level, layer);
 // }
+// static void  glowNamedFramebufferTextureLayerEXT(GPNAMEDFRAMEBUFFERTEXTURELAYEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(framebuffer, attachment, texture, level, layer);
+// }
+// static void  glowNamedProgramLocalParameter4dEXT(GPNAMEDPROGRAMLOCALPARAMETER4DEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4dvEXT(GPNAMEDPROGRAMLOCALPARAMETER4DVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameter4fEXT(GPNAMEDPROGRAMLOCALPARAMETER4FEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4fvEXT(GPNAMEDPROGRAMLOCALPARAMETER4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4iEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4uiEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameters4fvEXT(GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramStringEXT(GPNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string) {
+//   (*fnptr)(program, target, format, len, string);
+// }
 // static void  glowNamedRenderbufferStorage(GPNAMEDRENDERBUFFERSTORAGE fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageEXT(GPNAMEDRENDERBUFFERSTORAGEEXT fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, internalformat, width, height);
 // }
 // static void  glowNamedRenderbufferStorageMultisample(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, samples, internalformat, width, height);
 // }
+// static void  glowNamedRenderbufferStorageMultisampleCoverageEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT fnptr, GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageMultisampleEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, samples, internalformat, width, height);
+// }
 // static void  glowNamedStringARB(GPNAMEDSTRINGARB fnptr, GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string) {
 //   (*fnptr)(type, namelen, name, stringlen, string);
+// }
+// static void  glowNormalFormatNV(GPNORMALFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
 // }
 // static void  glowObjectLabel(GPOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(identifier, name, length, label);
@@ -2036,6 +3522,60 @@ package gl
 // static void  glowPatchParameteri(GPPATCHPARAMETERI fnptr, GLenum  pname, GLint  value) {
 //   (*fnptr)(pname, value);
 // }
+// static void  glowPathCommandsNV(GPPATHCOMMANDSNV fnptr, GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathCoordsNV(GPPATHCOORDSNV fnptr, GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCoords, coordType, coords);
+// }
+// static void  glowPathCoverDepthFuncNV(GPPATHCOVERDEPTHFUNCNV fnptr, GLenum  func) {
+//   (*fnptr)(func);
+// }
+// static void  glowPathDashArrayNV(GPPATHDASHARRAYNV fnptr, GLuint  path, GLsizei  dashCount, const GLfloat * dashArray) {
+//   (*fnptr)(path, dashCount, dashArray);
+// }
+// static GLenum  glowPathGlyphIndexArrayNV(GPPATHGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathGlyphIndexRangeNV(GPPATHGLYPHINDEXRANGENV fnptr, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount) {
+//   return (*fnptr)(fontTarget, fontName, fontStyle, pathParameterTemplate, emScale, baseAndCount);
+// }
+// static void  glowPathGlyphRangeNV(GPPATHGLYPHRANGENV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyph, numGlyphs, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathGlyphsNV(GPPATHGLYPHSNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, numGlyphs, type, charcodes, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathMemoryGlyphIndexArrayNV(GPPATHMEMORYGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontSize, fontData, faceIndex, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathParameterfNV(GPPATHPARAMETERFNV fnptr, GLuint  path, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterfvNV(GPPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, const GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameteriNV(GPPATHPARAMETERINV fnptr, GLuint  path, GLenum  pname, GLint  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterivNV(GPPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, const GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathStencilDepthOffsetNV(GPPATHSTENCILDEPTHOFFSETNV fnptr, GLfloat  factor, GLfloat  units) {
+//   (*fnptr)(factor, units);
+// }
+// static void  glowPathStencilFuncNV(GPPATHSTENCILFUNCNV fnptr, GLenum  func, GLint  ref, GLuint  mask) {
+//   (*fnptr)(func, ref, mask);
+// }
+// static void  glowPathStringNV(GPPATHSTRINGNV fnptr, GLuint  path, GLenum  format, GLsizei  length, const void * pathString) {
+//   (*fnptr)(path, format, length, pathString);
+// }
+// static void  glowPathSubCommandsNV(GPPATHSUBCOMMANDSNV fnptr, GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, commandStart, commandsToDelete, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathSubCoordsNV(GPPATHSUBCOORDSNV fnptr, GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, coordStart, numCoords, coordType, coords);
+// }
 // static void  glowPauseTransformFeedback(GPPAUSETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -2044,6 +3584,9 @@ package gl
 // }
 // static void  glowPixelStorei(GPPIXELSTOREI fnptr, GLenum  pname, GLint  param) {
 //   (*fnptr)(pname, param);
+// }
+// static GLboolean  glowPointAlongPathNV(GPPOINTALONGPATHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY) {
+//   return (*fnptr)(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
 // }
 // static void  glowPointParameterf(GPPOINTPARAMETERF fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
@@ -2066,11 +3609,23 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPopDebugGroup(GPPOPDEBUGGROUP fnptr) {
 //   (*fnptr)();
 // }
 // static void  glowPopDebugGroupKHR(GPPOPDEBUGGROUPKHR fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowPopGroupMarkerEXT(GPPOPGROUPMARKEREXT fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -2081,164 +3636,434 @@ package gl
 // static void  glowProgramParameteri(GPPROGRAMPARAMETERI fnptr, GLuint  program, GLenum  pname, GLint  value) {
 //   (*fnptr)(program, pname, value);
 // }
+// static void  glowProgramParameteriARB(GPPROGRAMPARAMETERIARB fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramParameteriEXT(GPPROGRAMPARAMETERIEXT fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramPathFragmentInputGenNV(GPPROGRAMPATHFRAGMENTINPUTGENNV fnptr, GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs) {
+//   (*fnptr)(program, location, genMode, components, coeffs);
+// }
 // static void  glowProgramUniform1d(GPPROGRAMUNIFORM1D fnptr, GLuint  program, GLint  location, GLdouble  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1dEXT(GPPROGRAMUNIFORM1DEXT fnptr, GLuint  program, GLint  location, GLdouble  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1dv(GPPROGRAMUNIFORM1DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1dvEXT(GPPROGRAMUNIFORM1DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1f(GPPROGRAMUNIFORM1F fnptr, GLuint  program, GLint  location, GLfloat  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1fEXT(GPPROGRAMUNIFORM1FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1fv(GPPROGRAMUNIFORM1FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1fvEXT(GPPROGRAMUNIFORM1FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1iEXT(GPPROGRAMUNIFORM1IEXT fnptr, GLuint  program, GLint  location, GLint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1iv(GPPROGRAMUNIFORM1IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ivEXT(GPPROGRAMUNIFORM1IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uiEXT(GPPROGRAMUNIFORM1UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1uiv(GPPROGRAMUNIFORM1UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uivEXT(GPPROGRAMUNIFORM1UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2d(GPPROGRAMUNIFORM2D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2dEXT(GPPROGRAMUNIFORM2DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2dv(GPPROGRAMUNIFORM2DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2dvEXT(GPPROGRAMUNIFORM2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2f(GPPROGRAMUNIFORM2F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2fEXT(GPPROGRAMUNIFORM2FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2fv(GPPROGRAMUNIFORM2FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2fvEXT(GPPROGRAMUNIFORM2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2iEXT(GPPROGRAMUNIFORM2IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2iv(GPPROGRAMUNIFORM2IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ivEXT(GPPROGRAMUNIFORM2IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uiEXT(GPPROGRAMUNIFORM2UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2uiv(GPPROGRAMUNIFORM2UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uivEXT(GPPROGRAMUNIFORM2UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3d(GPPROGRAMUNIFORM3D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3dEXT(GPPROGRAMUNIFORM3DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3dv(GPPROGRAMUNIFORM3DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3dvEXT(GPPROGRAMUNIFORM3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3f(GPPROGRAMUNIFORM3F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3fEXT(GPPROGRAMUNIFORM3FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3fv(GPPROGRAMUNIFORM3FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3fvEXT(GPPROGRAMUNIFORM3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3iEXT(GPPROGRAMUNIFORM3IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3iv(GPPROGRAMUNIFORM3IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ivEXT(GPPROGRAMUNIFORM3IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uiEXT(GPPROGRAMUNIFORM3UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3uiv(GPPROGRAMUNIFORM3UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uivEXT(GPPROGRAMUNIFORM3UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4d(GPPROGRAMUNIFORM4D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4dEXT(GPPROGRAMUNIFORM4DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4dv(GPPROGRAMUNIFORM4DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4dvEXT(GPPROGRAMUNIFORM4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4f(GPPROGRAMUNIFORM4F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4fEXT(GPPROGRAMUNIFORM4FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4fv(GPPROGRAMUNIFORM4FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4fvEXT(GPPROGRAMUNIFORM4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4iEXT(GPPROGRAMUNIFORM4IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4iv(GPPROGRAMUNIFORM4IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ivEXT(GPPROGRAMUNIFORM4IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uiEXT(GPPROGRAMUNIFORM4UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4uiv(GPPROGRAMUNIFORM4UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uivEXT(GPPROGRAMUNIFORM4UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniformHandleui64ARB(GPPROGRAMUNIFORMHANDLEUI64ARB fnptr, GLuint  program, GLint  location, GLuint64  value) {
 //   (*fnptr)(program, location, value);
 // }
+// static void  glowProgramUniformHandleui64NV(GPPROGRAMUNIFORMHANDLEUI64NV fnptr, GLuint  program, GLint  location, GLuint64  value) {
+//   (*fnptr)(program, location, value);
+// }
 // static void  glowProgramUniformHandleui64vARB(GPPROGRAMUNIFORMHANDLEUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
+//   (*fnptr)(program, location, count, values);
+// }
+// static void  glowProgramUniformHandleui64vNV(GPPROGRAMUNIFORMHANDLEUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
 //   (*fnptr)(program, location, count, values);
 // }
 // static void  glowProgramUniformMatrix2dv(GPPROGRAMUNIFORMMATRIX2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2dvEXT(GPPROGRAMUNIFORMMATRIX2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2fv(GPPROGRAMUNIFORMMATRIX2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2fvEXT(GPPROGRAMUNIFORMMATRIX2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x3dv(GPPROGRAMUNIFORMMATRIX2X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x3dvEXT(GPPROGRAMUNIFORMMATRIX2X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x3fv(GPPROGRAMUNIFORMMATRIX2X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x3fvEXT(GPPROGRAMUNIFORMMATRIX2X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x4dv(GPPROGRAMUNIFORMMATRIX2X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x4dvEXT(GPPROGRAMUNIFORMMATRIX2X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x4fv(GPPROGRAMUNIFORMMATRIX2X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x4fvEXT(GPPROGRAMUNIFORMMATRIX2X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3dv(GPPROGRAMUNIFORMMATRIX3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3dvEXT(GPPROGRAMUNIFORMMATRIX3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3fv(GPPROGRAMUNIFORMMATRIX3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3fvEXT(GPPROGRAMUNIFORMMATRIX3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x2dv(GPPROGRAMUNIFORMMATRIX3X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x2dvEXT(GPPROGRAMUNIFORMMATRIX3X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x2fv(GPPROGRAMUNIFORMMATRIX3X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x2fvEXT(GPPROGRAMUNIFORMMATRIX3X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x4dv(GPPROGRAMUNIFORMMATRIX3X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x4dvEXT(GPPROGRAMUNIFORMMATRIX3X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x4fv(GPPROGRAMUNIFORMMATRIX3X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x4fvEXT(GPPROGRAMUNIFORMMATRIX3X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4dv(GPPROGRAMUNIFORMMATRIX4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4dvEXT(GPPROGRAMUNIFORMMATRIX4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4fv(GPPROGRAMUNIFORMMATRIX4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4fvEXT(GPPROGRAMUNIFORMMATRIX4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x2dv(GPPROGRAMUNIFORMMATRIX4X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x2dvEXT(GPPROGRAMUNIFORMMATRIX4X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x2fv(GPPROGRAMUNIFORMMATRIX4X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4x2fvEXT(GPPROGRAMUNIFORMMATRIX4X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x3dv(GPPROGRAMUNIFORMMATRIX4X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3dvEXT(GPPROGRAMUNIFORMMATRIX4X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x3fv(GPPROGRAMUNIFORMMATRIX4X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3fvEXT(GPPROGRAMUNIFORMMATRIX4X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformui64NV(GPPROGRAMUNIFORMUI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(program, location, value);
+// }
+// static void  glowProgramUniformui64vNV(GPPROGRAMUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
 // static void  glowProvokingVertex(GPPROVOKINGVERTEX fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
+// }
+// static void  glowPushClientAttribDefaultEXT(GPPUSHCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static void  glowPushDebugGroup(GPPUSHDEBUGGROUP fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
@@ -2246,8 +4071,14 @@ package gl
 // static void  glowPushDebugGroupKHR(GPPUSHDEBUGGROUPKHR fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
 // }
+// static void  glowPushGroupMarkerEXT(GPPUSHGROUPMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
 // static void  glowQueryCounter(GPQUERYCOUNTER fnptr, GLuint  id, GLenum  target) {
 //   (*fnptr)(id, target);
+// }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
 // }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
@@ -2272,6 +4103,12 @@ package gl
 // }
 // static void  glowRenderbufferStorageMultisample(GPRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, samples, internalformat, width, height);
+// }
+// static void  glowRenderbufferStorageMultisampleCoverageNV(GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV fnptr, GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(target, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
@@ -2312,6 +4149,12 @@ package gl
 // static void  glowScissorIndexedv(GPSCISSORINDEXEDV fnptr, GLuint  index, const GLint * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowSecondaryColorFormatNV(GPSECONDARYCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
+// static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
+//   (*fnptr)(monitor, enable, group, numCounters, counterList);
+// }
 // static void  glowShaderBinary(GPSHADERBINARY fnptr, GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length) {
 //   (*fnptr)(count, shaders, binaryformat, binary, length);
 // }
@@ -2320,6 +4163,24 @@ package gl
 // }
 // static void  glowShaderStorageBlockBinding(GPSHADERSTORAGEBLOCKBINDING fnptr, GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding) {
 //   (*fnptr)(program, storageBlockIndex, storageBlockBinding);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
+// }
+// static void  glowStencilFillPathInstancedNV(GPSTENCILFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, transformType, transformValues);
+// }
+// static void  glowStencilFillPathNV(GPSTENCILFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask) {
+//   (*fnptr)(path, fillMode, mask);
 // }
 // static void  glowStencilFunc(GPSTENCILFUNC fnptr, GLenum  func, GLint  ref, GLuint  mask) {
 //   (*fnptr)(func, ref, mask);
@@ -2339,11 +4200,38 @@ package gl
 // static void  glowStencilOpSeparate(GPSTENCILOPSEPARATE fnptr, GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass) {
 //   (*fnptr)(face, sfail, dpfail, dppass);
 // }
+// static void  glowStencilStrokePathInstancedNV(GPSTENCILSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, transformType, transformValues);
+// }
+// static void  glowStencilStrokePathNV(GPSTENCILSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask) {
+//   (*fnptr)(path, reference, mask);
+// }
+// static void  glowStencilThenCoverFillPathInstancedNV(GPSTENCILTHENCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverFillPathNV(GPSTENCILTHENCOVERFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, fillMode, mask, coverMode);
+// }
+// static void  glowStencilThenCoverStrokePathInstancedNV(GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverStrokePathNV(GPSTENCILTHENCOVERSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, reference, mask, coverMode);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
+// }
 // static void  glowTexBuffer(GPTEXBUFFER fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(target, internalformat, buffer);
+// }
+// static void  glowTexBufferARB(GPTEXBUFFERARB fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(target, internalformat, buffer);
 // }
 // static void  glowTexBufferRange(GPTEXBUFFERRANGE fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, internalformat, buffer, offset, size);
+// }
+// static void  glowTexCoordFormatNV(GPTEXCOORDFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
 // }
 // static void  glowTexImage1D(GPTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, border, format, type, pixels);
@@ -2360,8 +4248,8 @@ package gl
 // static void  glowTexImage3DMultisample(GPTEXIMAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -2408,53 +4296,119 @@ package gl
 // static void  glowTextureBarrier(GPTEXTUREBARRIER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowTextureBarrierNV(GPTEXTUREBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowTextureBuffer(GPTEXTUREBUFFER fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texture, target, internalformat, buffer);
+// }
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
+//   (*fnptr)(texture, target, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureImage1DEXT(GPTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowTextureImage2DEXT(GPTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowTextureImage3DEXT(GPTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowTextureParameterIivEXT(GPTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowTextureParameterIuiv(GPTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, const GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowTextureParameterIuivEXT(GPTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameterf(GPTEXTUREPARAMETERF fnptr, GLuint  texture, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameterfEXT(GPTEXTUREPARAMETERFEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameterfv(GPTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, const GLfloat * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterfvEXT(GPTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameteri(GPTEXTUREPARAMETERI fnptr, GLuint  texture, GLenum  pname, GLint  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameteriEXT(GPTEXTUREPARAMETERIEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameteriv(GPTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, const GLint * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterivEXT(GPTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
+// static void  glowTextureRenderbufferEXT(GPTEXTURERENDERBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texture, target, renderbuffer);
 // }
 // static void  glowTextureStorage1D(GPTEXTURESTORAGE1D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
 //   (*fnptr)(texture, levels, internalformat, width);
 // }
+// static void  glowTextureStorage1DEXT(GPTEXTURESTORAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
+//   (*fnptr)(texture, target, levels, internalformat, width);
+// }
 // static void  glowTextureStorage2D(GPTEXTURESTORAGE2D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, levels, internalformat, width, height);
+// }
+// static void  glowTextureStorage2DEXT(GPTEXTURESTORAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height);
 // }
 // static void  glowTextureStorage2DMultisample(GPTEXTURESTORAGE2DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, fixedsamplelocations);
 // }
+// static void  glowTextureStorage2DMultisampleEXT(GPTEXTURESTORAGE2DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, fixedsamplelocations);
+// }
 // static void  glowTextureStorage3D(GPTEXTURESTORAGE3D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
 //   (*fnptr)(texture, levels, internalformat, width, height, depth);
+// }
+// static void  glowTextureStorage3DEXT(GPTEXTURESTORAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height, depth);
 // }
 // static void  glowTextureStorage3DMultisample(GPTEXTURESTORAGE3DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
+// }
 // static void  glowTextureSubImage1D(GPTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowTextureSubImage1DEXT(GPTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, type, pixels);
 // }
 // static void  glowTextureSubImage2D(GPTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, type, pixels);
 // }
+// static void  glowTextureSubImage2DEXT(GPTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
 // static void  glowTextureSubImage3D(GPTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowTextureSubImage3DEXT(GPTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
 // static void  glowTextureView(GPTEXTUREVIEW fnptr, GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers) {
 //   (*fnptr)(texture, target, origtexture, internalformat, minlevel, numlevels, minlayer, numlayers);
@@ -2462,11 +4416,14 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackVaryings(GPTRANSFORMFEEDBACKVARYINGS fnptr, GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode) {
 //   (*fnptr)(program, count, varyings, bufferMode);
+// }
+// static void  glowTransformPathNV(GPTRANSFORMPATHNV fnptr, GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(resultPath, srcPath, transformType, transformValues);
 // }
 // static void  glowUniform1d(GPUNIFORM1D fnptr, GLint  location, GLdouble  x) {
 //   (*fnptr)(location, x);
@@ -2483,11 +4440,35 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform1iv(GPUNIFORM1IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
+// }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1uiv(GPUNIFORM1UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2507,11 +4488,35 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform2iv(GPUNIFORM2IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
+// }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2uiv(GPUNIFORM2UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2531,11 +4536,35 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform3iv(GPUNIFORM3IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
+// }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3uiv(GPUNIFORM3UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2555,11 +4584,35 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform4iv(GPUNIFORM4IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
+// }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4uiv(GPUNIFORM4UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2570,7 +4623,13 @@ package gl
 // static void  glowUniformHandleui64ARB(GPUNIFORMHANDLEUI64ARB fnptr, GLint  location, GLuint64  value) {
 //   (*fnptr)(location, value);
 // }
+// static void  glowUniformHandleui64NV(GPUNIFORMHANDLEUI64NV fnptr, GLint  location, GLuint64  value) {
+//   (*fnptr)(location, value);
+// }
 // static void  glowUniformHandleui64vARB(GPUNIFORMHANDLEUI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniformHandleui64vNV(GPUNIFORMHANDLEUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniformMatrix2dv(GPUNIFORMMATRIX2DV fnptr, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
@@ -2630,10 +4689,19 @@ package gl
 // static void  glowUniformSubroutinesuiv(GPUNIFORMSUBROUTINESUIV fnptr, GLenum  shadertype, GLsizei  count, const GLuint * indices) {
 //   (*fnptr)(shadertype, count, indices);
 // }
+// static void  glowUniformui64NV(GPUNIFORMUI64NV fnptr, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(location, value);
+// }
+// static void  glowUniformui64vNV(GPUNIFORMUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static GLboolean  glowUnmapBuffer(GPUNMAPBUFFER fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLboolean  glowUnmapNamedBuffer(GPUNMAPNAMEDBUFFER fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
+// static GLboolean  glowUnmapNamedBufferEXT(GPUNMAPNAMEDBUFFEREXT fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
 // static void  glowUseProgram(GPUSEPROGRAM fnptr, GLuint  program) {
@@ -2642,10 +4710,19 @@ package gl
 // static void  glowUseProgramStages(GPUSEPROGRAMSTAGES fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
 //   (*fnptr)(pipeline, stages, program);
 // }
+// static void  glowUseProgramStagesEXT(GPUSEPROGRAMSTAGESEXT fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
+//   (*fnptr)(pipeline, stages, program);
+// }
+// static void  glowUseShaderProgramEXT(GPUSESHADERPROGRAMEXT fnptr, GLenum  type, GLuint  program) {
+//   (*fnptr)(type, program);
+// }
 // static void  glowValidateProgram(GPVALIDATEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowValidateProgramPipeline(GPVALIDATEPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowValidateProgramPipelineEXT(GPVALIDATEPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowVertexArrayAttribBinding(GPVERTEXARRAYATTRIBBINDING fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
@@ -2660,17 +4737,74 @@ package gl
 // static void  glowVertexArrayAttribLFormat(GPVERTEXARRAYATTRIBLFORMAT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexArrayBindVertexBufferEXT(GPVERTEXARRAYBINDVERTEXBUFFEREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
+//   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
+// }
 // static void  glowVertexArrayBindingDivisor(GPVERTEXARRAYBINDINGDIVISOR fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(vaobj, bindingindex, divisor);
 // }
+// static void  glowVertexArrayColorOffsetEXT(GPVERTEXARRAYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayEdgeFlagOffsetEXT(GPVERTEXARRAYEDGEFLAGOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, stride, offset);
+// }
 // static void  glowVertexArrayElementBuffer(GPVERTEXARRAYELEMENTBUFFER fnptr, GLuint  vaobj, GLuint  buffer) {
 //   (*fnptr)(vaobj, buffer);
+// }
+// static void  glowVertexArrayFogCoordOffsetEXT(GPVERTEXARRAYFOGCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayIndexOffsetEXT(GPVERTEXARRAYINDEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayMultiTexCoordOffsetEXT(GPVERTEXARRAYMULTITEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, texunit, size, type, stride, offset);
+// }
+// static void  glowVertexArrayNormalOffsetEXT(GPVERTEXARRAYNORMALOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArraySecondaryColorOffsetEXT(GPVERTEXARRAYSECONDARYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayTexCoordOffsetEXT(GPVERTEXARRAYTEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribBindingEXT(GPVERTEXARRAYVERTEXATTRIBBINDINGEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
+//   (*fnptr)(vaobj, attribindex, bindingindex);
+// }
+// static void  glowVertexArrayVertexAttribDivisorEXT(GPVERTEXARRAYVERTEXATTRIBDIVISOREXT fnptr, GLuint  vaobj, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(vaobj, index, divisor);
+// }
+// static void  glowVertexArrayVertexAttribFormatEXT(GPVERTEXARRAYVERTEXATTRIBFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIFormatEXT(GPVERTEXARRAYVERTEXATTRIBIFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIOffsetEXT(GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribLFormatEXT(GPVERTEXARRAYVERTEXATTRIBLFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribLOffsetEXT(GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribOffsetEXT(GPVERTEXARRAYVERTEXATTRIBOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, normalized, stride, offset);
+// }
+// static void  glowVertexArrayVertexBindingDivisorEXT(GPVERTEXARRAYVERTEXBINDINGDIVISOREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
+//   (*fnptr)(vaobj, bindingindex, divisor);
 // }
 // static void  glowVertexArrayVertexBuffer(GPVERTEXARRAYVERTEXBUFFER fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
 //   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
 // }
 // static void  glowVertexArrayVertexBuffers(GPVERTEXARRAYVERTEXBUFFERS fnptr, GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(vaobj, first, count, buffers, offsets, strides);
+// }
+// static void  glowVertexArrayVertexOffsetEXT(GPVERTEXARRAYVERTEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
 // }
 // static void  glowVertexAttrib1d(GPVERTEXATTRIB1D fnptr, GLuint  index, GLdouble  x) {
 //   (*fnptr)(index, x);
@@ -2786,8 +4920,14 @@ package gl
 // static void  glowVertexAttribDivisor(GPVERTEXATTRIBDIVISOR fnptr, GLuint  index, GLuint  divisor) {
 //   (*fnptr)(index, divisor);
 // }
+// static void  glowVertexAttribDivisorARB(GPVERTEXATTRIBDIVISORARB fnptr, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(index, divisor);
+// }
 // static void  glowVertexAttribFormat(GPVERTEXATTRIBFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexAttribFormatNV(GPVERTEXATTRIBFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride) {
+//   (*fnptr)(index, size, type, normalized, stride);
 // }
 // static void  glowVertexAttribI1i(GPVERTEXATTRIBI1I fnptr, GLuint  index, GLint  x) {
 //   (*fnptr)(index, x);
@@ -2852,6 +4992,9 @@ package gl
 // static void  glowVertexAttribIFormat(GPVERTEXATTRIBIFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexAttribIFormatNV(GPVERTEXATTRIBIFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
+// }
 // static void  glowVertexAttribIPointer(GPVERTEXATTRIBIPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
 // }
@@ -2861,10 +5004,22 @@ package gl
 // static void  glowVertexAttribL1dv(GPVERTEXATTRIBL1DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL1i64NV(GPVERTEXATTRIBL1I64NV fnptr, GLuint  index, GLint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
+// static void  glowVertexAttribL1i64vNV(GPVERTEXATTRIBL1I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL1ui64ARB(GPVERTEXATTRIBL1UI64ARB fnptr, GLuint  index, GLuint64EXT  x) {
 //   (*fnptr)(index, x);
 // }
+// static void  glowVertexAttribL1ui64NV(GPVERTEXATTRIBL1UI64NV fnptr, GLuint  index, GLuint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
 // static void  glowVertexAttribL1ui64vARB(GPVERTEXATTRIBL1UI64VARB fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL1ui64vNV(GPVERTEXATTRIBL1UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL2d(GPVERTEXATTRIBL2D fnptr, GLuint  index, GLdouble  x, GLdouble  y) {
@@ -2873,10 +5028,34 @@ package gl
 // static void  glowVertexAttribL2dv(GPVERTEXATTRIBL2DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL2i64NV(GPVERTEXATTRIBL2I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2i64vNV(GPVERTEXATTRIBL2I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL2ui64NV(GPVERTEXATTRIBL2UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2ui64vNV(GPVERTEXATTRIBL2UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL3d(GPVERTEXATTRIBL3D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z) {
 //   (*fnptr)(index, x, y, z);
 // }
 // static void  glowVertexAttribL3dv(GPVERTEXATTRIBL3DV fnptr, GLuint  index, const GLdouble * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3i64NV(GPVERTEXATTRIBL3I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3i64vNV(GPVERTEXATTRIBL3I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3ui64NV(GPVERTEXATTRIBL3UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3ui64vNV(GPVERTEXATTRIBL3UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL4d(GPVERTEXATTRIBL4D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
@@ -2885,8 +5064,23 @@ package gl
 // static void  glowVertexAttribL4dv(GPVERTEXATTRIBL4DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL4i64NV(GPVERTEXATTRIBL4I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4i64vNV(GPVERTEXATTRIBL4I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL4ui64NV(GPVERTEXATTRIBL4UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4ui64vNV(GPVERTEXATTRIBL4UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribLFormat(GPVERTEXATTRIBLFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexAttribLFormatNV(GPVERTEXATTRIBLFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
 // }
 // static void  glowVertexAttribLPointer(GPVERTEXATTRIBLPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
@@ -2921,6 +5115,9 @@ package gl
 // static void  glowVertexBindingDivisor(GPVERTEXBINDINGDIVISOR fnptr, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(bindingindex, divisor);
 // }
+// static void  glowVertexFormatNV(GPVERTEXFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
 // static void  glowViewport(GPVIEWPORT fnptr, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(x, y, width, height);
 // }
@@ -2933,8 +5130,23 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
+//   (*fnptr)(resultPath, numPaths, paths, weights);
+// }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
 // }
 import "C"
 import (
@@ -2943,10 +5155,12 @@ import (
 )
 
 const (
+	ACCUM_ADJACENT_PAIRS_NV                                    = 0x90AD
 	ACTIVE_ATOMIC_COUNTER_BUFFERS                              = 0x92D9
 	ACTIVE_ATTRIBUTES                                          = 0x8B89
 	ACTIVE_ATTRIBUTE_MAX_LENGTH                                = 0x8B8A
 	ACTIVE_PROGRAM                                             = 0x8259
+	ACTIVE_PROGRAM_EXT                                         = 0x8B8D
 	ACTIVE_RESOURCES                                           = 0x92F5
 	ACTIVE_SUBROUTINES                                         = 0x8DE5
 	ACTIVE_SUBROUTINE_MAX_LENGTH                               = 0x8E48
@@ -2959,10 +5173,15 @@ const (
 	ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH                       = 0x8A35
 	ACTIVE_UNIFORM_MAX_LENGTH                                  = 0x8B87
 	ACTIVE_VARIABLES                                           = 0x9305
+	ADJACENT_PAIRS_NV                                          = 0x90AE
+	AFFINE_2D_NV                                               = 0x9092
+	AFFINE_3D_NV                                               = 0x9094
 	ALIASED_LINE_WIDTH_RANGE                                   = 0x846E
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
+	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALPHA                                                      = 0x1906
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	AND                                                        = 0x1501
@@ -2970,6 +5189,7 @@ const (
 	AND_REVERSE                                                = 0x1502
 	ANY_SAMPLES_PASSED                                         = 0x8C2F
 	ANY_SAMPLES_PASSED_CONSERVATIVE                            = 0x8D6A
+	ARC_TO_NV                                                  = 0xFE
 	ARRAY_BUFFER                                               = 0x8892
 	ARRAY_BUFFER_BINDING                                       = 0x8894
 	ARRAY_SIZE                                                 = 0x92FB
@@ -2990,43 +5210,56 @@ const (
 	ATOMIC_COUNTER_BUFFER_SIZE                                 = 0x92C3
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	AUTO_GENERATE_MIPMAP                                       = 0x8295
 	BACK                                                       = 0x0405
 	BACK_LEFT                                                  = 0x0402
 	BACK_RIGHT                                                 = 0x0403
+	BEVEL_NV                                                   = 0x90A6
 	BGR                                                        = 0x80E0
 	BGRA                                                       = 0x80E1
 	BGRA_INTEGER                                               = 0x8D9B
 	BGR_INTEGER                                                = 0x8D9A
 	BLEND                                                      = 0x0BE2
+	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
+	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
 	BLEND_DST_RGB                                              = 0x80C8
 	BLEND_EQUATION                                             = 0x8009
 	BLEND_EQUATION_ALPHA                                       = 0x883D
 	BLEND_EQUATION_RGB                                         = 0x8009
+	BLEND_OVERLAP_NV                                           = 0x9281
+	BLEND_PREMULTIPLIED_SRC_NV                                 = 0x9280
 	BLEND_SRC                                                  = 0x0BE1
 	BLEND_SRC_ALPHA                                            = 0x80CB
 	BLEND_SRC_RGB                                              = 0x80C9
 	BLOCK_INDEX                                                = 0x92FD
 	BLUE                                                       = 0x1905
 	BLUE_INTEGER                                               = 0x8D96
+	BLUE_NV                                                    = 0x1905
+	BOLD_BIT_NV                                                = 0x01
 	BOOL                                                       = 0x8B56
 	BOOL_VEC2                                                  = 0x8B57
 	BOOL_VEC3                                                  = 0x8B58
 	BOOL_VEC4                                                  = 0x8B59
+	BOUNDING_BOX_NV                                            = 0x908D
+	BOUNDING_BOX_OF_BOUNDING_BOXES_NV                          = 0x909C
 	BUFFER                                                     = 0x82E0
 	BUFFER_ACCESS                                              = 0x88BB
 	BUFFER_ACCESS_FLAGS                                        = 0x911F
 	BUFFER_BINDING                                             = 0x9302
 	BUFFER_DATA_SIZE                                           = 0x9303
+	BUFFER_GPU_ADDRESS_NV                                      = 0x8F1D
 	BUFFER_IMMUTABLE_STORAGE                                   = 0x821F
 	BUFFER_KHR                                                 = 0x82E0
 	BUFFER_MAPPED                                              = 0x88BC
 	BUFFER_MAP_LENGTH                                          = 0x9120
 	BUFFER_MAP_OFFSET                                          = 0x9121
 	BUFFER_MAP_POINTER                                         = 0x88BD
+	BUFFER_OBJECT_EXT                                          = 0x9151
 	BUFFER_SIZE                                                = 0x8764
 	BUFFER_STORAGE_FLAGS                                       = 0x8220
 	BUFFER_UPDATE_BARRIER_BIT                                  = 0x00000200
@@ -3035,8 +5268,12 @@ const (
 	BYTE                                                       = 0x1400
 	CAVEAT_SUPPORT                                             = 0x82B8
 	CCW                                                        = 0x0901
+	CIRCULAR_CCW_ARC_TO_NV                                     = 0xF8
+	CIRCULAR_CW_ARC_TO_NV                                      = 0xFA
+	CIRCULAR_TANGENT_ARC_TO_NV                                 = 0xFC
 	CLAMP_READ_COLOR                                           = 0x891C
 	CLAMP_TO_BORDER                                            = 0x812D
+	CLAMP_TO_BORDER_ARB                                        = 0x812D
 	CLAMP_TO_EDGE                                              = 0x812F
 	CLEAR                                                      = 0x1500
 	CLEAR_BUFFER                                               = 0x82B4
@@ -3055,7 +5292,14 @@ const (
 	CLIP_DISTANCE6                                             = 0x3006
 	CLIP_DISTANCE7                                             = 0x3007
 	CLIP_ORIGIN                                                = 0x935C
+	CLOSE_PATH_NV                                              = 0x00
 	COLOR                                                      = 0x1800
+	COLORBURN_KHR                                              = 0x929A
+	COLORBURN_NV                                               = 0x929A
+	COLORDODGE_KHR                                             = 0x9299
+	COLORDODGE_NV                                              = 0x9299
+	COLOR_ARRAY_ADDRESS_NV                                     = 0x8F23
+	COLOR_ARRAY_LENGTH_NV                                      = 0x8F2D
 	COLOR_ATTACHMENT0                                          = 0x8CE0
 	COLOR_ATTACHMENT1                                          = 0x8CE1
 	COLOR_ATTACHMENT10                                         = 0x8CEA
@@ -3064,8 +5308,24 @@ const (
 	COLOR_ATTACHMENT13                                         = 0x8CED
 	COLOR_ATTACHMENT14                                         = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT5                                          = 0x8CE5
 	COLOR_ATTACHMENT6                                          = 0x8CE6
@@ -3078,11 +5338,14 @@ const (
 	COLOR_ENCODING                                             = 0x8296
 	COLOR_LOGIC_OP                                             = 0x0BF2
 	COLOR_RENDERABLE                                           = 0x8286
+	COLOR_SAMPLES_NV                                           = 0x8E20
 	COLOR_WRITEMASK                                            = 0x0C23
 	COMMAND_BARRIER_BIT                                        = 0x00000040
 	COMPARE_REF_TO_TEXTURE                                     = 0x884E
 	COMPATIBLE_SUBROUTINES                                     = 0x8E4B
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_R11_EAC                                         = 0x9270
 	COMPRESSED_RED                                             = 0x8225
 	COMPRESSED_RED_RGTC1                                       = 0x8DBB
@@ -3109,10 +5372,14 @@ const (
 	COMPRESSED_RGBA_ASTC_8x8_KHR                               = 0x93B7
 	COMPRESSED_RGBA_BPTC_UNORM                                 = 0x8E8C
 	COMPRESSED_RGBA_BPTC_UNORM_ARB                             = 0x8E8C
+	COMPRESSED_RGBA_S3TC_DXT1_EXT                              = 0x83F1
+	COMPRESSED_RGBA_S3TC_DXT3_EXT                              = 0x83F2
+	COMPRESSED_RGBA_S3TC_DXT5_EXT                              = 0x83F3
 	COMPRESSED_RGB_BPTC_SIGNED_FLOAT                           = 0x8E8E
 	COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB                       = 0x8E8E
 	COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT                         = 0x8E8F
 	COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB                     = 0x8E8F
+	COMPRESSED_RGB_S3TC_DXT1_EXT                               = 0x83F0
 	COMPRESSED_RG_RGTC2                                        = 0x8DBD
 	COMPRESSED_SIGNED_R11_EAC                                  = 0x9271
 	COMPRESSED_SIGNED_RED_RGTC1                                = 0x8DBC
@@ -3148,6 +5415,18 @@ const (
 	COMPUTE_TEXTURE                                            = 0x82A0
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
+	CONIC_CURVE_TO_NV                                          = 0x1A
+	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSTANT_ALPHA                                             = 0x8003
 	CONSTANT_COLOR                                             = 0x8001
 	CONTEXT_COMPATIBILITY_PROFILE_BIT                          = 0x00000002
@@ -3156,6 +5435,7 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
 	CONTEXT_LOST_KHR                                           = 0x0507
@@ -3166,18 +5446,30 @@ const (
 	CONTEXT_RELEASE_BEHAVIOR_KHR                               = 0x82FB
 	CONTEXT_ROBUST_ACCESS                                      = 0x90F3
 	CONTEXT_ROBUST_ACCESS_KHR                                  = 0x90F3
+	CONTRAST_NV                                                = 0x92A1
+	CONVEX_HULL_NV                                             = 0x908B
 	COPY                                                       = 0x1503
 	COPY_INVERTED                                              = 0x150C
 	COPY_READ_BUFFER                                           = 0x8F36
 	COPY_READ_BUFFER_BINDING                                   = 0x8F36
 	COPY_WRITE_BUFFER                                          = 0x8F37
 	COPY_WRITE_BUFFER_BINDING                                  = 0x8F37
+	COUNTER_RANGE_AMD                                          = 0x8BC1
+	COUNTER_TYPE_AMD                                           = 0x8BC0
+	COUNT_DOWN_NV                                              = 0x9089
+	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
+	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CULL_FACE                                                  = 0x0B44
 	CULL_FACE_MODE                                             = 0x0B45
 	CURRENT_PROGRAM                                            = 0x8B8D
 	CURRENT_QUERY                                              = 0x8865
 	CURRENT_VERTEX_ATTRIB                                      = 0x8626
 	CW                                                         = 0x0900
+	DARKEN_KHR                                                 = 0x9297
+	DARKEN_NV                                                  = 0x9297
 	DEBUG_CALLBACK_FUNCTION                                    = 0x8244
 	DEBUG_CALLBACK_FUNCTION_ARB                                = 0x8244
 	DEBUG_CALLBACK_FUNCTION_KHR                                = 0x8244
@@ -3250,6 +5542,7 @@ const (
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR                              = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_ARB                          = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_KHR                          = 0x824E
+	DECODE_EXT                                                 = 0x8A49
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DELETE_STATUS                                              = 0x8B80
@@ -3269,11 +5562,15 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
 	DEPTH_STENCIL_TEXTURE_MODE                                 = 0x90EA
 	DEPTH_TEST                                                 = 0x0B71
 	DEPTH_WRITEMASK                                            = 0x0B72
+	DIFFERENCE_KHR                                             = 0x929E
+	DIFFERENCE_NV                                              = 0x929E
+	DISJOINT_NV                                                = 0x9283
 	DISPATCH_INDIRECT_BUFFER                                   = 0x90EE
 	DISPATCH_INDIRECT_BUFFER_BINDING                           = 0x90EF
 	DITHER                                                     = 0x0BD0
@@ -3292,6 +5589,9 @@ const (
 	DOUBLE_VEC2                                                = 0x8FFC
 	DOUBLE_VEC3                                                = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER1                                               = 0x8826
@@ -3309,30 +5609,62 @@ const (
 	DRAW_BUFFER7                                               = 0x882C
 	DRAW_BUFFER8                                               = 0x882D
 	DRAW_BUFFER9                                               = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
+	DRAW_INDIRECT_ADDRESS_NV                                   = 0x8F41
 	DRAW_INDIRECT_BUFFER                                       = 0x8F3F
 	DRAW_INDIRECT_BUFFER_BINDING                               = 0x8F43
+	DRAW_INDIRECT_LENGTH_NV                                    = 0x8F42
+	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DST_ALPHA                                                  = 0x0304
+	DST_ATOP_NV                                                = 0x928F
 	DST_COLOR                                                  = 0x0306
+	DST_IN_NV                                                  = 0x928B
+	DST_NV                                                     = 0x9287
+	DST_OUT_NV                                                 = 0x928D
+	DST_OVER_NV                                                = 0x9289
+	DUP_FIRST_CUBIC_CURVE_TO_NV                                = 0xF2
+	DUP_LAST_CUBIC_CURVE_TO_NV                                 = 0xF4
 	DYNAMIC_COPY                                               = 0x88EA
 	DYNAMIC_DRAW                                               = 0x88E8
 	DYNAMIC_READ                                               = 0x88E9
 	DYNAMIC_STORAGE_BIT                                        = 0x0100
+	EDGE_FLAG_ARRAY_ADDRESS_NV                                 = 0x8F26
+	EDGE_FLAG_ARRAY_LENGTH_NV                                  = 0x8F30
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
+	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_BARRIER_BIT                                  = 0x00000002
 	ELEMENT_ARRAY_BUFFER                                       = 0x8893
 	ELEMENT_ARRAY_BUFFER_BINDING                               = 0x8895
+	ELEMENT_ARRAY_LENGTH_NV                                    = 0x8F33
+	ELEMENT_ARRAY_UNIFIED_NV                                   = 0x8F1F
 	EQUAL                                                      = 0x0202
 	EQUIV                                                      = 0x1509
+	EXCLUSION_KHR                                              = 0x92A0
+	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXTENSIONS                                                 = 0x1F03
+	FACTOR_MAX_AMD                                             = 0x901D
+	FACTOR_MIN_AMD                                             = 0x901C
 	FALSE                                                      = 0
 	FASTEST                                                    = 0x1101
+	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
+	FIRST_TO_REST_NV                                           = 0x90AF
 	FIRST_VERTEX_CONVENTION                                    = 0x8E4D
 	FIXED                                                      = 0x140C
 	FIXED_ONLY                                                 = 0x891D
 	FLOAT                                                      = 0x1406
+	FLOAT16_NV                                                 = 0x8FF8
+	FLOAT16_VEC2_NV                                            = 0x8FF9
+	FLOAT16_VEC3_NV                                            = 0x8FFA
+	FLOAT16_VEC4_NV                                            = 0x8FFB
 	FLOAT_32_UNSIGNED_INT_24_8_REV                             = 0x8DAD
 	FLOAT_MAT2                                                 = 0x8B5A
 	FLOAT_MAT2x3                                               = 0x8B65
@@ -3346,12 +5678,37 @@ const (
 	FLOAT_VEC2                                                 = 0x8B50
 	FLOAT_VEC3                                                 = 0x8B51
 	FLOAT_VEC4                                                 = 0x8B52
+	FOG_COORD_ARRAY_ADDRESS_NV                                 = 0x8F28
+	FOG_COORD_ARRAY_LENGTH_NV                                  = 0x8F32
+	FONT_ASCENDER_BIT_NV                                       = 0x00200000
+	FONT_DESCENDER_BIT_NV                                      = 0x00400000
+	FONT_GLYPHS_AVAILABLE_NV                                   = 0x9368
+	FONT_HAS_KERNING_BIT_NV                                    = 0x10000000
+	FONT_HEIGHT_BIT_NV                                         = 0x00800000
+	FONT_MAX_ADVANCE_HEIGHT_BIT_NV                             = 0x02000000
+	FONT_MAX_ADVANCE_WIDTH_BIT_NV                              = 0x01000000
+	FONT_NUM_GLYPH_INDICES_BIT_NV                              = 0x20000000
+	FONT_TARGET_UNAVAILABLE_NV                                 = 0x9369
+	FONT_UNAVAILABLE_NV                                        = 0x936A
+	FONT_UNDERLINE_POSITION_BIT_NV                             = 0x04000000
+	FONT_UNDERLINE_THICKNESS_BIT_NV                            = 0x08000000
+	FONT_UNINTELLIGIBLE_NV                                     = 0x936B
+	FONT_UNITS_PER_EM_BIT_NV                                   = 0x00100000
+	FONT_X_MAX_BOUNDS_BIT_NV                                   = 0x00040000
+	FONT_X_MIN_BOUNDS_BIT_NV                                   = 0x00010000
+	FONT_Y_MAX_BOUNDS_BIT_NV                                   = 0x00080000
+	FONT_Y_MIN_BOUNDS_BIT_NV                                   = 0x00020000
 	FRACTIONAL_EVEN                                            = 0x8E7C
 	FRACTIONAL_ODD                                             = 0x8E7B
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
+	FRAGMENT_INPUT_NV                                          = 0x936D
 	FRAGMENT_INTERPOLATION_OFFSET_BITS                         = 0x8E5D
 	FRAGMENT_SHADER                                            = 0x8B30
 	FRAGMENT_SHADER_BIT                                        = 0x00000002
+	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -3364,13 +5721,16 @@ const (
 	FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE                          = 0x8216
 	FRAMEBUFFER_ATTACHMENT_GREEN_SIZE                          = 0x8213
 	FRAMEBUFFER_ATTACHMENT_LAYERED                             = 0x8DA7
+	FRAMEBUFFER_ATTACHMENT_LAYERED_ARB                         = 0x8DA7
 	FRAMEBUFFER_ATTACHMENT_OBJECT_NAME                         = 0x8CD1
 	FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE                         = 0x8CD0
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
 	FRAMEBUFFER_BLEND                                          = 0x828B
@@ -3383,18 +5743,26 @@ const (
 	FRAMEBUFFER_DEFAULT_WIDTH                                  = 0x9310
 	FRAMEBUFFER_INCOMPLETE_ATTACHMENT                          = 0x8CD6
 	FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER                         = 0x8CDB
+	FRAMEBUFFER_INCOMPLETE_LAYER_COUNT_ARB                     = 0x8DA9
 	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS                       = 0x8DA8
+	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS_ARB                   = 0x8DA8
 	FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT                  = 0x8CD7
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE                         = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_UNDEFINED                                      = 0x8219
 	FRAMEBUFFER_UNSUPPORTED                                    = 0x8CDD
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_SUPPORT                                               = 0x82B7
@@ -3402,8 +5770,11 @@ const (
 	FUNC_REVERSE_SUBTRACT                                      = 0x800B
 	FUNC_SUBTRACT                                              = 0x800A
 	GEOMETRY_INPUT_TYPE                                        = 0x8917
+	GEOMETRY_INPUT_TYPE_ARB                                    = 0x8DDB
 	GEOMETRY_OUTPUT_TYPE                                       = 0x8918
+	GEOMETRY_OUTPUT_TYPE_ARB                                   = 0x8DDC
 	GEOMETRY_SHADER                                            = 0x8DD9
+	GEOMETRY_SHADER_ARB                                        = 0x8DD9
 	GEOMETRY_SHADER_BIT                                        = 0x00000004
 	GEOMETRY_SHADER_INVOCATIONS                                = 0x887F
 	GEOMETRY_SHADER_PRIMITIVES_EMITTED_ARB                     = 0x82F3
@@ -3411,18 +5782,42 @@ const (
 	GEOMETRY_SUBROUTINE_UNIFORM                                = 0x92F1
 	GEOMETRY_TEXTURE                                           = 0x829E
 	GEOMETRY_VERTICES_OUT                                      = 0x8916
+	GEOMETRY_VERTICES_OUT_ARB                                  = 0x8DDA
 	GEQUAL                                                     = 0x0206
 	GET_TEXTURE_IMAGE_FORMAT                                   = 0x8291
 	GET_TEXTURE_IMAGE_TYPE                                     = 0x8292
+	GLYPH_HAS_KERNING_BIT_NV                                   = 0x100
+	GLYPH_HEIGHT_BIT_NV                                        = 0x02
+	GLYPH_HORIZONTAL_BEARING_ADVANCE_BIT_NV                    = 0x10
+	GLYPH_HORIZONTAL_BEARING_X_BIT_NV                          = 0x04
+	GLYPH_HORIZONTAL_BEARING_Y_BIT_NV                          = 0x08
+	GLYPH_VERTICAL_BEARING_ADVANCE_BIT_NV                      = 0x80
+	GLYPH_VERTICAL_BEARING_X_BIT_NV                            = 0x20
+	GLYPH_VERTICAL_BEARING_Y_BIT_NV                            = 0x40
+	GLYPH_WIDTH_BIT_NV                                         = 0x01
+	GPU_ADDRESS_NV                                             = 0x8F34
 	GREATER                                                    = 0x0204
 	GREEN                                                      = 0x1904
 	GREEN_INTEGER                                              = 0x8D95
+	GREEN_NV                                                   = 0x1904
 	GUILTY_CONTEXT_RESET                                       = 0x8253
 	GUILTY_CONTEXT_RESET_ARB                                   = 0x8253
 	GUILTY_CONTEXT_RESET_KHR                                   = 0x8253
 	HALF_FLOAT                                                 = 0x140B
+	HARDLIGHT_KHR                                              = 0x929B
+	HARDLIGHT_NV                                               = 0x929B
+	HARDMIX_NV                                                 = 0x92A9
 	HIGH_FLOAT                                                 = 0x8DF2
 	HIGH_INT                                                   = 0x8DF5
+	HORIZONTAL_LINE_TO_NV                                      = 0x06
+	HSL_COLOR_KHR                                              = 0x92AF
+	HSL_COLOR_NV                                               = 0x92AF
+	HSL_HUE_KHR                                                = 0x92AD
+	HSL_HUE_NV                                                 = 0x92AD
+	HSL_LUMINOSITY_KHR                                         = 0x92B0
+	HSL_LUMINOSITY_NV                                          = 0x92B0
+	HSL_SATURATION_KHR                                         = 0x92AE
+	HSL_SATURATION_NV                                          = 0x92AE
 	IMAGE_1D                                                   = 0x904C
 	IMAGE_1D_ARRAY                                             = 0x9052
 	IMAGE_2D                                                   = 0x904D
@@ -3460,13 +5855,32 @@ const (
 	IMAGE_TEXEL_SIZE                                           = 0x82A7
 	IMPLEMENTATION_COLOR_READ_FORMAT                           = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
+	INDEX_ARRAY_ADDRESS_NV                                     = 0x8F24
+	INDEX_ARRAY_LENGTH_NV                                      = 0x8F2E
 	INFO_LOG_LENGTH                                            = 0x8B84
 	INNOCENT_CONTEXT_RESET                                     = 0x8254
 	INNOCENT_CONTEXT_RESET_ARB                                 = 0x8254
 	INNOCENT_CONTEXT_RESET_KHR                                 = 0x8254
 	INT                                                        = 0x1404
+	INT16_NV                                                   = 0x8FE4
+	INT16_VEC2_NV                                              = 0x8FE5
+	INT16_VEC3_NV                                              = 0x8FE6
+	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
+	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
+	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
+	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
+	INT64_VEC4_NV                                              = 0x8FEB
+	INT8_NV                                                    = 0x8FE0
+	INT8_VEC2_NV                                               = 0x8FE1
+	INT8_VEC3_NV                                               = 0x8FE2
+	INT8_VEC4_NV                                               = 0x8FE3
 	INTERLEAVED_ATTRIBS                                        = 0x8C8C
 	INTERNALFORMAT_ALPHA_SIZE                                  = 0x8274
 	INTERNALFORMAT_ALPHA_TYPE                                  = 0x827B
@@ -3516,27 +5930,41 @@ const (
 	INVALID_OPERATION                                          = 0x0502
 	INVALID_VALUE                                              = 0x0501
 	INVERT                                                     = 0x150A
+	INVERT_OVG_NV                                              = 0x92B4
+	INVERT_RGB_NV                                              = 0x92A3
 	ISOLINES                                                   = 0x8E7A
 	IS_PER_PATCH                                               = 0x92E7
 	IS_ROW_MAJOR                                               = 0x9300
+	ITALIC_BIT_NV                                              = 0x02
 	KEEP                                                       = 0x1E00
+	LARGE_CCW_ARC_TO_NV                                        = 0x16
+	LARGE_CW_ARC_TO_NV                                         = 0x18
 	LAST_VERTEX_CONVENTION                                     = 0x8E4E
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LESS                                                       = 0x0201
+	LIGHTEN_KHR                                                = 0x9298
+	LIGHTEN_NV                                                 = 0x9298
 	LINE                                                       = 0x1B01
 	LINEAR                                                     = 0x2601
+	LINEARBURN_NV                                              = 0x92A5
+	LINEARDODGE_NV                                             = 0x92A4
+	LINEARLIGHT_NV                                             = 0x92A7
 	LINEAR_MIPMAP_LINEAR                                       = 0x2703
 	LINEAR_MIPMAP_NEAREST                                      = 0x2701
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
+	LINES_ADJACENCY_ARB                                        = 0x000A
 	LINE_LOOP                                                  = 0x0002
 	LINE_SMOOTH                                                = 0x0B20
 	LINE_SMOOTH_HINT                                           = 0x0C52
 	LINE_STRIP                                                 = 0x0003
 	LINE_STRIP_ADJACENCY                                       = 0x000B
+	LINE_STRIP_ADJACENCY_ARB                                   = 0x000B
+	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -3636,12 +6064,17 @@ const (
 	MAX_GEOMETRY_INPUT_COMPONENTS                              = 0x9123
 	MAX_GEOMETRY_OUTPUT_COMPONENTS                             = 0x9124
 	MAX_GEOMETRY_OUTPUT_VERTICES                               = 0x8DE0
+	MAX_GEOMETRY_OUTPUT_VERTICES_ARB                           = 0x8DE0
 	MAX_GEOMETRY_SHADER_INVOCATIONS                            = 0x8E5A
 	MAX_GEOMETRY_SHADER_STORAGE_BLOCKS                         = 0x90D7
 	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS                           = 0x8C29
+	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS_ARB                       = 0x8C29
 	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS                       = 0x8DE1
+	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS_ARB                   = 0x8DE1
 	MAX_GEOMETRY_UNIFORM_BLOCKS                                = 0x8A2C
 	MAX_GEOMETRY_UNIFORM_COMPONENTS                            = 0x8DDF
+	MAX_GEOMETRY_UNIFORM_COMPONENTS_ARB                        = 0x8DDF
+	MAX_GEOMETRY_VARYING_COMPONENTS_ARB                        = 0x8DDD
 	MAX_HEIGHT                                                 = 0x827F
 	MAX_IMAGE_SAMPLES                                          = 0x906D
 	MAX_IMAGE_UNITS                                            = 0x8F38
@@ -3649,6 +6082,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_MULTISAMPLE_COVERAGE_MODES_NV                          = 0x8E11
 	MAX_NAME_LENGTH                                            = 0x92F6
 	MAX_NUM_ACTIVE_VARIABLES                                   = 0x92F7
 	MAX_NUM_COMPATIBLE_SUBROUTINES                             = 0x92F8
@@ -3657,16 +6091,21 @@ const (
 	MAX_PROGRAM_TEXTURE_GATHER_COMPONENTS_ARB                  = 0x8F9F
 	MAX_PROGRAM_TEXTURE_GATHER_OFFSET                          = 0x8E5F
 	MAX_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5F
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RENDERBUFFER_SIZE                                      = 0x84E8
 	MAX_SAMPLES                                                = 0x8D57
 	MAX_SAMPLE_MASK_WORDS                                      = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
+	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SPARSE_3D_TEXTURE_SIZE_ARB                             = 0x9199
 	MAX_SPARSE_ARRAY_TEXTURE_LAYERS_ARB                        = 0x919A
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -3691,8 +6130,10 @@ const (
 	MAX_TESS_GEN_LEVEL                                         = 0x8E7E
 	MAX_TESS_PATCH_COMPONENTS                                  = 0x8E84
 	MAX_TEXTURE_BUFFER_SIZE                                    = 0x8C2B
+	MAX_TEXTURE_BUFFER_SIZE_ARB                                = 0x8C2B
 	MAX_TEXTURE_IMAGE_UNITS                                    = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TRANSFORM_FEEDBACK_BUFFERS                             = 0x8E70
 	MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS              = 0x8C8A
@@ -3717,13 +6158,18 @@ const (
 	MAX_VERTEX_UNIFORM_BLOCKS                                  = 0x8A2B
 	MAX_VERTEX_UNIFORM_COMPONENTS                              = 0x8B4A
 	MAX_VERTEX_UNIFORM_VECTORS                                 = 0x8DFB
+	MAX_VERTEX_VARYING_COMPONENTS_ARB                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
 	MINOR_VERSION                                              = 0x821C
+	MINUS_CLAMPED_NV                                           = 0x92B3
+	MINUS_NV                                                   = 0x929F
 	MIN_FRAGMENT_INTERPOLATION_OFFSET                          = 0x8E5B
 	MIN_MAP_BUFFER_ALIGNMENT                                   = 0x90BC
 	MIN_PROGRAM_TEXEL_OFFSET                                   = 0x8904
@@ -3731,11 +6177,25 @@ const (
 	MIN_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5E
 	MIN_SAMPLE_SHADING_VALUE                                   = 0x8C37
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
+	MIRRORED_REPEAT_ARB                                        = 0x8370
 	MIRROR_CLAMP_TO_EDGE                                       = 0x8743
+	MITER_REVERT_NV                                            = 0x90A7
+	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
+	MOVE_TO_CONTINUES_NV                                       = 0x90B6
+	MOVE_TO_NV                                                 = 0x02
+	MOVE_TO_RESETS_NV                                          = 0x90B5
+	MULTIPLY_KHR                                               = 0x9294
+	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
+	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	NAMED_STRING_LENGTH_ARB                                    = 0x8DE9
 	NAMED_STRING_TYPE_ARB                                      = 0x8DEA
 	NAME_LENGTH                                                = 0x92F9
@@ -3748,7 +6208,10 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
+	NORMAL_ARRAY_ADDRESS_NV                                    = 0x8F22
+	NORMAL_ARRAY_LENGTH_NV                                     = 0x8F2C
 	NOTEQUAL                                                   = 0x0205
 	NO_ERROR                                                   = 0
 	NO_RESET_NOTIFICATION                                      = 0x8261
@@ -3762,7 +6225,10 @@ const (
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
 	NUM_SHADING_LANGUAGE_VERSIONS                              = 0x82E9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_TYPE                                                = 0x9112
 	OFFSET                                                     = 0x92FC
 	ONE                                                        = 1
@@ -3778,6 +6244,8 @@ const (
 	OR_INVERTED                                                = 0x150D
 	OR_REVERSE                                                 = 0x150B
 	OUT_OF_MEMORY                                              = 0x0505
+	OVERLAY_KHR                                                = 0x9296
+	OVERLAY_NV                                                 = 0x9296
 	PACK_ALIGNMENT                                             = 0x0D05
 	PACK_COMPRESSED_BLOCK_DEPTH                                = 0x912D
 	PACK_COMPRESSED_BLOCK_HEIGHT                               = 0x912C
@@ -3796,11 +6264,90 @@ const (
 	PATCH_DEFAULT_INNER_LEVEL                                  = 0x8E73
 	PATCH_DEFAULT_OUTER_LEVEL                                  = 0x8E74
 	PATCH_VERTICES                                             = 0x8E72
+	PATH_CLIENT_LENGTH_NV                                      = 0x907F
+	PATH_COMMAND_COUNT_NV                                      = 0x909D
+	PATH_COMPUTED_LENGTH_NV                                    = 0x90A0
+	PATH_COORD_COUNT_NV                                        = 0x909E
+	PATH_COVER_DEPTH_FUNC_NV                                   = 0x90BF
+	PATH_DASH_ARRAY_COUNT_NV                                   = 0x909F
+	PATH_DASH_CAPS_NV                                          = 0x907B
+	PATH_DASH_OFFSET_NV                                        = 0x907E
+	PATH_DASH_OFFSET_RESET_NV                                  = 0x90B4
+	PATH_END_CAPS_NV                                           = 0x9076
+	PATH_ERROR_POSITION_NV                                     = 0x90AB
+	PATH_FILL_BOUNDING_BOX_NV                                  = 0x90A1
+	PATH_FILL_COVER_MODE_NV                                    = 0x9082
+	PATH_FILL_MASK_NV                                          = 0x9081
+	PATH_FILL_MODE_NV                                          = 0x9080
+	PATH_FORMAT_PS_NV                                          = 0x9071
+	PATH_FORMAT_SVG_NV                                         = 0x9070
+	PATH_GEN_COEFF_NV                                          = 0x90B1
+	PATH_GEN_COMPONENTS_NV                                     = 0x90B3
+	PATH_GEN_MODE_NV                                           = 0x90B0
+	PATH_INITIAL_DASH_CAP_NV                                   = 0x907C
+	PATH_INITIAL_END_CAP_NV                                    = 0x9077
+	PATH_JOIN_STYLE_NV                                         = 0x9079
+	PATH_MAX_MODELVIEW_STACK_DEPTH_NV                          = 0x0D36
+	PATH_MAX_PROJECTION_STACK_DEPTH_NV                         = 0x0D38
+	PATH_MITER_LIMIT_NV                                        = 0x907A
+	PATH_MODELVIEW_MATRIX_NV                                   = 0x0BA6
+	PATH_MODELVIEW_NV                                          = 0x1700
+	PATH_MODELVIEW_STACK_DEPTH_NV                              = 0x0BA3
+	PATH_OBJECT_BOUNDING_BOX_NV                                = 0x908A
+	PATH_PROJECTION_MATRIX_NV                                  = 0x0BA7
+	PATH_PROJECTION_NV                                         = 0x1701
+	PATH_PROJECTION_STACK_DEPTH_NV                             = 0x0BA4
+	PATH_STENCIL_DEPTH_OFFSET_FACTOR_NV                        = 0x90BD
+	PATH_STENCIL_DEPTH_OFFSET_UNITS_NV                         = 0x90BE
+	PATH_STENCIL_FUNC_NV                                       = 0x90B7
+	PATH_STENCIL_REF_NV                                        = 0x90B8
+	PATH_STENCIL_VALUE_MASK_NV                                 = 0x90B9
+	PATH_STROKE_BOUNDING_BOX_NV                                = 0x90A2
+	PATH_STROKE_COVER_MODE_NV                                  = 0x9083
+	PATH_STROKE_MASK_NV                                        = 0x9084
+	PATH_STROKE_WIDTH_NV                                       = 0x9075
+	PATH_TERMINAL_DASH_CAP_NV                                  = 0x907D
+	PATH_TERMINAL_END_CAP_NV                                   = 0x9078
+	PATH_TRANSPOSE_MODELVIEW_MATRIX_NV                         = 0x84E3
+	PATH_TRANSPOSE_PROJECTION_MATRIX_NV                        = 0x84E4
+	PERCENTAGE_AMD                                             = 0x8BC3
+	PERFMON_RESULT_AMD                                         = 0x8BC6
+	PERFMON_RESULT_AVAILABLE_AMD                               = 0x8BC4
+	PERFMON_RESULT_SIZE_AMD                                    = 0x8BC5
+	PERFQUERY_COUNTER_DATA_BOOL32_INTEL                        = 0x94FC
+	PERFQUERY_COUNTER_DATA_DOUBLE_INTEL                        = 0x94FB
+	PERFQUERY_COUNTER_DATA_FLOAT_INTEL                         = 0x94FA
+	PERFQUERY_COUNTER_DATA_UINT32_INTEL                        = 0x94F8
+	PERFQUERY_COUNTER_DATA_UINT64_INTEL                        = 0x94F9
+	PERFQUERY_COUNTER_DESC_LENGTH_MAX_INTEL                    = 0x94FF
+	PERFQUERY_COUNTER_DURATION_NORM_INTEL                      = 0x94F1
+	PERFQUERY_COUNTER_DURATION_RAW_INTEL                       = 0x94F2
+	PERFQUERY_COUNTER_EVENT_INTEL                              = 0x94F0
+	PERFQUERY_COUNTER_NAME_LENGTH_MAX_INTEL                    = 0x94FE
+	PERFQUERY_COUNTER_RAW_INTEL                                = 0x94F4
+	PERFQUERY_COUNTER_THROUGHPUT_INTEL                         = 0x94F3
+	PERFQUERY_COUNTER_TIMESTAMP_INTEL                          = 0x94F5
+	PERFQUERY_DONOT_FLUSH_INTEL                                = 0x83F9
+	PERFQUERY_FLUSH_INTEL                                      = 0x83FA
+	PERFQUERY_GLOBAL_CONTEXT_INTEL                             = 0x00000001
+	PERFQUERY_GPA_EXTENDED_COUNTERS_INTEL                      = 0x9500
+	PERFQUERY_QUERY_NAME_LENGTH_MAX_INTEL                      = 0x94FD
+	PERFQUERY_SINGLE_CONTEXT_INTEL                             = 0x00000000
+	PERFQUERY_WAIT_INTEL                                       = 0x83FB
+	PINLIGHT_NV                                                = 0x92A8
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_PACK_BUFFER                                          = 0x88EB
+	PIXEL_PACK_BUFFER_ARB                                      = 0x88EB
 	PIXEL_PACK_BUFFER_BINDING                                  = 0x88ED
+	PIXEL_PACK_BUFFER_BINDING_ARB                              = 0x88ED
 	PIXEL_UNPACK_BUFFER                                        = 0x88EC
+	PIXEL_UNPACK_BUFFER_ARB                                    = 0x88EC
 	PIXEL_UNPACK_BUFFER_BINDING                                = 0x88EF
+	PIXEL_UNPACK_BUFFER_BINDING_ARB                            = 0x88EF
+	PLUS_CLAMPED_ALPHA_NV                                      = 0x92B2
+	PLUS_CLAMPED_NV                                            = 0x92B1
+	PLUS_DARKER_NV                                             = 0x9292
+	PLUS_NV                                                    = 0x9291
 	POINT                                                      = 0x1B00
 	POINTS                                                     = 0x0000
 	POINT_FADE_THRESHOLD_SIZE                                  = 0x8128
@@ -3809,6 +6356,9 @@ const (
 	POINT_SIZE_RANGE                                           = 0x0B12
 	POINT_SPRITE_COORD_ORIGIN                                  = 0x8CA0
 	POLYGON_MODE                                               = 0x0B40
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FILL                                        = 0x8037
 	POLYGON_OFFSET_LINE                                        = 0x2A02
@@ -3818,20 +6368,33 @@ const (
 	POLYGON_SMOOTH_HINT                                        = 0x0C53
 	PRIMITIVES_GENERATED                                       = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
 	PRIMITIVE_RESTART_INDEX                                    = 0x8F9E
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_INPUT                                              = 0x92E3
 	PROGRAM_KHR                                                = 0x82E2
+	PROGRAM_MATRIX_EXT                                         = 0x8E2D
+	PROGRAM_MATRIX_STACK_DEPTH_EXT                             = 0x8E2F
+	PROGRAM_OBJECT_EXT                                         = 0x8B40
 	PROGRAM_OUTPUT                                             = 0x92E4
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
+	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
+	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
+	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
 	PROGRAM_SEPARABLE                                          = 0x8258
+	PROGRAM_SEPARABLE_EXT                                      = 0x8258
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROXY_TEXTURE_1D                                           = 0x8063
 	PROXY_TEXTURE_1D_ARRAY                                     = 0x8C19
@@ -3844,6 +6407,7 @@ const (
 	PROXY_TEXTURE_CUBE_MAP_ARRAY                               = 0x900B
 	PROXY_TEXTURE_CUBE_MAP_ARRAY_ARB                           = 0x900B
 	PROXY_TEXTURE_RECTANGLE                                    = 0x84F7
+	QUADRATIC_CURVE_TO_NV                                      = 0x0A
 	QUADS                                                      = 0x0007
 	QUADS_FOLLOW_PROVOKING_VERTEX_CONVENTION                   = 0x8E4C
 	QUERY                                                      = 0x82E3
@@ -3852,18 +6416,23 @@ const (
 	QUERY_BUFFER_BINDING                                       = 0x9193
 	QUERY_BY_REGION_NO_WAIT                                    = 0x8E16
 	QUERY_BY_REGION_NO_WAIT_INVERTED                           = 0x8E1A
+	QUERY_BY_REGION_NO_WAIT_NV                                 = 0x8E16
 	QUERY_BY_REGION_WAIT                                       = 0x8E15
 	QUERY_BY_REGION_WAIT_INVERTED                              = 0x8E19
+	QUERY_BY_REGION_WAIT_NV                                    = 0x8E15
 	QUERY_COUNTER_BITS                                         = 0x8864
 	QUERY_KHR                                                  = 0x82E3
 	QUERY_NO_WAIT                                              = 0x8E14
 	QUERY_NO_WAIT_INVERTED                                     = 0x8E18
+	QUERY_NO_WAIT_NV                                           = 0x8E14
+	QUERY_OBJECT_EXT                                           = 0x9153
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
 	QUERY_RESULT_NO_WAIT                                       = 0x9194
 	QUERY_TARGET                                               = 0x82EA
 	QUERY_WAIT                                                 = 0x8E13
 	QUERY_WAIT_INVERTED                                        = 0x8E17
+	QUERY_WAIT_NV                                              = 0x8E13
 	R11F_G11F_B10F                                             = 0x8C3A
 	R16                                                        = 0x822A
 	R16F                                                       = 0x822D
@@ -3879,6 +6448,9 @@ const (
 	R8UI                                                       = 0x8232
 	R8_SNORM                                                   = 0x8F94
 	RASTERIZER_DISCARD                                         = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -3887,18 +6459,41 @@ const (
 	READ_PIXELS_FORMAT                                         = 0x828D
 	READ_PIXELS_TYPE                                           = 0x828E
 	READ_WRITE                                                 = 0x88BA
+	RECT_NV                                                    = 0xF6
 	RED                                                        = 0x1903
 	RED_INTEGER                                                = 0x8D94
+	RED_NV                                                     = 0x1903
 	REFERENCED_BY_COMPUTE_SHADER                               = 0x930B
 	REFERENCED_BY_FRAGMENT_SHADER                              = 0x930A
 	REFERENCED_BY_GEOMETRY_SHADER                              = 0x9309
 	REFERENCED_BY_TESS_CONTROL_SHADER                          = 0x9307
 	REFERENCED_BY_TESS_EVALUATION_SHADER                       = 0x9308
 	REFERENCED_BY_VERTEX_SHADER                                = 0x9306
+	RELATIVE_ARC_TO_NV                                         = 0xFF
+	RELATIVE_CONIC_CURVE_TO_NV                                 = 0x1B
+	RELATIVE_CUBIC_CURVE_TO_NV                                 = 0x0D
+	RELATIVE_HORIZONTAL_LINE_TO_NV                             = 0x07
+	RELATIVE_LARGE_CCW_ARC_TO_NV                               = 0x17
+	RELATIVE_LARGE_CW_ARC_TO_NV                                = 0x19
+	RELATIVE_LINE_TO_NV                                        = 0x05
+	RELATIVE_MOVE_TO_NV                                        = 0x03
+	RELATIVE_QUADRATIC_CURVE_TO_NV                             = 0x0B
+	RELATIVE_RECT_NV                                           = 0xF7
+	RELATIVE_ROUNDED_RECT2_NV                                  = 0xEB
+	RELATIVE_ROUNDED_RECT4_NV                                  = 0xED
+	RELATIVE_ROUNDED_RECT8_NV                                  = 0xEF
+	RELATIVE_ROUNDED_RECT_NV                                   = 0xE9
+	RELATIVE_SMALL_CCW_ARC_TO_NV                               = 0x13
+	RELATIVE_SMALL_CW_ARC_TO_NV                                = 0x15
+	RELATIVE_SMOOTH_CUBIC_CURVE_TO_NV                          = 0x11
+	RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV                      = 0x0F
+	RELATIVE_VERTICAL_LINE_TO_NV                               = 0x09
 	RENDERBUFFER                                               = 0x8D41
 	RENDERBUFFER_ALPHA_SIZE                                    = 0x8D53
 	RENDERBUFFER_BINDING                                       = 0x8CA7
 	RENDERBUFFER_BLUE_SIZE                                     = 0x8D52
+	RENDERBUFFER_COLOR_SAMPLES_NV                              = 0x8E10
+	RENDERBUFFER_COVERAGE_SAMPLES_NV                           = 0x8CAB
 	RENDERBUFFER_DEPTH_SIZE                                    = 0x8D54
 	RENDERBUFFER_GREEN_SIZE                                    = 0x8D51
 	RENDERBUFFER_HEIGHT                                        = 0x8D43
@@ -3913,6 +6508,7 @@ const (
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
 	RESET_NOTIFICATION_STRATEGY_ARB                            = 0x8256
 	RESET_NOTIFICATION_STRATEGY_KHR                            = 0x8256
+	RESTART_PATH_NV                                            = 0xF0
 	RG                                                         = 0x8227
 	RG16                                                       = 0x822C
 	RG16F                                                      = 0x822F
@@ -3965,9 +6561,16 @@ const (
 	RGBA8UI                                                    = 0x8D7C
 	RGBA8_SNORM                                                = 0x8F97
 	RGBA_INTEGER                                               = 0x8D99
+	RGB_422_APPLE                                              = 0x8A1F
 	RGB_INTEGER                                                = 0x8D98
+	RGB_RAW_422_APPLE                                          = 0x8A51
 	RG_INTEGER                                                 = 0x8228
 	RIGHT                                                      = 0x0407
+	ROUNDED_RECT2_NV                                           = 0xEA
+	ROUNDED_RECT4_NV                                           = 0xEC
+	ROUNDED_RECT8_NV                                           = 0xEE
+	ROUNDED_RECT_NV                                            = 0xE8
+	ROUND_NV                                                   = 0x90A4
 	SAMPLER                                                    = 0x82E6
 	SAMPLER_1D                                                 = 0x8B5D
 	SAMPLER_1D_ARRAY                                           = 0x8DC0
@@ -3999,24 +6602,40 @@ const (
 	SAMPLE_COVERAGE                                            = 0x80A0
 	SAMPLE_COVERAGE_INVERT                                     = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_VALUE                                          = 0x8E52
 	SAMPLE_POSITION                                            = 0x8E50
 	SAMPLE_SHADING                                             = 0x8C36
 	SAMPLE_SHADING_ARB                                         = 0x8C36
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
+	SCREEN_KHR                                                 = 0x9295
+	SCREEN_NV                                                  = 0x9295
+	SECONDARY_COLOR_ARRAY_ADDRESS_NV                           = 0x8F27
+	SECONDARY_COLOR_ARRAY_LENGTH_NV                            = 0x8F31
 	SEPARATE_ATTRIBS                                           = 0x8C8D
 	SET                                                        = 0x150F
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
+	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
 	SHADER_IMAGE_ACCESS_BARRIER_BIT                            = 0x00000020
 	SHADER_IMAGE_ATOMIC                                        = 0x82A6
 	SHADER_IMAGE_LOAD                                          = 0x82A4
 	SHADER_IMAGE_STORE                                         = 0x82A5
 	SHADER_INCLUDE_ARB                                         = 0x8DAE
 	SHADER_KHR                                                 = 0x82E1
+	SHADER_OBJECT_EXT                                          = 0x8B48
 	SHADER_SOURCE_LENGTH                                       = 0x8B88
 	SHADER_STORAGE_BARRIER_BIT                                 = 0x00002000
 	SHADER_STORAGE_BLOCK                                       = 0x92E6
@@ -4027,6 +6646,7 @@ const (
 	SHADER_STORAGE_BUFFER_START                                = 0x90D4
 	SHADER_TYPE                                                = 0x8B4F
 	SHADING_LANGUAGE_VERSION                                   = 0x8B8C
+	SHARED_EDGE_NV                                             = 0xC0
 	SHORT                                                      = 0x1402
 	SIGNALED                                                   = 0x9119
 	SIGNED_NORMALIZED                                          = 0x8F9C
@@ -4034,18 +6654,35 @@ const (
 	SIMULTANEOUS_TEXTURE_AND_DEPTH_WRITE                       = 0x82AE
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_TEST                      = 0x82AD
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_WRITE                     = 0x82AF
+	SKIP_DECODE_EXT                                            = 0x8A4A
+	SKIP_MISSING_GLYPH_NV                                      = 0x90A9
+	SMALL_CCW_ARC_TO_NV                                        = 0x12
+	SMALL_CW_ARC_TO_NV                                         = 0x14
+	SMOOTH_CUBIC_CURVE_TO_NV                                   = 0x10
 	SMOOTH_LINE_WIDTH_GRANULARITY                              = 0x0B23
 	SMOOTH_LINE_WIDTH_RANGE                                    = 0x0B22
 	SMOOTH_POINT_SIZE_GRANULARITY                              = 0x0B13
 	SMOOTH_POINT_SIZE_RANGE                                    = 0x0B12
+	SMOOTH_QUADRATIC_CURVE_TO_NV                               = 0x0E
+	SM_COUNT_NV                                                = 0x933B
+	SOFTLIGHT_KHR                                              = 0x929C
+	SOFTLIGHT_NV                                               = 0x929C
 	SPARSE_BUFFER_PAGE_SIZE_ARB                                = 0x82F8
 	SPARSE_STORAGE_BIT_ARB                                     = 0x0400
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
+	SQUARE_NV                                                  = 0x90A3
 	SRC1_ALPHA                                                 = 0x8589
 	SRC1_COLOR                                                 = 0x88F9
 	SRC_ALPHA                                                  = 0x0302
 	SRC_ALPHA_SATURATE                                         = 0x0308
+	SRC_ATOP_NV                                                = 0x928E
 	SRC_COLOR                                                  = 0x0300
+	SRC_IN_NV                                                  = 0x928A
+	SRC_NV                                                     = 0x9286
+	SRC_OUT_NV                                                 = 0x928C
+	SRC_OVER_NV                                                = 0x9288
 	SRGB                                                       = 0x8C40
 	SRGB8                                                      = 0x8C41
 	SRGB8_ALPHA8                                               = 0x8C43
@@ -4057,6 +6694,8 @@ const (
 	STACK_OVERFLOW_KHR                                         = 0x0503
 	STACK_UNDERFLOW                                            = 0x0504
 	STACK_UNDERFLOW_KHR                                        = 0x0504
+	STANDARD_FONT_FORMAT_NV                                    = 0x936C
+	STANDARD_FONT_NAME_NV                                      = 0x9072
 	STATIC_COPY                                                = 0x88E6
 	STATIC_DRAW                                                = 0x88E4
 	STATIC_READ                                                = 0x88E5
@@ -4082,7 +6721,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_VALUE_MASK                                         = 0x0B93
 	STENCIL_WRITEMASK                                          = 0x0B98
@@ -4091,6 +6732,10 @@ const (
 	STREAM_DRAW                                                = 0x88E0
 	STREAM_READ                                                = 0x88E1
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SYNC_CL_EVENT_ARB                                          = 0x8240
 	SYNC_CL_EVENT_COMPLETE_ARB                                 = 0x8241
 	SYNC_CONDITION                                             = 0x9113
@@ -4099,6 +6744,8 @@ const (
 	SYNC_FLUSH_COMMANDS_BIT                                    = 0x00000001
 	SYNC_GPU_COMMANDS_COMPLETE                                 = 0x9117
 	SYNC_STATUS                                                = 0x9114
+	SYSTEM_FONT_NAME_NV                                        = 0x9073
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
 	TESS_CONTROL_SHADER                                        = 0x8E88
 	TESS_CONTROL_SHADER_BIT                                    = 0x00000008
@@ -4159,7 +6806,6 @@ const (
 	TEXTURE_ALPHA_SIZE                                         = 0x805F
 	TEXTURE_ALPHA_TYPE                                         = 0x8C13
 	TEXTURE_BASE_LEVEL                                         = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_2D                                         = 0x8069
@@ -4168,6 +6814,7 @@ const (
 	TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY                       = 0x9105
 	TEXTURE_BINDING_3D                                         = 0x806A
 	TEXTURE_BINDING_BUFFER                                     = 0x8C2C
+	TEXTURE_BINDING_BUFFER_ARB                                 = 0x8C2C
 	TEXTURE_BINDING_CUBE_MAP                                   = 0x8514
 	TEXTURE_BINDING_CUBE_MAP_ARRAY                             = 0x900A
 	TEXTURE_BINDING_CUBE_MAP_ARRAY_ARB                         = 0x900A
@@ -4176,7 +6823,10 @@ const (
 	TEXTURE_BLUE_TYPE                                          = 0x8C12
 	TEXTURE_BORDER_COLOR                                       = 0x1004
 	TEXTURE_BUFFER                                             = 0x8C2A
+	TEXTURE_BUFFER_ARB                                         = 0x8C2A
 	TEXTURE_BUFFER_DATA_STORE_BINDING                          = 0x8C2D
+	TEXTURE_BUFFER_DATA_STORE_BINDING_ARB                      = 0x8C2D
+	TEXTURE_BUFFER_FORMAT_ARB                                  = 0x8C2E
 	TEXTURE_BUFFER_OFFSET                                      = 0x919D
 	TEXTURE_BUFFER_OFFSET_ALIGNMENT                            = 0x919F
 	TEXTURE_BUFFER_SIZE                                        = 0x919E
@@ -4188,6 +6838,8 @@ const (
 	TEXTURE_COMPRESSED_BLOCK_WIDTH                             = 0x82B1
 	TEXTURE_COMPRESSED_IMAGE_SIZE                              = 0x86A0
 	TEXTURE_COMPRESSION_HINT                                   = 0x84EF
+	TEXTURE_COORD_ARRAY_ADDRESS_NV                             = 0x8F25
+	TEXTURE_COORD_ARRAY_LENGTH_NV                              = 0x8F2F
 	TEXTURE_CUBE_MAP                                           = 0x8513
 	TEXTURE_CUBE_MAP_ARRAY                                     = 0x9009
 	TEXTURE_CUBE_MAP_ARRAY_ARB                                 = 0x9009
@@ -4215,17 +6867,21 @@ const (
 	TEXTURE_INTERNAL_FORMAT                                    = 0x1003
 	TEXTURE_LOD_BIAS                                           = 0x8501
 	TEXTURE_MAG_FILTER                                         = 0x2800
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_LEVEL                                          = 0x813D
 	TEXTURE_MAX_LOD                                            = 0x813B
 	TEXTURE_MIN_FILTER                                         = 0x2801
 	TEXTURE_MIN_LOD                                            = 0x813A
 	TEXTURE_RECTANGLE                                          = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
 	TEXTURE_SAMPLES                                            = 0x9106
 	TEXTURE_SHADOW                                             = 0x82A1
 	TEXTURE_SHARED_SIZE                                        = 0x8C3F
 	TEXTURE_SPARSE_ARB                                         = 0x91A6
+	TEXTURE_SRGB_DECODE_EXT                                    = 0x8A48
 	TEXTURE_STENCIL_SIZE                                       = 0x88F1
 	TEXTURE_SWIZZLE_A                                          = 0x8E45
 	TEXTURE_SWIZZLE_B                                          = 0x8E44
@@ -4269,15 +6925,27 @@ const (
 	TRANSFORM_FEEDBACK_VARYING                                 = 0x92F4
 	TRANSFORM_FEEDBACK_VARYINGS                                = 0x8C83
 	TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH                      = 0x8C76
+	TRANSLATE_2D_NV                                            = 0x9090
+	TRANSLATE_3D_NV                                            = 0x9091
+	TRANSLATE_X_NV                                             = 0x908E
+	TRANSLATE_Y_NV                                             = 0x908F
+	TRANSPOSE_AFFINE_2D_NV                                     = 0x9096
+	TRANSPOSE_AFFINE_3D_NV                                     = 0x9098
+	TRANSPOSE_PROGRAM_MATRIX_EXT                               = 0x8E2E
 	TRIANGLES                                                  = 0x0004
 	TRIANGLES_ADJACENCY                                        = 0x000C
+	TRIANGLES_ADJACENCY_ARB                                    = 0x000C
 	TRIANGLE_FAN                                               = 0x0006
 	TRIANGLE_STRIP                                             = 0x0005
 	TRIANGLE_STRIP_ADJACENCY                                   = 0x000D
+	TRIANGLE_STRIP_ADJACENCY_ARB                               = 0x000D
+	TRIANGULAR_NV                                              = 0x90A5
 	TRUE                                                       = 1
 	TYPE                                                       = 0x92FA
+	UNCORRELATED_NV                                            = 0x9282
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -4295,10 +6963,13 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -4325,7 +6996,23 @@ const (
 	UNSIGNED_BYTE_2_3_3_REV                                    = 0x8362
 	UNSIGNED_BYTE_3_3_2                                        = 0x8032
 	UNSIGNED_INT                                               = 0x1405
+	UNSIGNED_INT16_NV                                          = 0x8FF0
+	UNSIGNED_INT16_VEC2_NV                                     = 0x8FF1
+	UNSIGNED_INT16_VEC3_NV                                     = 0x8FF2
+	UNSIGNED_INT16_VEC4_NV                                     = 0x8FF3
+	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
+	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
+	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
+	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
+	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
+	UNSIGNED_INT8_NV                                           = 0x8FEC
+	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
+	UNSIGNED_INT8_VEC3_NV                                      = 0x8FEE
+	UNSIGNED_INT8_VEC4_NV                                      = 0x8FEF
 	UNSIGNED_INT_10F_11F_11F_REV                               = 0x8C3B
 	UNSIGNED_INT_10_10_10_2                                    = 0x8036
 	UNSIGNED_INT_24_8                                          = 0x84FA
@@ -4368,24 +7055,36 @@ const (
 	UNSIGNED_SHORT_5_5_5_1                                     = 0x8034
 	UNSIGNED_SHORT_5_6_5                                       = 0x8363
 	UNSIGNED_SHORT_5_6_5_REV                                   = 0x8364
+	UNSIGNED_SHORT_8_8_APPLE                                   = 0x85BA
+	UNSIGNED_SHORT_8_8_REV_APPLE                               = 0x85BB
 	UPPER_LEFT                                                 = 0x8CA2
+	USE_MISSING_GLYPH_NV                                       = 0x90AA
+	UTF16_NV                                                   = 0x909B
+	UTF8_NV                                                    = 0x909A
 	VALIDATE_STATUS                                            = 0x8B83
 	VENDOR                                                     = 0x1F00
 	VERSION                                                    = 0x1F02
 	VERTEX_ARRAY                                               = 0x8074
+	VERTEX_ARRAY_ADDRESS_NV                                    = 0x8F21
 	VERTEX_ARRAY_BINDING                                       = 0x85B5
 	VERTEX_ARRAY_KHR                                           = 0x8074
+	VERTEX_ARRAY_LENGTH_NV                                     = 0x8F2B
+	VERTEX_ARRAY_OBJECT_EXT                                    = 0x9154
+	VERTEX_ATTRIB_ARRAY_ADDRESS_NV                             = 0x8F20
 	VERTEX_ATTRIB_ARRAY_BARRIER_BIT                            = 0x00000001
 	VERTEX_ATTRIB_ARRAY_BUFFER_BINDING                         = 0x889F
 	VERTEX_ATTRIB_ARRAY_DIVISOR                                = 0x88FE
+	VERTEX_ATTRIB_ARRAY_DIVISOR_ARB                            = 0x88FE
 	VERTEX_ATTRIB_ARRAY_ENABLED                                = 0x8622
 	VERTEX_ATTRIB_ARRAY_INTEGER                                = 0x88FD
+	VERTEX_ATTRIB_ARRAY_LENGTH_NV                              = 0x8F2A
 	VERTEX_ATTRIB_ARRAY_LONG                                   = 0x874E
 	VERTEX_ATTRIB_ARRAY_NORMALIZED                             = 0x886A
 	VERTEX_ATTRIB_ARRAY_POINTER                                = 0x8645
 	VERTEX_ATTRIB_ARRAY_SIZE                                   = 0x8623
 	VERTEX_ATTRIB_ARRAY_STRIDE                                 = 0x8624
 	VERTEX_ATTRIB_ARRAY_TYPE                                   = 0x8625
+	VERTEX_ATTRIB_ARRAY_UNIFIED_NV                             = 0x8F1E
 	VERTEX_ATTRIB_BINDING                                      = 0x82D4
 	VERTEX_ATTRIB_RELATIVE_OFFSET                              = 0x82D5
 	VERTEX_BINDING_BUFFER                                      = 0x8F4F
@@ -4395,15 +7094,33 @@ const (
 	VERTEX_PROGRAM_POINT_SIZE                                  = 0x8642
 	VERTEX_SHADER                                              = 0x8B31
 	VERTEX_SHADER_BIT                                          = 0x00000001
+	VERTEX_SHADER_BIT_EXT                                      = 0x00000001
 	VERTEX_SHADER_INVOCATIONS_ARB                              = 0x82F0
 	VERTEX_SUBROUTINE                                          = 0x92E8
 	VERTEX_SUBROUTINE_UNIFORM                                  = 0x92EE
 	VERTEX_TEXTURE                                             = 0x829B
+	VERTICAL_LINE_TO_NV                                        = 0x08
 	VERTICES_SUBMITTED_ARB                                     = 0x82EE
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -4425,723 +7142,1284 @@ const (
 	VIRTUAL_PAGE_SIZE_X_ARB                                    = 0x9195
 	VIRTUAL_PAGE_SIZE_Y_ARB                                    = 0x9196
 	VIRTUAL_PAGE_SIZE_Z_ARB                                    = 0x9197
+	VIVIDLIGHT_NV                                              = 0x92A6
 	WAIT_FAILED                                                = 0x911D
+	WARPS_PER_SM_NV                                            = 0x933A
+	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRITE_ONLY                                                 = 0x88B9
 	XOR                                                        = 0x1506
+	XOR_NV                                                     = 0x1506
 	ZERO                                                       = 0
 	ZERO_TO_ONE                                                = 0x935F
 )
 
 var (
-	gpActiveShaderProgram                         C.GPACTIVESHADERPROGRAM
-	gpActiveTexture                               C.GPACTIVETEXTURE
-	gpAttachShader                                C.GPATTACHSHADER
-	gpBeginConditionalRender                      C.GPBEGINCONDITIONALRENDER
-	gpBeginQuery                                  C.GPBEGINQUERY
-	gpBeginQueryIndexed                           C.GPBEGINQUERYINDEXED
-	gpBeginTransformFeedback                      C.GPBEGINTRANSFORMFEEDBACK
-	gpBindAttribLocation                          C.GPBINDATTRIBLOCATION
-	gpBindBuffer                                  C.GPBINDBUFFER
-	gpBindBufferBase                              C.GPBINDBUFFERBASE
-	gpBindBufferRange                             C.GPBINDBUFFERRANGE
-	gpBindBuffersBase                             C.GPBINDBUFFERSBASE
-	gpBindBuffersRange                            C.GPBINDBUFFERSRANGE
-	gpBindFragDataLocation                        C.GPBINDFRAGDATALOCATION
-	gpBindFragDataLocationIndexed                 C.GPBINDFRAGDATALOCATIONINDEXED
-	gpBindFramebuffer                             C.GPBINDFRAMEBUFFER
-	gpBindImageTexture                            C.GPBINDIMAGETEXTURE
-	gpBindImageTextures                           C.GPBINDIMAGETEXTURES
-	gpBindProgramPipeline                         C.GPBINDPROGRAMPIPELINE
-	gpBindRenderbuffer                            C.GPBINDRENDERBUFFER
-	gpBindSampler                                 C.GPBINDSAMPLER
-	gpBindSamplers                                C.GPBINDSAMPLERS
-	gpBindTexture                                 C.GPBINDTEXTURE
-	gpBindTextureUnit                             C.GPBINDTEXTUREUNIT
-	gpBindTextures                                C.GPBINDTEXTURES
-	gpBindTransformFeedback                       C.GPBINDTRANSFORMFEEDBACK
-	gpBindVertexArray                             C.GPBINDVERTEXARRAY
-	gpBindVertexBuffer                            C.GPBINDVERTEXBUFFER
-	gpBindVertexBuffers                           C.GPBINDVERTEXBUFFERS
-	gpBlendColor                                  C.GPBLENDCOLOR
-	gpBlendEquation                               C.GPBLENDEQUATION
-	gpBlendEquationSeparate                       C.GPBLENDEQUATIONSEPARATE
-	gpBlendEquationSeparatei                      C.GPBLENDEQUATIONSEPARATEI
-	gpBlendEquationSeparateiARB                   C.GPBLENDEQUATIONSEPARATEIARB
-	gpBlendEquationi                              C.GPBLENDEQUATIONI
-	gpBlendEquationiARB                           C.GPBLENDEQUATIONIARB
-	gpBlendFunc                                   C.GPBLENDFUNC
-	gpBlendFuncSeparate                           C.GPBLENDFUNCSEPARATE
-	gpBlendFuncSeparatei                          C.GPBLENDFUNCSEPARATEI
-	gpBlendFuncSeparateiARB                       C.GPBLENDFUNCSEPARATEIARB
-	gpBlendFunci                                  C.GPBLENDFUNCI
-	gpBlendFunciARB                               C.GPBLENDFUNCIARB
-	gpBlitFramebuffer                             C.GPBLITFRAMEBUFFER
-	gpBlitNamedFramebuffer                        C.GPBLITNAMEDFRAMEBUFFER
-	gpBufferData                                  C.GPBUFFERDATA
-	gpBufferPageCommitmentARB                     C.GPBUFFERPAGECOMMITMENTARB
-	gpBufferStorage                               C.GPBUFFERSTORAGE
-	gpBufferSubData                               C.GPBUFFERSUBDATA
-	gpCheckFramebufferStatus                      C.GPCHECKFRAMEBUFFERSTATUS
-	gpCheckNamedFramebufferStatus                 C.GPCHECKNAMEDFRAMEBUFFERSTATUS
-	gpClampColor                                  C.GPCLAMPCOLOR
-	gpClear                                       C.GPCLEAR
-	gpClearBufferData                             C.GPCLEARBUFFERDATA
-	gpClearBufferSubData                          C.GPCLEARBUFFERSUBDATA
-	gpClearBufferfi                               C.GPCLEARBUFFERFI
-	gpClearBufferfv                               C.GPCLEARBUFFERFV
-	gpClearBufferiv                               C.GPCLEARBUFFERIV
-	gpClearBufferuiv                              C.GPCLEARBUFFERUIV
-	gpClearColor                                  C.GPCLEARCOLOR
-	gpClearDepth                                  C.GPCLEARDEPTH
-	gpClearDepthf                                 C.GPCLEARDEPTHF
-	gpClearNamedBufferData                        C.GPCLEARNAMEDBUFFERDATA
-	gpClearNamedBufferSubData                     C.GPCLEARNAMEDBUFFERSUBDATA
-	gpClearNamedFramebufferfi                     C.GPCLEARNAMEDFRAMEBUFFERFI
-	gpClearNamedFramebufferfv                     C.GPCLEARNAMEDFRAMEBUFFERFV
-	gpClearNamedFramebufferiv                     C.GPCLEARNAMEDFRAMEBUFFERIV
-	gpClearNamedFramebufferuiv                    C.GPCLEARNAMEDFRAMEBUFFERUIV
-	gpClearStencil                                C.GPCLEARSTENCIL
-	gpClearTexImage                               C.GPCLEARTEXIMAGE
-	gpClearTexSubImage                            C.GPCLEARTEXSUBIMAGE
-	gpClientWaitSync                              C.GPCLIENTWAITSYNC
-	gpClipControl                                 C.GPCLIPCONTROL
-	gpColorMask                                   C.GPCOLORMASK
-	gpColorMaski                                  C.GPCOLORMASKI
-	gpCompileShader                               C.GPCOMPILESHADER
-	gpCompileShaderIncludeARB                     C.GPCOMPILESHADERINCLUDEARB
-	gpCompressedTexImage1D                        C.GPCOMPRESSEDTEXIMAGE1D
-	gpCompressedTexImage2D                        C.GPCOMPRESSEDTEXIMAGE2D
-	gpCompressedTexImage3D                        C.GPCOMPRESSEDTEXIMAGE3D
-	gpCompressedTexSubImage1D                     C.GPCOMPRESSEDTEXSUBIMAGE1D
-	gpCompressedTexSubImage2D                     C.GPCOMPRESSEDTEXSUBIMAGE2D
-	gpCompressedTexSubImage3D                     C.GPCOMPRESSEDTEXSUBIMAGE3D
-	gpCompressedTextureSubImage1D                 C.GPCOMPRESSEDTEXTURESUBIMAGE1D
-	gpCompressedTextureSubImage2D                 C.GPCOMPRESSEDTEXTURESUBIMAGE2D
-	gpCompressedTextureSubImage3D                 C.GPCOMPRESSEDTEXTURESUBIMAGE3D
-	gpCopyBufferSubData                           C.GPCOPYBUFFERSUBDATA
-	gpCopyImageSubData                            C.GPCOPYIMAGESUBDATA
-	gpCopyNamedBufferSubData                      C.GPCOPYNAMEDBUFFERSUBDATA
-	gpCopyTexImage1D                              C.GPCOPYTEXIMAGE1D
-	gpCopyTexImage2D                              C.GPCOPYTEXIMAGE2D
-	gpCopyTexSubImage1D                           C.GPCOPYTEXSUBIMAGE1D
-	gpCopyTexSubImage2D                           C.GPCOPYTEXSUBIMAGE2D
-	gpCopyTexSubImage3D                           C.GPCOPYTEXSUBIMAGE3D
-	gpCopyTextureSubImage1D                       C.GPCOPYTEXTURESUBIMAGE1D
-	gpCopyTextureSubImage2D                       C.GPCOPYTEXTURESUBIMAGE2D
-	gpCopyTextureSubImage3D                       C.GPCOPYTEXTURESUBIMAGE3D
-	gpCreateBuffers                               C.GPCREATEBUFFERS
-	gpCreateFramebuffers                          C.GPCREATEFRAMEBUFFERS
-	gpCreateProgram                               C.GPCREATEPROGRAM
-	gpCreateProgramPipelines                      C.GPCREATEPROGRAMPIPELINES
-	gpCreateQueries                               C.GPCREATEQUERIES
-	gpCreateRenderbuffers                         C.GPCREATERENDERBUFFERS
-	gpCreateSamplers                              C.GPCREATESAMPLERS
-	gpCreateShader                                C.GPCREATESHADER
-	gpCreateShaderProgramv                        C.GPCREATESHADERPROGRAMV
-	gpCreateSyncFromCLeventARB                    C.GPCREATESYNCFROMCLEVENTARB
-	gpCreateTextures                              C.GPCREATETEXTURES
-	gpCreateTransformFeedbacks                    C.GPCREATETRANSFORMFEEDBACKS
-	gpCreateVertexArrays                          C.GPCREATEVERTEXARRAYS
-	gpCullFace                                    C.GPCULLFACE
-	gpDebugMessageCallback                        C.GPDEBUGMESSAGECALLBACK
-	gpDebugMessageCallbackARB                     C.GPDEBUGMESSAGECALLBACKARB
-	gpDebugMessageCallbackKHR                     C.GPDEBUGMESSAGECALLBACKKHR
-	gpDebugMessageControl                         C.GPDEBUGMESSAGECONTROL
-	gpDebugMessageControlARB                      C.GPDEBUGMESSAGECONTROLARB
-	gpDebugMessageControlKHR                      C.GPDEBUGMESSAGECONTROLKHR
-	gpDebugMessageInsert                          C.GPDEBUGMESSAGEINSERT
-	gpDebugMessageInsertARB                       C.GPDEBUGMESSAGEINSERTARB
-	gpDebugMessageInsertKHR                       C.GPDEBUGMESSAGEINSERTKHR
-	gpDeleteBuffers                               C.GPDELETEBUFFERS
-	gpDeleteFramebuffers                          C.GPDELETEFRAMEBUFFERS
-	gpDeleteNamedStringARB                        C.GPDELETENAMEDSTRINGARB
-	gpDeleteProgram                               C.GPDELETEPROGRAM
-	gpDeleteProgramPipelines                      C.GPDELETEPROGRAMPIPELINES
-	gpDeleteQueries                               C.GPDELETEQUERIES
-	gpDeleteRenderbuffers                         C.GPDELETERENDERBUFFERS
-	gpDeleteSamplers                              C.GPDELETESAMPLERS
-	gpDeleteShader                                C.GPDELETESHADER
-	gpDeleteSync                                  C.GPDELETESYNC
-	gpDeleteTextures                              C.GPDELETETEXTURES
-	gpDeleteTransformFeedbacks                    C.GPDELETETRANSFORMFEEDBACKS
-	gpDeleteVertexArrays                          C.GPDELETEVERTEXARRAYS
-	gpDepthFunc                                   C.GPDEPTHFUNC
-	gpDepthMask                                   C.GPDEPTHMASK
-	gpDepthRange                                  C.GPDEPTHRANGE
-	gpDepthRangeArrayv                            C.GPDEPTHRANGEARRAYV
-	gpDepthRangeIndexed                           C.GPDEPTHRANGEINDEXED
-	gpDepthRangef                                 C.GPDEPTHRANGEF
-	gpDetachShader                                C.GPDETACHSHADER
-	gpDisable                                     C.GPDISABLE
-	gpDisableVertexArrayAttrib                    C.GPDISABLEVERTEXARRAYATTRIB
-	gpDisableVertexAttribArray                    C.GPDISABLEVERTEXATTRIBARRAY
-	gpDisablei                                    C.GPDISABLEI
-	gpDispatchCompute                             C.GPDISPATCHCOMPUTE
-	gpDispatchComputeGroupSizeARB                 C.GPDISPATCHCOMPUTEGROUPSIZEARB
-	gpDispatchComputeIndirect                     C.GPDISPATCHCOMPUTEINDIRECT
-	gpDrawArrays                                  C.GPDRAWARRAYS
-	gpDrawArraysIndirect                          C.GPDRAWARRAYSINDIRECT
-	gpDrawArraysInstanced                         C.GPDRAWARRAYSINSTANCED
-	gpDrawArraysInstancedBaseInstance             C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
-	gpDrawBuffer                                  C.GPDRAWBUFFER
-	gpDrawBuffers                                 C.GPDRAWBUFFERS
-	gpDrawElements                                C.GPDRAWELEMENTS
-	gpDrawElementsBaseVertex                      C.GPDRAWELEMENTSBASEVERTEX
-	gpDrawElementsIndirect                        C.GPDRAWELEMENTSINDIRECT
-	gpDrawElementsInstanced                       C.GPDRAWELEMENTSINSTANCED
-	gpDrawElementsInstancedBaseInstance           C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
-	gpDrawElementsInstancedBaseVertex             C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
-	gpDrawElementsInstancedBaseVertexBaseInstance C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
-	gpDrawRangeElements                           C.GPDRAWRANGEELEMENTS
-	gpDrawRangeElementsBaseVertex                 C.GPDRAWRANGEELEMENTSBASEVERTEX
-	gpDrawTransformFeedback                       C.GPDRAWTRANSFORMFEEDBACK
-	gpDrawTransformFeedbackInstanced              C.GPDRAWTRANSFORMFEEDBACKINSTANCED
-	gpDrawTransformFeedbackStream                 C.GPDRAWTRANSFORMFEEDBACKSTREAM
-	gpDrawTransformFeedbackStreamInstanced        C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
-	gpEnable                                      C.GPENABLE
-	gpEnableVertexArrayAttrib                     C.GPENABLEVERTEXARRAYATTRIB
-	gpEnableVertexAttribArray                     C.GPENABLEVERTEXATTRIBARRAY
-	gpEnablei                                     C.GPENABLEI
-	gpEndConditionalRender                        C.GPENDCONDITIONALRENDER
-	gpEndQuery                                    C.GPENDQUERY
-	gpEndQueryIndexed                             C.GPENDQUERYINDEXED
-	gpEndTransformFeedback                        C.GPENDTRANSFORMFEEDBACK
-	gpFenceSync                                   C.GPFENCESYNC
-	gpFinish                                      C.GPFINISH
-	gpFlush                                       C.GPFLUSH
-	gpFlushMappedBufferRange                      C.GPFLUSHMAPPEDBUFFERRANGE
-	gpFlushMappedNamedBufferRange                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
-	gpFramebufferParameteri                       C.GPFRAMEBUFFERPARAMETERI
-	gpFramebufferRenderbuffer                     C.GPFRAMEBUFFERRENDERBUFFER
-	gpFramebufferTexture                          C.GPFRAMEBUFFERTEXTURE
-	gpFramebufferTexture1D                        C.GPFRAMEBUFFERTEXTURE1D
-	gpFramebufferTexture2D                        C.GPFRAMEBUFFERTEXTURE2D
-	gpFramebufferTexture3D                        C.GPFRAMEBUFFERTEXTURE3D
-	gpFramebufferTextureLayer                     C.GPFRAMEBUFFERTEXTURELAYER
-	gpFrontFace                                   C.GPFRONTFACE
-	gpGenBuffers                                  C.GPGENBUFFERS
-	gpGenFramebuffers                             C.GPGENFRAMEBUFFERS
-	gpGenProgramPipelines                         C.GPGENPROGRAMPIPELINES
-	gpGenQueries                                  C.GPGENQUERIES
-	gpGenRenderbuffers                            C.GPGENRENDERBUFFERS
-	gpGenSamplers                                 C.GPGENSAMPLERS
-	gpGenTextures                                 C.GPGENTEXTURES
-	gpGenTransformFeedbacks                       C.GPGENTRANSFORMFEEDBACKS
-	gpGenVertexArrays                             C.GPGENVERTEXARRAYS
-	gpGenerateMipmap                              C.GPGENERATEMIPMAP
-	gpGenerateTextureMipmap                       C.GPGENERATETEXTUREMIPMAP
-	gpGetActiveAtomicCounterBufferiv              C.GPGETACTIVEATOMICCOUNTERBUFFERIV
-	gpGetActiveAttrib                             C.GPGETACTIVEATTRIB
-	gpGetActiveSubroutineName                     C.GPGETACTIVESUBROUTINENAME
-	gpGetActiveSubroutineUniformName              C.GPGETACTIVESUBROUTINEUNIFORMNAME
-	gpGetActiveSubroutineUniformiv                C.GPGETACTIVESUBROUTINEUNIFORMIV
-	gpGetActiveUniform                            C.GPGETACTIVEUNIFORM
-	gpGetActiveUniformBlockName                   C.GPGETACTIVEUNIFORMBLOCKNAME
-	gpGetActiveUniformBlockiv                     C.GPGETACTIVEUNIFORMBLOCKIV
-	gpGetActiveUniformName                        C.GPGETACTIVEUNIFORMNAME
-	gpGetActiveUniformsiv                         C.GPGETACTIVEUNIFORMSIV
-	gpGetAttachedShaders                          C.GPGETATTACHEDSHADERS
-	gpGetAttribLocation                           C.GPGETATTRIBLOCATION
-	gpGetBooleani_v                               C.GPGETBOOLEANI_V
-	gpGetBooleanv                                 C.GPGETBOOLEANV
-	gpGetBufferParameteri64v                      C.GPGETBUFFERPARAMETERI64V
-	gpGetBufferParameteriv                        C.GPGETBUFFERPARAMETERIV
-	gpGetBufferPointerv                           C.GPGETBUFFERPOINTERV
-	gpGetBufferSubData                            C.GPGETBUFFERSUBDATA
-	gpGetCompressedTexImage                       C.GPGETCOMPRESSEDTEXIMAGE
-	gpGetCompressedTextureImage                   C.GPGETCOMPRESSEDTEXTUREIMAGE
-	gpGetCompressedTextureSubImage                C.GPGETCOMPRESSEDTEXTURESUBIMAGE
-	gpGetDebugMessageLog                          C.GPGETDEBUGMESSAGELOG
-	gpGetDebugMessageLogARB                       C.GPGETDEBUGMESSAGELOGARB
-	gpGetDebugMessageLogKHR                       C.GPGETDEBUGMESSAGELOGKHR
-	gpGetDoublei_v                                C.GPGETDOUBLEI_V
-	gpGetDoublev                                  C.GPGETDOUBLEV
-	gpGetError                                    C.GPGETERROR
-	gpGetFloati_v                                 C.GPGETFLOATI_V
-	gpGetFloatv                                   C.GPGETFLOATV
-	gpGetFragDataIndex                            C.GPGETFRAGDATAINDEX
-	gpGetFragDataLocation                         C.GPGETFRAGDATALOCATION
-	gpGetFramebufferAttachmentParameteriv         C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetFramebufferParameteriv                   C.GPGETFRAMEBUFFERPARAMETERIV
-	gpGetGraphicsResetStatus                      C.GPGETGRAPHICSRESETSTATUS
-	gpGetGraphicsResetStatusARB                   C.GPGETGRAPHICSRESETSTATUSARB
-	gpGetGraphicsResetStatusKHR                   C.GPGETGRAPHICSRESETSTATUSKHR
-	gpGetImageHandleARB                           C.GPGETIMAGEHANDLEARB
-	gpGetInteger64i_v                             C.GPGETINTEGER64I_V
-	gpGetInteger64v                               C.GPGETINTEGER64V
-	gpGetIntegeri_v                               C.GPGETINTEGERI_V
-	gpGetIntegerv                                 C.GPGETINTEGERV
-	gpGetInternalformati64v                       C.GPGETINTERNALFORMATI64V
-	gpGetInternalformativ                         C.GPGETINTERNALFORMATIV
-	gpGetMultisamplefv                            C.GPGETMULTISAMPLEFV
-	gpGetNamedBufferParameteri64v                 C.GPGETNAMEDBUFFERPARAMETERI64V
-	gpGetNamedBufferParameteriv                   C.GPGETNAMEDBUFFERPARAMETERIV
-	gpGetNamedBufferPointerv                      C.GPGETNAMEDBUFFERPOINTERV
-	gpGetNamedBufferSubData                       C.GPGETNAMEDBUFFERSUBDATA
-	gpGetNamedFramebufferAttachmentParameteriv    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetNamedFramebufferParameteriv              C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
-	gpGetNamedRenderbufferParameteriv             C.GPGETNAMEDRENDERBUFFERPARAMETERIV
-	gpGetNamedStringARB                           C.GPGETNAMEDSTRINGARB
-	gpGetNamedStringivARB                         C.GPGETNAMEDSTRINGIVARB
-	gpGetObjectLabel                              C.GPGETOBJECTLABEL
-	gpGetObjectLabelKHR                           C.GPGETOBJECTLABELKHR
-	gpGetObjectPtrLabel                           C.GPGETOBJECTPTRLABEL
-	gpGetObjectPtrLabelKHR                        C.GPGETOBJECTPTRLABELKHR
-	gpGetPointerv                                 C.GPGETPOINTERV
-	gpGetPointervKHR                              C.GPGETPOINTERVKHR
-	gpGetProgramBinary                            C.GPGETPROGRAMBINARY
-	gpGetProgramInfoLog                           C.GPGETPROGRAMINFOLOG
-	gpGetProgramInterfaceiv                       C.GPGETPROGRAMINTERFACEIV
-	gpGetProgramPipelineInfoLog                   C.GPGETPROGRAMPIPELINEINFOLOG
-	gpGetProgramPipelineiv                        C.GPGETPROGRAMPIPELINEIV
-	gpGetProgramResourceIndex                     C.GPGETPROGRAMRESOURCEINDEX
-	gpGetProgramResourceLocation                  C.GPGETPROGRAMRESOURCELOCATION
-	gpGetProgramResourceLocationIndex             C.GPGETPROGRAMRESOURCELOCATIONINDEX
-	gpGetProgramResourceName                      C.GPGETPROGRAMRESOURCENAME
-	gpGetProgramResourceiv                        C.GPGETPROGRAMRESOURCEIV
-	gpGetProgramStageiv                           C.GPGETPROGRAMSTAGEIV
-	gpGetProgramiv                                C.GPGETPROGRAMIV
-	gpGetQueryIndexediv                           C.GPGETQUERYINDEXEDIV
-	gpGetQueryObjecti64v                          C.GPGETQUERYOBJECTI64V
-	gpGetQueryObjectiv                            C.GPGETQUERYOBJECTIV
-	gpGetQueryObjectui64v                         C.GPGETQUERYOBJECTUI64V
-	gpGetQueryObjectuiv                           C.GPGETQUERYOBJECTUIV
-	gpGetQueryiv                                  C.GPGETQUERYIV
-	gpGetRenderbufferParameteriv                  C.GPGETRENDERBUFFERPARAMETERIV
-	gpGetSamplerParameterIiv                      C.GPGETSAMPLERPARAMETERIIV
-	gpGetSamplerParameterIuiv                     C.GPGETSAMPLERPARAMETERIUIV
-	gpGetSamplerParameterfv                       C.GPGETSAMPLERPARAMETERFV
-	gpGetSamplerParameteriv                       C.GPGETSAMPLERPARAMETERIV
-	gpGetShaderInfoLog                            C.GPGETSHADERINFOLOG
-	gpGetShaderPrecisionFormat                    C.GPGETSHADERPRECISIONFORMAT
-	gpGetShaderSource                             C.GPGETSHADERSOURCE
-	gpGetShaderiv                                 C.GPGETSHADERIV
-	gpGetString                                   C.GPGETSTRING
-	gpGetStringi                                  C.GPGETSTRINGI
-	gpGetSubroutineIndex                          C.GPGETSUBROUTINEINDEX
-	gpGetSubroutineUniformLocation                C.GPGETSUBROUTINEUNIFORMLOCATION
-	gpGetSynciv                                   C.GPGETSYNCIV
-	gpGetTexImage                                 C.GPGETTEXIMAGE
-	gpGetTexLevelParameterfv                      C.GPGETTEXLEVELPARAMETERFV
-	gpGetTexLevelParameteriv                      C.GPGETTEXLEVELPARAMETERIV
-	gpGetTexParameterIiv                          C.GPGETTEXPARAMETERIIV
-	gpGetTexParameterIuiv                         C.GPGETTEXPARAMETERIUIV
-	gpGetTexParameterfv                           C.GPGETTEXPARAMETERFV
-	gpGetTexParameteriv                           C.GPGETTEXPARAMETERIV
-	gpGetTextureHandleARB                         C.GPGETTEXTUREHANDLEARB
-	gpGetTextureImage                             C.GPGETTEXTUREIMAGE
-	gpGetTextureLevelParameterfv                  C.GPGETTEXTURELEVELPARAMETERFV
-	gpGetTextureLevelParameteriv                  C.GPGETTEXTURELEVELPARAMETERIV
-	gpGetTextureParameterIiv                      C.GPGETTEXTUREPARAMETERIIV
-	gpGetTextureParameterIuiv                     C.GPGETTEXTUREPARAMETERIUIV
-	gpGetTextureParameterfv                       C.GPGETTEXTUREPARAMETERFV
-	gpGetTextureParameteriv                       C.GPGETTEXTUREPARAMETERIV
-	gpGetTextureSamplerHandleARB                  C.GPGETTEXTURESAMPLERHANDLEARB
-	gpGetTextureSubImage                          C.GPGETTEXTURESUBIMAGE
-	gpGetTransformFeedbackVarying                 C.GPGETTRANSFORMFEEDBACKVARYING
-	gpGetTransformFeedbacki64_v                   C.GPGETTRANSFORMFEEDBACKI64_V
-	gpGetTransformFeedbacki_v                     C.GPGETTRANSFORMFEEDBACKI_V
-	gpGetTransformFeedbackiv                      C.GPGETTRANSFORMFEEDBACKIV
-	gpGetUniformBlockIndex                        C.GPGETUNIFORMBLOCKINDEX
-	gpGetUniformIndices                           C.GPGETUNIFORMINDICES
-	gpGetUniformLocation                          C.GPGETUNIFORMLOCATION
-	gpGetUniformSubroutineuiv                     C.GPGETUNIFORMSUBROUTINEUIV
-	gpGetUniformdv                                C.GPGETUNIFORMDV
-	gpGetUniformfv                                C.GPGETUNIFORMFV
-	gpGetUniformiv                                C.GPGETUNIFORMIV
-	gpGetUniformuiv                               C.GPGETUNIFORMUIV
-	gpGetVertexArrayIndexed64iv                   C.GPGETVERTEXARRAYINDEXED64IV
-	gpGetVertexArrayIndexediv                     C.GPGETVERTEXARRAYINDEXEDIV
-	gpGetVertexArrayiv                            C.GPGETVERTEXARRAYIV
-	gpGetVertexAttribIiv                          C.GPGETVERTEXATTRIBIIV
-	gpGetVertexAttribIuiv                         C.GPGETVERTEXATTRIBIUIV
-	gpGetVertexAttribLdv                          C.GPGETVERTEXATTRIBLDV
-	gpGetVertexAttribLui64vARB                    C.GPGETVERTEXATTRIBLUI64VARB
-	gpGetVertexAttribPointerv                     C.GPGETVERTEXATTRIBPOINTERV
-	gpGetVertexAttribdv                           C.GPGETVERTEXATTRIBDV
-	gpGetVertexAttribfv                           C.GPGETVERTEXATTRIBFV
-	gpGetVertexAttribiv                           C.GPGETVERTEXATTRIBIV
-	gpGetnCompressedTexImageARB                   C.GPGETNCOMPRESSEDTEXIMAGEARB
-	gpGetnTexImageARB                             C.GPGETNTEXIMAGEARB
-	gpGetnUniformdvARB                            C.GPGETNUNIFORMDVARB
-	gpGetnUniformfv                               C.GPGETNUNIFORMFV
-	gpGetnUniformfvARB                            C.GPGETNUNIFORMFVARB
-	gpGetnUniformfvKHR                            C.GPGETNUNIFORMFVKHR
-	gpGetnUniformiv                               C.GPGETNUNIFORMIV
-	gpGetnUniformivARB                            C.GPGETNUNIFORMIVARB
-	gpGetnUniformivKHR                            C.GPGETNUNIFORMIVKHR
-	gpGetnUniformuiv                              C.GPGETNUNIFORMUIV
-	gpGetnUniformuivARB                           C.GPGETNUNIFORMUIVARB
-	gpGetnUniformuivKHR                           C.GPGETNUNIFORMUIVKHR
-	gpHint                                        C.GPHINT
-	gpInvalidateBufferData                        C.GPINVALIDATEBUFFERDATA
-	gpInvalidateBufferSubData                     C.GPINVALIDATEBUFFERSUBDATA
-	gpInvalidateFramebuffer                       C.GPINVALIDATEFRAMEBUFFER
-	gpInvalidateNamedFramebufferData              C.GPINVALIDATENAMEDFRAMEBUFFERDATA
-	gpInvalidateNamedFramebufferSubData           C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
-	gpInvalidateSubFramebuffer                    C.GPINVALIDATESUBFRAMEBUFFER
-	gpInvalidateTexImage                          C.GPINVALIDATETEXIMAGE
-	gpInvalidateTexSubImage                       C.GPINVALIDATETEXSUBIMAGE
-	gpIsBuffer                                    C.GPISBUFFER
-	gpIsEnabled                                   C.GPISENABLED
-	gpIsEnabledi                                  C.GPISENABLEDI
-	gpIsFramebuffer                               C.GPISFRAMEBUFFER
-	gpIsImageHandleResidentARB                    C.GPISIMAGEHANDLERESIDENTARB
-	gpIsNamedStringARB                            C.GPISNAMEDSTRINGARB
-	gpIsProgram                                   C.GPISPROGRAM
-	gpIsProgramPipeline                           C.GPISPROGRAMPIPELINE
-	gpIsQuery                                     C.GPISQUERY
-	gpIsRenderbuffer                              C.GPISRENDERBUFFER
-	gpIsSampler                                   C.GPISSAMPLER
-	gpIsShader                                    C.GPISSHADER
-	gpIsSync                                      C.GPISSYNC
-	gpIsTexture                                   C.GPISTEXTURE
-	gpIsTextureHandleResidentARB                  C.GPISTEXTUREHANDLERESIDENTARB
-	gpIsTransformFeedback                         C.GPISTRANSFORMFEEDBACK
-	gpIsVertexArray                               C.GPISVERTEXARRAY
-	gpLineWidth                                   C.GPLINEWIDTH
-	gpLinkProgram                                 C.GPLINKPROGRAM
-	gpLogicOp                                     C.GPLOGICOP
-	gpMakeImageHandleNonResidentARB               C.GPMAKEIMAGEHANDLENONRESIDENTARB
-	gpMakeImageHandleResidentARB                  C.GPMAKEIMAGEHANDLERESIDENTARB
-	gpMakeTextureHandleNonResidentARB             C.GPMAKETEXTUREHANDLENONRESIDENTARB
-	gpMakeTextureHandleResidentARB                C.GPMAKETEXTUREHANDLERESIDENTARB
-	gpMapBuffer                                   C.GPMAPBUFFER
-	gpMapBufferRange                              C.GPMAPBUFFERRANGE
-	gpMapNamedBuffer                              C.GPMAPNAMEDBUFFER
-	gpMapNamedBufferRange                         C.GPMAPNAMEDBUFFERRANGE
-	gpMemoryBarrier                               C.GPMEMORYBARRIER
-	gpMemoryBarrierByRegion                       C.GPMEMORYBARRIERBYREGION
-	gpMinSampleShading                            C.GPMINSAMPLESHADING
-	gpMinSampleShadingARB                         C.GPMINSAMPLESHADINGARB
-	gpMultiDrawArrays                             C.GPMULTIDRAWARRAYS
-	gpMultiDrawArraysIndirect                     C.GPMULTIDRAWARRAYSINDIRECT
-	gpMultiDrawArraysIndirectCountARB             C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
-	gpMultiDrawElements                           C.GPMULTIDRAWELEMENTS
-	gpMultiDrawElementsBaseVertex                 C.GPMULTIDRAWELEMENTSBASEVERTEX
-	gpMultiDrawElementsIndirect                   C.GPMULTIDRAWELEMENTSINDIRECT
-	gpMultiDrawElementsIndirectCountARB           C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
-	gpNamedBufferData                             C.GPNAMEDBUFFERDATA
-	gpNamedBufferPageCommitmentARB                C.GPNAMEDBUFFERPAGECOMMITMENTARB
-	gpNamedBufferPageCommitmentEXT                C.GPNAMEDBUFFERPAGECOMMITMENTEXT
-	gpNamedBufferStorage                          C.GPNAMEDBUFFERSTORAGE
-	gpNamedBufferSubData                          C.GPNAMEDBUFFERSUBDATA
-	gpNamedFramebufferDrawBuffer                  C.GPNAMEDFRAMEBUFFERDRAWBUFFER
-	gpNamedFramebufferDrawBuffers                 C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
-	gpNamedFramebufferParameteri                  C.GPNAMEDFRAMEBUFFERPARAMETERI
-	gpNamedFramebufferReadBuffer                  C.GPNAMEDFRAMEBUFFERREADBUFFER
-	gpNamedFramebufferRenderbuffer                C.GPNAMEDFRAMEBUFFERRENDERBUFFER
-	gpNamedFramebufferTexture                     C.GPNAMEDFRAMEBUFFERTEXTURE
-	gpNamedFramebufferTextureLayer                C.GPNAMEDFRAMEBUFFERTEXTURELAYER
-	gpNamedRenderbufferStorage                    C.GPNAMEDRENDERBUFFERSTORAGE
-	gpNamedRenderbufferStorageMultisample         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
-	gpNamedStringARB                              C.GPNAMEDSTRINGARB
-	gpObjectLabel                                 C.GPOBJECTLABEL
-	gpObjectLabelKHR                              C.GPOBJECTLABELKHR
-	gpObjectPtrLabel                              C.GPOBJECTPTRLABEL
-	gpObjectPtrLabelKHR                           C.GPOBJECTPTRLABELKHR
-	gpPatchParameterfv                            C.GPPATCHPARAMETERFV
-	gpPatchParameteri                             C.GPPATCHPARAMETERI
-	gpPauseTransformFeedback                      C.GPPAUSETRANSFORMFEEDBACK
-	gpPixelStoref                                 C.GPPIXELSTOREF
-	gpPixelStorei                                 C.GPPIXELSTOREI
-	gpPointParameterf                             C.GPPOINTPARAMETERF
-	gpPointParameterfv                            C.GPPOINTPARAMETERFV
-	gpPointParameteri                             C.GPPOINTPARAMETERI
-	gpPointParameteriv                            C.GPPOINTPARAMETERIV
-	gpPointSize                                   C.GPPOINTSIZE
-	gpPolygonMode                                 C.GPPOLYGONMODE
-	gpPolygonOffset                               C.GPPOLYGONOFFSET
-	gpPopDebugGroup                               C.GPPOPDEBUGGROUP
-	gpPopDebugGroupKHR                            C.GPPOPDEBUGGROUPKHR
-	gpPrimitiveRestartIndex                       C.GPPRIMITIVERESTARTINDEX
-	gpProgramBinary                               C.GPPROGRAMBINARY
-	gpProgramParameteri                           C.GPPROGRAMPARAMETERI
-	gpProgramUniform1d                            C.GPPROGRAMUNIFORM1D
-	gpProgramUniform1dv                           C.GPPROGRAMUNIFORM1DV
-	gpProgramUniform1f                            C.GPPROGRAMUNIFORM1F
-	gpProgramUniform1fv                           C.GPPROGRAMUNIFORM1FV
-	gpProgramUniform1i                            C.GPPROGRAMUNIFORM1I
-	gpProgramUniform1iv                           C.GPPROGRAMUNIFORM1IV
-	gpProgramUniform1ui                           C.GPPROGRAMUNIFORM1UI
-	gpProgramUniform1uiv                          C.GPPROGRAMUNIFORM1UIV
-	gpProgramUniform2d                            C.GPPROGRAMUNIFORM2D
-	gpProgramUniform2dv                           C.GPPROGRAMUNIFORM2DV
-	gpProgramUniform2f                            C.GPPROGRAMUNIFORM2F
-	gpProgramUniform2fv                           C.GPPROGRAMUNIFORM2FV
-	gpProgramUniform2i                            C.GPPROGRAMUNIFORM2I
-	gpProgramUniform2iv                           C.GPPROGRAMUNIFORM2IV
-	gpProgramUniform2ui                           C.GPPROGRAMUNIFORM2UI
-	gpProgramUniform2uiv                          C.GPPROGRAMUNIFORM2UIV
-	gpProgramUniform3d                            C.GPPROGRAMUNIFORM3D
-	gpProgramUniform3dv                           C.GPPROGRAMUNIFORM3DV
-	gpProgramUniform3f                            C.GPPROGRAMUNIFORM3F
-	gpProgramUniform3fv                           C.GPPROGRAMUNIFORM3FV
-	gpProgramUniform3i                            C.GPPROGRAMUNIFORM3I
-	gpProgramUniform3iv                           C.GPPROGRAMUNIFORM3IV
-	gpProgramUniform3ui                           C.GPPROGRAMUNIFORM3UI
-	gpProgramUniform3uiv                          C.GPPROGRAMUNIFORM3UIV
-	gpProgramUniform4d                            C.GPPROGRAMUNIFORM4D
-	gpProgramUniform4dv                           C.GPPROGRAMUNIFORM4DV
-	gpProgramUniform4f                            C.GPPROGRAMUNIFORM4F
-	gpProgramUniform4fv                           C.GPPROGRAMUNIFORM4FV
-	gpProgramUniform4i                            C.GPPROGRAMUNIFORM4I
-	gpProgramUniform4iv                           C.GPPROGRAMUNIFORM4IV
-	gpProgramUniform4ui                           C.GPPROGRAMUNIFORM4UI
-	gpProgramUniform4uiv                          C.GPPROGRAMUNIFORM4UIV
-	gpProgramUniformHandleui64ARB                 C.GPPROGRAMUNIFORMHANDLEUI64ARB
-	gpProgramUniformHandleui64vARB                C.GPPROGRAMUNIFORMHANDLEUI64VARB
-	gpProgramUniformMatrix2dv                     C.GPPROGRAMUNIFORMMATRIX2DV
-	gpProgramUniformMatrix2fv                     C.GPPROGRAMUNIFORMMATRIX2FV
-	gpProgramUniformMatrix2x3dv                   C.GPPROGRAMUNIFORMMATRIX2X3DV
-	gpProgramUniformMatrix2x3fv                   C.GPPROGRAMUNIFORMMATRIX2X3FV
-	gpProgramUniformMatrix2x4dv                   C.GPPROGRAMUNIFORMMATRIX2X4DV
-	gpProgramUniformMatrix2x4fv                   C.GPPROGRAMUNIFORMMATRIX2X4FV
-	gpProgramUniformMatrix3dv                     C.GPPROGRAMUNIFORMMATRIX3DV
-	gpProgramUniformMatrix3fv                     C.GPPROGRAMUNIFORMMATRIX3FV
-	gpProgramUniformMatrix3x2dv                   C.GPPROGRAMUNIFORMMATRIX3X2DV
-	gpProgramUniformMatrix3x2fv                   C.GPPROGRAMUNIFORMMATRIX3X2FV
-	gpProgramUniformMatrix3x4dv                   C.GPPROGRAMUNIFORMMATRIX3X4DV
-	gpProgramUniformMatrix3x4fv                   C.GPPROGRAMUNIFORMMATRIX3X4FV
-	gpProgramUniformMatrix4dv                     C.GPPROGRAMUNIFORMMATRIX4DV
-	gpProgramUniformMatrix4fv                     C.GPPROGRAMUNIFORMMATRIX4FV
-	gpProgramUniformMatrix4x2dv                   C.GPPROGRAMUNIFORMMATRIX4X2DV
-	gpProgramUniformMatrix4x2fv                   C.GPPROGRAMUNIFORMMATRIX4X2FV
-	gpProgramUniformMatrix4x3dv                   C.GPPROGRAMUNIFORMMATRIX4X3DV
-	gpProgramUniformMatrix4x3fv                   C.GPPROGRAMUNIFORMMATRIX4X3FV
-	gpProvokingVertex                             C.GPPROVOKINGVERTEX
-	gpPushDebugGroup                              C.GPPUSHDEBUGGROUP
-	gpPushDebugGroupKHR                           C.GPPUSHDEBUGGROUPKHR
-	gpQueryCounter                                C.GPQUERYCOUNTER
-	gpReadBuffer                                  C.GPREADBUFFER
-	gpReadPixels                                  C.GPREADPIXELS
-	gpReadnPixels                                 C.GPREADNPIXELS
-	gpReadnPixelsARB                              C.GPREADNPIXELSARB
-	gpReadnPixelsKHR                              C.GPREADNPIXELSKHR
-	gpReleaseShaderCompiler                       C.GPRELEASESHADERCOMPILER
-	gpRenderbufferStorage                         C.GPRENDERBUFFERSTORAGE
-	gpRenderbufferStorageMultisample              C.GPRENDERBUFFERSTORAGEMULTISAMPLE
-	gpResumeTransformFeedback                     C.GPRESUMETRANSFORMFEEDBACK
-	gpSampleCoverage                              C.GPSAMPLECOVERAGE
-	gpSampleMaski                                 C.GPSAMPLEMASKI
-	gpSamplerParameterIiv                         C.GPSAMPLERPARAMETERIIV
-	gpSamplerParameterIuiv                        C.GPSAMPLERPARAMETERIUIV
-	gpSamplerParameterf                           C.GPSAMPLERPARAMETERF
-	gpSamplerParameterfv                          C.GPSAMPLERPARAMETERFV
-	gpSamplerParameteri                           C.GPSAMPLERPARAMETERI
-	gpSamplerParameteriv                          C.GPSAMPLERPARAMETERIV
-	gpScissor                                     C.GPSCISSOR
-	gpScissorArrayv                               C.GPSCISSORARRAYV
-	gpScissorIndexed                              C.GPSCISSORINDEXED
-	gpScissorIndexedv                             C.GPSCISSORINDEXEDV
-	gpShaderBinary                                C.GPSHADERBINARY
-	gpShaderSource                                C.GPSHADERSOURCE
-	gpShaderStorageBlockBinding                   C.GPSHADERSTORAGEBLOCKBINDING
-	gpStencilFunc                                 C.GPSTENCILFUNC
-	gpStencilFuncSeparate                         C.GPSTENCILFUNCSEPARATE
-	gpStencilMask                                 C.GPSTENCILMASK
-	gpStencilMaskSeparate                         C.GPSTENCILMASKSEPARATE
-	gpStencilOp                                   C.GPSTENCILOP
-	gpStencilOpSeparate                           C.GPSTENCILOPSEPARATE
-	gpTexBuffer                                   C.GPTEXBUFFER
-	gpTexBufferRange                              C.GPTEXBUFFERRANGE
-	gpTexImage1D                                  C.GPTEXIMAGE1D
-	gpTexImage2D                                  C.GPTEXIMAGE2D
-	gpTexImage2DMultisample                       C.GPTEXIMAGE2DMULTISAMPLE
-	gpTexImage3D                                  C.GPTEXIMAGE3D
-	gpTexImage3DMultisample                       C.GPTEXIMAGE3DMULTISAMPLE
-	gpTexPageCommitmentARB                        C.GPTEXPAGECOMMITMENTARB
-	gpTexParameterIiv                             C.GPTEXPARAMETERIIV
-	gpTexParameterIuiv                            C.GPTEXPARAMETERIUIV
-	gpTexParameterf                               C.GPTEXPARAMETERF
-	gpTexParameterfv                              C.GPTEXPARAMETERFV
-	gpTexParameteri                               C.GPTEXPARAMETERI
-	gpTexParameteriv                              C.GPTEXPARAMETERIV
-	gpTexStorage1D                                C.GPTEXSTORAGE1D
-	gpTexStorage2D                                C.GPTEXSTORAGE2D
-	gpTexStorage2DMultisample                     C.GPTEXSTORAGE2DMULTISAMPLE
-	gpTexStorage3D                                C.GPTEXSTORAGE3D
-	gpTexStorage3DMultisample                     C.GPTEXSTORAGE3DMULTISAMPLE
-	gpTexSubImage1D                               C.GPTEXSUBIMAGE1D
-	gpTexSubImage2D                               C.GPTEXSUBIMAGE2D
-	gpTexSubImage3D                               C.GPTEXSUBIMAGE3D
-	gpTextureBarrier                              C.GPTEXTUREBARRIER
-	gpTextureBuffer                               C.GPTEXTUREBUFFER
-	gpTextureBufferRange                          C.GPTEXTUREBUFFERRANGE
-	gpTextureParameterIiv                         C.GPTEXTUREPARAMETERIIV
-	gpTextureParameterIuiv                        C.GPTEXTUREPARAMETERIUIV
-	gpTextureParameterf                           C.GPTEXTUREPARAMETERF
-	gpTextureParameterfv                          C.GPTEXTUREPARAMETERFV
-	gpTextureParameteri                           C.GPTEXTUREPARAMETERI
-	gpTextureParameteriv                          C.GPTEXTUREPARAMETERIV
-	gpTextureStorage1D                            C.GPTEXTURESTORAGE1D
-	gpTextureStorage2D                            C.GPTEXTURESTORAGE2D
-	gpTextureStorage2DMultisample                 C.GPTEXTURESTORAGE2DMULTISAMPLE
-	gpTextureStorage3D                            C.GPTEXTURESTORAGE3D
-	gpTextureStorage3DMultisample                 C.GPTEXTURESTORAGE3DMULTISAMPLE
-	gpTextureSubImage1D                           C.GPTEXTURESUBIMAGE1D
-	gpTextureSubImage2D                           C.GPTEXTURESUBIMAGE2D
-	gpTextureSubImage3D                           C.GPTEXTURESUBIMAGE3D
-	gpTextureView                                 C.GPTEXTUREVIEW
-	gpTransformFeedbackBufferBase                 C.GPTRANSFORMFEEDBACKBUFFERBASE
-	gpTransformFeedbackBufferRange                C.GPTRANSFORMFEEDBACKBUFFERRANGE
-	gpTransformFeedbackVaryings                   C.GPTRANSFORMFEEDBACKVARYINGS
-	gpUniform1d                                   C.GPUNIFORM1D
-	gpUniform1dv                                  C.GPUNIFORM1DV
-	gpUniform1f                                   C.GPUNIFORM1F
-	gpUniform1fv                                  C.GPUNIFORM1FV
-	gpUniform1i                                   C.GPUNIFORM1I
-	gpUniform1iv                                  C.GPUNIFORM1IV
-	gpUniform1ui                                  C.GPUNIFORM1UI
-	gpUniform1uiv                                 C.GPUNIFORM1UIV
-	gpUniform2d                                   C.GPUNIFORM2D
-	gpUniform2dv                                  C.GPUNIFORM2DV
-	gpUniform2f                                   C.GPUNIFORM2F
-	gpUniform2fv                                  C.GPUNIFORM2FV
-	gpUniform2i                                   C.GPUNIFORM2I
-	gpUniform2iv                                  C.GPUNIFORM2IV
-	gpUniform2ui                                  C.GPUNIFORM2UI
-	gpUniform2uiv                                 C.GPUNIFORM2UIV
-	gpUniform3d                                   C.GPUNIFORM3D
-	gpUniform3dv                                  C.GPUNIFORM3DV
-	gpUniform3f                                   C.GPUNIFORM3F
-	gpUniform3fv                                  C.GPUNIFORM3FV
-	gpUniform3i                                   C.GPUNIFORM3I
-	gpUniform3iv                                  C.GPUNIFORM3IV
-	gpUniform3ui                                  C.GPUNIFORM3UI
-	gpUniform3uiv                                 C.GPUNIFORM3UIV
-	gpUniform4d                                   C.GPUNIFORM4D
-	gpUniform4dv                                  C.GPUNIFORM4DV
-	gpUniform4f                                   C.GPUNIFORM4F
-	gpUniform4fv                                  C.GPUNIFORM4FV
-	gpUniform4i                                   C.GPUNIFORM4I
-	gpUniform4iv                                  C.GPUNIFORM4IV
-	gpUniform4ui                                  C.GPUNIFORM4UI
-	gpUniform4uiv                                 C.GPUNIFORM4UIV
-	gpUniformBlockBinding                         C.GPUNIFORMBLOCKBINDING
-	gpUniformHandleui64ARB                        C.GPUNIFORMHANDLEUI64ARB
-	gpUniformHandleui64vARB                       C.GPUNIFORMHANDLEUI64VARB
-	gpUniformMatrix2dv                            C.GPUNIFORMMATRIX2DV
-	gpUniformMatrix2fv                            C.GPUNIFORMMATRIX2FV
-	gpUniformMatrix2x3dv                          C.GPUNIFORMMATRIX2X3DV
-	gpUniformMatrix2x3fv                          C.GPUNIFORMMATRIX2X3FV
-	gpUniformMatrix2x4dv                          C.GPUNIFORMMATRIX2X4DV
-	gpUniformMatrix2x4fv                          C.GPUNIFORMMATRIX2X4FV
-	gpUniformMatrix3dv                            C.GPUNIFORMMATRIX3DV
-	gpUniformMatrix3fv                            C.GPUNIFORMMATRIX3FV
-	gpUniformMatrix3x2dv                          C.GPUNIFORMMATRIX3X2DV
-	gpUniformMatrix3x2fv                          C.GPUNIFORMMATRIX3X2FV
-	gpUniformMatrix3x4dv                          C.GPUNIFORMMATRIX3X4DV
-	gpUniformMatrix3x4fv                          C.GPUNIFORMMATRIX3X4FV
-	gpUniformMatrix4dv                            C.GPUNIFORMMATRIX4DV
-	gpUniformMatrix4fv                            C.GPUNIFORMMATRIX4FV
-	gpUniformMatrix4x2dv                          C.GPUNIFORMMATRIX4X2DV
-	gpUniformMatrix4x2fv                          C.GPUNIFORMMATRIX4X2FV
-	gpUniformMatrix4x3dv                          C.GPUNIFORMMATRIX4X3DV
-	gpUniformMatrix4x3fv                          C.GPUNIFORMMATRIX4X3FV
-	gpUniformSubroutinesuiv                       C.GPUNIFORMSUBROUTINESUIV
-	gpUnmapBuffer                                 C.GPUNMAPBUFFER
-	gpUnmapNamedBuffer                            C.GPUNMAPNAMEDBUFFER
-	gpUseProgram                                  C.GPUSEPROGRAM
-	gpUseProgramStages                            C.GPUSEPROGRAMSTAGES
-	gpValidateProgram                             C.GPVALIDATEPROGRAM
-	gpValidateProgramPipeline                     C.GPVALIDATEPROGRAMPIPELINE
-	gpVertexArrayAttribBinding                    C.GPVERTEXARRAYATTRIBBINDING
-	gpVertexArrayAttribFormat                     C.GPVERTEXARRAYATTRIBFORMAT
-	gpVertexArrayAttribIFormat                    C.GPVERTEXARRAYATTRIBIFORMAT
-	gpVertexArrayAttribLFormat                    C.GPVERTEXARRAYATTRIBLFORMAT
-	gpVertexArrayBindingDivisor                   C.GPVERTEXARRAYBINDINGDIVISOR
-	gpVertexArrayElementBuffer                    C.GPVERTEXARRAYELEMENTBUFFER
-	gpVertexArrayVertexBuffer                     C.GPVERTEXARRAYVERTEXBUFFER
-	gpVertexArrayVertexBuffers                    C.GPVERTEXARRAYVERTEXBUFFERS
-	gpVertexAttrib1d                              C.GPVERTEXATTRIB1D
-	gpVertexAttrib1dv                             C.GPVERTEXATTRIB1DV
-	gpVertexAttrib1f                              C.GPVERTEXATTRIB1F
-	gpVertexAttrib1fv                             C.GPVERTEXATTRIB1FV
-	gpVertexAttrib1s                              C.GPVERTEXATTRIB1S
-	gpVertexAttrib1sv                             C.GPVERTEXATTRIB1SV
-	gpVertexAttrib2d                              C.GPVERTEXATTRIB2D
-	gpVertexAttrib2dv                             C.GPVERTEXATTRIB2DV
-	gpVertexAttrib2f                              C.GPVERTEXATTRIB2F
-	gpVertexAttrib2fv                             C.GPVERTEXATTRIB2FV
-	gpVertexAttrib2s                              C.GPVERTEXATTRIB2S
-	gpVertexAttrib2sv                             C.GPVERTEXATTRIB2SV
-	gpVertexAttrib3d                              C.GPVERTEXATTRIB3D
-	gpVertexAttrib3dv                             C.GPVERTEXATTRIB3DV
-	gpVertexAttrib3f                              C.GPVERTEXATTRIB3F
-	gpVertexAttrib3fv                             C.GPVERTEXATTRIB3FV
-	gpVertexAttrib3s                              C.GPVERTEXATTRIB3S
-	gpVertexAttrib3sv                             C.GPVERTEXATTRIB3SV
-	gpVertexAttrib4Nbv                            C.GPVERTEXATTRIB4NBV
-	gpVertexAttrib4Niv                            C.GPVERTEXATTRIB4NIV
-	gpVertexAttrib4Nsv                            C.GPVERTEXATTRIB4NSV
-	gpVertexAttrib4Nub                            C.GPVERTEXATTRIB4NUB
-	gpVertexAttrib4Nubv                           C.GPVERTEXATTRIB4NUBV
-	gpVertexAttrib4Nuiv                           C.GPVERTEXATTRIB4NUIV
-	gpVertexAttrib4Nusv                           C.GPVERTEXATTRIB4NUSV
-	gpVertexAttrib4bv                             C.GPVERTEXATTRIB4BV
-	gpVertexAttrib4d                              C.GPVERTEXATTRIB4D
-	gpVertexAttrib4dv                             C.GPVERTEXATTRIB4DV
-	gpVertexAttrib4f                              C.GPVERTEXATTRIB4F
-	gpVertexAttrib4fv                             C.GPVERTEXATTRIB4FV
-	gpVertexAttrib4iv                             C.GPVERTEXATTRIB4IV
-	gpVertexAttrib4s                              C.GPVERTEXATTRIB4S
-	gpVertexAttrib4sv                             C.GPVERTEXATTRIB4SV
-	gpVertexAttrib4ubv                            C.GPVERTEXATTRIB4UBV
-	gpVertexAttrib4uiv                            C.GPVERTEXATTRIB4UIV
-	gpVertexAttrib4usv                            C.GPVERTEXATTRIB4USV
-	gpVertexAttribBinding                         C.GPVERTEXATTRIBBINDING
-	gpVertexAttribDivisor                         C.GPVERTEXATTRIBDIVISOR
-	gpVertexAttribFormat                          C.GPVERTEXATTRIBFORMAT
-	gpVertexAttribI1i                             C.GPVERTEXATTRIBI1I
-	gpVertexAttribI1iv                            C.GPVERTEXATTRIBI1IV
-	gpVertexAttribI1ui                            C.GPVERTEXATTRIBI1UI
-	gpVertexAttribI1uiv                           C.GPVERTEXATTRIBI1UIV
-	gpVertexAttribI2i                             C.GPVERTEXATTRIBI2I
-	gpVertexAttribI2iv                            C.GPVERTEXATTRIBI2IV
-	gpVertexAttribI2ui                            C.GPVERTEXATTRIBI2UI
-	gpVertexAttribI2uiv                           C.GPVERTEXATTRIBI2UIV
-	gpVertexAttribI3i                             C.GPVERTEXATTRIBI3I
-	gpVertexAttribI3iv                            C.GPVERTEXATTRIBI3IV
-	gpVertexAttribI3ui                            C.GPVERTEXATTRIBI3UI
-	gpVertexAttribI3uiv                           C.GPVERTEXATTRIBI3UIV
-	gpVertexAttribI4bv                            C.GPVERTEXATTRIBI4BV
-	gpVertexAttribI4i                             C.GPVERTEXATTRIBI4I
-	gpVertexAttribI4iv                            C.GPVERTEXATTRIBI4IV
-	gpVertexAttribI4sv                            C.GPVERTEXATTRIBI4SV
-	gpVertexAttribI4ubv                           C.GPVERTEXATTRIBI4UBV
-	gpVertexAttribI4ui                            C.GPVERTEXATTRIBI4UI
-	gpVertexAttribI4uiv                           C.GPVERTEXATTRIBI4UIV
-	gpVertexAttribI4usv                           C.GPVERTEXATTRIBI4USV
-	gpVertexAttribIFormat                         C.GPVERTEXATTRIBIFORMAT
-	gpVertexAttribIPointer                        C.GPVERTEXATTRIBIPOINTER
-	gpVertexAttribL1d                             C.GPVERTEXATTRIBL1D
-	gpVertexAttribL1dv                            C.GPVERTEXATTRIBL1DV
-	gpVertexAttribL1ui64ARB                       C.GPVERTEXATTRIBL1UI64ARB
-	gpVertexAttribL1ui64vARB                      C.GPVERTEXATTRIBL1UI64VARB
-	gpVertexAttribL2d                             C.GPVERTEXATTRIBL2D
-	gpVertexAttribL2dv                            C.GPVERTEXATTRIBL2DV
-	gpVertexAttribL3d                             C.GPVERTEXATTRIBL3D
-	gpVertexAttribL3dv                            C.GPVERTEXATTRIBL3DV
-	gpVertexAttribL4d                             C.GPVERTEXATTRIBL4D
-	gpVertexAttribL4dv                            C.GPVERTEXATTRIBL4DV
-	gpVertexAttribLFormat                         C.GPVERTEXATTRIBLFORMAT
-	gpVertexAttribLPointer                        C.GPVERTEXATTRIBLPOINTER
-	gpVertexAttribP1ui                            C.GPVERTEXATTRIBP1UI
-	gpVertexAttribP1uiv                           C.GPVERTEXATTRIBP1UIV
-	gpVertexAttribP2ui                            C.GPVERTEXATTRIBP2UI
-	gpVertexAttribP2uiv                           C.GPVERTEXATTRIBP2UIV
-	gpVertexAttribP3ui                            C.GPVERTEXATTRIBP3UI
-	gpVertexAttribP3uiv                           C.GPVERTEXATTRIBP3UIV
-	gpVertexAttribP4ui                            C.GPVERTEXATTRIBP4UI
-	gpVertexAttribP4uiv                           C.GPVERTEXATTRIBP4UIV
-	gpVertexAttribPointer                         C.GPVERTEXATTRIBPOINTER
-	gpVertexBindingDivisor                        C.GPVERTEXBINDINGDIVISOR
-	gpViewport                                    C.GPVIEWPORT
-	gpViewportArrayv                              C.GPVIEWPORTARRAYV
-	gpViewportIndexedf                            C.GPVIEWPORTINDEXEDF
-	gpViewportIndexedfv                           C.GPVIEWPORTINDEXEDFV
-	gpWaitSync                                    C.GPWAITSYNC
+	gpActiveProgramEXT                               C.GPACTIVEPROGRAMEXT
+	gpActiveShaderProgram                            C.GPACTIVESHADERPROGRAM
+	gpActiveShaderProgramEXT                         C.GPACTIVESHADERPROGRAMEXT
+	gpActiveTexture                                  C.GPACTIVETEXTURE
+	gpApplyFramebufferAttachmentCMAAINTEL            C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
+	gpAttachShader                                   C.GPATTACHSHADER
+	gpBeginConditionalRender                         C.GPBEGINCONDITIONALRENDER
+	gpBeginConditionalRenderNV                       C.GPBEGINCONDITIONALRENDERNV
+	gpBeginPerfMonitorAMD                            C.GPBEGINPERFMONITORAMD
+	gpBeginPerfQueryINTEL                            C.GPBEGINPERFQUERYINTEL
+	gpBeginQuery                                     C.GPBEGINQUERY
+	gpBeginQueryIndexed                              C.GPBEGINQUERYINDEXED
+	gpBeginTransformFeedback                         C.GPBEGINTRANSFORMFEEDBACK
+	gpBindAttribLocation                             C.GPBINDATTRIBLOCATION
+	gpBindBuffer                                     C.GPBINDBUFFER
+	gpBindBufferBase                                 C.GPBINDBUFFERBASE
+	gpBindBufferRange                                C.GPBINDBUFFERRANGE
+	gpBindBuffersBase                                C.GPBINDBUFFERSBASE
+	gpBindBuffersRange                               C.GPBINDBUFFERSRANGE
+	gpBindFragDataLocation                           C.GPBINDFRAGDATALOCATION
+	gpBindFragDataLocationIndexed                    C.GPBINDFRAGDATALOCATIONINDEXED
+	gpBindFramebuffer                                C.GPBINDFRAMEBUFFER
+	gpBindImageTexture                               C.GPBINDIMAGETEXTURE
+	gpBindImageTextures                              C.GPBINDIMAGETEXTURES
+	gpBindMultiTextureEXT                            C.GPBINDMULTITEXTUREEXT
+	gpBindProgramPipeline                            C.GPBINDPROGRAMPIPELINE
+	gpBindProgramPipelineEXT                         C.GPBINDPROGRAMPIPELINEEXT
+	gpBindRenderbuffer                               C.GPBINDRENDERBUFFER
+	gpBindSampler                                    C.GPBINDSAMPLER
+	gpBindSamplers                                   C.GPBINDSAMPLERS
+	gpBindTexture                                    C.GPBINDTEXTURE
+	gpBindTextureUnit                                C.GPBINDTEXTUREUNIT
+	gpBindTextures                                   C.GPBINDTEXTURES
+	gpBindTransformFeedback                          C.GPBINDTRANSFORMFEEDBACK
+	gpBindVertexArray                                C.GPBINDVERTEXARRAY
+	gpBindVertexBuffer                               C.GPBINDVERTEXBUFFER
+	gpBindVertexBuffers                              C.GPBINDVERTEXBUFFERS
+	gpBlendBarrierKHR                                C.GPBLENDBARRIERKHR
+	gpBlendBarrierNV                                 C.GPBLENDBARRIERNV
+	gpBlendColor                                     C.GPBLENDCOLOR
+	gpBlendEquation                                  C.GPBLENDEQUATION
+	gpBlendEquationSeparate                          C.GPBLENDEQUATIONSEPARATE
+	gpBlendEquationSeparatei                         C.GPBLENDEQUATIONSEPARATEI
+	gpBlendEquationSeparateiARB                      C.GPBLENDEQUATIONSEPARATEIARB
+	gpBlendEquationi                                 C.GPBLENDEQUATIONI
+	gpBlendEquationiARB                              C.GPBLENDEQUATIONIARB
+	gpBlendFunc                                      C.GPBLENDFUNC
+	gpBlendFuncSeparate                              C.GPBLENDFUNCSEPARATE
+	gpBlendFuncSeparatei                             C.GPBLENDFUNCSEPARATEI
+	gpBlendFuncSeparateiARB                          C.GPBLENDFUNCSEPARATEIARB
+	gpBlendFunci                                     C.GPBLENDFUNCI
+	gpBlendFunciARB                                  C.GPBLENDFUNCIARB
+	gpBlendParameteriNV                              C.GPBLENDPARAMETERINV
+	gpBlitFramebuffer                                C.GPBLITFRAMEBUFFER
+	gpBlitNamedFramebuffer                           C.GPBLITNAMEDFRAMEBUFFER
+	gpBufferAddressRangeNV                           C.GPBUFFERADDRESSRANGENV
+	gpBufferData                                     C.GPBUFFERDATA
+	gpBufferPageCommitmentARB                        C.GPBUFFERPAGECOMMITMENTARB
+	gpBufferStorage                                  C.GPBUFFERSTORAGE
+	gpBufferSubData                                  C.GPBUFFERSUBDATA
+	gpCallCommandListNV                              C.GPCALLCOMMANDLISTNV
+	gpCheckFramebufferStatus                         C.GPCHECKFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatus                    C.GPCHECKNAMEDFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatusEXT                 C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT
+	gpClampColor                                     C.GPCLAMPCOLOR
+	gpClear                                          C.GPCLEAR
+	gpClearBufferData                                C.GPCLEARBUFFERDATA
+	gpClearBufferSubData                             C.GPCLEARBUFFERSUBDATA
+	gpClearBufferfi                                  C.GPCLEARBUFFERFI
+	gpClearBufferfv                                  C.GPCLEARBUFFERFV
+	gpClearBufferiv                                  C.GPCLEARBUFFERIV
+	gpClearBufferuiv                                 C.GPCLEARBUFFERUIV
+	gpClearColor                                     C.GPCLEARCOLOR
+	gpClearDepth                                     C.GPCLEARDEPTH
+	gpClearDepthf                                    C.GPCLEARDEPTHF
+	gpClearNamedBufferData                           C.GPCLEARNAMEDBUFFERDATA
+	gpClearNamedBufferDataEXT                        C.GPCLEARNAMEDBUFFERDATAEXT
+	gpClearNamedBufferSubData                        C.GPCLEARNAMEDBUFFERSUBDATA
+	gpClearNamedBufferSubDataEXT                     C.GPCLEARNAMEDBUFFERSUBDATAEXT
+	gpClearNamedFramebufferfi                        C.GPCLEARNAMEDFRAMEBUFFERFI
+	gpClearNamedFramebufferfv                        C.GPCLEARNAMEDFRAMEBUFFERFV
+	gpClearNamedFramebufferiv                        C.GPCLEARNAMEDFRAMEBUFFERIV
+	gpClearNamedFramebufferuiv                       C.GPCLEARNAMEDFRAMEBUFFERUIV
+	gpClearStencil                                   C.GPCLEARSTENCIL
+	gpClearTexImage                                  C.GPCLEARTEXIMAGE
+	gpClearTexSubImage                               C.GPCLEARTEXSUBIMAGE
+	gpClientAttribDefaultEXT                         C.GPCLIENTATTRIBDEFAULTEXT
+	gpClientWaitSync                                 C.GPCLIENTWAITSYNC
+	gpClipControl                                    C.GPCLIPCONTROL
+	gpColorFormatNV                                  C.GPCOLORFORMATNV
+	gpColorMask                                      C.GPCOLORMASK
+	gpColorMaski                                     C.GPCOLORMASKI
+	gpCommandListSegmentsNV                          C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                           C.GPCOMPILECOMMANDLISTNV
+	gpCompileShader                                  C.GPCOMPILESHADER
+	gpCompileShaderIncludeARB                        C.GPCOMPILESHADERINCLUDEARB
+	gpCompressedMultiTexImage1DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE1DEXT
+	gpCompressedMultiTexImage2DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE2DEXT
+	gpCompressedMultiTexImage3DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE3DEXT
+	gpCompressedMultiTexSubImage1DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT
+	gpCompressedMultiTexSubImage2DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT
+	gpCompressedMultiTexSubImage3DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT
+	gpCompressedTexImage1D                           C.GPCOMPRESSEDTEXIMAGE1D
+	gpCompressedTexImage2D                           C.GPCOMPRESSEDTEXIMAGE2D
+	gpCompressedTexImage3D                           C.GPCOMPRESSEDTEXIMAGE3D
+	gpCompressedTexSubImage1D                        C.GPCOMPRESSEDTEXSUBIMAGE1D
+	gpCompressedTexSubImage2D                        C.GPCOMPRESSEDTEXSUBIMAGE2D
+	gpCompressedTexSubImage3D                        C.GPCOMPRESSEDTEXSUBIMAGE3D
+	gpCompressedTextureImage1DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE1DEXT
+	gpCompressedTextureImage2DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE2DEXT
+	gpCompressedTextureImage3DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE3DEXT
+	gpCompressedTextureSubImage1D                    C.GPCOMPRESSEDTEXTURESUBIMAGE1D
+	gpCompressedTextureSubImage1DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT
+	gpCompressedTextureSubImage2D                    C.GPCOMPRESSEDTEXTURESUBIMAGE2D
+	gpCompressedTextureSubImage2DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
+	gpCompressedTextureSubImage3D                    C.GPCOMPRESSEDTEXTURESUBIMAGE3D
+	gpCompressedTextureSubImage3DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                 C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                 C.GPCONSERVATIVERASTERPARAMETERINV
+	gpCopyBufferSubData                              C.GPCOPYBUFFERSUBDATA
+	gpCopyImageSubData                               C.GPCOPYIMAGESUBDATA
+	gpCopyMultiTexImage1DEXT                         C.GPCOPYMULTITEXIMAGE1DEXT
+	gpCopyMultiTexImage2DEXT                         C.GPCOPYMULTITEXIMAGE2DEXT
+	gpCopyMultiTexSubImage1DEXT                      C.GPCOPYMULTITEXSUBIMAGE1DEXT
+	gpCopyMultiTexSubImage2DEXT                      C.GPCOPYMULTITEXSUBIMAGE2DEXT
+	gpCopyMultiTexSubImage3DEXT                      C.GPCOPYMULTITEXSUBIMAGE3DEXT
+	gpCopyNamedBufferSubData                         C.GPCOPYNAMEDBUFFERSUBDATA
+	gpCopyPathNV                                     C.GPCOPYPATHNV
+	gpCopyTexImage1D                                 C.GPCOPYTEXIMAGE1D
+	gpCopyTexImage2D                                 C.GPCOPYTEXIMAGE2D
+	gpCopyTexSubImage1D                              C.GPCOPYTEXSUBIMAGE1D
+	gpCopyTexSubImage2D                              C.GPCOPYTEXSUBIMAGE2D
+	gpCopyTexSubImage3D                              C.GPCOPYTEXSUBIMAGE3D
+	gpCopyTextureImage1DEXT                          C.GPCOPYTEXTUREIMAGE1DEXT
+	gpCopyTextureImage2DEXT                          C.GPCOPYTEXTUREIMAGE2DEXT
+	gpCopyTextureSubImage1D                          C.GPCOPYTEXTURESUBIMAGE1D
+	gpCopyTextureSubImage1DEXT                       C.GPCOPYTEXTURESUBIMAGE1DEXT
+	gpCopyTextureSubImage2D                          C.GPCOPYTEXTURESUBIMAGE2D
+	gpCopyTextureSubImage2DEXT                       C.GPCOPYTEXTURESUBIMAGE2DEXT
+	gpCopyTextureSubImage3D                          C.GPCOPYTEXTURESUBIMAGE3D
+	gpCopyTextureSubImage3DEXT                       C.GPCOPYTEXTURESUBIMAGE3DEXT
+	gpCoverFillPathInstancedNV                       C.GPCOVERFILLPATHINSTANCEDNV
+	gpCoverFillPathNV                                C.GPCOVERFILLPATHNV
+	gpCoverStrokePathInstancedNV                     C.GPCOVERSTROKEPATHINSTANCEDNV
+	gpCoverStrokePathNV                              C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                           C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                      C.GPCOVERAGEMODULATIONTABLENV
+	gpCreateBuffers                                  C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                           C.GPCREATECOMMANDLISTSNV
+	gpCreateFramebuffers                             C.GPCREATEFRAMEBUFFERS
+	gpCreatePerfQueryINTEL                           C.GPCREATEPERFQUERYINTEL
+	gpCreateProgram                                  C.GPCREATEPROGRAM
+	gpCreateProgramPipelines                         C.GPCREATEPROGRAMPIPELINES
+	gpCreateQueries                                  C.GPCREATEQUERIES
+	gpCreateRenderbuffers                            C.GPCREATERENDERBUFFERS
+	gpCreateSamplers                                 C.GPCREATESAMPLERS
+	gpCreateShader                                   C.GPCREATESHADER
+	gpCreateShaderProgramEXT                         C.GPCREATESHADERPROGRAMEXT
+	gpCreateShaderProgramv                           C.GPCREATESHADERPROGRAMV
+	gpCreateShaderProgramvEXT                        C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                 C.GPCREATESTATESNV
+	gpCreateSyncFromCLeventARB                       C.GPCREATESYNCFROMCLEVENTARB
+	gpCreateTextures                                 C.GPCREATETEXTURES
+	gpCreateTransformFeedbacks                       C.GPCREATETRANSFORMFEEDBACKS
+	gpCreateVertexArrays                             C.GPCREATEVERTEXARRAYS
+	gpCullFace                                       C.GPCULLFACE
+	gpDebugMessageCallback                           C.GPDEBUGMESSAGECALLBACK
+	gpDebugMessageCallbackARB                        C.GPDEBUGMESSAGECALLBACKARB
+	gpDebugMessageCallbackKHR                        C.GPDEBUGMESSAGECALLBACKKHR
+	gpDebugMessageControl                            C.GPDEBUGMESSAGECONTROL
+	gpDebugMessageControlARB                         C.GPDEBUGMESSAGECONTROLARB
+	gpDebugMessageControlKHR                         C.GPDEBUGMESSAGECONTROLKHR
+	gpDebugMessageInsert                             C.GPDEBUGMESSAGEINSERT
+	gpDebugMessageInsertARB                          C.GPDEBUGMESSAGEINSERTARB
+	gpDebugMessageInsertKHR                          C.GPDEBUGMESSAGEINSERTKHR
+	gpDeleteBuffers                                  C.GPDELETEBUFFERS
+	gpDeleteCommandListsNV                           C.GPDELETECOMMANDLISTSNV
+	gpDeleteFramebuffers                             C.GPDELETEFRAMEBUFFERS
+	gpDeleteNamedStringARB                           C.GPDELETENAMEDSTRINGARB
+	gpDeletePathsNV                                  C.GPDELETEPATHSNV
+	gpDeletePerfMonitorsAMD                          C.GPDELETEPERFMONITORSAMD
+	gpDeletePerfQueryINTEL                           C.GPDELETEPERFQUERYINTEL
+	gpDeleteProgram                                  C.GPDELETEPROGRAM
+	gpDeleteProgramPipelines                         C.GPDELETEPROGRAMPIPELINES
+	gpDeleteProgramPipelinesEXT                      C.GPDELETEPROGRAMPIPELINESEXT
+	gpDeleteQueries                                  C.GPDELETEQUERIES
+	gpDeleteRenderbuffers                            C.GPDELETERENDERBUFFERS
+	gpDeleteSamplers                                 C.GPDELETESAMPLERS
+	gpDeleteShader                                   C.GPDELETESHADER
+	gpDeleteStatesNV                                 C.GPDELETESTATESNV
+	gpDeleteSync                                     C.GPDELETESYNC
+	gpDeleteTextures                                 C.GPDELETETEXTURES
+	gpDeleteTransformFeedbacks                       C.GPDELETETRANSFORMFEEDBACKS
+	gpDeleteVertexArrays                             C.GPDELETEVERTEXARRAYS
+	gpDepthFunc                                      C.GPDEPTHFUNC
+	gpDepthMask                                      C.GPDEPTHMASK
+	gpDepthRange                                     C.GPDEPTHRANGE
+	gpDepthRangeArrayv                               C.GPDEPTHRANGEARRAYV
+	gpDepthRangeIndexed                              C.GPDEPTHRANGEINDEXED
+	gpDepthRangef                                    C.GPDEPTHRANGEF
+	gpDetachShader                                   C.GPDETACHSHADER
+	gpDisable                                        C.GPDISABLE
+	gpDisableClientStateIndexedEXT                   C.GPDISABLECLIENTSTATEINDEXEDEXT
+	gpDisableClientStateiEXT                         C.GPDISABLECLIENTSTATEIEXT
+	gpDisableIndexedEXT                              C.GPDISABLEINDEXEDEXT
+	gpDisableVertexArrayAttrib                       C.GPDISABLEVERTEXARRAYATTRIB
+	gpDisableVertexArrayAttribEXT                    C.GPDISABLEVERTEXARRAYATTRIBEXT
+	gpDisableVertexArrayEXT                          C.GPDISABLEVERTEXARRAYEXT
+	gpDisableVertexAttribArray                       C.GPDISABLEVERTEXATTRIBARRAY
+	gpDisablei                                       C.GPDISABLEI
+	gpDispatchCompute                                C.GPDISPATCHCOMPUTE
+	gpDispatchComputeGroupSizeARB                    C.GPDISPATCHCOMPUTEGROUPSIZEARB
+	gpDispatchComputeIndirect                        C.GPDISPATCHCOMPUTEINDIRECT
+	gpDrawArrays                                     C.GPDRAWARRAYS
+	gpDrawArraysIndirect                             C.GPDRAWARRAYSINDIRECT
+	gpDrawArraysInstanced                            C.GPDRAWARRAYSINSTANCED
+	gpDrawArraysInstancedARB                         C.GPDRAWARRAYSINSTANCEDARB
+	gpDrawArraysInstancedBaseInstance                C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
+	gpDrawArraysInstancedEXT                         C.GPDRAWARRAYSINSTANCEDEXT
+	gpDrawBuffer                                     C.GPDRAWBUFFER
+	gpDrawBuffers                                    C.GPDRAWBUFFERS
+	gpDrawCommandsAddressNV                          C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                 C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                    C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                           C.GPDRAWCOMMANDSSTATESNV
+	gpDrawElements                                   C.GPDRAWELEMENTS
+	gpDrawElementsBaseVertex                         C.GPDRAWELEMENTSBASEVERTEX
+	gpDrawElementsIndirect                           C.GPDRAWELEMENTSINDIRECT
+	gpDrawElementsInstanced                          C.GPDRAWELEMENTSINSTANCED
+	gpDrawElementsInstancedARB                       C.GPDRAWELEMENTSINSTANCEDARB
+	gpDrawElementsInstancedBaseInstance              C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
+	gpDrawElementsInstancedBaseVertex                C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
+	gpDrawElementsInstancedBaseVertexBaseInstance    C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
+	gpDrawElementsInstancedEXT                       C.GPDRAWELEMENTSINSTANCEDEXT
+	gpDrawRangeElements                              C.GPDRAWRANGEELEMENTS
+	gpDrawRangeElementsBaseVertex                    C.GPDRAWRANGEELEMENTSBASEVERTEX
+	gpDrawTransformFeedback                          C.GPDRAWTRANSFORMFEEDBACK
+	gpDrawTransformFeedbackInstanced                 C.GPDRAWTRANSFORMFEEDBACKINSTANCED
+	gpDrawTransformFeedbackStream                    C.GPDRAWTRANSFORMFEEDBACKSTREAM
+	gpDrawTransformFeedbackStreamInstanced           C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                  C.GPDRAWVKIMAGENV
+	gpEdgeFlagFormatNV                               C.GPEDGEFLAGFORMATNV
+	gpEnable                                         C.GPENABLE
+	gpEnableClientStateIndexedEXT                    C.GPENABLECLIENTSTATEINDEXEDEXT
+	gpEnableClientStateiEXT                          C.GPENABLECLIENTSTATEIEXT
+	gpEnableIndexedEXT                               C.GPENABLEINDEXEDEXT
+	gpEnableVertexArrayAttrib                        C.GPENABLEVERTEXARRAYATTRIB
+	gpEnableVertexArrayAttribEXT                     C.GPENABLEVERTEXARRAYATTRIBEXT
+	gpEnableVertexArrayEXT                           C.GPENABLEVERTEXARRAYEXT
+	gpEnableVertexAttribArray                        C.GPENABLEVERTEXATTRIBARRAY
+	gpEnablei                                        C.GPENABLEI
+	gpEndConditionalRender                           C.GPENDCONDITIONALRENDER
+	gpEndConditionalRenderNV                         C.GPENDCONDITIONALRENDERNV
+	gpEndPerfMonitorAMD                              C.GPENDPERFMONITORAMD
+	gpEndPerfQueryINTEL                              C.GPENDPERFQUERYINTEL
+	gpEndQuery                                       C.GPENDQUERY
+	gpEndQueryIndexed                                C.GPENDQUERYINDEXED
+	gpEndTransformFeedback                           C.GPENDTRANSFORMFEEDBACK
+	gpEvaluateDepthValuesARB                         C.GPEVALUATEDEPTHVALUESARB
+	gpFenceSync                                      C.GPFENCESYNC
+	gpFinish                                         C.GPFINISH
+	gpFlush                                          C.GPFLUSH
+	gpFlushMappedBufferRange                         C.GPFLUSHMAPPEDBUFFERRANGE
+	gpFlushMappedNamedBufferRange                    C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
+	gpFlushMappedNamedBufferRangeEXT                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT
+	gpFogCoordFormatNV                               C.GPFOGCOORDFORMATNV
+	gpFragmentCoverageColorNV                        C.GPFRAGMENTCOVERAGECOLORNV
+	gpFramebufferDrawBufferEXT                       C.GPFRAMEBUFFERDRAWBUFFEREXT
+	gpFramebufferDrawBuffersEXT                      C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                     C.GPFRAMEBUFFERFETCHBARRIEREXT
+	gpFramebufferParameteri                          C.GPFRAMEBUFFERPARAMETERI
+	gpFramebufferReadBufferEXT                       C.GPFRAMEBUFFERREADBUFFEREXT
+	gpFramebufferRenderbuffer                        C.GPFRAMEBUFFERRENDERBUFFER
+	gpFramebufferSampleLocationsfvARB                C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                 C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferTexture                             C.GPFRAMEBUFFERTEXTURE
+	gpFramebufferTexture1D                           C.GPFRAMEBUFFERTEXTURE1D
+	gpFramebufferTexture2D                           C.GPFRAMEBUFFERTEXTURE2D
+	gpFramebufferTexture3D                           C.GPFRAMEBUFFERTEXTURE3D
+	gpFramebufferTextureARB                          C.GPFRAMEBUFFERTEXTUREARB
+	gpFramebufferTextureFaceARB                      C.GPFRAMEBUFFERTEXTUREFACEARB
+	gpFramebufferTextureLayer                        C.GPFRAMEBUFFERTEXTURELAYER
+	gpFramebufferTextureLayerARB                     C.GPFRAMEBUFFERTEXTURELAYERARB
+	gpFramebufferTextureMultiviewOVR                 C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
+	gpFrontFace                                      C.GPFRONTFACE
+	gpGenBuffers                                     C.GPGENBUFFERS
+	gpGenFramebuffers                                C.GPGENFRAMEBUFFERS
+	gpGenPathsNV                                     C.GPGENPATHSNV
+	gpGenPerfMonitorsAMD                             C.GPGENPERFMONITORSAMD
+	gpGenProgramPipelines                            C.GPGENPROGRAMPIPELINES
+	gpGenProgramPipelinesEXT                         C.GPGENPROGRAMPIPELINESEXT
+	gpGenQueries                                     C.GPGENQUERIES
+	gpGenRenderbuffers                               C.GPGENRENDERBUFFERS
+	gpGenSamplers                                    C.GPGENSAMPLERS
+	gpGenTextures                                    C.GPGENTEXTURES
+	gpGenTransformFeedbacks                          C.GPGENTRANSFORMFEEDBACKS
+	gpGenVertexArrays                                C.GPGENVERTEXARRAYS
+	gpGenerateMipmap                                 C.GPGENERATEMIPMAP
+	gpGenerateMultiTexMipmapEXT                      C.GPGENERATEMULTITEXMIPMAPEXT
+	gpGenerateTextureMipmap                          C.GPGENERATETEXTUREMIPMAP
+	gpGenerateTextureMipmapEXT                       C.GPGENERATETEXTUREMIPMAPEXT
+	gpGetActiveAtomicCounterBufferiv                 C.GPGETACTIVEATOMICCOUNTERBUFFERIV
+	gpGetActiveAttrib                                C.GPGETACTIVEATTRIB
+	gpGetActiveSubroutineName                        C.GPGETACTIVESUBROUTINENAME
+	gpGetActiveSubroutineUniformName                 C.GPGETACTIVESUBROUTINEUNIFORMNAME
+	gpGetActiveSubroutineUniformiv                   C.GPGETACTIVESUBROUTINEUNIFORMIV
+	gpGetActiveUniform                               C.GPGETACTIVEUNIFORM
+	gpGetActiveUniformBlockName                      C.GPGETACTIVEUNIFORMBLOCKNAME
+	gpGetActiveUniformBlockiv                        C.GPGETACTIVEUNIFORMBLOCKIV
+	gpGetActiveUniformName                           C.GPGETACTIVEUNIFORMNAME
+	gpGetActiveUniformsiv                            C.GPGETACTIVEUNIFORMSIV
+	gpGetAttachedShaders                             C.GPGETATTACHEDSHADERS
+	gpGetAttribLocation                              C.GPGETATTRIBLOCATION
+	gpGetBooleanIndexedvEXT                          C.GPGETBOOLEANINDEXEDVEXT
+	gpGetBooleani_v                                  C.GPGETBOOLEANI_V
+	gpGetBooleanv                                    C.GPGETBOOLEANV
+	gpGetBufferParameteri64v                         C.GPGETBUFFERPARAMETERI64V
+	gpGetBufferParameteriv                           C.GPGETBUFFERPARAMETERIV
+	gpGetBufferParameterui64vNV                      C.GPGETBUFFERPARAMETERUI64VNV
+	gpGetBufferPointerv                              C.GPGETBUFFERPOINTERV
+	gpGetBufferSubData                               C.GPGETBUFFERSUBDATA
+	gpGetCommandHeaderNV                             C.GPGETCOMMANDHEADERNV
+	gpGetCompressedMultiTexImageEXT                  C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
+	gpGetCompressedTexImage                          C.GPGETCOMPRESSEDTEXIMAGE
+	gpGetCompressedTextureImage                      C.GPGETCOMPRESSEDTEXTUREIMAGE
+	gpGetCompressedTextureImageEXT                   C.GPGETCOMPRESSEDTEXTUREIMAGEEXT
+	gpGetCompressedTextureSubImage                   C.GPGETCOMPRESSEDTEXTURESUBIMAGE
+	gpGetCoverageModulationTableNV                   C.GPGETCOVERAGEMODULATIONTABLENV
+	gpGetDebugMessageLog                             C.GPGETDEBUGMESSAGELOG
+	gpGetDebugMessageLogARB                          C.GPGETDEBUGMESSAGELOGARB
+	gpGetDebugMessageLogKHR                          C.GPGETDEBUGMESSAGELOGKHR
+	gpGetDoubleIndexedvEXT                           C.GPGETDOUBLEINDEXEDVEXT
+	gpGetDoublei_v                                   C.GPGETDOUBLEI_V
+	gpGetDoublei_vEXT                                C.GPGETDOUBLEI_VEXT
+	gpGetDoublev                                     C.GPGETDOUBLEV
+	gpGetError                                       C.GPGETERROR
+	gpGetFirstPerfQueryIdINTEL                       C.GPGETFIRSTPERFQUERYIDINTEL
+	gpGetFloatIndexedvEXT                            C.GPGETFLOATINDEXEDVEXT
+	gpGetFloati_v                                    C.GPGETFLOATI_V
+	gpGetFloati_vEXT                                 C.GPGETFLOATI_VEXT
+	gpGetFloatv                                      C.GPGETFLOATV
+	gpGetFragDataIndex                               C.GPGETFRAGDATAINDEX
+	gpGetFragDataLocation                            C.GPGETFRAGDATALOCATION
+	gpGetFramebufferAttachmentParameteriv            C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetFramebufferParameteriv                      C.GPGETFRAMEBUFFERPARAMETERIV
+	gpGetFramebufferParameterivEXT                   C.GPGETFRAMEBUFFERPARAMETERIVEXT
+	gpGetGraphicsResetStatus                         C.GPGETGRAPHICSRESETSTATUS
+	gpGetGraphicsResetStatusARB                      C.GPGETGRAPHICSRESETSTATUSARB
+	gpGetGraphicsResetStatusKHR                      C.GPGETGRAPHICSRESETSTATUSKHR
+	gpGetImageHandleARB                              C.GPGETIMAGEHANDLEARB
+	gpGetImageHandleNV                               C.GPGETIMAGEHANDLENV
+	gpGetInteger64i_v                                C.GPGETINTEGER64I_V
+	gpGetInteger64v                                  C.GPGETINTEGER64V
+	gpGetIntegerIndexedvEXT                          C.GPGETINTEGERINDEXEDVEXT
+	gpGetIntegeri_v                                  C.GPGETINTEGERI_V
+	gpGetIntegerui64i_vNV                            C.GPGETINTEGERUI64I_VNV
+	gpGetIntegerui64vNV                              C.GPGETINTEGERUI64VNV
+	gpGetIntegerv                                    C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                    C.GPGETINTERNALFORMATSAMPLEIVNV
+	gpGetInternalformati64v                          C.GPGETINTERNALFORMATI64V
+	gpGetInternalformativ                            C.GPGETINTERNALFORMATIV
+	gpGetMultiTexEnvfvEXT                            C.GPGETMULTITEXENVFVEXT
+	gpGetMultiTexEnvivEXT                            C.GPGETMULTITEXENVIVEXT
+	gpGetMultiTexGendvEXT                            C.GPGETMULTITEXGENDVEXT
+	gpGetMultiTexGenfvEXT                            C.GPGETMULTITEXGENFVEXT
+	gpGetMultiTexGenivEXT                            C.GPGETMULTITEXGENIVEXT
+	gpGetMultiTexImageEXT                            C.GPGETMULTITEXIMAGEEXT
+	gpGetMultiTexLevelParameterfvEXT                 C.GPGETMULTITEXLEVELPARAMETERFVEXT
+	gpGetMultiTexLevelParameterivEXT                 C.GPGETMULTITEXLEVELPARAMETERIVEXT
+	gpGetMultiTexParameterIivEXT                     C.GPGETMULTITEXPARAMETERIIVEXT
+	gpGetMultiTexParameterIuivEXT                    C.GPGETMULTITEXPARAMETERIUIVEXT
+	gpGetMultiTexParameterfvEXT                      C.GPGETMULTITEXPARAMETERFVEXT
+	gpGetMultiTexParameterivEXT                      C.GPGETMULTITEXPARAMETERIVEXT
+	gpGetMultisamplefv                               C.GPGETMULTISAMPLEFV
+	gpGetNamedBufferParameteri64v                    C.GPGETNAMEDBUFFERPARAMETERI64V
+	gpGetNamedBufferParameteriv                      C.GPGETNAMEDBUFFERPARAMETERIV
+	gpGetNamedBufferParameterivEXT                   C.GPGETNAMEDBUFFERPARAMETERIVEXT
+	gpGetNamedBufferParameterui64vNV                 C.GPGETNAMEDBUFFERPARAMETERUI64VNV
+	gpGetNamedBufferPointerv                         C.GPGETNAMEDBUFFERPOINTERV
+	gpGetNamedBufferPointervEXT                      C.GPGETNAMEDBUFFERPOINTERVEXT
+	gpGetNamedBufferSubData                          C.GPGETNAMEDBUFFERSUBDATA
+	gpGetNamedBufferSubDataEXT                       C.GPGETNAMEDBUFFERSUBDATAEXT
+	gpGetNamedFramebufferAttachmentParameteriv       C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetNamedFramebufferAttachmentParameterivEXT    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameteriv                 C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
+	gpGetNamedFramebufferParameterivEXT              C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
+	gpGetNamedProgramLocalParameterIivEXT            C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
+	gpGetNamedProgramLocalParameterIuivEXT           C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT
+	gpGetNamedProgramLocalParameterdvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT
+	gpGetNamedProgramLocalParameterfvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT
+	gpGetNamedProgramStringEXT                       C.GPGETNAMEDPROGRAMSTRINGEXT
+	gpGetNamedProgramivEXT                           C.GPGETNAMEDPROGRAMIVEXT
+	gpGetNamedRenderbufferParameteriv                C.GPGETNAMEDRENDERBUFFERPARAMETERIV
+	gpGetNamedRenderbufferParameterivEXT             C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT
+	gpGetNamedStringARB                              C.GPGETNAMEDSTRINGARB
+	gpGetNamedStringivARB                            C.GPGETNAMEDSTRINGIVARB
+	gpGetNextPerfQueryIdINTEL                        C.GPGETNEXTPERFQUERYIDINTEL
+	gpGetObjectLabel                                 C.GPGETOBJECTLABEL
+	gpGetObjectLabelEXT                              C.GPGETOBJECTLABELEXT
+	gpGetObjectLabelKHR                              C.GPGETOBJECTLABELKHR
+	gpGetObjectPtrLabel                              C.GPGETOBJECTPTRLABEL
+	gpGetObjectPtrLabelKHR                           C.GPGETOBJECTPTRLABELKHR
+	gpGetPathCommandsNV                              C.GPGETPATHCOMMANDSNV
+	gpGetPathCoordsNV                                C.GPGETPATHCOORDSNV
+	gpGetPathDashArrayNV                             C.GPGETPATHDASHARRAYNV
+	gpGetPathLengthNV                                C.GPGETPATHLENGTHNV
+	gpGetPathMetricRangeNV                           C.GPGETPATHMETRICRANGENV
+	gpGetPathMetricsNV                               C.GPGETPATHMETRICSNV
+	gpGetPathParameterfvNV                           C.GPGETPATHPARAMETERFVNV
+	gpGetPathParameterivNV                           C.GPGETPATHPARAMETERIVNV
+	gpGetPathSpacingNV                               C.GPGETPATHSPACINGNV
+	gpGetPerfCounterInfoINTEL                        C.GPGETPERFCOUNTERINFOINTEL
+	gpGetPerfMonitorCounterDataAMD                   C.GPGETPERFMONITORCOUNTERDATAAMD
+	gpGetPerfMonitorCounterInfoAMD                   C.GPGETPERFMONITORCOUNTERINFOAMD
+	gpGetPerfMonitorCounterStringAMD                 C.GPGETPERFMONITORCOUNTERSTRINGAMD
+	gpGetPerfMonitorCountersAMD                      C.GPGETPERFMONITORCOUNTERSAMD
+	gpGetPerfMonitorGroupStringAMD                   C.GPGETPERFMONITORGROUPSTRINGAMD
+	gpGetPerfMonitorGroupsAMD                        C.GPGETPERFMONITORGROUPSAMD
+	gpGetPerfQueryDataINTEL                          C.GPGETPERFQUERYDATAINTEL
+	gpGetPerfQueryIdByNameINTEL                      C.GPGETPERFQUERYIDBYNAMEINTEL
+	gpGetPerfQueryInfoINTEL                          C.GPGETPERFQUERYINFOINTEL
+	gpGetPointerIndexedvEXT                          C.GPGETPOINTERINDEXEDVEXT
+	gpGetPointeri_vEXT                               C.GPGETPOINTERI_VEXT
+	gpGetPointerv                                    C.GPGETPOINTERV
+	gpGetPointervKHR                                 C.GPGETPOINTERVKHR
+	gpGetProgramBinary                               C.GPGETPROGRAMBINARY
+	gpGetProgramInfoLog                              C.GPGETPROGRAMINFOLOG
+	gpGetProgramInterfaceiv                          C.GPGETPROGRAMINTERFACEIV
+	gpGetProgramPipelineInfoLog                      C.GPGETPROGRAMPIPELINEINFOLOG
+	gpGetProgramPipelineInfoLogEXT                   C.GPGETPROGRAMPIPELINEINFOLOGEXT
+	gpGetProgramPipelineiv                           C.GPGETPROGRAMPIPELINEIV
+	gpGetProgramPipelineivEXT                        C.GPGETPROGRAMPIPELINEIVEXT
+	gpGetProgramResourceIndex                        C.GPGETPROGRAMRESOURCEINDEX
+	gpGetProgramResourceLocation                     C.GPGETPROGRAMRESOURCELOCATION
+	gpGetProgramResourceLocationIndex                C.GPGETPROGRAMRESOURCELOCATIONINDEX
+	gpGetProgramResourceName                         C.GPGETPROGRAMRESOURCENAME
+	gpGetProgramResourcefvNV                         C.GPGETPROGRAMRESOURCEFVNV
+	gpGetProgramResourceiv                           C.GPGETPROGRAMRESOURCEIV
+	gpGetProgramStageiv                              C.GPGETPROGRAMSTAGEIV
+	gpGetProgramiv                                   C.GPGETPROGRAMIV
+	gpGetQueryBufferObjecti64v                       C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                         C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                      C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                        C.GPGETQUERYBUFFEROBJECTUIV
+	gpGetQueryIndexediv                              C.GPGETQUERYINDEXEDIV
+	gpGetQueryObjecti64v                             C.GPGETQUERYOBJECTI64V
+	gpGetQueryObjectiv                               C.GPGETQUERYOBJECTIV
+	gpGetQueryObjectui64v                            C.GPGETQUERYOBJECTUI64V
+	gpGetQueryObjectuiv                              C.GPGETQUERYOBJECTUIV
+	gpGetQueryiv                                     C.GPGETQUERYIV
+	gpGetRenderbufferParameteriv                     C.GPGETRENDERBUFFERPARAMETERIV
+	gpGetSamplerParameterIiv                         C.GPGETSAMPLERPARAMETERIIV
+	gpGetSamplerParameterIuiv                        C.GPGETSAMPLERPARAMETERIUIV
+	gpGetSamplerParameterfv                          C.GPGETSAMPLERPARAMETERFV
+	gpGetSamplerParameteriv                          C.GPGETSAMPLERPARAMETERIV
+	gpGetShaderInfoLog                               C.GPGETSHADERINFOLOG
+	gpGetShaderPrecisionFormat                       C.GPGETSHADERPRECISIONFORMAT
+	gpGetShaderSource                                C.GPGETSHADERSOURCE
+	gpGetShaderiv                                    C.GPGETSHADERIV
+	gpGetStageIndexNV                                C.GPGETSTAGEINDEXNV
+	gpGetString                                      C.GPGETSTRING
+	gpGetStringi                                     C.GPGETSTRINGI
+	gpGetSubroutineIndex                             C.GPGETSUBROUTINEINDEX
+	gpGetSubroutineUniformLocation                   C.GPGETSUBROUTINEUNIFORMLOCATION
+	gpGetSynciv                                      C.GPGETSYNCIV
+	gpGetTexImage                                    C.GPGETTEXIMAGE
+	gpGetTexLevelParameterfv                         C.GPGETTEXLEVELPARAMETERFV
+	gpGetTexLevelParameteriv                         C.GPGETTEXLEVELPARAMETERIV
+	gpGetTexParameterIiv                             C.GPGETTEXPARAMETERIIV
+	gpGetTexParameterIuiv                            C.GPGETTEXPARAMETERIUIV
+	gpGetTexParameterfv                              C.GPGETTEXPARAMETERFV
+	gpGetTexParameteriv                              C.GPGETTEXPARAMETERIV
+	gpGetTextureHandleARB                            C.GPGETTEXTUREHANDLEARB
+	gpGetTextureHandleNV                             C.GPGETTEXTUREHANDLENV
+	gpGetTextureImage                                C.GPGETTEXTUREIMAGE
+	gpGetTextureImageEXT                             C.GPGETTEXTUREIMAGEEXT
+	gpGetTextureLevelParameterfv                     C.GPGETTEXTURELEVELPARAMETERFV
+	gpGetTextureLevelParameterfvEXT                  C.GPGETTEXTURELEVELPARAMETERFVEXT
+	gpGetTextureLevelParameteriv                     C.GPGETTEXTURELEVELPARAMETERIV
+	gpGetTextureLevelParameterivEXT                  C.GPGETTEXTURELEVELPARAMETERIVEXT
+	gpGetTextureParameterIiv                         C.GPGETTEXTUREPARAMETERIIV
+	gpGetTextureParameterIivEXT                      C.GPGETTEXTUREPARAMETERIIVEXT
+	gpGetTextureParameterIuiv                        C.GPGETTEXTUREPARAMETERIUIV
+	gpGetTextureParameterIuivEXT                     C.GPGETTEXTUREPARAMETERIUIVEXT
+	gpGetTextureParameterfv                          C.GPGETTEXTUREPARAMETERFV
+	gpGetTextureParameterfvEXT                       C.GPGETTEXTUREPARAMETERFVEXT
+	gpGetTextureParameteriv                          C.GPGETTEXTUREPARAMETERIV
+	gpGetTextureParameterivEXT                       C.GPGETTEXTUREPARAMETERIVEXT
+	gpGetTextureSamplerHandleARB                     C.GPGETTEXTURESAMPLERHANDLEARB
+	gpGetTextureSamplerHandleNV                      C.GPGETTEXTURESAMPLERHANDLENV
+	gpGetTextureSubImage                             C.GPGETTEXTURESUBIMAGE
+	gpGetTransformFeedbackVarying                    C.GPGETTRANSFORMFEEDBACKVARYING
+	gpGetTransformFeedbacki64_v                      C.GPGETTRANSFORMFEEDBACKI64_V
+	gpGetTransformFeedbacki_v                        C.GPGETTRANSFORMFEEDBACKI_V
+	gpGetTransformFeedbackiv                         C.GPGETTRANSFORMFEEDBACKIV
+	gpGetUniformBlockIndex                           C.GPGETUNIFORMBLOCKINDEX
+	gpGetUniformIndices                              C.GPGETUNIFORMINDICES
+	gpGetUniformLocation                             C.GPGETUNIFORMLOCATION
+	gpGetUniformSubroutineuiv                        C.GPGETUNIFORMSUBROUTINEUIV
+	gpGetUniformdv                                   C.GPGETUNIFORMDV
+	gpGetUniformfv                                   C.GPGETUNIFORMFV
+	gpGetUniformi64vARB                              C.GPGETUNIFORMI64VARB
+	gpGetUniformi64vNV                               C.GPGETUNIFORMI64VNV
+	gpGetUniformiv                                   C.GPGETUNIFORMIV
+	gpGetUniformui64vARB                             C.GPGETUNIFORMUI64VARB
+	gpGetUniformui64vNV                              C.GPGETUNIFORMUI64VNV
+	gpGetUniformuiv                                  C.GPGETUNIFORMUIV
+	gpGetVertexArrayIndexed64iv                      C.GPGETVERTEXARRAYINDEXED64IV
+	gpGetVertexArrayIndexediv                        C.GPGETVERTEXARRAYINDEXEDIV
+	gpGetVertexArrayIntegeri_vEXT                    C.GPGETVERTEXARRAYINTEGERI_VEXT
+	gpGetVertexArrayIntegervEXT                      C.GPGETVERTEXARRAYINTEGERVEXT
+	gpGetVertexArrayPointeri_vEXT                    C.GPGETVERTEXARRAYPOINTERI_VEXT
+	gpGetVertexArrayPointervEXT                      C.GPGETVERTEXARRAYPOINTERVEXT
+	gpGetVertexArrayiv                               C.GPGETVERTEXARRAYIV
+	gpGetVertexAttribIiv                             C.GPGETVERTEXATTRIBIIV
+	gpGetVertexAttribIuiv                            C.GPGETVERTEXATTRIBIUIV
+	gpGetVertexAttribLdv                             C.GPGETVERTEXATTRIBLDV
+	gpGetVertexAttribLi64vNV                         C.GPGETVERTEXATTRIBLI64VNV
+	gpGetVertexAttribLui64vARB                       C.GPGETVERTEXATTRIBLUI64VARB
+	gpGetVertexAttribLui64vNV                        C.GPGETVERTEXATTRIBLUI64VNV
+	gpGetVertexAttribPointerv                        C.GPGETVERTEXATTRIBPOINTERV
+	gpGetVertexAttribdv                              C.GPGETVERTEXATTRIBDV
+	gpGetVertexAttribfv                              C.GPGETVERTEXATTRIBFV
+	gpGetVertexAttribiv                              C.GPGETVERTEXATTRIBIV
+	gpGetVkProcAddrNV                                C.GPGETVKPROCADDRNV
+	gpGetnCompressedTexImageARB                      C.GPGETNCOMPRESSEDTEXIMAGEARB
+	gpGetnTexImageARB                                C.GPGETNTEXIMAGEARB
+	gpGetnUniformdvARB                               C.GPGETNUNIFORMDVARB
+	gpGetnUniformfv                                  C.GPGETNUNIFORMFV
+	gpGetnUniformfvARB                               C.GPGETNUNIFORMFVARB
+	gpGetnUniformfvKHR                               C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                             C.GPGETNUNIFORMI64VARB
+	gpGetnUniformiv                                  C.GPGETNUNIFORMIV
+	gpGetnUniformivARB                               C.GPGETNUNIFORMIVARB
+	gpGetnUniformivKHR                               C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                            C.GPGETNUNIFORMUI64VARB
+	gpGetnUniformuiv                                 C.GPGETNUNIFORMUIV
+	gpGetnUniformuivARB                              C.GPGETNUNIFORMUIVARB
+	gpGetnUniformuivKHR                              C.GPGETNUNIFORMUIVKHR
+	gpHint                                           C.GPHINT
+	gpIndexFormatNV                                  C.GPINDEXFORMATNV
+	gpInsertEventMarkerEXT                           C.GPINSERTEVENTMARKEREXT
+	gpInterpolatePathsNV                             C.GPINTERPOLATEPATHSNV
+	gpInvalidateBufferData                           C.GPINVALIDATEBUFFERDATA
+	gpInvalidateBufferSubData                        C.GPINVALIDATEBUFFERSUBDATA
+	gpInvalidateFramebuffer                          C.GPINVALIDATEFRAMEBUFFER
+	gpInvalidateNamedFramebufferData                 C.GPINVALIDATENAMEDFRAMEBUFFERDATA
+	gpInvalidateNamedFramebufferSubData              C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
+	gpInvalidateSubFramebuffer                       C.GPINVALIDATESUBFRAMEBUFFER
+	gpInvalidateTexImage                             C.GPINVALIDATETEXIMAGE
+	gpInvalidateTexSubImage                          C.GPINVALIDATETEXSUBIMAGE
+	gpIsBuffer                                       C.GPISBUFFER
+	gpIsBufferResidentNV                             C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                C.GPISCOMMANDLISTNV
+	gpIsEnabled                                      C.GPISENABLED
+	gpIsEnabledIndexedEXT                            C.GPISENABLEDINDEXEDEXT
+	gpIsEnabledi                                     C.GPISENABLEDI
+	gpIsFramebuffer                                  C.GPISFRAMEBUFFER
+	gpIsImageHandleResidentARB                       C.GPISIMAGEHANDLERESIDENTARB
+	gpIsImageHandleResidentNV                        C.GPISIMAGEHANDLERESIDENTNV
+	gpIsNamedBufferResidentNV                        C.GPISNAMEDBUFFERRESIDENTNV
+	gpIsNamedStringARB                               C.GPISNAMEDSTRINGARB
+	gpIsPathNV                                       C.GPISPATHNV
+	gpIsPointInFillPathNV                            C.GPISPOINTINFILLPATHNV
+	gpIsPointInStrokePathNV                          C.GPISPOINTINSTROKEPATHNV
+	gpIsProgram                                      C.GPISPROGRAM
+	gpIsProgramPipeline                              C.GPISPROGRAMPIPELINE
+	gpIsProgramPipelineEXT                           C.GPISPROGRAMPIPELINEEXT
+	gpIsQuery                                        C.GPISQUERY
+	gpIsRenderbuffer                                 C.GPISRENDERBUFFER
+	gpIsSampler                                      C.GPISSAMPLER
+	gpIsShader                                       C.GPISSHADER
+	gpIsStateNV                                      C.GPISSTATENV
+	gpIsSync                                         C.GPISSYNC
+	gpIsTexture                                      C.GPISTEXTURE
+	gpIsTextureHandleResidentARB                     C.GPISTEXTUREHANDLERESIDENTARB
+	gpIsTextureHandleResidentNV                      C.GPISTEXTUREHANDLERESIDENTNV
+	gpIsTransformFeedback                            C.GPISTRANSFORMFEEDBACK
+	gpIsVertexArray                                  C.GPISVERTEXARRAY
+	gpLabelObjectEXT                                 C.GPLABELOBJECTEXT
+	gpLineWidth                                      C.GPLINEWIDTH
+	gpLinkProgram                                    C.GPLINKPROGRAM
+	gpListDrawCommandsStatesClientNV                 C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
+	gpLogicOp                                        C.GPLOGICOP
+	gpMakeBufferNonResidentNV                        C.GPMAKEBUFFERNONRESIDENTNV
+	gpMakeBufferResidentNV                           C.GPMAKEBUFFERRESIDENTNV
+	gpMakeImageHandleNonResidentARB                  C.GPMAKEIMAGEHANDLENONRESIDENTARB
+	gpMakeImageHandleNonResidentNV                   C.GPMAKEIMAGEHANDLENONRESIDENTNV
+	gpMakeImageHandleResidentARB                     C.GPMAKEIMAGEHANDLERESIDENTARB
+	gpMakeImageHandleResidentNV                      C.GPMAKEIMAGEHANDLERESIDENTNV
+	gpMakeNamedBufferNonResidentNV                   C.GPMAKENAMEDBUFFERNONRESIDENTNV
+	gpMakeNamedBufferResidentNV                      C.GPMAKENAMEDBUFFERRESIDENTNV
+	gpMakeTextureHandleNonResidentARB                C.GPMAKETEXTUREHANDLENONRESIDENTARB
+	gpMakeTextureHandleNonResidentNV                 C.GPMAKETEXTUREHANDLENONRESIDENTNV
+	gpMakeTextureHandleResidentARB                   C.GPMAKETEXTUREHANDLERESIDENTARB
+	gpMakeTextureHandleResidentNV                    C.GPMAKETEXTUREHANDLERESIDENTNV
+	gpMapBuffer                                      C.GPMAPBUFFER
+	gpMapBufferRange                                 C.GPMAPBUFFERRANGE
+	gpMapNamedBuffer                                 C.GPMAPNAMEDBUFFER
+	gpMapNamedBufferEXT                              C.GPMAPNAMEDBUFFEREXT
+	gpMapNamedBufferRange                            C.GPMAPNAMEDBUFFERRANGE
+	gpMapNamedBufferRangeEXT                         C.GPMAPNAMEDBUFFERRANGEEXT
+	gpMatrixFrustumEXT                               C.GPMATRIXFRUSTUMEXT
+	gpMatrixLoad3x2fNV                               C.GPMATRIXLOAD3X2FNV
+	gpMatrixLoad3x3fNV                               C.GPMATRIXLOAD3X3FNV
+	gpMatrixLoadIdentityEXT                          C.GPMATRIXLOADIDENTITYEXT
+	gpMatrixLoadTranspose3x3fNV                      C.GPMATRIXLOADTRANSPOSE3X3FNV
+	gpMatrixLoadTransposedEXT                        C.GPMATRIXLOADTRANSPOSEDEXT
+	gpMatrixLoadTransposefEXT                        C.GPMATRIXLOADTRANSPOSEFEXT
+	gpMatrixLoaddEXT                                 C.GPMATRIXLOADDEXT
+	gpMatrixLoadfEXT                                 C.GPMATRIXLOADFEXT
+	gpMatrixMult3x2fNV                               C.GPMATRIXMULT3X2FNV
+	gpMatrixMult3x3fNV                               C.GPMATRIXMULT3X3FNV
+	gpMatrixMultTranspose3x3fNV                      C.GPMATRIXMULTTRANSPOSE3X3FNV
+	gpMatrixMultTransposedEXT                        C.GPMATRIXMULTTRANSPOSEDEXT
+	gpMatrixMultTransposefEXT                        C.GPMATRIXMULTTRANSPOSEFEXT
+	gpMatrixMultdEXT                                 C.GPMATRIXMULTDEXT
+	gpMatrixMultfEXT                                 C.GPMATRIXMULTFEXT
+	gpMatrixOrthoEXT                                 C.GPMATRIXORTHOEXT
+	gpMatrixPopEXT                                   C.GPMATRIXPOPEXT
+	gpMatrixPushEXT                                  C.GPMATRIXPUSHEXT
+	gpMatrixRotatedEXT                               C.GPMATRIXROTATEDEXT
+	gpMatrixRotatefEXT                               C.GPMATRIXROTATEFEXT
+	gpMatrixScaledEXT                                C.GPMATRIXSCALEDEXT
+	gpMatrixScalefEXT                                C.GPMATRIXSCALEFEXT
+	gpMatrixTranslatedEXT                            C.GPMATRIXTRANSLATEDEXT
+	gpMatrixTranslatefEXT                            C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                    C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                    C.GPMAXSHADERCOMPILERTHREADSKHR
+	gpMemoryBarrier                                  C.GPMEMORYBARRIER
+	gpMemoryBarrierByRegion                          C.GPMEMORYBARRIERBYREGION
+	gpMinSampleShading                               C.GPMINSAMPLESHADING
+	gpMinSampleShadingARB                            C.GPMINSAMPLESHADINGARB
+	gpMultiDrawArrays                                C.GPMULTIDRAWARRAYS
+	gpMultiDrawArraysIndirect                        C.GPMULTIDRAWARRAYSINDIRECT
+	gpMultiDrawArraysIndirectBindlessCountNV         C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawArraysIndirectBindlessNV              C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV
+	gpMultiDrawArraysIndirectCountARB                C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
+	gpMultiDrawElements                              C.GPMULTIDRAWELEMENTS
+	gpMultiDrawElementsBaseVertex                    C.GPMULTIDRAWELEMENTSBASEVERTEX
+	gpMultiDrawElementsIndirect                      C.GPMULTIDRAWELEMENTSINDIRECT
+	gpMultiDrawElementsIndirectBindlessCountNV       C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawElementsIndirectBindlessNV            C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV
+	gpMultiDrawElementsIndirectCountARB              C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
+	gpMultiTexBufferEXT                              C.GPMULTITEXBUFFEREXT
+	gpMultiTexCoordPointerEXT                        C.GPMULTITEXCOORDPOINTEREXT
+	gpMultiTexEnvfEXT                                C.GPMULTITEXENVFEXT
+	gpMultiTexEnvfvEXT                               C.GPMULTITEXENVFVEXT
+	gpMultiTexEnviEXT                                C.GPMULTITEXENVIEXT
+	gpMultiTexEnvivEXT                               C.GPMULTITEXENVIVEXT
+	gpMultiTexGendEXT                                C.GPMULTITEXGENDEXT
+	gpMultiTexGendvEXT                               C.GPMULTITEXGENDVEXT
+	gpMultiTexGenfEXT                                C.GPMULTITEXGENFEXT
+	gpMultiTexGenfvEXT                               C.GPMULTITEXGENFVEXT
+	gpMultiTexGeniEXT                                C.GPMULTITEXGENIEXT
+	gpMultiTexGenivEXT                               C.GPMULTITEXGENIVEXT
+	gpMultiTexImage1DEXT                             C.GPMULTITEXIMAGE1DEXT
+	gpMultiTexImage2DEXT                             C.GPMULTITEXIMAGE2DEXT
+	gpMultiTexImage3DEXT                             C.GPMULTITEXIMAGE3DEXT
+	gpMultiTexParameterIivEXT                        C.GPMULTITEXPARAMETERIIVEXT
+	gpMultiTexParameterIuivEXT                       C.GPMULTITEXPARAMETERIUIVEXT
+	gpMultiTexParameterfEXT                          C.GPMULTITEXPARAMETERFEXT
+	gpMultiTexParameterfvEXT                         C.GPMULTITEXPARAMETERFVEXT
+	gpMultiTexParameteriEXT                          C.GPMULTITEXPARAMETERIEXT
+	gpMultiTexParameterivEXT                         C.GPMULTITEXPARAMETERIVEXT
+	gpMultiTexRenderbufferEXT                        C.GPMULTITEXRENDERBUFFEREXT
+	gpMultiTexSubImage1DEXT                          C.GPMULTITEXSUBIMAGE1DEXT
+	gpMultiTexSubImage2DEXT                          C.GPMULTITEXSUBIMAGE2DEXT
+	gpMultiTexSubImage3DEXT                          C.GPMULTITEXSUBIMAGE3DEXT
+	gpNamedBufferData                                C.GPNAMEDBUFFERDATA
+	gpNamedBufferDataEXT                             C.GPNAMEDBUFFERDATAEXT
+	gpNamedBufferPageCommitmentARB                   C.GPNAMEDBUFFERPAGECOMMITMENTARB
+	gpNamedBufferPageCommitmentEXT                   C.GPNAMEDBUFFERPAGECOMMITMENTEXT
+	gpNamedBufferStorage                             C.GPNAMEDBUFFERSTORAGE
+	gpNamedBufferStorageEXT                          C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferSubData                             C.GPNAMEDBUFFERSUBDATA
+	gpNamedBufferSubDataEXT                          C.GPNAMEDBUFFERSUBDATAEXT
+	gpNamedCopyBufferSubDataEXT                      C.GPNAMEDCOPYBUFFERSUBDATAEXT
+	gpNamedFramebufferDrawBuffer                     C.GPNAMEDFRAMEBUFFERDRAWBUFFER
+	gpNamedFramebufferDrawBuffers                    C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
+	gpNamedFramebufferParameteri                     C.GPNAMEDFRAMEBUFFERPARAMETERI
+	gpNamedFramebufferParameteriEXT                  C.GPNAMEDFRAMEBUFFERPARAMETERIEXT
+	gpNamedFramebufferReadBuffer                     C.GPNAMEDFRAMEBUFFERREADBUFFER
+	gpNamedFramebufferRenderbuffer                   C.GPNAMEDFRAMEBUFFERRENDERBUFFER
+	gpNamedFramebufferRenderbufferEXT                C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB           C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV            C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferTexture                        C.GPNAMEDFRAMEBUFFERTEXTURE
+	gpNamedFramebufferTexture1DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
+	gpNamedFramebufferTexture2DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
+	gpNamedFramebufferTexture3DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT
+	gpNamedFramebufferTextureEXT                     C.GPNAMEDFRAMEBUFFERTEXTUREEXT
+	gpNamedFramebufferTextureFaceEXT                 C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT
+	gpNamedFramebufferTextureLayer                   C.GPNAMEDFRAMEBUFFERTEXTURELAYER
+	gpNamedFramebufferTextureLayerEXT                C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT
+	gpNamedProgramLocalParameter4dEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT
+	gpNamedProgramLocalParameter4dvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT
+	gpNamedProgramLocalParameter4fEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT
+	gpNamedProgramLocalParameter4fvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT
+	gpNamedProgramLocalParameterI4iEXT               C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT
+	gpNamedProgramLocalParameterI4ivEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT
+	gpNamedProgramLocalParameterI4uiEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT
+	gpNamedProgramLocalParameterI4uivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT
+	gpNamedProgramLocalParameters4fvEXT              C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT
+	gpNamedProgramLocalParametersI4ivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT
+	gpNamedProgramLocalParametersI4uivEXT            C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT
+	gpNamedProgramStringEXT                          C.GPNAMEDPROGRAMSTRINGEXT
+	gpNamedRenderbufferStorage                       C.GPNAMEDRENDERBUFFERSTORAGE
+	gpNamedRenderbufferStorageEXT                    C.GPNAMEDRENDERBUFFERSTORAGEEXT
+	gpNamedRenderbufferStorageMultisample            C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
+	gpNamedRenderbufferStorageMultisampleCoverageEXT C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT
+	gpNamedRenderbufferStorageMultisampleEXT         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT
+	gpNamedStringARB                                 C.GPNAMEDSTRINGARB
+	gpNormalFormatNV                                 C.GPNORMALFORMATNV
+	gpObjectLabel                                    C.GPOBJECTLABEL
+	gpObjectLabelKHR                                 C.GPOBJECTLABELKHR
+	gpObjectPtrLabel                                 C.GPOBJECTPTRLABEL
+	gpObjectPtrLabelKHR                              C.GPOBJECTPTRLABELKHR
+	gpPatchParameterfv                               C.GPPATCHPARAMETERFV
+	gpPatchParameteri                                C.GPPATCHPARAMETERI
+	gpPathCommandsNV                                 C.GPPATHCOMMANDSNV
+	gpPathCoordsNV                                   C.GPPATHCOORDSNV
+	gpPathCoverDepthFuncNV                           C.GPPATHCOVERDEPTHFUNCNV
+	gpPathDashArrayNV                                C.GPPATHDASHARRAYNV
+	gpPathGlyphIndexArrayNV                          C.GPPATHGLYPHINDEXARRAYNV
+	gpPathGlyphIndexRangeNV                          C.GPPATHGLYPHINDEXRANGENV
+	gpPathGlyphRangeNV                               C.GPPATHGLYPHRANGENV
+	gpPathGlyphsNV                                   C.GPPATHGLYPHSNV
+	gpPathMemoryGlyphIndexArrayNV                    C.GPPATHMEMORYGLYPHINDEXARRAYNV
+	gpPathParameterfNV                               C.GPPATHPARAMETERFNV
+	gpPathParameterfvNV                              C.GPPATHPARAMETERFVNV
+	gpPathParameteriNV                               C.GPPATHPARAMETERINV
+	gpPathParameterivNV                              C.GPPATHPARAMETERIVNV
+	gpPathStencilDepthOffsetNV                       C.GPPATHSTENCILDEPTHOFFSETNV
+	gpPathStencilFuncNV                              C.GPPATHSTENCILFUNCNV
+	gpPathStringNV                                   C.GPPATHSTRINGNV
+	gpPathSubCommandsNV                              C.GPPATHSUBCOMMANDSNV
+	gpPathSubCoordsNV                                C.GPPATHSUBCOORDSNV
+	gpPauseTransformFeedback                         C.GPPAUSETRANSFORMFEEDBACK
+	gpPixelStoref                                    C.GPPIXELSTOREF
+	gpPixelStorei                                    C.GPPIXELSTOREI
+	gpPointAlongPathNV                               C.GPPOINTALONGPATHNV
+	gpPointParameterf                                C.GPPOINTPARAMETERF
+	gpPointParameterfv                               C.GPPOINTPARAMETERFV
+	gpPointParameteri                                C.GPPOINTPARAMETERI
+	gpPointParameteriv                               C.GPPOINTPARAMETERIV
+	gpPointSize                                      C.GPPOINTSIZE
+	gpPolygonMode                                    C.GPPOLYGONMODE
+	gpPolygonOffset                                  C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                             C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                          C.GPPOLYGONOFFSETCLAMPEXT
+	gpPopDebugGroup                                  C.GPPOPDEBUGGROUP
+	gpPopDebugGroupKHR                               C.GPPOPDEBUGGROUPKHR
+	gpPopGroupMarkerEXT                              C.GPPOPGROUPMARKEREXT
+	gpPrimitiveBoundingBoxARB                        C.GPPRIMITIVEBOUNDINGBOXARB
+	gpPrimitiveRestartIndex                          C.GPPRIMITIVERESTARTINDEX
+	gpProgramBinary                                  C.GPPROGRAMBINARY
+	gpProgramParameteri                              C.GPPROGRAMPARAMETERI
+	gpProgramParameteriARB                           C.GPPROGRAMPARAMETERIARB
+	gpProgramParameteriEXT                           C.GPPROGRAMPARAMETERIEXT
+	gpProgramPathFragmentInputGenNV                  C.GPPROGRAMPATHFRAGMENTINPUTGENNV
+	gpProgramUniform1d                               C.GPPROGRAMUNIFORM1D
+	gpProgramUniform1dEXT                            C.GPPROGRAMUNIFORM1DEXT
+	gpProgramUniform1dv                              C.GPPROGRAMUNIFORM1DV
+	gpProgramUniform1dvEXT                           C.GPPROGRAMUNIFORM1DVEXT
+	gpProgramUniform1f                               C.GPPROGRAMUNIFORM1F
+	gpProgramUniform1fEXT                            C.GPPROGRAMUNIFORM1FEXT
+	gpProgramUniform1fv                              C.GPPROGRAMUNIFORM1FV
+	gpProgramUniform1fvEXT                           C.GPPROGRAMUNIFORM1FVEXT
+	gpProgramUniform1i                               C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                          C.GPPROGRAMUNIFORM1I64ARB
+	gpProgramUniform1i64NV                           C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                         C.GPPROGRAMUNIFORM1I64VARB
+	gpProgramUniform1i64vNV                          C.GPPROGRAMUNIFORM1I64VNV
+	gpProgramUniform1iEXT                            C.GPPROGRAMUNIFORM1IEXT
+	gpProgramUniform1iv                              C.GPPROGRAMUNIFORM1IV
+	gpProgramUniform1ivEXT                           C.GPPROGRAMUNIFORM1IVEXT
+	gpProgramUniform1ui                              C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                         C.GPPROGRAMUNIFORM1UI64ARB
+	gpProgramUniform1ui64NV                          C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                        C.GPPROGRAMUNIFORM1UI64VARB
+	gpProgramUniform1ui64vNV                         C.GPPROGRAMUNIFORM1UI64VNV
+	gpProgramUniform1uiEXT                           C.GPPROGRAMUNIFORM1UIEXT
+	gpProgramUniform1uiv                             C.GPPROGRAMUNIFORM1UIV
+	gpProgramUniform1uivEXT                          C.GPPROGRAMUNIFORM1UIVEXT
+	gpProgramUniform2d                               C.GPPROGRAMUNIFORM2D
+	gpProgramUniform2dEXT                            C.GPPROGRAMUNIFORM2DEXT
+	gpProgramUniform2dv                              C.GPPROGRAMUNIFORM2DV
+	gpProgramUniform2dvEXT                           C.GPPROGRAMUNIFORM2DVEXT
+	gpProgramUniform2f                               C.GPPROGRAMUNIFORM2F
+	gpProgramUniform2fEXT                            C.GPPROGRAMUNIFORM2FEXT
+	gpProgramUniform2fv                              C.GPPROGRAMUNIFORM2FV
+	gpProgramUniform2fvEXT                           C.GPPROGRAMUNIFORM2FVEXT
+	gpProgramUniform2i                               C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                          C.GPPROGRAMUNIFORM2I64ARB
+	gpProgramUniform2i64NV                           C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                         C.GPPROGRAMUNIFORM2I64VARB
+	gpProgramUniform2i64vNV                          C.GPPROGRAMUNIFORM2I64VNV
+	gpProgramUniform2iEXT                            C.GPPROGRAMUNIFORM2IEXT
+	gpProgramUniform2iv                              C.GPPROGRAMUNIFORM2IV
+	gpProgramUniform2ivEXT                           C.GPPROGRAMUNIFORM2IVEXT
+	gpProgramUniform2ui                              C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                         C.GPPROGRAMUNIFORM2UI64ARB
+	gpProgramUniform2ui64NV                          C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                        C.GPPROGRAMUNIFORM2UI64VARB
+	gpProgramUniform2ui64vNV                         C.GPPROGRAMUNIFORM2UI64VNV
+	gpProgramUniform2uiEXT                           C.GPPROGRAMUNIFORM2UIEXT
+	gpProgramUniform2uiv                             C.GPPROGRAMUNIFORM2UIV
+	gpProgramUniform2uivEXT                          C.GPPROGRAMUNIFORM2UIVEXT
+	gpProgramUniform3d                               C.GPPROGRAMUNIFORM3D
+	gpProgramUniform3dEXT                            C.GPPROGRAMUNIFORM3DEXT
+	gpProgramUniform3dv                              C.GPPROGRAMUNIFORM3DV
+	gpProgramUniform3dvEXT                           C.GPPROGRAMUNIFORM3DVEXT
+	gpProgramUniform3f                               C.GPPROGRAMUNIFORM3F
+	gpProgramUniform3fEXT                            C.GPPROGRAMUNIFORM3FEXT
+	gpProgramUniform3fv                              C.GPPROGRAMUNIFORM3FV
+	gpProgramUniform3fvEXT                           C.GPPROGRAMUNIFORM3FVEXT
+	gpProgramUniform3i                               C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                          C.GPPROGRAMUNIFORM3I64ARB
+	gpProgramUniform3i64NV                           C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                         C.GPPROGRAMUNIFORM3I64VARB
+	gpProgramUniform3i64vNV                          C.GPPROGRAMUNIFORM3I64VNV
+	gpProgramUniform3iEXT                            C.GPPROGRAMUNIFORM3IEXT
+	gpProgramUniform3iv                              C.GPPROGRAMUNIFORM3IV
+	gpProgramUniform3ivEXT                           C.GPPROGRAMUNIFORM3IVEXT
+	gpProgramUniform3ui                              C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                         C.GPPROGRAMUNIFORM3UI64ARB
+	gpProgramUniform3ui64NV                          C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                        C.GPPROGRAMUNIFORM3UI64VARB
+	gpProgramUniform3ui64vNV                         C.GPPROGRAMUNIFORM3UI64VNV
+	gpProgramUniform3uiEXT                           C.GPPROGRAMUNIFORM3UIEXT
+	gpProgramUniform3uiv                             C.GPPROGRAMUNIFORM3UIV
+	gpProgramUniform3uivEXT                          C.GPPROGRAMUNIFORM3UIVEXT
+	gpProgramUniform4d                               C.GPPROGRAMUNIFORM4D
+	gpProgramUniform4dEXT                            C.GPPROGRAMUNIFORM4DEXT
+	gpProgramUniform4dv                              C.GPPROGRAMUNIFORM4DV
+	gpProgramUniform4dvEXT                           C.GPPROGRAMUNIFORM4DVEXT
+	gpProgramUniform4f                               C.GPPROGRAMUNIFORM4F
+	gpProgramUniform4fEXT                            C.GPPROGRAMUNIFORM4FEXT
+	gpProgramUniform4fv                              C.GPPROGRAMUNIFORM4FV
+	gpProgramUniform4fvEXT                           C.GPPROGRAMUNIFORM4FVEXT
+	gpProgramUniform4i                               C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                          C.GPPROGRAMUNIFORM4I64ARB
+	gpProgramUniform4i64NV                           C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                         C.GPPROGRAMUNIFORM4I64VARB
+	gpProgramUniform4i64vNV                          C.GPPROGRAMUNIFORM4I64VNV
+	gpProgramUniform4iEXT                            C.GPPROGRAMUNIFORM4IEXT
+	gpProgramUniform4iv                              C.GPPROGRAMUNIFORM4IV
+	gpProgramUniform4ivEXT                           C.GPPROGRAMUNIFORM4IVEXT
+	gpProgramUniform4ui                              C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                         C.GPPROGRAMUNIFORM4UI64ARB
+	gpProgramUniform4ui64NV                          C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                        C.GPPROGRAMUNIFORM4UI64VARB
+	gpProgramUniform4ui64vNV                         C.GPPROGRAMUNIFORM4UI64VNV
+	gpProgramUniform4uiEXT                           C.GPPROGRAMUNIFORM4UIEXT
+	gpProgramUniform4uiv                             C.GPPROGRAMUNIFORM4UIV
+	gpProgramUniform4uivEXT                          C.GPPROGRAMUNIFORM4UIVEXT
+	gpProgramUniformHandleui64ARB                    C.GPPROGRAMUNIFORMHANDLEUI64ARB
+	gpProgramUniformHandleui64NV                     C.GPPROGRAMUNIFORMHANDLEUI64NV
+	gpProgramUniformHandleui64vARB                   C.GPPROGRAMUNIFORMHANDLEUI64VARB
+	gpProgramUniformHandleui64vNV                    C.GPPROGRAMUNIFORMHANDLEUI64VNV
+	gpProgramUniformMatrix2dv                        C.GPPROGRAMUNIFORMMATRIX2DV
+	gpProgramUniformMatrix2dvEXT                     C.GPPROGRAMUNIFORMMATRIX2DVEXT
+	gpProgramUniformMatrix2fv                        C.GPPROGRAMUNIFORMMATRIX2FV
+	gpProgramUniformMatrix2fvEXT                     C.GPPROGRAMUNIFORMMATRIX2FVEXT
+	gpProgramUniformMatrix2x3dv                      C.GPPROGRAMUNIFORMMATRIX2X3DV
+	gpProgramUniformMatrix2x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3DVEXT
+	gpProgramUniformMatrix2x3fv                      C.GPPROGRAMUNIFORMMATRIX2X3FV
+	gpProgramUniformMatrix2x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3FVEXT
+	gpProgramUniformMatrix2x4dv                      C.GPPROGRAMUNIFORMMATRIX2X4DV
+	gpProgramUniformMatrix2x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4DVEXT
+	gpProgramUniformMatrix2x4fv                      C.GPPROGRAMUNIFORMMATRIX2X4FV
+	gpProgramUniformMatrix2x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4FVEXT
+	gpProgramUniformMatrix3dv                        C.GPPROGRAMUNIFORMMATRIX3DV
+	gpProgramUniformMatrix3dvEXT                     C.GPPROGRAMUNIFORMMATRIX3DVEXT
+	gpProgramUniformMatrix3fv                        C.GPPROGRAMUNIFORMMATRIX3FV
+	gpProgramUniformMatrix3fvEXT                     C.GPPROGRAMUNIFORMMATRIX3FVEXT
+	gpProgramUniformMatrix3x2dv                      C.GPPROGRAMUNIFORMMATRIX3X2DV
+	gpProgramUniformMatrix3x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2DVEXT
+	gpProgramUniformMatrix3x2fv                      C.GPPROGRAMUNIFORMMATRIX3X2FV
+	gpProgramUniformMatrix3x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2FVEXT
+	gpProgramUniformMatrix3x4dv                      C.GPPROGRAMUNIFORMMATRIX3X4DV
+	gpProgramUniformMatrix3x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4DVEXT
+	gpProgramUniformMatrix3x4fv                      C.GPPROGRAMUNIFORMMATRIX3X4FV
+	gpProgramUniformMatrix3x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4FVEXT
+	gpProgramUniformMatrix4dv                        C.GPPROGRAMUNIFORMMATRIX4DV
+	gpProgramUniformMatrix4dvEXT                     C.GPPROGRAMUNIFORMMATRIX4DVEXT
+	gpProgramUniformMatrix4fv                        C.GPPROGRAMUNIFORMMATRIX4FV
+	gpProgramUniformMatrix4fvEXT                     C.GPPROGRAMUNIFORMMATRIX4FVEXT
+	gpProgramUniformMatrix4x2dv                      C.GPPROGRAMUNIFORMMATRIX4X2DV
+	gpProgramUniformMatrix4x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2DVEXT
+	gpProgramUniformMatrix4x2fv                      C.GPPROGRAMUNIFORMMATRIX4X2FV
+	gpProgramUniformMatrix4x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2FVEXT
+	gpProgramUniformMatrix4x3dv                      C.GPPROGRAMUNIFORMMATRIX4X3DV
+	gpProgramUniformMatrix4x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3DVEXT
+	gpProgramUniformMatrix4x3fv                      C.GPPROGRAMUNIFORMMATRIX4X3FV
+	gpProgramUniformMatrix4x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3FVEXT
+	gpProgramUniformui64NV                           C.GPPROGRAMUNIFORMUI64NV
+	gpProgramUniformui64vNV                          C.GPPROGRAMUNIFORMUI64VNV
+	gpProvokingVertex                                C.GPPROVOKINGVERTEX
+	gpPushClientAttribDefaultEXT                     C.GPPUSHCLIENTATTRIBDEFAULTEXT
+	gpPushDebugGroup                                 C.GPPUSHDEBUGGROUP
+	gpPushDebugGroupKHR                              C.GPPUSHDEBUGGROUPKHR
+	gpPushGroupMarkerEXT                             C.GPPUSHGROUPMARKEREXT
+	gpQueryCounter                                   C.GPQUERYCOUNTER
+	gpRasterSamplesEXT                               C.GPRASTERSAMPLESEXT
+	gpReadBuffer                                     C.GPREADBUFFER
+	gpReadPixels                                     C.GPREADPIXELS
+	gpReadnPixels                                    C.GPREADNPIXELS
+	gpReadnPixelsARB                                 C.GPREADNPIXELSARB
+	gpReadnPixelsKHR                                 C.GPREADNPIXELSKHR
+	gpReleaseShaderCompiler                          C.GPRELEASESHADERCOMPILER
+	gpRenderbufferStorage                            C.GPRENDERBUFFERSTORAGE
+	gpRenderbufferStorageMultisample                 C.GPRENDERBUFFERSTORAGEMULTISAMPLE
+	gpRenderbufferStorageMultisampleCoverageNV       C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV
+	gpResolveDepthValuesNV                           C.GPRESOLVEDEPTHVALUESNV
+	gpResumeTransformFeedback                        C.GPRESUMETRANSFORMFEEDBACK
+	gpSampleCoverage                                 C.GPSAMPLECOVERAGE
+	gpSampleMaski                                    C.GPSAMPLEMASKI
+	gpSamplerParameterIiv                            C.GPSAMPLERPARAMETERIIV
+	gpSamplerParameterIuiv                           C.GPSAMPLERPARAMETERIUIV
+	gpSamplerParameterf                              C.GPSAMPLERPARAMETERF
+	gpSamplerParameterfv                             C.GPSAMPLERPARAMETERFV
+	gpSamplerParameteri                              C.GPSAMPLERPARAMETERI
+	gpSamplerParameteriv                             C.GPSAMPLERPARAMETERIV
+	gpScissor                                        C.GPSCISSOR
+	gpScissorArrayv                                  C.GPSCISSORARRAYV
+	gpScissorIndexed                                 C.GPSCISSORINDEXED
+	gpScissorIndexedv                                C.GPSCISSORINDEXEDV
+	gpSecondaryColorFormatNV                         C.GPSECONDARYCOLORFORMATNV
+	gpSelectPerfMonitorCountersAMD                   C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpShaderBinary                                   C.GPSHADERBINARY
+	gpShaderSource                                   C.GPSHADERSOURCE
+	gpShaderStorageBlockBinding                      C.GPSHADERSTORAGEBLOCKBINDING
+	gpSignalVkFenceNV                                C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                            C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                            C.GPSPECIALIZESHADERARB
+	gpStateCaptureNV                                 C.GPSTATECAPTURENV
+	gpStencilFillPathInstancedNV                     C.GPSTENCILFILLPATHINSTANCEDNV
+	gpStencilFillPathNV                              C.GPSTENCILFILLPATHNV
+	gpStencilFunc                                    C.GPSTENCILFUNC
+	gpStencilFuncSeparate                            C.GPSTENCILFUNCSEPARATE
+	gpStencilMask                                    C.GPSTENCILMASK
+	gpStencilMaskSeparate                            C.GPSTENCILMASKSEPARATE
+	gpStencilOp                                      C.GPSTENCILOP
+	gpStencilOpSeparate                              C.GPSTENCILOPSEPARATE
+	gpStencilStrokePathInstancedNV                   C.GPSTENCILSTROKEPATHINSTANCEDNV
+	gpStencilStrokePathNV                            C.GPSTENCILSTROKEPATHNV
+	gpStencilThenCoverFillPathInstancedNV            C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV
+	gpStencilThenCoverFillPathNV                     C.GPSTENCILTHENCOVERFILLPATHNV
+	gpStencilThenCoverStrokePathInstancedNV          C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV
+	gpStencilThenCoverStrokePathNV                   C.GPSTENCILTHENCOVERSTROKEPATHNV
+	gpSubpixelPrecisionBiasNV                        C.GPSUBPIXELPRECISIONBIASNV
+	gpTexBuffer                                      C.GPTEXBUFFER
+	gpTexBufferARB                                   C.GPTEXBUFFERARB
+	gpTexBufferRange                                 C.GPTEXBUFFERRANGE
+	gpTexCoordFormatNV                               C.GPTEXCOORDFORMATNV
+	gpTexImage1D                                     C.GPTEXIMAGE1D
+	gpTexImage2D                                     C.GPTEXIMAGE2D
+	gpTexImage2DMultisample                          C.GPTEXIMAGE2DMULTISAMPLE
+	gpTexImage3D                                     C.GPTEXIMAGE3D
+	gpTexImage3DMultisample                          C.GPTEXIMAGE3DMULTISAMPLE
+	gpTexPageCommitmentARB                           C.GPTEXPAGECOMMITMENTARB
+	gpTexParameterIiv                                C.GPTEXPARAMETERIIV
+	gpTexParameterIuiv                               C.GPTEXPARAMETERIUIV
+	gpTexParameterf                                  C.GPTEXPARAMETERF
+	gpTexParameterfv                                 C.GPTEXPARAMETERFV
+	gpTexParameteri                                  C.GPTEXPARAMETERI
+	gpTexParameteriv                                 C.GPTEXPARAMETERIV
+	gpTexStorage1D                                   C.GPTEXSTORAGE1D
+	gpTexStorage2D                                   C.GPTEXSTORAGE2D
+	gpTexStorage2DMultisample                        C.GPTEXSTORAGE2DMULTISAMPLE
+	gpTexStorage3D                                   C.GPTEXSTORAGE3D
+	gpTexStorage3DMultisample                        C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexSubImage1D                                  C.GPTEXSUBIMAGE1D
+	gpTexSubImage2D                                  C.GPTEXSUBIMAGE2D
+	gpTexSubImage3D                                  C.GPTEXSUBIMAGE3D
+	gpTextureBarrier                                 C.GPTEXTUREBARRIER
+	gpTextureBarrierNV                               C.GPTEXTUREBARRIERNV
+	gpTextureBuffer                                  C.GPTEXTUREBUFFER
+	gpTextureBufferEXT                               C.GPTEXTUREBUFFEREXT
+	gpTextureBufferRange                             C.GPTEXTUREBUFFERRANGE
+	gpTextureBufferRangeEXT                          C.GPTEXTUREBUFFERRANGEEXT
+	gpTextureImage1DEXT                              C.GPTEXTUREIMAGE1DEXT
+	gpTextureImage2DEXT                              C.GPTEXTUREIMAGE2DEXT
+	gpTextureImage3DEXT                              C.GPTEXTUREIMAGE3DEXT
+	gpTexturePageCommitmentEXT                       C.GPTEXTUREPAGECOMMITMENTEXT
+	gpTextureParameterIiv                            C.GPTEXTUREPARAMETERIIV
+	gpTextureParameterIivEXT                         C.GPTEXTUREPARAMETERIIVEXT
+	gpTextureParameterIuiv                           C.GPTEXTUREPARAMETERIUIV
+	gpTextureParameterIuivEXT                        C.GPTEXTUREPARAMETERIUIVEXT
+	gpTextureParameterf                              C.GPTEXTUREPARAMETERF
+	gpTextureParameterfEXT                           C.GPTEXTUREPARAMETERFEXT
+	gpTextureParameterfv                             C.GPTEXTUREPARAMETERFV
+	gpTextureParameterfvEXT                          C.GPTEXTUREPARAMETERFVEXT
+	gpTextureParameteri                              C.GPTEXTUREPARAMETERI
+	gpTextureParameteriEXT                           C.GPTEXTUREPARAMETERIEXT
+	gpTextureParameteriv                             C.GPTEXTUREPARAMETERIV
+	gpTextureParameterivEXT                          C.GPTEXTUREPARAMETERIVEXT
+	gpTextureRenderbufferEXT                         C.GPTEXTURERENDERBUFFEREXT
+	gpTextureStorage1D                               C.GPTEXTURESTORAGE1D
+	gpTextureStorage1DEXT                            C.GPTEXTURESTORAGE1DEXT
+	gpTextureStorage2D                               C.GPTEXTURESTORAGE2D
+	gpTextureStorage2DEXT                            C.GPTEXTURESTORAGE2DEXT
+	gpTextureStorage2DMultisample                    C.GPTEXTURESTORAGE2DMULTISAMPLE
+	gpTextureStorage2DMultisampleEXT                 C.GPTEXTURESTORAGE2DMULTISAMPLEEXT
+	gpTextureStorage3D                               C.GPTEXTURESTORAGE3D
+	gpTextureStorage3DEXT                            C.GPTEXTURESTORAGE3DEXT
+	gpTextureStorage3DMultisample                    C.GPTEXTURESTORAGE3DMULTISAMPLE
+	gpTextureStorage3DMultisampleEXT                 C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureSubImage1D                              C.GPTEXTURESUBIMAGE1D
+	gpTextureSubImage1DEXT                           C.GPTEXTURESUBIMAGE1DEXT
+	gpTextureSubImage2D                              C.GPTEXTURESUBIMAGE2D
+	gpTextureSubImage2DEXT                           C.GPTEXTURESUBIMAGE2DEXT
+	gpTextureSubImage3D                              C.GPTEXTURESUBIMAGE3D
+	gpTextureSubImage3DEXT                           C.GPTEXTURESUBIMAGE3DEXT
+	gpTextureView                                    C.GPTEXTUREVIEW
+	gpTransformFeedbackBufferBase                    C.GPTRANSFORMFEEDBACKBUFFERBASE
+	gpTransformFeedbackBufferRange                   C.GPTRANSFORMFEEDBACKBUFFERRANGE
+	gpTransformFeedbackVaryings                      C.GPTRANSFORMFEEDBACKVARYINGS
+	gpTransformPathNV                                C.GPTRANSFORMPATHNV
+	gpUniform1d                                      C.GPUNIFORM1D
+	gpUniform1dv                                     C.GPUNIFORM1DV
+	gpUniform1f                                      C.GPUNIFORM1F
+	gpUniform1fv                                     C.GPUNIFORM1FV
+	gpUniform1i                                      C.GPUNIFORM1I
+	gpUniform1i64ARB                                 C.GPUNIFORM1I64ARB
+	gpUniform1i64NV                                  C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                C.GPUNIFORM1I64VARB
+	gpUniform1i64vNV                                 C.GPUNIFORM1I64VNV
+	gpUniform1iv                                     C.GPUNIFORM1IV
+	gpUniform1ui                                     C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                C.GPUNIFORM1UI64ARB
+	gpUniform1ui64NV                                 C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                               C.GPUNIFORM1UI64VARB
+	gpUniform1ui64vNV                                C.GPUNIFORM1UI64VNV
+	gpUniform1uiv                                    C.GPUNIFORM1UIV
+	gpUniform2d                                      C.GPUNIFORM2D
+	gpUniform2dv                                     C.GPUNIFORM2DV
+	gpUniform2f                                      C.GPUNIFORM2F
+	gpUniform2fv                                     C.GPUNIFORM2FV
+	gpUniform2i                                      C.GPUNIFORM2I
+	gpUniform2i64ARB                                 C.GPUNIFORM2I64ARB
+	gpUniform2i64NV                                  C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                C.GPUNIFORM2I64VARB
+	gpUniform2i64vNV                                 C.GPUNIFORM2I64VNV
+	gpUniform2iv                                     C.GPUNIFORM2IV
+	gpUniform2ui                                     C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                C.GPUNIFORM2UI64ARB
+	gpUniform2ui64NV                                 C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                               C.GPUNIFORM2UI64VARB
+	gpUniform2ui64vNV                                C.GPUNIFORM2UI64VNV
+	gpUniform2uiv                                    C.GPUNIFORM2UIV
+	gpUniform3d                                      C.GPUNIFORM3D
+	gpUniform3dv                                     C.GPUNIFORM3DV
+	gpUniform3f                                      C.GPUNIFORM3F
+	gpUniform3fv                                     C.GPUNIFORM3FV
+	gpUniform3i                                      C.GPUNIFORM3I
+	gpUniform3i64ARB                                 C.GPUNIFORM3I64ARB
+	gpUniform3i64NV                                  C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                C.GPUNIFORM3I64VARB
+	gpUniform3i64vNV                                 C.GPUNIFORM3I64VNV
+	gpUniform3iv                                     C.GPUNIFORM3IV
+	gpUniform3ui                                     C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                C.GPUNIFORM3UI64ARB
+	gpUniform3ui64NV                                 C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                               C.GPUNIFORM3UI64VARB
+	gpUniform3ui64vNV                                C.GPUNIFORM3UI64VNV
+	gpUniform3uiv                                    C.GPUNIFORM3UIV
+	gpUniform4d                                      C.GPUNIFORM4D
+	gpUniform4dv                                     C.GPUNIFORM4DV
+	gpUniform4f                                      C.GPUNIFORM4F
+	gpUniform4fv                                     C.GPUNIFORM4FV
+	gpUniform4i                                      C.GPUNIFORM4I
+	gpUniform4i64ARB                                 C.GPUNIFORM4I64ARB
+	gpUniform4i64NV                                  C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                C.GPUNIFORM4I64VARB
+	gpUniform4i64vNV                                 C.GPUNIFORM4I64VNV
+	gpUniform4iv                                     C.GPUNIFORM4IV
+	gpUniform4ui                                     C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                C.GPUNIFORM4UI64ARB
+	gpUniform4ui64NV                                 C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                               C.GPUNIFORM4UI64VARB
+	gpUniform4ui64vNV                                C.GPUNIFORM4UI64VNV
+	gpUniform4uiv                                    C.GPUNIFORM4UIV
+	gpUniformBlockBinding                            C.GPUNIFORMBLOCKBINDING
+	gpUniformHandleui64ARB                           C.GPUNIFORMHANDLEUI64ARB
+	gpUniformHandleui64NV                            C.GPUNIFORMHANDLEUI64NV
+	gpUniformHandleui64vARB                          C.GPUNIFORMHANDLEUI64VARB
+	gpUniformHandleui64vNV                           C.GPUNIFORMHANDLEUI64VNV
+	gpUniformMatrix2dv                               C.GPUNIFORMMATRIX2DV
+	gpUniformMatrix2fv                               C.GPUNIFORMMATRIX2FV
+	gpUniformMatrix2x3dv                             C.GPUNIFORMMATRIX2X3DV
+	gpUniformMatrix2x3fv                             C.GPUNIFORMMATRIX2X3FV
+	gpUniformMatrix2x4dv                             C.GPUNIFORMMATRIX2X4DV
+	gpUniformMatrix2x4fv                             C.GPUNIFORMMATRIX2X4FV
+	gpUniformMatrix3dv                               C.GPUNIFORMMATRIX3DV
+	gpUniformMatrix3fv                               C.GPUNIFORMMATRIX3FV
+	gpUniformMatrix3x2dv                             C.GPUNIFORMMATRIX3X2DV
+	gpUniformMatrix3x2fv                             C.GPUNIFORMMATRIX3X2FV
+	gpUniformMatrix3x4dv                             C.GPUNIFORMMATRIX3X4DV
+	gpUniformMatrix3x4fv                             C.GPUNIFORMMATRIX3X4FV
+	gpUniformMatrix4dv                               C.GPUNIFORMMATRIX4DV
+	gpUniformMatrix4fv                               C.GPUNIFORMMATRIX4FV
+	gpUniformMatrix4x2dv                             C.GPUNIFORMMATRIX4X2DV
+	gpUniformMatrix4x2fv                             C.GPUNIFORMMATRIX4X2FV
+	gpUniformMatrix4x3dv                             C.GPUNIFORMMATRIX4X3DV
+	gpUniformMatrix4x3fv                             C.GPUNIFORMMATRIX4X3FV
+	gpUniformSubroutinesuiv                          C.GPUNIFORMSUBROUTINESUIV
+	gpUniformui64NV                                  C.GPUNIFORMUI64NV
+	gpUniformui64vNV                                 C.GPUNIFORMUI64VNV
+	gpUnmapBuffer                                    C.GPUNMAPBUFFER
+	gpUnmapNamedBuffer                               C.GPUNMAPNAMEDBUFFER
+	gpUnmapNamedBufferEXT                            C.GPUNMAPNAMEDBUFFEREXT
+	gpUseProgram                                     C.GPUSEPROGRAM
+	gpUseProgramStages                               C.GPUSEPROGRAMSTAGES
+	gpUseProgramStagesEXT                            C.GPUSEPROGRAMSTAGESEXT
+	gpUseShaderProgramEXT                            C.GPUSESHADERPROGRAMEXT
+	gpValidateProgram                                C.GPVALIDATEPROGRAM
+	gpValidateProgramPipeline                        C.GPVALIDATEPROGRAMPIPELINE
+	gpValidateProgramPipelineEXT                     C.GPVALIDATEPROGRAMPIPELINEEXT
+	gpVertexArrayAttribBinding                       C.GPVERTEXARRAYATTRIBBINDING
+	gpVertexArrayAttribFormat                        C.GPVERTEXARRAYATTRIBFORMAT
+	gpVertexArrayAttribIFormat                       C.GPVERTEXARRAYATTRIBIFORMAT
+	gpVertexArrayAttribLFormat                       C.GPVERTEXARRAYATTRIBLFORMAT
+	gpVertexArrayBindVertexBufferEXT                 C.GPVERTEXARRAYBINDVERTEXBUFFEREXT
+	gpVertexArrayBindingDivisor                      C.GPVERTEXARRAYBINDINGDIVISOR
+	gpVertexArrayColorOffsetEXT                      C.GPVERTEXARRAYCOLOROFFSETEXT
+	gpVertexArrayEdgeFlagOffsetEXT                   C.GPVERTEXARRAYEDGEFLAGOFFSETEXT
+	gpVertexArrayElementBuffer                       C.GPVERTEXARRAYELEMENTBUFFER
+	gpVertexArrayFogCoordOffsetEXT                   C.GPVERTEXARRAYFOGCOORDOFFSETEXT
+	gpVertexArrayIndexOffsetEXT                      C.GPVERTEXARRAYINDEXOFFSETEXT
+	gpVertexArrayMultiTexCoordOffsetEXT              C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT
+	gpVertexArrayNormalOffsetEXT                     C.GPVERTEXARRAYNORMALOFFSETEXT
+	gpVertexArraySecondaryColorOffsetEXT             C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT
+	gpVertexArrayTexCoordOffsetEXT                   C.GPVERTEXARRAYTEXCOORDOFFSETEXT
+	gpVertexArrayVertexAttribBindingEXT              C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT
+	gpVertexArrayVertexAttribDivisorEXT              C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT
+	gpVertexArrayVertexAttribFormatEXT               C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT
+	gpVertexArrayVertexAttribIFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT
+	gpVertexArrayVertexAttribIOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT
+	gpVertexArrayVertexAttribLFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT
+	gpVertexArrayVertexAttribLOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT
+	gpVertexArrayVertexAttribOffsetEXT               C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT
+	gpVertexArrayVertexBindingDivisorEXT             C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT
+	gpVertexArrayVertexBuffer                        C.GPVERTEXARRAYVERTEXBUFFER
+	gpVertexArrayVertexBuffers                       C.GPVERTEXARRAYVERTEXBUFFERS
+	gpVertexArrayVertexOffsetEXT                     C.GPVERTEXARRAYVERTEXOFFSETEXT
+	gpVertexAttrib1d                                 C.GPVERTEXATTRIB1D
+	gpVertexAttrib1dv                                C.GPVERTEXATTRIB1DV
+	gpVertexAttrib1f                                 C.GPVERTEXATTRIB1F
+	gpVertexAttrib1fv                                C.GPVERTEXATTRIB1FV
+	gpVertexAttrib1s                                 C.GPVERTEXATTRIB1S
+	gpVertexAttrib1sv                                C.GPVERTEXATTRIB1SV
+	gpVertexAttrib2d                                 C.GPVERTEXATTRIB2D
+	gpVertexAttrib2dv                                C.GPVERTEXATTRIB2DV
+	gpVertexAttrib2f                                 C.GPVERTEXATTRIB2F
+	gpVertexAttrib2fv                                C.GPVERTEXATTRIB2FV
+	gpVertexAttrib2s                                 C.GPVERTEXATTRIB2S
+	gpVertexAttrib2sv                                C.GPVERTEXATTRIB2SV
+	gpVertexAttrib3d                                 C.GPVERTEXATTRIB3D
+	gpVertexAttrib3dv                                C.GPVERTEXATTRIB3DV
+	gpVertexAttrib3f                                 C.GPVERTEXATTRIB3F
+	gpVertexAttrib3fv                                C.GPVERTEXATTRIB3FV
+	gpVertexAttrib3s                                 C.GPVERTEXATTRIB3S
+	gpVertexAttrib3sv                                C.GPVERTEXATTRIB3SV
+	gpVertexAttrib4Nbv                               C.GPVERTEXATTRIB4NBV
+	gpVertexAttrib4Niv                               C.GPVERTEXATTRIB4NIV
+	gpVertexAttrib4Nsv                               C.GPVERTEXATTRIB4NSV
+	gpVertexAttrib4Nub                               C.GPVERTEXATTRIB4NUB
+	gpVertexAttrib4Nubv                              C.GPVERTEXATTRIB4NUBV
+	gpVertexAttrib4Nuiv                              C.GPVERTEXATTRIB4NUIV
+	gpVertexAttrib4Nusv                              C.GPVERTEXATTRIB4NUSV
+	gpVertexAttrib4bv                                C.GPVERTEXATTRIB4BV
+	gpVertexAttrib4d                                 C.GPVERTEXATTRIB4D
+	gpVertexAttrib4dv                                C.GPVERTEXATTRIB4DV
+	gpVertexAttrib4f                                 C.GPVERTEXATTRIB4F
+	gpVertexAttrib4fv                                C.GPVERTEXATTRIB4FV
+	gpVertexAttrib4iv                                C.GPVERTEXATTRIB4IV
+	gpVertexAttrib4s                                 C.GPVERTEXATTRIB4S
+	gpVertexAttrib4sv                                C.GPVERTEXATTRIB4SV
+	gpVertexAttrib4ubv                               C.GPVERTEXATTRIB4UBV
+	gpVertexAttrib4uiv                               C.GPVERTEXATTRIB4UIV
+	gpVertexAttrib4usv                               C.GPVERTEXATTRIB4USV
+	gpVertexAttribBinding                            C.GPVERTEXATTRIBBINDING
+	gpVertexAttribDivisor                            C.GPVERTEXATTRIBDIVISOR
+	gpVertexAttribDivisorARB                         C.GPVERTEXATTRIBDIVISORARB
+	gpVertexAttribFormat                             C.GPVERTEXATTRIBFORMAT
+	gpVertexAttribFormatNV                           C.GPVERTEXATTRIBFORMATNV
+	gpVertexAttribI1i                                C.GPVERTEXATTRIBI1I
+	gpVertexAttribI1iv                               C.GPVERTEXATTRIBI1IV
+	gpVertexAttribI1ui                               C.GPVERTEXATTRIBI1UI
+	gpVertexAttribI1uiv                              C.GPVERTEXATTRIBI1UIV
+	gpVertexAttribI2i                                C.GPVERTEXATTRIBI2I
+	gpVertexAttribI2iv                               C.GPVERTEXATTRIBI2IV
+	gpVertexAttribI2ui                               C.GPVERTEXATTRIBI2UI
+	gpVertexAttribI2uiv                              C.GPVERTEXATTRIBI2UIV
+	gpVertexAttribI3i                                C.GPVERTEXATTRIBI3I
+	gpVertexAttribI3iv                               C.GPVERTEXATTRIBI3IV
+	gpVertexAttribI3ui                               C.GPVERTEXATTRIBI3UI
+	gpVertexAttribI3uiv                              C.GPVERTEXATTRIBI3UIV
+	gpVertexAttribI4bv                               C.GPVERTEXATTRIBI4BV
+	gpVertexAttribI4i                                C.GPVERTEXATTRIBI4I
+	gpVertexAttribI4iv                               C.GPVERTEXATTRIBI4IV
+	gpVertexAttribI4sv                               C.GPVERTEXATTRIBI4SV
+	gpVertexAttribI4ubv                              C.GPVERTEXATTRIBI4UBV
+	gpVertexAttribI4ui                               C.GPVERTEXATTRIBI4UI
+	gpVertexAttribI4uiv                              C.GPVERTEXATTRIBI4UIV
+	gpVertexAttribI4usv                              C.GPVERTEXATTRIBI4USV
+	gpVertexAttribIFormat                            C.GPVERTEXATTRIBIFORMAT
+	gpVertexAttribIFormatNV                          C.GPVERTEXATTRIBIFORMATNV
+	gpVertexAttribIPointer                           C.GPVERTEXATTRIBIPOINTER
+	gpVertexAttribL1d                                C.GPVERTEXATTRIBL1D
+	gpVertexAttribL1dv                               C.GPVERTEXATTRIBL1DV
+	gpVertexAttribL1i64NV                            C.GPVERTEXATTRIBL1I64NV
+	gpVertexAttribL1i64vNV                           C.GPVERTEXATTRIBL1I64VNV
+	gpVertexAttribL1ui64ARB                          C.GPVERTEXATTRIBL1UI64ARB
+	gpVertexAttribL1ui64NV                           C.GPVERTEXATTRIBL1UI64NV
+	gpVertexAttribL1ui64vARB                         C.GPVERTEXATTRIBL1UI64VARB
+	gpVertexAttribL1ui64vNV                          C.GPVERTEXATTRIBL1UI64VNV
+	gpVertexAttribL2d                                C.GPVERTEXATTRIBL2D
+	gpVertexAttribL2dv                               C.GPVERTEXATTRIBL2DV
+	gpVertexAttribL2i64NV                            C.GPVERTEXATTRIBL2I64NV
+	gpVertexAttribL2i64vNV                           C.GPVERTEXATTRIBL2I64VNV
+	gpVertexAttribL2ui64NV                           C.GPVERTEXATTRIBL2UI64NV
+	gpVertexAttribL2ui64vNV                          C.GPVERTEXATTRIBL2UI64VNV
+	gpVertexAttribL3d                                C.GPVERTEXATTRIBL3D
+	gpVertexAttribL3dv                               C.GPVERTEXATTRIBL3DV
+	gpVertexAttribL3i64NV                            C.GPVERTEXATTRIBL3I64NV
+	gpVertexAttribL3i64vNV                           C.GPVERTEXATTRIBL3I64VNV
+	gpVertexAttribL3ui64NV                           C.GPVERTEXATTRIBL3UI64NV
+	gpVertexAttribL3ui64vNV                          C.GPVERTEXATTRIBL3UI64VNV
+	gpVertexAttribL4d                                C.GPVERTEXATTRIBL4D
+	gpVertexAttribL4dv                               C.GPVERTEXATTRIBL4DV
+	gpVertexAttribL4i64NV                            C.GPVERTEXATTRIBL4I64NV
+	gpVertexAttribL4i64vNV                           C.GPVERTEXATTRIBL4I64VNV
+	gpVertexAttribL4ui64NV                           C.GPVERTEXATTRIBL4UI64NV
+	gpVertexAttribL4ui64vNV                          C.GPVERTEXATTRIBL4UI64VNV
+	gpVertexAttribLFormat                            C.GPVERTEXATTRIBLFORMAT
+	gpVertexAttribLFormatNV                          C.GPVERTEXATTRIBLFORMATNV
+	gpVertexAttribLPointer                           C.GPVERTEXATTRIBLPOINTER
+	gpVertexAttribP1ui                               C.GPVERTEXATTRIBP1UI
+	gpVertexAttribP1uiv                              C.GPVERTEXATTRIBP1UIV
+	gpVertexAttribP2ui                               C.GPVERTEXATTRIBP2UI
+	gpVertexAttribP2uiv                              C.GPVERTEXATTRIBP2UIV
+	gpVertexAttribP3ui                               C.GPVERTEXATTRIBP3UI
+	gpVertexAttribP3uiv                              C.GPVERTEXATTRIBP3UIV
+	gpVertexAttribP4ui                               C.GPVERTEXATTRIBP4UI
+	gpVertexAttribP4uiv                              C.GPVERTEXATTRIBP4UIV
+	gpVertexAttribPointer                            C.GPVERTEXATTRIBPOINTER
+	gpVertexBindingDivisor                           C.GPVERTEXBINDINGDIVISOR
+	gpVertexFormatNV                                 C.GPVERTEXFORMATNV
+	gpViewport                                       C.GPVIEWPORT
+	gpViewportArrayv                                 C.GPVIEWPORTARRAYV
+	gpViewportIndexedf                               C.GPVIEWPORTINDEXEDF
+	gpViewportIndexedfv                              C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                       C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                              C.GPVIEWPORTSWIZZLENV
+	gpWaitSync                                       C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                              C.GPWAITVKSEMAPHORENV
+	gpWeightPathsNV                                  C.GPWEIGHTPATHSNV
+	gpWindowRectanglesEXT                            C.GPWINDOWRECTANGLESEXT
 )
 
 // Helper functions
@@ -5151,15 +8429,24 @@ func boolToInt(b bool) int {
 	}
 	return 0
 }
+func ActiveProgramEXT(program uint32) {
+	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
+}
 
 // set the active program object for a program pipeline object
 func ActiveShaderProgram(pipeline uint32, program uint32) {
 	C.glowActiveShaderProgram(gpActiveShaderProgram, (C.GLuint)(pipeline), (C.GLuint)(program))
 }
+func ActiveShaderProgramEXT(pipeline uint32, program uint32) {
+	C.glowActiveShaderProgramEXT(gpActiveShaderProgramEXT, (C.GLuint)(pipeline), (C.GLuint)(program))
+}
 
 // select active texture unit
 func ActiveTexture(texture uint32) {
 	C.glowActiveTexture(gpActiveTexture, (C.GLenum)(texture))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 
 // Attaches a shader object to a program object
@@ -5170,6 +8457,15 @@ func AttachShader(program uint32, shader uint32) {
 // start conditional rendering
 func BeginConditionalRender(id uint32, mode uint32) {
 	C.glowBeginConditionalRender(gpBeginConditionalRender, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginConditionalRenderNV(id uint32, mode uint32) {
+	C.glowBeginConditionalRenderNV(gpBeginConditionalRenderNV, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginPerfMonitorAMD(monitor uint32) {
+	C.glowBeginPerfMonitorAMD(gpBeginPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func BeginPerfQueryINTEL(queryHandle uint32) {
+	C.glowBeginPerfQueryINTEL(gpBeginPerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // delimit the boundaries of a query object
@@ -5239,10 +8535,16 @@ func BindImageTexture(unit uint32, texture uint32, level int32, layered bool, la
 func BindImageTextures(first uint32, count int32, textures *uint32) {
 	C.glowBindImageTextures(gpBindImageTextures, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(textures)))
 }
+func BindMultiTextureEXT(texunit uint32, target uint32, texture uint32) {
+	C.glowBindMultiTextureEXT(gpBindMultiTextureEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(texture))
+}
 
 // bind a program pipeline to the current context
 func BindProgramPipeline(pipeline uint32) {
 	C.glowBindProgramPipeline(gpBindProgramPipeline, (C.GLuint)(pipeline))
+}
+func BindProgramPipelineEXT(pipeline uint32) {
+	C.glowBindProgramPipelineEXT(gpBindProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 
 // bind a renderbuffer to a renderbuffer target
@@ -5294,6 +8596,12 @@ func BindVertexBuffer(bindingindex uint32, buffer uint32, offset int, stride int
 func BindVertexBuffers(first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowBindVertexBuffers(gpBindVertexBuffers, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
 }
+func BlendBarrierKHR() {
+	C.glowBlendBarrierKHR(gpBlendBarrierKHR)
+}
+func BlendBarrierNV() {
+	C.glowBlendBarrierNV(gpBlendBarrierNV)
+}
 
 // set the blend color
 func BlendColor(red float32, green float32, blue float32, alpha float32) {
@@ -5343,6 +8651,9 @@ func BlendFunci(buf uint32, src uint32, dst uint32) {
 func BlendFunciARB(buf uint32, src uint32, dst uint32) {
 	C.glowBlendFunciARB(gpBlendFunciARB, (C.GLuint)(buf), (C.GLenum)(src), (C.GLenum)(dst))
 }
+func BlendParameteriNV(pname uint32, value int32) {
+	C.glowBlendParameteriNV(gpBlendParameteriNV, (C.GLenum)(pname), (C.GLint)(value))
+}
 
 // copy a block of pixels from one framebuffer object to another
 func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
@@ -5353,13 +8664,16 @@ func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 i
 func BlitNamedFramebuffer(readFramebuffer uint32, drawFramebuffer uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
 	C.glowBlitNamedFramebuffer(gpBlitNamedFramebuffer, (C.GLuint)(readFramebuffer), (C.GLuint)(drawFramebuffer), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
 }
+func BufferAddressRangeNV(pname uint32, index uint32, address uint64, length int) {
+	C.glowBufferAddressRangeNV(gpBufferAddressRangeNV, (C.GLenum)(pname), (C.GLuint)(index), (C.GLuint64EXT)(address), (C.GLsizeiptr)(length))
+}
 
 // creates and initializes a buffer object's data     store
 func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferData(gpBufferData, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
@@ -5371,6 +8685,9 @@ func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubData(gpBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
+}
 
 // check the completeness status of a framebuffer
 func CheckFramebufferStatus(target uint32) uint32 {
@@ -5381,6 +8698,10 @@ func CheckFramebufferStatus(target uint32) uint32 {
 // check the completeness status of a framebuffer
 func CheckNamedFramebufferStatus(framebuffer uint32, target uint32) uint32 {
 	ret := C.glowCheckNamedFramebufferStatus(gpCheckNamedFramebufferStatus, (C.GLuint)(framebuffer), (C.GLenum)(target))
+	return (uint32)(ret)
+}
+func CheckNamedFramebufferStatusEXT(framebuffer uint32, target uint32) uint32 {
+	ret := C.glowCheckNamedFramebufferStatusEXT(gpCheckNamedFramebufferStatusEXT, (C.GLuint)(framebuffer), (C.GLenum)(target))
 	return (uint32)(ret)
 }
 
@@ -5425,6 +8746,8 @@ func ClearColor(red float32, green float32, blue float32, alpha float32) {
 func ClearDepth(depth float64) {
 	C.glowClearDepth(gpClearDepth, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -5433,13 +8756,19 @@ func ClearDepthf(d float32) {
 func ClearNamedBufferData(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferData(gpClearNamedBufferData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferDataEXT(gpClearNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -5465,9 +8794,12 @@ func ClearTexImage(texture uint32, level int32, format uint32, xtype uint32, dat
 func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearTexSubImage(gpClearTexSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClientAttribDefaultEXT(mask uint32) {
+	C.glowClientAttribDefaultEXT(gpClientAttribDefaultEXT, (C.GLbitfield)(mask))
+}
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -5476,11 +8808,20 @@ func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
 func ClipControl(origin uint32, depth uint32) {
 	C.glowClipControl(gpClipControl, (C.GLenum)(origin), (C.GLenum)(depth))
 }
+func ColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowColorFormatNV(gpColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func ColorMask(red bool, green bool, blue bool, alpha bool) {
 	C.glowColorMask(gpColorMask, (C.GLboolean)(boolToInt(red)), (C.GLboolean)(boolToInt(green)), (C.GLboolean)(boolToInt(blue)), (C.GLboolean)(boolToInt(alpha)))
 }
 func ColorMaski(index uint32, r bool, g bool, b bool, a bool) {
 	C.glowColorMaski(gpColorMaski, (C.GLuint)(index), (C.GLboolean)(boolToInt(r)), (C.GLboolean)(boolToInt(g)), (C.GLboolean)(boolToInt(b)), (C.GLboolean)(boolToInt(a)))
+}
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
 }
 
 // Compiles a shader object
@@ -5489,6 +8830,24 @@ func CompileShader(shader uint32) {
 }
 func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
+}
+func CompressedMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage1DEXT(gpCompressedMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage2DEXT(gpCompressedMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage3DEXT(gpCompressedMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage1DEXT(gpCompressedMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage2DEXT(gpCompressedMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage3DEXT(gpCompressedMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a one-dimensional texture image in a compressed format
@@ -5520,20 +8879,44 @@ func CompressedTexSubImage2D(target uint32, level int32, xoffset int32, yoffset 
 func CompressedTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTexSubImage3D(gpCompressedTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage1DEXT(gpCompressedTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage2DEXT(gpCompressedTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage3DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage3DEXT(gpCompressedTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a one-dimensional texture subimage in a compressed     format
 func CompressedTextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage1D(gpCompressedTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage1DEXT(gpCompressedTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a two-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage2D(gpCompressedTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage2DEXT(gpCompressedTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a three-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3D(gpCompressedTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
@@ -5545,10 +8928,28 @@ func CopyBufferSubData(readTarget uint32, writeTarget uint32, readOffset int, wr
 func CopyImageSubData(srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
 	C.glowCopyImageSubData(gpCopyImageSubData, (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
 }
+func CopyMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyMultiTexImage1DEXT(gpCopyMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyMultiTexImage2DEXT(gpCopyMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
+func CopyMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyMultiTexSubImage1DEXT(gpCopyMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage2DEXT(gpCopyMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage3DEXT(gpCopyMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func CopyPathNV(resultPath uint32, srcPath uint32) {
+	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
 }
 
 // copy pixels into a 1D texture image
@@ -5575,30 +8976,69 @@ func CopyTexSubImage2D(target uint32, level int32, xoffset int32, yoffset int32,
 func CopyTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTexSubImage3D(gpCopyTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyTextureImage1DEXT(gpCopyTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyTextureImage2DEXT(gpCopyTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
 
 // copy a one-dimensional texture subimage
 func CopyTextureSubImage1D(texture uint32, level int32, xoffset int32, x int32, y int32, width int32) {
 	C.glowCopyTextureSubImage1D(gpCopyTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyTextureSubImage1DEXT(gpCopyTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
 }
 
 // copy a two-dimensional texture subimage
 func CopyTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage2D(gpCopyTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage2DEXT(gpCopyTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy a three-dimensional texture subimage
 func CopyTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage3D(gpCopyTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage3DEXT(gpCopyTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverFillPathInstancedNV(gpCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverFillPathNV(path uint32, coverMode uint32) {
+	C.glowCoverFillPathNV(gpCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverStrokePathInstancedNV(gpCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverStrokePathNV(path uint32, coverMode uint32) {
+	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
+	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
 }
 
 // Creates a program object
@@ -5632,15 +9072,26 @@ func CreateShader(xtype uint32) uint32 {
 	ret := C.glowCreateShader(gpCreateShader, (C.GLenum)(xtype))
 	return (uint32)(ret)
 }
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
+	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
+	return (uint32)(ret)
+}
 
 // create a stand-alone program from an array of null-terminated source code strings
 func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
+	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
+	return (uint32)(ret)
+}
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -5703,6 +9154,9 @@ func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint
 func DeleteBuffers(n int32, buffers *uint32) {
 	C.glowDeleteBuffers(gpDeleteBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // delete framebuffer objects
 func DeleteFramebuffers(n int32, framebuffers *uint32) {
@@ -5710,6 +9164,15 @@ func DeleteFramebuffers(n int32, framebuffers *uint32) {
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+}
+func DeletePathsNV(path uint32, xrange int32) {
+	C.glowDeletePathsNV(gpDeletePathsNV, (C.GLuint)(path), (C.GLsizei)(xrange))
+}
+func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowDeletePerfMonitorsAMD(gpDeletePerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
+func DeletePerfQueryINTEL(queryHandle uint32) {
+	C.glowDeletePerfQueryINTEL(gpDeletePerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // Deletes a program object
@@ -5720,6 +9183,9 @@ func DeleteProgram(program uint32) {
 // delete program pipeline objects
 func DeleteProgramPipelines(n int32, pipelines *uint32) {
 	C.glowDeleteProgramPipelines(gpDeleteProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func DeleteProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowDeleteProgramPipelinesEXT(gpDeleteProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // delete named query objects
@@ -5741,9 +9207,12 @@ func DeleteSamplers(count int32, samplers *uint32) {
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -5784,6 +9253,8 @@ func DepthRangeArrayv(first uint32, count int32, v *float64) {
 func DepthRangeIndexed(index uint32, n float64, f float64) {
 	C.glowDepthRangeIndexed(gpDepthRangeIndexed, (C.GLuint)(index), (C.GLdouble)(n), (C.GLdouble)(f))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -5795,10 +9266,25 @@ func DetachShader(program uint32, shader uint32) {
 func Disable(cap uint32) {
 	C.glowDisable(gpDisable, (C.GLenum)(cap))
 }
+func DisableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowDisableClientStateIndexedEXT(gpDisableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableClientStateiEXT(array uint32, index uint32) {
+	C.glowDisableClientStateiEXT(gpDisableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableIndexedEXT(target uint32, index uint32) {
+	C.glowDisableIndexedEXT(gpDisableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func DisableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowDisableVertexArrayAttrib(gpDisableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowDisableVertexArrayAttribEXT(gpDisableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowDisableVertexArrayEXT(gpDisableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -5836,10 +9322,16 @@ func DrawArraysIndirect(mode uint32, indirect unsafe.Pointer) {
 func DrawArraysInstanced(mode uint32, first int32, count int32, instancecount int32) {
 	C.glowDrawArraysInstanced(gpDrawArraysInstanced, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount))
 }
+func DrawArraysInstancedARB(mode uint32, first int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedARB(gpDrawArraysInstancedARB, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a range of elements with offset applied to instanced attributes
 func DrawArraysInstancedBaseInstance(mode uint32, first int32, count int32, instancecount int32, baseinstance uint32) {
 	C.glowDrawArraysInstancedBaseInstance(gpDrawArraysInstancedBaseInstance, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount), (C.GLuint)(baseinstance))
+}
+func DrawArraysInstancedEXT(mode uint32, start int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedEXT(gpDrawArraysInstancedEXT, (C.GLenum)(mode), (C.GLint)(start), (C.GLsizei)(count), (C.GLsizei)(primcount))
 }
 
 // specify which color buffers are to be drawn into
@@ -5850,6 +9342,18 @@ func DrawBuffer(buf uint32) {
 // Specifies a list of color buffers to be drawn     into
 func DrawBuffers(n int32, bufs *uint32) {
 	C.glowDrawBuffers(gpDrawBuffers, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 
 // render primitives from array data
@@ -5871,6 +9375,9 @@ func DrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer) {
 func DrawElementsInstanced(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32) {
 	C.glowDrawElementsInstanced(gpDrawElementsInstanced, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount))
 }
+func DrawElementsInstancedARB(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedARB(gpDrawElementsInstancedARB, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a set of elements with offset applied to instanced attributes
 func DrawElementsInstancedBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, baseinstance uint32) {
@@ -5885,6 +9392,9 @@ func DrawElementsInstancedBaseVertex(mode uint32, count int32, xtype uint32, ind
 // render multiple instances of a set of primitives from array data with a per-element offset
 func DrawElementsInstancedBaseVertexBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, basevertex int32, baseinstance uint32) {
 	C.glowDrawElementsInstancedBaseVertexBaseInstance(gpDrawElementsInstancedBaseVertexBaseInstance, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount), (C.GLint)(basevertex), (C.GLuint)(baseinstance))
+}
+func DrawElementsInstancedEXT(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedEXT(gpDrawElementsInstancedEXT, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
 }
 
 // render primitives from array data
@@ -5916,15 +9426,36 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
 }
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
+}
+func EdgeFlagFormatNV(stride int32) {
+	C.glowEdgeFlagFormatNV(gpEdgeFlagFormatNV, (C.GLsizei)(stride))
+}
 
 // enable or disable server-side GL capabilities
 func Enable(cap uint32) {
 	C.glowEnable(gpEnable, (C.GLenum)(cap))
 }
+func EnableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowEnableClientStateIndexedEXT(gpEnableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableClientStateiEXT(array uint32, index uint32) {
+	C.glowEnableClientStateiEXT(gpEnableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableIndexedEXT(target uint32, index uint32) {
+	C.glowEnableIndexedEXT(gpEnableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func EnableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowEnableVertexArrayAttrib(gpEnableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowEnableVertexArrayAttribEXT(gpEnableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowEnableVertexArrayEXT(gpEnableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -5937,6 +9468,15 @@ func Enablei(target uint32, index uint32) {
 func EndConditionalRender() {
 	C.glowEndConditionalRender(gpEndConditionalRender)
 }
+func EndConditionalRenderNV() {
+	C.glowEndConditionalRenderNV(gpEndConditionalRenderNV)
+}
+func EndPerfMonitorAMD(monitor uint32) {
+	C.glowEndPerfMonitorAMD(gpEndPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func EndPerfQueryINTEL(queryHandle uint32) {
+	C.glowEndPerfQueryINTEL(gpEndPerfQueryINTEL, (C.GLuint)(queryHandle))
+}
 func EndQuery(target uint32) {
 	C.glowEndQuery(gpEndQuery, (C.GLenum)(target))
 }
@@ -5946,11 +9486,14 @@ func EndQueryIndexed(target uint32, index uint32) {
 func EndTransformFeedback() {
 	C.glowEndTransformFeedback(gpEndTransformFeedback)
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -5969,18 +9512,45 @@ func FlushMappedBufferRange(target uint32, offset int, length int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FogCoordFormatNV(xtype uint32, stride int32) {
+	C.glowFogCoordFormatNV(gpFogCoordFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
+func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferDrawBufferEXT(gpFramebufferDrawBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
+func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
+	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
 }
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
 	C.glowFramebufferParameteri(gpFramebufferParameteri, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
 }
+func FramebufferReadBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferReadBufferEXT(gpFramebufferReadBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
 
 // attach a renderbuffer as a logical buffer of a framebuffer object
 func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbuffer(gpFramebufferRenderbuffer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
@@ -5990,16 +9560,30 @@ func FramebufferTexture(target uint32, attachment uint32, texture uint32, level 
 func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1D(gpFramebufferTexture1D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
 func FramebufferTexture3D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
 	C.glowFramebufferTexture3D(gpFramebufferTexture3D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
 }
+func FramebufferTextureARB(target uint32, attachment uint32, texture uint32, level int32) {
+	C.glowFramebufferTextureARB(gpFramebufferTextureARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func FramebufferTextureFaceARB(target uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowFramebufferTextureFaceARB(gpFramebufferTextureFaceARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
+}
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func FramebufferTextureLayer(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayer(gpFramebufferTextureLayer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowFramebufferTextureLayerARB(gpFramebufferTextureLayerARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 
 // define front- and back-facing polygons
@@ -6016,10 +9600,20 @@ func GenBuffers(n int32, buffers *uint32) {
 func GenFramebuffers(n int32, framebuffers *uint32) {
 	C.glowGenFramebuffers(gpGenFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
 }
+func GenPathsNV(xrange int32) uint32 {
+	ret := C.glowGenPathsNV(gpGenPathsNV, (C.GLsizei)(xrange))
+	return (uint32)(ret)
+}
+func GenPerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowGenPerfMonitorsAMD(gpGenPerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
 
 // reserve program pipeline object names
 func GenProgramPipelines(n int32, pipelines *uint32) {
 	C.glowGenProgramPipelines(gpGenProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func GenProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowGenProgramPipelinesEXT(gpGenProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // generate query object names
@@ -6056,10 +9650,16 @@ func GenVertexArrays(n int32, arrays *uint32) {
 func GenerateMipmap(target uint32) {
 	C.glowGenerateMipmap(gpGenerateMipmap, (C.GLenum)(target))
 }
+func GenerateMultiTexMipmapEXT(texunit uint32, target uint32) {
+	C.glowGenerateMultiTexMipmapEXT(gpGenerateMultiTexMipmapEXT, (C.GLenum)(texunit), (C.GLenum)(target))
+}
 
 // generate mipmaps for a specified texture object
 func GenerateTextureMipmap(texture uint32) {
 	C.glowGenerateTextureMipmap(gpGenerateTextureMipmap, (C.GLuint)(texture))
+}
+func GenerateTextureMipmapEXT(texture uint32, target uint32) {
+	C.glowGenerateTextureMipmapEXT(gpGenerateTextureMipmapEXT, (C.GLuint)(texture), (C.GLenum)(target))
 }
 
 // retrieve information about the set of active atomic counter buffers for a program
@@ -6094,6 +9694,8 @@ func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6118,6 +9720,9 @@ func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
+func GetBooleanIndexedvEXT(target uint32, index uint32, data *bool) {
+	C.glowGetBooleanIndexedvEXT(gpGetBooleanIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
+}
 func GetBooleani_v(target uint32, index uint32, data *bool) {
 	C.glowGetBooleani_v(gpGetBooleani_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
 }
@@ -6134,6 +9739,9 @@ func GetBufferParameteri64v(target uint32, pname uint32, params *int64) {
 func GetBufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetBufferParameteriv(gpGetBufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetBufferParameterui64vNV(target uint32, pname uint32, params *uint64) {
+	C.glowGetBufferParameterui64vNV(gpGetBufferParameterui64vNV, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
@@ -6143,6 +9751,13 @@ func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
 // returns a subset of a buffer object's data store
 func GetBufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetBufferSubData(gpGetBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
+func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
 
 // return a compressed texture image
@@ -6154,10 +9769,16 @@ func GetCompressedTexImage(target uint32, level int32, img unsafe.Pointer) {
 func GetCompressedTextureImage(texture uint32, level int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureImage(gpGetCompressedTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLsizei)(bufSize), pixels)
 }
+func GetCompressedTextureImageEXT(texture uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedTextureImageEXT(gpGetCompressedTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(lod), img)
+}
 
 // retrieve a sub-region of a compressed texture image from a     compressed texture object
 func GetCompressedTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureSubImage(gpGetCompressedTextureSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(bufSize), pixels)
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -6173,8 +9794,14 @@ func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
+func GetDoubleIndexedvEXT(target uint32, index uint32, data *float64) {
+	C.glowGetDoubleIndexedvEXT(gpGetDoubleIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
 func GetDoublei_v(target uint32, index uint32, data *float64) {
 	C.glowGetDoublei_v(gpGetDoublei_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
+func GetDoublei_vEXT(pname uint32, index uint32, params *float64) {
+	C.glowGetDoublei_vEXT(gpGetDoublei_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
 }
 func GetDoublev(pname uint32, data *float64) {
 	C.glowGetDoublev(gpGetDoublev, (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(data)))
@@ -6185,8 +9812,17 @@ func GetError() uint32 {
 	ret := C.glowGetError(gpGetError)
 	return (uint32)(ret)
 }
+func GetFirstPerfQueryIdINTEL(queryId *uint32) {
+	C.glowGetFirstPerfQueryIdINTEL(gpGetFirstPerfQueryIdINTEL, (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetFloatIndexedvEXT(target uint32, index uint32, data *float32) {
+	C.glowGetFloatIndexedvEXT(gpGetFloatIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
 func GetFloati_v(target uint32, index uint32, data *float32) {
 	C.glowGetFloati_v(gpGetFloati_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
+func GetFloati_vEXT(pname uint32, index uint32, params *float32) {
+	C.glowGetFloati_vEXT(gpGetFloati_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetFloatv(pname uint32, data *float32) {
 	C.glowGetFloatv(gpGetFloatv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(data)))
@@ -6204,14 +9840,17 @@ func GetFragDataLocation(program uint32, name *uint8) int32 {
 	return (int32)(ret)
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetFramebufferParameterivEXT(gpGetFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // check if the rendering context has not been lost due to software or hardware issues
@@ -6231,23 +9870,77 @@ func GetImageHandleARB(texture uint32, level int32, layered bool, layer int32, f
 	ret := C.glowGetImageHandleARB(gpGetImageHandleARB, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
 	return (uint64)(ret)
 }
+func GetImageHandleNV(texture uint32, level int32, layered bool, layer int32, format uint32) uint64 {
+	ret := C.glowGetImageHandleNV(gpGetImageHandleNV, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
+	return (uint64)(ret)
+}
 func GetInteger64i_v(target uint32, index uint32, data *int64) {
 	C.glowGetInteger64i_v(gpGetInteger64i_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint64)(unsafe.Pointer(data)))
 }
 func GetInteger64v(pname uint32, data *int64) {
 	C.glowGetInteger64v(gpGetInteger64v, (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(data)))
 }
+func GetIntegerIndexedvEXT(target uint32, index uint32, data *int32) {
+	C.glowGetIntegerIndexedvEXT(gpGetIntegerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
 func GetIntegeri_v(target uint32, index uint32, data *int32) {
 	C.glowGetIntegeri_v(gpGetIntegeri_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
+func GetIntegerui64i_vNV(value uint32, index uint32, result *uint64) {
+	C.glowGetIntegerui64i_vNV(gpGetIntegerui64i_vNV, (C.GLenum)(value), (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(result)))
+}
+func GetIntegerui64vNV(value uint32, result *uint64) {
+	C.glowGetIntegerui64vNV(gpGetIntegerui64vNV, (C.GLenum)(value), (*C.GLuint64EXT)(unsafe.Pointer(result)))
 }
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexEnvfvEXT(gpGetMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexEnvivEXT(gpGetMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowGetMultiTexGendvEXT(gpGetMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexGenfvEXT(gpGetMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexGenivEXT(gpGetMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexImageEXT(texunit uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetMultiTexImageEXT(gpGetMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func GetMultiTexLevelParameterfvEXT(texunit uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetMultiTexLevelParameterfvEXT(gpGetMultiTexLevelParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexLevelParameterivEXT(texunit uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetMultiTexLevelParameterivEXT(gpGetMultiTexLevelParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterIivEXT(gpGetMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetMultiTexParameterIuivEXT(gpGetMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexParameterfvEXT(gpGetMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterivEXT(gpGetMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // retrieve the location of a sample
@@ -6264,30 +9957,69 @@ func GetNamedBufferParameteri64v(buffer uint32, pname uint32, params *int64) {
 func GetNamedBufferParameteriv(buffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedBufferParameteriv(gpGetNamedBufferParameteriv, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedBufferParameterivEXT(buffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedBufferParameterivEXT(gpGetNamedBufferParameterivEXT, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedBufferParameterui64vNV(buffer uint32, pname uint32, params *uint64) {
+	C.glowGetNamedBufferParameterui64vNV(gpGetNamedBufferParameterui64vNV, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetNamedBufferPointerv(buffer uint32, pname uint32, params *unsafe.Pointer) {
 	C.glowGetNamedBufferPointerv(gpGetNamedBufferPointerv, (C.GLuint)(buffer), (C.GLenum)(pname), params)
 }
+func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Pointer) {
+	C.glowGetNamedBufferPointervEXT(gpGetNamedBufferPointervEXT, (C.GLuint)(buffer), (C.GLenum)(pname), params)
+}
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 
 // retrieve information about attachments of a framebuffer object
 func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameteriv(gpGetNamedFramebufferAttachmentParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a framebuffer object
 func GetNamedFramebufferParameteriv(framebuffer uint32, pname uint32, param *int32) {
 	C.glowGetNamedFramebufferParameteriv(gpGetNamedFramebufferParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
 }
+func GetNamedFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferParameterivEXT(gpGetNamedFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowGetNamedProgramLocalParameterIivEXT(gpGetNamedProgramLocalParameterIivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIuivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowGetNamedProgramLocalParameterIuivEXT(gpGetNamedProgramLocalParameterIuivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterdvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowGetNamedProgramLocalParameterdvEXT(gpGetNamedProgramLocalParameterdvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterfvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowGetNamedProgramLocalParameterfvEXT(gpGetNamedProgramLocalParameterfvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetNamedProgramStringEXT(program uint32, target uint32, pname uint32, xstring unsafe.Pointer) {
+	C.glowGetNamedProgramStringEXT(gpGetNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), xstring)
+}
+func GetNamedProgramivEXT(program uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetNamedProgramivEXT(gpGetNamedProgramivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a renderbuffer object
 func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameteriv(gpGetNamedRenderbufferParameteriv, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedRenderbufferParameterivEXT(renderbuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedRenderbufferParameterivEXT(gpGetNamedRenderbufferParameterivEXT, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
@@ -6295,10 +10027,16 @@ func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int
 func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
+	C.glowGetNextPerfQueryIdINTEL(gpGetNextPerfQueryIdINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(nextQueryId)))
+}
 
 // retrieve the label of a named object identified within a namespace
 func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
+	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
@@ -6310,6 +10048,70 @@ func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *
 }
 func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetPathCommandsNV(path uint32, commands *uint8) {
+	C.glowGetPathCommandsNV(gpGetPathCommandsNV, (C.GLuint)(path), (*C.GLubyte)(unsafe.Pointer(commands)))
+}
+func GetPathCoordsNV(path uint32, coords *float32) {
+	C.glowGetPathCoordsNV(gpGetPathCoordsNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(coords)))
+}
+func GetPathDashArrayNV(path uint32, dashArray *float32) {
+	C.glowGetPathDashArrayNV(gpGetPathDashArrayNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func GetPathLengthNV(path uint32, startSegment int32, numSegments int32) float32 {
+	ret := C.glowGetPathLengthNV(gpGetPathLengthNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments))
+	return (float32)(ret)
+}
+func GetPathMetricRangeNV(metricQueryMask uint32, firstPathName uint32, numPaths int32, stride int32, metrics *float32) {
+	C.glowGetPathMetricRangeNV(gpGetPathMetricRangeNV, (C.GLbitfield)(metricQueryMask), (C.GLuint)(firstPathName), (C.GLsizei)(numPaths), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathMetricsNV(metricQueryMask uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, stride int32, metrics *float32) {
+	C.glowGetPathMetricsNV(gpGetPathMetricsNV, (C.GLbitfield)(metricQueryMask), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowGetPathParameterfvNV(gpGetPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func GetPathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowGetPathParameterivNV(gpGetPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func GetPathSpacingNV(pathListMode uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, advanceScale float32, kerningScale float32, transformType uint32, returnedSpacing *float32) {
+	C.glowGetPathSpacingNV(gpGetPathSpacingNV, (C.GLenum)(pathListMode), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLfloat)(advanceScale), (C.GLfloat)(kerningScale), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(returnedSpacing)))
+}
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
+}
+func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
+	C.glowGetPerfMonitorCounterDataAMD(gpGetPerfMonitorCounterDataAMD, (C.GLuint)(monitor), (C.GLenum)(pname), (C.GLsizei)(dataSize), (*C.GLuint)(unsafe.Pointer(data)), (*C.GLint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
+	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
+}
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
+	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
+}
+func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
+	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
+}
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
+	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
+}
+func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
+	C.glowGetPerfMonitorGroupsAMD(gpGetPerfMonitorGroupsAMD, (*C.GLint)(unsafe.Pointer(numGroups)), (C.GLsizei)(groupsSize), (*C.GLuint)(unsafe.Pointer(groups)))
+}
+func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
+	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
+	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
+}
+func GetPointerIndexedvEXT(target uint32, index uint32, data *unsafe.Pointer) {
+	C.glowGetPointerIndexedvEXT(gpGetPointerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), data)
+}
+func GetPointeri_vEXT(pname uint32, index uint32, params *unsafe.Pointer) {
+	C.glowGetPointeri_vEXT(gpGetPointeri_vEXT, (C.GLenum)(pname), (C.GLuint)(index), params)
 }
 
 // return the address of the specified pointer
@@ -6337,8 +10139,14 @@ func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32
 func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
+	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
+}
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
 	C.glowGetProgramPipelineiv(gpGetProgramPipelineiv, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
+	C.glowGetProgramPipelineivEXT(gpGetProgramPipelineivEXT, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // query the index of a named resource within a program
@@ -6363,6 +10171,9 @@ func GetProgramResourceLocationIndex(program uint32, programInterface uint32, na
 func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
+func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
+	C.glowGetProgramResourcefvNV(gpGetProgramResourcefvNV, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLfloat)(unsafe.Pointer(params)))
+}
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
 	C.glowGetProgramResourceiv(gpGetProgramResourceiv, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6373,6 +10184,18 @@ func GetProgramStageiv(program uint32, shadertype uint32, pname uint32, values *
 // Returns a parameter from a program object
 func GetProgramiv(program uint32, pname uint32, params *int32) {
 	C.glowGetProgramiv(gpGetProgramiv, (C.GLuint)(program), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
 }
 
 // return parameters of an indexed query object target
@@ -6388,6 +10211,8 @@ func GetQueryObjectiv(id uint32, pname uint32, params *int32) {
 func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64v(gpGetQueryObjectui64v, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -6397,7 +10222,7 @@ func GetQueryiv(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryiv(gpGetQueryiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6433,6 +10258,10 @@ func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8)
 func GetShaderiv(shader uint32, pname uint32, params *int32) {
 	C.glowGetShaderiv(gpGetShaderiv, (C.GLuint)(shader), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -6457,7 +10286,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 
@@ -6487,31 +10316,60 @@ func GetTextureHandleARB(texture uint32) uint64 {
 	ret := C.glowGetTextureHandleARB(gpGetTextureHandleARB, (C.GLuint)(texture))
 	return (uint64)(ret)
 }
+func GetTextureHandleNV(texture uint32) uint64 {
+	ret := C.glowGetTextureHandleNV(gpGetTextureHandleNV, (C.GLuint)(texture))
+	return (uint64)(ret)
+}
 
 // return a texture image
 func GetTextureImage(texture uint32, level int32, format uint32, xtype uint32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetTextureImage(gpGetTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), pixels)
 }
+func GetTextureImageEXT(texture uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetTextureImageEXT(gpGetTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 func GetTextureLevelParameterfv(texture uint32, level int32, pname uint32, params *float32) {
 	C.glowGetTextureLevelParameterfv(gpGetTextureLevelParameterfv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureLevelParameterfvEXT(texture uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetTextureLevelParameterfvEXT(gpGetTextureLevelParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureLevelParameteriv(texture uint32, level int32, pname uint32, params *int32) {
 	C.glowGetTextureLevelParameteriv(gpGetTextureLevelParameteriv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureLevelParameterivEXT(texture uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetTextureLevelParameterivEXT(gpGetTextureLevelParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameterIiv(gpGetTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetTextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterIivEXT(gpGetTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetTextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowGetTextureParameterIuiv(gpGetTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetTextureParameterIuivEXT(gpGetTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterfv(texture uint32, pname uint32, params *float32) {
 	C.glowGetTextureParameterfv(gpGetTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetTextureParameterfvEXT(gpGetTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureParameteriv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameteriv(gpGetTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterivEXT(gpGetTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureSamplerHandleARB(texture uint32, sampler uint32) uint64 {
 	ret := C.glowGetTextureSamplerHandleARB(gpGetTextureSamplerHandleARB, (C.GLuint)(texture), (C.GLuint)(sampler))
+	return (uint64)(ret)
+}
+func GetTextureSamplerHandleNV(texture uint32, sampler uint32) uint64 {
+	ret := C.glowGetTextureSamplerHandleNV(gpGetTextureSamplerHandleNV, (C.GLuint)(texture), (C.GLuint)(sampler))
 	return (uint64)(ret)
 }
 
@@ -6563,10 +10421,22 @@ func GetUniformdv(program uint32, location int32, params *float64) {
 func GetUniformfv(program uint32, location int32, params *float32) {
 	C.glowGetUniformfv(gpGetUniformfv, (C.GLuint)(program), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func GetUniformi64vNV(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 
 // Returns the value of a uniform variable
 func GetUniformiv(program uint32, location int32, params *int32) {
 	C.glowGetUniformiv(gpGetUniformiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func GetUniformui64vNV(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 func GetUniformuiv(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuiv(gpGetUniformuiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
@@ -6576,6 +10446,18 @@ func GetVertexArrayIndexed64iv(vaobj uint32, index uint32, pname uint32, param *
 }
 func GetVertexArrayIndexediv(vaobj uint32, index uint32, pname uint32, param *int32) {
 	C.glowGetVertexArrayIndexediv(gpGetVertexArrayIndexediv, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegeri_vEXT(vaobj uint32, index uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegeri_vEXT(gpGetVertexArrayIntegeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegervEXT(vaobj uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegervEXT(gpGetVertexArrayIntegervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayPointeri_vEXT(vaobj uint32, index uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointeri_vEXT(gpGetVertexArrayPointeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), param)
+}
+func GetVertexArrayPointervEXT(vaobj uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointervEXT(gpGetVertexArrayPointervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), param)
 }
 
 // retrieve parameters of a vertex array object
@@ -6597,8 +10479,14 @@ func GetVertexAttribIuiv(index uint32, pname uint32, params *uint32) {
 func GetVertexAttribLdv(index uint32, pname uint32, params *float64) {
 	C.glowGetVertexAttribLdv(gpGetVertexAttribLdv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
 }
+func GetVertexAttribLi64vNV(index uint32, pname uint32, params *int64) {
+	C.glowGetVertexAttribLi64vNV(gpGetVertexAttribLi64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 func GetVertexAttribLui64vARB(index uint32, pname uint32, params *uint64) {
 	C.glowGetVertexAttribLui64vARB(gpGetVertexAttribLui64vARB, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
+func GetVertexAttribLui64vNV(index uint32, pname uint32, params *uint64) {
+	C.glowGetVertexAttribLui64vNV(gpGetVertexAttribLui64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 
 // return the address of the specified generic vertex attribute pointer
@@ -6620,6 +10508,10 @@ func GetVertexAttribfv(index uint32, pname uint32, params *float32) {
 func GetVertexAttribiv(index uint32, pname uint32, params *int32) {
 	C.glowGetVertexAttribiv(gpGetVertexAttribiv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
+}
 func GetnCompressedTexImageARB(target uint32, lod int32, bufSize int32, img unsafe.Pointer) {
 	C.glowGetnCompressedTexImageARB(gpGetnCompressedTexImageARB, (C.GLenum)(target), (C.GLint)(lod), (C.GLsizei)(bufSize), img)
 }
@@ -6638,6 +10530,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6646,6 +10541,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -6660,6 +10558,15 @@ func GetnUniformuivKHR(program uint32, location int32, bufSize int32, params *ui
 // specify implementation-specific hints
 func Hint(target uint32, mode uint32) {
 	C.glowHint(gpHint, (C.GLenum)(target), (C.GLenum)(mode))
+}
+func IndexFormatNV(xtype uint32, stride int32) {
+	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func InsertEventMarkerEXT(length int32, marker *uint8) {
+	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
+func InterpolatePathsNV(resultPath uint32, pathA uint32, pathB uint32, weight float32) {
+	C.glowInterpolatePathsNV(gpInterpolatePathsNV, (C.GLuint)(resultPath), (C.GLuint)(pathA), (C.GLuint)(pathB), (C.GLfloat)(weight))
 }
 
 // invalidate the content of a buffer object's data store
@@ -6707,8 +10614,20 @@ func IsBuffer(buffer uint32) bool {
 	ret := C.glowIsBuffer(gpIsBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func IsBufferResidentNV(target uint32) bool {
+	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
+	return ret == TRUE
+}
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
+	return ret == TRUE
+}
+func IsEnabledIndexedEXT(target uint32, index uint32) bool {
+	ret := C.glowIsEnabledIndexedEXT(gpIsEnabledIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
 	return ret == TRUE
 }
 func IsEnabledi(target uint32, index uint32) bool {
@@ -6725,8 +10644,28 @@ func IsImageHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsImageHandleResidentARB(gpIsImageHandleResidentARB, (C.GLuint64)(handle))
 	return ret == TRUE
 }
+func IsImageHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsImageHandleResidentNV(gpIsImageHandleResidentNV, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsNamedBufferResidentNV(buffer uint32) bool {
+	ret := C.glowIsNamedBufferResidentNV(gpIsNamedBufferResidentNV, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+	return ret == TRUE
+}
+func IsPathNV(path uint32) bool {
+	ret := C.glowIsPathNV(gpIsPathNV, (C.GLuint)(path))
+	return ret == TRUE
+}
+func IsPointInFillPathNV(path uint32, mask uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInFillPathNV(gpIsPointInFillPathNV, (C.GLuint)(path), (C.GLuint)(mask), (C.GLfloat)(x), (C.GLfloat)(y))
+	return ret == TRUE
+}
+func IsPointInStrokePathNV(path uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInStrokePathNV(gpIsPointInStrokePathNV, (C.GLuint)(path), (C.GLfloat)(x), (C.GLfloat)(y))
 	return ret == TRUE
 }
 
@@ -6739,6 +10678,10 @@ func IsProgram(program uint32) bool {
 // determine if a name corresponds to a program pipeline object
 func IsProgramPipeline(pipeline uint32) bool {
 	ret := C.glowIsProgramPipeline(gpIsProgramPipeline, (C.GLuint)(pipeline))
+	return ret == TRUE
+}
+func IsProgramPipelineEXT(pipeline uint32) bool {
+	ret := C.glowIsProgramPipelineEXT(gpIsProgramPipelineEXT, (C.GLuint)(pipeline))
 	return ret == TRUE
 }
 
@@ -6765,9 +10708,13 @@ func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -6779,6 +10726,10 @@ func IsTexture(texture uint32) bool {
 }
 func IsTextureHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsTextureHandleResidentARB(gpIsTextureHandleResidentARB, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsTextureHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsTextureHandleResidentNV(gpIsTextureHandleResidentNV, (C.GLuint64)(handle))
 	return ret == TRUE
 }
 
@@ -6793,6 +10744,9 @@ func IsVertexArray(array uint32) bool {
 	ret := C.glowIsVertexArray(gpIsVertexArray, (C.GLuint)(array))
 	return ret == TRUE
 }
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
+	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
+}
 
 // specify the width of rasterized lines
 func LineWidth(width float32) {
@@ -6803,22 +10757,49 @@ func LineWidth(width float32) {
 func LinkProgram(program uint32) {
 	C.glowLinkProgram(gpLinkProgram, (C.GLuint)(program))
 }
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 
 // specify a logical pixel operation for rendering
 func LogicOp(opcode uint32) {
 	C.glowLogicOp(gpLogicOp, (C.GLenum)(opcode))
 }
+func MakeBufferNonResidentNV(target uint32) {
+	C.glowMakeBufferNonResidentNV(gpMakeBufferNonResidentNV, (C.GLenum)(target))
+}
+func MakeBufferResidentNV(target uint32, access uint32) {
+	C.glowMakeBufferResidentNV(gpMakeBufferResidentNV, (C.GLenum)(target), (C.GLenum)(access))
+}
 func MakeImageHandleNonResidentARB(handle uint64) {
 	C.glowMakeImageHandleNonResidentARB(gpMakeImageHandleNonResidentARB, (C.GLuint64)(handle))
+}
+func MakeImageHandleNonResidentNV(handle uint64) {
+	C.glowMakeImageHandleNonResidentNV(gpMakeImageHandleNonResidentNV, (C.GLuint64)(handle))
 }
 func MakeImageHandleResidentARB(handle uint64, access uint32) {
 	C.glowMakeImageHandleResidentARB(gpMakeImageHandleResidentARB, (C.GLuint64)(handle), (C.GLenum)(access))
 }
+func MakeImageHandleResidentNV(handle uint64, access uint32) {
+	C.glowMakeImageHandleResidentNV(gpMakeImageHandleResidentNV, (C.GLuint64)(handle), (C.GLenum)(access))
+}
+func MakeNamedBufferNonResidentNV(buffer uint32) {
+	C.glowMakeNamedBufferNonResidentNV(gpMakeNamedBufferNonResidentNV, (C.GLuint)(buffer))
+}
+func MakeNamedBufferResidentNV(buffer uint32, access uint32) {
+	C.glowMakeNamedBufferResidentNV(gpMakeNamedBufferResidentNV, (C.GLuint)(buffer), (C.GLenum)(access))
+}
 func MakeTextureHandleNonResidentARB(handle uint64) {
 	C.glowMakeTextureHandleNonResidentARB(gpMakeTextureHandleNonResidentARB, (C.GLuint64)(handle))
 }
+func MakeTextureHandleNonResidentNV(handle uint64) {
+	C.glowMakeTextureHandleNonResidentNV(gpMakeTextureHandleNonResidentNV, (C.GLuint64)(handle))
+}
 func MakeTextureHandleResidentARB(handle uint64) {
 	C.glowMakeTextureHandleResidentARB(gpMakeTextureHandleResidentARB, (C.GLuint64)(handle))
+}
+func MakeTextureHandleResidentNV(handle uint64) {
+	C.glowMakeTextureHandleResidentNV(gpMakeTextureHandleResidentNV, (C.GLuint64)(handle))
 }
 
 // map all of a buffer object's data store into the client's address space
@@ -6838,11 +10819,100 @@ func MapNamedBuffer(buffer uint32, access uint32) unsafe.Pointer {
 	ret := C.glowMapNamedBuffer(gpMapNamedBuffer, (C.GLuint)(buffer), (C.GLenum)(access))
 	return (unsafe.Pointer)(ret)
 }
+func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferEXT(gpMapNamedBufferEXT, (C.GLuint)(buffer), (C.GLenum)(access))
+	return (unsafe.Pointer)(ret)
+}
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
+}
+func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRangeEXT(gpMapNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
+	return (unsafe.Pointer)(ret)
+}
+func MatrixFrustumEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixFrustumEXT(gpMatrixFrustumEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixLoad3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x2fNV(gpMatrixLoad3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoad3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x3fNV(gpMatrixLoad3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadIdentityEXT(mode uint32) {
+	C.glowMatrixLoadIdentityEXT(gpMatrixLoadIdentityEXT, (C.GLenum)(mode))
+}
+func MatrixLoadTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoadTranspose3x3fNV(gpMatrixLoadTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixLoadTransposedEXT(gpMatrixLoadTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadTransposefEXT(gpMatrixLoadTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoaddEXT(mode uint32, m *float64) {
+	C.glowMatrixLoaddEXT(gpMatrixLoaddEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadfEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadfEXT(gpMatrixLoadfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x2fNV(gpMatrixMult3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x3fNV(gpMatrixMult3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMultTranspose3x3fNV(gpMatrixMultTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixMultTransposedEXT(gpMatrixMultTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixMultTransposefEXT(gpMatrixMultTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultdEXT(mode uint32, m *float64) {
+	C.glowMatrixMultdEXT(gpMatrixMultdEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultfEXT(mode uint32, m *float32) {
+	C.glowMatrixMultfEXT(gpMatrixMultfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixOrthoEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixOrthoEXT(gpMatrixOrthoEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixPopEXT(mode uint32) {
+	C.glowMatrixPopEXT(gpMatrixPopEXT, (C.GLenum)(mode))
+}
+func MatrixPushEXT(mode uint32) {
+	C.glowMatrixPushEXT(gpMatrixPushEXT, (C.GLenum)(mode))
+}
+func MatrixRotatedEXT(mode uint32, angle float64, x float64, y float64, z float64) {
+	C.glowMatrixRotatedEXT(gpMatrixRotatedEXT, (C.GLenum)(mode), (C.GLdouble)(angle), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixRotatefEXT(mode uint32, angle float32, x float32, y float32, z float32) {
+	C.glowMatrixRotatefEXT(gpMatrixRotatefEXT, (C.GLenum)(mode), (C.GLfloat)(angle), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixScaledEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixScaledEXT(gpMatrixScaledEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixScalefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixScalefEXT(gpMatrixScalefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixTranslatedEXT(gpMatrixTranslatedEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
 }
 
 // defines a barrier ordering memory transactions
@@ -6870,8 +10940,14 @@ func MultiDrawArrays(mode uint32, first *int32, count *int32, drawcount int32) {
 func MultiDrawArraysIndirect(mode uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawArraysIndirect(gpMultiDrawArraysIndirect, (C.GLenum)(mode), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessCountNV(gpMultiDrawArraysIndirectBindlessCountNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 
 // render multiple sets of primitives by specifying indices of array data elements
@@ -6888,29 +10964,122 @@ func MultiDrawElementsBaseVertex(mode uint32, count *int32, xtype uint32, indice
 func MultiDrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawElementsIndirect(gpMultiDrawElementsIndirect, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessCountNV(gpMultiDrawElementsIndirectBindlessCountNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+}
+func MultiTexBufferEXT(texunit uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowMultiTexBufferEXT(gpMultiTexBufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
+func MultiTexCoordPointerEXT(texunit uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
+	C.glowMultiTexCoordPointerEXT(gpMultiTexCoordPointerEXT, (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
+}
+func MultiTexEnvfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexEnvfEXT(gpMultiTexEnvfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexEnvfvEXT(gpMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexEnviEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexEnviEXT(gpMultiTexEnviEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexEnvivEXT(gpMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexGendEXT(texunit uint32, coord uint32, pname uint32, param float64) {
+	C.glowMultiTexGendEXT(gpMultiTexGendEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLdouble)(param))
+}
+func MultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowMultiTexGendvEXT(gpMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func MultiTexGenfEXT(texunit uint32, coord uint32, pname uint32, param float32) {
+	C.glowMultiTexGenfEXT(gpMultiTexGenfEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowMultiTexGenfvEXT(gpMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexGeniEXT(texunit uint32, coord uint32, pname uint32, param int32) {
+	C.glowMultiTexGeniEXT(gpMultiTexGeniEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowMultiTexGenivEXT(gpMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage1DEXT(gpMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage2DEXT(gpMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage3DEXT(gpMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterIivEXT(gpMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowMultiTexParameterIuivEXT(gpMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexParameterfEXT(gpMultiTexParameterfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexParameterfvEXT(gpMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexParameteriEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexParameteriEXT(gpMultiTexParameteriEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterivEXT(gpMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexRenderbufferEXT(texunit uint32, target uint32, renderbuffer uint32) {
+	C.glowMultiTexRenderbufferEXT(gpMultiTexRenderbufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(renderbuffer))
+}
+func MultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage1DEXT(gpMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage2DEXT(gpMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
+}
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
+}
+func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedCopyBufferSubDataEXT(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowNamedCopyBufferSubDataEXT(gpNamedCopyBufferSubDataEXT, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 
 // specify which color buffers are to be drawn into
@@ -6927,6 +11096,9 @@ func NamedFramebufferDrawBuffers(framebuffer uint32, n int32, bufs *uint32) {
 func NamedFramebufferParameteri(framebuffer uint32, pname uint32, param int32) {
 	C.glowNamedFramebufferParameteri(gpNamedFramebufferParameteri, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
 }
+func NamedFramebufferParameteriEXT(framebuffer uint32, pname uint32, param int32) {
+	C.glowNamedFramebufferParameteriEXT(gpNamedFramebufferParameteriEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // select a color buffer source for pixels
 func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
@@ -6937,26 +11109,101 @@ func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
 func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbuffer(gpNamedFramebufferRenderbuffer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
+	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture1DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture1DEXT(gpNamedFramebufferTexture1DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture2DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture2DEXT(gpNamedFramebufferTexture2DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture3DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
+	C.glowNamedFramebufferTexture3DEXT(gpNamedFramebufferTexture3DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
+}
+func NamedFramebufferTextureEXT(framebuffer uint32, attachment uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTextureEXT(gpNamedFramebufferTextureEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTextureFaceEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowNamedFramebufferTextureFaceEXT(gpNamedFramebufferTextureFaceEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
 }
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func NamedFramebufferTextureLayer(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowNamedFramebufferTextureLayer(gpNamedFramebufferTextureLayer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
 }
+func NamedFramebufferTextureLayerEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowNamedFramebufferTextureLayerEXT(gpNamedFramebufferTextureLayerEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func NamedProgramLocalParameter4dEXT(program uint32, target uint32, index uint32, x float64, y float64, z float64, w float64) {
+	C.glowNamedProgramLocalParameter4dEXT(gpNamedProgramLocalParameter4dEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
+func NamedProgramLocalParameter4dvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowNamedProgramLocalParameter4dvEXT(gpNamedProgramLocalParameter4dvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameter4fEXT(program uint32, target uint32, index uint32, x float32, y float32, z float32, w float32) {
+	C.glowNamedProgramLocalParameter4fEXT(gpNamedProgramLocalParameter4fEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z), (C.GLfloat)(w))
+}
+func NamedProgramLocalParameter4fvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowNamedProgramLocalParameter4fvEXT(gpNamedProgramLocalParameter4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4iEXT(program uint32, target uint32, index uint32, x int32, y int32, z int32, w int32) {
+	C.glowNamedProgramLocalParameterI4iEXT(gpNamedProgramLocalParameterI4iEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLint)(x), (C.GLint)(y), (C.GLint)(z), (C.GLint)(w))
+}
+func NamedProgramLocalParameterI4ivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowNamedProgramLocalParameterI4ivEXT(gpNamedProgramLocalParameterI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4uiEXT(program uint32, target uint32, index uint32, x uint32, y uint32, z uint32, w uint32) {
+	C.glowNamedProgramLocalParameterI4uiEXT(gpNamedProgramLocalParameterI4uiEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(x), (C.GLuint)(y), (C.GLuint)(z), (C.GLuint)(w))
+}
+func NamedProgramLocalParameterI4uivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowNamedProgramLocalParameterI4uivEXT(gpNamedProgramLocalParameterI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameters4fvEXT(program uint32, target uint32, index uint32, count int32, params *float32) {
+	C.glowNamedProgramLocalParameters4fvEXT(gpNamedProgramLocalParameters4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4ivEXT(program uint32, target uint32, index uint32, count int32, params *int32) {
+	C.glowNamedProgramLocalParametersI4ivEXT(gpNamedProgramLocalParametersI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4uivEXT(program uint32, target uint32, index uint32, count int32, params *uint32) {
+	C.glowNamedProgramLocalParametersI4uivEXT(gpNamedProgramLocalParametersI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramStringEXT(program uint32, target uint32, format uint32, len int32, xstring unsafe.Pointer) {
+	C.glowNamedProgramStringEXT(gpNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(format), (C.GLsizei)(len), xstring)
+}
 
 // establish data storage, format and dimensions of a     renderbuffer object's image
 func NamedRenderbufferStorage(renderbuffer uint32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorage(gpNamedRenderbufferStorage, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageEXT(renderbuffer uint32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageEXT(gpNamedRenderbufferStorageEXT, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func NamedRenderbufferStorageMultisample(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisample(gpNamedRenderbufferStorageMultisample, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func NamedRenderbufferStorageMultisampleCoverageEXT(renderbuffer uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleCoverageEXT(gpNamedRenderbufferStorageMultisampleCoverageEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageMultisampleEXT(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleEXT(gpNamedRenderbufferStorageMultisampleEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
+}
+func NormalFormatNV(xtype uint32, stride int32) {
+	C.glowNormalFormatNV(gpNormalFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // label a named object identified within a namespace
@@ -6977,8 +11224,67 @@ func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathCommandsNV(path uint32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCommandsNV(gpPathCommandsNV, (C.GLuint)(path), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoordsNV(path uint32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCoordsNV(gpPathCoordsNV, (C.GLuint)(path), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoverDepthFuncNV(xfunc uint32) {
+	C.glowPathCoverDepthFuncNV(gpPathCoverDepthFuncNV, (C.GLenum)(xfunc))
+}
+func PathDashArrayNV(path uint32, dashCount int32, dashArray *float32) {
+	C.glowPathDashArrayNV(gpPathDashArrayNV, (C.GLuint)(path), (C.GLsizei)(dashCount), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func PathGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathGlyphIndexArrayNV(gpPathGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathGlyphIndexRangeNV(fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, pathParameterTemplate uint32, emScale float32, baseAndCount *uint32) uint32 {
+	ret := C.glowPathGlyphIndexRangeNV(gpPathGlyphIndexRangeNV, (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale), (*C.GLuint)(unsafe.Pointer(baseAndCount)))
+	return (uint32)(ret)
+}
+func PathGlyphRangeNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyph uint32, numGlyphs int32, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphRangeNV(gpPathGlyphRangeNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyph), (C.GLsizei)(numGlyphs), (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathGlyphsNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, numGlyphs int32, xtype uint32, charcodes unsafe.Pointer, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphsNV(gpPathGlyphsNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLsizei)(numGlyphs), (C.GLenum)(xtype), charcodes, (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathMemoryGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontSize int, fontData unsafe.Pointer, faceIndex int32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathMemoryGlyphIndexArrayNV(gpPathMemoryGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), (C.GLsizeiptr)(fontSize), fontData, (C.GLsizei)(faceIndex), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathParameterfNV(path uint32, pname uint32, value float32) {
+	C.glowPathParameterfNV(gpPathParameterfNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func PathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowPathParameterfvNV(gpPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func PathParameteriNV(path uint32, pname uint32, value int32) {
+	C.glowPathParameteriNV(gpPathParameteriNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowPathParameterivNV(gpPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func PathStencilDepthOffsetNV(factor float32, units float32) {
+	C.glowPathStencilDepthOffsetNV(gpPathStencilDepthOffsetNV, (C.GLfloat)(factor), (C.GLfloat)(units))
+}
+func PathStencilFuncNV(xfunc uint32, ref int32, mask uint32) {
+	C.glowPathStencilFuncNV(gpPathStencilFuncNV, (C.GLenum)(xfunc), (C.GLint)(ref), (C.GLuint)(mask))
+}
+func PathStringNV(path uint32, format uint32, length int32, pathString unsafe.Pointer) {
+	C.glowPathStringNV(gpPathStringNV, (C.GLuint)(path), (C.GLenum)(format), (C.GLsizei)(length), pathString)
+}
+func PathSubCommandsNV(path uint32, commandStart int32, commandsToDelete int32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCommandsNV(gpPathSubCommandsNV, (C.GLuint)(path), (C.GLsizei)(commandStart), (C.GLsizei)(commandsToDelete), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathSubCoordsNV(path uint32, coordStart int32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCoordsNV(gpPathSubCoordsNV, (C.GLuint)(path), (C.GLsizei)(coordStart), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
 }
 
 // pause transform feedback operations
@@ -6988,8 +11294,14 @@ func PauseTransformFeedback() {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
+}
+func PointAlongPathNV(path uint32, startSegment int32, numSegments int32, distance float32, x *float32, y *float32, tangentX *float32, tangentY *float32) bool {
+	ret := C.glowPointAlongPathNV(gpPointAlongPathNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments), (C.GLfloat)(distance), (*C.GLfloat)(unsafe.Pointer(x)), (*C.GLfloat)(unsafe.Pointer(y)), (*C.GLfloat)(unsafe.Pointer(tangentX)), (*C.GLfloat)(unsafe.Pointer(tangentY)))
+	return ret == TRUE
 }
 func PointParameterf(pname uint32, param float32) {
 	C.glowPointParameterf(gpPointParameterf, (C.GLenum)(pname), (C.GLfloat)(param))
@@ -7018,6 +11330,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 
 // pop the active debug group
 func PopDebugGroup() {
@@ -7025,6 +11343,12 @@ func PopDebugGroup() {
 }
 func PopDebugGroupKHR() {
 	C.glowPopDebugGroupKHR(gpPopDebugGroupKHR)
+}
+func PopGroupMarkerEXT() {
+	C.glowPopGroupMarkerEXT(gpPopGroupMarkerEXT)
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -7036,235 +11360,507 @@ func PrimitiveRestartIndex(index uint32) {
 func ProgramBinary(program uint32, binaryFormat uint32, binary unsafe.Pointer, length int32) {
 	C.glowProgramBinary(gpProgramBinary, (C.GLuint)(program), (C.GLenum)(binaryFormat), binary, (C.GLsizei)(length))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriARB(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriARB(gpProgramParameteriARB, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriEXT(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriEXT(gpProgramParameteriEXT, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramPathFragmentInputGenNV(program uint32, location int32, genMode uint32, components int32, coeffs *float32) {
+	C.glowProgramPathFragmentInputGenNV(gpProgramPathFragmentInputGenNV, (C.GLuint)(program), (C.GLint)(location), (C.GLenum)(genMode), (C.GLint)(components), (*C.GLfloat)(unsafe.Pointer(coeffs)))
 }
 func ProgramUniform1d(program uint32, location int32, v0 float64) {
 	C.glowProgramUniform1d(gpProgramUniform1d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0))
 }
+func ProgramUniform1dEXT(program uint32, location int32, x float64) {
+	C.glowProgramUniform1dEXT(gpProgramUniform1dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x))
+}
 func ProgramUniform1dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform1dv(gpProgramUniform1dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform1dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform1dvEXT(gpProgramUniform1dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1f(program uint32, location int32, v0 float32) {
 	C.glowProgramUniform1f(gpProgramUniform1f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
 }
+func ProgramUniform1fEXT(program uint32, location int32, v0 float32) {
+	C.glowProgramUniform1fEXT(gpProgramUniform1fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform1fv(gpProgramUniform1fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform1fvEXT(gpProgramUniform1fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
+func ProgramUniform1i64NV(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1iEXT(program uint32, location int32, v0 int32) {
+	C.glowProgramUniform1iEXT(gpProgramUniform1iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform1iv(gpProgramUniform1iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform1ivEXT(gpProgramUniform1ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
+func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1uiEXT(program uint32, location int32, v0 uint32) {
+	C.glowProgramUniform1uiEXT(gpProgramUniform1uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform1uiv(gpProgramUniform1uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform1uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform1uivEXT(gpProgramUniform1uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform2d(program uint32, location int32, v0 float64, v1 float64) {
 	C.glowProgramUniform2d(gpProgramUniform2d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1))
 }
+func ProgramUniform2dEXT(program uint32, location int32, x float64, y float64) {
+	C.glowProgramUniform2dEXT(gpProgramUniform2dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y))
+}
 func ProgramUniform2dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform2dv(gpProgramUniform2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform2dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform2dvEXT(gpProgramUniform2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2f(program uint32, location int32, v0 float32, v1 float32) {
 	C.glowProgramUniform2f(gpProgramUniform2f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
 }
+func ProgramUniform2fEXT(program uint32, location int32, v0 float32, v1 float32) {
+	C.glowProgramUniform2fEXT(gpProgramUniform2fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform2fv(gpProgramUniform2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform2fvEXT(gpProgramUniform2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2iEXT(program uint32, location int32, v0 int32, v1 int32) {
+	C.glowProgramUniform2iEXT(gpProgramUniform2iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform2iv(gpProgramUniform2iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform2ivEXT(gpProgramUniform2ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2uiEXT(program uint32, location int32, v0 uint32, v1 uint32) {
+	C.glowProgramUniform2uiEXT(gpProgramUniform2uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform2uiv(gpProgramUniform2uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform2uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform2uivEXT(gpProgramUniform2uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform3d(program uint32, location int32, v0 float64, v1 float64, v2 float64) {
 	C.glowProgramUniform3d(gpProgramUniform3d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2))
 }
+func ProgramUniform3dEXT(program uint32, location int32, x float64, y float64, z float64) {
+	C.glowProgramUniform3dEXT(gpProgramUniform3dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
 func ProgramUniform3dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform3dv(gpProgramUniform3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform3dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform3dvEXT(gpProgramUniform3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3f(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
 	C.glowProgramUniform3f(gpProgramUniform3f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
 }
+func ProgramUniform3fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
+	C.glowProgramUniform3fEXT(gpProgramUniform3fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform3fv(gpProgramUniform3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform3fvEXT(gpProgramUniform3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
+	C.glowProgramUniform3iEXT(gpProgramUniform3iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform3iv(gpProgramUniform3iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform3ivEXT(gpProgramUniform3ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
+	C.glowProgramUniform3uiEXT(gpProgramUniform3uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform3uiv(gpProgramUniform3uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform3uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform3uivEXT(gpProgramUniform3uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform4d(program uint32, location int32, v0 float64, v1 float64, v2 float64, v3 float64) {
 	C.glowProgramUniform4d(gpProgramUniform4d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2), (C.GLdouble)(v3))
 }
+func ProgramUniform4dEXT(program uint32, location int32, x float64, y float64, z float64, w float64) {
+	C.glowProgramUniform4dEXT(gpProgramUniform4dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
 func ProgramUniform4dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform4dv(gpProgramUniform4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform4dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform4dvEXT(gpProgramUniform4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4f(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
 	C.glowProgramUniform4f(gpProgramUniform4f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
 }
+func ProgramUniform4fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
+	C.glowProgramUniform4fEXT(gpProgramUniform4fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform4fv(gpProgramUniform4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform4fvEXT(gpProgramUniform4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
+	C.glowProgramUniform4iEXT(gpProgramUniform4iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform4iv(gpProgramUniform4iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform4ivEXT(gpProgramUniform4ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
+	C.glowProgramUniform4uiEXT(gpProgramUniform4uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform4uiv(gpProgramUniform4uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform4uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform4uivEXT(gpProgramUniform4uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniformHandleui64ARB(program uint32, location int32, value uint64) {
 	C.glowProgramUniformHandleui64ARB(gpProgramUniformHandleui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
+}
+func ProgramUniformHandleui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformHandleui64NV(gpProgramUniformHandleui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
 }
 func ProgramUniformHandleui64vARB(program uint32, location int32, count int32, values *uint64) {
 	C.glowProgramUniformHandleui64vARB(gpProgramUniformHandleui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
 }
+func ProgramUniformHandleui64vNV(program uint32, location int32, count int32, values *uint64) {
+	C.glowProgramUniformHandleui64vNV(gpProgramUniformHandleui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
+}
 func ProgramUniformMatrix2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2dv(gpProgramUniformMatrix2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2dvEXT(gpProgramUniformMatrix2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2fv(gpProgramUniformMatrix2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2fvEXT(gpProgramUniformMatrix2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x3dv(gpProgramUniformMatrix2x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x3dvEXT(gpProgramUniformMatrix2x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x3fv(gpProgramUniformMatrix2x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x3fvEXT(gpProgramUniformMatrix2x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x4dv(gpProgramUniformMatrix2x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x4dvEXT(gpProgramUniformMatrix2x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x4fv(gpProgramUniformMatrix2x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x4fvEXT(gpProgramUniformMatrix2x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3dv(gpProgramUniformMatrix3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3dvEXT(gpProgramUniformMatrix3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3fv(gpProgramUniformMatrix3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3fvEXT(gpProgramUniformMatrix3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x2dv(gpProgramUniformMatrix3x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x2dvEXT(gpProgramUniformMatrix3x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x2fv(gpProgramUniformMatrix3x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x2fvEXT(gpProgramUniformMatrix3x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x4dv(gpProgramUniformMatrix3x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x4dvEXT(gpProgramUniformMatrix3x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x4fv(gpProgramUniformMatrix3x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x4fvEXT(gpProgramUniformMatrix3x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4dv(gpProgramUniformMatrix4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4dvEXT(gpProgramUniformMatrix4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4fv(gpProgramUniformMatrix4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4fvEXT(gpProgramUniformMatrix4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x2dv(gpProgramUniformMatrix4x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x2dvEXT(gpProgramUniformMatrix4x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x2fv(gpProgramUniformMatrix4x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x2fvEXT(gpProgramUniformMatrix4x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x3dv(gpProgramUniformMatrix4x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x3dvEXT(gpProgramUniformMatrix4x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x3fv(gpProgramUniformMatrix4x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x3fvEXT(gpProgramUniformMatrix4x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniformui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformui64NV(gpProgramUniformui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func ProgramUniformui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniformui64vNV(gpProgramUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // specifiy the vertex to be used as the source of data for flat shaded varyings
 func ProvokingVertex(mode uint32) {
 	C.glowProvokingVertex(gpProvokingVertex, (C.GLenum)(mode))
+}
+func PushClientAttribDefaultEXT(mask uint32) {
+	C.glowPushClientAttribDefaultEXT(gpPushClientAttribDefaultEXT, (C.GLbitfield)(mask))
 }
 
 // push a named debug group into the command stream
@@ -7274,10 +11870,16 @@ func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
+func PushGroupMarkerEXT(length int32, marker *uint8) {
+	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
 
 // record the GL time into a query object after all previous commands have reached the GL server but have not yet necessarily executed.
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
+}
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
 
 // select a color buffer source for pixels
@@ -7314,6 +11916,12 @@ func RenderbufferStorage(target uint32, internalformat uint32, width int32, heig
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func RenderbufferStorageMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowRenderbufferStorageMultisample(gpRenderbufferStorageMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func RenderbufferStorageMultisampleCoverageNV(target uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowRenderbufferStorageMultisampleCoverageNV(gpRenderbufferStorageMultisampleCoverageNV, (C.GLenum)(target), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
 }
 
 // resume transform feedback operations
@@ -7364,6 +11972,12 @@ func ScissorIndexed(index uint32, left int32, bottom int32, width int32, height 
 func ScissorIndexedv(index uint32, v *int32) {
 	C.glowScissorIndexedv(gpScissorIndexedv, (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(v)))
 }
+func SecondaryColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowSecondaryColorFormatNV(gpSecondaryColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
+	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
+}
 
 // load pre-compiled shader binaries
 func ShaderBinary(count int32, shaders *uint32, binaryformat uint32, binary unsafe.Pointer, length int32) {
@@ -7378,6 +11992,24 @@ func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 // change an active shader storage block binding
 func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storageBlockBinding uint32) {
 	C.glowShaderStorageBlockBinding(gpShaderStorageBlockBinding, (C.GLuint)(program), (C.GLuint)(storageBlockIndex), (C.GLuint)(storageBlockBinding))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
+}
+func StencilFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilFillPathInstancedNV(gpStencilFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilFillPathNV(path uint32, fillMode uint32, mask uint32) {
+	C.glowStencilFillPathNV(gpStencilFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask))
 }
 
 // set front and back function and reference value for stencil testing
@@ -7409,15 +12041,42 @@ func StencilOp(fail uint32, zfail uint32, zpass uint32) {
 func StencilOpSeparate(face uint32, sfail uint32, dpfail uint32, dppass uint32) {
 	C.glowStencilOpSeparate(gpStencilOpSeparate, (C.GLenum)(face), (C.GLenum)(sfail), (C.GLenum)(dpfail), (C.GLenum)(dppass))
 }
+func StencilStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilStrokePathInstancedNV(gpStencilStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilStrokePathNV(path uint32, reference int32, mask uint32) {
+	C.glowStencilStrokePathNV(gpStencilStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask))
+}
+func StencilThenCoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverFillPathInstancedNV(gpStencilThenCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverFillPathNV(path uint32, fillMode uint32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverFillPathNV(gpStencilThenCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func StencilThenCoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverStrokePathInstancedNV(gpStencilThenCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverStrokePathNV(path uint32, reference int32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverStrokePathNV(gpStencilThenCoverStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TexBuffer(target uint32, internalformat uint32, buffer uint32) {
 	C.glowTexBuffer(gpTexBuffer, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TexBufferARB(target uint32, internalformat uint32, buffer uint32) {
+	C.glowTexBufferARB(gpTexBufferARB, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
 func TexBufferRange(target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTexBufferRange(gpTexBufferRange, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TexCoordFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowTexCoordFormatNV(gpTexCoordFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // specify a one-dimensional texture image
@@ -7444,8 +12103,8 @@ func TexImage3D(target uint32, level int32, internalformat int32, width int32, h
 func TexImage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexImage3DMultisample(gpTexImage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -7510,73 +12169,139 @@ func TexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zof
 func TextureBarrier() {
 	C.glowTextureBarrier(gpTextureBarrier)
 }
+func TextureBarrierNV() {
+	C.glowTextureBarrierNV(gpTextureBarrierNV)
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TextureBuffer(texture uint32, internalformat uint32, buffer uint32) {
 	C.glowTextureBuffer(gpTextureBuffer, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowTextureBufferEXT(gpTextureBufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureImage1DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage1DEXT(gpTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage2DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage2DEXT(gpTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage3DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage3DEXT(gpTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func TextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterIivEXT(gpTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func TextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowTextureParameterIuiv(gpTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func TextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowTextureParameterIuivEXT(gpTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
 func TextureParameterf(texture uint32, pname uint32, param float32) {
 	C.glowTextureParameterf(gpTextureParameterf, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLfloat)(param))
 }
+func TextureParameterfEXT(texture uint32, target uint32, pname uint32, param float32) {
+	C.glowTextureParameterfEXT(gpTextureParameterfEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
 func TextureParameterfv(texture uint32, pname uint32, param *float32) {
 	C.glowTextureParameterfv(gpTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(param)))
+}
+func TextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowTextureParameterfvEXT(gpTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func TextureParameteri(texture uint32, pname uint32, param int32) {
 	C.glowTextureParameteri(gpTextureParameteri, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLint)(param))
 }
+func TextureParameteriEXT(texture uint32, target uint32, pname uint32, param int32) {
+	C.glowTextureParameteriEXT(gpTextureParameteriEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
 func TextureParameteriv(texture uint32, pname uint32, param *int32) {
 	C.glowTextureParameteriv(gpTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func TextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterivEXT(gpTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func TextureRenderbufferEXT(texture uint32, target uint32, renderbuffer uint32) {
+	C.glowTextureRenderbufferEXT(gpTextureRenderbufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLuint)(renderbuffer))
 }
 
 // simultaneously specify storage for all levels of a one-dimensional texture
 func TextureStorage1D(texture uint32, levels int32, internalformat uint32, width int32) {
 	C.glowTextureStorage1D(gpTextureStorage1D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
 }
+func TextureStorage1DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32) {
+	C.glowTextureStorage1DEXT(gpTextureStorage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
+}
 
 // simultaneously specify storage for all levels of a two-dimensional or one-dimensional array texture
 func TextureStorage2D(texture uint32, levels int32, internalformat uint32, width int32, height int32) {
 	C.glowTextureStorage2D(gpTextureStorage2D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func TextureStorage2DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32) {
+	C.glowTextureStorage2DEXT(gpTextureStorage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // specify storage for a two-dimensional multisample texture
 func TextureStorage2DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
 	C.glowTextureStorage2DMultisample(gpTextureStorage2DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage2DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
+	C.glowTextureStorage2DMultisampleEXT(gpTextureStorage2DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // simultaneously specify storage for all levels of a three-dimensional, two-dimensional array or cube-map array texture
 func TextureStorage3D(texture uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
 	C.glowTextureStorage3D(gpTextureStorage3D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func TextureStorage3DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
+	C.glowTextureStorage3DEXT(gpTextureStorage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
 }
 
 // specify storage for a two-dimensional multisample array texture
 func TextureStorage3DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisample(gpTextureStorage3DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
+	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // specify a one-dimensional texture subimage
 func TextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage1D(gpTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage1DEXT(gpTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // specify a two-dimensional texture subimage
 func TextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage2D(gpTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func TextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage2DEXT(gpTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 
 // specify a three-dimensional texture subimage
 func TextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage3D(gpTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage3DEXT(gpTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // initialize a texture as a data alias of another texture's data store
@@ -7590,13 +12315,16 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 
 // specify values to record in transform feedback buffers
 func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
+}
+func TransformPathNV(resultPath uint32, srcPath uint32, transformType uint32, transformValues *float32) {
+	C.glowTransformPathNV(gpTransformPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
 }
 func Uniform1d(location int32, x float64) {
 	C.glowUniform1d(gpUniform1d, (C.GLint)(location), (C.GLdouble)(x))
@@ -7619,6 +12347,18 @@ func Uniform1fv(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
+func Uniform1i64NV(location int32, x int64) {
+	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform1i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform1iv(location int32, count int32, value *int32) {
@@ -7628,6 +12368,18 @@ func Uniform1iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
+}
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
+func Uniform1ui64NV(location int32, x uint64) {
+	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform1ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7655,6 +12407,18 @@ func Uniform2fv(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func Uniform2i64NV(location int32, x int64, y int64) {
+	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform2i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform2iv(location int32, count int32, value *int32) {
@@ -7664,6 +12428,18 @@ func Uniform2iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func Uniform2ui64NV(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform2ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7691,6 +12467,18 @@ func Uniform3fv(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func Uniform3i64NV(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform3i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform3iv(location int32, count int32, value *int32) {
@@ -7700,6 +12488,18 @@ func Uniform3iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform3ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7727,6 +12527,18 @@ func Uniform4fv(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform4i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform4iv(location int32, count int32, value *int32) {
@@ -7736,6 +12548,18 @@ func Uniform4iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform4ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7750,8 +12574,14 @@ func UniformBlockBinding(program uint32, uniformBlockIndex uint32, uniformBlockB
 func UniformHandleui64ARB(location int32, value uint64) {
 	C.glowUniformHandleui64ARB(gpUniformHandleui64ARB, (C.GLint)(location), (C.GLuint64)(value))
 }
+func UniformHandleui64NV(location int32, value uint64) {
+	C.glowUniformHandleui64NV(gpUniformHandleui64NV, (C.GLint)(location), (C.GLuint64)(value))
+}
 func UniformHandleui64vARB(location int32, count int32, value *uint64) {
 	C.glowUniformHandleui64vARB(gpUniformHandleui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func UniformHandleui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformHandleui64vNV(gpUniformHandleui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func UniformMatrix2dv(location int32, count int32, transpose bool, value *float64) {
 	C.glowUniformMatrix2dv(gpUniformMatrix2dv, (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
@@ -7828,6 +12658,12 @@ func UniformMatrix4x3fv(location int32, count int32, transpose bool, value *floa
 func UniformSubroutinesuiv(shadertype uint32, count int32, indices *uint32) {
 	C.glowUniformSubroutinesuiv(gpUniformSubroutinesuiv, (C.GLenum)(shadertype), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(indices)))
 }
+func Uniformui64NV(location int32, value uint64) {
+	C.glowUniformui64NV(gpUniformui64NV, (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func Uniformui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformui64vNV(gpUniformui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // release the mapping of a buffer object's data store into the client's address space
 func UnmapBuffer(target uint32) bool {
@@ -7840,6 +12676,10 @@ func UnmapNamedBuffer(buffer uint32) bool {
 	ret := C.glowUnmapNamedBuffer(gpUnmapNamedBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func UnmapNamedBufferEXT(buffer uint32) bool {
+	ret := C.glowUnmapNamedBufferEXT(gpUnmapNamedBufferEXT, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 
 // Installs a program object as part of current rendering state
 func UseProgram(program uint32) {
@@ -7850,6 +12690,12 @@ func UseProgram(program uint32) {
 func UseProgramStages(pipeline uint32, stages uint32, program uint32) {
 	C.glowUseProgramStages(gpUseProgramStages, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
 }
+func UseProgramStagesEXT(pipeline uint32, stages uint32, program uint32) {
+	C.glowUseProgramStagesEXT(gpUseProgramStagesEXT, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
+}
+func UseShaderProgramEXT(xtype uint32, program uint32) {
+	C.glowUseShaderProgramEXT(gpUseShaderProgramEXT, (C.GLenum)(xtype), (C.GLuint)(program))
+}
 
 // Validates a program object
 func ValidateProgram(program uint32) {
@@ -7859,6 +12705,9 @@ func ValidateProgram(program uint32) {
 // validate a program pipeline object against current GL state
 func ValidateProgramPipeline(pipeline uint32) {
 	C.glowValidateProgramPipeline(gpValidateProgramPipeline, (C.GLuint)(pipeline))
+}
+func ValidateProgramPipelineEXT(pipeline uint32) {
+	C.glowValidateProgramPipelineEXT(gpValidateProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 func VertexArrayAttribBinding(vaobj uint32, attribindex uint32, bindingindex uint32) {
 	C.glowVertexArrayAttribBinding(gpVertexArrayAttribBinding, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
@@ -7874,15 +12723,69 @@ func VertexArrayAttribIFormat(vaobj uint32, attribindex uint32, size int32, xtyp
 func VertexArrayAttribLFormat(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexArrayAttribLFormat(gpVertexArrayAttribLFormat, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexArrayBindVertexBufferEXT(vaobj uint32, bindingindex uint32, buffer uint32, offset int, stride int32) {
+	C.glowVertexArrayBindVertexBufferEXT(gpVertexArrayBindVertexBufferEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(stride))
+}
 
 // modify the rate at which generic vertex attributes     advance
 func VertexArrayBindingDivisor(vaobj uint32, bindingindex uint32, divisor uint32) {
 	C.glowVertexArrayBindingDivisor(gpVertexArrayBindingDivisor, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexArrayColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayColorOffsetEXT(gpVertexArrayColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayEdgeFlagOffsetEXT(vaobj uint32, buffer uint32, stride int32, offset int) {
+	C.glowVertexArrayEdgeFlagOffsetEXT(gpVertexArrayEdgeFlagOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
 
 // configures element array buffer binding of a vertex array object
 func VertexArrayElementBuffer(vaobj uint32, buffer uint32) {
 	C.glowVertexArrayElementBuffer(gpVertexArrayElementBuffer, (C.GLuint)(vaobj), (C.GLuint)(buffer))
+}
+func VertexArrayFogCoordOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayFogCoordOffsetEXT(gpVertexArrayFogCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayIndexOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayIndexOffsetEXT(gpVertexArrayIndexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayMultiTexCoordOffsetEXT(vaobj uint32, buffer uint32, texunit uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayMultiTexCoordOffsetEXT(gpVertexArrayMultiTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayNormalOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayNormalOffsetEXT(gpVertexArrayNormalOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArraySecondaryColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArraySecondaryColorOffsetEXT(gpVertexArraySecondaryColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayTexCoordOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayTexCoordOffsetEXT(gpVertexArrayTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribBindingEXT(vaobj uint32, attribindex uint32, bindingindex uint32) {
+	C.glowVertexArrayVertexAttribBindingEXT(gpVertexArrayVertexAttribBindingEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
+}
+func VertexArrayVertexAttribDivisorEXT(vaobj uint32, index uint32, divisor uint32) {
+	C.glowVertexArrayVertexAttribDivisorEXT(gpVertexArrayVertexAttribDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLuint)(divisor))
+}
+func VertexArrayVertexAttribFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribFormatEXT(gpVertexArrayVertexAttribFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribIFormatEXT(gpVertexArrayVertexAttribIFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribIOffsetEXT(gpVertexArrayVertexAttribIOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribLFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribLFormatEXT(gpVertexArrayVertexAttribLFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribLOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribLOffsetEXT(gpVertexArrayVertexAttribLOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, normalized bool, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribOffsetEXT(gpVertexArrayVertexAttribOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexBindingDivisorEXT(vaobj uint32, bindingindex uint32, divisor uint32) {
+	C.glowVertexArrayVertexBindingDivisorEXT(gpVertexArrayVertexBindingDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
 
 // bind a buffer to a vertex buffer bind point
@@ -7893,6 +12796,9 @@ func VertexArrayVertexBuffer(vaobj uint32, bindingindex uint32, buffer uint32, o
 // attach multiple buffer objects to a vertex array object
 func VertexArrayVertexBuffers(vaobj uint32, first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowVertexArrayVertexBuffers(gpVertexArrayVertexBuffers, (C.GLuint)(vaobj), (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
+}
+func VertexArrayVertexOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexOffsetEXT(gpVertexArrayVertexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
 }
 func VertexAttrib1d(index uint32, x float64) {
 	C.glowVertexAttrib1d(gpVertexAttrib1d, (C.GLuint)(index), (C.GLdouble)(x))
@@ -8012,10 +12918,16 @@ func VertexAttribBinding(attribindex uint32, bindingindex uint32) {
 func VertexAttribDivisor(index uint32, divisor uint32) {
 	C.glowVertexAttribDivisor(gpVertexAttribDivisor, (C.GLuint)(index), (C.GLuint)(divisor))
 }
+func VertexAttribDivisorARB(index uint32, divisor uint32) {
+	C.glowVertexAttribDivisorARB(gpVertexAttribDivisorARB, (C.GLuint)(index), (C.GLuint)(divisor))
+}
 
 // specify the organization of vertex arrays
 func VertexAttribFormat(attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
 	C.glowVertexAttribFormat(gpVertexAttribFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexAttribFormatNV(index uint32, size int32, xtype uint32, normalized bool, stride int32) {
+	C.glowVertexAttribFormatNV(gpVertexAttribFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride))
 }
 func VertexAttribI1i(index uint32, x int32) {
 	C.glowVertexAttribI1i(gpVertexAttribI1i, (C.GLuint)(index), (C.GLint)(x))
@@ -8080,6 +12992,9 @@ func VertexAttribI4usv(index uint32, v *uint16) {
 func VertexAttribIFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribIFormat(gpVertexAttribIFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexAttribIFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribIFormatNV(gpVertexAttribIFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func VertexAttribIPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribIPointer(gpVertexAttribIPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
 }
@@ -8089,11 +13004,23 @@ func VertexAttribL1d(index uint32, x float64) {
 func VertexAttribL1dv(index uint32, v *float64) {
 	C.glowVertexAttribL1dv(gpVertexAttribL1dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL1i64NV(index uint32, x int64) {
+	C.glowVertexAttribL1i64NV(gpVertexAttribL1i64NV, (C.GLuint)(index), (C.GLint64EXT)(x))
+}
+func VertexAttribL1i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL1i64vNV(gpVertexAttribL1i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL1ui64ARB(index uint32, x uint64) {
 	C.glowVertexAttribL1ui64ARB(gpVertexAttribL1ui64ARB, (C.GLuint)(index), (C.GLuint64EXT)(x))
 }
+func VertexAttribL1ui64NV(index uint32, x uint64) {
+	C.glowVertexAttribL1ui64NV(gpVertexAttribL1ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x))
+}
 func VertexAttribL1ui64vARB(index uint32, v *uint64) {
 	C.glowVertexAttribL1ui64vARB(gpVertexAttribL1ui64vARB, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL1ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL1ui64vNV(gpVertexAttribL1ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL2d(index uint32, x float64, y float64) {
 	C.glowVertexAttribL2d(gpVertexAttribL2d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y))
@@ -8101,11 +13028,35 @@ func VertexAttribL2d(index uint32, x float64, y float64) {
 func VertexAttribL2dv(index uint32, v *float64) {
 	C.glowVertexAttribL2dv(gpVertexAttribL2dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL2i64NV(index uint32, x int64, y int64) {
+	C.glowVertexAttribL2i64NV(gpVertexAttribL2i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func VertexAttribL2i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL2i64vNV(gpVertexAttribL2i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL2ui64NV(index uint32, x uint64, y uint64) {
+	C.glowVertexAttribL2ui64NV(gpVertexAttribL2ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func VertexAttribL2ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL2ui64vNV(gpVertexAttribL2ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL3d(index uint32, x float64, y float64, z float64) {
 	C.glowVertexAttribL3d(gpVertexAttribL3d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
 }
 func VertexAttribL3dv(index uint32, v *float64) {
 	C.glowVertexAttribL3dv(gpVertexAttribL3dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
+}
+func VertexAttribL3i64NV(index uint32, x int64, y int64, z int64) {
+	C.glowVertexAttribL3i64NV(gpVertexAttribL3i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func VertexAttribL3i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL3i64vNV(gpVertexAttribL3i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL3ui64NV(index uint32, x uint64, y uint64, z uint64) {
+	C.glowVertexAttribL3ui64NV(gpVertexAttribL3ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func VertexAttribL3ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL3ui64vNV(gpVertexAttribL3ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 	C.glowVertexAttribL4d(gpVertexAttribL4d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
@@ -8113,8 +13064,23 @@ func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 func VertexAttribL4dv(index uint32, v *float64) {
 	C.glowVertexAttribL4dv(gpVertexAttribL4dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL4i64NV(index uint32, x int64, y int64, z int64, w int64) {
+	C.glowVertexAttribL4i64NV(gpVertexAttribL4i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func VertexAttribL4i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL4i64vNV(gpVertexAttribL4i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL4ui64NV(index uint32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowVertexAttribL4ui64NV(gpVertexAttribL4ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func VertexAttribL4ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL4ui64vNV(gpVertexAttribL4ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribLFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribLFormat(gpVertexAttribLFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexAttribLFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribLFormatNV(gpVertexAttribLFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 func VertexAttribLPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribLPointer(gpVertexAttribLPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
@@ -8153,6 +13119,9 @@ func VertexAttribPointer(index uint32, size int32, xtype uint32, normalized bool
 func VertexBindingDivisor(bindingindex uint32, divisor uint32) {
 	C.glowVertexBindingDivisor(gpVertexBindingDivisor, (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowVertexFormatNV(gpVertexFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 
 // set the viewport
 func Viewport(x int32, y int32, width int32, height int32) {
@@ -8167,10 +13136,25 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
+	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
+}
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
 }
 
 // Init initializes the OpenGL bindings by loading the function pointers (for
@@ -8200,14 +13184,17 @@ func Init() error {
 // function pointer loading function. For more cases Init should be used
 // instead.
 func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
+	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
 	if gpActiveShaderProgram == nil {
 		return errors.New("glActiveShaderProgram")
 	}
+	gpActiveShaderProgramEXT = (C.GPACTIVESHADERPROGRAMEXT)(getProcAddr("glActiveShaderProgramEXT"))
 	gpActiveTexture = (C.GPACTIVETEXTURE)(getProcAddr("glActiveTexture"))
 	if gpActiveTexture == nil {
 		return errors.New("glActiveTexture")
 	}
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpAttachShader = (C.GPATTACHSHADER)(getProcAddr("glAttachShader"))
 	if gpAttachShader == nil {
 		return errors.New("glAttachShader")
@@ -8216,6 +13203,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBeginConditionalRender == nil {
 		return errors.New("glBeginConditionalRender")
 	}
+	gpBeginConditionalRenderNV = (C.GPBEGINCONDITIONALRENDERNV)(getProcAddr("glBeginConditionalRenderNV"))
+	gpBeginPerfMonitorAMD = (C.GPBEGINPERFMONITORAMD)(getProcAddr("glBeginPerfMonitorAMD"))
+	gpBeginPerfQueryINTEL = (C.GPBEGINPERFQUERYINTEL)(getProcAddr("glBeginPerfQueryINTEL"))
 	gpBeginQuery = (C.GPBEGINQUERY)(getProcAddr("glBeginQuery"))
 	if gpBeginQuery == nil {
 		return errors.New("glBeginQuery")
@@ -8263,10 +13253,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glBindImageTexture")
 	}
 	gpBindImageTextures = (C.GPBINDIMAGETEXTURES)(getProcAddr("glBindImageTextures"))
+	gpBindMultiTextureEXT = (C.GPBINDMULTITEXTUREEXT)(getProcAddr("glBindMultiTextureEXT"))
 	gpBindProgramPipeline = (C.GPBINDPROGRAMPIPELINE)(getProcAddr("glBindProgramPipeline"))
 	if gpBindProgramPipeline == nil {
 		return errors.New("glBindProgramPipeline")
 	}
+	gpBindProgramPipelineEXT = (C.GPBINDPROGRAMPIPELINEEXT)(getProcAddr("glBindProgramPipelineEXT"))
 	gpBindRenderbuffer = (C.GPBINDRENDERBUFFER)(getProcAddr("glBindRenderbuffer"))
 	if gpBindRenderbuffer == nil {
 		return errors.New("glBindRenderbuffer")
@@ -8295,6 +13287,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glBindVertexBuffer")
 	}
 	gpBindVertexBuffers = (C.GPBINDVERTEXBUFFERS)(getProcAddr("glBindVertexBuffers"))
+	gpBlendBarrierKHR = (C.GPBLENDBARRIERKHR)(getProcAddr("glBlendBarrierKHR"))
+	gpBlendBarrierNV = (C.GPBLENDBARRIERNV)(getProcAddr("glBlendBarrierNV"))
 	gpBlendColor = (C.GPBLENDCOLOR)(getProcAddr("glBlendColor"))
 	if gpBlendColor == nil {
 		return errors.New("glBlendColor")
@@ -8335,11 +13329,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glBlendFunci")
 	}
 	gpBlendFunciARB = (C.GPBLENDFUNCIARB)(getProcAddr("glBlendFunciARB"))
+	gpBlendParameteriNV = (C.GPBLENDPARAMETERINV)(getProcAddr("glBlendParameteriNV"))
 	gpBlitFramebuffer = (C.GPBLITFRAMEBUFFER)(getProcAddr("glBlitFramebuffer"))
 	if gpBlitFramebuffer == nil {
 		return errors.New("glBlitFramebuffer")
 	}
 	gpBlitNamedFramebuffer = (C.GPBLITNAMEDFRAMEBUFFER)(getProcAddr("glBlitNamedFramebuffer"))
+	gpBufferAddressRangeNV = (C.GPBUFFERADDRESSRANGENV)(getProcAddr("glBufferAddressRangeNV"))
 	gpBufferData = (C.GPBUFFERDATA)(getProcAddr("glBufferData"))
 	if gpBufferData == nil {
 		return errors.New("glBufferData")
@@ -8350,11 +13346,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCheckFramebufferStatus = (C.GPCHECKFRAMEBUFFERSTATUS)(getProcAddr("glCheckFramebufferStatus"))
 	if gpCheckFramebufferStatus == nil {
 		return errors.New("glCheckFramebufferStatus")
 	}
 	gpCheckNamedFramebufferStatus = (C.GPCHECKNAMEDFRAMEBUFFERSTATUS)(getProcAddr("glCheckNamedFramebufferStatus"))
+	gpCheckNamedFramebufferStatusEXT = (C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(getProcAddr("glCheckNamedFramebufferStatusEXT"))
 	gpClampColor = (C.GPCLAMPCOLOR)(getProcAddr("glClampColor"))
 	if gpClampColor == nil {
 		return errors.New("glClampColor")
@@ -8400,7 +13398,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glClearDepthf")
 	}
 	gpClearNamedBufferData = (C.GPCLEARNAMEDBUFFERDATA)(getProcAddr("glClearNamedBufferData"))
+	gpClearNamedBufferDataEXT = (C.GPCLEARNAMEDBUFFERDATAEXT)(getProcAddr("glClearNamedBufferDataEXT"))
 	gpClearNamedBufferSubData = (C.GPCLEARNAMEDBUFFERSUBDATA)(getProcAddr("glClearNamedBufferSubData"))
+	gpClearNamedBufferSubDataEXT = (C.GPCLEARNAMEDBUFFERSUBDATAEXT)(getProcAddr("glClearNamedBufferSubDataEXT"))
 	gpClearNamedFramebufferfi = (C.GPCLEARNAMEDFRAMEBUFFERFI)(getProcAddr("glClearNamedFramebufferfi"))
 	gpClearNamedFramebufferfv = (C.GPCLEARNAMEDFRAMEBUFFERFV)(getProcAddr("glClearNamedFramebufferfv"))
 	gpClearNamedFramebufferiv = (C.GPCLEARNAMEDFRAMEBUFFERIV)(getProcAddr("glClearNamedFramebufferiv"))
@@ -8411,11 +13411,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpClearTexImage = (C.GPCLEARTEXIMAGE)(getProcAddr("glClearTexImage"))
 	gpClearTexSubImage = (C.GPCLEARTEXSUBIMAGE)(getProcAddr("glClearTexSubImage"))
+	gpClientAttribDefaultEXT = (C.GPCLIENTATTRIBDEFAULTEXT)(getProcAddr("glClientAttribDefaultEXT"))
 	gpClientWaitSync = (C.GPCLIENTWAITSYNC)(getProcAddr("glClientWaitSync"))
 	if gpClientWaitSync == nil {
 		return errors.New("glClientWaitSync")
 	}
 	gpClipControl = (C.GPCLIPCONTROL)(getProcAddr("glClipControl"))
+	gpColorFormatNV = (C.GPCOLORFORMATNV)(getProcAddr("glColorFormatNV"))
 	gpColorMask = (C.GPCOLORMASK)(getProcAddr("glColorMask"))
 	if gpColorMask == nil {
 		return errors.New("glColorMask")
@@ -8424,11 +13426,19 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpColorMaski == nil {
 		return errors.New("glColorMaski")
 	}
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
 	}
 	gpCompileShaderIncludeARB = (C.GPCOMPILESHADERINCLUDEARB)(getProcAddr("glCompileShaderIncludeARB"))
+	gpCompressedMultiTexImage1DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE1DEXT)(getProcAddr("glCompressedMultiTexImage1DEXT"))
+	gpCompressedMultiTexImage2DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE2DEXT)(getProcAddr("glCompressedMultiTexImage2DEXT"))
+	gpCompressedMultiTexImage3DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE3DEXT)(getProcAddr("glCompressedMultiTexImage3DEXT"))
+	gpCompressedMultiTexSubImage1DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCompressedMultiTexSubImage1DEXT"))
+	gpCompressedMultiTexSubImage2DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCompressedMultiTexSubImage2DEXT"))
+	gpCompressedMultiTexSubImage3DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCompressedMultiTexSubImage3DEXT"))
 	gpCompressedTexImage1D = (C.GPCOMPRESSEDTEXIMAGE1D)(getProcAddr("glCompressedTexImage1D"))
 	if gpCompressedTexImage1D == nil {
 		return errors.New("glCompressedTexImage1D")
@@ -8453,9 +13463,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCompressedTexSubImage3D == nil {
 		return errors.New("glCompressedTexSubImage3D")
 	}
+	gpCompressedTextureImage1DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE1DEXT)(getProcAddr("glCompressedTextureImage1DEXT"))
+	gpCompressedTextureImage2DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE2DEXT)(getProcAddr("glCompressedTextureImage2DEXT"))
+	gpCompressedTextureImage3DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE3DEXT)(getProcAddr("glCompressedTextureImage3DEXT"))
 	gpCompressedTextureSubImage1D = (C.GPCOMPRESSEDTEXTURESUBIMAGE1D)(getProcAddr("glCompressedTextureSubImage1D"))
+	gpCompressedTextureSubImage1DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(getProcAddr("glCompressedTextureSubImage1DEXT"))
 	gpCompressedTextureSubImage2D = (C.GPCOMPRESSEDTEXTURESUBIMAGE2D)(getProcAddr("glCompressedTextureSubImage2D"))
+	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
+	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpCopyBufferSubData = (C.GPCOPYBUFFERSUBDATA)(getProcAddr("glCopyBufferSubData"))
 	if gpCopyBufferSubData == nil {
 		return errors.New("glCopyBufferSubData")
@@ -8464,7 +13482,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCopyImageSubData == nil {
 		return errors.New("glCopyImageSubData")
 	}
+	gpCopyMultiTexImage1DEXT = (C.GPCOPYMULTITEXIMAGE1DEXT)(getProcAddr("glCopyMultiTexImage1DEXT"))
+	gpCopyMultiTexImage2DEXT = (C.GPCOPYMULTITEXIMAGE2DEXT)(getProcAddr("glCopyMultiTexImage2DEXT"))
+	gpCopyMultiTexSubImage1DEXT = (C.GPCOPYMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCopyMultiTexSubImage1DEXT"))
+	gpCopyMultiTexSubImage2DEXT = (C.GPCOPYMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCopyMultiTexSubImage2DEXT"))
+	gpCopyMultiTexSubImage3DEXT = (C.GPCOPYMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCopyMultiTexSubImage3DEXT"))
 	gpCopyNamedBufferSubData = (C.GPCOPYNAMEDBUFFERSUBDATA)(getProcAddr("glCopyNamedBufferSubData"))
+	gpCopyPathNV = (C.GPCOPYPATHNV)(getProcAddr("glCopyPathNV"))
 	gpCopyTexImage1D = (C.GPCOPYTEXIMAGE1D)(getProcAddr("glCopyTexImage1D"))
 	if gpCopyTexImage1D == nil {
 		return errors.New("glCopyTexImage1D")
@@ -8485,11 +13509,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCopyTexSubImage3D == nil {
 		return errors.New("glCopyTexSubImage3D")
 	}
+	gpCopyTextureImage1DEXT = (C.GPCOPYTEXTUREIMAGE1DEXT)(getProcAddr("glCopyTextureImage1DEXT"))
+	gpCopyTextureImage2DEXT = (C.GPCOPYTEXTUREIMAGE2DEXT)(getProcAddr("glCopyTextureImage2DEXT"))
 	gpCopyTextureSubImage1D = (C.GPCOPYTEXTURESUBIMAGE1D)(getProcAddr("glCopyTextureSubImage1D"))
+	gpCopyTextureSubImage1DEXT = (C.GPCOPYTEXTURESUBIMAGE1DEXT)(getProcAddr("glCopyTextureSubImage1DEXT"))
 	gpCopyTextureSubImage2D = (C.GPCOPYTEXTURESUBIMAGE2D)(getProcAddr("glCopyTextureSubImage2D"))
+	gpCopyTextureSubImage2DEXT = (C.GPCOPYTEXTURESUBIMAGE2DEXT)(getProcAddr("glCopyTextureSubImage2DEXT"))
 	gpCopyTextureSubImage3D = (C.GPCOPYTEXTURESUBIMAGE3D)(getProcAddr("glCopyTextureSubImage3D"))
+	gpCopyTextureSubImage3DEXT = (C.GPCOPYTEXTURESUBIMAGE3DEXT)(getProcAddr("glCopyTextureSubImage3DEXT"))
+	gpCoverFillPathInstancedNV = (C.GPCOVERFILLPATHINSTANCEDNV)(getProcAddr("glCoverFillPathInstancedNV"))
+	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
+	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
+	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
+	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
 		return errors.New("glCreateProgram")
@@ -8502,10 +13539,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCreateShader == nil {
 		return errors.New("glCreateShader")
 	}
+	gpCreateShaderProgramEXT = (C.GPCREATESHADERPROGRAMEXT)(getProcAddr("glCreateShaderProgramEXT"))
 	gpCreateShaderProgramv = (C.GPCREATESHADERPROGRAMV)(getProcAddr("glCreateShaderProgramv"))
 	if gpCreateShaderProgramv == nil {
 		return errors.New("glCreateShaderProgramv")
 	}
+	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	gpCreateTransformFeedbacks = (C.GPCREATETRANSFORMFEEDBACKS)(getProcAddr("glCreateTransformFeedbacks"))
@@ -8536,11 +13576,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteBuffers == nil {
 		return errors.New("glDeleteBuffers")
 	}
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFramebuffers = (C.GPDELETEFRAMEBUFFERS)(getProcAddr("glDeleteFramebuffers"))
 	if gpDeleteFramebuffers == nil {
 		return errors.New("glDeleteFramebuffers")
 	}
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
+	gpDeletePathsNV = (C.GPDELETEPATHSNV)(getProcAddr("glDeletePathsNV"))
+	gpDeletePerfMonitorsAMD = (C.GPDELETEPERFMONITORSAMD)(getProcAddr("glDeletePerfMonitorsAMD"))
+	gpDeletePerfQueryINTEL = (C.GPDELETEPERFQUERYINTEL)(getProcAddr("glDeletePerfQueryINTEL"))
 	gpDeleteProgram = (C.GPDELETEPROGRAM)(getProcAddr("glDeleteProgram"))
 	if gpDeleteProgram == nil {
 		return errors.New("glDeleteProgram")
@@ -8549,6 +13593,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteProgramPipelines == nil {
 		return errors.New("glDeleteProgramPipelines")
 	}
+	gpDeleteProgramPipelinesEXT = (C.GPDELETEPROGRAMPIPELINESEXT)(getProcAddr("glDeleteProgramPipelinesEXT"))
 	gpDeleteQueries = (C.GPDELETEQUERIES)(getProcAddr("glDeleteQueries"))
 	if gpDeleteQueries == nil {
 		return errors.New("glDeleteQueries")
@@ -8565,6 +13610,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	if gpDeleteSync == nil {
 		return errors.New("glDeleteSync")
@@ -8613,7 +13659,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDisable == nil {
 		return errors.New("glDisable")
 	}
+	gpDisableClientStateIndexedEXT = (C.GPDISABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glDisableClientStateIndexedEXT"))
+	gpDisableClientStateiEXT = (C.GPDISABLECLIENTSTATEIEXT)(getProcAddr("glDisableClientStateiEXT"))
+	gpDisableIndexedEXT = (C.GPDISABLEINDEXEDEXT)(getProcAddr("glDisableIndexedEXT"))
 	gpDisableVertexArrayAttrib = (C.GPDISABLEVERTEXARRAYATTRIB)(getProcAddr("glDisableVertexArrayAttrib"))
+	gpDisableVertexArrayAttribEXT = (C.GPDISABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glDisableVertexArrayAttribEXT"))
+	gpDisableVertexArrayEXT = (C.GPDISABLEVERTEXARRAYEXT)(getProcAddr("glDisableVertexArrayEXT"))
 	gpDisableVertexAttribArray = (C.GPDISABLEVERTEXATTRIBARRAY)(getProcAddr("glDisableVertexAttribArray"))
 	if gpDisableVertexAttribArray == nil {
 		return errors.New("glDisableVertexAttribArray")
@@ -8643,10 +13694,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawArraysInstanced == nil {
 		return errors.New("glDrawArraysInstanced")
 	}
+	gpDrawArraysInstancedARB = (C.GPDRAWARRAYSINSTANCEDARB)(getProcAddr("glDrawArraysInstancedARB"))
 	gpDrawArraysInstancedBaseInstance = (C.GPDRAWARRAYSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawArraysInstancedBaseInstance"))
 	if gpDrawArraysInstancedBaseInstance == nil {
 		return errors.New("glDrawArraysInstancedBaseInstance")
 	}
+	gpDrawArraysInstancedEXT = (C.GPDRAWARRAYSINSTANCEDEXT)(getProcAddr("glDrawArraysInstancedEXT"))
 	gpDrawBuffer = (C.GPDRAWBUFFER)(getProcAddr("glDrawBuffer"))
 	if gpDrawBuffer == nil {
 		return errors.New("glDrawBuffer")
@@ -8655,6 +13708,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawBuffers == nil {
 		return errors.New("glDrawBuffers")
 	}
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
 	if gpDrawElements == nil {
 		return errors.New("glDrawElements")
@@ -8671,6 +13728,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawElementsInstanced == nil {
 		return errors.New("glDrawElementsInstanced")
 	}
+	gpDrawElementsInstancedARB = (C.GPDRAWELEMENTSINSTANCEDARB)(getProcAddr("glDrawElementsInstancedARB"))
 	gpDrawElementsInstancedBaseInstance = (C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawElementsInstancedBaseInstance"))
 	if gpDrawElementsInstancedBaseInstance == nil {
 		return errors.New("glDrawElementsInstancedBaseInstance")
@@ -8683,6 +13741,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawElementsInstancedBaseVertexBaseInstance == nil {
 		return errors.New("glDrawElementsInstancedBaseVertexBaseInstance")
 	}
+	gpDrawElementsInstancedEXT = (C.GPDRAWELEMENTSINSTANCEDEXT)(getProcAddr("glDrawElementsInstancedEXT"))
 	gpDrawRangeElements = (C.GPDRAWRANGEELEMENTS)(getProcAddr("glDrawRangeElements"))
 	if gpDrawRangeElements == nil {
 		return errors.New("glDrawRangeElements")
@@ -8707,11 +13766,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawTransformFeedbackStreamInstanced == nil {
 		return errors.New("glDrawTransformFeedbackStreamInstanced")
 	}
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
+	gpEdgeFlagFormatNV = (C.GPEDGEFLAGFORMATNV)(getProcAddr("glEdgeFlagFormatNV"))
 	gpEnable = (C.GPENABLE)(getProcAddr("glEnable"))
 	if gpEnable == nil {
 		return errors.New("glEnable")
 	}
+	gpEnableClientStateIndexedEXT = (C.GPENABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glEnableClientStateIndexedEXT"))
+	gpEnableClientStateiEXT = (C.GPENABLECLIENTSTATEIEXT)(getProcAddr("glEnableClientStateiEXT"))
+	gpEnableIndexedEXT = (C.GPENABLEINDEXEDEXT)(getProcAddr("glEnableIndexedEXT"))
 	gpEnableVertexArrayAttrib = (C.GPENABLEVERTEXARRAYATTRIB)(getProcAddr("glEnableVertexArrayAttrib"))
+	gpEnableVertexArrayAttribEXT = (C.GPENABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glEnableVertexArrayAttribEXT"))
+	gpEnableVertexArrayEXT = (C.GPENABLEVERTEXARRAYEXT)(getProcAddr("glEnableVertexArrayEXT"))
 	gpEnableVertexAttribArray = (C.GPENABLEVERTEXATTRIBARRAY)(getProcAddr("glEnableVertexAttribArray"))
 	if gpEnableVertexAttribArray == nil {
 		return errors.New("glEnableVertexAttribArray")
@@ -8724,6 +13790,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEndConditionalRender == nil {
 		return errors.New("glEndConditionalRender")
 	}
+	gpEndConditionalRenderNV = (C.GPENDCONDITIONALRENDERNV)(getProcAddr("glEndConditionalRenderNV"))
+	gpEndPerfMonitorAMD = (C.GPENDPERFMONITORAMD)(getProcAddr("glEndPerfMonitorAMD"))
+	gpEndPerfQueryINTEL = (C.GPENDPERFQUERYINTEL)(getProcAddr("glEndPerfQueryINTEL"))
 	gpEndQuery = (C.GPENDQUERY)(getProcAddr("glEndQuery"))
 	if gpEndQuery == nil {
 		return errors.New("glEndQuery")
@@ -8736,6 +13805,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEndTransformFeedback == nil {
 		return errors.New("glEndTransformFeedback")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpFenceSync = (C.GPFENCESYNC)(getProcAddr("glFenceSync"))
 	if gpFenceSync == nil {
 		return errors.New("glFenceSync")
@@ -8753,14 +13823,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glFlushMappedBufferRange")
 	}
 	gpFlushMappedNamedBufferRange = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGE)(getProcAddr("glFlushMappedNamedBufferRange"))
+	gpFlushMappedNamedBufferRangeEXT = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(getProcAddr("glFlushMappedNamedBufferRangeEXT"))
+	gpFogCoordFormatNV = (C.GPFOGCOORDFORMATNV)(getProcAddr("glFogCoordFormatNV"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
+	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
+	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
 	if gpFramebufferParameteri == nil {
 		return errors.New("glFramebufferParameteri")
 	}
+	gpFramebufferReadBufferEXT = (C.GPFRAMEBUFFERREADBUFFEREXT)(getProcAddr("glFramebufferReadBufferEXT"))
 	gpFramebufferRenderbuffer = (C.GPFRAMEBUFFERRENDERBUFFER)(getProcAddr("glFramebufferRenderbuffer"))
 	if gpFramebufferRenderbuffer == nil {
 		return errors.New("glFramebufferRenderbuffer")
 	}
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	if gpFramebufferTexture == nil {
 		return errors.New("glFramebufferTexture")
@@ -8777,10 +13856,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpFramebufferTexture3D == nil {
 		return errors.New("glFramebufferTexture3D")
 	}
+	gpFramebufferTextureARB = (C.GPFRAMEBUFFERTEXTUREARB)(getProcAddr("glFramebufferTextureARB"))
+	gpFramebufferTextureFaceARB = (C.GPFRAMEBUFFERTEXTUREFACEARB)(getProcAddr("glFramebufferTextureFaceARB"))
 	gpFramebufferTextureLayer = (C.GPFRAMEBUFFERTEXTURELAYER)(getProcAddr("glFramebufferTextureLayer"))
 	if gpFramebufferTextureLayer == nil {
 		return errors.New("glFramebufferTextureLayer")
 	}
+	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
 		return errors.New("glFrontFace")
@@ -8793,10 +13876,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenFramebuffers == nil {
 		return errors.New("glGenFramebuffers")
 	}
+	gpGenPathsNV = (C.GPGENPATHSNV)(getProcAddr("glGenPathsNV"))
+	gpGenPerfMonitorsAMD = (C.GPGENPERFMONITORSAMD)(getProcAddr("glGenPerfMonitorsAMD"))
 	gpGenProgramPipelines = (C.GPGENPROGRAMPIPELINES)(getProcAddr("glGenProgramPipelines"))
 	if gpGenProgramPipelines == nil {
 		return errors.New("glGenProgramPipelines")
 	}
+	gpGenProgramPipelinesEXT = (C.GPGENPROGRAMPIPELINESEXT)(getProcAddr("glGenProgramPipelinesEXT"))
 	gpGenQueries = (C.GPGENQUERIES)(getProcAddr("glGenQueries"))
 	if gpGenQueries == nil {
 		return errors.New("glGenQueries")
@@ -8825,7 +13911,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenerateMipmap == nil {
 		return errors.New("glGenerateMipmap")
 	}
+	gpGenerateMultiTexMipmapEXT = (C.GPGENERATEMULTITEXMIPMAPEXT)(getProcAddr("glGenerateMultiTexMipmapEXT"))
 	gpGenerateTextureMipmap = (C.GPGENERATETEXTUREMIPMAP)(getProcAddr("glGenerateTextureMipmap"))
+	gpGenerateTextureMipmapEXT = (C.GPGENERATETEXTUREMIPMAPEXT)(getProcAddr("glGenerateTextureMipmapEXT"))
 	gpGetActiveAtomicCounterBufferiv = (C.GPGETACTIVEATOMICCOUNTERBUFFERIV)(getProcAddr("glGetActiveAtomicCounterBufferiv"))
 	if gpGetActiveAtomicCounterBufferiv == nil {
 		return errors.New("glGetActiveAtomicCounterBufferiv")
@@ -8874,6 +13962,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetAttribLocation == nil {
 		return errors.New("glGetAttribLocation")
 	}
+	gpGetBooleanIndexedvEXT = (C.GPGETBOOLEANINDEXEDVEXT)(getProcAddr("glGetBooleanIndexedvEXT"))
 	gpGetBooleani_v = (C.GPGETBOOLEANI_V)(getProcAddr("glGetBooleani_v"))
 	if gpGetBooleani_v == nil {
 		return errors.New("glGetBooleani_v")
@@ -8890,6 +13979,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetBufferParameteriv == nil {
 		return errors.New("glGetBufferParameteriv")
 	}
+	gpGetBufferParameterui64vNV = (C.GPGETBUFFERPARAMETERUI64VNV)(getProcAddr("glGetBufferParameterui64vNV"))
 	gpGetBufferPointerv = (C.GPGETBUFFERPOINTERV)(getProcAddr("glGetBufferPointerv"))
 	if gpGetBufferPointerv == nil {
 		return errors.New("glGetBufferPointerv")
@@ -8898,22 +13988,28 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetBufferSubData == nil {
 		return errors.New("glGetBufferSubData")
 	}
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
+	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
 		return errors.New("glGetCompressedTexImage")
 	}
 	gpGetCompressedTextureImage = (C.GPGETCOMPRESSEDTEXTUREIMAGE)(getProcAddr("glGetCompressedTextureImage"))
+	gpGetCompressedTextureImageEXT = (C.GPGETCOMPRESSEDTEXTUREIMAGEEXT)(getProcAddr("glGetCompressedTextureImageEXT"))
 	gpGetCompressedTextureSubImage = (C.GPGETCOMPRESSEDTEXTURESUBIMAGE)(getProcAddr("glGetCompressedTextureSubImage"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	if gpGetDebugMessageLog == nil {
 		return errors.New("glGetDebugMessageLog")
 	}
 	gpGetDebugMessageLogARB = (C.GPGETDEBUGMESSAGELOGARB)(getProcAddr("glGetDebugMessageLogARB"))
 	gpGetDebugMessageLogKHR = (C.GPGETDEBUGMESSAGELOGKHR)(getProcAddr("glGetDebugMessageLogKHR"))
+	gpGetDoubleIndexedvEXT = (C.GPGETDOUBLEINDEXEDVEXT)(getProcAddr("glGetDoubleIndexedvEXT"))
 	gpGetDoublei_v = (C.GPGETDOUBLEI_V)(getProcAddr("glGetDoublei_v"))
 	if gpGetDoublei_v == nil {
 		return errors.New("glGetDoublei_v")
 	}
+	gpGetDoublei_vEXT = (C.GPGETDOUBLEI_VEXT)(getProcAddr("glGetDoublei_vEXT"))
 	gpGetDoublev = (C.GPGETDOUBLEV)(getProcAddr("glGetDoublev"))
 	if gpGetDoublev == nil {
 		return errors.New("glGetDoublev")
@@ -8922,10 +14018,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetError == nil {
 		return errors.New("glGetError")
 	}
+	gpGetFirstPerfQueryIdINTEL = (C.GPGETFIRSTPERFQUERYIDINTEL)(getProcAddr("glGetFirstPerfQueryIdINTEL"))
+	gpGetFloatIndexedvEXT = (C.GPGETFLOATINDEXEDVEXT)(getProcAddr("glGetFloatIndexedvEXT"))
 	gpGetFloati_v = (C.GPGETFLOATI_V)(getProcAddr("glGetFloati_v"))
 	if gpGetFloati_v == nil {
 		return errors.New("glGetFloati_v")
 	}
+	gpGetFloati_vEXT = (C.GPGETFLOATI_VEXT)(getProcAddr("glGetFloati_vEXT"))
 	gpGetFloatv = (C.GPGETFLOATV)(getProcAddr("glGetFloatv"))
 	if gpGetFloatv == nil {
 		return errors.New("glGetFloatv")
@@ -8946,10 +14045,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetFramebufferParameteriv == nil {
 		return errors.New("glGetFramebufferParameteriv")
 	}
+	gpGetFramebufferParameterivEXT = (C.GPGETFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetFramebufferParameterivEXT"))
 	gpGetGraphicsResetStatus = (C.GPGETGRAPHICSRESETSTATUS)(getProcAddr("glGetGraphicsResetStatus"))
 	gpGetGraphicsResetStatusARB = (C.GPGETGRAPHICSRESETSTATUSARB)(getProcAddr("glGetGraphicsResetStatusARB"))
 	gpGetGraphicsResetStatusKHR = (C.GPGETGRAPHICSRESETSTATUSKHR)(getProcAddr("glGetGraphicsResetStatusKHR"))
 	gpGetImageHandleARB = (C.GPGETIMAGEHANDLEARB)(getProcAddr("glGetImageHandleARB"))
+	gpGetImageHandleNV = (C.GPGETIMAGEHANDLENV)(getProcAddr("glGetImageHandleNV"))
 	gpGetInteger64i_v = (C.GPGETINTEGER64I_V)(getProcAddr("glGetInteger64i_v"))
 	if gpGetInteger64i_v == nil {
 		return errors.New("glGetInteger64i_v")
@@ -8958,14 +14059,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetInteger64v == nil {
 		return errors.New("glGetInteger64v")
 	}
+	gpGetIntegerIndexedvEXT = (C.GPGETINTEGERINDEXEDVEXT)(getProcAddr("glGetIntegerIndexedvEXT"))
 	gpGetIntegeri_v = (C.GPGETINTEGERI_V)(getProcAddr("glGetIntegeri_v"))
 	if gpGetIntegeri_v == nil {
 		return errors.New("glGetIntegeri_v")
 	}
+	gpGetIntegerui64i_vNV = (C.GPGETINTEGERUI64I_VNV)(getProcAddr("glGetIntegerui64i_vNV"))
+	gpGetIntegerui64vNV = (C.GPGETINTEGERUI64VNV)(getProcAddr("glGetIntegerui64vNV"))
 	gpGetIntegerv = (C.GPGETINTEGERV)(getProcAddr("glGetIntegerv"))
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	if gpGetInternalformati64v == nil {
 		return errors.New("glGetInternalformati64v")
@@ -8974,29 +14079,77 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetInternalformativ == nil {
 		return errors.New("glGetInternalformativ")
 	}
+	gpGetMultiTexEnvfvEXT = (C.GPGETMULTITEXENVFVEXT)(getProcAddr("glGetMultiTexEnvfvEXT"))
+	gpGetMultiTexEnvivEXT = (C.GPGETMULTITEXENVIVEXT)(getProcAddr("glGetMultiTexEnvivEXT"))
+	gpGetMultiTexGendvEXT = (C.GPGETMULTITEXGENDVEXT)(getProcAddr("glGetMultiTexGendvEXT"))
+	gpGetMultiTexGenfvEXT = (C.GPGETMULTITEXGENFVEXT)(getProcAddr("glGetMultiTexGenfvEXT"))
+	gpGetMultiTexGenivEXT = (C.GPGETMULTITEXGENIVEXT)(getProcAddr("glGetMultiTexGenivEXT"))
+	gpGetMultiTexImageEXT = (C.GPGETMULTITEXIMAGEEXT)(getProcAddr("glGetMultiTexImageEXT"))
+	gpGetMultiTexLevelParameterfvEXT = (C.GPGETMULTITEXLEVELPARAMETERFVEXT)(getProcAddr("glGetMultiTexLevelParameterfvEXT"))
+	gpGetMultiTexLevelParameterivEXT = (C.GPGETMULTITEXLEVELPARAMETERIVEXT)(getProcAddr("glGetMultiTexLevelParameterivEXT"))
+	gpGetMultiTexParameterIivEXT = (C.GPGETMULTITEXPARAMETERIIVEXT)(getProcAddr("glGetMultiTexParameterIivEXT"))
+	gpGetMultiTexParameterIuivEXT = (C.GPGETMULTITEXPARAMETERIUIVEXT)(getProcAddr("glGetMultiTexParameterIuivEXT"))
+	gpGetMultiTexParameterfvEXT = (C.GPGETMULTITEXPARAMETERFVEXT)(getProcAddr("glGetMultiTexParameterfvEXT"))
+	gpGetMultiTexParameterivEXT = (C.GPGETMULTITEXPARAMETERIVEXT)(getProcAddr("glGetMultiTexParameterivEXT"))
 	gpGetMultisamplefv = (C.GPGETMULTISAMPLEFV)(getProcAddr("glGetMultisamplefv"))
 	if gpGetMultisamplefv == nil {
 		return errors.New("glGetMultisamplefv")
 	}
 	gpGetNamedBufferParameteri64v = (C.GPGETNAMEDBUFFERPARAMETERI64V)(getProcAddr("glGetNamedBufferParameteri64v"))
 	gpGetNamedBufferParameteriv = (C.GPGETNAMEDBUFFERPARAMETERIV)(getProcAddr("glGetNamedBufferParameteriv"))
+	gpGetNamedBufferParameterivEXT = (C.GPGETNAMEDBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedBufferParameterivEXT"))
+	gpGetNamedBufferParameterui64vNV = (C.GPGETNAMEDBUFFERPARAMETERUI64VNV)(getProcAddr("glGetNamedBufferParameterui64vNV"))
 	gpGetNamedBufferPointerv = (C.GPGETNAMEDBUFFERPOINTERV)(getProcAddr("glGetNamedBufferPointerv"))
+	gpGetNamedBufferPointervEXT = (C.GPGETNAMEDBUFFERPOINTERVEXT)(getProcAddr("glGetNamedBufferPointervEXT"))
 	gpGetNamedBufferSubData = (C.GPGETNAMEDBUFFERSUBDATA)(getProcAddr("glGetNamedBufferSubData"))
+	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
+	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
+	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
+	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
+	gpGetNamedProgramLocalParameterIuivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIuivEXT"))
+	gpGetNamedProgramLocalParameterdvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(getProcAddr("glGetNamedProgramLocalParameterdvEXT"))
+	gpGetNamedProgramLocalParameterfvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(getProcAddr("glGetNamedProgramLocalParameterfvEXT"))
+	gpGetNamedProgramStringEXT = (C.GPGETNAMEDPROGRAMSTRINGEXT)(getProcAddr("glGetNamedProgramStringEXT"))
+	gpGetNamedProgramivEXT = (C.GPGETNAMEDPROGRAMIVEXT)(getProcAddr("glGetNamedProgramivEXT"))
 	gpGetNamedRenderbufferParameteriv = (C.GPGETNAMEDRENDERBUFFERPARAMETERIV)(getProcAddr("glGetNamedRenderbufferParameteriv"))
+	gpGetNamedRenderbufferParameterivEXT = (C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedRenderbufferParameterivEXT"))
 	gpGetNamedStringARB = (C.GPGETNAMEDSTRINGARB)(getProcAddr("glGetNamedStringARB"))
 	gpGetNamedStringivARB = (C.GPGETNAMEDSTRINGIVARB)(getProcAddr("glGetNamedStringivARB"))
+	gpGetNextPerfQueryIdINTEL = (C.GPGETNEXTPERFQUERYIDINTEL)(getProcAddr("glGetNextPerfQueryIdINTEL"))
 	gpGetObjectLabel = (C.GPGETOBJECTLABEL)(getProcAddr("glGetObjectLabel"))
 	if gpGetObjectLabel == nil {
 		return errors.New("glGetObjectLabel")
 	}
+	gpGetObjectLabelEXT = (C.GPGETOBJECTLABELEXT)(getProcAddr("glGetObjectLabelEXT"))
 	gpGetObjectLabelKHR = (C.GPGETOBJECTLABELKHR)(getProcAddr("glGetObjectLabelKHR"))
 	gpGetObjectPtrLabel = (C.GPGETOBJECTPTRLABEL)(getProcAddr("glGetObjectPtrLabel"))
 	if gpGetObjectPtrLabel == nil {
 		return errors.New("glGetObjectPtrLabel")
 	}
 	gpGetObjectPtrLabelKHR = (C.GPGETOBJECTPTRLABELKHR)(getProcAddr("glGetObjectPtrLabelKHR"))
+	gpGetPathCommandsNV = (C.GPGETPATHCOMMANDSNV)(getProcAddr("glGetPathCommandsNV"))
+	gpGetPathCoordsNV = (C.GPGETPATHCOORDSNV)(getProcAddr("glGetPathCoordsNV"))
+	gpGetPathDashArrayNV = (C.GPGETPATHDASHARRAYNV)(getProcAddr("glGetPathDashArrayNV"))
+	gpGetPathLengthNV = (C.GPGETPATHLENGTHNV)(getProcAddr("glGetPathLengthNV"))
+	gpGetPathMetricRangeNV = (C.GPGETPATHMETRICRANGENV)(getProcAddr("glGetPathMetricRangeNV"))
+	gpGetPathMetricsNV = (C.GPGETPATHMETRICSNV)(getProcAddr("glGetPathMetricsNV"))
+	gpGetPathParameterfvNV = (C.GPGETPATHPARAMETERFVNV)(getProcAddr("glGetPathParameterfvNV"))
+	gpGetPathParameterivNV = (C.GPGETPATHPARAMETERIVNV)(getProcAddr("glGetPathParameterivNV"))
+	gpGetPathSpacingNV = (C.GPGETPATHSPACINGNV)(getProcAddr("glGetPathSpacingNV"))
+	gpGetPerfCounterInfoINTEL = (C.GPGETPERFCOUNTERINFOINTEL)(getProcAddr("glGetPerfCounterInfoINTEL"))
+	gpGetPerfMonitorCounterDataAMD = (C.GPGETPERFMONITORCOUNTERDATAAMD)(getProcAddr("glGetPerfMonitorCounterDataAMD"))
+	gpGetPerfMonitorCounterInfoAMD = (C.GPGETPERFMONITORCOUNTERINFOAMD)(getProcAddr("glGetPerfMonitorCounterInfoAMD"))
+	gpGetPerfMonitorCounterStringAMD = (C.GPGETPERFMONITORCOUNTERSTRINGAMD)(getProcAddr("glGetPerfMonitorCounterStringAMD"))
+	gpGetPerfMonitorCountersAMD = (C.GPGETPERFMONITORCOUNTERSAMD)(getProcAddr("glGetPerfMonitorCountersAMD"))
+	gpGetPerfMonitorGroupStringAMD = (C.GPGETPERFMONITORGROUPSTRINGAMD)(getProcAddr("glGetPerfMonitorGroupStringAMD"))
+	gpGetPerfMonitorGroupsAMD = (C.GPGETPERFMONITORGROUPSAMD)(getProcAddr("glGetPerfMonitorGroupsAMD"))
+	gpGetPerfQueryDataINTEL = (C.GPGETPERFQUERYDATAINTEL)(getProcAddr("glGetPerfQueryDataINTEL"))
+	gpGetPerfQueryIdByNameINTEL = (C.GPGETPERFQUERYIDBYNAMEINTEL)(getProcAddr("glGetPerfQueryIdByNameINTEL"))
+	gpGetPerfQueryInfoINTEL = (C.GPGETPERFQUERYINFOINTEL)(getProcAddr("glGetPerfQueryInfoINTEL"))
+	gpGetPointerIndexedvEXT = (C.GPGETPOINTERINDEXEDVEXT)(getProcAddr("glGetPointerIndexedvEXT"))
+	gpGetPointeri_vEXT = (C.GPGETPOINTERI_VEXT)(getProcAddr("glGetPointeri_vEXT"))
 	gpGetPointerv = (C.GPGETPOINTERV)(getProcAddr("glGetPointerv"))
 	if gpGetPointerv == nil {
 		return errors.New("glGetPointerv")
@@ -9018,10 +14171,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetProgramPipelineInfoLog == nil {
 		return errors.New("glGetProgramPipelineInfoLog")
 	}
+	gpGetProgramPipelineInfoLogEXT = (C.GPGETPROGRAMPIPELINEINFOLOGEXT)(getProcAddr("glGetProgramPipelineInfoLogEXT"))
 	gpGetProgramPipelineiv = (C.GPGETPROGRAMPIPELINEIV)(getProcAddr("glGetProgramPipelineiv"))
 	if gpGetProgramPipelineiv == nil {
 		return errors.New("glGetProgramPipelineiv")
 	}
+	gpGetProgramPipelineivEXT = (C.GPGETPROGRAMPIPELINEIVEXT)(getProcAddr("glGetProgramPipelineivEXT"))
 	gpGetProgramResourceIndex = (C.GPGETPROGRAMRESOURCEINDEX)(getProcAddr("glGetProgramResourceIndex"))
 	if gpGetProgramResourceIndex == nil {
 		return errors.New("glGetProgramResourceIndex")
@@ -9038,6 +14193,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetProgramResourceName == nil {
 		return errors.New("glGetProgramResourceName")
 	}
+	gpGetProgramResourcefvNV = (C.GPGETPROGRAMRESOURCEFVNV)(getProcAddr("glGetProgramResourcefvNV"))
 	gpGetProgramResourceiv = (C.GPGETPROGRAMRESOURCEIV)(getProcAddr("glGetProgramResourceiv"))
 	if gpGetProgramResourceiv == nil {
 		return errors.New("glGetProgramResourceiv")
@@ -9050,6 +14206,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetProgramiv == nil {
 		return errors.New("glGetProgramiv")
 	}
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	if gpGetQueryIndexediv == nil {
 		return errors.New("glGetQueryIndexediv")
@@ -9110,6 +14270,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetShaderiv == nil {
 		return errors.New("glGetShaderiv")
 	}
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -9159,14 +14320,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetTexParameteriv")
 	}
 	gpGetTextureHandleARB = (C.GPGETTEXTUREHANDLEARB)(getProcAddr("glGetTextureHandleARB"))
+	gpGetTextureHandleNV = (C.GPGETTEXTUREHANDLENV)(getProcAddr("glGetTextureHandleNV"))
 	gpGetTextureImage = (C.GPGETTEXTUREIMAGE)(getProcAddr("glGetTextureImage"))
+	gpGetTextureImageEXT = (C.GPGETTEXTUREIMAGEEXT)(getProcAddr("glGetTextureImageEXT"))
 	gpGetTextureLevelParameterfv = (C.GPGETTEXTURELEVELPARAMETERFV)(getProcAddr("glGetTextureLevelParameterfv"))
+	gpGetTextureLevelParameterfvEXT = (C.GPGETTEXTURELEVELPARAMETERFVEXT)(getProcAddr("glGetTextureLevelParameterfvEXT"))
 	gpGetTextureLevelParameteriv = (C.GPGETTEXTURELEVELPARAMETERIV)(getProcAddr("glGetTextureLevelParameteriv"))
+	gpGetTextureLevelParameterivEXT = (C.GPGETTEXTURELEVELPARAMETERIVEXT)(getProcAddr("glGetTextureLevelParameterivEXT"))
 	gpGetTextureParameterIiv = (C.GPGETTEXTUREPARAMETERIIV)(getProcAddr("glGetTextureParameterIiv"))
+	gpGetTextureParameterIivEXT = (C.GPGETTEXTUREPARAMETERIIVEXT)(getProcAddr("glGetTextureParameterIivEXT"))
 	gpGetTextureParameterIuiv = (C.GPGETTEXTUREPARAMETERIUIV)(getProcAddr("glGetTextureParameterIuiv"))
+	gpGetTextureParameterIuivEXT = (C.GPGETTEXTUREPARAMETERIUIVEXT)(getProcAddr("glGetTextureParameterIuivEXT"))
 	gpGetTextureParameterfv = (C.GPGETTEXTUREPARAMETERFV)(getProcAddr("glGetTextureParameterfv"))
+	gpGetTextureParameterfvEXT = (C.GPGETTEXTUREPARAMETERFVEXT)(getProcAddr("glGetTextureParameterfvEXT"))
 	gpGetTextureParameteriv = (C.GPGETTEXTUREPARAMETERIV)(getProcAddr("glGetTextureParameteriv"))
+	gpGetTextureParameterivEXT = (C.GPGETTEXTUREPARAMETERIVEXT)(getProcAddr("glGetTextureParameterivEXT"))
 	gpGetTextureSamplerHandleARB = (C.GPGETTEXTURESAMPLERHANDLEARB)(getProcAddr("glGetTextureSamplerHandleARB"))
+	gpGetTextureSamplerHandleNV = (C.GPGETTEXTURESAMPLERHANDLENV)(getProcAddr("glGetTextureSamplerHandleNV"))
 	gpGetTextureSubImage = (C.GPGETTEXTURESUBIMAGE)(getProcAddr("glGetTextureSubImage"))
 	gpGetTransformFeedbackVarying = (C.GPGETTRANSFORMFEEDBACKVARYING)(getProcAddr("glGetTransformFeedbackVarying"))
 	if gpGetTransformFeedbackVarying == nil {
@@ -9199,16 +14369,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetUniformfv == nil {
 		return errors.New("glGetUniformfv")
 	}
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
+	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
+	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
 	}
 	gpGetVertexArrayIndexed64iv = (C.GPGETVERTEXARRAYINDEXED64IV)(getProcAddr("glGetVertexArrayIndexed64iv"))
 	gpGetVertexArrayIndexediv = (C.GPGETVERTEXARRAYINDEXEDIV)(getProcAddr("glGetVertexArrayIndexediv"))
+	gpGetVertexArrayIntegeri_vEXT = (C.GPGETVERTEXARRAYINTEGERI_VEXT)(getProcAddr("glGetVertexArrayIntegeri_vEXT"))
+	gpGetVertexArrayIntegervEXT = (C.GPGETVERTEXARRAYINTEGERVEXT)(getProcAddr("glGetVertexArrayIntegervEXT"))
+	gpGetVertexArrayPointeri_vEXT = (C.GPGETVERTEXARRAYPOINTERI_VEXT)(getProcAddr("glGetVertexArrayPointeri_vEXT"))
+	gpGetVertexArrayPointervEXT = (C.GPGETVERTEXARRAYPOINTERVEXT)(getProcAddr("glGetVertexArrayPointervEXT"))
 	gpGetVertexArrayiv = (C.GPGETVERTEXARRAYIV)(getProcAddr("glGetVertexArrayiv"))
 	gpGetVertexAttribIiv = (C.GPGETVERTEXATTRIBIIV)(getProcAddr("glGetVertexAttribIiv"))
 	if gpGetVertexAttribIiv == nil {
@@ -9222,7 +14400,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetVertexAttribLdv == nil {
 		return errors.New("glGetVertexAttribLdv")
 	}
+	gpGetVertexAttribLi64vNV = (C.GPGETVERTEXATTRIBLI64VNV)(getProcAddr("glGetVertexAttribLi64vNV"))
 	gpGetVertexAttribLui64vARB = (C.GPGETVERTEXATTRIBLUI64VARB)(getProcAddr("glGetVertexAttribLui64vARB"))
+	gpGetVertexAttribLui64vNV = (C.GPGETVERTEXATTRIBLUI64VNV)(getProcAddr("glGetVertexAttribLui64vNV"))
 	gpGetVertexAttribPointerv = (C.GPGETVERTEXATTRIBPOINTERV)(getProcAddr("glGetVertexAttribPointerv"))
 	if gpGetVertexAttribPointerv == nil {
 		return errors.New("glGetVertexAttribPointerv")
@@ -9239,15 +14419,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetVertexAttribiv == nil {
 		return errors.New("glGetVertexAttribiv")
 	}
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnCompressedTexImageARB = (C.GPGETNCOMPRESSEDTEXIMAGEARB)(getProcAddr("glGetnCompressedTexImageARB"))
 	gpGetnTexImageARB = (C.GPGETNTEXIMAGEARB)(getProcAddr("glGetnTexImageARB"))
 	gpGetnUniformdvARB = (C.GPGETNUNIFORMDVARB)(getProcAddr("glGetnUniformdvARB"))
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	gpGetnUniformuivARB = (C.GPGETNUNIFORMUIVARB)(getProcAddr("glGetnUniformuivARB"))
 	gpGetnUniformuivKHR = (C.GPGETNUNIFORMUIVKHR)(getProcAddr("glGetnUniformuivKHR"))
@@ -9255,6 +14438,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpHint == nil {
 		return errors.New("glHint")
 	}
+	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
+	gpInsertEventMarkerEXT = (C.GPINSERTEVENTMARKEREXT)(getProcAddr("glInsertEventMarkerEXT"))
+	gpInterpolatePathsNV = (C.GPINTERPOLATEPATHSNV)(getProcAddr("glInterpolatePathsNV"))
 	gpInvalidateBufferData = (C.GPINVALIDATEBUFFERDATA)(getProcAddr("glInvalidateBufferData"))
 	if gpInvalidateBufferData == nil {
 		return errors.New("glInvalidateBufferData")
@@ -9285,10 +14471,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsBuffer == nil {
 		return errors.New("glIsBuffer")
 	}
+	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
 	}
+	gpIsEnabledIndexedEXT = (C.GPISENABLEDINDEXEDEXT)(getProcAddr("glIsEnabledIndexedEXT"))
 	gpIsEnabledi = (C.GPISENABLEDI)(getProcAddr("glIsEnabledi"))
 	if gpIsEnabledi == nil {
 		return errors.New("glIsEnabledi")
@@ -9298,7 +14487,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsFramebuffer")
 	}
 	gpIsImageHandleResidentARB = (C.GPISIMAGEHANDLERESIDENTARB)(getProcAddr("glIsImageHandleResidentARB"))
+	gpIsImageHandleResidentNV = (C.GPISIMAGEHANDLERESIDENTNV)(getProcAddr("glIsImageHandleResidentNV"))
+	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
+	gpIsPathNV = (C.GPISPATHNV)(getProcAddr("glIsPathNV"))
+	gpIsPointInFillPathNV = (C.GPISPOINTINFILLPATHNV)(getProcAddr("glIsPointInFillPathNV"))
+	gpIsPointInStrokePathNV = (C.GPISPOINTINSTROKEPATHNV)(getProcAddr("glIsPointInStrokePathNV"))
 	gpIsProgram = (C.GPISPROGRAM)(getProcAddr("glIsProgram"))
 	if gpIsProgram == nil {
 		return errors.New("glIsProgram")
@@ -9307,6 +14501,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsProgramPipeline == nil {
 		return errors.New("glIsProgramPipeline")
 	}
+	gpIsProgramPipelineEXT = (C.GPISPROGRAMPIPELINEEXT)(getProcAddr("glIsProgramPipelineEXT"))
 	gpIsQuery = (C.GPISQUERY)(getProcAddr("glIsQuery"))
 	if gpIsQuery == nil {
 		return errors.New("glIsQuery")
@@ -9323,6 +14518,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	if gpIsSync == nil {
 		return errors.New("glIsSync")
@@ -9332,6 +14528,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsTexture")
 	}
 	gpIsTextureHandleResidentARB = (C.GPISTEXTUREHANDLERESIDENTARB)(getProcAddr("glIsTextureHandleResidentARB"))
+	gpIsTextureHandleResidentNV = (C.GPISTEXTUREHANDLERESIDENTNV)(getProcAddr("glIsTextureHandleResidentNV"))
 	gpIsTransformFeedback = (C.GPISTRANSFORMFEEDBACK)(getProcAddr("glIsTransformFeedback"))
 	if gpIsTransformFeedback == nil {
 		return errors.New("glIsTransformFeedback")
@@ -9340,6 +14537,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsVertexArray == nil {
 		return errors.New("glIsVertexArray")
 	}
+	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLineWidth = (C.GPLINEWIDTH)(getProcAddr("glLineWidth"))
 	if gpLineWidth == nil {
 		return errors.New("glLineWidth")
@@ -9348,14 +14546,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpLinkProgram == nil {
 		return errors.New("glLinkProgram")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpLogicOp = (C.GPLOGICOP)(getProcAddr("glLogicOp"))
 	if gpLogicOp == nil {
 		return errors.New("glLogicOp")
 	}
+	gpMakeBufferNonResidentNV = (C.GPMAKEBUFFERNONRESIDENTNV)(getProcAddr("glMakeBufferNonResidentNV"))
+	gpMakeBufferResidentNV = (C.GPMAKEBUFFERRESIDENTNV)(getProcAddr("glMakeBufferResidentNV"))
 	gpMakeImageHandleNonResidentARB = (C.GPMAKEIMAGEHANDLENONRESIDENTARB)(getProcAddr("glMakeImageHandleNonResidentARB"))
+	gpMakeImageHandleNonResidentNV = (C.GPMAKEIMAGEHANDLENONRESIDENTNV)(getProcAddr("glMakeImageHandleNonResidentNV"))
 	gpMakeImageHandleResidentARB = (C.GPMAKEIMAGEHANDLERESIDENTARB)(getProcAddr("glMakeImageHandleResidentARB"))
+	gpMakeImageHandleResidentNV = (C.GPMAKEIMAGEHANDLERESIDENTNV)(getProcAddr("glMakeImageHandleResidentNV"))
+	gpMakeNamedBufferNonResidentNV = (C.GPMAKENAMEDBUFFERNONRESIDENTNV)(getProcAddr("glMakeNamedBufferNonResidentNV"))
+	gpMakeNamedBufferResidentNV = (C.GPMAKENAMEDBUFFERRESIDENTNV)(getProcAddr("glMakeNamedBufferResidentNV"))
 	gpMakeTextureHandleNonResidentARB = (C.GPMAKETEXTUREHANDLENONRESIDENTARB)(getProcAddr("glMakeTextureHandleNonResidentARB"))
+	gpMakeTextureHandleNonResidentNV = (C.GPMAKETEXTUREHANDLENONRESIDENTNV)(getProcAddr("glMakeTextureHandleNonResidentNV"))
 	gpMakeTextureHandleResidentARB = (C.GPMAKETEXTUREHANDLERESIDENTARB)(getProcAddr("glMakeTextureHandleResidentARB"))
+	gpMakeTextureHandleResidentNV = (C.GPMAKETEXTUREHANDLERESIDENTNV)(getProcAddr("glMakeTextureHandleResidentNV"))
 	gpMapBuffer = (C.GPMAPBUFFER)(getProcAddr("glMapBuffer"))
 	if gpMapBuffer == nil {
 		return errors.New("glMapBuffer")
@@ -9365,7 +14572,36 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMapBufferRange")
 	}
 	gpMapNamedBuffer = (C.GPMAPNAMEDBUFFER)(getProcAddr("glMapNamedBuffer"))
+	gpMapNamedBufferEXT = (C.GPMAPNAMEDBUFFEREXT)(getProcAddr("glMapNamedBufferEXT"))
 	gpMapNamedBufferRange = (C.GPMAPNAMEDBUFFERRANGE)(getProcAddr("glMapNamedBufferRange"))
+	gpMapNamedBufferRangeEXT = (C.GPMAPNAMEDBUFFERRANGEEXT)(getProcAddr("glMapNamedBufferRangeEXT"))
+	gpMatrixFrustumEXT = (C.GPMATRIXFRUSTUMEXT)(getProcAddr("glMatrixFrustumEXT"))
+	gpMatrixLoad3x2fNV = (C.GPMATRIXLOAD3X2FNV)(getProcAddr("glMatrixLoad3x2fNV"))
+	gpMatrixLoad3x3fNV = (C.GPMATRIXLOAD3X3FNV)(getProcAddr("glMatrixLoad3x3fNV"))
+	gpMatrixLoadIdentityEXT = (C.GPMATRIXLOADIDENTITYEXT)(getProcAddr("glMatrixLoadIdentityEXT"))
+	gpMatrixLoadTranspose3x3fNV = (C.GPMATRIXLOADTRANSPOSE3X3FNV)(getProcAddr("glMatrixLoadTranspose3x3fNV"))
+	gpMatrixLoadTransposedEXT = (C.GPMATRIXLOADTRANSPOSEDEXT)(getProcAddr("glMatrixLoadTransposedEXT"))
+	gpMatrixLoadTransposefEXT = (C.GPMATRIXLOADTRANSPOSEFEXT)(getProcAddr("glMatrixLoadTransposefEXT"))
+	gpMatrixLoaddEXT = (C.GPMATRIXLOADDEXT)(getProcAddr("glMatrixLoaddEXT"))
+	gpMatrixLoadfEXT = (C.GPMATRIXLOADFEXT)(getProcAddr("glMatrixLoadfEXT"))
+	gpMatrixMult3x2fNV = (C.GPMATRIXMULT3X2FNV)(getProcAddr("glMatrixMult3x2fNV"))
+	gpMatrixMult3x3fNV = (C.GPMATRIXMULT3X3FNV)(getProcAddr("glMatrixMult3x3fNV"))
+	gpMatrixMultTranspose3x3fNV = (C.GPMATRIXMULTTRANSPOSE3X3FNV)(getProcAddr("glMatrixMultTranspose3x3fNV"))
+	gpMatrixMultTransposedEXT = (C.GPMATRIXMULTTRANSPOSEDEXT)(getProcAddr("glMatrixMultTransposedEXT"))
+	gpMatrixMultTransposefEXT = (C.GPMATRIXMULTTRANSPOSEFEXT)(getProcAddr("glMatrixMultTransposefEXT"))
+	gpMatrixMultdEXT = (C.GPMATRIXMULTDEXT)(getProcAddr("glMatrixMultdEXT"))
+	gpMatrixMultfEXT = (C.GPMATRIXMULTFEXT)(getProcAddr("glMatrixMultfEXT"))
+	gpMatrixOrthoEXT = (C.GPMATRIXORTHOEXT)(getProcAddr("glMatrixOrthoEXT"))
+	gpMatrixPopEXT = (C.GPMATRIXPOPEXT)(getProcAddr("glMatrixPopEXT"))
+	gpMatrixPushEXT = (C.GPMATRIXPUSHEXT)(getProcAddr("glMatrixPushEXT"))
+	gpMatrixRotatedEXT = (C.GPMATRIXROTATEDEXT)(getProcAddr("glMatrixRotatedEXT"))
+	gpMatrixRotatefEXT = (C.GPMATRIXROTATEFEXT)(getProcAddr("glMatrixRotatefEXT"))
+	gpMatrixScaledEXT = (C.GPMATRIXSCALEDEXT)(getProcAddr("glMatrixScaledEXT"))
+	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
+	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
+	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	if gpMemoryBarrier == nil {
 		return errors.New("glMemoryBarrier")
@@ -9384,6 +14620,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpMultiDrawArraysIndirect == nil {
 		return errors.New("glMultiDrawArraysIndirect")
 	}
+	gpMultiDrawArraysIndirectBindlessCountNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawArraysIndirectBindlessCountNV"))
+	gpMultiDrawArraysIndirectBindlessNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawArraysIndirectBindlessNV"))
 	gpMultiDrawArraysIndirectCountARB = (C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawArraysIndirectCountARB"))
 	gpMultiDrawElements = (C.GPMULTIDRAWELEMENTS)(getProcAddr("glMultiDrawElements"))
 	if gpMultiDrawElements == nil {
@@ -9397,22 +14635,79 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpMultiDrawElementsIndirect == nil {
 		return errors.New("glMultiDrawElementsIndirect")
 	}
+	gpMultiDrawElementsIndirectBindlessCountNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawElementsIndirectBindlessCountNV"))
+	gpMultiDrawElementsIndirectBindlessNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawElementsIndirectBindlessNV"))
 	gpMultiDrawElementsIndirectCountARB = (C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawElementsIndirectCountARB"))
+	gpMultiTexBufferEXT = (C.GPMULTITEXBUFFEREXT)(getProcAddr("glMultiTexBufferEXT"))
+	gpMultiTexCoordPointerEXT = (C.GPMULTITEXCOORDPOINTEREXT)(getProcAddr("glMultiTexCoordPointerEXT"))
+	gpMultiTexEnvfEXT = (C.GPMULTITEXENVFEXT)(getProcAddr("glMultiTexEnvfEXT"))
+	gpMultiTexEnvfvEXT = (C.GPMULTITEXENVFVEXT)(getProcAddr("glMultiTexEnvfvEXT"))
+	gpMultiTexEnviEXT = (C.GPMULTITEXENVIEXT)(getProcAddr("glMultiTexEnviEXT"))
+	gpMultiTexEnvivEXT = (C.GPMULTITEXENVIVEXT)(getProcAddr("glMultiTexEnvivEXT"))
+	gpMultiTexGendEXT = (C.GPMULTITEXGENDEXT)(getProcAddr("glMultiTexGendEXT"))
+	gpMultiTexGendvEXT = (C.GPMULTITEXGENDVEXT)(getProcAddr("glMultiTexGendvEXT"))
+	gpMultiTexGenfEXT = (C.GPMULTITEXGENFEXT)(getProcAddr("glMultiTexGenfEXT"))
+	gpMultiTexGenfvEXT = (C.GPMULTITEXGENFVEXT)(getProcAddr("glMultiTexGenfvEXT"))
+	gpMultiTexGeniEXT = (C.GPMULTITEXGENIEXT)(getProcAddr("glMultiTexGeniEXT"))
+	gpMultiTexGenivEXT = (C.GPMULTITEXGENIVEXT)(getProcAddr("glMultiTexGenivEXT"))
+	gpMultiTexImage1DEXT = (C.GPMULTITEXIMAGE1DEXT)(getProcAddr("glMultiTexImage1DEXT"))
+	gpMultiTexImage2DEXT = (C.GPMULTITEXIMAGE2DEXT)(getProcAddr("glMultiTexImage2DEXT"))
+	gpMultiTexImage3DEXT = (C.GPMULTITEXIMAGE3DEXT)(getProcAddr("glMultiTexImage3DEXT"))
+	gpMultiTexParameterIivEXT = (C.GPMULTITEXPARAMETERIIVEXT)(getProcAddr("glMultiTexParameterIivEXT"))
+	gpMultiTexParameterIuivEXT = (C.GPMULTITEXPARAMETERIUIVEXT)(getProcAddr("glMultiTexParameterIuivEXT"))
+	gpMultiTexParameterfEXT = (C.GPMULTITEXPARAMETERFEXT)(getProcAddr("glMultiTexParameterfEXT"))
+	gpMultiTexParameterfvEXT = (C.GPMULTITEXPARAMETERFVEXT)(getProcAddr("glMultiTexParameterfvEXT"))
+	gpMultiTexParameteriEXT = (C.GPMULTITEXPARAMETERIEXT)(getProcAddr("glMultiTexParameteriEXT"))
+	gpMultiTexParameterivEXT = (C.GPMULTITEXPARAMETERIVEXT)(getProcAddr("glMultiTexParameterivEXT"))
+	gpMultiTexRenderbufferEXT = (C.GPMULTITEXRENDERBUFFEREXT)(getProcAddr("glMultiTexRenderbufferEXT"))
+	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
+	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
+	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
+	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
+	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
+	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
+	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
 	gpNamedFramebufferDrawBuffer = (C.GPNAMEDFRAMEBUFFERDRAWBUFFER)(getProcAddr("glNamedFramebufferDrawBuffer"))
 	gpNamedFramebufferDrawBuffers = (C.GPNAMEDFRAMEBUFFERDRAWBUFFERS)(getProcAddr("glNamedFramebufferDrawBuffers"))
 	gpNamedFramebufferParameteri = (C.GPNAMEDFRAMEBUFFERPARAMETERI)(getProcAddr("glNamedFramebufferParameteri"))
+	gpNamedFramebufferParameteriEXT = (C.GPNAMEDFRAMEBUFFERPARAMETERIEXT)(getProcAddr("glNamedFramebufferParameteriEXT"))
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	gpNamedFramebufferRenderbuffer = (C.GPNAMEDFRAMEBUFFERRENDERBUFFER)(getProcAddr("glNamedFramebufferRenderbuffer"))
+	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
+	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
+	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
+	gpNamedFramebufferTexture3DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(getProcAddr("glNamedFramebufferTexture3DEXT"))
+	gpNamedFramebufferTextureEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREEXT)(getProcAddr("glNamedFramebufferTextureEXT"))
+	gpNamedFramebufferTextureFaceEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(getProcAddr("glNamedFramebufferTextureFaceEXT"))
 	gpNamedFramebufferTextureLayer = (C.GPNAMEDFRAMEBUFFERTEXTURELAYER)(getProcAddr("glNamedFramebufferTextureLayer"))
+	gpNamedFramebufferTextureLayerEXT = (C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glNamedFramebufferTextureLayerEXT"))
+	gpNamedProgramLocalParameter4dEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(getProcAddr("glNamedProgramLocalParameter4dEXT"))
+	gpNamedProgramLocalParameter4dvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(getProcAddr("glNamedProgramLocalParameter4dvEXT"))
+	gpNamedProgramLocalParameter4fEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(getProcAddr("glNamedProgramLocalParameter4fEXT"))
+	gpNamedProgramLocalParameter4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(getProcAddr("glNamedProgramLocalParameter4fvEXT"))
+	gpNamedProgramLocalParameterI4iEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(getProcAddr("glNamedProgramLocalParameterI4iEXT"))
+	gpNamedProgramLocalParameterI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(getProcAddr("glNamedProgramLocalParameterI4ivEXT"))
+	gpNamedProgramLocalParameterI4uiEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(getProcAddr("glNamedProgramLocalParameterI4uiEXT"))
+	gpNamedProgramLocalParameterI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(getProcAddr("glNamedProgramLocalParameterI4uivEXT"))
+	gpNamedProgramLocalParameters4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(getProcAddr("glNamedProgramLocalParameters4fvEXT"))
+	gpNamedProgramLocalParametersI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(getProcAddr("glNamedProgramLocalParametersI4ivEXT"))
+	gpNamedProgramLocalParametersI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(getProcAddr("glNamedProgramLocalParametersI4uivEXT"))
+	gpNamedProgramStringEXT = (C.GPNAMEDPROGRAMSTRINGEXT)(getProcAddr("glNamedProgramStringEXT"))
 	gpNamedRenderbufferStorage = (C.GPNAMEDRENDERBUFFERSTORAGE)(getProcAddr("glNamedRenderbufferStorage"))
+	gpNamedRenderbufferStorageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEEXT)(getProcAddr("glNamedRenderbufferStorageEXT"))
 	gpNamedRenderbufferStorageMultisample = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(getProcAddr("glNamedRenderbufferStorageMultisample"))
+	gpNamedRenderbufferStorageMultisampleCoverageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleCoverageEXT"))
+	gpNamedRenderbufferStorageMultisampleEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleEXT"))
 	gpNamedStringARB = (C.GPNAMEDSTRINGARB)(getProcAddr("glNamedStringARB"))
+	gpNormalFormatNV = (C.GPNORMALFORMATNV)(getProcAddr("glNormalFormatNV"))
 	gpObjectLabel = (C.GPOBJECTLABEL)(getProcAddr("glObjectLabel"))
 	if gpObjectLabel == nil {
 		return errors.New("glObjectLabel")
@@ -9431,6 +14726,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPatchParameteri == nil {
 		return errors.New("glPatchParameteri")
 	}
+	gpPathCommandsNV = (C.GPPATHCOMMANDSNV)(getProcAddr("glPathCommandsNV"))
+	gpPathCoordsNV = (C.GPPATHCOORDSNV)(getProcAddr("glPathCoordsNV"))
+	gpPathCoverDepthFuncNV = (C.GPPATHCOVERDEPTHFUNCNV)(getProcAddr("glPathCoverDepthFuncNV"))
+	gpPathDashArrayNV = (C.GPPATHDASHARRAYNV)(getProcAddr("glPathDashArrayNV"))
+	gpPathGlyphIndexArrayNV = (C.GPPATHGLYPHINDEXARRAYNV)(getProcAddr("glPathGlyphIndexArrayNV"))
+	gpPathGlyphIndexRangeNV = (C.GPPATHGLYPHINDEXRANGENV)(getProcAddr("glPathGlyphIndexRangeNV"))
+	gpPathGlyphRangeNV = (C.GPPATHGLYPHRANGENV)(getProcAddr("glPathGlyphRangeNV"))
+	gpPathGlyphsNV = (C.GPPATHGLYPHSNV)(getProcAddr("glPathGlyphsNV"))
+	gpPathMemoryGlyphIndexArrayNV = (C.GPPATHMEMORYGLYPHINDEXARRAYNV)(getProcAddr("glPathMemoryGlyphIndexArrayNV"))
+	gpPathParameterfNV = (C.GPPATHPARAMETERFNV)(getProcAddr("glPathParameterfNV"))
+	gpPathParameterfvNV = (C.GPPATHPARAMETERFVNV)(getProcAddr("glPathParameterfvNV"))
+	gpPathParameteriNV = (C.GPPATHPARAMETERINV)(getProcAddr("glPathParameteriNV"))
+	gpPathParameterivNV = (C.GPPATHPARAMETERIVNV)(getProcAddr("glPathParameterivNV"))
+	gpPathStencilDepthOffsetNV = (C.GPPATHSTENCILDEPTHOFFSETNV)(getProcAddr("glPathStencilDepthOffsetNV"))
+	gpPathStencilFuncNV = (C.GPPATHSTENCILFUNCNV)(getProcAddr("glPathStencilFuncNV"))
+	gpPathStringNV = (C.GPPATHSTRINGNV)(getProcAddr("glPathStringNV"))
+	gpPathSubCommandsNV = (C.GPPATHSUBCOMMANDSNV)(getProcAddr("glPathSubCommandsNV"))
+	gpPathSubCoordsNV = (C.GPPATHSUBCOORDSNV)(getProcAddr("glPathSubCoordsNV"))
 	gpPauseTransformFeedback = (C.GPPAUSETRANSFORMFEEDBACK)(getProcAddr("glPauseTransformFeedback"))
 	if gpPauseTransformFeedback == nil {
 		return errors.New("glPauseTransformFeedback")
@@ -9443,6 +14756,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPixelStorei == nil {
 		return errors.New("glPixelStorei")
 	}
+	gpPointAlongPathNV = (C.GPPOINTALONGPATHNV)(getProcAddr("glPointAlongPathNV"))
 	gpPointParameterf = (C.GPPOINTPARAMETERF)(getProcAddr("glPointParameterf"))
 	if gpPointParameterf == nil {
 		return errors.New("glPointParameterf")
@@ -9471,11 +14785,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPopDebugGroup = (C.GPPOPDEBUGGROUP)(getProcAddr("glPopDebugGroup"))
 	if gpPopDebugGroup == nil {
 		return errors.New("glPopDebugGroup")
 	}
 	gpPopDebugGroupKHR = (C.GPPOPDEBUGGROUPKHR)(getProcAddr("glPopDebugGroupKHR"))
+	gpPopGroupMarkerEXT = (C.GPPOPGROUPMARKEREXT)(getProcAddr("glPopGroupMarkerEXT"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	if gpPrimitiveRestartIndex == nil {
 		return errors.New("glPrimitiveRestartIndex")
@@ -9488,221 +14806,313 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramParameteri == nil {
 		return errors.New("glProgramParameteri")
 	}
+	gpProgramParameteriARB = (C.GPPROGRAMPARAMETERIARB)(getProcAddr("glProgramParameteriARB"))
+	gpProgramParameteriEXT = (C.GPPROGRAMPARAMETERIEXT)(getProcAddr("glProgramParameteriEXT"))
+	gpProgramPathFragmentInputGenNV = (C.GPPROGRAMPATHFRAGMENTINPUTGENNV)(getProcAddr("glProgramPathFragmentInputGenNV"))
 	gpProgramUniform1d = (C.GPPROGRAMUNIFORM1D)(getProcAddr("glProgramUniform1d"))
 	if gpProgramUniform1d == nil {
 		return errors.New("glProgramUniform1d")
 	}
+	gpProgramUniform1dEXT = (C.GPPROGRAMUNIFORM1DEXT)(getProcAddr("glProgramUniform1dEXT"))
 	gpProgramUniform1dv = (C.GPPROGRAMUNIFORM1DV)(getProcAddr("glProgramUniform1dv"))
 	if gpProgramUniform1dv == nil {
 		return errors.New("glProgramUniform1dv")
 	}
+	gpProgramUniform1dvEXT = (C.GPPROGRAMUNIFORM1DVEXT)(getProcAddr("glProgramUniform1dvEXT"))
 	gpProgramUniform1f = (C.GPPROGRAMUNIFORM1F)(getProcAddr("glProgramUniform1f"))
 	if gpProgramUniform1f == nil {
 		return errors.New("glProgramUniform1f")
 	}
+	gpProgramUniform1fEXT = (C.GPPROGRAMUNIFORM1FEXT)(getProcAddr("glProgramUniform1fEXT"))
 	gpProgramUniform1fv = (C.GPPROGRAMUNIFORM1FV)(getProcAddr("glProgramUniform1fv"))
 	if gpProgramUniform1fv == nil {
 		return errors.New("glProgramUniform1fv")
 	}
+	gpProgramUniform1fvEXT = (C.GPPROGRAMUNIFORM1FVEXT)(getProcAddr("glProgramUniform1fvEXT"))
 	gpProgramUniform1i = (C.GPPROGRAMUNIFORM1I)(getProcAddr("glProgramUniform1i"))
 	if gpProgramUniform1i == nil {
 		return errors.New("glProgramUniform1i")
 	}
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
+	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
+	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
+	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
 	if gpProgramUniform1iv == nil {
 		return errors.New("glProgramUniform1iv")
 	}
+	gpProgramUniform1ivEXT = (C.GPPROGRAMUNIFORM1IVEXT)(getProcAddr("glProgramUniform1ivEXT"))
 	gpProgramUniform1ui = (C.GPPROGRAMUNIFORM1UI)(getProcAddr("glProgramUniform1ui"))
 	if gpProgramUniform1ui == nil {
 		return errors.New("glProgramUniform1ui")
 	}
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
+	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
+	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
+	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
 	if gpProgramUniform1uiv == nil {
 		return errors.New("glProgramUniform1uiv")
 	}
+	gpProgramUniform1uivEXT = (C.GPPROGRAMUNIFORM1UIVEXT)(getProcAddr("glProgramUniform1uivEXT"))
 	gpProgramUniform2d = (C.GPPROGRAMUNIFORM2D)(getProcAddr("glProgramUniform2d"))
 	if gpProgramUniform2d == nil {
 		return errors.New("glProgramUniform2d")
 	}
+	gpProgramUniform2dEXT = (C.GPPROGRAMUNIFORM2DEXT)(getProcAddr("glProgramUniform2dEXT"))
 	gpProgramUniform2dv = (C.GPPROGRAMUNIFORM2DV)(getProcAddr("glProgramUniform2dv"))
 	if gpProgramUniform2dv == nil {
 		return errors.New("glProgramUniform2dv")
 	}
+	gpProgramUniform2dvEXT = (C.GPPROGRAMUNIFORM2DVEXT)(getProcAddr("glProgramUniform2dvEXT"))
 	gpProgramUniform2f = (C.GPPROGRAMUNIFORM2F)(getProcAddr("glProgramUniform2f"))
 	if gpProgramUniform2f == nil {
 		return errors.New("glProgramUniform2f")
 	}
+	gpProgramUniform2fEXT = (C.GPPROGRAMUNIFORM2FEXT)(getProcAddr("glProgramUniform2fEXT"))
 	gpProgramUniform2fv = (C.GPPROGRAMUNIFORM2FV)(getProcAddr("glProgramUniform2fv"))
 	if gpProgramUniform2fv == nil {
 		return errors.New("glProgramUniform2fv")
 	}
+	gpProgramUniform2fvEXT = (C.GPPROGRAMUNIFORM2FVEXT)(getProcAddr("glProgramUniform2fvEXT"))
 	gpProgramUniform2i = (C.GPPROGRAMUNIFORM2I)(getProcAddr("glProgramUniform2i"))
 	if gpProgramUniform2i == nil {
 		return errors.New("glProgramUniform2i")
 	}
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
+	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
+	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
+	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
 	if gpProgramUniform2iv == nil {
 		return errors.New("glProgramUniform2iv")
 	}
+	gpProgramUniform2ivEXT = (C.GPPROGRAMUNIFORM2IVEXT)(getProcAddr("glProgramUniform2ivEXT"))
 	gpProgramUniform2ui = (C.GPPROGRAMUNIFORM2UI)(getProcAddr("glProgramUniform2ui"))
 	if gpProgramUniform2ui == nil {
 		return errors.New("glProgramUniform2ui")
 	}
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
+	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
+	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
+	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
 	if gpProgramUniform2uiv == nil {
 		return errors.New("glProgramUniform2uiv")
 	}
+	gpProgramUniform2uivEXT = (C.GPPROGRAMUNIFORM2UIVEXT)(getProcAddr("glProgramUniform2uivEXT"))
 	gpProgramUniform3d = (C.GPPROGRAMUNIFORM3D)(getProcAddr("glProgramUniform3d"))
 	if gpProgramUniform3d == nil {
 		return errors.New("glProgramUniform3d")
 	}
+	gpProgramUniform3dEXT = (C.GPPROGRAMUNIFORM3DEXT)(getProcAddr("glProgramUniform3dEXT"))
 	gpProgramUniform3dv = (C.GPPROGRAMUNIFORM3DV)(getProcAddr("glProgramUniform3dv"))
 	if gpProgramUniform3dv == nil {
 		return errors.New("glProgramUniform3dv")
 	}
+	gpProgramUniform3dvEXT = (C.GPPROGRAMUNIFORM3DVEXT)(getProcAddr("glProgramUniform3dvEXT"))
 	gpProgramUniform3f = (C.GPPROGRAMUNIFORM3F)(getProcAddr("glProgramUniform3f"))
 	if gpProgramUniform3f == nil {
 		return errors.New("glProgramUniform3f")
 	}
+	gpProgramUniform3fEXT = (C.GPPROGRAMUNIFORM3FEXT)(getProcAddr("glProgramUniform3fEXT"))
 	gpProgramUniform3fv = (C.GPPROGRAMUNIFORM3FV)(getProcAddr("glProgramUniform3fv"))
 	if gpProgramUniform3fv == nil {
 		return errors.New("glProgramUniform3fv")
 	}
+	gpProgramUniform3fvEXT = (C.GPPROGRAMUNIFORM3FVEXT)(getProcAddr("glProgramUniform3fvEXT"))
 	gpProgramUniform3i = (C.GPPROGRAMUNIFORM3I)(getProcAddr("glProgramUniform3i"))
 	if gpProgramUniform3i == nil {
 		return errors.New("glProgramUniform3i")
 	}
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
+	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
+	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
+	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
 	if gpProgramUniform3iv == nil {
 		return errors.New("glProgramUniform3iv")
 	}
+	gpProgramUniform3ivEXT = (C.GPPROGRAMUNIFORM3IVEXT)(getProcAddr("glProgramUniform3ivEXT"))
 	gpProgramUniform3ui = (C.GPPROGRAMUNIFORM3UI)(getProcAddr("glProgramUniform3ui"))
 	if gpProgramUniform3ui == nil {
 		return errors.New("glProgramUniform3ui")
 	}
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
+	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
+	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
+	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
 	if gpProgramUniform3uiv == nil {
 		return errors.New("glProgramUniform3uiv")
 	}
+	gpProgramUniform3uivEXT = (C.GPPROGRAMUNIFORM3UIVEXT)(getProcAddr("glProgramUniform3uivEXT"))
 	gpProgramUniform4d = (C.GPPROGRAMUNIFORM4D)(getProcAddr("glProgramUniform4d"))
 	if gpProgramUniform4d == nil {
 		return errors.New("glProgramUniform4d")
 	}
+	gpProgramUniform4dEXT = (C.GPPROGRAMUNIFORM4DEXT)(getProcAddr("glProgramUniform4dEXT"))
 	gpProgramUniform4dv = (C.GPPROGRAMUNIFORM4DV)(getProcAddr("glProgramUniform4dv"))
 	if gpProgramUniform4dv == nil {
 		return errors.New("glProgramUniform4dv")
 	}
+	gpProgramUniform4dvEXT = (C.GPPROGRAMUNIFORM4DVEXT)(getProcAddr("glProgramUniform4dvEXT"))
 	gpProgramUniform4f = (C.GPPROGRAMUNIFORM4F)(getProcAddr("glProgramUniform4f"))
 	if gpProgramUniform4f == nil {
 		return errors.New("glProgramUniform4f")
 	}
+	gpProgramUniform4fEXT = (C.GPPROGRAMUNIFORM4FEXT)(getProcAddr("glProgramUniform4fEXT"))
 	gpProgramUniform4fv = (C.GPPROGRAMUNIFORM4FV)(getProcAddr("glProgramUniform4fv"))
 	if gpProgramUniform4fv == nil {
 		return errors.New("glProgramUniform4fv")
 	}
+	gpProgramUniform4fvEXT = (C.GPPROGRAMUNIFORM4FVEXT)(getProcAddr("glProgramUniform4fvEXT"))
 	gpProgramUniform4i = (C.GPPROGRAMUNIFORM4I)(getProcAddr("glProgramUniform4i"))
 	if gpProgramUniform4i == nil {
 		return errors.New("glProgramUniform4i")
 	}
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
+	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
+	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
+	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
 	if gpProgramUniform4iv == nil {
 		return errors.New("glProgramUniform4iv")
 	}
+	gpProgramUniform4ivEXT = (C.GPPROGRAMUNIFORM4IVEXT)(getProcAddr("glProgramUniform4ivEXT"))
 	gpProgramUniform4ui = (C.GPPROGRAMUNIFORM4UI)(getProcAddr("glProgramUniform4ui"))
 	if gpProgramUniform4ui == nil {
 		return errors.New("glProgramUniform4ui")
 	}
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
+	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
+	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
+	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
 	if gpProgramUniform4uiv == nil {
 		return errors.New("glProgramUniform4uiv")
 	}
+	gpProgramUniform4uivEXT = (C.GPPROGRAMUNIFORM4UIVEXT)(getProcAddr("glProgramUniform4uivEXT"))
 	gpProgramUniformHandleui64ARB = (C.GPPROGRAMUNIFORMHANDLEUI64ARB)(getProcAddr("glProgramUniformHandleui64ARB"))
+	gpProgramUniformHandleui64NV = (C.GPPROGRAMUNIFORMHANDLEUI64NV)(getProcAddr("glProgramUniformHandleui64NV"))
 	gpProgramUniformHandleui64vARB = (C.GPPROGRAMUNIFORMHANDLEUI64VARB)(getProcAddr("glProgramUniformHandleui64vARB"))
+	gpProgramUniformHandleui64vNV = (C.GPPROGRAMUNIFORMHANDLEUI64VNV)(getProcAddr("glProgramUniformHandleui64vNV"))
 	gpProgramUniformMatrix2dv = (C.GPPROGRAMUNIFORMMATRIX2DV)(getProcAddr("glProgramUniformMatrix2dv"))
 	if gpProgramUniformMatrix2dv == nil {
 		return errors.New("glProgramUniformMatrix2dv")
 	}
+	gpProgramUniformMatrix2dvEXT = (C.GPPROGRAMUNIFORMMATRIX2DVEXT)(getProcAddr("glProgramUniformMatrix2dvEXT"))
 	gpProgramUniformMatrix2fv = (C.GPPROGRAMUNIFORMMATRIX2FV)(getProcAddr("glProgramUniformMatrix2fv"))
 	if gpProgramUniformMatrix2fv == nil {
 		return errors.New("glProgramUniformMatrix2fv")
 	}
+	gpProgramUniformMatrix2fvEXT = (C.GPPROGRAMUNIFORMMATRIX2FVEXT)(getProcAddr("glProgramUniformMatrix2fvEXT"))
 	gpProgramUniformMatrix2x3dv = (C.GPPROGRAMUNIFORMMATRIX2X3DV)(getProcAddr("glProgramUniformMatrix2x3dv"))
 	if gpProgramUniformMatrix2x3dv == nil {
 		return errors.New("glProgramUniformMatrix2x3dv")
 	}
+	gpProgramUniformMatrix2x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3DVEXT)(getProcAddr("glProgramUniformMatrix2x3dvEXT"))
 	gpProgramUniformMatrix2x3fv = (C.GPPROGRAMUNIFORMMATRIX2X3FV)(getProcAddr("glProgramUniformMatrix2x3fv"))
 	if gpProgramUniformMatrix2x3fv == nil {
 		return errors.New("glProgramUniformMatrix2x3fv")
 	}
+	gpProgramUniformMatrix2x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3FVEXT)(getProcAddr("glProgramUniformMatrix2x3fvEXT"))
 	gpProgramUniformMatrix2x4dv = (C.GPPROGRAMUNIFORMMATRIX2X4DV)(getProcAddr("glProgramUniformMatrix2x4dv"))
 	if gpProgramUniformMatrix2x4dv == nil {
 		return errors.New("glProgramUniformMatrix2x4dv")
 	}
+	gpProgramUniformMatrix2x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4DVEXT)(getProcAddr("glProgramUniformMatrix2x4dvEXT"))
 	gpProgramUniformMatrix2x4fv = (C.GPPROGRAMUNIFORMMATRIX2X4FV)(getProcAddr("glProgramUniformMatrix2x4fv"))
 	if gpProgramUniformMatrix2x4fv == nil {
 		return errors.New("glProgramUniformMatrix2x4fv")
 	}
+	gpProgramUniformMatrix2x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4FVEXT)(getProcAddr("glProgramUniformMatrix2x4fvEXT"))
 	gpProgramUniformMatrix3dv = (C.GPPROGRAMUNIFORMMATRIX3DV)(getProcAddr("glProgramUniformMatrix3dv"))
 	if gpProgramUniformMatrix3dv == nil {
 		return errors.New("glProgramUniformMatrix3dv")
 	}
+	gpProgramUniformMatrix3dvEXT = (C.GPPROGRAMUNIFORMMATRIX3DVEXT)(getProcAddr("glProgramUniformMatrix3dvEXT"))
 	gpProgramUniformMatrix3fv = (C.GPPROGRAMUNIFORMMATRIX3FV)(getProcAddr("glProgramUniformMatrix3fv"))
 	if gpProgramUniformMatrix3fv == nil {
 		return errors.New("glProgramUniformMatrix3fv")
 	}
+	gpProgramUniformMatrix3fvEXT = (C.GPPROGRAMUNIFORMMATRIX3FVEXT)(getProcAddr("glProgramUniformMatrix3fvEXT"))
 	gpProgramUniformMatrix3x2dv = (C.GPPROGRAMUNIFORMMATRIX3X2DV)(getProcAddr("glProgramUniformMatrix3x2dv"))
 	if gpProgramUniformMatrix3x2dv == nil {
 		return errors.New("glProgramUniformMatrix3x2dv")
 	}
+	gpProgramUniformMatrix3x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2DVEXT)(getProcAddr("glProgramUniformMatrix3x2dvEXT"))
 	gpProgramUniformMatrix3x2fv = (C.GPPROGRAMUNIFORMMATRIX3X2FV)(getProcAddr("glProgramUniformMatrix3x2fv"))
 	if gpProgramUniformMatrix3x2fv == nil {
 		return errors.New("glProgramUniformMatrix3x2fv")
 	}
+	gpProgramUniformMatrix3x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2FVEXT)(getProcAddr("glProgramUniformMatrix3x2fvEXT"))
 	gpProgramUniformMatrix3x4dv = (C.GPPROGRAMUNIFORMMATRIX3X4DV)(getProcAddr("glProgramUniformMatrix3x4dv"))
 	if gpProgramUniformMatrix3x4dv == nil {
 		return errors.New("glProgramUniformMatrix3x4dv")
 	}
+	gpProgramUniformMatrix3x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4DVEXT)(getProcAddr("glProgramUniformMatrix3x4dvEXT"))
 	gpProgramUniformMatrix3x4fv = (C.GPPROGRAMUNIFORMMATRIX3X4FV)(getProcAddr("glProgramUniformMatrix3x4fv"))
 	if gpProgramUniformMatrix3x4fv == nil {
 		return errors.New("glProgramUniformMatrix3x4fv")
 	}
+	gpProgramUniformMatrix3x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4FVEXT)(getProcAddr("glProgramUniformMatrix3x4fvEXT"))
 	gpProgramUniformMatrix4dv = (C.GPPROGRAMUNIFORMMATRIX4DV)(getProcAddr("glProgramUniformMatrix4dv"))
 	if gpProgramUniformMatrix4dv == nil {
 		return errors.New("glProgramUniformMatrix4dv")
 	}
+	gpProgramUniformMatrix4dvEXT = (C.GPPROGRAMUNIFORMMATRIX4DVEXT)(getProcAddr("glProgramUniformMatrix4dvEXT"))
 	gpProgramUniformMatrix4fv = (C.GPPROGRAMUNIFORMMATRIX4FV)(getProcAddr("glProgramUniformMatrix4fv"))
 	if gpProgramUniformMatrix4fv == nil {
 		return errors.New("glProgramUniformMatrix4fv")
 	}
+	gpProgramUniformMatrix4fvEXT = (C.GPPROGRAMUNIFORMMATRIX4FVEXT)(getProcAddr("glProgramUniformMatrix4fvEXT"))
 	gpProgramUniformMatrix4x2dv = (C.GPPROGRAMUNIFORMMATRIX4X2DV)(getProcAddr("glProgramUniformMatrix4x2dv"))
 	if gpProgramUniformMatrix4x2dv == nil {
 		return errors.New("glProgramUniformMatrix4x2dv")
 	}
+	gpProgramUniformMatrix4x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2DVEXT)(getProcAddr("glProgramUniformMatrix4x2dvEXT"))
 	gpProgramUniformMatrix4x2fv = (C.GPPROGRAMUNIFORMMATRIX4X2FV)(getProcAddr("glProgramUniformMatrix4x2fv"))
 	if gpProgramUniformMatrix4x2fv == nil {
 		return errors.New("glProgramUniformMatrix4x2fv")
 	}
+	gpProgramUniformMatrix4x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2FVEXT)(getProcAddr("glProgramUniformMatrix4x2fvEXT"))
 	gpProgramUniformMatrix4x3dv = (C.GPPROGRAMUNIFORMMATRIX4X3DV)(getProcAddr("glProgramUniformMatrix4x3dv"))
 	if gpProgramUniformMatrix4x3dv == nil {
 		return errors.New("glProgramUniformMatrix4x3dv")
 	}
+	gpProgramUniformMatrix4x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3DVEXT)(getProcAddr("glProgramUniformMatrix4x3dvEXT"))
 	gpProgramUniformMatrix4x3fv = (C.GPPROGRAMUNIFORMMATRIX4X3FV)(getProcAddr("glProgramUniformMatrix4x3fv"))
 	if gpProgramUniformMatrix4x3fv == nil {
 		return errors.New("glProgramUniformMatrix4x3fv")
 	}
+	gpProgramUniformMatrix4x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3FVEXT)(getProcAddr("glProgramUniformMatrix4x3fvEXT"))
+	gpProgramUniformui64NV = (C.GPPROGRAMUNIFORMUI64NV)(getProcAddr("glProgramUniformui64NV"))
+	gpProgramUniformui64vNV = (C.GPPROGRAMUNIFORMUI64VNV)(getProcAddr("glProgramUniformui64vNV"))
 	gpProvokingVertex = (C.GPPROVOKINGVERTEX)(getProcAddr("glProvokingVertex"))
 	if gpProvokingVertex == nil {
 		return errors.New("glProvokingVertex")
 	}
+	gpPushClientAttribDefaultEXT = (C.GPPUSHCLIENTATTRIBDEFAULTEXT)(getProcAddr("glPushClientAttribDefaultEXT"))
 	gpPushDebugGroup = (C.GPPUSHDEBUGGROUP)(getProcAddr("glPushDebugGroup"))
 	if gpPushDebugGroup == nil {
 		return errors.New("glPushDebugGroup")
 	}
 	gpPushDebugGroupKHR = (C.GPPUSHDEBUGGROUPKHR)(getProcAddr("glPushDebugGroupKHR"))
+	gpPushGroupMarkerEXT = (C.GPPUSHGROUPMARKEREXT)(getProcAddr("glPushGroupMarkerEXT"))
 	gpQueryCounter = (C.GPQUERYCOUNTER)(getProcAddr("glQueryCounter"))
 	if gpQueryCounter == nil {
 		return errors.New("glQueryCounter")
 	}
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -9726,6 +15136,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpRenderbufferStorageMultisample == nil {
 		return errors.New("glRenderbufferStorageMultisample")
 	}
+	gpRenderbufferStorageMultisampleCoverageNV = (C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(getProcAddr("glRenderbufferStorageMultisampleCoverageNV"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	if gpResumeTransformFeedback == nil {
 		return errors.New("glResumeTransformFeedback")
@@ -9778,6 +15190,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpScissorIndexedv == nil {
 		return errors.New("glScissorIndexedv")
 	}
+	gpSecondaryColorFormatNV = (C.GPSECONDARYCOLORFORMATNV)(getProcAddr("glSecondaryColorFormatNV"))
+	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
 	gpShaderBinary = (C.GPSHADERBINARY)(getProcAddr("glShaderBinary"))
 	if gpShaderBinary == nil {
 		return errors.New("glShaderBinary")
@@ -9790,6 +15204,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpShaderStorageBlockBinding == nil {
 		return errors.New("glShaderStorageBlockBinding")
 	}
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
+	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
+	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
 	gpStencilFunc = (C.GPSTENCILFUNC)(getProcAddr("glStencilFunc"))
 	if gpStencilFunc == nil {
 		return errors.New("glStencilFunc")
@@ -9814,14 +15234,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpStencilOpSeparate == nil {
 		return errors.New("glStencilOpSeparate")
 	}
+	gpStencilStrokePathInstancedNV = (C.GPSTENCILSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilStrokePathInstancedNV"))
+	gpStencilStrokePathNV = (C.GPSTENCILSTROKEPATHNV)(getProcAddr("glStencilStrokePathNV"))
+	gpStencilThenCoverFillPathInstancedNV = (C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverFillPathInstancedNV"))
+	gpStencilThenCoverFillPathNV = (C.GPSTENCILTHENCOVERFILLPATHNV)(getProcAddr("glStencilThenCoverFillPathNV"))
+	gpStencilThenCoverStrokePathInstancedNV = (C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverStrokePathInstancedNV"))
+	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpTexBuffer = (C.GPTEXBUFFER)(getProcAddr("glTexBuffer"))
 	if gpTexBuffer == nil {
 		return errors.New("glTexBuffer")
 	}
+	gpTexBufferARB = (C.GPTEXBUFFERARB)(getProcAddr("glTexBufferARB"))
 	gpTexBufferRange = (C.GPTEXBUFFERRANGE)(getProcAddr("glTexBufferRange"))
 	if gpTexBufferRange == nil {
 		return errors.New("glTexBufferRange")
 	}
+	gpTexCoordFormatNV = (C.GPTEXCOORDFORMATNV)(getProcAddr("glTexCoordFormatNV"))
 	gpTexImage1D = (C.GPTEXIMAGE1D)(getProcAddr("glTexImage1D"))
 	if gpTexImage1D == nil {
 		return errors.New("glTexImage1D")
@@ -9900,22 +15329,44 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glTexSubImage3D")
 	}
 	gpTextureBarrier = (C.GPTEXTUREBARRIER)(getProcAddr("glTextureBarrier"))
+	gpTextureBarrierNV = (C.GPTEXTUREBARRIERNV)(getProcAddr("glTextureBarrierNV"))
 	gpTextureBuffer = (C.GPTEXTUREBUFFER)(getProcAddr("glTextureBuffer"))
+	gpTextureBufferEXT = (C.GPTEXTUREBUFFEREXT)(getProcAddr("glTextureBufferEXT"))
 	gpTextureBufferRange = (C.GPTEXTUREBUFFERRANGE)(getProcAddr("glTextureBufferRange"))
+	gpTextureBufferRangeEXT = (C.GPTEXTUREBUFFERRANGEEXT)(getProcAddr("glTextureBufferRangeEXT"))
+	gpTextureImage1DEXT = (C.GPTEXTUREIMAGE1DEXT)(getProcAddr("glTextureImage1DEXT"))
+	gpTextureImage2DEXT = (C.GPTEXTUREIMAGE2DEXT)(getProcAddr("glTextureImage2DEXT"))
+	gpTextureImage3DEXT = (C.GPTEXTUREIMAGE3DEXT)(getProcAddr("glTextureImage3DEXT"))
+	gpTexturePageCommitmentEXT = (C.GPTEXTUREPAGECOMMITMENTEXT)(getProcAddr("glTexturePageCommitmentEXT"))
 	gpTextureParameterIiv = (C.GPTEXTUREPARAMETERIIV)(getProcAddr("glTextureParameterIiv"))
+	gpTextureParameterIivEXT = (C.GPTEXTUREPARAMETERIIVEXT)(getProcAddr("glTextureParameterIivEXT"))
 	gpTextureParameterIuiv = (C.GPTEXTUREPARAMETERIUIV)(getProcAddr("glTextureParameterIuiv"))
+	gpTextureParameterIuivEXT = (C.GPTEXTUREPARAMETERIUIVEXT)(getProcAddr("glTextureParameterIuivEXT"))
 	gpTextureParameterf = (C.GPTEXTUREPARAMETERF)(getProcAddr("glTextureParameterf"))
+	gpTextureParameterfEXT = (C.GPTEXTUREPARAMETERFEXT)(getProcAddr("glTextureParameterfEXT"))
 	gpTextureParameterfv = (C.GPTEXTUREPARAMETERFV)(getProcAddr("glTextureParameterfv"))
+	gpTextureParameterfvEXT = (C.GPTEXTUREPARAMETERFVEXT)(getProcAddr("glTextureParameterfvEXT"))
 	gpTextureParameteri = (C.GPTEXTUREPARAMETERI)(getProcAddr("glTextureParameteri"))
+	gpTextureParameteriEXT = (C.GPTEXTUREPARAMETERIEXT)(getProcAddr("glTextureParameteriEXT"))
 	gpTextureParameteriv = (C.GPTEXTUREPARAMETERIV)(getProcAddr("glTextureParameteriv"))
+	gpTextureParameterivEXT = (C.GPTEXTUREPARAMETERIVEXT)(getProcAddr("glTextureParameterivEXT"))
+	gpTextureRenderbufferEXT = (C.GPTEXTURERENDERBUFFEREXT)(getProcAddr("glTextureRenderbufferEXT"))
 	gpTextureStorage1D = (C.GPTEXTURESTORAGE1D)(getProcAddr("glTextureStorage1D"))
+	gpTextureStorage1DEXT = (C.GPTEXTURESTORAGE1DEXT)(getProcAddr("glTextureStorage1DEXT"))
 	gpTextureStorage2D = (C.GPTEXTURESTORAGE2D)(getProcAddr("glTextureStorage2D"))
+	gpTextureStorage2DEXT = (C.GPTEXTURESTORAGE2DEXT)(getProcAddr("glTextureStorage2DEXT"))
 	gpTextureStorage2DMultisample = (C.GPTEXTURESTORAGE2DMULTISAMPLE)(getProcAddr("glTextureStorage2DMultisample"))
+	gpTextureStorage2DMultisampleEXT = (C.GPTEXTURESTORAGE2DMULTISAMPLEEXT)(getProcAddr("glTextureStorage2DMultisampleEXT"))
 	gpTextureStorage3D = (C.GPTEXTURESTORAGE3D)(getProcAddr("glTextureStorage3D"))
+	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
+	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
+	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
 	gpTextureSubImage2D = (C.GPTEXTURESUBIMAGE2D)(getProcAddr("glTextureSubImage2D"))
+	gpTextureSubImage2DEXT = (C.GPTEXTURESUBIMAGE2DEXT)(getProcAddr("glTextureSubImage2DEXT"))
 	gpTextureSubImage3D = (C.GPTEXTURESUBIMAGE3D)(getProcAddr("glTextureSubImage3D"))
+	gpTextureSubImage3DEXT = (C.GPTEXTURESUBIMAGE3DEXT)(getProcAddr("glTextureSubImage3DEXT"))
 	gpTextureView = (C.GPTEXTUREVIEW)(getProcAddr("glTextureView"))
 	if gpTextureView == nil {
 		return errors.New("glTextureView")
@@ -9926,6 +15377,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpTransformFeedbackVaryings == nil {
 		return errors.New("glTransformFeedbackVaryings")
 	}
+	gpTransformPathNV = (C.GPTRANSFORMPATHNV)(getProcAddr("glTransformPathNV"))
 	gpUniform1d = (C.GPUNIFORM1D)(getProcAddr("glUniform1d"))
 	if gpUniform1d == nil {
 		return errors.New("glUniform1d")
@@ -9946,6 +15398,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
+	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
+	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
 	if gpUniform1iv == nil {
 		return errors.New("glUniform1iv")
@@ -9954,6 +15410,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
+	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
+	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
 	if gpUniform1uiv == nil {
 		return errors.New("glUniform1uiv")
@@ -9978,6 +15438,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
+	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
+	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
 	if gpUniform2iv == nil {
 		return errors.New("glUniform2iv")
@@ -9986,6 +15450,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
+	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
+	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
 	if gpUniform2uiv == nil {
 		return errors.New("glUniform2uiv")
@@ -10010,6 +15478,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
+	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
+	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
 	if gpUniform3iv == nil {
 		return errors.New("glUniform3iv")
@@ -10018,6 +15490,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
+	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
+	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
 	if gpUniform3uiv == nil {
 		return errors.New("glUniform3uiv")
@@ -10042,6 +15518,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
+	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
+	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
 	if gpUniform4iv == nil {
 		return errors.New("glUniform4iv")
@@ -10050,6 +15530,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
+	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
+	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
 	if gpUniform4uiv == nil {
 		return errors.New("glUniform4uiv")
@@ -10059,7 +15543,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glUniformBlockBinding")
 	}
 	gpUniformHandleui64ARB = (C.GPUNIFORMHANDLEUI64ARB)(getProcAddr("glUniformHandleui64ARB"))
+	gpUniformHandleui64NV = (C.GPUNIFORMHANDLEUI64NV)(getProcAddr("glUniformHandleui64NV"))
 	gpUniformHandleui64vARB = (C.GPUNIFORMHANDLEUI64VARB)(getProcAddr("glUniformHandleui64vARB"))
+	gpUniformHandleui64vNV = (C.GPUNIFORMHANDLEUI64VNV)(getProcAddr("glUniformHandleui64vNV"))
 	gpUniformMatrix2dv = (C.GPUNIFORMMATRIX2DV)(getProcAddr("glUniformMatrix2dv"))
 	if gpUniformMatrix2dv == nil {
 		return errors.New("glUniformMatrix2dv")
@@ -10136,11 +15622,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniformSubroutinesuiv == nil {
 		return errors.New("glUniformSubroutinesuiv")
 	}
+	gpUniformui64NV = (C.GPUNIFORMUI64NV)(getProcAddr("glUniformui64NV"))
+	gpUniformui64vNV = (C.GPUNIFORMUI64VNV)(getProcAddr("glUniformui64vNV"))
 	gpUnmapBuffer = (C.GPUNMAPBUFFER)(getProcAddr("glUnmapBuffer"))
 	if gpUnmapBuffer == nil {
 		return errors.New("glUnmapBuffer")
 	}
 	gpUnmapNamedBuffer = (C.GPUNMAPNAMEDBUFFER)(getProcAddr("glUnmapNamedBuffer"))
+	gpUnmapNamedBufferEXT = (C.GPUNMAPNAMEDBUFFEREXT)(getProcAddr("glUnmapNamedBufferEXT"))
 	gpUseProgram = (C.GPUSEPROGRAM)(getProcAddr("glUseProgram"))
 	if gpUseProgram == nil {
 		return errors.New("glUseProgram")
@@ -10149,6 +15638,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUseProgramStages == nil {
 		return errors.New("glUseProgramStages")
 	}
+	gpUseProgramStagesEXT = (C.GPUSEPROGRAMSTAGESEXT)(getProcAddr("glUseProgramStagesEXT"))
+	gpUseShaderProgramEXT = (C.GPUSESHADERPROGRAMEXT)(getProcAddr("glUseShaderProgramEXT"))
 	gpValidateProgram = (C.GPVALIDATEPROGRAM)(getProcAddr("glValidateProgram"))
 	if gpValidateProgram == nil {
 		return errors.New("glValidateProgram")
@@ -10157,14 +15648,34 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpValidateProgramPipeline == nil {
 		return errors.New("glValidateProgramPipeline")
 	}
+	gpValidateProgramPipelineEXT = (C.GPVALIDATEPROGRAMPIPELINEEXT)(getProcAddr("glValidateProgramPipelineEXT"))
 	gpVertexArrayAttribBinding = (C.GPVERTEXARRAYATTRIBBINDING)(getProcAddr("glVertexArrayAttribBinding"))
 	gpVertexArrayAttribFormat = (C.GPVERTEXARRAYATTRIBFORMAT)(getProcAddr("glVertexArrayAttribFormat"))
 	gpVertexArrayAttribIFormat = (C.GPVERTEXARRAYATTRIBIFORMAT)(getProcAddr("glVertexArrayAttribIFormat"))
 	gpVertexArrayAttribLFormat = (C.GPVERTEXARRAYATTRIBLFORMAT)(getProcAddr("glVertexArrayAttribLFormat"))
+	gpVertexArrayBindVertexBufferEXT = (C.GPVERTEXARRAYBINDVERTEXBUFFEREXT)(getProcAddr("glVertexArrayBindVertexBufferEXT"))
 	gpVertexArrayBindingDivisor = (C.GPVERTEXARRAYBINDINGDIVISOR)(getProcAddr("glVertexArrayBindingDivisor"))
+	gpVertexArrayColorOffsetEXT = (C.GPVERTEXARRAYCOLOROFFSETEXT)(getProcAddr("glVertexArrayColorOffsetEXT"))
+	gpVertexArrayEdgeFlagOffsetEXT = (C.GPVERTEXARRAYEDGEFLAGOFFSETEXT)(getProcAddr("glVertexArrayEdgeFlagOffsetEXT"))
 	gpVertexArrayElementBuffer = (C.GPVERTEXARRAYELEMENTBUFFER)(getProcAddr("glVertexArrayElementBuffer"))
+	gpVertexArrayFogCoordOffsetEXT = (C.GPVERTEXARRAYFOGCOORDOFFSETEXT)(getProcAddr("glVertexArrayFogCoordOffsetEXT"))
+	gpVertexArrayIndexOffsetEXT = (C.GPVERTEXARRAYINDEXOFFSETEXT)(getProcAddr("glVertexArrayIndexOffsetEXT"))
+	gpVertexArrayMultiTexCoordOffsetEXT = (C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayMultiTexCoordOffsetEXT"))
+	gpVertexArrayNormalOffsetEXT = (C.GPVERTEXARRAYNORMALOFFSETEXT)(getProcAddr("glVertexArrayNormalOffsetEXT"))
+	gpVertexArraySecondaryColorOffsetEXT = (C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(getProcAddr("glVertexArraySecondaryColorOffsetEXT"))
+	gpVertexArrayTexCoordOffsetEXT = (C.GPVERTEXARRAYTEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayTexCoordOffsetEXT"))
+	gpVertexArrayVertexAttribBindingEXT = (C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(getProcAddr("glVertexArrayVertexAttribBindingEXT"))
+	gpVertexArrayVertexAttribDivisorEXT = (C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(getProcAddr("glVertexArrayVertexAttribDivisorEXT"))
+	gpVertexArrayVertexAttribFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(getProcAddr("glVertexArrayVertexAttribFormatEXT"))
+	gpVertexArrayVertexAttribIFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(getProcAddr("glVertexArrayVertexAttribIFormatEXT"))
+	gpVertexArrayVertexAttribIOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribIOffsetEXT"))
+	gpVertexArrayVertexAttribLFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(getProcAddr("glVertexArrayVertexAttribLFormatEXT"))
+	gpVertexArrayVertexAttribLOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribLOffsetEXT"))
+	gpVertexArrayVertexAttribOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribOffsetEXT"))
+	gpVertexArrayVertexBindingDivisorEXT = (C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(getProcAddr("glVertexArrayVertexBindingDivisorEXT"))
 	gpVertexArrayVertexBuffer = (C.GPVERTEXARRAYVERTEXBUFFER)(getProcAddr("glVertexArrayVertexBuffer"))
 	gpVertexArrayVertexBuffers = (C.GPVERTEXARRAYVERTEXBUFFERS)(getProcAddr("glVertexArrayVertexBuffers"))
+	gpVertexArrayVertexOffsetEXT = (C.GPVERTEXARRAYVERTEXOFFSETEXT)(getProcAddr("glVertexArrayVertexOffsetEXT"))
 	gpVertexAttrib1d = (C.GPVERTEXATTRIB1D)(getProcAddr("glVertexAttrib1d"))
 	if gpVertexAttrib1d == nil {
 		return errors.New("glVertexAttrib1d")
@@ -10317,10 +15828,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribDivisor == nil {
 		return errors.New("glVertexAttribDivisor")
 	}
+	gpVertexAttribDivisorARB = (C.GPVERTEXATTRIBDIVISORARB)(getProcAddr("glVertexAttribDivisorARB"))
 	gpVertexAttribFormat = (C.GPVERTEXATTRIBFORMAT)(getProcAddr("glVertexAttribFormat"))
 	if gpVertexAttribFormat == nil {
 		return errors.New("glVertexAttribFormat")
 	}
+	gpVertexAttribFormatNV = (C.GPVERTEXATTRIBFORMATNV)(getProcAddr("glVertexAttribFormatNV"))
 	gpVertexAttribI1i = (C.GPVERTEXATTRIBI1I)(getProcAddr("glVertexAttribI1i"))
 	if gpVertexAttribI1i == nil {
 		return errors.New("glVertexAttribI1i")
@@ -10405,6 +15918,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribIFormat == nil {
 		return errors.New("glVertexAttribIFormat")
 	}
+	gpVertexAttribIFormatNV = (C.GPVERTEXATTRIBIFORMATNV)(getProcAddr("glVertexAttribIFormatNV"))
 	gpVertexAttribIPointer = (C.GPVERTEXATTRIBIPOINTER)(getProcAddr("glVertexAttribIPointer"))
 	if gpVertexAttribIPointer == nil {
 		return errors.New("glVertexAttribIPointer")
@@ -10417,8 +15931,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL1dv == nil {
 		return errors.New("glVertexAttribL1dv")
 	}
+	gpVertexAttribL1i64NV = (C.GPVERTEXATTRIBL1I64NV)(getProcAddr("glVertexAttribL1i64NV"))
+	gpVertexAttribL1i64vNV = (C.GPVERTEXATTRIBL1I64VNV)(getProcAddr("glVertexAttribL1i64vNV"))
 	gpVertexAttribL1ui64ARB = (C.GPVERTEXATTRIBL1UI64ARB)(getProcAddr("glVertexAttribL1ui64ARB"))
+	gpVertexAttribL1ui64NV = (C.GPVERTEXATTRIBL1UI64NV)(getProcAddr("glVertexAttribL1ui64NV"))
 	gpVertexAttribL1ui64vARB = (C.GPVERTEXATTRIBL1UI64VARB)(getProcAddr("glVertexAttribL1ui64vARB"))
+	gpVertexAttribL1ui64vNV = (C.GPVERTEXATTRIBL1UI64VNV)(getProcAddr("glVertexAttribL1ui64vNV"))
 	gpVertexAttribL2d = (C.GPVERTEXATTRIBL2D)(getProcAddr("glVertexAttribL2d"))
 	if gpVertexAttribL2d == nil {
 		return errors.New("glVertexAttribL2d")
@@ -10427,6 +15945,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL2dv == nil {
 		return errors.New("glVertexAttribL2dv")
 	}
+	gpVertexAttribL2i64NV = (C.GPVERTEXATTRIBL2I64NV)(getProcAddr("glVertexAttribL2i64NV"))
+	gpVertexAttribL2i64vNV = (C.GPVERTEXATTRIBL2I64VNV)(getProcAddr("glVertexAttribL2i64vNV"))
+	gpVertexAttribL2ui64NV = (C.GPVERTEXATTRIBL2UI64NV)(getProcAddr("glVertexAttribL2ui64NV"))
+	gpVertexAttribL2ui64vNV = (C.GPVERTEXATTRIBL2UI64VNV)(getProcAddr("glVertexAttribL2ui64vNV"))
 	gpVertexAttribL3d = (C.GPVERTEXATTRIBL3D)(getProcAddr("glVertexAttribL3d"))
 	if gpVertexAttribL3d == nil {
 		return errors.New("glVertexAttribL3d")
@@ -10435,6 +15957,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL3dv == nil {
 		return errors.New("glVertexAttribL3dv")
 	}
+	gpVertexAttribL3i64NV = (C.GPVERTEXATTRIBL3I64NV)(getProcAddr("glVertexAttribL3i64NV"))
+	gpVertexAttribL3i64vNV = (C.GPVERTEXATTRIBL3I64VNV)(getProcAddr("glVertexAttribL3i64vNV"))
+	gpVertexAttribL3ui64NV = (C.GPVERTEXATTRIBL3UI64NV)(getProcAddr("glVertexAttribL3ui64NV"))
+	gpVertexAttribL3ui64vNV = (C.GPVERTEXATTRIBL3UI64VNV)(getProcAddr("glVertexAttribL3ui64vNV"))
 	gpVertexAttribL4d = (C.GPVERTEXATTRIBL4D)(getProcAddr("glVertexAttribL4d"))
 	if gpVertexAttribL4d == nil {
 		return errors.New("glVertexAttribL4d")
@@ -10443,10 +15969,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL4dv == nil {
 		return errors.New("glVertexAttribL4dv")
 	}
+	gpVertexAttribL4i64NV = (C.GPVERTEXATTRIBL4I64NV)(getProcAddr("glVertexAttribL4i64NV"))
+	gpVertexAttribL4i64vNV = (C.GPVERTEXATTRIBL4I64VNV)(getProcAddr("glVertexAttribL4i64vNV"))
+	gpVertexAttribL4ui64NV = (C.GPVERTEXATTRIBL4UI64NV)(getProcAddr("glVertexAttribL4ui64NV"))
+	gpVertexAttribL4ui64vNV = (C.GPVERTEXATTRIBL4UI64VNV)(getProcAddr("glVertexAttribL4ui64vNV"))
 	gpVertexAttribLFormat = (C.GPVERTEXATTRIBLFORMAT)(getProcAddr("glVertexAttribLFormat"))
 	if gpVertexAttribLFormat == nil {
 		return errors.New("glVertexAttribLFormat")
 	}
+	gpVertexAttribLFormatNV = (C.GPVERTEXATTRIBLFORMATNV)(getProcAddr("glVertexAttribLFormatNV"))
 	gpVertexAttribLPointer = (C.GPVERTEXATTRIBLPOINTER)(getProcAddr("glVertexAttribLPointer"))
 	if gpVertexAttribLPointer == nil {
 		return errors.New("glVertexAttribLPointer")
@@ -10491,6 +16022,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexBindingDivisor == nil {
 		return errors.New("glVertexBindingDivisor")
 	}
+	gpVertexFormatNV = (C.GPVERTEXFORMATNV)(getProcAddr("glVertexFormatNV"))
 	gpViewport = (C.GPVIEWPORT)(getProcAddr("glViewport"))
 	if gpViewport == nil {
 		return errors.New("glViewport")
@@ -10507,9 +16039,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpViewportIndexedfv == nil {
 		return errors.New("glViewportIndexedfv")
 	}
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
+	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	return nil
 }

--- a/v4.3-core/gl/procaddr.go
+++ b/v4.3-core/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcore43(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v4.4-compatibility/gl/package.go
+++ b/v4.4-compatibility/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -75,7 +73,6 @@ package gl
 // typedef unsigned int GLenum;
 // typedef unsigned char GLboolean;
 // typedef unsigned int GLbitfield;
-// typedef void GLvoid;
 // typedef signed char GLbyte;
 // typedef short GLshort;
 // typedef int GLint;
@@ -88,6 +85,7 @@ package gl
 // typedef float GLclampf;
 // typedef double GLdouble;
 // typedef double GLclampd;
+// typedef void *GLeglClientBufferEXT;
 // typedef char GLchar;
 // typedef char GLcharARB;
 // #ifdef __APPLE__
@@ -104,7 +102,7 @@ package gl
 // typedef ptrdiff_t GLsizeiptrARB;
 // typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
@@ -113,12 +111,14 @@ package gl
 // typedef void (APIENTRY *GLDEBUGPROCAMD)(GLuint id,GLenum category,GLenum severity,GLsizei length,const GLchar *message,void *userParam);
 // typedef unsigned short GLhalfNV;
 // typedef GLintptr GLvdpauSurfaceNV;
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcompatibility44(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcompatibility44(source, type, id, severity, length, message, userParam);
 // }
 // typedef void  (APIENTRYP GPACCUM)(GLenum  op, GLfloat  value);
 // typedef void  (APIENTRYP GPACCUMXOES)(GLenum  op, GLfixed  value);
+// typedef GLboolean  (APIENTRYP GPACQUIREKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key, GLuint  timeout);
 // typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
@@ -131,6 +131,8 @@ package gl
 // typedef void  (APIENTRYP GPALPHAFRAGMENTOP3ATI)(GLenum  op, GLuint  dst, GLuint  dstMod, GLuint  arg1, GLuint  arg1Rep, GLuint  arg1Mod, GLuint  arg2, GLuint  arg2Rep, GLuint  arg2Mod, GLuint  arg3, GLuint  arg3Rep, GLuint  arg3Mod);
 // typedef void  (APIENTRYP GPALPHAFUNC)(GLenum  func, GLfloat  ref);
 // typedef void  (APIENTRYP GPALPHAFUNCXOES)(GLenum  func, GLfixed  ref);
+// typedef void  (APIENTRYP GPALPHATOCOVERAGEDITHERCONTROLNV)(GLenum  mode);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPAPPLYTEXTUREEXT)(GLenum  mode);
 // typedef GLboolean  (APIENTRYP GPAREPROGRAMSRESIDENTNV)(GLsizei  n, const GLuint * programs, GLboolean * residences);
 // typedef GLboolean  (APIENTRYP GPARETEXTURESRESIDENT)(GLsizei  n, const GLuint * textures, GLboolean * residences);
@@ -252,11 +254,14 @@ package gl
 // typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPBUFFERDATAARB)(GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERPARAMETERIAPPLE)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEEXTERNALEXT)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEMEMEXT)(GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPBUFFERSUBDATAARB)(GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLIST)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLISTS)(GLsizei  n, GLenum  type, const void * lists);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
@@ -286,9 +291,9 @@ package gl
 // typedef void  (APIENTRYP GPCLEARINDEX)(GLfloat  c);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
@@ -384,6 +389,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERIVNV)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERARB)(GLhandleARB  shaderObj);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
@@ -414,6 +421,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER2D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * image);
@@ -444,7 +453,7 @@ package gl
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  type);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
@@ -469,8 +478,12 @@ package gl
 // typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEMEMORYOBJECTSEXT)(GLsizei  n, GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef GLhandleARB  (APIENTRYP GPCREATEPROGRAMOBJECTARB)();
@@ -483,6 +496,7 @@ package gl
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -509,12 +523,14 @@ package gl
 // typedef void  (APIENTRYP GPDELETEASYNCMARKERSSGIX)(GLuint  marker, GLsizei  range);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
 // typedef void  (APIENTRYP GPDELETEBUFFERSARB)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFENCESAPPLE)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFENCESNV)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFRAGMENTSHADERATI)(GLuint  id);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERSEXT)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETELISTS)(GLuint  list, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEMEMORYOBJECTSEXT)(GLsizei  n, const GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
 // typedef void  (APIENTRYP GPDELETENAMESAMD)(GLenum  identifier, GLuint  num, const GLuint * names);
 // typedef void  (APIENTRYP GPDELETEOBJECTARB)(GLhandleARB  obj);
@@ -529,10 +545,13 @@ package gl
 // typedef void  (APIENTRYP GPDELETEPROGRAMSNV)(GLsizei  n, const GLuint * programs);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETEQUERIESARB)(GLsizei  n, const GLuint * ids);
+// typedef void  (APIENTRYP GPDELETEQUERYRESOURCETAGNV)(GLsizei  n, const GLint * tagIds);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERSEXT)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
+// typedef void  (APIENTRYP GPDELETESEMAPHORESEXT)(GLsizei  n, const GLuint * semaphores);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETEXTURESEXT)(GLsizei  n, const GLuint * textures);
@@ -582,6 +601,10 @@ package gl
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSARB)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSATI)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYAPPLE)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYATI)(GLenum  mode, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
@@ -606,6 +629,7 @@ package gl
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKNV)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
 // typedef void  (APIENTRYP GPEDGEFLAG)(GLboolean  flag);
 // typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPEDGEFLAGPOINTER)(GLsizei  stride, const void * pointer);
@@ -661,6 +685,7 @@ package gl
 // typedef void  (APIENTRYP GPEVALMESH2)(GLenum  mode, GLint  i1, GLint  i2, GLint  j1, GLint  j2);
 // typedef void  (APIENTRYP GPEVALPOINT1)(GLint  i);
 // typedef void  (APIENTRYP GPEVALPOINT2)(GLint  i, GLint  j);
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef void  (APIENTRYP GPEXECUTEPROGRAMNV)(GLenum  target, GLuint  id, const GLfloat * params);
 // typedef void  (APIENTRYP GPEXTRACTCOMPONENTEXT)(GLuint  res, GLuint  src, GLuint  num);
 // typedef void  (APIENTRYP GPFEEDBACKBUFFER)(GLsizei  size, GLenum  type, GLfloat * buffer);
@@ -676,7 +701,7 @@ package gl
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGEAPPLE)(GLenum  target, GLintptr  offset, GLsizeiptr  size);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHPIXELDATARANGENV)(GLenum  target);
 // typedef void  (APIENTRYP GPFLUSHRASTERSGIX)();
@@ -705,6 +730,7 @@ package gl
 // typedef void  (APIENTRYP GPFOGXOES)(GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPFOGXVOES)(GLenum  pname, const GLfixed * param);
 // typedef void  (APIENTRYP GPFRAGMENTCOLORMATERIALSGIX)(GLenum  face, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELISGIX)(GLenum  pname, GLint  param);
@@ -721,10 +747,14 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEZOOMSGIX)(GLint  factor);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFEREXT)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1DEXT)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -739,6 +769,7 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYEREXT)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFREEOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPFRUSTUM)(GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
@@ -763,9 +794,11 @@ package gl
 // typedef void  (APIENTRYP GPGENPROGRAMSNV)(GLsizei  n, GLuint * programs);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENQUERIESARB)(GLsizei  n, GLuint * ids);
+// typedef void  (APIENTRYP GPGENQUERYRESOURCETAGNV)(GLsizei  n, GLint * tagIds);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERSEXT)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
+// typedef void  (APIENTRYP GPGENSEMAPHORESEXT)(GLsizei  n, GLuint * semaphores);
 // typedef GLuint  (APIENTRYP GPGENSYMBOLSEXT)(GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components);
 // typedef void  (APIENTRYP GPGENTEXTURES)(GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPGENTEXTURESEXT)(GLsizei  n, GLuint * textures);
@@ -826,6 +859,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERFVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERIVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, GLfloat * params);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  level, void * img);
@@ -839,6 +873,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIVEXT)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERXVOES)(GLenum  target, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGAMD)(GLuint  count, GLsizei  bufsize, GLenum * categories, GLuint * severities, GLuint * ids, GLsizei * lengths, GLchar * message);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
@@ -868,6 +903,7 @@ package gl
 // typedef void  (APIENTRYP GPGETFRAGMENTMATERIALIVSGIX)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERFVAMD)(GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
@@ -894,6 +930,7 @@ package gl
 // typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -921,6 +958,7 @@ package gl
 // typedef void  (APIENTRYP GPGETMATERIALIV)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMATERIALXOES)(GLenum  face, GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPGETMATERIALXVOES)(GLenum  face, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMINMAX)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXEXT)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
@@ -947,10 +985,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
@@ -996,7 +1035,7 @@ package gl
 // typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
-// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
 // typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
 // typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
 // typedef void  (APIENTRYP GPGETPIXELMAPFV)(GLenum  map, GLfloat * values);
@@ -1045,6 +1084,10 @@ package gl
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVARB)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVNV)(GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64VEXT)(GLuint  id, GLenum  pname, GLint64 * params);
@@ -1062,6 +1105,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIUIV)(GLuint  sampler, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERFV)(GLuint  sampler, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIV)(GLuint  sampler, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTER)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTEREXT)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSHADERINFOLOG)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
@@ -1070,6 +1114,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERSOURCEARB)(GLhandleARB  obj, GLsizei  maxLength, GLsizei * length, GLcharARB * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETSHARPENTEXFUNCSGIS)(GLenum  target, GLfloat * points);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -1133,12 +1178,16 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFVARB)(GLhandleARB  programObj, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIVARB)(GLhandleARB  programObj, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIVEXT)(GLuint  program, GLint  location, GLuint * params);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEI_VEXT)(GLenum  target, GLuint  index, GLubyte * data);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEVEXT)(GLenum  pname, GLubyte * data);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTFVATI)(GLuint  id, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTIVATI)(GLuint  id, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -1184,6 +1233,7 @@ package gl
 // typedef void  (APIENTRYP GPGETVIDEOIVNV)(GLuint  video_slot, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVIDEOUI64VNV)(GLuint  video_slot, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVIDEOUIVNV)(GLuint  video_slot, GLenum  pname, GLuint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOLORTABLEARB)(GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNCONVOLUTIONFILTERARB)(GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * image);
@@ -1202,9 +1252,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
@@ -1225,6 +1277,12 @@ package gl
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERFVHP)(GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIHP)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIVHP)(GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPIMPORTMEMORYFDEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32HANDLEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32NAMEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, const void * name);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREFDEXT)(GLuint  semaphore, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32HANDLEEXT)(GLuint  semaphore, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32NAMEEXT)(GLuint  semaphore, GLenum  handleType, const void * name);
 // typedef GLsync  (APIENTRYP GPIMPORTSYNCEXT)(GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags);
 // typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPINDEXFUNCEXT)(GLenum  func, GLclampf  ref);
@@ -1263,6 +1321,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERARB)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
 // typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
@@ -1273,6 +1332,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISLIST)(GLuint  list);
+// typedef GLboolean  (APIENTRYP GPISMEMORYOBJECTEXT)(GLuint  memoryObject);
 // typedef GLboolean  (APIENTRYP GPISNAMEAMD)(GLenum  identifier, GLuint  name);
 // typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
@@ -1291,7 +1351,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFEREXT)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
+// typedef GLboolean  (APIENTRYP GPISSEMAPHOREEXT)(GLuint  semaphore);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREEXT)(GLuint  texture);
@@ -1303,6 +1365,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAYAPPLE)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXATTRIBENABLEDAPPLE)(GLuint  index, GLenum  pname);
+// typedef void  (APIENTRYP GPLGPUCOPYIMAGESUBDATANVX)(GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPLGPUINTERLOCKNVX)();
+// typedef void  (APIENTRYP GPLGPUNAMEDBUFFERSUBDATANVX)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLIGHTENVISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPLIGHTMODELF)(GLenum  pname, GLfloat  param);
@@ -1323,6 +1388,7 @@ package gl
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPLINKPROGRAMARB)(GLhandleARB  programObj);
 // typedef void  (APIENTRYP GPLISTBASE)(GLuint  base);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLISTPARAMETERFSGIX)(GLuint  list, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPLISTPARAMETERFVSGIX)(GLuint  list, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPLISTPARAMETERISGIX)(GLuint  list, GLenum  pname, GLint  param);
@@ -1371,7 +1437,7 @@ package gl
 // typedef void  (APIENTRYP GPMAPGRID2XOES)(GLint  n, GLfixed  u1, GLfixed  u2, GLfixed  v1, GLfixed  v2);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPMAPPARAMETERFVNV)(GLenum  target, GLenum  pname, const GLfloat * params);
@@ -1417,9 +1483,12 @@ package gl
 // typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIEREXT)(GLbitfield  barriers);
+// typedef void  (APIENTRYP GPMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPMINSAMPLESHADING)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINMAX)(GLenum  target, GLenum  internalformat, GLboolean  sink);
@@ -1438,7 +1507,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTAMD)(GLenum  mode, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTARRAYAPPLE)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
@@ -1447,7 +1516,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTAMD)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWRANGEELEMENTARRAYAPPLE)(GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWARRAYSIBM)(const GLenum * mode, const GLint * first, const GLsizei * count, GLsizei  primcount, GLint  modestride);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWELEMENTSIBM)(const GLenum * mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  primcount, GLint  modestride);
@@ -1572,13 +1641,26 @@ package gl
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPMULTICASTBARRIERNV)();
+// typedef void  (APIENTRYP GPMULTICASTBLITFRAMEBUFFERNV)(GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPMULTICASTBUFFERSUBDATANV)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPMULTICASTCOPYBUFFERSUBDATANV)(GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPMULTICASTCOPYIMAGESUBDATANV)(GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
+// typedef void  (APIENTRYP GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPMULTICASTWAITSYNCNV)(GLuint  signalGpu, GLbitfield  waitGpuMask);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXTERNALEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEMEMEXT)(GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
@@ -1588,6 +1670,9 @@ package gl
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -1731,6 +1816,8 @@ package gl
 // typedef GLint  (APIENTRYP GPPOLLINSTRUMENTSSGIX)(GLint * marker_p);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETEXT)(GLfloat  factor, GLfloat  bias);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETXOES)(GLfixed  factor, GLfixed  units);
 // typedef void  (APIENTRYP GPPOLYGONSTIPPLE)(const GLubyte * mask);
@@ -1743,6 +1830,7 @@ package gl
 // typedef void  (APIENTRYP GPPOPNAME)();
 // typedef void  (APIENTRYP GPPRESENTFRAMEDUALFILLNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLenum  target1, GLuint  fill1, GLenum  target2, GLuint  fill2, GLenum  target3, GLuint  fill3);
 // typedef void  (APIENTRYP GPPRESENTFRAMEKEYEDNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1);
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEXNV)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTNV)();
@@ -1800,13 +1888,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1820,13 +1912,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1840,13 +1936,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1860,13 +1960,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1927,6 +2031,8 @@ package gl
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
 // typedef GLbitfield  (APIENTRYP GPQUERYMATRIXXOES)(GLfixed * mantissa, GLint * exponent);
 // typedef void  (APIENTRYP GPQUERYOBJECTPARAMETERUIAMD)(GLenum  target, GLuint  id, GLenum  pname, GLuint  param);
+// typedef GLint  (APIENTRYP GPQUERYRESOURCENV)(GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer);
+// typedef void  (APIENTRYP GPQUERYRESOURCETAGNV)(GLint  tagId, const GLchar * tagString);
 // typedef void  (APIENTRYP GPRASTERPOS2D)(GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPRASTERPOS2DV)(const GLdouble * v);
 // typedef void  (APIENTRYP GPRASTERPOS2F)(GLfloat  x, GLfloat  y);
@@ -1957,6 +2063,7 @@ package gl
 // typedef void  (APIENTRYP GPRASTERPOS4SV)(const GLshort * v);
 // typedef void  (APIENTRYP GPRASTERPOS4XOES)(GLfixed  x, GLfixed  y, GLfixed  z, GLfixed  w);
 // typedef void  (APIENTRYP GPRASTERPOS4XVOES)(const GLfixed * coords);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
@@ -1974,7 +2081,9 @@ package gl
 // typedef void  (APIENTRYP GPRECTXOES)(GLfixed  x1, GLfixed  y1, GLfixed  x2, GLfixed  y2);
 // typedef void  (APIENTRYP GPRECTXVOES)(const GLfixed * v1, const GLfixed * v2);
 // typedef void  (APIENTRYP GPREFERENCEPLANESGIX)(const GLdouble * equation);
+// typedef GLboolean  (APIENTRYP GPRELEASEKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key);
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
+// typedef void  (APIENTRYP GPRENDERGPUMASKNV)(GLbitfield  mask);
 // typedef GLint  (APIENTRYP GPRENDERMODE)(GLenum  mode);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
@@ -2010,6 +2119,7 @@ package gl
 // typedef void  (APIENTRYP GPRESETMINMAX)(GLenum  target);
 // typedef void  (APIENTRYP GPRESETMINMAXEXT)(GLenum  target);
 // typedef void  (APIENTRYP GPRESIZEBUFFERSMESA)();
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACKNV)();
 // typedef void  (APIENTRYP GPROTATED)(GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
@@ -2017,7 +2127,6 @@ package gl
 // typedef void  (APIENTRYP GPROTATEXOES)(GLfixed  angle, GLfixed  x, GLfixed  y, GLfixed  z);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEARB)(GLfloat  value, GLboolean  invert);
-// typedef void  (APIENTRYP GPSAMPLECOVERAGEOES)(GLfixed  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEXOES)(GLclampx  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMAPATI)(GLuint  dst, GLuint  interp, GLenum  swizzle);
 // typedef void  (APIENTRYP GPSAMPLEMASKEXT)(GLclampf  value, GLboolean  invert);
@@ -2081,6 +2190,7 @@ package gl
 // typedef void  (APIENTRYP GPSECONDARYCOLORPOINTERLISTIBM)(GLint  size, GLenum  type, GLint  stride, const void ** pointer, GLint  ptrstride);
 // typedef void  (APIENTRYP GPSELECTBUFFER)(GLsizei  size, GLuint * buffer);
 // typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
+// typedef void  (APIENTRYP GPSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, const GLuint64 * params);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSETFENCEAPPLE)(GLuint  fence);
@@ -2098,11 +2208,16 @@ package gl
 // typedef void  (APIENTRYP GPSHADERSOURCEARB)(GLhandleARB  shaderObj, GLsizei  count, const GLcharARB ** string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
 // typedef void  (APIENTRYP GPSHARPENTEXFUNCSGIS)(GLenum  target, GLsizei  n, const GLfloat * points);
+// typedef void  (APIENTRYP GPSIGNALSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERIVSGIX)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPSTARTINSTRUMENTSSGIX)();
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
 // typedef void  (APIENTRYP GPSTENCILCLEARTAGEXT)(GLsizei  stencilTagBits, GLuint  stencilClearTag);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
@@ -2123,6 +2238,7 @@ package gl
 // typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
 // typedef void  (APIENTRYP GPSTOPINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPSTRINGMARKERGREMEDY)(GLsizei  len, const void * string);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPSWIZZLEEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // typedef void  (APIENTRYP GPSYNCTEXTUREINTEL)(GLuint  texture);
 // typedef void  (APIENTRYP GPTAGSAMPLEBUFFERSGIX)();
@@ -2256,7 +2372,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLint  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations);
 // typedef void  (APIENTRYP GPTEXIMAGE4DSGIS)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIVEXT)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
@@ -2273,6 +2389,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXSTORAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXSTORAGE3D)(GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXSTORAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM1DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXSTORAGESPARSEAMD)(GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1DEXT)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2285,7 +2406,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTURECOLORMASKSGIS)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
@@ -2298,7 +2419,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURELIGHTEXT)(GLenum  pname);
 // typedef void  (APIENTRYP GPTEXTUREMATERIALEXT)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPTEXTURENORMALEXT)(GLenum  mode);
-// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
@@ -2323,6 +2444,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM1DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXTURESTORAGESPARSEAMD)(GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2334,7 +2460,7 @@ package gl
 // typedef void  (APIENTRYP GPTRACKMATRIXNV)(GLenum  target, GLuint  address, GLenum  matrix, GLenum  transform);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKATTRIBSNV)(GLsizei  count, const GLint * attribs, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKSTREAMATTRIBSNV)(GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGSEXT)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
@@ -2350,13 +2476,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IARB)(GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIEXT)(GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2368,13 +2498,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IARB)(GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIEXT)(GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2386,13 +2520,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2404,13 +2542,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2837,7 +2979,11 @@ package gl
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
+// typedef void  (APIENTRYP GPWAITSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
 // typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
 // typedef void  (APIENTRYP GPWEIGHTPOINTERARB)(GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPWEIGHTBVARB)(GLint  size, const GLbyte * weights);
@@ -2904,12 +3050,16 @@ package gl
 // typedef void  (APIENTRYP GPWINDOWPOS4IVMESA)(const GLint * v);
 // typedef void  (APIENTRYP GPWINDOWPOS4SMESA)(GLshort  x, GLshort  y, GLshort  z, GLshort  w);
 // typedef void  (APIENTRYP GPWINDOWPOS4SVMESA)(const GLshort * v);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
 // typedef void  (APIENTRYP GPWRITEMASKEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // static void  glowAccum(GPACCUM fnptr, GLenum  op, GLfloat  value) {
 //   (*fnptr)(op, value);
 // }
 // static void  glowAccumxOES(GPACCUMXOES fnptr, GLenum  op, GLfixed  value) {
 //   (*fnptr)(op, value);
+// }
+// static GLboolean  glowAcquireKeyedMutexWin32EXT(GPACQUIREKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key, GLuint  timeout) {
+//   return (*fnptr)(memory, key, timeout);
 // }
 // static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
 //   (*fnptr)(program);
@@ -2946,6 +3096,12 @@ package gl
 // }
 // static void  glowAlphaFuncxOES(GPALPHAFUNCXOES fnptr, GLenum  func, GLfixed  ref) {
 //   (*fnptr)(func, ref);
+// }
+// static void  glowAlphaToCoverageDitherControlNV(GPALPHATOCOVERAGEDITHERCONTROLNV fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowApplyTextureEXT(GPAPPLYTEXTUREEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -3310,7 +3466,7 @@ package gl
 // static void  glowBufferDataARB(GPBUFFERDATAARB fnptr, GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferParameteriAPPLE(GPBUFFERPARAMETERIAPPLE fnptr, GLenum  target, GLenum  pname, GLint  param) {
@@ -3319,11 +3475,20 @@ package gl
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(target, size, data, flags);
 // }
+// static void  glowBufferStorageExternalEXT(GPBUFFERSTORAGEEXTERNALEXT fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(target, offset, size, clientBuffer, flags);
+// }
+// static void  glowBufferStorageMemEXT(GPBUFFERSTORAGEMEMEXT fnptr, GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, size, memory, offset);
+// }
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
 // static void  glowBufferSubDataARB(GPBUFFERSUBDATAARB fnptr, GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
 // }
 // static void  glowCallList(GPCALLLIST fnptr, GLuint  list) {
 //   (*fnptr)(list);
@@ -3412,14 +3577,14 @@ package gl
 // static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
 // static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -3706,6 +3871,12 @@ package gl
 // static void  glowCombinerStageParameterfvNV(GPCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, const GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
@@ -3795,6 +3966,12 @@ package gl
 // }
 // static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
 //   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowConvolutionFilter1D(GPCONVOLUTIONFILTER1D fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image) {
 //   (*fnptr)(target, internalformat, width, format, type, image);
@@ -3886,7 +4063,7 @@ package gl
 // static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
@@ -3961,11 +4138,23 @@ package gl
 // static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
 //   (*fnptr)(path, coverMode);
 // }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
+// }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreateMemoryObjectsEXT(GPCREATEMEMORYOBJECTSEXT fnptr, GLsizei  n, GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
 //   (*fnptr)(queryId, queryHandle);
@@ -4002,6 +4191,9 @@ package gl
 // }
 // static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -4081,6 +4273,9 @@ package gl
 // static void  glowDeleteBuffersARB(GPDELETEBUFFERSARB fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFencesAPPLE(GPDELETEFENCESAPPLE fnptr, GLsizei  n, const GLuint * fences) {
 //   (*fnptr)(n, fences);
 // }
@@ -4098,6 +4293,9 @@ package gl
 // }
 // static void  glowDeleteLists(GPDELETELISTS fnptr, GLuint  list, GLsizei  range) {
 //   (*fnptr)(list, range);
+// }
+// static void  glowDeleteMemoryObjectsEXT(GPDELETEMEMORYOBJECTSEXT fnptr, GLsizei  n, const GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
@@ -4141,6 +4339,9 @@ package gl
 // static void  glowDeleteQueriesARB(GPDELETEQUERIESARB fnptr, GLsizei  n, const GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowDeleteQueryResourceTagNV(GPDELETEQUERYRESOURCETAGNV fnptr, GLsizei  n, const GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowDeleteRenderbuffers(GPDELETERENDERBUFFERS fnptr, GLsizei  n, const GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4150,8 +4351,14 @@ package gl
 // static void  glowDeleteSamplers(GPDELETESAMPLERS fnptr, GLsizei  count, const GLuint * samplers) {
 //   (*fnptr)(count, samplers);
 // }
+// static void  glowDeleteSemaphoresEXT(GPDELETESEMAPHORESEXT fnptr, GLsizei  n, const GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
+// }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -4300,6 +4507,18 @@ package gl
 // static void  glowDrawBuffersATI(GPDRAWBUFFERSATI fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
 // }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
+// }
 // static void  glowDrawElementArrayAPPLE(GPDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, GLint  first, GLsizei  count) {
 //   (*fnptr)(mode, first, count);
 // }
@@ -4371,6 +4590,9 @@ package gl
 // }
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
+// }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
 // }
 // static void  glowEdgeFlag(GPEDGEFLAG fnptr, GLboolean  flag) {
 //   (*fnptr)(flag);
@@ -4537,6 +4759,9 @@ package gl
 // static void  glowEvalPoint2(GPEVALPOINT2 fnptr, GLint  i, GLint  j) {
 //   (*fnptr)(i, j);
 // }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowExecuteProgramNV(GPEXECUTEPROGRAMNV fnptr, GLenum  target, GLuint  id, const GLfloat * params) {
 //   (*fnptr)(target, id, params);
 // }
@@ -4582,7 +4807,7 @@ package gl
 // static void  glowFlushMappedBufferRangeAPPLE(GPFLUSHMAPPEDBUFFERRANGEAPPLE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, offset, size);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
 // }
 // static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
@@ -4669,6 +4894,9 @@ package gl
 // static void  glowFragmentColorMaterialSGIX(GPFRAGMENTCOLORMATERIALSGIX fnptr, GLenum  face, GLenum  mode) {
 //   (*fnptr)(face, mode);
 // }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
 // static void  glowFragmentLightModelfSGIX(GPFRAGMENTLIGHTMODELFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -4717,6 +4945,9 @@ package gl
 // static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(framebuffer, n, bufs);
 // }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
@@ -4728,6 +4959,15 @@ package gl
 // }
 // static void  glowFramebufferRenderbufferEXT(GPFRAMEBUFFERRENDERBUFFEREXT fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSamplePositionsfvAMD(GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(target, numsamples, pixelindex, values);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -4770,6 +5010,9 @@ package gl
 // }
 // static void  glowFramebufferTextureLayerEXT(GPFRAMEBUFFERTEXTURELAYEREXT fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFreeObjectBufferATI(GPFREEOBJECTBUFFERATI fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -4843,6 +5086,9 @@ package gl
 // static void  glowGenQueriesARB(GPGENQUERIESARB fnptr, GLsizei  n, GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowGenQueryResourceTagNV(GPGENQUERYRESOURCETAGNV fnptr, GLsizei  n, GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowGenRenderbuffers(GPGENRENDERBUFFERS fnptr, GLsizei  n, GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4851,6 +5097,9 @@ package gl
 // }
 // static void  glowGenSamplers(GPGENSAMPLERS fnptr, GLsizei  count, GLuint * samplers) {
 //   (*fnptr)(count, samplers);
+// }
+// static void  glowGenSemaphoresEXT(GPGENSEMAPHORESEXT fnptr, GLsizei  n, GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
 // }
 // static GLuint  glowGenSymbolsEXT(GPGENSYMBOLSEXT fnptr, GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components) {
 //   return (*fnptr)(datatype, storagetype, range, components);
@@ -5032,6 +5281,9 @@ package gl
 // static void  glowGetCombinerStageParameterfvNV(GPGETCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
 // static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
 //   (*fnptr)(texunit, target, lod, img);
 // }
@@ -5070,6 +5322,9 @@ package gl
 // }
 // static void  glowGetConvolutionParameterxvOES(GPGETCONVOLUTIONPARAMETERXVOES fnptr, GLenum  target, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -5158,6 +5413,9 @@ package gl
 // static void  glowGetFramebufferAttachmentParameterivEXT(GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLenum  target, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, attachment, pname, params);
 // }
+// static void  glowGetFramebufferParameterfvAMD(GPGETFRAMEBUFFERPARAMETERFVAMD fnptr, GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(target, pname, numsamples, pixelindex, size, values);
+// }
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
@@ -5235,6 +5493,9 @@ package gl
 // }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
@@ -5317,6 +5578,9 @@ package gl
 // static void  glowGetMaterialxvOES(GPGETMATERIALXVOES fnptr, GLenum  face, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(face, pname, params);
 // }
+// static void  glowGetMemoryObjectParameterivEXT(GPGETMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
+// }
 // static void  glowGetMinmax(GPGETMINMAX fnptr, GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values) {
 //   (*fnptr)(target, reset, format, type, values);
 // }
@@ -5395,7 +5659,7 @@ package gl
 // static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
@@ -5406,6 +5670,9 @@ package gl
 // }
 // static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
+// }
+// static void  glowGetNamedFramebufferParameterfvAMD(GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD fnptr, GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(framebuffer, pname, numsamples, pixelindex, size, values);
 // }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
@@ -5542,7 +5809,7 @@ package gl
 // static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
 //   (*fnptr)(numGroups, groupsSize, groups);
 // }
-// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten) {
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
 //   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
 // }
 // static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
@@ -5689,6 +5956,18 @@ package gl
 // static void  glowGetProgramivNV(GPGETPROGRAMIVNV fnptr, GLuint  id, GLenum  pname, GLint * params) {
 //   (*fnptr)(id, pname, params);
 // }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
 // }
@@ -5740,6 +6019,9 @@ package gl
 // static void  glowGetSamplerParameteriv(GPGETSAMPLERPARAMETERIV fnptr, GLuint  sampler, GLenum  pname, GLint * params) {
 //   (*fnptr)(sampler, pname, params);
 // }
+// static void  glowGetSemaphoreParameterui64vEXT(GPGETSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowGetSeparableFilter(GPGETSEPARABLEFILTER fnptr, GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span) {
 //   (*fnptr)(target, format, type, row, column, span);
 // }
@@ -5763,6 +6045,9 @@ package gl
 // }
 // static void  glowGetSharpenTexFuncSGIS(GPGETSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLfloat * points) {
 //   (*fnptr)(target, points);
+// }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
 // }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
@@ -5953,6 +6238,9 @@ package gl
 // static void  glowGetUniformfvARB(GPGETUNIFORMFVARB fnptr, GLhandleARB  programObj, GLint  location, GLfloat * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5962,6 +6250,9 @@ package gl
 // static void  glowGetUniformivARB(GPGETUNIFORMIVARB fnptr, GLhandleARB  programObj, GLint  location, GLint * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5970,6 +6261,12 @@ package gl
 // }
 // static void  glowGetUniformuivEXT(GPGETUNIFORMUIVEXT fnptr, GLuint  program, GLint  location, GLuint * params) {
 //   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUnsignedBytei_vEXT(GPGETUNSIGNEDBYTEI_VEXT fnptr, GLenum  target, GLuint  index, GLubyte * data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetUnsignedBytevEXT(GPGETUNSIGNEDBYTEVEXT fnptr, GLenum  pname, GLubyte * data) {
+//   (*fnptr)(pname, data);
 // }
 // static void  glowGetVariantArrayObjectfvATI(GPGETVARIANTARRAYOBJECTFVATI fnptr, GLuint  id, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(id, pname, params);
@@ -6106,6 +6403,9 @@ package gl
 // static void  glowGetVideouivNV(GPGETVIDEOUIVNV fnptr, GLuint  video_slot, GLenum  pname, GLuint * params) {
 //   (*fnptr)(video_slot, pname, params);
 // }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
+// }
 // static void  glowGetnColorTableARB(GPGETNCOLORTABLEARB fnptr, GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table) {
 //   (*fnptr)(target, format, type, bufSize, table);
 // }
@@ -6160,6 +6460,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -6167,6 +6470,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -6228,6 +6534,24 @@ package gl
 // }
 // static void  glowImageTransformParameterivHP(GPIMAGETRANSFORMPARAMETERIVHP fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowImportMemoryFdEXT(GPIMPORTMEMORYFDEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(memory, size, handleType, fd);
+// }
+// static void  glowImportMemoryWin32HandleEXT(GPIMPORTMEMORYWIN32HANDLEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, void * handle) {
+//   (*fnptr)(memory, size, handleType, handle);
+// }
+// static void  glowImportMemoryWin32NameEXT(GPIMPORTMEMORYWIN32NAMEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, const void * name) {
+//   (*fnptr)(memory, size, handleType, name);
+// }
+// static void  glowImportSemaphoreFdEXT(GPIMPORTSEMAPHOREFDEXT fnptr, GLuint  semaphore, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(semaphore, handleType, fd);
+// }
+// static void  glowImportSemaphoreWin32HandleEXT(GPIMPORTSEMAPHOREWIN32HANDLEEXT fnptr, GLuint  semaphore, GLenum  handleType, void * handle) {
+//   (*fnptr)(semaphore, handleType, handle);
+// }
+// static void  glowImportSemaphoreWin32NameEXT(GPIMPORTSEMAPHOREWIN32NAMEEXT fnptr, GLuint  semaphore, GLenum  handleType, const void * name) {
+//   (*fnptr)(semaphore, handleType, name);
 // }
 // static GLsync  glowImportSyncEXT(GPIMPORTSYNCEXT fnptr, GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags) {
 //   return (*fnptr)(external_sync_type, external_sync, flags);
@@ -6343,6 +6667,9 @@ package gl
 // static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
 // }
@@ -6372,6 +6699,9 @@ package gl
 // }
 // static GLboolean  glowIsList(GPISLIST fnptr, GLuint  list) {
 //   return (*fnptr)(list);
+// }
+// static GLboolean  glowIsMemoryObjectEXT(GPISMEMORYOBJECTEXT fnptr, GLuint  memoryObject) {
+//   return (*fnptr)(memoryObject);
 // }
 // static GLboolean  glowIsNameAMD(GPISNAMEAMD fnptr, GLenum  identifier, GLuint  name) {
 //   return (*fnptr)(identifier, name);
@@ -6427,8 +6757,14 @@ package gl
 // static GLboolean  glowIsSampler(GPISSAMPLER fnptr, GLuint  sampler) {
 //   return (*fnptr)(sampler);
 // }
+// static GLboolean  glowIsSemaphoreEXT(GPISSEMAPHOREEXT fnptr, GLuint  semaphore) {
+//   return (*fnptr)(semaphore);
+// }
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
+// }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
 // }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
@@ -6462,6 +6798,15 @@ package gl
 // }
 // static GLboolean  glowIsVertexAttribEnabledAPPLE(GPISVERTEXATTRIBENABLEDAPPLE fnptr, GLuint  index, GLenum  pname) {
 //   return (*fnptr)(index, pname);
+// }
+// static void  glowLGPUCopyImageSubDataNVX(GPLGPUCOPYIMAGESUBDATANVX fnptr, GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(sourceGpu, destinationGpuMask, srcName, srcTarget, srcLevel, srcX, srxY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, width, height, depth);
+// }
+// static void  glowLGPUInterlockNVX(GPLGPUINTERLOCKNVX fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowLGPUNamedBufferSubDataNVX(GPLGPUNAMEDBUFFERSUBDATANVX fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
 // }
 // static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(type, object, length, label);
@@ -6522,6 +6867,9 @@ package gl
 // }
 // static void  glowListBase(GPLISTBASE fnptr, GLuint  base) {
 //   (*fnptr)(base);
+// }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
 // }
 // static void  glowListParameterfSGIX(GPLISTPARAMETERFSGIX fnptr, GLuint  list, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(list, pname, param);
@@ -6667,7 +7015,7 @@ package gl
 // static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
 // }
 // static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
@@ -6805,6 +7153,12 @@ package gl
 // static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
 //   (*fnptr)(mode, x, y, z);
 // }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
 // }
@@ -6813,6 +7167,9 @@ package gl
 // }
 // static void  glowMemoryBarrierEXT(GPMEMORYBARRIEREXT fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
+// }
+// static void  glowMemoryObjectParameterivEXT(GPMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, const GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
 // }
 // static void  glowMinSampleShading(GPMINSAMPLESHADING fnptr, GLfloat  value) {
 //   (*fnptr)(value);
@@ -6868,7 +7225,7 @@ package gl
 // static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElementArrayAPPLE(GPMULTIDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -6895,7 +7252,7 @@ package gl
 // static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawRangeElementArrayAPPLE(GPMULTIDRAWRANGEELEMENTARRAYAPPLE fnptr, GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -7270,25 +7627,64 @@ package gl
 // static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMulticastBarrierNV(GPMULTICASTBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowMulticastBlitFramebufferNV(GPMULTICASTBLITFRAMEBUFFERNV fnptr, GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
+//   (*fnptr)(srcGpu, dstGpu, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+// }
+// static void  glowMulticastBufferSubDataNV(GPMULTICASTBUFFERSUBDATANV fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
+// }
+// static void  glowMulticastCopyBufferSubDataNV(GPMULTICASTCOPYBUFFERSUBDATANV fnptr, GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readGpu, writeGpuMask, readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowMulticastCopyImageSubDataNV(GPMULTICASTCOPYIMAGESUBDATANV fnptr, GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
+//   (*fnptr)(srcGpu, dstGpuMask, srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
+// }
+// static void  glowMulticastFramebufferSampleLocationsfvNV(GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(gpu, framebuffer, start, count, v);
+// }
+// static void  glowMulticastGetQueryObjecti64vNV(GPMULTICASTGETQUERYOBJECTI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectivNV(GPMULTICASTGETQUERYOBJECTIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectui64vNV(GPMULTICASTGETQUERYOBJECTUI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectuivNV(GPMULTICASTGETQUERYOBJECTUIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastWaitSyncNV(GPMULTICASTWAITSYNCNV fnptr, GLuint  signalGpu, GLbitfield  waitGpuMask) {
+//   (*fnptr)(signalGpu, waitGpuMask);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
 // static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
 // static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageExternalEXT(GPNAMEDBUFFERSTORAGEEXTERNALEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(buffer, offset, size, clientBuffer, flags);
+// }
+// static void  glowNamedBufferStorageMemEXT(GPNAMEDBUFFERSTORAGEMEMEXT fnptr, GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(buffer, size, memory, offset);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
@@ -7317,6 +7713,15 @@ package gl
 // }
 // static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSamplePositionsfvAMD(GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(framebuffer, numsamples, pixelindex, values);
 // }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
@@ -7747,6 +8152,12 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPolygonOffsetEXT(GPPOLYGONOFFSETEXT fnptr, GLfloat  factor, GLfloat  bias) {
 //   (*fnptr)(factor, bias);
 // }
@@ -7782,6 +8193,9 @@ package gl
 // }
 // static void  glowPresentFrameKeyedNV(GPPRESENTFRAMEKEYEDNV fnptr, GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1) {
 //   (*fnptr)(video_slot, minPresentTime, beginPresentTimeId, presentDurationId, type, target0, fill0, key0, target1, fill1, key1);
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -7954,8 +8368,14 @@ package gl
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -7972,8 +8392,14 @@ package gl
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8014,8 +8440,14 @@ package gl
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8032,8 +8464,14 @@ package gl
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8074,8 +8512,14 @@ package gl
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8092,8 +8536,14 @@ package gl
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8134,8 +8584,14 @@ package gl
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8152,8 +8608,14 @@ package gl
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8335,6 +8797,12 @@ package gl
 // static void  glowQueryObjectParameteruiAMD(GPQUERYOBJECTPARAMETERUIAMD fnptr, GLenum  target, GLuint  id, GLenum  pname, GLuint  param) {
 //   (*fnptr)(target, id, pname, param);
 // }
+// static GLint  glowQueryResourceNV(GPQUERYRESOURCENV fnptr, GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer) {
+//   return (*fnptr)(queryType, tagId, bufSize, buffer);
+// }
+// static void  glowQueryResourceTagNV(GPQUERYRESOURCETAGNV fnptr, GLint  tagId, const GLchar * tagString) {
+//   (*fnptr)(tagId, tagString);
+// }
 // static void  glowRasterPos2d(GPRASTERPOS2D fnptr, GLdouble  x, GLdouble  y) {
 //   (*fnptr)(x, y);
 // }
@@ -8425,6 +8893,9 @@ package gl
 // static void  glowRasterPos4xvOES(GPRASTERPOS4XVOES fnptr, const GLfixed * coords) {
 //   (*fnptr)(coords);
 // }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
+// }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
 // }
@@ -8476,8 +8947,14 @@ package gl
 // static void  glowReferencePlaneSGIX(GPREFERENCEPLANESGIX fnptr, const GLdouble * equation) {
 //   (*fnptr)(equation);
 // }
+// static GLboolean  glowReleaseKeyedMutexWin32EXT(GPRELEASEKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key) {
+//   return (*fnptr)(memory, key);
+// }
 // static void  glowReleaseShaderCompiler(GPRELEASESHADERCOMPILER fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowRenderGpuMaskNV(GPRENDERGPUMASKNV fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static GLint  glowRenderMode(GPRENDERMODE fnptr, GLenum  mode) {
 //   return (*fnptr)(mode);
@@ -8584,6 +9061,9 @@ package gl
 // static void  glowResizeBuffersMESA(GPRESIZEBUFFERSMESA fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -8603,9 +9083,6 @@ package gl
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoverageARB(GPSAMPLECOVERAGEARB fnptr, GLfloat  value, GLboolean  invert) {
-//   (*fnptr)(value, invert);
-// }
-// static void  glowSampleCoverageOES(GPSAMPLECOVERAGEOES fnptr, GLfixed  value, GLboolean  invert) {
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoveragexOES(GPSAMPLECOVERAGEXOES fnptr, GLclampx  value, GLboolean  invert) {
@@ -8797,6 +9274,9 @@ package gl
 // static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
 //   (*fnptr)(monitor, enable, group, numCounters, counterList);
 // }
+// static void  glowSemaphoreParameterui64vEXT(GPSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, const GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowSeparableFilter2D(GPSEPARABLEFILTER2D fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column) {
 //   (*fnptr)(target, internalformat, width, height, format, type, row, column);
 // }
@@ -8848,6 +9328,18 @@ package gl
 // static void  glowSharpenTexFuncSGIS(GPSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLsizei  n, const GLfloat * points) {
 //   (*fnptr)(target, n, points);
 // }
+// static void  glowSignalSemaphoreEXT(GPSIGNALSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, dstLayouts);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
 // static void  glowSpriteParameterfSGIX(GPSPRITEPARAMETERFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -8862,6 +9354,9 @@ package gl
 // }
 // static void  glowStartInstrumentsSGIX(GPSTARTINSTRUMENTSSGIX fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
 // }
 // static void  glowStencilClearTagEXT(GPSTENCILCLEARTAGEXT fnptr, GLsizei  stencilTagBits, GLuint  stencilClearTag) {
 //   (*fnptr)(stencilTagBits, stencilClearTag);
@@ -8922,6 +9417,9 @@ package gl
 // }
 // static void  glowStringMarkerGREMEDY(GPSTRINGMARKERGREMEDY fnptr, GLsizei  len, const void * string) {
 //   (*fnptr)(len, string);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
 // }
 // static void  glowSwizzleEXT(GPSWIZZLEEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
@@ -9322,8 +9820,8 @@ package gl
 // static void  glowTexImage4DSGIS(GPTEXIMAGE4DSGIS fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, height, depth, size4d, border, format, type, pixels);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -9373,6 +9871,21 @@ package gl
 // static void  glowTexStorage3DMultisample(GPTEXSTORAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTexStorageMem1DEXT(GPTEXSTORAGEMEM1DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTexStorageMem2DEXT(GPTEXSTORAGEMEM2DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTexStorageMem2DMultisampleEXT(GPTEXSTORAGEMEM2DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTexStorageMem3DEXT(GPTEXSTORAGEMEM3DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTexStorageMem3DMultisampleEXT(GPTEXSTORAGEMEM3DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTexStorageSparseAMD(GPTEXSTORAGESPARSEAMD fnptr, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9409,7 +9922,7 @@ package gl
 // static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, target, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
 // }
 // static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
@@ -9448,8 +9961,8 @@ package gl
 // static void  glowTextureNormalEXT(GPTEXTURENORMALEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
 // }
-// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
@@ -9523,6 +10036,21 @@ package gl
 // static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorageMem1DEXT(GPTEXTURESTORAGEMEM1DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTextureStorageMem2DEXT(GPTEXTURESTORAGEMEM2DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTextureStorageMem2DMultisampleEXT(GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTextureStorageMem3DEXT(GPTEXTURESTORAGEMEM3DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTextureStorageMem3DMultisampleEXT(GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTextureStorageSparseAMD(GPTEXTURESTORAGESPARSEAMD fnptr, GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(texture, target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9556,7 +10084,7 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackStreamAttribsNV(GPTRANSFORMFEEDBACKSTREAMATTRIBSNV fnptr, GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode) {
@@ -9604,8 +10132,14 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9622,8 +10156,14 @@ package gl
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9658,8 +10198,14 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9676,8 +10222,14 @@ package gl
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9712,8 +10264,14 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9730,8 +10288,14 @@ package gl
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9766,8 +10330,14 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9784,8 +10354,14 @@ package gl
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -11065,8 +11641,20 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
+// static void  glowWaitSemaphoreEXT(GPWAITSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, srcLayouts);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
 // }
 // static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
 //   (*fnptr)(resultPath, numPaths, paths, weights);
@@ -11266,6 +11854,9 @@ package gl
 // static void  glowWindowPos4svMESA(GPWINDOWPOS4SVMESA fnptr, const GLshort * v) {
 //   (*fnptr)(v);
 // }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
+// }
 // static void  glowWriteMaskEXT(GPWRITEMASKEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
 // }
@@ -11357,6 +11948,7 @@ const (
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_BARRIER_BITS_EXT                                       = 0xFFFFFFFF
 	ALL_COMPLETED_NV                                           = 0x84F2
+	ALL_PIXELS_AMD                                             = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
 	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALL_STATIC_DATA_IBM                                        = 103060
@@ -11391,11 +11983,16 @@ const (
 	ALPHA_MAX_SGIX                                             = 0x8321
 	ALPHA_MIN_CLAMP_INGR                                       = 0x8563
 	ALPHA_MIN_SGIX                                             = 0x8320
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALPHA_SCALE                                                = 0x0D1C
 	ALPHA_SNORM                                                = 0x9010
 	ALPHA_TEST                                                 = 0x0BC0
 	ALPHA_TEST_FUNC                                            = 0x0BC1
 	ALPHA_TEST_REF                                             = 0x0BC2
+	ALPHA_TO_COVERAGE_DITHER_DEFAULT_NV                        = 0x934D
+	ALPHA_TO_COVERAGE_DITHER_DISABLE_NV                        = 0x934F
+	ALPHA_TO_COVERAGE_DITHER_ENABLE_NV                         = 0x934E
+	ALPHA_TO_COVERAGE_DITHER_MODE_NV                           = 0x92BF
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	ALWAYS_FAST_HINT_PGI                                       = 0x1A20C
@@ -11441,6 +12038,7 @@ const (
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
 	ATTENUATION_EXT                                            = 0x834D
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	ATTRIB_ARRAY_POINTER_NV                                    = 0x8645
 	ATTRIB_ARRAY_SIZE_NV                                       = 0x8623
 	ATTRIB_ARRAY_STRIDE_NV                                     = 0x8624
@@ -11483,6 +12081,7 @@ const (
 	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
 	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_COLOR_EXT                                            = 0x8005
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
@@ -11660,10 +12259,26 @@ const (
 	COLOR_ATTACHMENT14_EXT                                     = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
 	COLOR_ATTACHMENT15_EXT                                     = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT1_EXT                                      = 0x8CE1
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT2_EXT                                      = 0x8CE2
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT3_EXT                                      = 0x8CE3
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT4_EXT                                      = 0x8CE4
@@ -11767,6 +12382,8 @@ const (
 	COMPILE                                                    = 0x1300
 	COMPILE_AND_EXECUTE                                        = 0x1301
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_ALPHA                                           = 0x84E9
 	COMPRESSED_ALPHA_ARB                                       = 0x84E9
 	COMPRESSED_INTENSITY                                       = 0x84EC
@@ -11870,8 +12487,18 @@ const (
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	COMP_BIT_ATI                                               = 0x00000002
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
 	CONIC_CURVE_TO_NV                                          = 0x1A
 	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSERVE_MEMORY_HINT_PGI                                   = 0x1A1FD
 	CONSTANT                                                   = 0x8576
 	CONSTANT_ALPHA                                             = 0x8003
@@ -11893,6 +12520,7 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
 	CONTEXT_LOST_KHR                                           = 0x0507
@@ -11971,6 +12599,9 @@ const (
 	COUNTER_TYPE_AMD                                           = 0x8BC0
 	COUNT_DOWN_NV                                              = 0x9089
 	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
 	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CUBIC_EXT                                                  = 0x8334
 	CUBIC_HP                                                   = 0x815F
@@ -12020,6 +12651,7 @@ const (
 	CURRENT_VERTEX_WEIGHT_EXT                                  = 0x850B
 	CURRENT_WEIGHT_ARB                                         = 0x86A8
 	CW                                                         = 0x0900
+	D3D12_FENCE_VALUE_EXT                                      = 0x9595
 	DARKEN_KHR                                                 = 0x9297
 	DARKEN_NV                                                  = 0x9297
 	DATA_BUFFER_AMD                                            = 0x9151
@@ -12112,6 +12744,7 @@ const (
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DECR_WRAP_EXT                                              = 0x8508
+	DEDICATED_MEMORY_OBJECT_EXT                                = 0x9581
 	DEFORMATIONS_MASK_SGIX                                     = 0x8196
 	DELETE_STATUS                                              = 0x8B80
 	DEPENDENT_AR_TEXTURE_2D_NV                                 = 0x86E9
@@ -12153,6 +12786,7 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_SCALE                                                = 0x0D1E
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
@@ -12170,6 +12804,9 @@ const (
 	DETAIL_TEXTURE_FUNC_POINTS_SGIS                            = 0x809C
 	DETAIL_TEXTURE_LEVEL_SGIS                                  = 0x809A
 	DETAIL_TEXTURE_MODE_SGIS                                   = 0x809B
+	DEVICE_LUID_EXT                                            = 0x9599
+	DEVICE_NODE_MASK_EXT                                       = 0x959A
+	DEVICE_UUID_EXT                                            = 0x9597
 	DIFFERENCE_KHR                                             = 0x929E
 	DIFFERENCE_NV                                              = 0x929E
 	DIFFUSE                                                    = 0x1201
@@ -12232,6 +12869,9 @@ const (
 	DOUBLE_VEC3_EXT                                            = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
 	DOUBLE_VEC4_EXT                                            = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER0_ARB                                           = 0x8825
@@ -12281,6 +12921,9 @@ const (
 	DRAW_BUFFER9                                               = 0x882E
 	DRAW_BUFFER9_ARB                                           = 0x882E
 	DRAW_BUFFER9_ATI                                           = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
 	DRAW_FRAMEBUFFER_BINDING_EXT                               = 0x8CA6
@@ -12292,6 +12935,7 @@ const (
 	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DRAW_PIXELS_APPLE                                          = 0x8A0A
 	DRAW_PIXEL_TOKEN                                           = 0x0705
+	DRIVER_UUID_EXT                                            = 0x9598
 	DSDT8_MAG8_INTENSITY8_NV                                   = 0x870B
 	DSDT8_MAG8_NV                                              = 0x870A
 	DSDT8_NV                                                   = 0x8709
@@ -12352,7 +12996,9 @@ const (
 	EDGE_FLAG_ARRAY_POINTER_EXT                                = 0x8093
 	EDGE_FLAG_ARRAY_STRIDE                                     = 0x808C
 	EDGE_FLAG_ARRAY_STRIDE_EXT                                 = 0x808C
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
 	EIGHTH_BIT_ATI                                             = 0x00000020
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
 	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_APPLE                                        = 0x8A0C
 	ELEMENT_ARRAY_ATI                                          = 0x8768
@@ -12397,6 +13043,7 @@ const (
 	EVAL_VERTEX_ATTRIB9_NV                                     = 0x86CF
 	EXCLUSION_KHR                                              = 0x92A0
 	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXP                                                        = 0x0800
 	EXP2                                                       = 0x0801
 	EXPAND_NEGATE_NV                                           = 0x8539
@@ -12430,6 +13077,7 @@ const (
 	FIELD_UPPER_NV                                             = 0x9022
 	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
 	FILTER4_SGIS                                               = 0x8146
 	FIRST_TO_REST_NV                                           = 0x90AF
@@ -12441,6 +13089,15 @@ const (
 	FIXED_ONLY_ARB                                             = 0x891D
 	FLAT                                                       = 0x1D00
 	FLOAT                                                      = 0x1406
+	FLOAT16_MAT2_AMD                                           = 0x91C5
+	FLOAT16_MAT2x3_AMD                                         = 0x91C8
+	FLOAT16_MAT2x4_AMD                                         = 0x91C9
+	FLOAT16_MAT3_AMD                                           = 0x91C6
+	FLOAT16_MAT3x2_AMD                                         = 0x91CA
+	FLOAT16_MAT3x4_AMD                                         = 0x91CB
+	FLOAT16_MAT4_AMD                                           = 0x91C7
+	FLOAT16_MAT4x2_AMD                                         = 0x91CC
+	FLOAT16_MAT4x3_AMD                                         = 0x91CD
 	FLOAT16_NV                                                 = 0x8FF8
 	FLOAT16_VEC2_NV                                            = 0x8FF9
 	FLOAT16_VEC3_NV                                            = 0x8FFA
@@ -12546,6 +13203,8 @@ const (
 	FRAGMENT_COLOR_MATERIAL_FACE_SGIX                          = 0x8402
 	FRAGMENT_COLOR_MATERIAL_PARAMETER_SGIX                     = 0x8403
 	FRAGMENT_COLOR_MATERIAL_SGIX                               = 0x8401
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
 	FRAGMENT_DEPTH                                             = 0x8452
 	FRAGMENT_DEPTH_EXT                                         = 0x8452
 	FRAGMENT_INPUT_NV                                          = 0x936D
@@ -12577,6 +13236,7 @@ const (
 	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
 	FRAGMENT_SHADER_DERIVATIVE_HINT_ARB                        = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -12598,12 +13258,14 @@ const (
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_3D_ZOFFSET_EXT              = 0x8CD4
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE_EXT           = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER_EXT                   = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL_EXT                   = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BARRIER_BIT_EXT                                = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
@@ -12635,8 +13297,13 @@ const (
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_EXT                     = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER_EXT                     = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_SRGB_CAPABLE_EXT                               = 0x8DBA
 	FRAMEBUFFER_SRGB_EXT                                       = 0x8DB9
@@ -12649,6 +13316,7 @@ const (
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_RANGE_EXT                                             = 0x87E1
@@ -12728,6 +13396,14 @@ const (
 	HALF_FLOAT                                                 = 0x140B
 	HALF_FLOAT_ARB                                             = 0x140B
 	HALF_FLOAT_NV                                              = 0x140B
+	HANDLE_TYPE_D3D11_IMAGE_EXT                                = 0x958B
+	HANDLE_TYPE_D3D11_IMAGE_KMT_EXT                            = 0x958C
+	HANDLE_TYPE_D3D12_FENCE_EXT                                = 0x9594
+	HANDLE_TYPE_D3D12_RESOURCE_EXT                             = 0x958A
+	HANDLE_TYPE_D3D12_TILEPOOL_EXT                             = 0x9589
+	HANDLE_TYPE_OPAQUE_FD_EXT                                  = 0x9586
+	HANDLE_TYPE_OPAQUE_WIN32_EXT                               = 0x9587
+	HANDLE_TYPE_OPAQUE_WIN32_KMT_EXT                           = 0x9588
 	HARDLIGHT_KHR                                              = 0x929B
 	HARDLIGHT_NV                                               = 0x929B
 	HARDMIX_NV                                                 = 0x92A9
@@ -12835,6 +13511,7 @@ const (
 	IMPLEMENTATION_COLOR_READ_FORMAT_OES                       = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
 	IMPLEMENTATION_COLOR_READ_TYPE_OES                         = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
 	INCR_WRAP_EXT                                              = 0x8507
@@ -12879,9 +13556,13 @@ const (
 	INT16_VEC2_NV                                              = 0x8FE5
 	INT16_VEC3_NV                                              = 0x8FE6
 	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
 	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
 	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
 	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
 	INT64_VEC4_NV                                              = 0x8FEB
 	INT8_NV                                                    = 0x8FE0
 	INT8_VEC2_NV                                               = 0x8FE1
@@ -13020,13 +13701,23 @@ const (
 	LAST_VIDEO_CAPTURE_STATUS_NV                               = 0x9027
 	LAYER_NV                                                   = 0x8DAA
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
+	LAYOUT_COLOR_ATTACHMENT_EXT                                = 0x958E
 	LAYOUT_DEFAULT_INTEL                                       = 0
+	LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT              = 0x9531
+	LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT              = 0x9530
+	LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT                        = 0x958F
+	LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT                         = 0x9590
+	LAYOUT_GENERAL_EXT                                         = 0x958D
 	LAYOUT_LINEAR_CPU_CACHED_INTEL                             = 2
 	LAYOUT_LINEAR_INTEL                                        = 1
+	LAYOUT_SHADER_READ_ONLY_EXT                                = 0x9591
+	LAYOUT_TRANSFER_DST_EXT                                    = 0x9593
+	LAYOUT_TRANSFER_SRC_EXT                                    = 0x9592
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LERP_ATI                                                   = 0x8969
 	LESS                                                       = 0x0201
+	LGPU_SEPARATE_STORAGE_BIT_NVX                              = 0x0800
 	LIGHT0                                                     = 0x4000
 	LIGHT1                                                     = 0x4001
 	LIGHT2                                                     = 0x4002
@@ -13062,6 +13753,7 @@ const (
 	LINEAR_SHARPEN_ALPHA_SGIS                                  = 0x80AE
 	LINEAR_SHARPEN_COLOR_SGIS                                  = 0x80AF
 	LINEAR_SHARPEN_SGIS                                        = 0x80AD
+	LINEAR_TILING_EXT                                          = 0x9585
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
 	LINES_ADJACENCY_ARB                                        = 0x000A
@@ -13081,6 +13773,7 @@ const (
 	LINE_TOKEN                                                 = 0x0702
 	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -13107,6 +13800,7 @@ const (
 	LOW_INT                                                    = 0x8DF3
 	LO_BIAS_NV                                                 = 0x8715
 	LO_SCALE_NV                                                = 0x870F
+	LUID_SIZE_EXT                                              = 8
 	LUMINANCE                                                  = 0x1909
 	LUMINANCE12                                                = 0x8041
 	LUMINANCE12_ALPHA12                                        = 0x8047
@@ -13440,6 +14134,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_LGPU_GPUS_NVX                                          = 0x92BA
 	MAX_LIGHTS                                                 = 0x0D31
 	MAX_LIST_NESTING                                           = 0x0B31
 	MAX_MAP_TESSELLATION_NV                                    = 0x86D6
@@ -13504,6 +14199,7 @@ const (
 	MAX_PROGRAM_TEX_INSTRUCTIONS_ARB                           = 0x880C
 	MAX_PROGRAM_TOTAL_OUTPUT_COMPONENTS_NV                     = 0x8C28
 	MAX_PROJECTION_STACK_DEPTH                                 = 0x0D38
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RATIONAL_EVAL_ORDER_NV                                 = 0x86D7
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RECTANGLE_TEXTURE_SIZE_ARB                             = 0x84F8
@@ -13516,6 +14212,8 @@ const (
 	MAX_SAMPLE_MASK_WORDS_NV                                   = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
 	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SHININESS_NV                                           = 0x8504
@@ -13526,6 +14224,7 @@ const (
 	MAX_SPARSE_TEXTURE_SIZE_AMD                                = 0x9198
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
 	MAX_SPOT_EXPONENT_NV                                       = 0x8505
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -13560,6 +14259,7 @@ const (
 	MAX_TEXTURE_IMAGE_UNITS_NV                                 = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
 	MAX_TEXTURE_LOD_BIAS_EXT                                   = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_MAX_ANISOTROPY_EXT                             = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TEXTURE_STACK_DEPTH                                    = 0x0D39
@@ -13616,7 +14316,9 @@ const (
 	MAX_VERTEX_VARYING_COMPONENTS_EXT                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
@@ -13643,7 +14345,6 @@ const (
 	MIN_SAMPLE_SHADING_VALUE                                   = 0x8C37
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
 	MIN_SPARSE_LEVEL_AMD                                       = 0x919B
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
 	MIRRORED_REPEAT_ARB                                        = 0x8370
@@ -13656,6 +14357,8 @@ const (
 	MIRROR_CLAMP_TO_EDGE_EXT                                   = 0x8743
 	MITER_REVERT_NV                                            = 0x90A7
 	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
 	MODELVIEW                                                  = 0x1700
 	MODELVIEW0_ARB                                             = 0x1700
 	MODELVIEW0_EXT                                             = 0x1700
@@ -13707,9 +14410,12 @@ const (
 	MOVE_TO_RESETS_NV                                          = 0x90B5
 	MOV_ATI                                                    = 0x8961
 	MULT                                                       = 0x0103
+	MULTICAST_GPUS_NV                                          = 0x92BA
+	MULTICAST_PROGRAMMABLE_SAMPLE_LOCATION_NV                  = 0x9549
 	MULTIPLY_KHR                                               = 0x9294
 	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
 	MULTISAMPLE_3DFX                                           = 0x86B2
 	MULTISAMPLE_ARB                                            = 0x809D
 	MULTISAMPLE_BIT                                            = 0x20000000
@@ -13719,6 +14425,9 @@ const (
 	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
 	MULTISAMPLE_EXT                                            = 0x809D
 	MULTISAMPLE_FILTER_HINT_NV                                 = 0x8534
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	MULTISAMPLE_SGIS                                           = 0x809D
 	MUL_ATI                                                    = 0x8964
 	MVP_MATRIX_EXT                                             = 0x87E3
@@ -13749,6 +14458,7 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
 	NORMALIZE                                                  = 0x0BA1
 	NORMALIZED_RANGE_EXT                                       = 0x87E0
@@ -13782,6 +14492,7 @@ const (
 	NUM_COMPATIBLE_SUBROUTINES                                 = 0x8E4A
 	NUM_COMPRESSED_TEXTURE_FORMATS                             = 0x86A2
 	NUM_COMPRESSED_TEXTURE_FORMATS_ARB                         = 0x86A2
+	NUM_DEVICE_UUIDS_EXT                                       = 0x9596
 	NUM_EXTENSIONS                                             = 0x821D
 	NUM_FILL_STREAMS_NV                                        = 0x8E29
 	NUM_FRAGMENT_CONSTANTS_ATI                                 = 0x896F
@@ -13796,8 +14507,12 @@ const (
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
 	NUM_SHADING_LANGUAGE_VERSIONS                              = 0x82E9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
+	NUM_TILING_TYPES_EXT                                       = 0x9582
 	NUM_VIDEO_CAPTURE_STREAMS_NV                               = 0x9024
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_ACTIVE_ATTRIBUTES_ARB                               = 0x8B89
 	OBJECT_ACTIVE_ATTRIBUTE_MAX_LENGTH_ARB                     = 0x8B8A
 	OBJECT_ACTIVE_UNIFORMS_ARB                                 = 0x8B86
@@ -13874,6 +14589,7 @@ const (
 	OPERAND2_RGB_EXT                                           = 0x8592
 	OPERAND3_ALPHA_NV                                          = 0x859B
 	OPERAND3_RGB_NV                                            = 0x8593
+	OPTIMAL_TILING_EXT                                         = 0x9584
 	OP_ADD_EXT                                                 = 0x8787
 	OP_CLAMP_EXT                                               = 0x878E
 	OP_CROSS_PRODUCT_EXT                                       = 0x8797
@@ -13953,7 +14669,7 @@ const (
 	PACK_INVERT_MESA                                           = 0x8758
 	PACK_LSB_FIRST                                             = 0x0D01
 	PACK_RESAMPLE_OML                                          = 0x8984
-	PACK_RESAMPLE_SGIX                                         = 0x842C
+	PACK_RESAMPLE_SGIX                                         = 0x842E
 	PACK_ROW_BYTES_APPLE                                       = 0x8A15
 	PACK_ROW_LENGTH                                            = 0x0D02
 	PACK_SKIP_IMAGES                                           = 0x806B
@@ -14058,10 +14774,14 @@ const (
 	PERFQUERY_WAIT_INTEL                                       = 0x83FB
 	PERSPECTIVE_CORRECTION_HINT                                = 0x0C50
 	PERTURB_EXT                                                = 0x85AE
+	PER_GPU_STORAGE_BIT_NV                                     = 0x0800
+	PER_GPU_STORAGE_NV                                         = 0x9548
 	PER_STAGE_CONSTANTS_NV                                     = 0x8535
 	PHONG_HINT_WIN                                             = 0x80EB
 	PHONG_WIN                                                  = 0x80EA
 	PINLIGHT_NV                                                = 0x92A8
+	PIXELS_PER_SAMPLE_PATTERN_X_AMD                            = 0x91AE
+	PIXELS_PER_SAMPLE_PATTERN_Y_AMD                            = 0x91AF
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_BUFFER_BARRIER_BIT_EXT                               = 0x00000080
 	PIXEL_COUNTER_BITS_NV                                      = 0x8864
@@ -14167,6 +14887,9 @@ const (
 	POLYGON_BIT                                                = 0x00000008
 	POLYGON_MODE                                               = 0x0B40
 	POLYGON_OFFSET_BIAS_EXT                                    = 0x8039
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_EXT                                         = 0x8037
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FACTOR_EXT                                  = 0x8038
@@ -14237,6 +14960,7 @@ const (
 	PRIMITIVES_GENERATED_EXT                                   = 0x8C87
 	PRIMITIVES_GENERATED_NV                                    = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_ID_NV                                            = 0x8C7C
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
@@ -14245,11 +14969,16 @@ const (
 	PRIMITIVE_RESTART_INDEX_NV                                 = 0x8559
 	PRIMITIVE_RESTART_NV                                       = 0x8558
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_ADDRESS_REGISTERS_ARB                              = 0x88B0
 	PROGRAM_ALU_INSTRUCTIONS_ARB                               = 0x8805
 	PROGRAM_ATTRIBS_ARB                                        = 0x88AC
 	PROGRAM_ATTRIB_COMPONENTS_NV                               = 0x8906
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
+	PROGRAM_BINARY_FORMAT_MESA                                 = 0x875F
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_BINDING_ARB                                        = 0x8677
@@ -14282,6 +15011,7 @@ const (
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
 	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
 	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
 	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
@@ -14300,6 +15030,7 @@ const (
 	PROJECTION                                                 = 0x1701
 	PROJECTION_MATRIX                                          = 0x0BA7
 	PROJECTION_STACK_DEPTH                                     = 0x0BA4
+	PROTECTED_MEMORY_OBJECT_EXT                                = 0x959B
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROVOKING_VERTEX_EXT                                       = 0x8E4F
 	PROXY_COLOR_TABLE                                          = 0x80D3
@@ -14336,6 +15067,7 @@ const (
 	PROXY_TEXTURE_RECTANGLE_ARB                                = 0x84F7
 	PROXY_TEXTURE_RECTANGLE_NV                                 = 0x84F7
 	PURGEABLE_APPLE                                            = 0x8A1D
+	PURGED_CONTEXT_RESET_NV                                    = 0x92BB
 	Q                                                          = 0x2003
 	QUADRATIC_ATTENUATION                                      = 0x1209
 	QUADRATIC_CURVE_TO_NV                                      = 0x0A
@@ -14376,6 +15108,12 @@ const (
 	QUERY_NO_WAIT_NV                                           = 0x8E14
 	QUERY_OBJECT_AMD                                           = 0x9153
 	QUERY_OBJECT_EXT                                           = 0x9153
+	QUERY_RESOURCE_BUFFEROBJECT_NV                             = 0x9547
+	QUERY_RESOURCE_MEMTYPE_VIDMEM_NV                           = 0x9542
+	QUERY_RESOURCE_RENDERBUFFER_NV                             = 0x9546
+	QUERY_RESOURCE_SYS_RESERVED_NV                             = 0x9544
+	QUERY_RESOURCE_TEXTURE_NV                                  = 0x9545
+	QUERY_RESOURCE_TYPE_VIDMEM_ALLOC_NV                        = 0x9540
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_ARB                                           = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
@@ -14414,7 +15152,10 @@ const (
 	RASTERIZER_DISCARD                                         = 0x8C89
 	RASTERIZER_DISCARD_EXT                                     = 0x8C89
 	RASTERIZER_DISCARD_NV                                      = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
 	RASTER_POSITION_UNCLIPPED_IBM                              = 0x19262
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -14539,6 +15280,7 @@ const (
 	RENDERBUFFER_WIDTH                                         = 0x8D42
 	RENDERBUFFER_WIDTH_EXT                                     = 0x8D42
 	RENDERER                                                   = 0x1F01
+	RENDER_GPU_MASK_NV                                         = 0x9558
 	RENDER_MODE                                                = 0x0C40
 	REPEAT                                                     = 0x2901
 	REPLACE                                                    = 0x1E01
@@ -14557,9 +15299,9 @@ const (
 	RESAMPLE_DECIMATE_OML                                      = 0x8989
 	RESAMPLE_DECIMATE_SGIX                                     = 0x8430
 	RESAMPLE_REPLICATE_OML                                     = 0x8986
-	RESAMPLE_REPLICATE_SGIX                                    = 0x842E
+	RESAMPLE_REPLICATE_SGIX                                    = 0x8433
 	RESAMPLE_ZERO_FILL_OML                                     = 0x8987
-	RESAMPLE_ZERO_FILL_SGIX                                    = 0x842F
+	RESAMPLE_ZERO_FILL_SGIX                                    = 0x8434
 	RESCALE_NORMAL                                             = 0x803A
 	RESCALE_NORMAL_EXT                                         = 0x803A
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
@@ -14757,6 +15499,14 @@ const (
 	SAMPLE_COVERAGE_INVERT_ARB                                 = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
 	SAMPLE_COVERAGE_VALUE_ARB                                  = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_EXT                                            = 0x80A0
 	SAMPLE_MASK_INVERT_EXT                                     = 0x80AB
@@ -14783,6 +15533,7 @@ const (
 	SCALE_BY_TWO_NV                                            = 0x853E
 	SCISSOR_BIT                                                = 0x00080000
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
 	SCREEN_COORDINATES_REND                                    = 0x8490
 	SCREEN_KHR                                                 = 0x9295
@@ -14819,6 +15570,7 @@ const (
 	SET_AMD                                                    = 0x874A
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
 	SHADER_CONSISTENT_NV                                       = 0x86DD
 	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
@@ -14846,6 +15598,7 @@ const (
 	SHADING_LANGUAGE_VERSION_ARB                               = 0x8B8C
 	SHADOW_AMBIENT_SGIX                                        = 0x80BF
 	SHADOW_ATTENUATION_EXT                                     = 0x834E
+	SHARED_EDGE_NV                                             = 0xC0
 	SHARED_TEXTURE_PALETTE_EXT                                 = 0x81FB
 	SHARPEN_TEXTURE_FUNC_POINTS_SGIS                           = 0x80B0
 	SHININESS                                                  = 0x1601
@@ -14932,6 +15685,8 @@ const (
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
 	SPECULAR                                                   = 0x1202
 	SPHERE_MAP                                                 = 0x2402
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
 	SPOT_CUTOFF                                                = 0x1206
 	SPOT_DIRECTION                                             = 0x1204
 	SPOT_EXPONENT                                              = 0x1205
@@ -15018,7 +15773,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TAG_BITS_EXT                                       = 0x88F2
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_TEST_TWO_SIDE_EXT                                  = 0x8910
@@ -15040,11 +15797,15 @@ const (
 	STRICT_LIGHTING_HINT_PGI                                   = 0x1A217
 	STRICT_SCISSOR_HINT_PGI                                    = 0x1A218
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
 	SUBSAMPLE_DISTANCE_AMD                                     = 0x883F
 	SUBTRACT                                                   = 0x84E7
 	SUBTRACT_ARB                                               = 0x84E7
 	SUB_ATI                                                    = 0x8965
 	SUCCESS_NV                                                 = 0x902F
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SURFACE_MAPPED_NV                                          = 0x8700
 	SURFACE_REGISTERED_NV                                      = 0x86FD
 	SURFACE_STATE_NV                                           = 0x86EB
@@ -15082,6 +15843,7 @@ const (
 	TANGENT_ARRAY_POINTER_EXT                                  = 0x8442
 	TANGENT_ARRAY_STRIDE_EXT                                   = 0x843F
 	TANGENT_ARRAY_TYPE_EXT                                     = 0x843E
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESSELLATION_FACTOR_AMD                                    = 0x9005
 	TESSELLATION_MODE_AMD                                      = 0x9004
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
@@ -15201,7 +15963,6 @@ const (
 	TEXTURE_APPLICATION_MODE_EXT                               = 0x834F
 	TEXTURE_BASE_LEVEL                                         = 0x813C
 	TEXTURE_BASE_LEVEL_SGIS                                    = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_1D_ARRAY_EXT                               = 0x8C1C
@@ -15378,6 +16139,7 @@ const (
 	TEXTURE_MATERIAL_FACE_EXT                                  = 0x8351
 	TEXTURE_MATERIAL_PARAMETER_EXT                             = 0x8352
 	TEXTURE_MATRIX                                             = 0x0BA8
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_ANISOTROPY_EXT                                 = 0x84FE
 	TEXTURE_MAX_CLAMP_R_SGIX                                   = 0x836B
 	TEXTURE_MAX_CLAMP_S_SGIX                                   = 0x8369
@@ -15401,6 +16163,8 @@ const (
 	TEXTURE_RECTANGLE                                          = 0x84F5
 	TEXTURE_RECTANGLE_ARB                                      = 0x84F5
 	TEXTURE_RECTANGLE_NV                                       = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_SIZE_EXT                                       = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
@@ -15432,6 +16196,7 @@ const (
 	TEXTURE_SWIZZLE_RGBA_EXT                                   = 0x8E46
 	TEXTURE_SWIZZLE_R_EXT                                      = 0x8E42
 	TEXTURE_TARGET                                             = 0x1006
+	TEXTURE_TILING_EXT                                         = 0x9580
 	TEXTURE_TOO_LARGE_EXT                                      = 0x8065
 	TEXTURE_UNSIGNED_REMAP_MODE_NV                             = 0x888F
 	TEXTURE_UPDATE_BARRIER_BIT                                 = 0x00000100
@@ -15448,6 +16213,10 @@ const (
 	TEXTURE_WRAP_S                                             = 0x2802
 	TEXTURE_WRAP_T                                             = 0x2803
 	TEXT_FRAGMENT_SHADER_ATI                                   = 0x8200
+	TILE_RASTER_ORDER_FIXED_MESA                               = 0x8BB8
+	TILE_RASTER_ORDER_INCREASING_X_MESA                        = 0x8BB9
+	TILE_RASTER_ORDER_INCREASING_Y_MESA                        = 0x8BBA
+	TILING_TYPES_EXT                                           = 0x9583
 	TIMEOUT_EXPIRED                                            = 0x911B
 	TIMEOUT_IGNORED                                            = 0xFFFFFFFFFFFFFFFF
 	TIMESTAMP                                                  = 0x8E28
@@ -15536,6 +16305,7 @@ const (
 	UNDEFINED_APPLE                                            = 0x8A1C
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -15554,12 +16324,15 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
 	UNIFORM_BUFFER_BINDING_EXT                                 = 0x8DEF
 	UNIFORM_BUFFER_EXT                                         = 0x8DEE
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -15582,7 +16355,7 @@ const (
 	UNPACK_IMAGE_HEIGHT_EXT                                    = 0x806E
 	UNPACK_LSB_FIRST                                           = 0x0CF1
 	UNPACK_RESAMPLE_OML                                        = 0x8985
-	UNPACK_RESAMPLE_SGIX                                       = 0x842D
+	UNPACK_RESAMPLE_SGIX                                       = 0x842F
 	UNPACK_ROW_BYTES_APPLE                                     = 0x8A16
 	UNPACK_ROW_LENGTH                                          = 0x0CF2
 	UNPACK_SKIP_IMAGES                                         = 0x806D
@@ -15606,8 +16379,11 @@ const (
 	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
 	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
 	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
 	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
 	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
 	UNSIGNED_INT8_NV                                           = 0x8FEC
 	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
@@ -15699,6 +16475,7 @@ const (
 	USE_MISSING_GLYPH_NV                                       = 0x90AA
 	UTF16_NV                                                   = 0x909B
 	UTF8_NV                                                    = 0x909A
+	UUID_SIZE_EXT                                              = 16
 	V2F                                                        = 0x2A20
 	V3F                                                        = 0x2A21
 	VALIDATE_STATUS                                            = 0x8B83
@@ -15882,8 +16659,24 @@ const (
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BIT                                               = 0x00000800
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -15913,6 +16706,8 @@ const (
 	WAIT_FAILED                                                = 0x911D
 	WARPS_PER_SM_NV                                            = 0x933A
 	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
 	WEIGHT_ARRAY_ARB                                           = 0x86AD
 	WEIGHT_ARRAY_BUFFER_BINDING                                = 0x889E
 	WEIGHT_ARRAY_BUFFER_BINDING_ARB                            = 0x889E
@@ -15922,6 +16717,8 @@ const (
 	WEIGHT_ARRAY_TYPE_ARB                                      = 0x86A9
 	WEIGHT_SUM_UNITY_ARB                                       = 0x86A6
 	WIDE_LINE_HINT_PGI                                         = 0x1A222
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRAP_BORDER_SUN                                            = 0x81D4
 	WRITE_DISCARD_NV                                           = 0x88BE
 	WRITE_ONLY                                                 = 0x88B9
@@ -15958,6 +16755,7 @@ const (
 var (
 	gpAccum                                                  C.GPACCUM
 	gpAccumxOES                                              C.GPACCUMXOES
+	gpAcquireKeyedMutexWin32EXT                              C.GPACQUIREKEYEDMUTEXWIN32EXT
 	gpActiveProgramEXT                                       C.GPACTIVEPROGRAMEXT
 	gpActiveShaderProgram                                    C.GPACTIVESHADERPROGRAM
 	gpActiveShaderProgramEXT                                 C.GPACTIVESHADERPROGRAMEXT
@@ -15970,6 +16768,8 @@ var (
 	gpAlphaFragmentOp3ATI                                    C.GPALPHAFRAGMENTOP3ATI
 	gpAlphaFunc                                              C.GPALPHAFUNC
 	gpAlphaFuncxOES                                          C.GPALPHAFUNCXOES
+	gpAlphaToCoverageDitherControlNV                         C.GPALPHATOCOVERAGEDITHERCONTROLNV
+	gpApplyFramebufferAttachmentCMAAINTEL                    C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
 	gpApplyTextureEXT                                        C.GPAPPLYTEXTUREEXT
 	gpAreProgramsResidentNV                                  C.GPAREPROGRAMSRESIDENTNV
 	gpAreTexturesResident                                    C.GPARETEXTURESRESIDENT
@@ -16094,8 +16894,11 @@ var (
 	gpBufferPageCommitmentARB                                C.GPBUFFERPAGECOMMITMENTARB
 	gpBufferParameteriAPPLE                                  C.GPBUFFERPARAMETERIAPPLE
 	gpBufferStorage                                          C.GPBUFFERSTORAGE
+	gpBufferStorageExternalEXT                               C.GPBUFFERSTORAGEEXTERNALEXT
+	gpBufferStorageMemEXT                                    C.GPBUFFERSTORAGEMEMEXT
 	gpBufferSubData                                          C.GPBUFFERSUBDATA
 	gpBufferSubDataARB                                       C.GPBUFFERSUBDATAARB
+	gpCallCommandListNV                                      C.GPCALLCOMMANDLISTNV
 	gpCallList                                               C.GPCALLLIST
 	gpCallLists                                              C.GPCALLLISTS
 	gpCheckFramebufferStatus                                 C.GPCHECKFRAMEBUFFERSTATUS
@@ -16223,6 +17026,8 @@ var (
 	gpCombinerParameteriNV                                   C.GPCOMBINERPARAMETERINV
 	gpCombinerParameterivNV                                  C.GPCOMBINERPARAMETERIVNV
 	gpCombinerStageParameterfvNV                             C.GPCOMBINERSTAGEPARAMETERFVNV
+	gpCommandListSegmentsNV                                  C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                                   C.GPCOMPILECOMMANDLISTNV
 	gpCompileShader                                          C.GPCOMPILESHADER
 	gpCompileShaderARB                                       C.GPCOMPILESHADERARB
 	gpCompileShaderIncludeARB                                C.GPCOMPILESHADERINCLUDEARB
@@ -16253,6 +17058,8 @@ var (
 	gpCompressedTextureSubImage2DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
 	gpCompressedTextureSubImage3D                            C.GPCOMPRESSEDTEXTURESUBIMAGE3D
 	gpCompressedTextureSubImage3DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                         C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                         C.GPCONSERVATIVERASTERPARAMETERINV
 	gpConvolutionFilter1D                                    C.GPCONVOLUTIONFILTER1D
 	gpConvolutionFilter1DEXT                                 C.GPCONVOLUTIONFILTER1DEXT
 	gpConvolutionFilter2D                                    C.GPCONVOLUTIONFILTER2D
@@ -16308,8 +17115,12 @@ var (
 	gpCoverFillPathNV                                        C.GPCOVERFILLPATHNV
 	gpCoverStrokePathInstancedNV                             C.GPCOVERSTROKEPATHINSTANCEDNV
 	gpCoverStrokePathNV                                      C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                                   C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                              C.GPCOVERAGEMODULATIONTABLENV
 	gpCreateBuffers                                          C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                                   C.GPCREATECOMMANDLISTSNV
 	gpCreateFramebuffers                                     C.GPCREATEFRAMEBUFFERS
+	gpCreateMemoryObjectsEXT                                 C.GPCREATEMEMORYOBJECTSEXT
 	gpCreatePerfQueryINTEL                                   C.GPCREATEPERFQUERYINTEL
 	gpCreateProgram                                          C.GPCREATEPROGRAM
 	gpCreateProgramObjectARB                                 C.GPCREATEPROGRAMOBJECTARB
@@ -16322,6 +17133,7 @@ var (
 	gpCreateShaderProgramEXT                                 C.GPCREATESHADERPROGRAMEXT
 	gpCreateShaderProgramv                                   C.GPCREATESHADERPROGRAMV
 	gpCreateShaderProgramvEXT                                C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                         C.GPCREATESTATESNV
 	gpCreateSyncFromCLeventARB                               C.GPCREATESYNCFROMCLEVENTARB
 	gpCreateTextures                                         C.GPCREATETEXTURES
 	gpCreateTransformFeedbacks                               C.GPCREATETRANSFORMFEEDBACKS
@@ -16348,12 +17160,14 @@ var (
 	gpDeleteAsyncMarkersSGIX                                 C.GPDELETEASYNCMARKERSSGIX
 	gpDeleteBuffers                                          C.GPDELETEBUFFERS
 	gpDeleteBuffersARB                                       C.GPDELETEBUFFERSARB
+	gpDeleteCommandListsNV                                   C.GPDELETECOMMANDLISTSNV
 	gpDeleteFencesAPPLE                                      C.GPDELETEFENCESAPPLE
 	gpDeleteFencesNV                                         C.GPDELETEFENCESNV
 	gpDeleteFragmentShaderATI                                C.GPDELETEFRAGMENTSHADERATI
 	gpDeleteFramebuffers                                     C.GPDELETEFRAMEBUFFERS
 	gpDeleteFramebuffersEXT                                  C.GPDELETEFRAMEBUFFERSEXT
 	gpDeleteLists                                            C.GPDELETELISTS
+	gpDeleteMemoryObjectsEXT                                 C.GPDELETEMEMORYOBJECTSEXT
 	gpDeleteNamedStringARB                                   C.GPDELETENAMEDSTRINGARB
 	gpDeleteNamesAMD                                         C.GPDELETENAMESAMD
 	gpDeleteObjectARB                                        C.GPDELETEOBJECTARB
@@ -16368,10 +17182,13 @@ var (
 	gpDeleteProgramsNV                                       C.GPDELETEPROGRAMSNV
 	gpDeleteQueries                                          C.GPDELETEQUERIES
 	gpDeleteQueriesARB                                       C.GPDELETEQUERIESARB
+	gpDeleteQueryResourceTagNV                               C.GPDELETEQUERYRESOURCETAGNV
 	gpDeleteRenderbuffers                                    C.GPDELETERENDERBUFFERS
 	gpDeleteRenderbuffersEXT                                 C.GPDELETERENDERBUFFERSEXT
 	gpDeleteSamplers                                         C.GPDELETESAMPLERS
+	gpDeleteSemaphoresEXT                                    C.GPDELETESEMAPHORESEXT
 	gpDeleteShader                                           C.GPDELETESHADER
+	gpDeleteStatesNV                                         C.GPDELETESTATESNV
 	gpDeleteSync                                             C.GPDELETESYNC
 	gpDeleteTextures                                         C.GPDELETETEXTURES
 	gpDeleteTexturesEXT                                      C.GPDELETETEXTURESEXT
@@ -16421,6 +17238,10 @@ var (
 	gpDrawBuffers                                            C.GPDRAWBUFFERS
 	gpDrawBuffersARB                                         C.GPDRAWBUFFERSARB
 	gpDrawBuffersATI                                         C.GPDRAWBUFFERSATI
+	gpDrawCommandsAddressNV                                  C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                         C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                            C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                                   C.GPDRAWCOMMANDSSTATESNV
 	gpDrawElementArrayAPPLE                                  C.GPDRAWELEMENTARRAYAPPLE
 	gpDrawElementArrayATI                                    C.GPDRAWELEMENTARRAYATI
 	gpDrawElements                                           C.GPDRAWELEMENTS
@@ -16445,6 +17266,7 @@ var (
 	gpDrawTransformFeedbackNV                                C.GPDRAWTRANSFORMFEEDBACKNV
 	gpDrawTransformFeedbackStream                            C.GPDRAWTRANSFORMFEEDBACKSTREAM
 	gpDrawTransformFeedbackStreamInstanced                   C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                          C.GPDRAWVKIMAGENV
 	gpEdgeFlag                                               C.GPEDGEFLAG
 	gpEdgeFlagFormatNV                                       C.GPEDGEFLAGFORMATNV
 	gpEdgeFlagPointer                                        C.GPEDGEFLAGPOINTER
@@ -16500,6 +17322,7 @@ var (
 	gpEvalMesh2                                              C.GPEVALMESH2
 	gpEvalPoint1                                             C.GPEVALPOINT1
 	gpEvalPoint2                                             C.GPEVALPOINT2
+	gpEvaluateDepthValuesARB                                 C.GPEVALUATEDEPTHVALUESARB
 	gpExecuteProgramNV                                       C.GPEXECUTEPROGRAMNV
 	gpExtractComponentEXT                                    C.GPEXTRACTCOMPONENTEXT
 	gpFeedbackBuffer                                         C.GPFEEDBACKBUFFER
@@ -16544,6 +17367,7 @@ var (
 	gpFogxOES                                                C.GPFOGXOES
 	gpFogxvOES                                               C.GPFOGXVOES
 	gpFragmentColorMaterialSGIX                              C.GPFRAGMENTCOLORMATERIALSGIX
+	gpFragmentCoverageColorNV                                C.GPFRAGMENTCOVERAGECOLORNV
 	gpFragmentLightModelfSGIX                                C.GPFRAGMENTLIGHTMODELFSGIX
 	gpFragmentLightModelfvSGIX                               C.GPFRAGMENTLIGHTMODELFVSGIX
 	gpFragmentLightModeliSGIX                                C.GPFRAGMENTLIGHTMODELISGIX
@@ -16560,10 +17384,14 @@ var (
 	gpFrameZoomSGIX                                          C.GPFRAMEZOOMSGIX
 	gpFramebufferDrawBufferEXT                               C.GPFRAMEBUFFERDRAWBUFFEREXT
 	gpFramebufferDrawBuffersEXT                              C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                             C.GPFRAMEBUFFERFETCHBARRIEREXT
 	gpFramebufferParameteri                                  C.GPFRAMEBUFFERPARAMETERI
 	gpFramebufferReadBufferEXT                               C.GPFRAMEBUFFERREADBUFFEREXT
 	gpFramebufferRenderbuffer                                C.GPFRAMEBUFFERRENDERBUFFER
 	gpFramebufferRenderbufferEXT                             C.GPFRAMEBUFFERRENDERBUFFEREXT
+	gpFramebufferSampleLocationsfvARB                        C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                         C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferSamplePositionsfvAMD                        C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpFramebufferTexture                                     C.GPFRAMEBUFFERTEXTURE
 	gpFramebufferTexture1D                                   C.GPFRAMEBUFFERTEXTURE1D
 	gpFramebufferTexture1DEXT                                C.GPFRAMEBUFFERTEXTURE1DEXT
@@ -16578,6 +17406,7 @@ var (
 	gpFramebufferTextureLayer                                C.GPFRAMEBUFFERTEXTURELAYER
 	gpFramebufferTextureLayerARB                             C.GPFRAMEBUFFERTEXTURELAYERARB
 	gpFramebufferTextureLayerEXT                             C.GPFRAMEBUFFERTEXTURELAYEREXT
+	gpFramebufferTextureMultiviewOVR                         C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
 	gpFreeObjectBufferATI                                    C.GPFREEOBJECTBUFFERATI
 	gpFrontFace                                              C.GPFRONTFACE
 	gpFrustum                                                C.GPFRUSTUM
@@ -16602,9 +17431,11 @@ var (
 	gpGenProgramsNV                                          C.GPGENPROGRAMSNV
 	gpGenQueries                                             C.GPGENQUERIES
 	gpGenQueriesARB                                          C.GPGENQUERIESARB
+	gpGenQueryResourceTagNV                                  C.GPGENQUERYRESOURCETAGNV
 	gpGenRenderbuffers                                       C.GPGENRENDERBUFFERS
 	gpGenRenderbuffersEXT                                    C.GPGENRENDERBUFFERSEXT
 	gpGenSamplers                                            C.GPGENSAMPLERS
+	gpGenSemaphoresEXT                                       C.GPGENSEMAPHORESEXT
 	gpGenSymbolsEXT                                          C.GPGENSYMBOLSEXT
 	gpGenTextures                                            C.GPGENTEXTURES
 	gpGenTexturesEXT                                         C.GPGENTEXTURESEXT
@@ -16665,6 +17496,7 @@ var (
 	gpGetCombinerOutputParameterfvNV                         C.GPGETCOMBINEROUTPUTPARAMETERFVNV
 	gpGetCombinerOutputParameterivNV                         C.GPGETCOMBINEROUTPUTPARAMETERIVNV
 	gpGetCombinerStageParameterfvNV                          C.GPGETCOMBINERSTAGEPARAMETERFVNV
+	gpGetCommandHeaderNV                                     C.GPGETCOMMANDHEADERNV
 	gpGetCompressedMultiTexImageEXT                          C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
 	gpGetCompressedTexImage                                  C.GPGETCOMPRESSEDTEXIMAGE
 	gpGetCompressedTexImageARB                               C.GPGETCOMPRESSEDTEXIMAGEARB
@@ -16678,6 +17510,7 @@ var (
 	gpGetConvolutionParameteriv                              C.GPGETCONVOLUTIONPARAMETERIV
 	gpGetConvolutionParameterivEXT                           C.GPGETCONVOLUTIONPARAMETERIVEXT
 	gpGetConvolutionParameterxvOES                           C.GPGETCONVOLUTIONPARAMETERXVOES
+	gpGetCoverageModulationTableNV                           C.GPGETCOVERAGEMODULATIONTABLENV
 	gpGetDebugMessageLog                                     C.GPGETDEBUGMESSAGELOG
 	gpGetDebugMessageLogAMD                                  C.GPGETDEBUGMESSAGELOGAMD
 	gpGetDebugMessageLogARB                                  C.GPGETDEBUGMESSAGELOGARB
@@ -16707,6 +17540,7 @@ var (
 	gpGetFragmentMaterialivSGIX                              C.GPGETFRAGMENTMATERIALIVSGIX
 	gpGetFramebufferAttachmentParameteriv                    C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetFramebufferAttachmentParameterivEXT                 C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetFramebufferParameterfvAMD                           C.GPGETFRAMEBUFFERPARAMETERFVAMD
 	gpGetFramebufferParameteriv                              C.GPGETFRAMEBUFFERPARAMETERIV
 	gpGetFramebufferParameterivEXT                           C.GPGETFRAMEBUFFERPARAMETERIVEXT
 	gpGetGraphicsResetStatus                                 C.GPGETGRAPHICSRESETSTATUS
@@ -16733,6 +17567,7 @@ var (
 	gpGetIntegerui64i_vNV                                    C.GPGETINTEGERUI64I_VNV
 	gpGetIntegerui64vNV                                      C.GPGETINTEGERUI64VNV
 	gpGetIntegerv                                            C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                            C.GPGETINTERNALFORMATSAMPLEIVNV
 	gpGetInternalformati64v                                  C.GPGETINTERNALFORMATI64V
 	gpGetInternalformativ                                    C.GPGETINTERNALFORMATIV
 	gpGetInvariantBooleanvEXT                                C.GPGETINVARIANTBOOLEANVEXT
@@ -16760,6 +17595,7 @@ var (
 	gpGetMaterialiv                                          C.GPGETMATERIALIV
 	gpGetMaterialxOES                                        C.GPGETMATERIALXOES
 	gpGetMaterialxvOES                                       C.GPGETMATERIALXVOES
+	gpGetMemoryObjectParameterivEXT                          C.GPGETMEMORYOBJECTPARAMETERIVEXT
 	gpGetMinmax                                              C.GPGETMINMAX
 	gpGetMinmaxEXT                                           C.GPGETMINMAXEXT
 	gpGetMinmaxParameterfv                                   C.GPGETMINMAXPARAMETERFV
@@ -16790,6 +17626,7 @@ var (
 	gpGetNamedBufferSubDataEXT                               C.GPGETNAMEDBUFFERSUBDATAEXT
 	gpGetNamedFramebufferAttachmentParameteriv               C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetNamedFramebufferAttachmentParameterivEXT            C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameterfvAMD                      C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD
 	gpGetNamedFramebufferParameteriv                         C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
 	gpGetNamedFramebufferParameterivEXT                      C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
 	gpGetNamedProgramLocalParameterIivEXT                    C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
@@ -16884,6 +17721,10 @@ var (
 	gpGetProgramiv                                           C.GPGETPROGRAMIV
 	gpGetProgramivARB                                        C.GPGETPROGRAMIVARB
 	gpGetProgramivNV                                         C.GPGETPROGRAMIVNV
+	gpGetQueryBufferObjecti64v                               C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                                 C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                              C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                                C.GPGETQUERYBUFFEROBJECTUIV
 	gpGetQueryIndexediv                                      C.GPGETQUERYINDEXEDIV
 	gpGetQueryObjecti64v                                     C.GPGETQUERYOBJECTI64V
 	gpGetQueryObjecti64vEXT                                  C.GPGETQUERYOBJECTI64VEXT
@@ -16901,6 +17742,7 @@ var (
 	gpGetSamplerParameterIuiv                                C.GPGETSAMPLERPARAMETERIUIV
 	gpGetSamplerParameterfv                                  C.GPGETSAMPLERPARAMETERFV
 	gpGetSamplerParameteriv                                  C.GPGETSAMPLERPARAMETERIV
+	gpGetSemaphoreParameterui64vEXT                          C.GPGETSEMAPHOREPARAMETERUI64VEXT
 	gpGetSeparableFilter                                     C.GPGETSEPARABLEFILTER
 	gpGetSeparableFilterEXT                                  C.GPGETSEPARABLEFILTEREXT
 	gpGetShaderInfoLog                                       C.GPGETSHADERINFOLOG
@@ -16909,6 +17751,7 @@ var (
 	gpGetShaderSourceARB                                     C.GPGETSHADERSOURCEARB
 	gpGetShaderiv                                            C.GPGETSHADERIV
 	gpGetSharpenTexFuncSGIS                                  C.GPGETSHARPENTEXFUNCSGIS
+	gpGetStageIndexNV                                        C.GPGETSTAGEINDEXNV
 	gpGetString                                              C.GPGETSTRING
 	gpGetStringi                                             C.GPGETSTRINGI
 	gpGetSubroutineIndex                                     C.GPGETSUBROUTINEINDEX
@@ -16972,12 +17815,16 @@ var (
 	gpGetUniformdv                                           C.GPGETUNIFORMDV
 	gpGetUniformfv                                           C.GPGETUNIFORMFV
 	gpGetUniformfvARB                                        C.GPGETUNIFORMFVARB
+	gpGetUniformi64vARB                                      C.GPGETUNIFORMI64VARB
 	gpGetUniformi64vNV                                       C.GPGETUNIFORMI64VNV
 	gpGetUniformiv                                           C.GPGETUNIFORMIV
 	gpGetUniformivARB                                        C.GPGETUNIFORMIVARB
+	gpGetUniformui64vARB                                     C.GPGETUNIFORMUI64VARB
 	gpGetUniformui64vNV                                      C.GPGETUNIFORMUI64VNV
 	gpGetUniformuiv                                          C.GPGETUNIFORMUIV
 	gpGetUniformuivEXT                                       C.GPGETUNIFORMUIVEXT
+	gpGetUnsignedBytei_vEXT                                  C.GPGETUNSIGNEDBYTEI_VEXT
+	gpGetUnsignedBytevEXT                                    C.GPGETUNSIGNEDBYTEVEXT
 	gpGetVariantArrayObjectfvATI                             C.GPGETVARIANTARRAYOBJECTFVATI
 	gpGetVariantArrayObjectivATI                             C.GPGETVARIANTARRAYOBJECTIVATI
 	gpGetVariantBooleanvEXT                                  C.GPGETVARIANTBOOLEANVEXT
@@ -17023,6 +17870,7 @@ var (
 	gpGetVideoivNV                                           C.GPGETVIDEOIVNV
 	gpGetVideoui64vNV                                        C.GPGETVIDEOUI64VNV
 	gpGetVideouivNV                                          C.GPGETVIDEOUIVNV
+	gpGetVkProcAddrNV                                        C.GPGETVKPROCADDRNV
 	gpGetnColorTableARB                                      C.GPGETNCOLORTABLEARB
 	gpGetnCompressedTexImageARB                              C.GPGETNCOMPRESSEDTEXIMAGEARB
 	gpGetnConvolutionFilterARB                               C.GPGETNCONVOLUTIONFILTERARB
@@ -17041,9 +17889,11 @@ var (
 	gpGetnUniformfv                                          C.GPGETNUNIFORMFV
 	gpGetnUniformfvARB                                       C.GPGETNUNIFORMFVARB
 	gpGetnUniformfvKHR                                       C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                                     C.GPGETNUNIFORMI64VARB
 	gpGetnUniformiv                                          C.GPGETNUNIFORMIV
 	gpGetnUniformivARB                                       C.GPGETNUNIFORMIVARB
 	gpGetnUniformivKHR                                       C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                                    C.GPGETNUNIFORMUI64VARB
 	gpGetnUniformuiv                                         C.GPGETNUNIFORMUIV
 	gpGetnUniformuivARB                                      C.GPGETNUNIFORMUIVARB
 	gpGetnUniformuivKHR                                      C.GPGETNUNIFORMUIVKHR
@@ -17064,6 +17914,12 @@ var (
 	gpImageTransformParameterfvHP                            C.GPIMAGETRANSFORMPARAMETERFVHP
 	gpImageTransformParameteriHP                             C.GPIMAGETRANSFORMPARAMETERIHP
 	gpImageTransformParameterivHP                            C.GPIMAGETRANSFORMPARAMETERIVHP
+	gpImportMemoryFdEXT                                      C.GPIMPORTMEMORYFDEXT
+	gpImportMemoryWin32HandleEXT                             C.GPIMPORTMEMORYWIN32HANDLEEXT
+	gpImportMemoryWin32NameEXT                               C.GPIMPORTMEMORYWIN32NAMEEXT
+	gpImportSemaphoreFdEXT                                   C.GPIMPORTSEMAPHOREFDEXT
+	gpImportSemaphoreWin32HandleEXT                          C.GPIMPORTSEMAPHOREWIN32HANDLEEXT
+	gpImportSemaphoreWin32NameEXT                            C.GPIMPORTSEMAPHOREWIN32NAMEEXT
 	gpImportSyncEXT                                          C.GPIMPORTSYNCEXT
 	gpIndexFormatNV                                          C.GPINDEXFORMATNV
 	gpIndexFuncEXT                                           C.GPINDEXFUNCEXT
@@ -17102,6 +17958,7 @@ var (
 	gpIsBuffer                                               C.GPISBUFFER
 	gpIsBufferARB                                            C.GPISBUFFERARB
 	gpIsBufferResidentNV                                     C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                        C.GPISCOMMANDLISTNV
 	gpIsEnabled                                              C.GPISENABLED
 	gpIsEnabledIndexedEXT                                    C.GPISENABLEDINDEXEDEXT
 	gpIsEnabledi                                             C.GPISENABLEDI
@@ -17112,6 +17969,7 @@ var (
 	gpIsImageHandleResidentARB                               C.GPISIMAGEHANDLERESIDENTARB
 	gpIsImageHandleResidentNV                                C.GPISIMAGEHANDLERESIDENTNV
 	gpIsList                                                 C.GPISLIST
+	gpIsMemoryObjectEXT                                      C.GPISMEMORYOBJECTEXT
 	gpIsNameAMD                                              C.GPISNAMEAMD
 	gpIsNamedBufferResidentNV                                C.GPISNAMEDBUFFERRESIDENTNV
 	gpIsNamedStringARB                                       C.GPISNAMEDSTRINGARB
@@ -17130,7 +17988,9 @@ var (
 	gpIsRenderbuffer                                         C.GPISRENDERBUFFER
 	gpIsRenderbufferEXT                                      C.GPISRENDERBUFFEREXT
 	gpIsSampler                                              C.GPISSAMPLER
+	gpIsSemaphoreEXT                                         C.GPISSEMAPHOREEXT
 	gpIsShader                                               C.GPISSHADER
+	gpIsStateNV                                              C.GPISSTATENV
 	gpIsSync                                                 C.GPISSYNC
 	gpIsTexture                                              C.GPISTEXTURE
 	gpIsTextureEXT                                           C.GPISTEXTUREEXT
@@ -17142,6 +18002,9 @@ var (
 	gpIsVertexArray                                          C.GPISVERTEXARRAY
 	gpIsVertexArrayAPPLE                                     C.GPISVERTEXARRAYAPPLE
 	gpIsVertexAttribEnabledAPPLE                             C.GPISVERTEXATTRIBENABLEDAPPLE
+	gpLGPUCopyImageSubDataNVX                                C.GPLGPUCOPYIMAGESUBDATANVX
+	gpLGPUInterlockNVX                                       C.GPLGPUINTERLOCKNVX
+	gpLGPUNamedBufferSubDataNVX                              C.GPLGPUNAMEDBUFFERSUBDATANVX
 	gpLabelObjectEXT                                         C.GPLABELOBJECTEXT
 	gpLightEnviSGIX                                          C.GPLIGHTENVISGIX
 	gpLightModelf                                            C.GPLIGHTMODELF
@@ -17162,6 +18025,7 @@ var (
 	gpLinkProgram                                            C.GPLINKPROGRAM
 	gpLinkProgramARB                                         C.GPLINKPROGRAMARB
 	gpListBase                                               C.GPLISTBASE
+	gpListDrawCommandsStatesClientNV                         C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
 	gpListParameterfSGIX                                     C.GPLISTPARAMETERFSGIX
 	gpListParameterfvSGIX                                    C.GPLISTPARAMETERFVSGIX
 	gpListParameteriSGIX                                     C.GPLISTPARAMETERISGIX
@@ -17256,9 +18120,12 @@ var (
 	gpMatrixScalefEXT                                        C.GPMATRIXSCALEFEXT
 	gpMatrixTranslatedEXT                                    C.GPMATRIXTRANSLATEDEXT
 	gpMatrixTranslatefEXT                                    C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                            C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                            C.GPMAXSHADERCOMPILERTHREADSKHR
 	gpMemoryBarrier                                          C.GPMEMORYBARRIER
 	gpMemoryBarrierByRegion                                  C.GPMEMORYBARRIERBYREGION
 	gpMemoryBarrierEXT                                       C.GPMEMORYBARRIEREXT
+	gpMemoryObjectParameterivEXT                             C.GPMEMORYOBJECTPARAMETERIVEXT
 	gpMinSampleShading                                       C.GPMINSAMPLESHADING
 	gpMinSampleShadingARB                                    C.GPMINSAMPLESHADINGARB
 	gpMinmax                                                 C.GPMINMAX
@@ -17411,12 +18278,25 @@ var (
 	gpMultiTexSubImage1DEXT                                  C.GPMULTITEXSUBIMAGE1DEXT
 	gpMultiTexSubImage2DEXT                                  C.GPMULTITEXSUBIMAGE2DEXT
 	gpMultiTexSubImage3DEXT                                  C.GPMULTITEXSUBIMAGE3DEXT
+	gpMulticastBarrierNV                                     C.GPMULTICASTBARRIERNV
+	gpMulticastBlitFramebufferNV                             C.GPMULTICASTBLITFRAMEBUFFERNV
+	gpMulticastBufferSubDataNV                               C.GPMULTICASTBUFFERSUBDATANV
+	gpMulticastCopyBufferSubDataNV                           C.GPMULTICASTCOPYBUFFERSUBDATANV
+	gpMulticastCopyImageSubDataNV                            C.GPMULTICASTCOPYIMAGESUBDATANV
+	gpMulticastFramebufferSampleLocationsfvNV                C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpMulticastGetQueryObjecti64vNV                          C.GPMULTICASTGETQUERYOBJECTI64VNV
+	gpMulticastGetQueryObjectivNV                            C.GPMULTICASTGETQUERYOBJECTIVNV
+	gpMulticastGetQueryObjectui64vNV                         C.GPMULTICASTGETQUERYOBJECTUI64VNV
+	gpMulticastGetQueryObjectuivNV                           C.GPMULTICASTGETQUERYOBJECTUIVNV
+	gpMulticastWaitSyncNV                                    C.GPMULTICASTWAITSYNCNV
 	gpNamedBufferData                                        C.GPNAMEDBUFFERDATA
 	gpNamedBufferDataEXT                                     C.GPNAMEDBUFFERDATAEXT
 	gpNamedBufferPageCommitmentARB                           C.GPNAMEDBUFFERPAGECOMMITMENTARB
 	gpNamedBufferPageCommitmentEXT                           C.GPNAMEDBUFFERPAGECOMMITMENTEXT
 	gpNamedBufferStorage                                     C.GPNAMEDBUFFERSTORAGE
 	gpNamedBufferStorageEXT                                  C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferStorageExternalEXT                          C.GPNAMEDBUFFERSTORAGEEXTERNALEXT
+	gpNamedBufferStorageMemEXT                               C.GPNAMEDBUFFERSTORAGEMEMEXT
 	gpNamedBufferSubData                                     C.GPNAMEDBUFFERSUBDATA
 	gpNamedBufferSubDataEXT                                  C.GPNAMEDBUFFERSUBDATAEXT
 	gpNamedCopyBufferSubDataEXT                              C.GPNAMEDCOPYBUFFERSUBDATAEXT
@@ -17427,6 +18307,9 @@ var (
 	gpNamedFramebufferReadBuffer                             C.GPNAMEDFRAMEBUFFERREADBUFFER
 	gpNamedFramebufferRenderbuffer                           C.GPNAMEDFRAMEBUFFERRENDERBUFFER
 	gpNamedFramebufferRenderbufferEXT                        C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB                   C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV                    C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferSamplePositionsfvAMD                   C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpNamedFramebufferTexture                                C.GPNAMEDFRAMEBUFFERTEXTURE
 	gpNamedFramebufferTexture1DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
 	gpNamedFramebufferTexture2DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
@@ -17570,6 +18453,8 @@ var (
 	gpPollInstrumentsSGIX                                    C.GPPOLLINSTRUMENTSSGIX
 	gpPolygonMode                                            C.GPPOLYGONMODE
 	gpPolygonOffset                                          C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                                     C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                                  C.GPPOLYGONOFFSETCLAMPEXT
 	gpPolygonOffsetEXT                                       C.GPPOLYGONOFFSETEXT
 	gpPolygonOffsetxOES                                      C.GPPOLYGONOFFSETXOES
 	gpPolygonStipple                                         C.GPPOLYGONSTIPPLE
@@ -17582,6 +18467,7 @@ var (
 	gpPopName                                                C.GPPOPNAME
 	gpPresentFrameDualFillNV                                 C.GPPRESENTFRAMEDUALFILLNV
 	gpPresentFrameKeyedNV                                    C.GPPRESENTFRAMEKEYEDNV
+	gpPrimitiveBoundingBoxARB                                C.GPPRIMITIVEBOUNDINGBOXARB
 	gpPrimitiveRestartIndex                                  C.GPPRIMITIVERESTARTINDEX
 	gpPrimitiveRestartIndexNV                                C.GPPRIMITIVERESTARTINDEXNV
 	gpPrimitiveRestartNV                                     C.GPPRIMITIVERESTARTNV
@@ -17639,13 +18525,17 @@ var (
 	gpProgramUniform1fv                                      C.GPPROGRAMUNIFORM1FV
 	gpProgramUniform1fvEXT                                   C.GPPROGRAMUNIFORM1FVEXT
 	gpProgramUniform1i                                       C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                                  C.GPPROGRAMUNIFORM1I64ARB
 	gpProgramUniform1i64NV                                   C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                                 C.GPPROGRAMUNIFORM1I64VARB
 	gpProgramUniform1i64vNV                                  C.GPPROGRAMUNIFORM1I64VNV
 	gpProgramUniform1iEXT                                    C.GPPROGRAMUNIFORM1IEXT
 	gpProgramUniform1iv                                      C.GPPROGRAMUNIFORM1IV
 	gpProgramUniform1ivEXT                                   C.GPPROGRAMUNIFORM1IVEXT
 	gpProgramUniform1ui                                      C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                                 C.GPPROGRAMUNIFORM1UI64ARB
 	gpProgramUniform1ui64NV                                  C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                                C.GPPROGRAMUNIFORM1UI64VARB
 	gpProgramUniform1ui64vNV                                 C.GPPROGRAMUNIFORM1UI64VNV
 	gpProgramUniform1uiEXT                                   C.GPPROGRAMUNIFORM1UIEXT
 	gpProgramUniform1uiv                                     C.GPPROGRAMUNIFORM1UIV
@@ -17659,13 +18549,17 @@ var (
 	gpProgramUniform2fv                                      C.GPPROGRAMUNIFORM2FV
 	gpProgramUniform2fvEXT                                   C.GPPROGRAMUNIFORM2FVEXT
 	gpProgramUniform2i                                       C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                                  C.GPPROGRAMUNIFORM2I64ARB
 	gpProgramUniform2i64NV                                   C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                                 C.GPPROGRAMUNIFORM2I64VARB
 	gpProgramUniform2i64vNV                                  C.GPPROGRAMUNIFORM2I64VNV
 	gpProgramUniform2iEXT                                    C.GPPROGRAMUNIFORM2IEXT
 	gpProgramUniform2iv                                      C.GPPROGRAMUNIFORM2IV
 	gpProgramUniform2ivEXT                                   C.GPPROGRAMUNIFORM2IVEXT
 	gpProgramUniform2ui                                      C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                                 C.GPPROGRAMUNIFORM2UI64ARB
 	gpProgramUniform2ui64NV                                  C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                                C.GPPROGRAMUNIFORM2UI64VARB
 	gpProgramUniform2ui64vNV                                 C.GPPROGRAMUNIFORM2UI64VNV
 	gpProgramUniform2uiEXT                                   C.GPPROGRAMUNIFORM2UIEXT
 	gpProgramUniform2uiv                                     C.GPPROGRAMUNIFORM2UIV
@@ -17679,13 +18573,17 @@ var (
 	gpProgramUniform3fv                                      C.GPPROGRAMUNIFORM3FV
 	gpProgramUniform3fvEXT                                   C.GPPROGRAMUNIFORM3FVEXT
 	gpProgramUniform3i                                       C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                                  C.GPPROGRAMUNIFORM3I64ARB
 	gpProgramUniform3i64NV                                   C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                                 C.GPPROGRAMUNIFORM3I64VARB
 	gpProgramUniform3i64vNV                                  C.GPPROGRAMUNIFORM3I64VNV
 	gpProgramUniform3iEXT                                    C.GPPROGRAMUNIFORM3IEXT
 	gpProgramUniform3iv                                      C.GPPROGRAMUNIFORM3IV
 	gpProgramUniform3ivEXT                                   C.GPPROGRAMUNIFORM3IVEXT
 	gpProgramUniform3ui                                      C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                                 C.GPPROGRAMUNIFORM3UI64ARB
 	gpProgramUniform3ui64NV                                  C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                                C.GPPROGRAMUNIFORM3UI64VARB
 	gpProgramUniform3ui64vNV                                 C.GPPROGRAMUNIFORM3UI64VNV
 	gpProgramUniform3uiEXT                                   C.GPPROGRAMUNIFORM3UIEXT
 	gpProgramUniform3uiv                                     C.GPPROGRAMUNIFORM3UIV
@@ -17699,13 +18597,17 @@ var (
 	gpProgramUniform4fv                                      C.GPPROGRAMUNIFORM4FV
 	gpProgramUniform4fvEXT                                   C.GPPROGRAMUNIFORM4FVEXT
 	gpProgramUniform4i                                       C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                                  C.GPPROGRAMUNIFORM4I64ARB
 	gpProgramUniform4i64NV                                   C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                                 C.GPPROGRAMUNIFORM4I64VARB
 	gpProgramUniform4i64vNV                                  C.GPPROGRAMUNIFORM4I64VNV
 	gpProgramUniform4iEXT                                    C.GPPROGRAMUNIFORM4IEXT
 	gpProgramUniform4iv                                      C.GPPROGRAMUNIFORM4IV
 	gpProgramUniform4ivEXT                                   C.GPPROGRAMUNIFORM4IVEXT
 	gpProgramUniform4ui                                      C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                                 C.GPPROGRAMUNIFORM4UI64ARB
 	gpProgramUniform4ui64NV                                  C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                                C.GPPROGRAMUNIFORM4UI64VARB
 	gpProgramUniform4ui64vNV                                 C.GPPROGRAMUNIFORM4UI64VNV
 	gpProgramUniform4uiEXT                                   C.GPPROGRAMUNIFORM4UIEXT
 	gpProgramUniform4uiv                                     C.GPPROGRAMUNIFORM4UIV
@@ -17766,6 +18668,8 @@ var (
 	gpQueryCounter                                           C.GPQUERYCOUNTER
 	gpQueryMatrixxOES                                        C.GPQUERYMATRIXXOES
 	gpQueryObjectParameteruiAMD                              C.GPQUERYOBJECTPARAMETERUIAMD
+	gpQueryResourceNV                                        C.GPQUERYRESOURCENV
+	gpQueryResourceTagNV                                     C.GPQUERYRESOURCETAGNV
 	gpRasterPos2d                                            C.GPRASTERPOS2D
 	gpRasterPos2dv                                           C.GPRASTERPOS2DV
 	gpRasterPos2f                                            C.GPRASTERPOS2F
@@ -17796,6 +18700,7 @@ var (
 	gpRasterPos4sv                                           C.GPRASTERPOS4SV
 	gpRasterPos4xOES                                         C.GPRASTERPOS4XOES
 	gpRasterPos4xvOES                                        C.GPRASTERPOS4XVOES
+	gpRasterSamplesEXT                                       C.GPRASTERSAMPLESEXT
 	gpReadBuffer                                             C.GPREADBUFFER
 	gpReadInstrumentsSGIX                                    C.GPREADINSTRUMENTSSGIX
 	gpReadPixels                                             C.GPREADPIXELS
@@ -17813,7 +18718,9 @@ var (
 	gpRectxOES                                               C.GPRECTXOES
 	gpRectxvOES                                              C.GPRECTXVOES
 	gpReferencePlaneSGIX                                     C.GPREFERENCEPLANESGIX
+	gpReleaseKeyedMutexWin32EXT                              C.GPRELEASEKEYEDMUTEXWIN32EXT
 	gpReleaseShaderCompiler                                  C.GPRELEASESHADERCOMPILER
+	gpRenderGpuMaskNV                                        C.GPRENDERGPUMASKNV
 	gpRenderMode                                             C.GPRENDERMODE
 	gpRenderbufferStorage                                    C.GPRENDERBUFFERSTORAGE
 	gpRenderbufferStorageEXT                                 C.GPRENDERBUFFERSTORAGEEXT
@@ -17849,6 +18756,7 @@ var (
 	gpResetMinmax                                            C.GPRESETMINMAX
 	gpResetMinmaxEXT                                         C.GPRESETMINMAXEXT
 	gpResizeBuffersMESA                                      C.GPRESIZEBUFFERSMESA
+	gpResolveDepthValuesNV                                   C.GPRESOLVEDEPTHVALUESNV
 	gpResumeTransformFeedback                                C.GPRESUMETRANSFORMFEEDBACK
 	gpResumeTransformFeedbackNV                              C.GPRESUMETRANSFORMFEEDBACKNV
 	gpRotated                                                C.GPROTATED
@@ -17856,7 +18764,6 @@ var (
 	gpRotatexOES                                             C.GPROTATEXOES
 	gpSampleCoverage                                         C.GPSAMPLECOVERAGE
 	gpSampleCoverageARB                                      C.GPSAMPLECOVERAGEARB
-	gpSampleCoverageOES                                      C.GPSAMPLECOVERAGEOES
 	gpSampleCoveragexOES                                     C.GPSAMPLECOVERAGEXOES
 	gpSampleMapATI                                           C.GPSAMPLEMAPATI
 	gpSampleMaskEXT                                          C.GPSAMPLEMASKEXT
@@ -17920,6 +18827,7 @@ var (
 	gpSecondaryColorPointerListIBM                           C.GPSECONDARYCOLORPOINTERLISTIBM
 	gpSelectBuffer                                           C.GPSELECTBUFFER
 	gpSelectPerfMonitorCountersAMD                           C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpSemaphoreParameterui64vEXT                             C.GPSEMAPHOREPARAMETERUI64VEXT
 	gpSeparableFilter2D                                      C.GPSEPARABLEFILTER2D
 	gpSeparableFilter2DEXT                                   C.GPSEPARABLEFILTER2DEXT
 	gpSetFenceAPPLE                                          C.GPSETFENCEAPPLE
@@ -17937,11 +18845,16 @@ var (
 	gpShaderSourceARB                                        C.GPSHADERSOURCEARB
 	gpShaderStorageBlockBinding                              C.GPSHADERSTORAGEBLOCKBINDING
 	gpSharpenTexFuncSGIS                                     C.GPSHARPENTEXFUNCSGIS
+	gpSignalSemaphoreEXT                                     C.GPSIGNALSEMAPHOREEXT
+	gpSignalVkFenceNV                                        C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                                    C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                                    C.GPSPECIALIZESHADERARB
 	gpSpriteParameterfSGIX                                   C.GPSPRITEPARAMETERFSGIX
 	gpSpriteParameterfvSGIX                                  C.GPSPRITEPARAMETERFVSGIX
 	gpSpriteParameteriSGIX                                   C.GPSPRITEPARAMETERISGIX
 	gpSpriteParameterivSGIX                                  C.GPSPRITEPARAMETERIVSGIX
 	gpStartInstrumentsSGIX                                   C.GPSTARTINSTRUMENTSSGIX
+	gpStateCaptureNV                                         C.GPSTATECAPTURENV
 	gpStencilClearTagEXT                                     C.GPSTENCILCLEARTAGEXT
 	gpStencilFillPathInstancedNV                             C.GPSTENCILFILLPATHINSTANCEDNV
 	gpStencilFillPathNV                                      C.GPSTENCILFILLPATHNV
@@ -17962,6 +18875,7 @@ var (
 	gpStencilThenCoverStrokePathNV                           C.GPSTENCILTHENCOVERSTROKEPATHNV
 	gpStopInstrumentsSGIX                                    C.GPSTOPINSTRUMENTSSGIX
 	gpStringMarkerGREMEDY                                    C.GPSTRINGMARKERGREMEDY
+	gpSubpixelPrecisionBiasNV                                C.GPSUBPIXELPRECISIONBIASNV
 	gpSwizzleEXT                                             C.GPSWIZZLEEXT
 	gpSyncTextureINTEL                                       C.GPSYNCTEXTUREINTEL
 	gpTagSampleBufferSGIX                                    C.GPTAGSAMPLEBUFFERSGIX
@@ -18112,6 +19026,11 @@ var (
 	gpTexStorage2DMultisample                                C.GPTEXSTORAGE2DMULTISAMPLE
 	gpTexStorage3D                                           C.GPTEXSTORAGE3D
 	gpTexStorage3DMultisample                                C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexStorageMem1DEXT                                     C.GPTEXSTORAGEMEM1DEXT
+	gpTexStorageMem2DEXT                                     C.GPTEXSTORAGEMEM2DEXT
+	gpTexStorageMem2DMultisampleEXT                          C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT
+	gpTexStorageMem3DEXT                                     C.GPTEXSTORAGEMEM3DEXT
+	gpTexStorageMem3DMultisampleEXT                          C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT
 	gpTexStorageSparseAMD                                    C.GPTEXSTORAGESPARSEAMD
 	gpTexSubImage1D                                          C.GPTEXSUBIMAGE1D
 	gpTexSubImage1DEXT                                       C.GPTEXSUBIMAGE1DEXT
@@ -18162,6 +19081,11 @@ var (
 	gpTextureStorage3DEXT                                    C.GPTEXTURESTORAGE3DEXT
 	gpTextureStorage3DMultisample                            C.GPTEXTURESTORAGE3DMULTISAMPLE
 	gpTextureStorage3DMultisampleEXT                         C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureStorageMem1DEXT                                 C.GPTEXTURESTORAGEMEM1DEXT
+	gpTextureStorageMem2DEXT                                 C.GPTEXTURESTORAGEMEM2DEXT
+	gpTextureStorageMem2DMultisampleEXT                      C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT
+	gpTextureStorageMem3DEXT                                 C.GPTEXTURESTORAGEMEM3DEXT
+	gpTextureStorageMem3DMultisampleEXT                      C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT
 	gpTextureStorageSparseAMD                                C.GPTEXTURESTORAGESPARSEAMD
 	gpTextureSubImage1D                                      C.GPTEXTURESUBIMAGE1D
 	gpTextureSubImage1DEXT                                   C.GPTEXTURESUBIMAGE1DEXT
@@ -18189,13 +19113,17 @@ var (
 	gpUniform1fv                                             C.GPUNIFORM1FV
 	gpUniform1fvARB                                          C.GPUNIFORM1FVARB
 	gpUniform1i                                              C.GPUNIFORM1I
+	gpUniform1i64ARB                                         C.GPUNIFORM1I64ARB
 	gpUniform1i64NV                                          C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                        C.GPUNIFORM1I64VARB
 	gpUniform1i64vNV                                         C.GPUNIFORM1I64VNV
 	gpUniform1iARB                                           C.GPUNIFORM1IARB
 	gpUniform1iv                                             C.GPUNIFORM1IV
 	gpUniform1ivARB                                          C.GPUNIFORM1IVARB
 	gpUniform1ui                                             C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                        C.GPUNIFORM1UI64ARB
 	gpUniform1ui64NV                                         C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                                       C.GPUNIFORM1UI64VARB
 	gpUniform1ui64vNV                                        C.GPUNIFORM1UI64VNV
 	gpUniform1uiEXT                                          C.GPUNIFORM1UIEXT
 	gpUniform1uiv                                            C.GPUNIFORM1UIV
@@ -18207,13 +19135,17 @@ var (
 	gpUniform2fv                                             C.GPUNIFORM2FV
 	gpUniform2fvARB                                          C.GPUNIFORM2FVARB
 	gpUniform2i                                              C.GPUNIFORM2I
+	gpUniform2i64ARB                                         C.GPUNIFORM2I64ARB
 	gpUniform2i64NV                                          C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                        C.GPUNIFORM2I64VARB
 	gpUniform2i64vNV                                         C.GPUNIFORM2I64VNV
 	gpUniform2iARB                                           C.GPUNIFORM2IARB
 	gpUniform2iv                                             C.GPUNIFORM2IV
 	gpUniform2ivARB                                          C.GPUNIFORM2IVARB
 	gpUniform2ui                                             C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                        C.GPUNIFORM2UI64ARB
 	gpUniform2ui64NV                                         C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                                       C.GPUNIFORM2UI64VARB
 	gpUniform2ui64vNV                                        C.GPUNIFORM2UI64VNV
 	gpUniform2uiEXT                                          C.GPUNIFORM2UIEXT
 	gpUniform2uiv                                            C.GPUNIFORM2UIV
@@ -18225,13 +19157,17 @@ var (
 	gpUniform3fv                                             C.GPUNIFORM3FV
 	gpUniform3fvARB                                          C.GPUNIFORM3FVARB
 	gpUniform3i                                              C.GPUNIFORM3I
+	gpUniform3i64ARB                                         C.GPUNIFORM3I64ARB
 	gpUniform3i64NV                                          C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                        C.GPUNIFORM3I64VARB
 	gpUniform3i64vNV                                         C.GPUNIFORM3I64VNV
 	gpUniform3iARB                                           C.GPUNIFORM3IARB
 	gpUniform3iv                                             C.GPUNIFORM3IV
 	gpUniform3ivARB                                          C.GPUNIFORM3IVARB
 	gpUniform3ui                                             C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                        C.GPUNIFORM3UI64ARB
 	gpUniform3ui64NV                                         C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                                       C.GPUNIFORM3UI64VARB
 	gpUniform3ui64vNV                                        C.GPUNIFORM3UI64VNV
 	gpUniform3uiEXT                                          C.GPUNIFORM3UIEXT
 	gpUniform3uiv                                            C.GPUNIFORM3UIV
@@ -18243,13 +19179,17 @@ var (
 	gpUniform4fv                                             C.GPUNIFORM4FV
 	gpUniform4fvARB                                          C.GPUNIFORM4FVARB
 	gpUniform4i                                              C.GPUNIFORM4I
+	gpUniform4i64ARB                                         C.GPUNIFORM4I64ARB
 	gpUniform4i64NV                                          C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                        C.GPUNIFORM4I64VARB
 	gpUniform4i64vNV                                         C.GPUNIFORM4I64VNV
 	gpUniform4iARB                                           C.GPUNIFORM4IARB
 	gpUniform4iv                                             C.GPUNIFORM4IV
 	gpUniform4ivARB                                          C.GPUNIFORM4IVARB
 	gpUniform4ui                                             C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                        C.GPUNIFORM4UI64ARB
 	gpUniform4ui64NV                                         C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                                       C.GPUNIFORM4UI64VARB
 	gpUniform4ui64vNV                                        C.GPUNIFORM4UI64VNV
 	gpUniform4uiEXT                                          C.GPUNIFORM4UIEXT
 	gpUniform4uiv                                            C.GPUNIFORM4UIV
@@ -18676,7 +19616,11 @@ var (
 	gpViewportArrayv                                         C.GPVIEWPORTARRAYV
 	gpViewportIndexedf                                       C.GPVIEWPORTINDEXEDF
 	gpViewportIndexedfv                                      C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                               C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                                      C.GPVIEWPORTSWIZZLENV
+	gpWaitSemaphoreEXT                                       C.GPWAITSEMAPHOREEXT
 	gpWaitSync                                               C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                                      C.GPWAITVKSEMAPHORENV
 	gpWeightPathsNV                                          C.GPWEIGHTPATHSNV
 	gpWeightPointerARB                                       C.GPWEIGHTPOINTERARB
 	gpWeightbvARB                                            C.GPWEIGHTBVARB
@@ -18743,6 +19687,7 @@ var (
 	gpWindowPos4ivMESA                                       C.GPWINDOWPOS4IVMESA
 	gpWindowPos4sMESA                                        C.GPWINDOWPOS4SMESA
 	gpWindowPos4svMESA                                       C.GPWINDOWPOS4SVMESA
+	gpWindowRectanglesEXT                                    C.GPWINDOWRECTANGLESEXT
 	gpWriteMaskEXT                                           C.GPWRITEMASKEXT
 )
 
@@ -18760,6 +19705,10 @@ func Accum(op uint32, value float32) {
 }
 func AccumxOES(op uint32, value int32) {
 	C.glowAccumxOES(gpAccumxOES, (C.GLenum)(op), (C.GLfixed)(value))
+}
+func AcquireKeyedMutexWin32EXT(memory uint32, key uint64, timeout uint32) bool {
+	ret := C.glowAcquireKeyedMutexWin32EXT(gpAcquireKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key), (C.GLuint)(timeout))
+	return ret == TRUE
 }
 func ActiveProgramEXT(program uint32) {
 	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
@@ -18802,6 +19751,12 @@ func AlphaFunc(xfunc uint32, ref float32) {
 }
 func AlphaFuncxOES(xfunc uint32, ref int32) {
 	C.glowAlphaFuncxOES(gpAlphaFuncxOES, (C.GLenum)(xfunc), (C.GLfixed)(ref))
+}
+func AlphaToCoverageDitherControlNV(mode uint32) {
+	C.glowAlphaToCoverageDitherControlNV(gpAlphaToCoverageDitherControlNV, (C.GLenum)(mode))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 func ApplyTextureEXT(mode uint32) {
 	C.glowApplyTextureEXT(gpApplyTextureEXT, (C.GLenum)(mode))
@@ -19250,8 +20205,8 @@ func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 func BufferDataARB(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferDataARB(gpBufferDataARB, (C.GLenum)(target), (C.GLsizeiptrARB)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 	C.glowBufferParameteriAPPLE(gpBufferParameteriAPPLE, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
@@ -19261,6 +20216,12 @@ func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowBufferStorage(gpBufferStorage, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func BufferStorageExternalEXT(target uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowBufferStorageExternalEXT(gpBufferStorageExternalEXT, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func BufferStorageMemEXT(target uint32, size int, memory uint32, offset uint64) {
+	C.glowBufferStorageMemEXT(gpBufferStorageMemEXT, (C.GLenum)(target), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
@@ -19268,6 +20229,9 @@ func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 }
 func BufferSubDataARB(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubDataARB(gpBufferSubDataARB, (C.GLenum)(target), (C.GLintptrARB)(offset), (C.GLsizeiptrARB)(size), data)
+}
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
 }
 
 // execute a display list
@@ -19364,6 +20328,8 @@ func ClearDepth(depth float64) {
 func ClearDepthdNV(depth float64) {
 	C.glowClearDepthdNV(gpClearDepthdNV, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -19388,14 +20354,14 @@ func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32
 }
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
 func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -19437,7 +20403,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -19705,6 +20671,12 @@ func CombinerParameterivNV(pname uint32, params *int32) {
 func CombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowCombinerStageParameterfvNV(gpCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
+}
 
 // Compiles a shader object
 func CompileShader(shader uint32) {
@@ -19815,6 +20787,12 @@ func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yof
 func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // define a one-dimensional convolution filter
 func ConvolutionFilter1D(target uint32, internalformat uint32, width int32, format uint32, xtype uint32, image unsafe.Pointer) {
@@ -19923,8 +20901,8 @@ func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffs
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 func CopyPathNV(resultPath uint32, srcPath uint32) {
 	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
@@ -20016,15 +20994,27 @@ func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsaf
 func CoverStrokePathNV(path uint32, coverMode uint32) {
 	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
 }
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreateMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowCreateMemoryObjectsEXT(gpCreateMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
 	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
@@ -20083,9 +21073,12 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -20181,6 +21174,9 @@ func DeleteBuffers(n int32, buffers *uint32) {
 func DeleteBuffersARB(n int32, buffers *uint32) {
 	C.glowDeleteBuffersARB(gpDeleteBuffersARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 func DeleteFencesAPPLE(n int32, fences *uint32) {
 	C.glowDeleteFencesAPPLE(gpDeleteFencesAPPLE, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(fences)))
 }
@@ -20202,6 +21198,9 @@ func DeleteFramebuffersEXT(n int32, framebuffers *uint32) {
 // delete a contiguous group of display lists
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
+}
+func DeleteMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowDeleteMemoryObjectsEXT(gpDeleteMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
@@ -20251,6 +21250,9 @@ func DeleteQueries(n int32, ids *uint32) {
 func DeleteQueriesARB(n int32, ids *uint32) {
 	C.glowDeleteQueriesARB(gpDeleteQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func DeleteQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowDeleteQueryResourceTagNV(gpDeleteQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // delete renderbuffer objects
 func DeleteRenderbuffers(n int32, renderbuffers *uint32) {
@@ -20264,14 +21266,20 @@ func DeleteRenderbuffersEXT(n int32, renderbuffers *uint32) {
 func DeleteSamplers(count int32, samplers *uint32) {
 	C.glowDeleteSamplers(gpDeleteSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
 }
+func DeleteSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowDeleteSemaphoresEXT(gpDeleteSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
+}
 
 // Deletes a shader object
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -20333,6 +21341,8 @@ func DepthRangeIndexed(index uint32, n float64, f float64) {
 func DepthRangedNV(zNear float64, zFar float64) {
 	C.glowDepthRangedNV(gpDepthRangedNV, (C.GLdouble)(zNear), (C.GLdouble)(zFar))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -20454,6 +21464,18 @@ func DrawBuffersARB(n int32, bufs *uint32) {
 func DrawBuffersATI(n int32, bufs *uint32) {
 	C.glowDrawBuffersATI(gpDrawBuffersATI, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 func DrawElementArrayAPPLE(mode uint32, first int32, count int32) {
 	C.glowDrawElementArrayAPPLE(gpDrawElementArrayAPPLE, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count))
 }
@@ -20553,6 +21575,9 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 // render multiple instances of primitives using a count derived from a specifed stream of a transform feedback object
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
+}
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
 }
 
 // flag edges as either boundary or nonboundary
@@ -20731,6 +21756,9 @@ func EvalPoint1(i int32) {
 func EvalPoint2(i int32, j int32) {
 	C.glowEvalPoint2(gpEvalPoint2, (C.GLint)(i), (C.GLint)(j))
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 func ExecuteProgramNV(target uint32, id uint32, params *float32) {
 	C.glowExecuteProgramNV(gpExecuteProgramNV, (C.GLenum)(target), (C.GLuint)(id), (*C.GLfloat)(unsafe.Pointer(params)))
 }
@@ -20747,9 +21775,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -20790,8 +21818,8 @@ func FlushMappedBufferRangeAPPLE(target uint32, offset int, size int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
 }
 func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
 	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
@@ -20879,6 +21907,9 @@ func FogxvOES(pname uint32, param *int32) {
 func FragmentColorMaterialSGIX(face uint32, mode uint32) {
 	C.glowFragmentColorMaterialSGIX(gpFragmentColorMaterialSGIX, (C.GLenum)(face), (C.GLenum)(mode))
 }
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
 func FragmentLightModelfSGIX(pname uint32, param float32) {
 	C.glowFragmentLightModelfSGIX(gpFragmentLightModelfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -20927,6 +21958,9 @@ func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
 func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
 	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
+}
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
@@ -20943,6 +21977,15 @@ func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarge
 func FramebufferRenderbufferEXT(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbufferEXT(gpFramebufferRenderbufferEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSamplePositionsfvAMD(target uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowFramebufferSamplePositionsfvAMD(gpFramebufferSamplePositionsfvAMD, (C.GLenum)(target), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
 func FramebufferTexture(target uint32, attachment uint32, texture uint32, level int32) {
@@ -20954,6 +21997,8 @@ func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, te
 func FramebufferTexture1DEXT(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1DEXT(gpFramebufferTexture1DEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
@@ -20988,6 +22033,9 @@ func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32
 }
 func FramebufferTextureLayerEXT(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayerEXT(gpFramebufferTextureLayerEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 func FreeObjectBufferATI(buffer uint32) {
 	C.glowFreeObjectBufferATI(gpFreeObjectBufferATI, (C.GLuint)(buffer))
@@ -21079,6 +22127,9 @@ func GenQueries(n int32, ids *uint32) {
 func GenQueriesARB(n int32, ids *uint32) {
 	C.glowGenQueriesARB(gpGenQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func GenQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowGenQueryResourceTagNV(gpGenQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // generate renderbuffer object names
 func GenRenderbuffers(n int32, renderbuffers *uint32) {
@@ -21091,6 +22142,9 @@ func GenRenderbuffersEXT(n int32, renderbuffers *uint32) {
 // generate sampler object names
 func GenSamplers(count int32, samplers *uint32) {
 	C.glowGenSamplers(gpGenSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
+}
+func GenSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowGenSemaphoresEXT(gpGenSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
 }
 func GenSymbolsEXT(datatype uint32, storagetype uint32, xrange uint32, components uint32) uint32 {
 	ret := C.glowGenSymbolsEXT(gpGenSymbolsEXT, (C.GLenum)(datatype), (C.GLenum)(storagetype), (C.GLenum)(xrange), (C.GLuint)(components))
@@ -21182,6 +22236,8 @@ func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, leng
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21318,6 +22374,10 @@ func GetCombinerOutputParameterivNV(stage uint32, portion uint32, pname uint32, 
 func GetCombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowGetCombinerStageParameterfvNV(gpGetCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
 func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
 	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
@@ -21364,6 +22424,9 @@ func GetConvolutionParameterivEXT(target uint32, pname uint32, params *int32) {
 }
 func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 	C.glowGetConvolutionParameterxvOES(gpGetConvolutionParameterxvOES, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -21463,15 +22526,18 @@ func GetFragmentMaterialivSGIX(face uint32, pname uint32, params *int32) {
 	C.glowGetFragmentMaterialivSGIX(gpGetFragmentMaterialivSGIX, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetFramebufferAttachmentParameterivEXT(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameterivEXT(gpGetFramebufferAttachmentParameterivEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetFramebufferParameterfvAMD(target uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetFramebufferParameterfvAMD(gpGetFramebufferParameterfvAMD, (C.GLenum)(target), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21561,9 +22627,14 @@ func GetIntegerui64vNV(value uint32, result *uint64) {
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21641,6 +22712,9 @@ func GetMaterialxOES(face uint32, pname uint32, param int32) {
 }
 func GetMaterialxvOES(face uint32, pname uint32, params *int32) {
 	C.glowGetMaterialxvOES(gpGetMaterialxvOES, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetMemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowGetMemoryObjectParameterivEXT(gpGetMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // get minimum and maximum pixel values
@@ -21732,8 +22806,8 @@ func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Point
 }
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -21745,6 +22819,9 @@ func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uin
 }
 func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedFramebufferParameterfvAMD(framebuffer uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetNamedFramebufferParameterfvAMD(gpGetNamedFramebufferParameterfvAMD, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 
 // query a named parameter of a framebuffer object
@@ -22060,6 +23137,18 @@ func GetProgramivARB(target uint32, pname uint32, params *int32) {
 func GetProgramivNV(id uint32, pname uint32, params *int32) {
 	C.glowGetProgramivNV(gpGetProgramivNV, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
 
 // return parameters of an indexed query object target
 func GetQueryIndexediv(target uint32, index uint32, pname uint32, params *int32) {
@@ -22083,6 +23172,8 @@ func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 func GetQueryObjectui64vEXT(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64vEXT(gpGetQueryObjectui64vEXT, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -22098,7 +23189,7 @@ func GetQueryivARB(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryivARB(gpGetQueryivARB, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -22116,6 +23207,9 @@ func GetSamplerParameterfv(sampler uint32, pname uint32, params *float32) {
 }
 func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 	C.glowGetSamplerParameteriv(gpGetSamplerParameteriv, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetSemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowGetSemaphoreParameterui64vEXT(gpGetSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 
 // get separable convolution filter kernel images
@@ -22151,6 +23245,10 @@ func GetShaderiv(shader uint32, pname uint32, params *int32) {
 func GetSharpenTexFuncSGIS(target uint32, points *float32) {
 	C.glowGetSharpenTexFuncSGIS(gpGetSharpenTexFuncSGIS, (C.GLenum)(target), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -22175,7 +23273,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -22379,6 +23477,9 @@ func GetUniformfv(program uint32, location int32, params *float32) {
 func GetUniformfvARB(programObj uintptr, location int32, params *float32) {
 	C.glowGetUniformfvARB(gpGetUniformfvARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetUniformi64vNV(program uint32, location int32, params *int64) {
 	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
 }
@@ -22390,6 +23491,9 @@ func GetUniformiv(program uint32, location int32, params *int32) {
 func GetUniformivARB(programObj uintptr, location int32, params *int32) {
 	C.glowGetUniformivARB(gpGetUniformivARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 func GetUniformui64vNV(program uint32, location int32, params *uint64) {
 	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
@@ -22398,6 +23502,12 @@ func GetUniformuiv(program uint32, location int32, params *uint32) {
 }
 func GetUniformuivEXT(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuivEXT(gpGetUniformuivEXT, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetUnsignedBytei_vEXT(target uint32, index uint32, data *uint8) {
+	C.glowGetUnsignedBytei_vEXT(gpGetUnsignedBytei_vEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLubyte)(unsafe.Pointer(data)))
+}
+func GetUnsignedBytevEXT(pname uint32, data *uint8) {
+	C.glowGetUnsignedBytevEXT(gpGetUnsignedBytevEXT, (C.GLenum)(pname), (*C.GLubyte)(unsafe.Pointer(data)))
 }
 func GetVariantArrayObjectfvATI(id uint32, pname uint32, params *float32) {
 	C.glowGetVariantArrayObjectfvATI(gpGetVariantArrayObjectfvATI, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
@@ -22551,6 +23661,10 @@ func GetVideoui64vNV(video_slot uint32, pname uint32, params *uint64) {
 func GetVideouivNV(video_slot uint32, pname uint32, params *uint32) {
 	C.glowGetVideouivNV(gpGetVideouivNV, (C.GLuint)(video_slot), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
+}
 func GetnColorTableARB(target uint32, format uint32, xtype uint32, bufSize int32, table unsafe.Pointer) {
 	C.glowGetnColorTableARB(gpGetnColorTableARB, (C.GLenum)(target), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), table)
 }
@@ -22605,6 +23719,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -22613,6 +23730,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -22678,9 +23798,27 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportMemoryFdEXT(memory uint32, size uint64, handleType uint32, fd int32) {
+	C.glowImportMemoryFdEXT(gpImportMemoryFdEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportMemoryWin32HandleEXT(memory uint32, size uint64, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportMemoryWin32HandleEXT(gpImportMemoryWin32HandleEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), handle)
+}
+func ImportMemoryWin32NameEXT(memory uint32, size uint64, handleType uint32, name unsafe.Pointer) {
+	C.glowImportMemoryWin32NameEXT(gpImportMemoryWin32NameEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), name)
+}
+func ImportSemaphoreFdEXT(semaphore uint32, handleType uint32, fd int32) {
+	C.glowImportSemaphoreFdEXT(gpImportSemaphoreFdEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportSemaphoreWin32HandleEXT(semaphore uint32, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportSemaphoreWin32HandleEXT(gpImportSemaphoreWin32HandleEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), handle)
+}
+func ImportSemaphoreWin32NameEXT(semaphore uint32, handleType uint32, name unsafe.Pointer) {
+	C.glowImportSemaphoreWin32NameEXT(gpImportSemaphoreWin32NameEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), name)
+}
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -22823,6 +23961,10 @@ func IsBufferResidentNV(target uint32) bool {
 	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
 	return ret == TRUE
 }
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
 	return ret == TRUE
@@ -22865,6 +24007,10 @@ func IsImageHandleResidentNV(handle uint64) bool {
 // determine if a name corresponds to a display list
 func IsList(list uint32) bool {
 	ret := C.glowIsList(gpIsList, (C.GLuint)(list))
+	return ret == TRUE
+}
+func IsMemoryObjectEXT(memoryObject uint32) bool {
+	ret := C.glowIsMemoryObjectEXT(gpIsMemoryObjectEXT, (C.GLuint)(memoryObject))
 	return ret == TRUE
 }
 func IsNameAMD(identifier uint32, name uint32) bool {
@@ -22949,15 +24095,23 @@ func IsSampler(sampler uint32) bool {
 	ret := C.glowIsSampler(gpIsSampler, (C.GLuint)(sampler))
 	return ret == TRUE
 }
+func IsSemaphoreEXT(semaphore uint32) bool {
+	ret := C.glowIsSemaphoreEXT(gpIsSemaphoreEXT, (C.GLuint)(semaphore))
+	return ret == TRUE
+}
 
 // Determines if a name corresponds to a shader object
 func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -23006,6 +24160,15 @@ func IsVertexArrayAPPLE(array uint32) bool {
 func IsVertexAttribEnabledAPPLE(index uint32, pname uint32) bool {
 	ret := C.glowIsVertexAttribEnabledAPPLE(gpIsVertexAttribEnabledAPPLE, (C.GLuint)(index), (C.GLenum)(pname))
 	return ret == TRUE
+}
+func LGPUCopyImageSubDataNVX(sourceGpu uint32, destinationGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srxY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, width int32, height int32, depth int32) {
+	C.glowLGPUCopyImageSubDataNVX(gpLGPUCopyImageSubDataNVX, (C.GLuint)(sourceGpu), (C.GLbitfield)(destinationGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srxY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func LGPUInterlockNVX() {
+	C.glowLGPUInterlockNVX(gpLGPUInterlockNVX)
+}
+func LGPUNamedBufferSubDataNVX(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowLGPUNamedBufferSubDataNVX(gpLGPUNamedBufferSubDataNVX, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
@@ -23074,6 +24237,9 @@ func LinkProgramARB(programObj uintptr) {
 // set the display-list base for
 func ListBase(base uint32) {
 	C.glowListBase(gpListBase, (C.GLuint)(base))
+}
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 func ListParameterfSGIX(list uint32, pname uint32, param float32) {
 	C.glowListParameterfSGIX(gpListParameterfSGIX, (C.GLuint)(list), (C.GLenum)(pname), (C.GLfloat)(param))
@@ -23238,8 +24404,8 @@ func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
 }
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
 }
 func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
@@ -23382,6 +24548,12 @@ func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
 func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
 	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
 }
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
+}
 
 // defines a barrier ordering memory transactions
 func MemoryBarrier(barriers uint32) {
@@ -23392,6 +24564,9 @@ func MemoryBarrierByRegion(barriers uint32) {
 }
 func MemoryBarrierEXT(barriers uint32) {
 	C.glowMemoryBarrierEXT(gpMemoryBarrierEXT, (C.GLbitfield)(barriers))
+}
+func MemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowMemoryObjectParameterivEXT(gpMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // specifies minimum rate at which sample shaing takes place
@@ -23455,8 +24630,8 @@ func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer
 func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawElementArrayAPPLE(mode uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawElementArrayAPPLE(gpMultiDrawElementArrayAPPLE, (C.GLenum)(mode), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -23488,8 +24663,8 @@ func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirec
 func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawRangeElementArrayAPPLE(mode uint32, start uint32, end uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawRangeElementArrayAPPLE(gpMultiDrawRangeElementArrayAPPLE, (C.GLenum)(mode), (C.GLuint)(start), (C.GLuint)(end), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -23863,32 +25038,71 @@ func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset i
 func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func MulticastBarrierNV() {
+	C.glowMulticastBarrierNV(gpMulticastBarrierNV)
+}
+func MulticastBlitFramebufferNV(srcGpu uint32, dstGpu uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
+	C.glowMulticastBlitFramebufferNV(gpMulticastBlitFramebufferNV, (C.GLuint)(srcGpu), (C.GLuint)(dstGpu), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
+}
+func MulticastBufferSubDataNV(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowMulticastBufferSubDataNV(gpMulticastBufferSubDataNV, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func MulticastCopyBufferSubDataNV(readGpu uint32, writeGpuMask uint32, readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowMulticastCopyBufferSubDataNV(gpMulticastCopyBufferSubDataNV, (C.GLuint)(readGpu), (C.GLbitfield)(writeGpuMask), (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func MulticastCopyImageSubDataNV(srcGpu uint32, dstGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
+	C.glowMulticastCopyImageSubDataNV(gpMulticastCopyImageSubDataNV, (C.GLuint)(srcGpu), (C.GLbitfield)(dstGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
+}
+func MulticastFramebufferSampleLocationsfvNV(gpu uint32, framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowMulticastFramebufferSampleLocationsfvNV(gpMulticastFramebufferSampleLocationsfvNV, (C.GLuint)(gpu), (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func MulticastGetQueryObjecti64vNV(gpu uint32, id uint32, pname uint32, params *int64) {
+	C.glowMulticastGetQueryObjecti64vNV(gpMulticastGetQueryObjecti64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectivNV(gpu uint32, id uint32, pname uint32, params *int32) {
+	C.glowMulticastGetQueryObjectivNV(gpMulticastGetQueryObjectivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectui64vNV(gpu uint32, id uint32, pname uint32, params *uint64) {
+	C.glowMulticastGetQueryObjectui64vNV(gpMulticastGetQueryObjectui64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectuivNV(gpu uint32, id uint32, pname uint32, params *uint32) {
+	C.glowMulticastGetQueryObjectuivNV(gpMulticastGetQueryObjectuivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MulticastWaitSyncNV(signalGpu uint32, waitGpuMask uint32) {
+	C.glowMulticastWaitSyncNV(gpMulticastWaitSyncNV, (C.GLuint)(signalGpu), (C.GLbitfield)(waitGpuMask))
+}
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
 func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func NamedBufferStorageExternalEXT(buffer uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowNamedBufferStorageExternalEXT(gpNamedBufferStorageExternalEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func NamedBufferStorageMemEXT(buffer uint32, size int, memory uint32, offset uint64) {
+	C.glowNamedBufferStorageMemEXT(gpNamedBufferStorageMemEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -23926,6 +25140,15 @@ func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderb
 }
 func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSamplePositionsfvAMD(framebuffer uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowNamedFramebufferSamplePositionsfvAMD(gpNamedFramebufferSamplePositionsfvAMD, (C.GLuint)(framebuffer), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
@@ -24176,6 +25399,8 @@ func PassThroughxOES(token int32) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -24271,6 +25496,8 @@ func PixelMapx(xmap uint32, size int32, values *int32) {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
 }
@@ -24393,6 +25620,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 func PolygonOffsetEXT(factor float32, bias float32) {
 	C.glowPolygonOffsetEXT(gpPolygonOffsetEXT, (C.GLfloat)(factor), (C.GLfloat)(bias))
 }
@@ -24432,6 +25665,9 @@ func PresentFrameDualFillNV(video_slot uint32, minPresentTime uint64, beginPrese
 }
 func PresentFrameKeyedNV(video_slot uint32, minPresentTime uint64, beginPresentTimeId uint32, presentDurationId uint32, xtype uint32, target0 uint32, fill0 uint32, key0 uint32, target1 uint32, fill1 uint32, key1 uint32) {
 	C.glowPresentFrameKeyedNV(gpPresentFrameKeyedNV, (C.GLuint)(video_slot), (C.GLuint64EXT)(minPresentTime), (C.GLuint)(beginPresentTimeId), (C.GLuint)(presentDurationId), (C.GLenum)(xtype), (C.GLenum)(target0), (C.GLuint)(fill0), (C.GLuint)(key0), (C.GLenum)(target1), (C.GLuint)(fill1), (C.GLuint)(key1))
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -24559,6 +25795,8 @@ func ProgramParameter4fNV(target uint32, index uint32, x float32, y float32, z f
 func ProgramParameter4fvNV(target uint32, index uint32, v *float32) {
 	C.glowProgramParameter4fvNV(gpProgramParameter4fvNV, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -24616,8 +25854,14 @@ func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
 func ProgramUniform1i64NV(program uint32, location int32, x int64) {
 	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24638,8 +25882,14 @@ func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
 func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
 	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24688,8 +25938,14 @@ func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
 	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24710,8 +25966,14 @@ func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
 	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24760,8 +26022,14 @@ func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
 	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24782,8 +26050,14 @@ func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
 	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24832,8 +26106,14 @@ func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
 	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24854,8 +26134,14 @@ func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -25065,12 +26351,21 @@ func PushName(name uint32) {
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
 }
+
+// return the values of the current matrix
 func QueryMatrixxOES(mantissa *int32, exponent *int32) uint32 {
 	ret := C.glowQueryMatrixxOES(gpQueryMatrixxOES, (*C.GLfixed)(unsafe.Pointer(mantissa)), (*C.GLint)(unsafe.Pointer(exponent)))
 	return (uint32)(ret)
 }
 func QueryObjectParameteruiAMD(target uint32, id uint32, pname uint32, param uint32) {
 	C.glowQueryObjectParameteruiAMD(gpQueryObjectParameteruiAMD, (C.GLenum)(target), (C.GLuint)(id), (C.GLenum)(pname), (C.GLuint)(param))
+}
+func QueryResourceNV(queryType uint32, tagId int32, bufSize uint32, buffer *int32) int32 {
+	ret := C.glowQueryResourceNV(gpQueryResourceNV, (C.GLenum)(queryType), (C.GLint)(tagId), (C.GLuint)(bufSize), (*C.GLint)(unsafe.Pointer(buffer)))
+	return (int32)(ret)
+}
+func QueryResourceTagNV(tagId int32, tagString *uint8) {
+	C.glowQueryResourceTagNV(gpQueryResourceTagNV, (C.GLint)(tagId), (*C.GLchar)(unsafe.Pointer(tagString)))
 }
 func RasterPos2d(x float64, y float64) {
 	C.glowRasterPos2d(gpRasterPos2d, (C.GLdouble)(x), (C.GLdouble)(y))
@@ -25162,6 +26457,9 @@ func RasterPos4xOES(x int32, y int32, z int32, w int32) {
 func RasterPos4xvOES(coords *int32) {
 	C.glowRasterPos4xvOES(gpRasterPos4xvOES, (*C.GLfixed)(unsafe.Pointer(coords)))
 }
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // select a color buffer source for pixels
 func ReadBuffer(src uint32) {
@@ -25219,10 +26517,17 @@ func RectxvOES(v1 *int32, v2 *int32) {
 func ReferencePlaneSGIX(equation *float64) {
 	C.glowReferencePlaneSGIX(gpReferencePlaneSGIX, (*C.GLdouble)(unsafe.Pointer(equation)))
 }
+func ReleaseKeyedMutexWin32EXT(memory uint32, key uint64) bool {
+	ret := C.glowReleaseKeyedMutexWin32EXT(gpReleaseKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key))
+	return ret == TRUE
+}
 
 // release resources consumed by the implementation's shader compiler
 func ReleaseShaderCompiler() {
 	C.glowReleaseShaderCompiler(gpReleaseShaderCompiler)
+}
+func RenderGpuMaskNV(mask uint32) {
+	C.glowRenderGpuMaskNV(gpRenderGpuMaskNV, (C.GLbitfield)(mask))
 }
 
 // set rasterization mode
@@ -25340,6 +26645,9 @@ func ResetMinmaxEXT(target uint32) {
 func ResizeBuffersMESA() {
 	C.glowResizeBuffersMESA(gpResizeBuffersMESA)
 }
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
+}
 
 // resume transform feedback operations
 func ResumeTransformFeedback() {
@@ -25364,9 +26672,6 @@ func SampleCoverage(value float32, invert bool) {
 }
 func SampleCoverageARB(value float32, invert bool) {
 	C.glowSampleCoverageARB(gpSampleCoverageARB, (C.GLfloat)(value), (C.GLboolean)(boolToInt(invert)))
-}
-func SampleCoverageOES(value int32, invert bool) {
-	C.glowSampleCoverageOES(gpSampleCoverageOES, (C.GLfixed)(value), (C.GLboolean)(boolToInt(invert)))
 }
 func SampleCoveragexOES(value int32, invert bool) {
 	C.glowSampleCoveragexOES(gpSampleCoveragexOES, (C.GLclampx)(value), (C.GLboolean)(boolToInt(invert)))
@@ -25567,6 +26872,9 @@ func SelectBuffer(size int32, buffer *uint32) {
 func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
 	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
 }
+func SemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowSemaphoreParameterui64vEXT(gpSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 
 // define a separable two-dimensional convolution filter
 func SeparableFilter2D(target uint32, internalformat uint32, width int32, height int32, format uint32, xtype uint32, row unsafe.Pointer, column unsafe.Pointer) {
@@ -25628,6 +26936,18 @@ func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storage
 func SharpenTexFuncSGIS(target uint32, n int32, points *float32) {
 	C.glowSharpenTexFuncSGIS(gpSharpenTexFuncSGIS, (C.GLenum)(target), (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func SignalSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, dstLayouts *uint32) {
+	C.glowSignalSemaphoreEXT(gpSignalSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(dstLayouts)))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
 func SpriteParameterfSGIX(pname uint32, param float32) {
 	C.glowSpriteParameterfSGIX(gpSpriteParameterfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -25642,6 +26962,9 @@ func SpriteParameterivSGIX(pname uint32, params *int32) {
 }
 func StartInstrumentsSGIX() {
 	C.glowStartInstrumentsSGIX(gpStartInstrumentsSGIX)
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
 }
 func StencilClearTagEXT(stencilTagBits int32, stencilClearTag uint32) {
 	C.glowStencilClearTagEXT(gpStencilClearTagEXT, (C.GLsizei)(stencilTagBits), (C.GLuint)(stencilClearTag))
@@ -25714,6 +27037,9 @@ func StopInstrumentsSGIX(marker int32) {
 }
 func StringMarkerGREMEDY(len int32, xstring unsafe.Pointer) {
 	C.glowStringMarkerGREMEDY(gpStringMarkerGREMEDY, (C.GLsizei)(len), xstring)
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
 }
 func SwizzleEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowSwizzleEXT(gpSwizzleEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
@@ -26133,8 +27459,8 @@ func TexImage3DMultisampleCoverageNV(target uint32, coverageSamples int32, color
 func TexImage4DSGIS(target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, size4d int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTexImage4DSGIS(gpTexImage4DSGIS, (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(size4d), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -26194,6 +27520,21 @@ func TexStorage3D(target uint32, levels int32, internalformat uint32, width int3
 func TexStorage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexStorage3DMultisample(gpTexStorage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TexStorageMem1DEXT(target uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem1DEXT(gpTexStorageMem1DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DEXT(gpTexStorageMem2DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DMultisampleEXT(gpTexStorageMem2DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DEXT(gpTexStorageMem3DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DMultisampleEXT(gpTexStorageMem3DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TexStorageSparseAMD(target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTexStorageSparseAMD(gpTexStorageSparseAMD, (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -26242,8 +27583,8 @@ func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buff
 }
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
@@ -26281,8 +27622,8 @@ func TextureMaterialEXT(face uint32, mode uint32) {
 func TextureNormalEXT(mode uint32) {
 	C.glowTextureNormalEXT(gpTextureNormalEXT, (C.GLenum)(mode))
 }
-func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -26366,6 +27707,21 @@ func TextureStorage3DMultisample(texture uint32, samples int32, internalformat u
 func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorageMem1DEXT(texture uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem1DEXT(gpTextureStorageMem1DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DEXT(gpTextureStorageMem2DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DMultisampleEXT(gpTextureStorageMem2DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DEXT(gpTextureStorageMem3DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DMultisampleEXT(gpTextureStorageMem3DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TextureStorageSparseAMD(texture uint32, target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTextureStorageSparseAMD(gpTextureStorageSparseAMD, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -26411,8 +27767,8 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TransformFeedbackStreamAttribsNV(count int32, attribs *int32, nbuffers int32, bufstreams *int32, bufferMode uint32) {
 	C.glowTransformFeedbackStreamAttribsNV(gpTransformFeedbackStreamAttribsNV, (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(attribs)), (C.GLsizei)(nbuffers), (*C.GLint)(unsafe.Pointer(bufstreams)), (C.GLenum)(bufferMode))
@@ -26467,8 +27823,14 @@ func Uniform1fvARB(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
 func Uniform1i64NV(location int32, x int64) {
 	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform1i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26489,8 +27851,14 @@ func Uniform1ivARB(location int32, count int32, value *int32) {
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
 }
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
 func Uniform1ui64NV(location int32, x uint64) {
 	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform1ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26533,8 +27901,14 @@ func Uniform2fvARB(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func Uniform2i64NV(location int32, x int64, y int64) {
 	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform2i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26555,8 +27929,14 @@ func Uniform2ivARB(location int32, count int32, value *int32) {
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func Uniform2ui64NV(location int32, x uint64, y uint64) {
 	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform2ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26599,8 +27979,14 @@ func Uniform3fvARB(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func Uniform3i64NV(location int32, x int64, y int64, z int64) {
 	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform3i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26621,8 +28007,14 @@ func Uniform3ivARB(location int32, count int32, value *int32) {
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
 	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform3ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26665,8 +28057,14 @@ func Uniform4fvARB(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
 	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform4i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26687,8 +28085,14 @@ func Uniform4ivARB(location int32, count int32, value *int32) {
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform4ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -28034,10 +29438,22 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
+func WaitSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, srcLayouts *uint32) {
+	C.glowWaitSemaphoreEXT(gpWaitSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(srcLayouts)))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
 	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
@@ -28237,6 +29653,9 @@ func WindowPos4sMESA(x int16, y int16, z int16, w int16) {
 func WindowPos4svMESA(v *int16) {
 	C.glowWindowPos4svMESA(gpWindowPos4svMESA, (*C.GLshort)(unsafe.Pointer(v)))
 }
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
+}
 func WriteMaskEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowWriteMaskEXT(gpWriteMaskEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
 }
@@ -28273,6 +29692,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAccum")
 	}
 	gpAccumxOES = (C.GPACCUMXOES)(getProcAddr("glAccumxOES"))
+	gpAcquireKeyedMutexWin32EXT = (C.GPACQUIREKEYEDMUTEXWIN32EXT)(getProcAddr("glAcquireKeyedMutexWin32EXT"))
 	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
 	if gpActiveShaderProgram == nil {
@@ -28294,6 +29714,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAlphaFunc")
 	}
 	gpAlphaFuncxOES = (C.GPALPHAFUNCXOES)(getProcAddr("glAlphaFuncxOES"))
+	gpAlphaToCoverageDitherControlNV = (C.GPALPHATOCOVERAGEDITHERCONTROLNV)(getProcAddr("glAlphaToCoverageDitherControlNV"))
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpApplyTextureEXT = (C.GPAPPLYTEXTUREEXT)(getProcAddr("glApplyTextureEXT"))
 	gpAreProgramsResidentNV = (C.GPAREPROGRAMSRESIDENTNV)(getProcAddr("glAreProgramsResidentNV"))
 	gpAreTexturesResident = (C.GPARETEXTURESRESIDENT)(getProcAddr("glAreTexturesResident"))
@@ -28544,11 +29966,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBufferStorage == nil {
 		return errors.New("glBufferStorage")
 	}
+	gpBufferStorageExternalEXT = (C.GPBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glBufferStorageExternalEXT"))
+	gpBufferStorageMemEXT = (C.GPBUFFERSTORAGEMEMEXT)(getProcAddr("glBufferStorageMemEXT"))
 	gpBufferSubData = (C.GPBUFFERSUBDATA)(getProcAddr("glBufferSubData"))
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
 	gpBufferSubDataARB = (C.GPBUFFERSUBDATAARB)(getProcAddr("glBufferSubDataARB"))
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCallList = (C.GPCALLLIST)(getProcAddr("glCallList"))
 	if gpCallList == nil {
 		return errors.New("glCallList")
@@ -28862,6 +30287,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCombinerParameteriNV = (C.GPCOMBINERPARAMETERINV)(getProcAddr("glCombinerParameteriNV"))
 	gpCombinerParameterivNV = (C.GPCOMBINERPARAMETERIVNV)(getProcAddr("glCombinerParameterivNV"))
 	gpCombinerStageParameterfvNV = (C.GPCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glCombinerStageParameterfvNV"))
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
@@ -28913,6 +30340,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
 	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpConvolutionFilter1D = (C.GPCONVOLUTIONFILTER1D)(getProcAddr("glConvolutionFilter1D"))
 	gpConvolutionFilter1DEXT = (C.GPCONVOLUTIONFILTER1DEXT)(getProcAddr("glConvolutionFilter1DEXT"))
 	gpConvolutionFilter2D = (C.GPCONVOLUTIONFILTER2D)(getProcAddr("glConvolutionFilter2D"))
@@ -28992,8 +30421,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
 	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
 	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
+	gpCreateMemoryObjectsEXT = (C.GPCREATEMEMORYOBJECTSEXT)(getProcAddr("glCreateMemoryObjectsEXT"))
 	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
@@ -29015,6 +30448,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glCreateShaderProgramv")
 	}
 	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	gpCreateTransformFeedbacks = (C.GPCREATETRANSFORMFEEDBACKS)(getProcAddr("glCreateTransformFeedbacks"))
@@ -29056,6 +30490,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteBuffers")
 	}
 	gpDeleteBuffersARB = (C.GPDELETEBUFFERSARB)(getProcAddr("glDeleteBuffersARB"))
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFencesAPPLE = (C.GPDELETEFENCESAPPLE)(getProcAddr("glDeleteFencesAPPLE"))
 	gpDeleteFencesNV = (C.GPDELETEFENCESNV)(getProcAddr("glDeleteFencesNV"))
 	gpDeleteFragmentShaderATI = (C.GPDELETEFRAGMENTSHADERATI)(getProcAddr("glDeleteFragmentShaderATI"))
@@ -29068,6 +30503,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteLists == nil {
 		return errors.New("glDeleteLists")
 	}
+	gpDeleteMemoryObjectsEXT = (C.GPDELETEMEMORYOBJECTSEXT)(getProcAddr("glDeleteMemoryObjectsEXT"))
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
 	gpDeleteNamesAMD = (C.GPDELETENAMESAMD)(getProcAddr("glDeleteNamesAMD"))
 	gpDeleteObjectARB = (C.GPDELETEOBJECTARB)(getProcAddr("glDeleteObjectARB"))
@@ -29091,6 +30527,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteQueries")
 	}
 	gpDeleteQueriesARB = (C.GPDELETEQUERIESARB)(getProcAddr("glDeleteQueriesARB"))
+	gpDeleteQueryResourceTagNV = (C.GPDELETEQUERYRESOURCETAGNV)(getProcAddr("glDeleteQueryResourceTagNV"))
 	gpDeleteRenderbuffers = (C.GPDELETERENDERBUFFERS)(getProcAddr("glDeleteRenderbuffers"))
 	if gpDeleteRenderbuffers == nil {
 		return errors.New("glDeleteRenderbuffers")
@@ -29100,10 +30537,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteSamplers == nil {
 		return errors.New("glDeleteSamplers")
 	}
+	gpDeleteSemaphoresEXT = (C.GPDELETESEMAPHORESEXT)(getProcAddr("glDeleteSemaphoresEXT"))
 	gpDeleteShader = (C.GPDELETESHADER)(getProcAddr("glDeleteShader"))
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	if gpDeleteSync == nil {
 		return errors.New("glDeleteSync")
@@ -29222,6 +30661,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpDrawBuffersARB = (C.GPDRAWBUFFERSARB)(getProcAddr("glDrawBuffersARB"))
 	gpDrawBuffersATI = (C.GPDRAWBUFFERSATI)(getProcAddr("glDrawBuffersATI"))
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElementArrayAPPLE = (C.GPDRAWELEMENTARRAYAPPLE)(getProcAddr("glDrawElementArrayAPPLE"))
 	gpDrawElementArrayATI = (C.GPDRAWELEMENTARRAYATI)(getProcAddr("glDrawElementArrayATI"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
@@ -29288,6 +30731,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawTransformFeedbackStreamInstanced == nil {
 		return errors.New("glDrawTransformFeedbackStreamInstanced")
 	}
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
 	gpEdgeFlag = (C.GPEDGEFLAG)(getProcAddr("glEdgeFlag"))
 	if gpEdgeFlag == nil {
 		return errors.New("glEdgeFlag")
@@ -29418,6 +30862,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEvalPoint2 == nil {
 		return errors.New("glEvalPoint2")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpExecuteProgramNV = (C.GPEXECUTEPROGRAMNV)(getProcAddr("glExecuteProgramNV"))
 	gpExtractComponentEXT = (C.GPEXTRACTCOMPONENTEXT)(getProcAddr("glExtractComponentEXT"))
 	gpFeedbackBuffer = (C.GPFEEDBACKBUFFER)(getProcAddr("glFeedbackBuffer"))
@@ -29504,6 +30949,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFogxOES = (C.GPFOGXOES)(getProcAddr("glFogxOES"))
 	gpFogxvOES = (C.GPFOGXVOES)(getProcAddr("glFogxvOES"))
 	gpFragmentColorMaterialSGIX = (C.GPFRAGMENTCOLORMATERIALSGIX)(getProcAddr("glFragmentColorMaterialSGIX"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
 	gpFragmentLightModelfSGIX = (C.GPFRAGMENTLIGHTMODELFSGIX)(getProcAddr("glFragmentLightModelfSGIX"))
 	gpFragmentLightModelfvSGIX = (C.GPFRAGMENTLIGHTMODELFVSGIX)(getProcAddr("glFragmentLightModelfvSGIX"))
 	gpFragmentLightModeliSGIX = (C.GPFRAGMENTLIGHTMODELISGIX)(getProcAddr("glFragmentLightModeliSGIX"))
@@ -29520,6 +30966,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFrameZoomSGIX = (C.GPFRAMEZOOMSGIX)(getProcAddr("glFrameZoomSGIX"))
 	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
 	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
 	if gpFramebufferParameteri == nil {
 		return errors.New("glFramebufferParameteri")
@@ -29530,6 +30977,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glFramebufferRenderbuffer")
 	}
 	gpFramebufferRenderbufferEXT = (C.GPFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glFramebufferRenderbufferEXT"))
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
+	gpFramebufferSamplePositionsfvAMD = (C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glFramebufferSamplePositionsfvAMD"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	if gpFramebufferTexture == nil {
 		return errors.New("glFramebufferTexture")
@@ -29559,6 +31009,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
 	gpFramebufferTextureLayerEXT = (C.GPFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glFramebufferTextureLayerEXT"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFreeObjectBufferATI = (C.GPFREEOBJECTBUFFERATI)(getProcAddr("glFreeObjectBufferATI"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
@@ -29604,6 +31055,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGenQueries")
 	}
 	gpGenQueriesARB = (C.GPGENQUERIESARB)(getProcAddr("glGenQueriesARB"))
+	gpGenQueryResourceTagNV = (C.GPGENQUERYRESOURCETAGNV)(getProcAddr("glGenQueryResourceTagNV"))
 	gpGenRenderbuffers = (C.GPGENRENDERBUFFERS)(getProcAddr("glGenRenderbuffers"))
 	if gpGenRenderbuffers == nil {
 		return errors.New("glGenRenderbuffers")
@@ -29613,6 +31065,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenSamplers == nil {
 		return errors.New("glGenSamplers")
 	}
+	gpGenSemaphoresEXT = (C.GPGENSEMAPHORESEXT)(getProcAddr("glGenSemaphoresEXT"))
 	gpGenSymbolsEXT = (C.GPGENSYMBOLSEXT)(getProcAddr("glGenSymbolsEXT"))
 	gpGenTextures = (C.GPGENTEXTURES)(getProcAddr("glGenTextures"))
 	if gpGenTextures == nil {
@@ -29742,6 +31195,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetCombinerOutputParameterfvNV = (C.GPGETCOMBINEROUTPUTPARAMETERFVNV)(getProcAddr("glGetCombinerOutputParameterfvNV"))
 	gpGetCombinerOutputParameterivNV = (C.GPGETCOMBINEROUTPUTPARAMETERIVNV)(getProcAddr("glGetCombinerOutputParameterivNV"))
 	gpGetCombinerStageParameterfvNV = (C.GPGETCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glGetCombinerStageParameterfvNV"))
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
 	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
@@ -29758,6 +31212,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetConvolutionParameteriv = (C.GPGETCONVOLUTIONPARAMETERIV)(getProcAddr("glGetConvolutionParameteriv"))
 	gpGetConvolutionParameterivEXT = (C.GPGETCONVOLUTIONPARAMETERIVEXT)(getProcAddr("glGetConvolutionParameterivEXT"))
 	gpGetConvolutionParameterxvOES = (C.GPGETCONVOLUTIONPARAMETERXVOES)(getProcAddr("glGetConvolutionParameterxvOES"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	if gpGetDebugMessageLog == nil {
 		return errors.New("glGetDebugMessageLog")
@@ -29814,6 +31269,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetFramebufferAttachmentParameteriv")
 	}
 	gpGetFramebufferAttachmentParameterivEXT = (C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetFramebufferAttachmentParameterivEXT"))
+	gpGetFramebufferParameterfvAMD = (C.GPGETFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetFramebufferParameterfvAMD"))
 	gpGetFramebufferParameteriv = (C.GPGETFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetFramebufferParameteriv"))
 	if gpGetFramebufferParameteriv == nil {
 		return errors.New("glGetFramebufferParameteriv")
@@ -29855,6 +31311,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	if gpGetInternalformati64v == nil {
 		return errors.New("glGetInternalformati64v")
@@ -29909,6 +31366,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetMaterialxOES = (C.GPGETMATERIALXOES)(getProcAddr("glGetMaterialxOES"))
 	gpGetMaterialxvOES = (C.GPGETMATERIALXVOES)(getProcAddr("glGetMaterialxvOES"))
+	gpGetMemoryObjectParameterivEXT = (C.GPGETMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glGetMemoryObjectParameterivEXT"))
 	gpGetMinmax = (C.GPGETMINMAX)(getProcAddr("glGetMinmax"))
 	gpGetMinmaxEXT = (C.GPGETMINMAXEXT)(getProcAddr("glGetMinmaxEXT"))
 	gpGetMinmaxParameterfv = (C.GPGETMINMAXPARAMETERFV)(getProcAddr("glGetMinmaxParameterfv"))
@@ -29942,6 +31400,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
 	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
+	gpGetNamedFramebufferParameterfvAMD = (C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetNamedFramebufferParameterfvAMD"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
 	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
 	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
@@ -30093,6 +31552,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetProgramivARB = (C.GPGETPROGRAMIVARB)(getProcAddr("glGetProgramivARB"))
 	gpGetProgramivNV = (C.GPGETPROGRAMIVNV)(getProcAddr("glGetProgramivNV"))
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	if gpGetQueryIndexediv == nil {
 		return errors.New("glGetQueryIndexediv")
@@ -30143,6 +31606,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetSamplerParameteriv == nil {
 		return errors.New("glGetSamplerParameteriv")
 	}
+	gpGetSemaphoreParameterui64vEXT = (C.GPGETSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glGetSemaphoreParameterui64vEXT"))
 	gpGetSeparableFilter = (C.GPGETSEPARABLEFILTER)(getProcAddr("glGetSeparableFilter"))
 	gpGetSeparableFilterEXT = (C.GPGETSEPARABLEFILTEREXT)(getProcAddr("glGetSeparableFilterEXT"))
 	gpGetShaderInfoLog = (C.GPGETSHADERINFOLOG)(getProcAddr("glGetShaderInfoLog"))
@@ -30163,6 +31627,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetShaderiv")
 	}
 	gpGetSharpenTexFuncSGIS = (C.GPGETSHARPENTEXFUNCSGIS)(getProcAddr("glGetSharpenTexFuncSGIS"))
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -30298,18 +31763,22 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetUniformfv")
 	}
 	gpGetUniformfvARB = (C.GPGETUNIFORMFVARB)(getProcAddr("glGetUniformfvARB"))
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
 	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
 	gpGetUniformivARB = (C.GPGETUNIFORMIVARB)(getProcAddr("glGetUniformivARB"))
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
 	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
 	}
 	gpGetUniformuivEXT = (C.GPGETUNIFORMUIVEXT)(getProcAddr("glGetUniformuivEXT"))
+	gpGetUnsignedBytei_vEXT = (C.GPGETUNSIGNEDBYTEI_VEXT)(getProcAddr("glGetUnsignedBytei_vEXT"))
+	gpGetUnsignedBytevEXT = (C.GPGETUNSIGNEDBYTEVEXT)(getProcAddr("glGetUnsignedBytevEXT"))
 	gpGetVariantArrayObjectfvATI = (C.GPGETVARIANTARRAYOBJECTFVATI)(getProcAddr("glGetVariantArrayObjectfvATI"))
 	gpGetVariantArrayObjectivATI = (C.GPGETVARIANTARRAYOBJECTIVATI)(getProcAddr("glGetVariantArrayObjectivATI"))
 	gpGetVariantBooleanvEXT = (C.GPGETVARIANTBOOLEANVEXT)(getProcAddr("glGetVariantBooleanvEXT"))
@@ -30376,6 +31845,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetVideoivNV = (C.GPGETVIDEOIVNV)(getProcAddr("glGetVideoivNV"))
 	gpGetVideoui64vNV = (C.GPGETVIDEOUI64VNV)(getProcAddr("glGetVideoui64vNV"))
 	gpGetVideouivNV = (C.GPGETVIDEOUIVNV)(getProcAddr("glGetVideouivNV"))
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnColorTableARB = (C.GPGETNCOLORTABLEARB)(getProcAddr("glGetnColorTableARB"))
 	gpGetnCompressedTexImageARB = (C.GPGETNCOMPRESSEDTEXIMAGEARB)(getProcAddr("glGetnCompressedTexImageARB"))
 	gpGetnConvolutionFilterARB = (C.GPGETNCONVOLUTIONFILTERARB)(getProcAddr("glGetnConvolutionFilterARB"))
@@ -30394,9 +31864,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	gpGetnUniformuivARB = (C.GPGETNUNIFORMUIVARB)(getProcAddr("glGetnUniformuivARB"))
 	gpGetnUniformuivKHR = (C.GPGETNUNIFORMUIVKHR)(getProcAddr("glGetnUniformuivKHR"))
@@ -30420,6 +31892,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpImageTransformParameterfvHP = (C.GPIMAGETRANSFORMPARAMETERFVHP)(getProcAddr("glImageTransformParameterfvHP"))
 	gpImageTransformParameteriHP = (C.GPIMAGETRANSFORMPARAMETERIHP)(getProcAddr("glImageTransformParameteriHP"))
 	gpImageTransformParameterivHP = (C.GPIMAGETRANSFORMPARAMETERIVHP)(getProcAddr("glImageTransformParameterivHP"))
+	gpImportMemoryFdEXT = (C.GPIMPORTMEMORYFDEXT)(getProcAddr("glImportMemoryFdEXT"))
+	gpImportMemoryWin32HandleEXT = (C.GPIMPORTMEMORYWIN32HANDLEEXT)(getProcAddr("glImportMemoryWin32HandleEXT"))
+	gpImportMemoryWin32NameEXT = (C.GPIMPORTMEMORYWIN32NAMEEXT)(getProcAddr("glImportMemoryWin32NameEXT"))
+	gpImportSemaphoreFdEXT = (C.GPIMPORTSEMAPHOREFDEXT)(getProcAddr("glImportSemaphoreFdEXT"))
+	gpImportSemaphoreWin32HandleEXT = (C.GPIMPORTSEMAPHOREWIN32HANDLEEXT)(getProcAddr("glImportSemaphoreWin32HandleEXT"))
+	gpImportSemaphoreWin32NameEXT = (C.GPIMPORTSEMAPHOREWIN32NAMEEXT)(getProcAddr("glImportSemaphoreWin32NameEXT"))
 	gpImportSyncEXT = (C.GPIMPORTSYNCEXT)(getProcAddr("glImportSyncEXT"))
 	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
 	gpIndexFuncEXT = (C.GPINDEXFUNCEXT)(getProcAddr("glIndexFuncEXT"))
@@ -30521,6 +31999,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsBufferARB = (C.GPISBUFFERARB)(getProcAddr("glIsBufferARB"))
 	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
@@ -30543,6 +32022,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsList == nil {
 		return errors.New("glIsList")
 	}
+	gpIsMemoryObjectEXT = (C.GPISMEMORYOBJECTEXT)(getProcAddr("glIsMemoryObjectEXT"))
 	gpIsNameAMD = (C.GPISNAMEAMD)(getProcAddr("glIsNameAMD"))
 	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
@@ -30576,10 +32056,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsSampler == nil {
 		return errors.New("glIsSampler")
 	}
+	gpIsSemaphoreEXT = (C.GPISSEMAPHOREEXT)(getProcAddr("glIsSemaphoreEXT"))
 	gpIsShader = (C.GPISSHADER)(getProcAddr("glIsShader"))
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	if gpIsSync == nil {
 		return errors.New("glIsSync")
@@ -30603,6 +32085,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsVertexArrayAPPLE = (C.GPISVERTEXARRAYAPPLE)(getProcAddr("glIsVertexArrayAPPLE"))
 	gpIsVertexAttribEnabledAPPLE = (C.GPISVERTEXATTRIBENABLEDAPPLE)(getProcAddr("glIsVertexAttribEnabledAPPLE"))
+	gpLGPUCopyImageSubDataNVX = (C.GPLGPUCOPYIMAGESUBDATANVX)(getProcAddr("glLGPUCopyImageSubDataNVX"))
+	gpLGPUInterlockNVX = (C.GPLGPUINTERLOCKNVX)(getProcAddr("glLGPUInterlockNVX"))
+	gpLGPUNamedBufferSubDataNVX = (C.GPLGPUNAMEDBUFFERSUBDATANVX)(getProcAddr("glLGPUNamedBufferSubDataNVX"))
 	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLightEnviSGIX = (C.GPLIGHTENVISGIX)(getProcAddr("glLightEnviSGIX"))
 	gpLightModelf = (C.GPLIGHTMODELF)(getProcAddr("glLightModelf"))
@@ -30659,6 +32144,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpListBase == nil {
 		return errors.New("glListBase")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpListParameterfSGIX = (C.GPLISTPARAMETERFSGIX)(getProcAddr("glListParameterfSGIX"))
 	gpListParameterfvSGIX = (C.GPLISTPARAMETERFVSGIX)(getProcAddr("glListParameterfvSGIX"))
 	gpListParameteriSGIX = (C.GPLISTPARAMETERISGIX)(getProcAddr("glListParameteriSGIX"))
@@ -30819,12 +32305,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
 	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
 	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	if gpMemoryBarrier == nil {
 		return errors.New("glMemoryBarrier")
 	}
 	gpMemoryBarrierByRegion = (C.GPMEMORYBARRIERBYREGION)(getProcAddr("glMemoryBarrierByRegion"))
 	gpMemoryBarrierEXT = (C.GPMEMORYBARRIEREXT)(getProcAddr("glMemoryBarrierEXT"))
+	gpMemoryObjectParameterivEXT = (C.GPMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glMemoryObjectParameterivEXT"))
 	gpMinSampleShading = (C.GPMINSAMPLESHADING)(getProcAddr("glMinSampleShading"))
 	if gpMinSampleShading == nil {
 		return errors.New("glMinSampleShading")
@@ -31127,12 +32616,25 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
 	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
 	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
+	gpMulticastBarrierNV = (C.GPMULTICASTBARRIERNV)(getProcAddr("glMulticastBarrierNV"))
+	gpMulticastBlitFramebufferNV = (C.GPMULTICASTBLITFRAMEBUFFERNV)(getProcAddr("glMulticastBlitFramebufferNV"))
+	gpMulticastBufferSubDataNV = (C.GPMULTICASTBUFFERSUBDATANV)(getProcAddr("glMulticastBufferSubDataNV"))
+	gpMulticastCopyBufferSubDataNV = (C.GPMULTICASTCOPYBUFFERSUBDATANV)(getProcAddr("glMulticastCopyBufferSubDataNV"))
+	gpMulticastCopyImageSubDataNV = (C.GPMULTICASTCOPYIMAGESUBDATANV)(getProcAddr("glMulticastCopyImageSubDataNV"))
+	gpMulticastFramebufferSampleLocationsfvNV = (C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glMulticastFramebufferSampleLocationsfvNV"))
+	gpMulticastGetQueryObjecti64vNV = (C.GPMULTICASTGETQUERYOBJECTI64VNV)(getProcAddr("glMulticastGetQueryObjecti64vNV"))
+	gpMulticastGetQueryObjectivNV = (C.GPMULTICASTGETQUERYOBJECTIVNV)(getProcAddr("glMulticastGetQueryObjectivNV"))
+	gpMulticastGetQueryObjectui64vNV = (C.GPMULTICASTGETQUERYOBJECTUI64VNV)(getProcAddr("glMulticastGetQueryObjectui64vNV"))
+	gpMulticastGetQueryObjectuivNV = (C.GPMULTICASTGETQUERYOBJECTUIVNV)(getProcAddr("glMulticastGetQueryObjectuivNV"))
+	gpMulticastWaitSyncNV = (C.GPMULTICASTWAITSYNCNV)(getProcAddr("glMulticastWaitSyncNV"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
 	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
 	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
+	gpNamedBufferStorageExternalEXT = (C.GPNAMEDBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glNamedBufferStorageExternalEXT"))
+	gpNamedBufferStorageMemEXT = (C.GPNAMEDBUFFERSTORAGEMEMEXT)(getProcAddr("glNamedBufferStorageMemEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
 	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
 	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
@@ -31143,6 +32645,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	gpNamedFramebufferRenderbuffer = (C.GPNAMEDFRAMEBUFFERRENDERBUFFER)(getProcAddr("glNamedFramebufferRenderbuffer"))
 	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
+	gpNamedFramebufferSamplePositionsfvAMD = (C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glNamedFramebufferSamplePositionsfvAMD"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
 	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
 	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
@@ -31394,6 +32899,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPolygonOffsetEXT = (C.GPPOLYGONOFFSETEXT)(getProcAddr("glPolygonOffsetEXT"))
 	gpPolygonOffsetxOES = (C.GPPOLYGONOFFSETXOES)(getProcAddr("glPolygonOffsetxOES"))
 	gpPolygonStipple = (C.GPPOLYGONSTIPPLE)(getProcAddr("glPolygonStipple"))
@@ -31424,6 +32931,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpPresentFrameDualFillNV = (C.GPPRESENTFRAMEDUALFILLNV)(getProcAddr("glPresentFrameDualFillNV"))
 	gpPresentFrameKeyedNV = (C.GPPRESENTFRAMEKEYEDNV)(getProcAddr("glPresentFrameKeyedNV"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	if gpPrimitiveRestartIndex == nil {
 		return errors.New("glPrimitiveRestartIndex")
@@ -31508,7 +33016,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform1i == nil {
 		return errors.New("glProgramUniform1i")
 	}
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
 	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
 	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
 	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
@@ -31520,7 +33030,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform1ui == nil {
 		return errors.New("glProgramUniform1ui")
 	}
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
 	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
 	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
 	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
@@ -31552,7 +33064,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform2i == nil {
 		return errors.New("glProgramUniform2i")
 	}
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
 	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
 	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
 	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
@@ -31564,7 +33078,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform2ui == nil {
 		return errors.New("glProgramUniform2ui")
 	}
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
 	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
 	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
 	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
@@ -31596,7 +33112,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform3i == nil {
 		return errors.New("glProgramUniform3i")
 	}
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
 	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
 	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
 	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
@@ -31608,7 +33126,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform3ui == nil {
 		return errors.New("glProgramUniform3ui")
 	}
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
 	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
 	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
 	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
@@ -31640,7 +33160,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform4i == nil {
 		return errors.New("glProgramUniform4i")
 	}
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
 	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
 	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
 	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
@@ -31652,7 +33174,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform4ui == nil {
 		return errors.New("glProgramUniform4ui")
 	}
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
 	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
 	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
 	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
@@ -31791,6 +33315,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpQueryMatrixxOES = (C.GPQUERYMATRIXXOES)(getProcAddr("glQueryMatrixxOES"))
 	gpQueryObjectParameteruiAMD = (C.GPQUERYOBJECTPARAMETERUIAMD)(getProcAddr("glQueryObjectParameteruiAMD"))
+	gpQueryResourceNV = (C.GPQUERYRESOURCENV)(getProcAddr("glQueryResourceNV"))
+	gpQueryResourceTagNV = (C.GPQUERYRESOURCETAGNV)(getProcAddr("glQueryResourceTagNV"))
 	gpRasterPos2d = (C.GPRASTERPOS2D)(getProcAddr("glRasterPos2d"))
 	if gpRasterPos2d == nil {
 		return errors.New("glRasterPos2d")
@@ -31893,6 +33419,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpRasterPos4xOES = (C.GPRASTERPOS4XOES)(getProcAddr("glRasterPos4xOES"))
 	gpRasterPos4xvOES = (C.GPRASTERPOS4XVOES)(getProcAddr("glRasterPos4xvOES"))
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -31940,10 +33467,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpRectxOES = (C.GPRECTXOES)(getProcAddr("glRectxOES"))
 	gpRectxvOES = (C.GPRECTXVOES)(getProcAddr("glRectxvOES"))
 	gpReferencePlaneSGIX = (C.GPREFERENCEPLANESGIX)(getProcAddr("glReferencePlaneSGIX"))
+	gpReleaseKeyedMutexWin32EXT = (C.GPRELEASEKEYEDMUTEXWIN32EXT)(getProcAddr("glReleaseKeyedMutexWin32EXT"))
 	gpReleaseShaderCompiler = (C.GPRELEASESHADERCOMPILER)(getProcAddr("glReleaseShaderCompiler"))
 	if gpReleaseShaderCompiler == nil {
 		return errors.New("glReleaseShaderCompiler")
 	}
+	gpRenderGpuMaskNV = (C.GPRENDERGPUMASKNV)(getProcAddr("glRenderGpuMaskNV"))
 	gpRenderMode = (C.GPRENDERMODE)(getProcAddr("glRenderMode"))
 	if gpRenderMode == nil {
 		return errors.New("glRenderMode")
@@ -31988,6 +33517,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpResetMinmax = (C.GPRESETMINMAX)(getProcAddr("glResetMinmax"))
 	gpResetMinmaxEXT = (C.GPRESETMINMAXEXT)(getProcAddr("glResetMinmaxEXT"))
 	gpResizeBuffersMESA = (C.GPRESIZEBUFFERSMESA)(getProcAddr("glResizeBuffersMESA"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	if gpResumeTransformFeedback == nil {
 		return errors.New("glResumeTransformFeedback")
@@ -32007,7 +33537,6 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSampleCoverage")
 	}
 	gpSampleCoverageARB = (C.GPSAMPLECOVERAGEARB)(getProcAddr("glSampleCoverageARB"))
-	gpSampleCoverageOES = (C.GPSAMPLECOVERAGEOES)(getProcAddr("glSampleCoverageOES"))
 	gpSampleCoveragexOES = (C.GPSAMPLECOVERAGEXOES)(getProcAddr("glSampleCoveragexOES"))
 	gpSampleMapATI = (C.GPSAMPLEMAPATI)(getProcAddr("glSampleMapATI"))
 	gpSampleMaskEXT = (C.GPSAMPLEMASKEXT)(getProcAddr("glSampleMaskEXT"))
@@ -32170,6 +33699,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSelectBuffer")
 	}
 	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
+	gpSemaphoreParameterui64vEXT = (C.GPSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glSemaphoreParameterui64vEXT"))
 	gpSeparableFilter2D = (C.GPSEPARABLEFILTER2D)(getProcAddr("glSeparableFilter2D"))
 	gpSeparableFilter2DEXT = (C.GPSEPARABLEFILTER2DEXT)(getProcAddr("glSeparableFilter2DEXT"))
 	gpSetFenceAPPLE = (C.GPSETFENCEAPPLE)(getProcAddr("glSetFenceAPPLE"))
@@ -32199,11 +33729,16 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glShaderStorageBlockBinding")
 	}
 	gpSharpenTexFuncSGIS = (C.GPSHARPENTEXFUNCSGIS)(getProcAddr("glSharpenTexFuncSGIS"))
+	gpSignalSemaphoreEXT = (C.GPSIGNALSEMAPHOREEXT)(getProcAddr("glSignalSemaphoreEXT"))
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
 	gpSpriteParameterfSGIX = (C.GPSPRITEPARAMETERFSGIX)(getProcAddr("glSpriteParameterfSGIX"))
 	gpSpriteParameterfvSGIX = (C.GPSPRITEPARAMETERFVSGIX)(getProcAddr("glSpriteParameterfvSGIX"))
 	gpSpriteParameteriSGIX = (C.GPSPRITEPARAMETERISGIX)(getProcAddr("glSpriteParameteriSGIX"))
 	gpSpriteParameterivSGIX = (C.GPSPRITEPARAMETERIVSGIX)(getProcAddr("glSpriteParameterivSGIX"))
 	gpStartInstrumentsSGIX = (C.GPSTARTINSTRUMENTSSGIX)(getProcAddr("glStartInstrumentsSGIX"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
 	gpStencilClearTagEXT = (C.GPSTENCILCLEARTAGEXT)(getProcAddr("glStencilClearTagEXT"))
 	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
 	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
@@ -32242,6 +33777,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
 	gpStopInstrumentsSGIX = (C.GPSTOPINSTRUMENTSSGIX)(getProcAddr("glStopInstrumentsSGIX"))
 	gpStringMarkerGREMEDY = (C.GPSTRINGMARKERGREMEDY)(getProcAddr("glStringMarkerGREMEDY"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpSwizzleEXT = (C.GPSWIZZLEEXT)(getProcAddr("glSwizzleEXT"))
 	gpSyncTextureINTEL = (C.GPSYNCTEXTUREINTEL)(getProcAddr("glSyncTextureINTEL"))
 	gpTagSampleBufferSGIX = (C.GPTAGSAMPLEBUFFERSGIX)(getProcAddr("glTagSampleBufferSGIX"))
@@ -32599,6 +34135,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpTexStorage3DMultisample == nil {
 		return errors.New("glTexStorage3DMultisample")
 	}
+	gpTexStorageMem1DEXT = (C.GPTEXSTORAGEMEM1DEXT)(getProcAddr("glTexStorageMem1DEXT"))
+	gpTexStorageMem2DEXT = (C.GPTEXSTORAGEMEM2DEXT)(getProcAddr("glTexStorageMem2DEXT"))
+	gpTexStorageMem2DMultisampleEXT = (C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem2DMultisampleEXT"))
+	gpTexStorageMem3DEXT = (C.GPTEXSTORAGEMEM3DEXT)(getProcAddr("glTexStorageMem3DEXT"))
+	gpTexStorageMem3DMultisampleEXT = (C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem3DMultisampleEXT"))
 	gpTexStorageSparseAMD = (C.GPTEXSTORAGESPARSEAMD)(getProcAddr("glTexStorageSparseAMD"))
 	gpTexSubImage1D = (C.GPTEXSUBIMAGE1D)(getProcAddr("glTexSubImage1D"))
 	if gpTexSubImage1D == nil {
@@ -32658,6 +34199,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
 	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
+	gpTextureStorageMem1DEXT = (C.GPTEXTURESTORAGEMEM1DEXT)(getProcAddr("glTextureStorageMem1DEXT"))
+	gpTextureStorageMem2DEXT = (C.GPTEXTURESTORAGEMEM2DEXT)(getProcAddr("glTextureStorageMem2DEXT"))
+	gpTextureStorageMem2DMultisampleEXT = (C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem2DMultisampleEXT"))
+	gpTextureStorageMem3DEXT = (C.GPTEXTURESTORAGEMEM3DEXT)(getProcAddr("glTextureStorageMem3DEXT"))
+	gpTextureStorageMem3DMultisampleEXT = (C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem3DMultisampleEXT"))
 	gpTextureStorageSparseAMD = (C.GPTEXTURESTORAGESPARSEAMD)(getProcAddr("glTextureStorageSparseAMD"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
 	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
@@ -32712,7 +34258,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
 	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
 	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iARB = (C.GPUNIFORM1IARB)(getProcAddr("glUniform1iARB"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
@@ -32724,7 +34272,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
 	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
 	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiEXT = (C.GPUNIFORM1UIEXT)(getProcAddr("glUniform1uiEXT"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
@@ -32754,7 +34304,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
 	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
 	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iARB = (C.GPUNIFORM2IARB)(getProcAddr("glUniform2iARB"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
@@ -32766,7 +34318,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
 	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
 	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiEXT = (C.GPUNIFORM2UIEXT)(getProcAddr("glUniform2uiEXT"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
@@ -32796,7 +34350,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
 	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
 	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iARB = (C.GPUNIFORM3IARB)(getProcAddr("glUniform3iARB"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
@@ -32808,7 +34364,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
 	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
 	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiEXT = (C.GPUNIFORM3UIEXT)(getProcAddr("glUniform3uiEXT"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
@@ -32838,7 +34396,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
 	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
 	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iARB = (C.GPUNIFORM4IARB)(getProcAddr("glUniform4iARB"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
@@ -32850,7 +34410,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
 	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
 	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiEXT = (C.GPUNIFORM4UIEXT)(getProcAddr("glUniform4uiEXT"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
@@ -33703,10 +35265,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpViewportIndexedfv == nil {
 		return errors.New("glViewportIndexedfv")
 	}
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
+	gpWaitSemaphoreEXT = (C.GPWAITSEMAPHOREEXT)(getProcAddr("glWaitSemaphoreEXT"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
 	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
 	gpWeightPointerARB = (C.GPWEIGHTPOINTERARB)(getProcAddr("glWeightPointerARB"))
 	gpWeightbvARB = (C.GPWEIGHTBVARB)(getProcAddr("glWeightbvARB"))
@@ -33821,6 +35387,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpWindowPos4ivMESA = (C.GPWINDOWPOS4IVMESA)(getProcAddr("glWindowPos4ivMESA"))
 	gpWindowPos4sMESA = (C.GPWINDOWPOS4SMESA)(getProcAddr("glWindowPos4sMESA"))
 	gpWindowPos4svMESA = (C.GPWINDOWPOS4SVMESA)(getProcAddr("glWindowPos4svMESA"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	gpWriteMaskEXT = (C.GPWRITEMASKEXT)(getProcAddr("glWriteMaskEXT"))
 	return nil
 }

--- a/v4.4-compatibility/gl/procaddr.go
+++ b/v4.4-compatibility/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcompatibility44(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v4.4-core/gl/package.go
+++ b/v4.4-core/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -89,21 +87,29 @@ package gl
 // typedef ptrdiff_t GLsizeiptr;
 // typedef int64_t GLint64;
 // typedef uint64_t GLuint64;
+// typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCARB)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCKHR)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcore44(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcore44(source, type, id, severity, length, message, userParam);
 // }
+// typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
+// typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVETEXTURE)(GLenum  texture);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPATTACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPBEGINCONDITIONALRENDER)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINCONDITIONALRENDERNV)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPBEGINPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPBEGINQUERY)(GLenum  target, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINQUERYINDEXED)(GLenum  target, GLuint  index, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINTRANSFORMFEEDBACK)(GLenum  primitiveMode);
@@ -118,7 +124,9 @@ package gl
 // typedef void  (APIENTRYP GPBINDFRAMEBUFFER)(GLenum  target, GLuint  framebuffer);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURE)(GLuint  unit, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  access, GLenum  format);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURES)(GLuint  first, GLsizei  count, const GLuint * textures);
+// typedef void  (APIENTRYP GPBINDMULTITEXTUREEXT)(GLenum  texunit, GLenum  target, GLuint  texture);
 // typedef void  (APIENTRYP GPBINDPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPBINDPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPBINDRENDERBUFFER)(GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPBINDSAMPLER)(GLuint  unit, GLuint  sampler);
 // typedef void  (APIENTRYP GPBINDSAMPLERS)(GLuint  first, GLsizei  count, const GLuint * samplers);
@@ -129,6 +137,8 @@ package gl
 // typedef void  (APIENTRYP GPBINDVERTEXARRAY)(GLuint  array);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFER)(GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFERS)(GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPBLENDBARRIERKHR)();
+// typedef void  (APIENTRYP GPBLENDBARRIERNV)();
 // typedef void  (APIENTRYP GPBLENDCOLOR)(GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha);
 // typedef void  (APIENTRYP GPBLENDEQUATION)(GLenum  mode);
 // typedef void  (APIENTRYP GPBLENDEQUATIONSEPARATE)(GLenum  modeRGB, GLenum  modeAlpha);
@@ -142,14 +152,18 @@ package gl
 // typedef void  (APIENTRYP GPBLENDFUNCSEPARATEIARB)(GLuint  buf, GLenum  srcRGB, GLenum  dstRGB, GLenum  srcAlpha, GLenum  dstAlpha);
 // typedef void  (APIENTRYP GPBLENDFUNCI)(GLuint  buf, GLenum  src, GLenum  dst);
 // typedef void  (APIENTRYP GPBLENDFUNCIARB)(GLuint  buf, GLenum  src, GLenum  dst);
+// typedef void  (APIENTRYP GPBLENDPARAMETERINV)(GLenum  pname, GLint  value);
 // typedef void  (APIENTRYP GPBLITFRAMEBUFFER)(GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
 // typedef void  (APIENTRYP GPBLITNAMEDFRAMEBUFFER)(GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
 // typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUS)(GLuint  framebuffer, GLenum  target);
+// typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(GLuint  framebuffer, GLenum  target);
 // typedef void  (APIENTRYP GPCLAMPCOLOR)(GLenum  target, GLenum  clamp);
 // typedef void  (APIENTRYP GPCLEAR)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPCLEARBUFFERDATA)(GLenum  target, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
@@ -162,49 +176,91 @@ package gl
 // typedef void  (APIENTRYP GPCLEARDEPTH)(GLdouble  depth);
 // typedef void  (APIENTRYP GPCLEARDEPTHF)(GLfloat  d);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
 // typedef void  (APIENTRYP GPCLEARSTENCIL)(GLint  s);
 // typedef void  (APIENTRYP GPCLEARTEXIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARTEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef GLenum  (APIENTRYP GPCLIENTWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
 // typedef void  (APIENTRYP GPCLIPCONTROL)(GLenum  origin, GLenum  depth);
+// typedef void  (APIENTRYP GPCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPCOLORMASK)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPCOLORMASKI)(GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE3D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOPYBUFFERSUBDATA)(GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYIMAGESUBDATA)(GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef void  (APIENTRYP GPCREATEPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPCREATEQUERIES)(GLenum  target, GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPCREATERENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPCREATESAMPLERS)(GLsizei  n, GLuint * samplers);
 // typedef GLuint  (APIENTRYP GPCREATESHADER)(GLenum  type);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -220,14 +276,20 @@ package gl
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTARB)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTKHR)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef void  (APIENTRYP GPDELETEPATHSNV)(GLuint  path, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
+// typedef void  (APIENTRYP GPDELETEPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPDELETEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINES)(GLsizei  n, const GLuint * pipelines);
+// typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINESEXT)(GLsizei  n, const GLuint * pipelines);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETRANSFORMFEEDBACKS)(GLsizei  n, const GLuint * ids);
@@ -240,7 +302,12 @@ package gl
 // typedef void  (APIENTRYP GPDEPTHRANGEF)(GLfloat  n, GLfloat  f);
 // typedef void  (APIENTRYP GPDETACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPDISABLE)(GLenum  cap);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPDISABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISPATCHCOMPUTE)(GLuint  num_groups_x, GLuint  num_groups_y, GLuint  num_groups_z);
@@ -249,46 +316,81 @@ package gl
 // typedef void  (APIENTRYP GPDRAWARRAYS)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCED)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDARB)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDBASEINSTANCE)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDEXT)(GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWBUFFER)(GLenum  buf);
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWELEMENTSBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCED)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDARB)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDEXT)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTS)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTSBASEVERTEX)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACK)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKINSTANCED)(GLenum  mode, GLuint  id, GLsizei  instancecount);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
+// typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPENABLE)(GLenum  cap);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPENABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPENABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDCONDITIONALRENDER)();
+// typedef void  (APIENTRYP GPENDCONDITIONALRENDERNV)();
+// typedef void  (APIENTRYP GPENDPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPENDPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPENDQUERY)(GLenum  target);
 // typedef void  (APIENTRYP GPENDQUERYINDEXED)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDTRANSFORMFEEDBACK)();
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef GLsync  (APIENTRYP GPFENCESYNC)(GLenum  condition, GLbitfield  flags);
 // typedef void  (APIENTRYP GPFINISH)();
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFOGCOORDFORMATNV)(GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE2D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE3D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREFACEARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPGENBUFFERS)(GLsizei  n, GLuint * buffers);
 // typedef void  (APIENTRYP GPGENFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef GLuint  (APIENTRYP GPGENPATHSNV)(GLsizei  range);
+// typedef void  (APIENTRYP GPGENPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
 // typedef void  (APIENTRYP GPGENPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
+// typedef void  (APIENTRYP GPGENPROGRAMPIPELINESEXT)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
@@ -296,7 +398,9 @@ package gl
 // typedef void  (APIENTRYP GPGENTRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENVERTEXARRAYS)(GLsizei  n, GLuint * arrays);
 // typedef void  (APIENTRYP GPGENERATEMIPMAP)(GLenum  target);
+// typedef void  (APIENTRYP GPGENERATEMULTITEXMIPMAPEXT)(GLenum  texunit, GLenum  target);
 // typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAP)(GLuint  texture);
+// typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAPEXT)(GLuint  texture, GLenum  target);
 // typedef void  (APIENTRYP GPGETACTIVEATOMICCOUNTERBUFFERIV)(GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETACTIVEATTRIB)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLint * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETACTIVESUBROUTINENAME)(GLuint  program, GLenum  shadertype, GLuint  index, GLsizei  bufsize, GLsizei * length, GLchar * name);
@@ -309,65 +413,137 @@ package gl
 // typedef void  (APIENTRYP GPGETACTIVEUNIFORMSIV)(GLuint  program, GLsizei  uniformCount, const GLuint * uniformIndices, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETATTACHEDSHADERS)(GLuint  program, GLsizei  maxCount, GLsizei * count, GLuint * shaders);
 // typedef GLint  (APIENTRYP GPGETATTRIBLOCATION)(GLuint  program, const GLchar * name);
+// typedef void  (APIENTRYP GPGETBOOLEANINDEXEDVEXT)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANI_V)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANV)(GLenum  pname, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERI64V)(GLenum  target, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETBUFFERPARAMETERUI64VNV)(GLenum  target, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETBUFFERPOINTERV)(GLenum  target, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGE)(GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGKHR)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
+// typedef void  (APIENTRYP GPGETDOUBLEINDEXEDVEXT)(GLenum  target, GLuint  index, GLdouble * data);
 // typedef void  (APIENTRYP GPGETDOUBLEI_V)(GLenum  target, GLuint  index, GLdouble * data);
+// typedef void  (APIENTRYP GPGETDOUBLEI_VEXT)(GLenum  pname, GLuint  index, GLdouble * params);
 // typedef void  (APIENTRYP GPGETDOUBLEV)(GLenum  pname, GLdouble * data);
 // typedef GLenum  (APIENTRYP GPGETERROR)();
+// typedef void  (APIENTRYP GPGETFIRSTPERFQUERYIDINTEL)(GLuint * queryId);
+// typedef void  (APIENTRYP GPGETFLOATINDEXEDVEXT)(GLenum  target, GLuint  index, GLfloat * data);
 // typedef void  (APIENTRYP GPGETFLOATI_V)(GLenum  target, GLuint  index, GLfloat * data);
+// typedef void  (APIENTRYP GPGETFLOATI_VEXT)(GLenum  pname, GLuint  index, GLfloat * params);
 // typedef void  (APIENTRYP GPGETFLOATV)(GLenum  pname, GLfloat * data);
 // typedef GLint  (APIENTRYP GPGETFRAGDATAINDEX)(GLuint  program, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETFRAGDATALOCATION)(GLuint  program, const GLchar * name);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSARB)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSKHR)();
 // typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLEARB)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
+// typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLENV)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
 // typedef void  (APIENTRYP GPGETINTEGER64I_V)(GLenum  target, GLuint  index, GLint64 * data);
 // typedef void  (APIENTRYP GPGETINTEGER64V)(GLenum  pname, GLint64 * data);
+// typedef void  (APIENTRYP GPGETINTEGERINDEXEDVEXT)(GLenum  target, GLuint  index, GLint * data);
 // typedef void  (APIENTRYP GPGETINTEGERI_V)(GLenum  target, GLuint  index, GLint * data);
+// typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
+// typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMULTISAMPLEFV)(GLenum  pname, GLuint  index, GLfloat * val);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERI64V)(GLuint  buffer, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIV)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIVEXT)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  pname, void * string);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMIVEXT)(GLuint  program, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIV)(GLuint  renderbuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(GLuint  renderbuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGARB)(GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGIVARB)(GLint  namelen, const GLchar * name, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNEXTPERFQUERYIDINTEL)(GLuint  queryId, GLuint * nextQueryId);
 // typedef void  (APIENTRYP GPGETOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETOBJECTLABELEXT)(GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABEL)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABELKHR)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETPATHCOMMANDSNV)(GLuint  path, GLubyte * commands);
+// typedef void  (APIENTRYP GPGETPATHCOORDSNV)(GLuint  path, GLfloat * coords);
+// typedef void  (APIENTRYP GPGETPATHDASHARRAYNV)(GLuint  path, GLfloat * dashArray);
+// typedef GLfloat  (APIENTRYP GPGETPATHLENGTHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments);
+// typedef void  (APIENTRYP GPGETPATHMETRICRANGENV)(GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHMETRICSNV)(GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, GLfloat * value);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, GLint * value);
+// typedef void  (APIENTRYP GPGETPATHSPACINGNV)(GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing);
+// typedef void  (APIENTRYP GPGETPERFCOUNTERINFOINTEL)(GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERDATAAMD)(GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERINFOAMD)(GLuint  group, GLuint  counter, GLenum  pname, void * data);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSTRINGAMD)(GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
+// typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
+// typedef void  (APIENTRYP GPGETPOINTERINDEXEDVEXT)(GLenum  target, GLuint  index, void ** data);
+// typedef void  (APIENTRYP GPGETPOINTERI_VEXT)(GLenum  pname, GLuint  index, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERV)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERVKHR)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPROGRAMBINARY)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLenum * binaryFormat, void * binary);
 // typedef void  (APIENTRYP GPGETPROGRAMINFOLOG)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMINTERFACEIV)(GLuint  program, GLenum  programInterface, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOG)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOGEXT)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIV)(GLuint  pipeline, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIVEXT)(GLuint  pipeline, GLenum  pname, GLint * params);
 // typedef GLuint  (APIENTRYP GPGETPROGRAMRESOURCEINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATION)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATIONINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCENAME)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name);
+// typedef void  (APIENTRYP GPGETPROGRAMRESOURCEFVNV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCEIV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMSTAGEIV)(GLuint  program, GLenum  shadertype, GLenum  pname, GLint * values);
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTIV)(GLuint  id, GLenum  pname, GLint * params);
@@ -383,6 +559,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERPRECISIONFORMAT)(GLenum  shadertype, GLenum  precisiontype, GLint * range, GLint * precision);
 // typedef void  (APIENTRYP GPGETSHADERSOURCE)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -396,14 +573,23 @@ package gl
 // typedef void  (APIENTRYP GPGETTEXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLEARB)(GLuint  texture);
+// typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLENV)(GLuint  texture);
 // typedef void  (APIENTRYP GPGETTEXTUREIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFV)(GLuint  texture, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIV)(GLuint  texture, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLEARB)(GLuint  texture, GLuint  sampler);
+// typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLENV)(GLuint  texture, GLuint  sampler);
 // typedef void  (APIENTRYP GPGETTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKVARYING)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLsizei * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKI64_V)(GLuint  xfb, GLenum  pname, GLuint  index, GLint64 * param);
@@ -415,32 +601,48 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMSUBROUTINEUIV)(GLenum  shadertype, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXED64IV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint64 * param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXEDIV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERVEXT)(GLuint  vaobj, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, void ** param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERVEXT)(GLuint  vaobj, GLenum  pname, void ** param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYIV)(GLuint  vaobj, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIIV)(GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIUIV)(GLuint  index, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLDV)(GLuint  index, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLI64VNV)(GLuint  index, GLenum  pname, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VARB)(GLuint  index, GLenum  pname, GLuint64EXT * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VNV)(GLuint  index, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBPOINTERV)(GLuint  index, GLenum  pname, void ** pointer);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBDV)(GLuint  index, GLenum  pname, GLdouble * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBFV)(GLuint  index, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIV)(GLuint  index, GLenum  pname, GLint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNTEXIMAGEARB)(GLenum  target, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNUNIFORMDVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLdouble * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPHINT)(GLenum  target, GLenum  mode);
+// typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPINSERTEVENTMARKEREXT)(GLsizei  length, const GLchar * marker);
+// typedef void  (APIENTRYP GPINTERPOLATEPATHSNV)(GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERDATA)(GLuint  buffer);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPINVALIDATEFRAMEBUFFER)(GLenum  target, GLsizei  numAttachments, const GLenum * attachments);
@@ -450,68 +652,196 @@ package gl
 // typedef void  (APIENTRYP GPINVALIDATETEXIMAGE)(GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPINVALIDATETEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
+// typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISFRAMEBUFFER)(GLuint  framebuffer);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef GLboolean  (APIENTRYP GPISPATHNV)(GLuint  path);
+// typedef GLboolean  (APIENTRYP GPISPOINTINFILLPATHNV)(GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y);
+// typedef GLboolean  (APIENTRYP GPISPOINTINSTROKEPATHNV)(GLuint  path, GLfloat  x, GLfloat  y);
 // typedef GLboolean  (APIENTRYP GPISPROGRAM)(GLuint  program);
 // typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef GLboolean  (APIENTRYP GPISQUERY)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISTRANSFORMFEEDBACK)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
+// typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLINEWIDTH)(GLfloat  width);
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLOGICOP)(GLenum  opcode);
+// typedef void  (APIENTRYP GPMAKEBUFFERNONRESIDENTNV)(GLenum  target);
+// typedef void  (APIENTRYP GPMAKEBUFFERRESIDENTNV)(GLenum  target, GLenum  access);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTARB)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTNV)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERNONRESIDENTNV)(GLuint  buffer);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERRESIDENTNV)(GLuint  buffer, GLenum  access);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef void * (APIENTRYP GPMAPBUFFER)(GLenum  target, GLenum  access);
 // typedef void * (APIENTRYP GPMAPBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void  (APIENTRYP GPMATRIXFRUSTUMEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADIDENTITYEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXORTHOEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXPOPEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXPUSHEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXROTATEDEXT)(GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXROTATEFEXT)(GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMINSAMPLESHADING)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYS)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTITEXBUFFEREXT)(GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPMULTITEXCOORDPOINTEREXT)(GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
+// typedef void  (APIENTRYP GPMULTITEXENVFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXENVIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXGENDEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param);
+// typedef void  (APIENTRYP GPMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params);
+// typedef void  (APIENTRYP GPMULTITEXGENFEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXGENIEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXRENDERBUFFEREXT)(GLenum  texunit, GLenum  target, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFERS)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERI)(GLuint  framebuffer, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERIEXT)(GLuint  framebuffer, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYER)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLdouble * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGE)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEEXT)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDSTRINGARB)(GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string);
+// typedef void  (APIENTRYP GPNORMALFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABEL)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABELKHR)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPPATCHPARAMETERFV)(GLenum  pname, const GLfloat * values);
 // typedef void  (APIENTRYP GPPATCHPARAMETERI)(GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHCOMMANDSNV)(GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOORDSNV)(GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOVERDEPTHFUNCNV)(GLenum  func);
+// typedef void  (APIENTRYP GPPATHDASHARRAYNV)(GLuint  path, GLsizei  dashCount, const GLfloat * dashArray);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXRANGENV)(GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount);
+// typedef void  (APIENTRYP GPPATHGLYPHRANGENV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHGLYPHSNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHMEMORYGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHPARAMETERFNV)(GLuint  path, GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, const GLfloat * value);
+// typedef void  (APIENTRYP GPPATHPARAMETERINV)(GLuint  path, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, const GLint * value);
+// typedef void  (APIENTRYP GPPATHSTENCILDEPTHOFFSETNV)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPATHSTENCILFUNCNV)(GLenum  func, GLint  ref, GLuint  mask);
+// typedef void  (APIENTRYP GPPATHSTRINGNV)(GLuint  path, GLenum  format, GLsizei  length, const void * pathString);
+// typedef void  (APIENTRYP GPPATHSUBCOMMANDSNV)(GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHSUBCOORDSNV)(GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords);
 // typedef void  (APIENTRYP GPPAUSETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPPIXELSTOREF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPIXELSTOREI)(GLenum  pname, GLint  param);
+// typedef GLboolean  (APIENTRYP GPPOINTALONGPATHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY);
 // typedef void  (APIENTRYP GPPOINTPARAMETERF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPOINTPARAMETERFV)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPPOINTPARAMETERI)(GLenum  pname, GLint  param);
@@ -519,67 +849,163 @@ package gl
 // typedef void  (APIENTRYP GPPOINTSIZE)(GLfloat  size);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOPDEBUGGROUP)();
 // typedef void  (APIENTRYP GPPOPDEBUGGROUPKHR)();
+// typedef void  (APIENTRYP GPPOPGROUPMARKEREXT)();
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPROGRAMBINARY)(GLuint  program, GLenum  binaryFormat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPPROGRAMPARAMETERI)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIARB)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIEXT)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPATHFRAGMENTINPUTGENNV)(GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1D)(GLuint  program, GLint  location, GLdouble  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DEXT)(GLuint  program, GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1F)(GLuint  program, GLint  location, GLfloat  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FEXT)(GLuint  program, GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64ARB)(GLuint  program, GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64NV)(GLuint  program, GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64NV)(GLuint  program, GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROVOKINGVERTEX)(GLenum  mode);
+// typedef void  (APIENTRYP GPPUSHCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUP)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUPKHR)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
+// typedef void  (APIENTRYP GPPUSHGROUPMARKEREXT)(GLsizei  length, const GLchar * marker);
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPREADNPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, GLsizei  bufSize, void * data);
@@ -588,6 +1014,8 @@ package gl
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMASKI)(GLuint  maskNumber, GLbitfield  mask);
@@ -601,23 +1029,40 @@ package gl
 // typedef void  (APIENTRYP GPSCISSORARRAYV)(GLuint  first, GLsizei  count, const GLint * v);
 // typedef void  (APIENTRYP GPSCISSORINDEXED)(GLuint  index, GLint  left, GLint  bottom, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPSCISSORINDEXEDV)(GLuint  index, const GLint * v);
+// typedef void  (APIENTRYP GPSECONDARYCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
 // typedef void  (APIENTRYP GPSHADERBINARY)(GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPSHADERSOURCE)(GLuint  shader, GLsizei  count, const GLchar *const* string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNC)(GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNCSEPARATE)(GLenum  face, GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASK)(GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASKSEPARATE)(GLenum  face, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILOP)(GLenum  fail, GLenum  zfail, GLenum  zpass);
 // typedef void  (APIENTRYP GPSTENCILOPSEPARATE)(GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPTEXBUFFER)(GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXBUFFERARB)(GLenum  target, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXBUFFERRANGE)(GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXCOORDFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPTEXIMAGE1D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE2D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERF)(GLenum  target, GLenum  pname, GLfloat  param);
@@ -633,61 +1078,118 @@ package gl
 // typedef void  (APIENTRYP GPTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREBARRIER)();
+// typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERF)(GLuint  texture, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, const GLfloat * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERI)(GLuint  texture, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, const GLint * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTURERENDERBUFFEREXT)(GLuint  texture, GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE1D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE1DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREVIEW)(GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
+// typedef void  (APIENTRYP GPTRANSFORMPATHNV)(GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPUNIFORM1D)(GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPUNIFORM1DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM1F)(GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM2D)(GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPUNIFORM2DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM2F)(GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM3D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPUNIFORM3DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM3F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM4D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPUNIFORM4DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM4F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORMBLOCKBINDING)(GLuint  program, GLuint  uniformBlockIndex, GLuint  uniformBlockBinding);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64ARB)(GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64NV)(GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VNV)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
@@ -707,20 +1209,45 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMSUBROUTINESUIV)(GLenum  shadertype, GLsizei  count, const GLuint * indices);
+// typedef void  (APIENTRYP GPUNIFORMUI64NV)(GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPUNIFORMUI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef GLboolean  (APIENTRYP GPUNMAPBUFFER)(GLenum  target);
 // typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFEREXT)(GLuint  buffer);
 // typedef void  (APIENTRYP GPUSEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPUSEPROGRAMSTAGES)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSEPROGRAMSTAGESEXT)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSESHADERPROGRAMEXT)(GLenum  type, GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBBINDING)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBIFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBLFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYBINDVERTEXBUFFEREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYBINDINGDIVISOR)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYEDGEFLAGOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXARRAYELEMENTBUFFER)(GLuint  vaobj, GLuint  buffer);
+// typedef void  (APIENTRYP GPVERTEXARRAYFOGCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYINDEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYNORMALOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYTEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(GLuint  vaobj, GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFER)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFERS)(GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1DV)(GLuint  index, const GLdouble * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1F)(GLuint  index, GLfloat  x);
@@ -759,7 +1286,9 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIB4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBBINDING)(GLuint  attribindex, GLuint  bindingindex);
 // typedef void  (APIENTRYP GPVERTEXATTRIBDIVISOR)(GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXATTRIBDIVISORARB)(GLuint  index, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXATTRIBFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1I)(GLuint  index, GLint  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1IV)(GLuint  index, const GLint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1UI)(GLuint  index, GLuint  x);
@@ -781,18 +1310,36 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4UIV)(GLuint  index, const GLuint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBIFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64NV)(GLuint  index, GLint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64VNV)(GLuint  index, const GLint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64ARB)(GLuint  index, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64NV)(GLuint  index, GLuint64EXT  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VARB)(GLuint  index, const GLuint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2D)(GLuint  index, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBLFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UI)(GLuint  index, GLenum  type, GLboolean  normalized, GLuint  value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
@@ -804,22 +1351,46 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBP4UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBPOINTER)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXBINDINGDIVISOR)(GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVIEWPORT)(GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
+// static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
+//   (*fnptr)(program);
+// }
 // static void  glowActiveShaderProgram(GPACTIVESHADERPROGRAM fnptr, GLuint  pipeline, GLuint  program) {
+//   (*fnptr)(pipeline, program);
+// }
+// static void  glowActiveShaderProgramEXT(GPACTIVESHADERPROGRAMEXT fnptr, GLuint  pipeline, GLuint  program) {
 //   (*fnptr)(pipeline, program);
 // }
 // static void  glowActiveTexture(GPACTIVETEXTURE fnptr, GLenum  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowAttachShader(GPATTACHSHADER fnptr, GLuint  program, GLuint  shader) {
 //   (*fnptr)(program, shader);
 // }
 // static void  glowBeginConditionalRender(GPBEGINCONDITIONALRENDER fnptr, GLuint  id, GLenum  mode) {
 //   (*fnptr)(id, mode);
+// }
+// static void  glowBeginConditionalRenderNV(GPBEGINCONDITIONALRENDERNV fnptr, GLuint  id, GLenum  mode) {
+//   (*fnptr)(id, mode);
+// }
+// static void  glowBeginPerfMonitorAMD(GPBEGINPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowBeginPerfQueryINTEL(GPBEGINPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
 // }
 // static void  glowBeginQuery(GPBEGINQUERY fnptr, GLenum  target, GLuint  id) {
 //   (*fnptr)(target, id);
@@ -863,7 +1434,13 @@ package gl
 // static void  glowBindImageTextures(GPBINDIMAGETEXTURES fnptr, GLuint  first, GLsizei  count, const GLuint * textures) {
 //   (*fnptr)(first, count, textures);
 // }
+// static void  glowBindMultiTextureEXT(GPBINDMULTITEXTUREEXT fnptr, GLenum  texunit, GLenum  target, GLuint  texture) {
+//   (*fnptr)(texunit, target, texture);
+// }
 // static void  glowBindProgramPipeline(GPBINDPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowBindProgramPipelineEXT(GPBINDPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowBindRenderbuffer(GPBINDRENDERBUFFER fnptr, GLenum  target, GLuint  renderbuffer) {
@@ -895,6 +1472,12 @@ package gl
 // }
 // static void  glowBindVertexBuffers(GPBINDVERTEXBUFFERS fnptr, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(first, count, buffers, offsets, strides);
+// }
+// static void  glowBlendBarrierKHR(GPBLENDBARRIERKHR fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowBlendBarrierNV(GPBLENDBARRIERNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowBlendColor(GPBLENDCOLOR fnptr, GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
@@ -935,16 +1518,22 @@ package gl
 // static void  glowBlendFunciARB(GPBLENDFUNCIARB fnptr, GLuint  buf, GLenum  src, GLenum  dst) {
 //   (*fnptr)(buf, src, dst);
 // }
+// static void  glowBlendParameteriNV(GPBLENDPARAMETERINV fnptr, GLenum  pname, GLint  value) {
+//   (*fnptr)(pname, value);
+// }
 // static void  glowBlitFramebuffer(GPBLITFRAMEBUFFER fnptr, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
 // static void  glowBlitNamedFramebuffer(GPBLITNAMEDFRAMEBUFFER fnptr, GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
+// static void  glowBufferAddressRangeNV(GPBUFFERADDRESSRANGENV fnptr, GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length) {
+//   (*fnptr)(pname, index, address, length);
+// }
 // static void  glowBufferData(GPBUFFERDATA fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
@@ -953,10 +1542,16 @@ package gl
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static GLenum  glowCheckFramebufferStatus(GPCHECKFRAMEBUFFERSTATUS fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLenum  glowCheckNamedFramebufferStatus(GPCHECKNAMEDFRAMEBUFFERSTATUS fnptr, GLuint  framebuffer, GLenum  target) {
+//   return (*fnptr)(framebuffer, target);
+// }
+// static GLenum  glowCheckNamedFramebufferStatusEXT(GPCHECKNAMEDFRAMEBUFFERSTATUSEXT fnptr, GLuint  framebuffer, GLenum  target) {
 //   return (*fnptr)(framebuffer, target);
 // }
 // static void  glowClampColor(GPCLAMPCOLOR fnptr, GLenum  target, GLenum  clamp) {
@@ -995,11 +1590,17 @@ package gl
 // static void  glowClearNamedBufferData(GPCLEARNAMEDBUFFERDATA fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, format, type, data);
+// }
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
+// }
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -1019,11 +1620,17 @@ package gl
 // static void  glowClearTexSubImage(GPCLEARTEXSUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data);
 // }
+// static void  glowClientAttribDefaultEXT(GPCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
+// }
 // static GLenum  glowClientWaitSync(GPCLIENTWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   return (*fnptr)(sync, flags, timeout);
 // }
 // static void  glowClipControl(GPCLIPCONTROL fnptr, GLenum  origin, GLenum  depth) {
 //   (*fnptr)(origin, depth);
+// }
+// static void  glowColorFormatNV(GPCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
 // }
 // static void  glowColorMask(GPCOLORMASK fnptr, GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
@@ -1031,11 +1638,35 @@ package gl
 // static void  glowColorMaski(GPCOLORMASKI fnptr, GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a) {
 //   (*fnptr)(index, r, g, b, a);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
 // static void  glowCompileShaderIncludeARB(GPCOMPILESHADERINCLUDEARB fnptr, GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length) {
 //   (*fnptr)(shader, count, path, length);
+// }
+// static void  glowCompressedMultiTexImage1DEXT(GPCOMPRESSEDMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage2DEXT(GPCOMPRESSEDMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage3DEXT(GPCOMPRESSEDMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage1DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage2DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage3DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
 // }
 // static void  glowCompressedTexImage1D(GPCOMPRESSEDTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, internalformat, width, border, imageSize, data);
@@ -1055,14 +1686,38 @@ package gl
 // static void  glowCompressedTexSubImage3D(GPCOMPRESSEDTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
 // }
+// static void  glowCompressedTextureImage1DEXT(GPCOMPRESSEDTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage2DEXT(GPCOMPRESSEDTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage3DEXT(GPCOMPRESSEDTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage1D(GPCOMPRESSEDTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, width, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage1DEXT(GPCOMPRESSEDTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, imageSize, bits);
 // }
 // static void  glowCompressedTextureSubImage2D(GPCOMPRESSEDTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, imageSize, data);
 // }
+// static void  glowCompressedTextureSubImage2DEXT(GPCOMPRESSEDTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage3D(GPCOMPRESSEDTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowCopyBufferSubData(GPCOPYBUFFERSUBDATA fnptr, GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readTarget, writeTarget, readOffset, writeOffset, size);
@@ -1070,8 +1725,26 @@ package gl
 // static void  glowCopyImageSubData(GPCOPYIMAGESUBDATA fnptr, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
 //   (*fnptr)(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyMultiTexImage1DEXT(GPCOPYMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyMultiTexImage2DEXT(GPCOPYMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, height, border);
+// }
+// static void  glowCopyMultiTexSubImage1DEXT(GPCOPYMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texunit, target, level, xoffset, x, y, width);
+// }
+// static void  glowCopyMultiTexSubImage2DEXT(GPCOPYMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, x, y, width, height);
+// }
+// static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
+//   (*fnptr)(resultPath, srcPath);
 // }
 // static void  glowCopyTexImage1D(GPCOPYTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
 //   (*fnptr)(target, level, internalformat, x, y, width, border);
@@ -1088,20 +1761,59 @@ package gl
 // static void  glowCopyTexSubImage3D(GPCOPYTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureImage1DEXT(GPCOPYTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyTextureImage2DEXT(GPCOPYTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, height, border);
+// }
 // static void  glowCopyTextureSubImage1D(GPCOPYTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
 //   (*fnptr)(texture, level, xoffset, x, y, width);
+// }
+// static void  glowCopyTextureSubImage1DEXT(GPCOPYTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texture, target, level, xoffset, x, y, width);
 // }
 // static void  glowCopyTextureSubImage2D(GPCOPYTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureSubImage2DEXT(GPCOPYTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, x, y, width, height);
+// }
 // static void  glowCopyTextureSubImage3D(GPCOPYTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyTextureSubImage3DEXT(GPCOPYTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCoverFillPathInstancedNV(GPCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverFillPathNV(GPCOVERFILLPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverStrokePathInstancedNV(GPCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
 // }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
+//   (*fnptr)(queryId, queryHandle);
 // }
 // static GLuint  glowCreateProgram(GPCREATEPROGRAM fnptr) {
 //   return (*fnptr)();
@@ -1121,8 +1833,17 @@ package gl
 // static GLuint  glowCreateShader(GPCREATESHADER fnptr, GLenum  type) {
 //   return (*fnptr)(type);
 // }
+// static GLuint  glowCreateShaderProgramEXT(GPCREATESHADERPROGRAMEXT fnptr, GLenum  type, const GLchar * string) {
+//   return (*fnptr)(type, string);
+// }
 // static GLuint  glowCreateShaderProgramv(GPCREATESHADERPROGRAMV fnptr, GLenum  type, GLsizei  count, const GLchar *const* strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
+//   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -1169,16 +1890,31 @@ package gl
 // static void  glowDeleteBuffers(GPDELETEBUFFERS fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFramebuffers(GPDELETEFRAMEBUFFERS fnptr, GLsizei  n, const GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
 // }
+// static void  glowDeletePathsNV(GPDELETEPATHSNV fnptr, GLuint  path, GLsizei  range) {
+//   (*fnptr)(path, range);
+// }
+// static void  glowDeletePerfMonitorsAMD(GPDELETEPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
+// static void  glowDeletePerfQueryINTEL(GPDELETEPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowDeleteProgram(GPDELETEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowDeleteProgramPipelines(GPDELETEPROGRAMPIPELINES fnptr, GLsizei  n, const GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowDeleteProgramPipelinesEXT(GPDELETEPROGRAMPIPELINESEXT fnptr, GLsizei  n, const GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowDeleteQueries(GPDELETEQUERIES fnptr, GLsizei  n, const GLuint * ids) {
@@ -1192,6 +1928,9 @@ package gl
 // }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -1229,8 +1968,23 @@ package gl
 // static void  glowDisable(GPDISABLE fnptr, GLenum  cap) {
 //   (*fnptr)(cap);
 // }
+// static void  glowDisableClientStateIndexedEXT(GPDISABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableClientStateiEXT(GPDISABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableIndexedEXT(GPDISABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowDisableVertexArrayAttrib(GPDISABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayAttribEXT(GPDISABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayEXT(GPDISABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowDisableVertexAttribArray(GPDISABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1256,14 +2010,32 @@ package gl
 // static void  glowDrawArraysInstanced(GPDRAWARRAYSINSTANCED fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount) {
 //   (*fnptr)(mode, first, count, instancecount);
 // }
+// static void  glowDrawArraysInstancedARB(GPDRAWARRAYSINSTANCEDARB fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, first, count, primcount);
+// }
 // static void  glowDrawArraysInstancedBaseInstance(GPDRAWARRAYSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, first, count, instancecount, baseinstance);
+// }
+// static void  glowDrawArraysInstancedEXT(GPDRAWARRAYSINSTANCEDEXT fnptr, GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, start, count, primcount);
 // }
 // static void  glowDrawBuffer(GPDRAWBUFFER fnptr, GLenum  buf) {
 //   (*fnptr)(buf);
 // }
 // static void  glowDrawBuffers(GPDRAWBUFFERS fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
+// }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
 // }
 // static void  glowDrawElements(GPDRAWELEMENTS fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, count, type, indices);
@@ -1277,6 +2049,9 @@ package gl
 // static void  glowDrawElementsInstanced(GPDRAWELEMENTSINSTANCED fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount) {
 //   (*fnptr)(mode, count, type, indices, instancecount);
 // }
+// static void  glowDrawElementsInstancedARB(GPDRAWELEMENTSINSTANCEDARB fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
+// }
 // static void  glowDrawElementsInstancedBaseInstance(GPDRAWELEMENTSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, baseinstance);
 // }
@@ -1285,6 +2060,9 @@ package gl
 // }
 // static void  glowDrawElementsInstancedBaseVertexBaseInstance(GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, basevertex, baseinstance);
+// }
+// static void  glowDrawElementsInstancedEXT(GPDRAWELEMENTSINSTANCEDEXT fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
 // }
 // static void  glowDrawRangeElements(GPDRAWRANGEELEMENTS fnptr, GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, start, end, count, type, indices);
@@ -1304,11 +2082,32 @@ package gl
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
 // }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
+// }
+// static void  glowEdgeFlagFormatNV(GPEDGEFLAGFORMATNV fnptr, GLsizei  stride) {
+//   (*fnptr)(stride);
+// }
 // static void  glowEnable(GPENABLE fnptr, GLenum  cap) {
 //   (*fnptr)(cap);
 // }
+// static void  glowEnableClientStateIndexedEXT(GPENABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableClientStateiEXT(GPENABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableIndexedEXT(GPENABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowEnableVertexArrayAttrib(GPENABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayAttribEXT(GPENABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayEXT(GPENABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowEnableVertexAttribArray(GPENABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1319,6 +2118,15 @@ package gl
 // static void  glowEndConditionalRender(GPENDCONDITIONALRENDER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowEndConditionalRenderNV(GPENDCONDITIONALRENDERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowEndPerfMonitorAMD(GPENDPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowEndPerfQueryINTEL(GPENDPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowEndQuery(GPENDQUERY fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
@@ -1326,6 +2134,9 @@ package gl
 //   (*fnptr)(target, index);
 // }
 // static void  glowEndTransformFeedback(GPENDTRANSFORMFEEDBACK fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
 //   (*fnptr)();
 // }
 // static GLsync  glowFenceSync(GPFENCESYNC fnptr, GLenum  condition, GLbitfield  flags) {
@@ -1340,14 +2151,41 @@ package gl
 // static void  glowFlushMappedBufferRange(GPFLUSHMAPPEDBUFFERRANGE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(target, offset, length);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
+//   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFogCoordFormatNV(GPFOGCOORDFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
+// static void  glowFramebufferDrawBufferEXT(GPFRAMEBUFFERDRAWBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
+// static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
+//   (*fnptr)(framebuffer, n, bufs);
+// }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
+// static void  glowFramebufferReadBufferEXT(GPFRAMEBUFFERREADBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
 // static void  glowFramebufferRenderbuffer(GPFRAMEBUFFERRENDERBUFFER fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -1361,8 +2199,20 @@ package gl
 // static void  glowFramebufferTexture3D(GPFRAMEBUFFERTEXTURE3D fnptr, GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
 //   (*fnptr)(target, attachment, textarget, texture, level, zoffset);
 // }
+// static void  glowFramebufferTextureARB(GPFRAMEBUFFERTEXTUREARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(target, attachment, texture, level);
+// }
+// static void  glowFramebufferTextureFaceARB(GPFRAMEBUFFERTEXTUREFACEARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(target, attachment, texture, level, face);
+// }
 // static void  glowFramebufferTextureLayer(GPFRAMEBUFFERTEXTURELAYER fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureLayerARB(GPFRAMEBUFFERTEXTURELAYERARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFrontFace(GPFRONTFACE fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -1373,7 +2223,16 @@ package gl
 // static void  glowGenFramebuffers(GPGENFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
+// static GLuint  glowGenPathsNV(GPGENPATHSNV fnptr, GLsizei  range) {
+//   return (*fnptr)(range);
+// }
+// static void  glowGenPerfMonitorsAMD(GPGENPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
 // static void  glowGenProgramPipelines(GPGENPROGRAMPIPELINES fnptr, GLsizei  n, GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowGenProgramPipelinesEXT(GPGENPROGRAMPIPELINESEXT fnptr, GLsizei  n, GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowGenQueries(GPGENQUERIES fnptr, GLsizei  n, GLuint * ids) {
@@ -1397,8 +2256,14 @@ package gl
 // static void  glowGenerateMipmap(GPGENERATEMIPMAP fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
+// static void  glowGenerateMultiTexMipmapEXT(GPGENERATEMULTITEXMIPMAPEXT fnptr, GLenum  texunit, GLenum  target) {
+//   (*fnptr)(texunit, target);
+// }
 // static void  glowGenerateTextureMipmap(GPGENERATETEXTUREMIPMAP fnptr, GLuint  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowGenerateTextureMipmapEXT(GPGENERATETEXTUREMIPMAPEXT fnptr, GLuint  texture, GLenum  target) {
+//   (*fnptr)(texture, target);
 // }
 // static void  glowGetActiveAtomicCounterBufferiv(GPGETACTIVEATOMICCOUNTERBUFFERIV fnptr, GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, bufferIndex, pname, params);
@@ -1436,6 +2301,9 @@ package gl
 // static GLint  glowGetAttribLocation(GPGETATTRIBLOCATION fnptr, GLuint  program, const GLchar * name) {
 //   return (*fnptr)(program, name);
 // }
+// static void  glowGetBooleanIndexedvEXT(GPGETBOOLEANINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLboolean * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetBooleani_v(GPGETBOOLEANI_V fnptr, GLenum  target, GLuint  index, GLboolean * data) {
 //   (*fnptr)(target, index, data);
 // }
@@ -1448,11 +2316,20 @@ package gl
 // static void  glowGetBufferParameteriv(GPGETBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetBufferParameterui64vNV(GPGETBUFFERPARAMETERUI64VNV fnptr, GLenum  target, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(target, pname, params);
+// }
 // static void  glowGetBufferPointerv(GPGETBUFFERPOINTERV fnptr, GLenum  target, GLenum  pname, void ** params) {
 //   (*fnptr)(target, pname, params);
 // }
 // static void  glowGetBufferSubData(GPGETBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
+// static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texunit, target, lod, img);
 // }
 // static void  glowGetCompressedTexImage(GPGETCOMPRESSEDTEXIMAGE fnptr, GLenum  target, GLint  level, void * img) {
 //   (*fnptr)(target, level, img);
@@ -1460,8 +2337,14 @@ package gl
 // static void  glowGetCompressedTextureImage(GPGETCOMPRESSEDTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, bufSize, pixels);
 // }
+// static void  glowGetCompressedTextureImageEXT(GPGETCOMPRESSEDTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texture, target, lod, img);
+// }
 // static void  glowGetCompressedTextureSubImage(GPGETCOMPRESSEDTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -1472,8 +2355,14 @@ package gl
 // static GLuint  glowGetDebugMessageLogKHR(GPGETDEBUGMESSAGELOGKHR fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
 // }
+// static void  glowGetDoubleIndexedvEXT(GPGETDOUBLEINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLdouble * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetDoublei_v(GPGETDOUBLEI_V fnptr, GLenum  target, GLuint  index, GLdouble * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetDoublei_vEXT(GPGETDOUBLEI_VEXT fnptr, GLenum  pname, GLuint  index, GLdouble * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetDoublev(GPGETDOUBLEV fnptr, GLenum  pname, GLdouble * data) {
 //   (*fnptr)(pname, data);
@@ -1481,8 +2370,17 @@ package gl
 // static GLenum  glowGetError(GPGETERROR fnptr) {
 //   return (*fnptr)();
 // }
+// static void  glowGetFirstPerfQueryIdINTEL(GPGETFIRSTPERFQUERYIDINTEL fnptr, GLuint * queryId) {
+//   (*fnptr)(queryId);
+// }
+// static void  glowGetFloatIndexedvEXT(GPGETFLOATINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLfloat * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetFloati_v(GPGETFLOATI_V fnptr, GLenum  target, GLuint  index, GLfloat * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetFloati_vEXT(GPGETFLOATI_VEXT fnptr, GLenum  pname, GLuint  index, GLfloat * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetFloatv(GPGETFLOATV fnptr, GLenum  pname, GLfloat * data) {
 //   (*fnptr)(pname, data);
@@ -1499,6 +2397,9 @@ package gl
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetFramebufferParameterivEXT(GPGETFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
 // static GLenum  glowGetGraphicsResetStatus(GPGETGRAPHICSRESETSTATUS fnptr) {
 //   return (*fnptr)();
 // }
@@ -1511,23 +2412,74 @@ package gl
 // static GLuint64  glowGetImageHandleARB(GPGETIMAGEHANDLEARB fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
 //   return (*fnptr)(texture, level, layered, layer, format);
 // }
+// static GLuint64  glowGetImageHandleNV(GPGETIMAGEHANDLENV fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
+//   return (*fnptr)(texture, level, layered, layer, format);
+// }
 // static void  glowGetInteger64i_v(GPGETINTEGER64I_V fnptr, GLenum  target, GLuint  index, GLint64 * data) {
 //   (*fnptr)(target, index, data);
 // }
 // static void  glowGetInteger64v(GPGETINTEGER64V fnptr, GLenum  pname, GLint64 * data) {
 //   (*fnptr)(pname, data);
 // }
+// static void  glowGetIntegerIndexedvEXT(GPGETINTEGERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLint * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetIntegeri_v(GPGETINTEGERI_V fnptr, GLenum  target, GLuint  index, GLint * data) {
 //   (*fnptr)(target, index, data);
 // }
+// static void  glowGetIntegerui64i_vNV(GPGETINTEGERUI64I_VNV fnptr, GLenum  value, GLuint  index, GLuint64EXT * result) {
+//   (*fnptr)(value, index, result);
+// }
+// static void  glowGetIntegerui64vNV(GPGETINTEGERUI64VNV fnptr, GLenum  value, GLuint64EXT * result) {
+//   (*fnptr)(value, result);
+// }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
 // }
 // static void  glowGetInternalformativ(GPGETINTERNALFORMATIV fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
+// }
+// static void  glowGetMultiTexEnvfvEXT(GPGETMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexEnvivEXT(GPGETMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexGendvEXT(GPGETMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenfvEXT(GPGETMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenivEXT(GPGETMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexImageEXT(GPGETMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texunit, target, level, format, type, pixels);
+// }
+// static void  glowGetMultiTexLevelParameterfvEXT(GPGETMULTITEXLEVELPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexLevelParameterivEXT(GPGETMULTITEXLEVELPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexParameterIivEXT(GPGETMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterIuivEXT(GPGETMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterfvEXT(GPGETMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterivEXT(GPGETMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
 // }
 // static void  glowGetMultisamplefv(GPGETMULTISAMPLEFV fnptr, GLenum  pname, GLuint  index, GLfloat * val) {
 //   (*fnptr)(pname, index, val);
@@ -1538,19 +2490,58 @@ package gl
 // static void  glowGetNamedBufferParameteriv(GPGETNAMEDBUFFERPARAMETERIV fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(buffer, pname, params);
 // }
+// static void  glowGetNamedBufferParameterivEXT(GPGETNAMEDBUFFERPARAMETERIVEXT fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferParameterui64vNV(GPGETNAMEDBUFFERPARAMETERUI64VNV fnptr, GLuint  buffer, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
 // static void  glowGetNamedBufferPointerv(GPGETNAMEDBUFFERPOINTERV fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedFramebufferAttachmentParameteriv(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
 // }
+// static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, attachment, pname, params);
+// }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowGetNamedFramebufferParameterivEXT(GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIuivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterdvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterfvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramStringEXT(GPGETNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, void * string) {
+//   (*fnptr)(program, target, pname, string);
+// }
+// static void  glowGetNamedProgramivEXT(GPGETNAMEDPROGRAMIVEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(program, target, pname, params);
+// }
 // static void  glowGetNamedRenderbufferParameteriv(GPGETNAMEDRENDERBUFFERPARAMETERIV fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(renderbuffer, pname, params);
+// }
+// static void  glowGetNamedRenderbufferParameterivEXT(GPGETNAMEDRENDERBUFFERPARAMETERIVEXT fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(renderbuffer, pname, params);
 // }
 // static void  glowGetNamedStringARB(GPGETNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string) {
@@ -1559,8 +2550,14 @@ package gl
 // static void  glowGetNamedStringivARB(GPGETNAMEDSTRINGIVARB fnptr, GLint  namelen, const GLchar * name, GLenum  pname, GLint * params) {
 //   (*fnptr)(namelen, name, pname, params);
 // }
+// static void  glowGetNextPerfQueryIdINTEL(GPGETNEXTPERFQUERYIDINTEL fnptr, GLuint  queryId, GLuint * nextQueryId) {
+//   (*fnptr)(queryId, nextQueryId);
+// }
 // static void  glowGetObjectLabel(GPGETOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
+// }
+// static void  glowGetObjectLabelEXT(GPGETOBJECTLABELEXT fnptr, GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label) {
+//   (*fnptr)(type, object, bufSize, length, label);
 // }
 // static void  glowGetObjectLabelKHR(GPGETOBJECTLABELKHR fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
@@ -1570,6 +2567,69 @@ package gl
 // }
 // static void  glowGetObjectPtrLabelKHR(GPGETOBJECTPTRLABELKHR fnptr, const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(ptr, bufSize, length, label);
+// }
+// static void  glowGetPathCommandsNV(GPGETPATHCOMMANDSNV fnptr, GLuint  path, GLubyte * commands) {
+//   (*fnptr)(path, commands);
+// }
+// static void  glowGetPathCoordsNV(GPGETPATHCOORDSNV fnptr, GLuint  path, GLfloat * coords) {
+//   (*fnptr)(path, coords);
+// }
+// static void  glowGetPathDashArrayNV(GPGETPATHDASHARRAYNV fnptr, GLuint  path, GLfloat * dashArray) {
+//   (*fnptr)(path, dashArray);
+// }
+// static GLfloat  glowGetPathLengthNV(GPGETPATHLENGTHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments) {
+//   return (*fnptr)(path, startSegment, numSegments);
+// }
+// static void  glowGetPathMetricRangeNV(GPGETPATHMETRICRANGENV fnptr, GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, firstPathName, numPaths, stride, metrics);
+// }
+// static void  glowGetPathMetricsNV(GPGETPATHMETRICSNV fnptr, GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, numPaths, pathNameType, paths, pathBase, stride, metrics);
+// }
+// static void  glowGetPathParameterfvNV(GPGETPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathParameterivNV(GPGETPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathSpacingNV(GPGETPATHSPACINGNV fnptr, GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing) {
+//   (*fnptr)(pathListMode, numPaths, pathNameType, paths, pathBase, advanceScale, kerningScale, transformType, returnedSpacing);
+// }
+// static void  glowGetPerfCounterInfoINTEL(GPGETPERFCOUNTERINFOINTEL fnptr, GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue) {
+//   (*fnptr)(queryId, counterId, counterNameLength, counterName, counterDescLength, counterDesc, counterOffset, counterDataSize, counterTypeEnum, counterDataTypeEnum, rawCounterMaxValue);
+// }
+// static void  glowGetPerfMonitorCounterDataAMD(GPGETPERFMONITORCOUNTERDATAAMD fnptr, GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten) {
+//   (*fnptr)(monitor, pname, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfMonitorCounterInfoAMD(GPGETPERFMONITORCOUNTERINFOAMD fnptr, GLuint  group, GLuint  counter, GLenum  pname, void * data) {
+//   (*fnptr)(group, counter, pname, data);
+// }
+// static void  glowGetPerfMonitorCounterStringAMD(GPGETPERFMONITORCOUNTERSTRINGAMD fnptr, GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString) {
+//   (*fnptr)(group, counter, bufSize, length, counterString);
+// }
+// static void  glowGetPerfMonitorCountersAMD(GPGETPERFMONITORCOUNTERSAMD fnptr, GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters) {
+//   (*fnptr)(group, numCounters, maxActiveCounters, counterSize, counters);
+// }
+// static void  glowGetPerfMonitorGroupStringAMD(GPGETPERFMONITORGROUPSTRINGAMD fnptr, GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString) {
+//   (*fnptr)(group, bufSize, length, groupString);
+// }
+// static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
+//   (*fnptr)(numGroups, groupsSize, groups);
+// }
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
+//   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
+//   (*fnptr)(queryName, queryId);
+// }
+// static void  glowGetPerfQueryInfoINTEL(GPGETPERFQUERYINFOINTEL fnptr, GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask) {
+//   (*fnptr)(queryId, queryNameLength, queryName, dataSize, noCounters, noInstances, capsMask);
+// }
+// static void  glowGetPointerIndexedvEXT(GPGETPOINTERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, void ** data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetPointeri_vEXT(GPGETPOINTERI_VEXT fnptr, GLenum  pname, GLuint  index, void ** params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetPointerv(GPGETPOINTERV fnptr, GLenum  pname, void ** params) {
 //   (*fnptr)(pname, params);
@@ -1589,7 +2649,13 @@ package gl
 // static void  glowGetProgramPipelineInfoLog(GPGETPROGRAMPIPELINEINFOLOG fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
 //   (*fnptr)(pipeline, bufSize, length, infoLog);
 // }
+// static void  glowGetProgramPipelineInfoLogEXT(GPGETPROGRAMPIPELINEINFOLOGEXT fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
+//   (*fnptr)(pipeline, bufSize, length, infoLog);
+// }
 // static void  glowGetProgramPipelineiv(GPGETPROGRAMPIPELINEIV fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
+//   (*fnptr)(pipeline, pname, params);
+// }
+// static void  glowGetProgramPipelineivEXT(GPGETPROGRAMPIPELINEIVEXT fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
 //   (*fnptr)(pipeline, pname, params);
 // }
 // static GLuint  glowGetProgramResourceIndex(GPGETPROGRAMRESOURCEINDEX fnptr, GLuint  program, GLenum  programInterface, const GLchar * name) {
@@ -1604,6 +2670,9 @@ package gl
 // static void  glowGetProgramResourceName(GPGETPROGRAMRESOURCENAME fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name) {
 //   (*fnptr)(program, programInterface, index, bufSize, length, name);
 // }
+// static void  glowGetProgramResourcefvNV(GPGETPROGRAMRESOURCEFVNV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params) {
+//   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
+// }
 // static void  glowGetProgramResourceiv(GPGETPROGRAMRESOURCEIV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params) {
 //   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
 // }
@@ -1612,6 +2681,18 @@ package gl
 // }
 // static void  glowGetProgramiv(GPGETPROGRAMIV fnptr, GLuint  program, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, pname, params);
+// }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
 // }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
@@ -1658,6 +2739,9 @@ package gl
 // static void  glowGetShaderiv(GPGETSHADERIV fnptr, GLuint  shader, GLenum  pname, GLint * params) {
 //   (*fnptr)(shader, pname, params);
 // }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
+// }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
 // }
@@ -1697,28 +2781,55 @@ package gl
 // static GLuint64  glowGetTextureHandleARB(GPGETTEXTUREHANDLEARB fnptr, GLuint  texture) {
 //   return (*fnptr)(texture);
 // }
+// static GLuint64  glowGetTextureHandleNV(GPGETTEXTUREHANDLENV fnptr, GLuint  texture) {
+//   return (*fnptr)(texture);
+// }
 // static void  glowGetTextureImage(GPGETTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, format, type, bufSize, pixels);
+// }
+// static void  glowGetTextureImageEXT(GPGETTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texture, target, level, format, type, pixels);
 // }
 // static void  glowGetTextureLevelParameterfv(GPGETTEXTURELEVELPARAMETERFV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, level, pname, params);
 // }
+// static void  glowGetTextureLevelParameterfvEXT(GPGETTEXTURELEVELPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, level, pname, params);
+// }
 // static void  glowGetTextureLevelParameteriv(GPGETTEXTURELEVELPARAMETERIV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, level, pname, params);
+// }
+// static void  glowGetTextureLevelParameterivEXT(GPGETTEXTURELEVELPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, level, pname, params);
 // }
 // static void  glowGetTextureParameterIiv(GPGETTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterIivEXT(GPGETTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameterIuiv(GPGETTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowGetTextureParameterIuivEXT(GPGETTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowGetTextureParameterfv(GPGETTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterfvEXT(GPGETTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameteriv(GPGETTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterivEXT(GPGETTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static GLuint64  glowGetTextureSamplerHandleARB(GPGETTEXTURESAMPLERHANDLEARB fnptr, GLuint  texture, GLuint  sampler) {
+//   return (*fnptr)(texture, sampler);
+// }
+// static GLuint64  glowGetTextureSamplerHandleNV(GPGETTEXTURESAMPLERHANDLENV fnptr, GLuint  texture, GLuint  sampler) {
 //   return (*fnptr)(texture, sampler);
 // }
 // static void  glowGetTextureSubImage(GPGETTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
@@ -1754,7 +2865,19 @@ package gl
 // static void  glowGetUniformfv(GPGETUNIFORMFV fnptr, GLuint  program, GLint  location, GLfloat * params) {
 //   (*fnptr)(program, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformiv(GPGETUNIFORMIV fnptr, GLuint  program, GLint  location, GLint * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
 // static void  glowGetUniformuiv(GPGETUNIFORMUIV fnptr, GLuint  program, GLint  location, GLuint * params) {
@@ -1765,6 +2888,18 @@ package gl
 // }
 // static void  glowGetVertexArrayIndexediv(GPGETVERTEXARRAYINDEXEDIV fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegeri_vEXT(GPGETVERTEXARRAYINTEGERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegervEXT(GPGETVERTEXARRAYINTEGERVEXT fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, pname, param);
+// }
+// static void  glowGetVertexArrayPointeri_vEXT(GPGETVERTEXARRAYPOINTERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayPointervEXT(GPGETVERTEXARRAYPOINTERVEXT fnptr, GLuint  vaobj, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, pname, param);
 // }
 // static void  glowGetVertexArrayiv(GPGETVERTEXARRAYIV fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, pname, param);
@@ -1778,7 +2913,13 @@ package gl
 // static void  glowGetVertexAttribLdv(GPGETVERTEXATTRIBLDV fnptr, GLuint  index, GLenum  pname, GLdouble * params) {
 //   (*fnptr)(index, pname, params);
 // }
+// static void  glowGetVertexAttribLi64vNV(GPGETVERTEXATTRIBLI64VNV fnptr, GLuint  index, GLenum  pname, GLint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
 // static void  glowGetVertexAttribLui64vARB(GPGETVERTEXATTRIBLUI64VARB fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
+// static void  glowGetVertexAttribLui64vNV(GPGETVERTEXATTRIBLUI64VNV fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
 //   (*fnptr)(index, pname, params);
 // }
 // static void  glowGetVertexAttribPointerv(GPGETVERTEXATTRIBPOINTERV fnptr, GLuint  index, GLenum  pname, void ** pointer) {
@@ -1792,6 +2933,9 @@ package gl
 // }
 // static void  glowGetVertexAttribiv(GPGETVERTEXATTRIBIV fnptr, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(index, pname, params);
+// }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
 // }
 // static void  glowGetnCompressedTexImageARB(GPGETNCOMPRESSEDTEXIMAGEARB fnptr, GLenum  target, GLint  lod, GLsizei  bufSize, void * img) {
 //   (*fnptr)(target, lod, bufSize, img);
@@ -1811,6 +2955,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -1818,6 +2965,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -1831,6 +2981,15 @@ package gl
 // }
 // static void  glowHint(GPHINT fnptr, GLenum  target, GLenum  mode) {
 //   (*fnptr)(target, mode);
+// }
+// static void  glowIndexFormatNV(GPINDEXFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
+// static void  glowInsertEventMarkerEXT(GPINSERTEVENTMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
+// static void  glowInterpolatePathsNV(GPINTERPOLATEPATHSNV fnptr, GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight) {
+//   (*fnptr)(resultPath, pathA, pathB, weight);
 // }
 // static void  glowInvalidateBufferData(GPINVALIDATEBUFFERDATA fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -1859,8 +3018,17 @@ package gl
 // static GLboolean  glowIsBuffer(GPISBUFFER fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
+// static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
+//   return (*fnptr)(target);
+// }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
+// }
+// static GLboolean  glowIsEnabledIndexedEXT(GPISENABLEDINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   return (*fnptr)(target, index);
 // }
 // static GLboolean  glowIsEnabledi(GPISENABLEDI fnptr, GLenum  target, GLuint  index) {
 //   return (*fnptr)(target, index);
@@ -1871,13 +3039,31 @@ package gl
 // static GLboolean  glowIsImageHandleResidentARB(GPISIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsImageHandleResidentNV(GPISIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
+// static GLboolean  glowIsNamedBufferResidentNV(GPISNAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
 // static GLboolean  glowIsNamedStringARB(GPISNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   return (*fnptr)(namelen, name);
+// }
+// static GLboolean  glowIsPathNV(GPISPATHNV fnptr, GLuint  path) {
+//   return (*fnptr)(path);
+// }
+// static GLboolean  glowIsPointInFillPathNV(GPISPOINTINFILLPATHNV fnptr, GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, mask, x, y);
+// }
+// static GLboolean  glowIsPointInStrokePathNV(GPISPOINTINSTROKEPATHNV fnptr, GLuint  path, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, x, y);
 // }
 // static GLboolean  glowIsProgram(GPISPROGRAM fnptr, GLuint  program) {
 //   return (*fnptr)(program);
 // }
 // static GLboolean  glowIsProgramPipeline(GPISPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   return (*fnptr)(pipeline);
+// }
+// static GLboolean  glowIsProgramPipelineEXT(GPISPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   return (*fnptr)(pipeline);
 // }
 // static GLboolean  glowIsQuery(GPISQUERY fnptr, GLuint  id) {
@@ -1892,6 +3078,9 @@ package gl
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
 // }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
+// }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
 // }
@@ -1901,11 +3090,17 @@ package gl
 // static GLboolean  glowIsTextureHandleResidentARB(GPISTEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsTextureHandleResidentNV(GPISTEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
 // static GLboolean  glowIsTransformFeedback(GPISTRANSFORMFEEDBACK fnptr, GLuint  id) {
 //   return (*fnptr)(id);
 // }
 // static GLboolean  glowIsVertexArray(GPISVERTEXARRAY fnptr, GLuint  array) {
 //   return (*fnptr)(array);
+// }
+// static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
+//   (*fnptr)(type, object, length, label);
 // }
 // static void  glowLineWidth(GPLINEWIDTH fnptr, GLfloat  width) {
 //   (*fnptr)(width);
@@ -1913,19 +3108,46 @@ package gl
 // static void  glowLinkProgram(GPLINKPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
+// }
 // static void  glowLogicOp(GPLOGICOP fnptr, GLenum  opcode) {
 //   (*fnptr)(opcode);
 // }
+// static void  glowMakeBufferNonResidentNV(GPMAKEBUFFERNONRESIDENTNV fnptr, GLenum  target) {
+//   (*fnptr)(target);
+// }
+// static void  glowMakeBufferResidentNV(GPMAKEBUFFERRESIDENTNV fnptr, GLenum  target, GLenum  access) {
+//   (*fnptr)(target, access);
+// }
 // static void  glowMakeImageHandleNonResidentARB(GPMAKEIMAGEHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeImageHandleNonResidentNV(GPMAKEIMAGEHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void  glowMakeImageHandleResidentARB(GPMAKEIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle, GLenum  access) {
 //   (*fnptr)(handle, access);
 // }
+// static void  glowMakeImageHandleResidentNV(GPMAKEIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle, GLenum  access) {
+//   (*fnptr)(handle, access);
+// }
+// static void  glowMakeNamedBufferNonResidentNV(GPMAKENAMEDBUFFERNONRESIDENTNV fnptr, GLuint  buffer) {
+//   (*fnptr)(buffer);
+// }
+// static void  glowMakeNamedBufferResidentNV(GPMAKENAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer, GLenum  access) {
+//   (*fnptr)(buffer, access);
+// }
 // static void  glowMakeTextureHandleNonResidentARB(GPMAKETEXTUREHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
+// static void  glowMakeTextureHandleNonResidentNV(GPMAKETEXTUREHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
 // static void  glowMakeTextureHandleResidentARB(GPMAKETEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeTextureHandleResidentNV(GPMAKETEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void * glowMapBuffer(GPMAPBUFFER fnptr, GLenum  target, GLenum  access) {
@@ -1937,8 +3159,95 @@ package gl
 // static void * glowMapNamedBuffer(GPMAPNAMEDBUFFER fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
+//   return (*fnptr)(buffer, access);
+// }
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
+//   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void  glowMatrixFrustumEXT(GPMATRIXFRUSTUMEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixLoad3x2fNV(GPMATRIXLOAD3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoad3x3fNV(GPMATRIXLOAD3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadIdentityEXT(GPMATRIXLOADIDENTITYEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixLoadTranspose3x3fNV(GPMATRIXLOADTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadTransposedEXT(GPMATRIXLOADTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadTransposefEXT(GPMATRIXLOADTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoaddEXT(GPMATRIXLOADDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadfEXT(GPMATRIXLOADFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMult3x2fNV(GPMATRIXMULT3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMult3x3fNV(GPMATRIXMULT3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTranspose3x3fNV(GPMATRIXMULTTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTransposedEXT(GPMATRIXMULTTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultTransposefEXT(GPMATRIXMULTTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultdEXT(GPMATRIXMULTDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultfEXT(GPMATRIXMULTFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixOrthoEXT(GPMATRIXORTHOEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixPopEXT(GPMATRIXPOPEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixPushEXT(GPMATRIXPUSHEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixRotatedEXT(GPMATRIXROTATEDEXT fnptr, GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixRotatefEXT(GPMATRIXROTATEFEXT fnptr, GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixScaledEXT(GPMATRIXSCALEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixScalefEXT(GPMATRIXSCALEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatedEXT(GPMATRIXTRANSLATEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
 // }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
@@ -1958,7 +3267,13 @@ package gl
 // static void  glowMultiDrawArraysIndirect(GPMULTIDRAWARRAYSINDIRECT fnptr, GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectBindlessCountNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElements(GPMULTIDRAWELEMENTS fnptr, GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount) {
@@ -1970,23 +3285,116 @@ package gl
 // static void  glowMultiDrawElementsIndirect(GPMULTIDRAWELEMENTSINDIRECT fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectBindlessCountNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMultiTexBufferEXT(GPMULTITEXBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texunit, target, internalformat, buffer);
+// }
+// static void  glowMultiTexCoordPointerEXT(GPMULTITEXCOORDPOINTEREXT fnptr, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
+//   (*fnptr)(texunit, size, type, stride, pointer);
+// }
+// static void  glowMultiTexEnvfEXT(GPMULTITEXENVFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvfvEXT(GPMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexEnviEXT(GPMULTITEXENVIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvivEXT(GPMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexGendEXT(GPMULTITEXGENDEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGendvEXT(GPMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGenfEXT(GPMULTITEXGENFEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenfvEXT(GPMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGeniEXT(GPMULTITEXGENIEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenivEXT(GPMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexImage1DEXT(GPMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage2DEXT(GPMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage3DEXT(GPMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowMultiTexParameterIivEXT(GPMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterIuivEXT(GPMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterfEXT(GPMULTITEXPARAMETERFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterfvEXT(GPMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameteriEXT(GPMULTITEXPARAMETERIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterivEXT(GPMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexRenderbufferEXT(GPMULTITEXRENDERBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texunit, target, renderbuffer);
+// }
+// static void  glowMultiTexSubImage1DEXT(GPMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage2DEXT(GPMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
+//   (*fnptr)(buffer, size, data, usage);
+// }
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
+//   (*fnptr)(buffer, size, data, flags);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedCopyBufferSubDataEXT(GPNAMEDCOPYBUFFERSUBDATAEXT fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowNamedFramebufferDrawBuffer(GPNAMEDFRAMEBUFFERDRAWBUFFER fnptr, GLuint  framebuffer, GLenum  buf) {
 //   (*fnptr)(framebuffer, buf);
@@ -1997,26 +3405,104 @@ package gl
 // static void  glowNamedFramebufferParameteri(GPNAMEDFRAMEBUFFERPARAMETERI fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowNamedFramebufferParameteriEXT(GPNAMEDFRAMEBUFFERPARAMETERIEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
+//   (*fnptr)(framebuffer, pname, param);
+// }
 // static void  glowNamedFramebufferReadBuffer(GPNAMEDFRAMEBUFFERREADBUFFER fnptr, GLuint  framebuffer, GLenum  src) {
 //   (*fnptr)(framebuffer, src);
 // }
 // static void  glowNamedFramebufferRenderbuffer(GPNAMEDFRAMEBUFFERRENDERBUFFER fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
 // }
+// static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
+//   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTexture1DEXT(GPNAMEDFRAMEBUFFERTEXTURE1DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture2DEXT(GPNAMEDFRAMEBUFFERTEXTURE2DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture3DEXT(GPNAMEDFRAMEBUFFERTEXTURE3DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level, zoffset);
+// }
+// static void  glowNamedFramebufferTextureEXT(GPNAMEDFRAMEBUFFERTEXTUREEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTextureFaceEXT(GPNAMEDFRAMEBUFFERTEXTUREFACEEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(framebuffer, attachment, texture, level, face);
 // }
 // static void  glowNamedFramebufferTextureLayer(GPNAMEDFRAMEBUFFERTEXTURELAYER fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(framebuffer, attachment, texture, level, layer);
 // }
+// static void  glowNamedFramebufferTextureLayerEXT(GPNAMEDFRAMEBUFFERTEXTURELAYEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(framebuffer, attachment, texture, level, layer);
+// }
+// static void  glowNamedProgramLocalParameter4dEXT(GPNAMEDPROGRAMLOCALPARAMETER4DEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4dvEXT(GPNAMEDPROGRAMLOCALPARAMETER4DVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameter4fEXT(GPNAMEDPROGRAMLOCALPARAMETER4FEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4fvEXT(GPNAMEDPROGRAMLOCALPARAMETER4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4iEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4uiEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameters4fvEXT(GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramStringEXT(GPNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string) {
+//   (*fnptr)(program, target, format, len, string);
+// }
 // static void  glowNamedRenderbufferStorage(GPNAMEDRENDERBUFFERSTORAGE fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageEXT(GPNAMEDRENDERBUFFERSTORAGEEXT fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, internalformat, width, height);
 // }
 // static void  glowNamedRenderbufferStorageMultisample(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, samples, internalformat, width, height);
 // }
+// static void  glowNamedRenderbufferStorageMultisampleCoverageEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT fnptr, GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageMultisampleEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, samples, internalformat, width, height);
+// }
 // static void  glowNamedStringARB(GPNAMEDSTRINGARB fnptr, GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string) {
 //   (*fnptr)(type, namelen, name, stringlen, string);
+// }
+// static void  glowNormalFormatNV(GPNORMALFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
 // }
 // static void  glowObjectLabel(GPOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(identifier, name, length, label);
@@ -2036,6 +3522,60 @@ package gl
 // static void  glowPatchParameteri(GPPATCHPARAMETERI fnptr, GLenum  pname, GLint  value) {
 //   (*fnptr)(pname, value);
 // }
+// static void  glowPathCommandsNV(GPPATHCOMMANDSNV fnptr, GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathCoordsNV(GPPATHCOORDSNV fnptr, GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCoords, coordType, coords);
+// }
+// static void  glowPathCoverDepthFuncNV(GPPATHCOVERDEPTHFUNCNV fnptr, GLenum  func) {
+//   (*fnptr)(func);
+// }
+// static void  glowPathDashArrayNV(GPPATHDASHARRAYNV fnptr, GLuint  path, GLsizei  dashCount, const GLfloat * dashArray) {
+//   (*fnptr)(path, dashCount, dashArray);
+// }
+// static GLenum  glowPathGlyphIndexArrayNV(GPPATHGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathGlyphIndexRangeNV(GPPATHGLYPHINDEXRANGENV fnptr, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount) {
+//   return (*fnptr)(fontTarget, fontName, fontStyle, pathParameterTemplate, emScale, baseAndCount);
+// }
+// static void  glowPathGlyphRangeNV(GPPATHGLYPHRANGENV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyph, numGlyphs, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathGlyphsNV(GPPATHGLYPHSNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, numGlyphs, type, charcodes, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathMemoryGlyphIndexArrayNV(GPPATHMEMORYGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontSize, fontData, faceIndex, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathParameterfNV(GPPATHPARAMETERFNV fnptr, GLuint  path, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterfvNV(GPPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, const GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameteriNV(GPPATHPARAMETERINV fnptr, GLuint  path, GLenum  pname, GLint  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterivNV(GPPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, const GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathStencilDepthOffsetNV(GPPATHSTENCILDEPTHOFFSETNV fnptr, GLfloat  factor, GLfloat  units) {
+//   (*fnptr)(factor, units);
+// }
+// static void  glowPathStencilFuncNV(GPPATHSTENCILFUNCNV fnptr, GLenum  func, GLint  ref, GLuint  mask) {
+//   (*fnptr)(func, ref, mask);
+// }
+// static void  glowPathStringNV(GPPATHSTRINGNV fnptr, GLuint  path, GLenum  format, GLsizei  length, const void * pathString) {
+//   (*fnptr)(path, format, length, pathString);
+// }
+// static void  glowPathSubCommandsNV(GPPATHSUBCOMMANDSNV fnptr, GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, commandStart, commandsToDelete, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathSubCoordsNV(GPPATHSUBCOORDSNV fnptr, GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, coordStart, numCoords, coordType, coords);
+// }
 // static void  glowPauseTransformFeedback(GPPAUSETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -2044,6 +3584,9 @@ package gl
 // }
 // static void  glowPixelStorei(GPPIXELSTOREI fnptr, GLenum  pname, GLint  param) {
 //   (*fnptr)(pname, param);
+// }
+// static GLboolean  glowPointAlongPathNV(GPPOINTALONGPATHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY) {
+//   return (*fnptr)(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
 // }
 // static void  glowPointParameterf(GPPOINTPARAMETERF fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
@@ -2066,11 +3609,23 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPopDebugGroup(GPPOPDEBUGGROUP fnptr) {
 //   (*fnptr)();
 // }
 // static void  glowPopDebugGroupKHR(GPPOPDEBUGGROUPKHR fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowPopGroupMarkerEXT(GPPOPGROUPMARKEREXT fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -2081,164 +3636,434 @@ package gl
 // static void  glowProgramParameteri(GPPROGRAMPARAMETERI fnptr, GLuint  program, GLenum  pname, GLint  value) {
 //   (*fnptr)(program, pname, value);
 // }
+// static void  glowProgramParameteriARB(GPPROGRAMPARAMETERIARB fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramParameteriEXT(GPPROGRAMPARAMETERIEXT fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramPathFragmentInputGenNV(GPPROGRAMPATHFRAGMENTINPUTGENNV fnptr, GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs) {
+//   (*fnptr)(program, location, genMode, components, coeffs);
+// }
 // static void  glowProgramUniform1d(GPPROGRAMUNIFORM1D fnptr, GLuint  program, GLint  location, GLdouble  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1dEXT(GPPROGRAMUNIFORM1DEXT fnptr, GLuint  program, GLint  location, GLdouble  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1dv(GPPROGRAMUNIFORM1DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1dvEXT(GPPROGRAMUNIFORM1DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1f(GPPROGRAMUNIFORM1F fnptr, GLuint  program, GLint  location, GLfloat  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1fEXT(GPPROGRAMUNIFORM1FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1fv(GPPROGRAMUNIFORM1FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1fvEXT(GPPROGRAMUNIFORM1FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1iEXT(GPPROGRAMUNIFORM1IEXT fnptr, GLuint  program, GLint  location, GLint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1iv(GPPROGRAMUNIFORM1IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ivEXT(GPPROGRAMUNIFORM1IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uiEXT(GPPROGRAMUNIFORM1UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1uiv(GPPROGRAMUNIFORM1UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uivEXT(GPPROGRAMUNIFORM1UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2d(GPPROGRAMUNIFORM2D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2dEXT(GPPROGRAMUNIFORM2DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2dv(GPPROGRAMUNIFORM2DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2dvEXT(GPPROGRAMUNIFORM2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2f(GPPROGRAMUNIFORM2F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2fEXT(GPPROGRAMUNIFORM2FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2fv(GPPROGRAMUNIFORM2FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2fvEXT(GPPROGRAMUNIFORM2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2iEXT(GPPROGRAMUNIFORM2IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2iv(GPPROGRAMUNIFORM2IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ivEXT(GPPROGRAMUNIFORM2IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uiEXT(GPPROGRAMUNIFORM2UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2uiv(GPPROGRAMUNIFORM2UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uivEXT(GPPROGRAMUNIFORM2UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3d(GPPROGRAMUNIFORM3D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3dEXT(GPPROGRAMUNIFORM3DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3dv(GPPROGRAMUNIFORM3DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3dvEXT(GPPROGRAMUNIFORM3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3f(GPPROGRAMUNIFORM3F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3fEXT(GPPROGRAMUNIFORM3FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3fv(GPPROGRAMUNIFORM3FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3fvEXT(GPPROGRAMUNIFORM3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3iEXT(GPPROGRAMUNIFORM3IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3iv(GPPROGRAMUNIFORM3IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ivEXT(GPPROGRAMUNIFORM3IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uiEXT(GPPROGRAMUNIFORM3UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3uiv(GPPROGRAMUNIFORM3UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uivEXT(GPPROGRAMUNIFORM3UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4d(GPPROGRAMUNIFORM4D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4dEXT(GPPROGRAMUNIFORM4DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4dv(GPPROGRAMUNIFORM4DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4dvEXT(GPPROGRAMUNIFORM4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4f(GPPROGRAMUNIFORM4F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4fEXT(GPPROGRAMUNIFORM4FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4fv(GPPROGRAMUNIFORM4FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4fvEXT(GPPROGRAMUNIFORM4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4iEXT(GPPROGRAMUNIFORM4IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4iv(GPPROGRAMUNIFORM4IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ivEXT(GPPROGRAMUNIFORM4IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uiEXT(GPPROGRAMUNIFORM4UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4uiv(GPPROGRAMUNIFORM4UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uivEXT(GPPROGRAMUNIFORM4UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniformHandleui64ARB(GPPROGRAMUNIFORMHANDLEUI64ARB fnptr, GLuint  program, GLint  location, GLuint64  value) {
 //   (*fnptr)(program, location, value);
 // }
+// static void  glowProgramUniformHandleui64NV(GPPROGRAMUNIFORMHANDLEUI64NV fnptr, GLuint  program, GLint  location, GLuint64  value) {
+//   (*fnptr)(program, location, value);
+// }
 // static void  glowProgramUniformHandleui64vARB(GPPROGRAMUNIFORMHANDLEUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
+//   (*fnptr)(program, location, count, values);
+// }
+// static void  glowProgramUniformHandleui64vNV(GPPROGRAMUNIFORMHANDLEUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
 //   (*fnptr)(program, location, count, values);
 // }
 // static void  glowProgramUniformMatrix2dv(GPPROGRAMUNIFORMMATRIX2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2dvEXT(GPPROGRAMUNIFORMMATRIX2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2fv(GPPROGRAMUNIFORMMATRIX2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2fvEXT(GPPROGRAMUNIFORMMATRIX2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x3dv(GPPROGRAMUNIFORMMATRIX2X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x3dvEXT(GPPROGRAMUNIFORMMATRIX2X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x3fv(GPPROGRAMUNIFORMMATRIX2X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x3fvEXT(GPPROGRAMUNIFORMMATRIX2X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x4dv(GPPROGRAMUNIFORMMATRIX2X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x4dvEXT(GPPROGRAMUNIFORMMATRIX2X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x4fv(GPPROGRAMUNIFORMMATRIX2X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x4fvEXT(GPPROGRAMUNIFORMMATRIX2X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3dv(GPPROGRAMUNIFORMMATRIX3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3dvEXT(GPPROGRAMUNIFORMMATRIX3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3fv(GPPROGRAMUNIFORMMATRIX3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3fvEXT(GPPROGRAMUNIFORMMATRIX3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x2dv(GPPROGRAMUNIFORMMATRIX3X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x2dvEXT(GPPROGRAMUNIFORMMATRIX3X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x2fv(GPPROGRAMUNIFORMMATRIX3X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x2fvEXT(GPPROGRAMUNIFORMMATRIX3X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x4dv(GPPROGRAMUNIFORMMATRIX3X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x4dvEXT(GPPROGRAMUNIFORMMATRIX3X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x4fv(GPPROGRAMUNIFORMMATRIX3X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x4fvEXT(GPPROGRAMUNIFORMMATRIX3X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4dv(GPPROGRAMUNIFORMMATRIX4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4dvEXT(GPPROGRAMUNIFORMMATRIX4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4fv(GPPROGRAMUNIFORMMATRIX4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4fvEXT(GPPROGRAMUNIFORMMATRIX4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x2dv(GPPROGRAMUNIFORMMATRIX4X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x2dvEXT(GPPROGRAMUNIFORMMATRIX4X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x2fv(GPPROGRAMUNIFORMMATRIX4X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4x2fvEXT(GPPROGRAMUNIFORMMATRIX4X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x3dv(GPPROGRAMUNIFORMMATRIX4X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3dvEXT(GPPROGRAMUNIFORMMATRIX4X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x3fv(GPPROGRAMUNIFORMMATRIX4X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3fvEXT(GPPROGRAMUNIFORMMATRIX4X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformui64NV(GPPROGRAMUNIFORMUI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(program, location, value);
+// }
+// static void  glowProgramUniformui64vNV(GPPROGRAMUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
 // static void  glowProvokingVertex(GPPROVOKINGVERTEX fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
+// }
+// static void  glowPushClientAttribDefaultEXT(GPPUSHCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static void  glowPushDebugGroup(GPPUSHDEBUGGROUP fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
@@ -2246,8 +4071,14 @@ package gl
 // static void  glowPushDebugGroupKHR(GPPUSHDEBUGGROUPKHR fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
 // }
+// static void  glowPushGroupMarkerEXT(GPPUSHGROUPMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
 // static void  glowQueryCounter(GPQUERYCOUNTER fnptr, GLuint  id, GLenum  target) {
 //   (*fnptr)(id, target);
+// }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
 // }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
@@ -2272,6 +4103,12 @@ package gl
 // }
 // static void  glowRenderbufferStorageMultisample(GPRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, samples, internalformat, width, height);
+// }
+// static void  glowRenderbufferStorageMultisampleCoverageNV(GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV fnptr, GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(target, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
@@ -2312,6 +4149,12 @@ package gl
 // static void  glowScissorIndexedv(GPSCISSORINDEXEDV fnptr, GLuint  index, const GLint * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowSecondaryColorFormatNV(GPSECONDARYCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
+// static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
+//   (*fnptr)(monitor, enable, group, numCounters, counterList);
+// }
 // static void  glowShaderBinary(GPSHADERBINARY fnptr, GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length) {
 //   (*fnptr)(count, shaders, binaryformat, binary, length);
 // }
@@ -2320,6 +4163,24 @@ package gl
 // }
 // static void  glowShaderStorageBlockBinding(GPSHADERSTORAGEBLOCKBINDING fnptr, GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding) {
 //   (*fnptr)(program, storageBlockIndex, storageBlockBinding);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
+// }
+// static void  glowStencilFillPathInstancedNV(GPSTENCILFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, transformType, transformValues);
+// }
+// static void  glowStencilFillPathNV(GPSTENCILFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask) {
+//   (*fnptr)(path, fillMode, mask);
 // }
 // static void  glowStencilFunc(GPSTENCILFUNC fnptr, GLenum  func, GLint  ref, GLuint  mask) {
 //   (*fnptr)(func, ref, mask);
@@ -2339,11 +4200,38 @@ package gl
 // static void  glowStencilOpSeparate(GPSTENCILOPSEPARATE fnptr, GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass) {
 //   (*fnptr)(face, sfail, dpfail, dppass);
 // }
+// static void  glowStencilStrokePathInstancedNV(GPSTENCILSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, transformType, transformValues);
+// }
+// static void  glowStencilStrokePathNV(GPSTENCILSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask) {
+//   (*fnptr)(path, reference, mask);
+// }
+// static void  glowStencilThenCoverFillPathInstancedNV(GPSTENCILTHENCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverFillPathNV(GPSTENCILTHENCOVERFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, fillMode, mask, coverMode);
+// }
+// static void  glowStencilThenCoverStrokePathInstancedNV(GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverStrokePathNV(GPSTENCILTHENCOVERSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, reference, mask, coverMode);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
+// }
 // static void  glowTexBuffer(GPTEXBUFFER fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(target, internalformat, buffer);
+// }
+// static void  glowTexBufferARB(GPTEXBUFFERARB fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(target, internalformat, buffer);
 // }
 // static void  glowTexBufferRange(GPTEXBUFFERRANGE fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, internalformat, buffer, offset, size);
+// }
+// static void  glowTexCoordFormatNV(GPTEXCOORDFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
 // }
 // static void  glowTexImage1D(GPTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, border, format, type, pixels);
@@ -2360,8 +4248,8 @@ package gl
 // static void  glowTexImage3DMultisample(GPTEXIMAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -2408,53 +4296,119 @@ package gl
 // static void  glowTextureBarrier(GPTEXTUREBARRIER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowTextureBarrierNV(GPTEXTUREBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowTextureBuffer(GPTEXTUREBUFFER fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texture, target, internalformat, buffer);
+// }
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
+//   (*fnptr)(texture, target, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureImage1DEXT(GPTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowTextureImage2DEXT(GPTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowTextureImage3DEXT(GPTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowTextureParameterIivEXT(GPTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowTextureParameterIuiv(GPTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, const GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowTextureParameterIuivEXT(GPTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameterf(GPTEXTUREPARAMETERF fnptr, GLuint  texture, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameterfEXT(GPTEXTUREPARAMETERFEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameterfv(GPTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, const GLfloat * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterfvEXT(GPTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameteri(GPTEXTUREPARAMETERI fnptr, GLuint  texture, GLenum  pname, GLint  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameteriEXT(GPTEXTUREPARAMETERIEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameteriv(GPTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, const GLint * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterivEXT(GPTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
+// static void  glowTextureRenderbufferEXT(GPTEXTURERENDERBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texture, target, renderbuffer);
 // }
 // static void  glowTextureStorage1D(GPTEXTURESTORAGE1D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
 //   (*fnptr)(texture, levels, internalformat, width);
 // }
+// static void  glowTextureStorage1DEXT(GPTEXTURESTORAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
+//   (*fnptr)(texture, target, levels, internalformat, width);
+// }
 // static void  glowTextureStorage2D(GPTEXTURESTORAGE2D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, levels, internalformat, width, height);
+// }
+// static void  glowTextureStorage2DEXT(GPTEXTURESTORAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height);
 // }
 // static void  glowTextureStorage2DMultisample(GPTEXTURESTORAGE2DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, fixedsamplelocations);
 // }
+// static void  glowTextureStorage2DMultisampleEXT(GPTEXTURESTORAGE2DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, fixedsamplelocations);
+// }
 // static void  glowTextureStorage3D(GPTEXTURESTORAGE3D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
 //   (*fnptr)(texture, levels, internalformat, width, height, depth);
+// }
+// static void  glowTextureStorage3DEXT(GPTEXTURESTORAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height, depth);
 // }
 // static void  glowTextureStorage3DMultisample(GPTEXTURESTORAGE3DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
+// }
 // static void  glowTextureSubImage1D(GPTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowTextureSubImage1DEXT(GPTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, type, pixels);
 // }
 // static void  glowTextureSubImage2D(GPTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, type, pixels);
 // }
+// static void  glowTextureSubImage2DEXT(GPTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
 // static void  glowTextureSubImage3D(GPTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowTextureSubImage3DEXT(GPTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
 // static void  glowTextureView(GPTEXTUREVIEW fnptr, GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers) {
 //   (*fnptr)(texture, target, origtexture, internalformat, minlevel, numlevels, minlayer, numlayers);
@@ -2462,11 +4416,14 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackVaryings(GPTRANSFORMFEEDBACKVARYINGS fnptr, GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode) {
 //   (*fnptr)(program, count, varyings, bufferMode);
+// }
+// static void  glowTransformPathNV(GPTRANSFORMPATHNV fnptr, GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(resultPath, srcPath, transformType, transformValues);
 // }
 // static void  glowUniform1d(GPUNIFORM1D fnptr, GLint  location, GLdouble  x) {
 //   (*fnptr)(location, x);
@@ -2483,11 +4440,35 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform1iv(GPUNIFORM1IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
+// }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1uiv(GPUNIFORM1UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2507,11 +4488,35 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform2iv(GPUNIFORM2IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
+// }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2uiv(GPUNIFORM2UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2531,11 +4536,35 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform3iv(GPUNIFORM3IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
+// }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3uiv(GPUNIFORM3UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2555,11 +4584,35 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform4iv(GPUNIFORM4IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
+// }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4uiv(GPUNIFORM4UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2570,7 +4623,13 @@ package gl
 // static void  glowUniformHandleui64ARB(GPUNIFORMHANDLEUI64ARB fnptr, GLint  location, GLuint64  value) {
 //   (*fnptr)(location, value);
 // }
+// static void  glowUniformHandleui64NV(GPUNIFORMHANDLEUI64NV fnptr, GLint  location, GLuint64  value) {
+//   (*fnptr)(location, value);
+// }
 // static void  glowUniformHandleui64vARB(GPUNIFORMHANDLEUI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniformHandleui64vNV(GPUNIFORMHANDLEUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniformMatrix2dv(GPUNIFORMMATRIX2DV fnptr, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
@@ -2630,10 +4689,19 @@ package gl
 // static void  glowUniformSubroutinesuiv(GPUNIFORMSUBROUTINESUIV fnptr, GLenum  shadertype, GLsizei  count, const GLuint * indices) {
 //   (*fnptr)(shadertype, count, indices);
 // }
+// static void  glowUniformui64NV(GPUNIFORMUI64NV fnptr, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(location, value);
+// }
+// static void  glowUniformui64vNV(GPUNIFORMUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static GLboolean  glowUnmapBuffer(GPUNMAPBUFFER fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLboolean  glowUnmapNamedBuffer(GPUNMAPNAMEDBUFFER fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
+// static GLboolean  glowUnmapNamedBufferEXT(GPUNMAPNAMEDBUFFEREXT fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
 // static void  glowUseProgram(GPUSEPROGRAM fnptr, GLuint  program) {
@@ -2642,10 +4710,19 @@ package gl
 // static void  glowUseProgramStages(GPUSEPROGRAMSTAGES fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
 //   (*fnptr)(pipeline, stages, program);
 // }
+// static void  glowUseProgramStagesEXT(GPUSEPROGRAMSTAGESEXT fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
+//   (*fnptr)(pipeline, stages, program);
+// }
+// static void  glowUseShaderProgramEXT(GPUSESHADERPROGRAMEXT fnptr, GLenum  type, GLuint  program) {
+//   (*fnptr)(type, program);
+// }
 // static void  glowValidateProgram(GPVALIDATEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowValidateProgramPipeline(GPVALIDATEPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowValidateProgramPipelineEXT(GPVALIDATEPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowVertexArrayAttribBinding(GPVERTEXARRAYATTRIBBINDING fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
@@ -2660,17 +4737,74 @@ package gl
 // static void  glowVertexArrayAttribLFormat(GPVERTEXARRAYATTRIBLFORMAT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexArrayBindVertexBufferEXT(GPVERTEXARRAYBINDVERTEXBUFFEREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
+//   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
+// }
 // static void  glowVertexArrayBindingDivisor(GPVERTEXARRAYBINDINGDIVISOR fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(vaobj, bindingindex, divisor);
 // }
+// static void  glowVertexArrayColorOffsetEXT(GPVERTEXARRAYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayEdgeFlagOffsetEXT(GPVERTEXARRAYEDGEFLAGOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, stride, offset);
+// }
 // static void  glowVertexArrayElementBuffer(GPVERTEXARRAYELEMENTBUFFER fnptr, GLuint  vaobj, GLuint  buffer) {
 //   (*fnptr)(vaobj, buffer);
+// }
+// static void  glowVertexArrayFogCoordOffsetEXT(GPVERTEXARRAYFOGCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayIndexOffsetEXT(GPVERTEXARRAYINDEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayMultiTexCoordOffsetEXT(GPVERTEXARRAYMULTITEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, texunit, size, type, stride, offset);
+// }
+// static void  glowVertexArrayNormalOffsetEXT(GPVERTEXARRAYNORMALOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArraySecondaryColorOffsetEXT(GPVERTEXARRAYSECONDARYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayTexCoordOffsetEXT(GPVERTEXARRAYTEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribBindingEXT(GPVERTEXARRAYVERTEXATTRIBBINDINGEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
+//   (*fnptr)(vaobj, attribindex, bindingindex);
+// }
+// static void  glowVertexArrayVertexAttribDivisorEXT(GPVERTEXARRAYVERTEXATTRIBDIVISOREXT fnptr, GLuint  vaobj, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(vaobj, index, divisor);
+// }
+// static void  glowVertexArrayVertexAttribFormatEXT(GPVERTEXARRAYVERTEXATTRIBFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIFormatEXT(GPVERTEXARRAYVERTEXATTRIBIFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIOffsetEXT(GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribLFormatEXT(GPVERTEXARRAYVERTEXATTRIBLFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribLOffsetEXT(GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribOffsetEXT(GPVERTEXARRAYVERTEXATTRIBOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, normalized, stride, offset);
+// }
+// static void  glowVertexArrayVertexBindingDivisorEXT(GPVERTEXARRAYVERTEXBINDINGDIVISOREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
+//   (*fnptr)(vaobj, bindingindex, divisor);
 // }
 // static void  glowVertexArrayVertexBuffer(GPVERTEXARRAYVERTEXBUFFER fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
 //   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
 // }
 // static void  glowVertexArrayVertexBuffers(GPVERTEXARRAYVERTEXBUFFERS fnptr, GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(vaobj, first, count, buffers, offsets, strides);
+// }
+// static void  glowVertexArrayVertexOffsetEXT(GPVERTEXARRAYVERTEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
 // }
 // static void  glowVertexAttrib1d(GPVERTEXATTRIB1D fnptr, GLuint  index, GLdouble  x) {
 //   (*fnptr)(index, x);
@@ -2786,8 +4920,14 @@ package gl
 // static void  glowVertexAttribDivisor(GPVERTEXATTRIBDIVISOR fnptr, GLuint  index, GLuint  divisor) {
 //   (*fnptr)(index, divisor);
 // }
+// static void  glowVertexAttribDivisorARB(GPVERTEXATTRIBDIVISORARB fnptr, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(index, divisor);
+// }
 // static void  glowVertexAttribFormat(GPVERTEXATTRIBFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexAttribFormatNV(GPVERTEXATTRIBFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride) {
+//   (*fnptr)(index, size, type, normalized, stride);
 // }
 // static void  glowVertexAttribI1i(GPVERTEXATTRIBI1I fnptr, GLuint  index, GLint  x) {
 //   (*fnptr)(index, x);
@@ -2852,6 +4992,9 @@ package gl
 // static void  glowVertexAttribIFormat(GPVERTEXATTRIBIFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexAttribIFormatNV(GPVERTEXATTRIBIFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
+// }
 // static void  glowVertexAttribIPointer(GPVERTEXATTRIBIPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
 // }
@@ -2861,10 +5004,22 @@ package gl
 // static void  glowVertexAttribL1dv(GPVERTEXATTRIBL1DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL1i64NV(GPVERTEXATTRIBL1I64NV fnptr, GLuint  index, GLint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
+// static void  glowVertexAttribL1i64vNV(GPVERTEXATTRIBL1I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL1ui64ARB(GPVERTEXATTRIBL1UI64ARB fnptr, GLuint  index, GLuint64EXT  x) {
 //   (*fnptr)(index, x);
 // }
+// static void  glowVertexAttribL1ui64NV(GPVERTEXATTRIBL1UI64NV fnptr, GLuint  index, GLuint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
 // static void  glowVertexAttribL1ui64vARB(GPVERTEXATTRIBL1UI64VARB fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL1ui64vNV(GPVERTEXATTRIBL1UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL2d(GPVERTEXATTRIBL2D fnptr, GLuint  index, GLdouble  x, GLdouble  y) {
@@ -2873,10 +5028,34 @@ package gl
 // static void  glowVertexAttribL2dv(GPVERTEXATTRIBL2DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL2i64NV(GPVERTEXATTRIBL2I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2i64vNV(GPVERTEXATTRIBL2I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL2ui64NV(GPVERTEXATTRIBL2UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2ui64vNV(GPVERTEXATTRIBL2UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL3d(GPVERTEXATTRIBL3D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z) {
 //   (*fnptr)(index, x, y, z);
 // }
 // static void  glowVertexAttribL3dv(GPVERTEXATTRIBL3DV fnptr, GLuint  index, const GLdouble * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3i64NV(GPVERTEXATTRIBL3I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3i64vNV(GPVERTEXATTRIBL3I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3ui64NV(GPVERTEXATTRIBL3UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3ui64vNV(GPVERTEXATTRIBL3UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL4d(GPVERTEXATTRIBL4D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
@@ -2885,8 +5064,23 @@ package gl
 // static void  glowVertexAttribL4dv(GPVERTEXATTRIBL4DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL4i64NV(GPVERTEXATTRIBL4I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4i64vNV(GPVERTEXATTRIBL4I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL4ui64NV(GPVERTEXATTRIBL4UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4ui64vNV(GPVERTEXATTRIBL4UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribLFormat(GPVERTEXATTRIBLFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexAttribLFormatNV(GPVERTEXATTRIBLFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
 // }
 // static void  glowVertexAttribLPointer(GPVERTEXATTRIBLPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
@@ -2921,6 +5115,9 @@ package gl
 // static void  glowVertexBindingDivisor(GPVERTEXBINDINGDIVISOR fnptr, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(bindingindex, divisor);
 // }
+// static void  glowVertexFormatNV(GPVERTEXFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
 // static void  glowViewport(GPVIEWPORT fnptr, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(x, y, width, height);
 // }
@@ -2933,8 +5130,23 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
+//   (*fnptr)(resultPath, numPaths, paths, weights);
+// }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
 // }
 import "C"
 import (
@@ -2943,10 +5155,12 @@ import (
 )
 
 const (
+	ACCUM_ADJACENT_PAIRS_NV                                    = 0x90AD
 	ACTIVE_ATOMIC_COUNTER_BUFFERS                              = 0x92D9
 	ACTIVE_ATTRIBUTES                                          = 0x8B89
 	ACTIVE_ATTRIBUTE_MAX_LENGTH                                = 0x8B8A
 	ACTIVE_PROGRAM                                             = 0x8259
+	ACTIVE_PROGRAM_EXT                                         = 0x8B8D
 	ACTIVE_RESOURCES                                           = 0x92F5
 	ACTIVE_SUBROUTINES                                         = 0x8DE5
 	ACTIVE_SUBROUTINE_MAX_LENGTH                               = 0x8E48
@@ -2959,10 +5173,15 @@ const (
 	ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH                       = 0x8A35
 	ACTIVE_UNIFORM_MAX_LENGTH                                  = 0x8B87
 	ACTIVE_VARIABLES                                           = 0x9305
+	ADJACENT_PAIRS_NV                                          = 0x90AE
+	AFFINE_2D_NV                                               = 0x9092
+	AFFINE_3D_NV                                               = 0x9094
 	ALIASED_LINE_WIDTH_RANGE                                   = 0x846E
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
+	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALPHA                                                      = 0x1906
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	AND                                                        = 0x1501
@@ -2970,6 +5189,7 @@ const (
 	AND_REVERSE                                                = 0x1502
 	ANY_SAMPLES_PASSED                                         = 0x8C2F
 	ANY_SAMPLES_PASSED_CONSERVATIVE                            = 0x8D6A
+	ARC_TO_NV                                                  = 0xFE
 	ARRAY_BUFFER                                               = 0x8892
 	ARRAY_BUFFER_BINDING                                       = 0x8894
 	ARRAY_SIZE                                                 = 0x92FB
@@ -2990,43 +5210,56 @@ const (
 	ATOMIC_COUNTER_BUFFER_SIZE                                 = 0x92C3
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	AUTO_GENERATE_MIPMAP                                       = 0x8295
 	BACK                                                       = 0x0405
 	BACK_LEFT                                                  = 0x0402
 	BACK_RIGHT                                                 = 0x0403
+	BEVEL_NV                                                   = 0x90A6
 	BGR                                                        = 0x80E0
 	BGRA                                                       = 0x80E1
 	BGRA_INTEGER                                               = 0x8D9B
 	BGR_INTEGER                                                = 0x8D9A
 	BLEND                                                      = 0x0BE2
+	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
+	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
 	BLEND_DST_RGB                                              = 0x80C8
 	BLEND_EQUATION                                             = 0x8009
 	BLEND_EQUATION_ALPHA                                       = 0x883D
 	BLEND_EQUATION_RGB                                         = 0x8009
+	BLEND_OVERLAP_NV                                           = 0x9281
+	BLEND_PREMULTIPLIED_SRC_NV                                 = 0x9280
 	BLEND_SRC                                                  = 0x0BE1
 	BLEND_SRC_ALPHA                                            = 0x80CB
 	BLEND_SRC_RGB                                              = 0x80C9
 	BLOCK_INDEX                                                = 0x92FD
 	BLUE                                                       = 0x1905
 	BLUE_INTEGER                                               = 0x8D96
+	BLUE_NV                                                    = 0x1905
+	BOLD_BIT_NV                                                = 0x01
 	BOOL                                                       = 0x8B56
 	BOOL_VEC2                                                  = 0x8B57
 	BOOL_VEC3                                                  = 0x8B58
 	BOOL_VEC4                                                  = 0x8B59
+	BOUNDING_BOX_NV                                            = 0x908D
+	BOUNDING_BOX_OF_BOUNDING_BOXES_NV                          = 0x909C
 	BUFFER                                                     = 0x82E0
 	BUFFER_ACCESS                                              = 0x88BB
 	BUFFER_ACCESS_FLAGS                                        = 0x911F
 	BUFFER_BINDING                                             = 0x9302
 	BUFFER_DATA_SIZE                                           = 0x9303
+	BUFFER_GPU_ADDRESS_NV                                      = 0x8F1D
 	BUFFER_IMMUTABLE_STORAGE                                   = 0x821F
 	BUFFER_KHR                                                 = 0x82E0
 	BUFFER_MAPPED                                              = 0x88BC
 	BUFFER_MAP_LENGTH                                          = 0x9120
 	BUFFER_MAP_OFFSET                                          = 0x9121
 	BUFFER_MAP_POINTER                                         = 0x88BD
+	BUFFER_OBJECT_EXT                                          = 0x9151
 	BUFFER_SIZE                                                = 0x8764
 	BUFFER_STORAGE_FLAGS                                       = 0x8220
 	BUFFER_UPDATE_BARRIER_BIT                                  = 0x00000200
@@ -3035,8 +5268,12 @@ const (
 	BYTE                                                       = 0x1400
 	CAVEAT_SUPPORT                                             = 0x82B8
 	CCW                                                        = 0x0901
+	CIRCULAR_CCW_ARC_TO_NV                                     = 0xF8
+	CIRCULAR_CW_ARC_TO_NV                                      = 0xFA
+	CIRCULAR_TANGENT_ARC_TO_NV                                 = 0xFC
 	CLAMP_READ_COLOR                                           = 0x891C
 	CLAMP_TO_BORDER                                            = 0x812D
+	CLAMP_TO_BORDER_ARB                                        = 0x812D
 	CLAMP_TO_EDGE                                              = 0x812F
 	CLEAR                                                      = 0x1500
 	CLEAR_BUFFER                                               = 0x82B4
@@ -3055,7 +5292,14 @@ const (
 	CLIP_DISTANCE6                                             = 0x3006
 	CLIP_DISTANCE7                                             = 0x3007
 	CLIP_ORIGIN                                                = 0x935C
+	CLOSE_PATH_NV                                              = 0x00
 	COLOR                                                      = 0x1800
+	COLORBURN_KHR                                              = 0x929A
+	COLORBURN_NV                                               = 0x929A
+	COLORDODGE_KHR                                             = 0x9299
+	COLORDODGE_NV                                              = 0x9299
+	COLOR_ARRAY_ADDRESS_NV                                     = 0x8F23
+	COLOR_ARRAY_LENGTH_NV                                      = 0x8F2D
 	COLOR_ATTACHMENT0                                          = 0x8CE0
 	COLOR_ATTACHMENT1                                          = 0x8CE1
 	COLOR_ATTACHMENT10                                         = 0x8CEA
@@ -3064,8 +5308,24 @@ const (
 	COLOR_ATTACHMENT13                                         = 0x8CED
 	COLOR_ATTACHMENT14                                         = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT5                                          = 0x8CE5
 	COLOR_ATTACHMENT6                                          = 0x8CE6
@@ -3078,11 +5338,14 @@ const (
 	COLOR_ENCODING                                             = 0x8296
 	COLOR_LOGIC_OP                                             = 0x0BF2
 	COLOR_RENDERABLE                                           = 0x8286
+	COLOR_SAMPLES_NV                                           = 0x8E20
 	COLOR_WRITEMASK                                            = 0x0C23
 	COMMAND_BARRIER_BIT                                        = 0x00000040
 	COMPARE_REF_TO_TEXTURE                                     = 0x884E
 	COMPATIBLE_SUBROUTINES                                     = 0x8E4B
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_R11_EAC                                         = 0x9270
 	COMPRESSED_RED                                             = 0x8225
 	COMPRESSED_RED_RGTC1                                       = 0x8DBB
@@ -3109,10 +5372,14 @@ const (
 	COMPRESSED_RGBA_ASTC_8x8_KHR                               = 0x93B7
 	COMPRESSED_RGBA_BPTC_UNORM                                 = 0x8E8C
 	COMPRESSED_RGBA_BPTC_UNORM_ARB                             = 0x8E8C
+	COMPRESSED_RGBA_S3TC_DXT1_EXT                              = 0x83F1
+	COMPRESSED_RGBA_S3TC_DXT3_EXT                              = 0x83F2
+	COMPRESSED_RGBA_S3TC_DXT5_EXT                              = 0x83F3
 	COMPRESSED_RGB_BPTC_SIGNED_FLOAT                           = 0x8E8E
 	COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB                       = 0x8E8E
 	COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT                         = 0x8E8F
 	COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB                     = 0x8E8F
+	COMPRESSED_RGB_S3TC_DXT1_EXT                               = 0x83F0
 	COMPRESSED_RG_RGTC2                                        = 0x8DBD
 	COMPRESSED_SIGNED_R11_EAC                                  = 0x9271
 	COMPRESSED_SIGNED_RED_RGTC1                                = 0x8DBC
@@ -3148,6 +5415,18 @@ const (
 	COMPUTE_TEXTURE                                            = 0x82A0
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
+	CONIC_CURVE_TO_NV                                          = 0x1A
+	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSTANT_ALPHA                                             = 0x8003
 	CONSTANT_COLOR                                             = 0x8001
 	CONTEXT_COMPATIBILITY_PROFILE_BIT                          = 0x00000002
@@ -3156,6 +5435,7 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
 	CONTEXT_LOST_KHR                                           = 0x0507
@@ -3166,18 +5446,30 @@ const (
 	CONTEXT_RELEASE_BEHAVIOR_KHR                               = 0x82FB
 	CONTEXT_ROBUST_ACCESS                                      = 0x90F3
 	CONTEXT_ROBUST_ACCESS_KHR                                  = 0x90F3
+	CONTRAST_NV                                                = 0x92A1
+	CONVEX_HULL_NV                                             = 0x908B
 	COPY                                                       = 0x1503
 	COPY_INVERTED                                              = 0x150C
 	COPY_READ_BUFFER                                           = 0x8F36
 	COPY_READ_BUFFER_BINDING                                   = 0x8F36
 	COPY_WRITE_BUFFER                                          = 0x8F37
 	COPY_WRITE_BUFFER_BINDING                                  = 0x8F37
+	COUNTER_RANGE_AMD                                          = 0x8BC1
+	COUNTER_TYPE_AMD                                           = 0x8BC0
+	COUNT_DOWN_NV                                              = 0x9089
+	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
+	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CULL_FACE                                                  = 0x0B44
 	CULL_FACE_MODE                                             = 0x0B45
 	CURRENT_PROGRAM                                            = 0x8B8D
 	CURRENT_QUERY                                              = 0x8865
 	CURRENT_VERTEX_ATTRIB                                      = 0x8626
 	CW                                                         = 0x0900
+	DARKEN_KHR                                                 = 0x9297
+	DARKEN_NV                                                  = 0x9297
 	DEBUG_CALLBACK_FUNCTION                                    = 0x8244
 	DEBUG_CALLBACK_FUNCTION_ARB                                = 0x8244
 	DEBUG_CALLBACK_FUNCTION_KHR                                = 0x8244
@@ -3250,6 +5542,7 @@ const (
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR                              = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_ARB                          = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_KHR                          = 0x824E
+	DECODE_EXT                                                 = 0x8A49
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DELETE_STATUS                                              = 0x8B80
@@ -3269,11 +5562,15 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
 	DEPTH_STENCIL_TEXTURE_MODE                                 = 0x90EA
 	DEPTH_TEST                                                 = 0x0B71
 	DEPTH_WRITEMASK                                            = 0x0B72
+	DIFFERENCE_KHR                                             = 0x929E
+	DIFFERENCE_NV                                              = 0x929E
+	DISJOINT_NV                                                = 0x9283
 	DISPATCH_INDIRECT_BUFFER                                   = 0x90EE
 	DISPATCH_INDIRECT_BUFFER_BINDING                           = 0x90EF
 	DITHER                                                     = 0x0BD0
@@ -3292,6 +5589,9 @@ const (
 	DOUBLE_VEC2                                                = 0x8FFC
 	DOUBLE_VEC3                                                = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER1                                               = 0x8826
@@ -3309,30 +5609,62 @@ const (
 	DRAW_BUFFER7                                               = 0x882C
 	DRAW_BUFFER8                                               = 0x882D
 	DRAW_BUFFER9                                               = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
+	DRAW_INDIRECT_ADDRESS_NV                                   = 0x8F41
 	DRAW_INDIRECT_BUFFER                                       = 0x8F3F
 	DRAW_INDIRECT_BUFFER_BINDING                               = 0x8F43
+	DRAW_INDIRECT_LENGTH_NV                                    = 0x8F42
+	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DST_ALPHA                                                  = 0x0304
+	DST_ATOP_NV                                                = 0x928F
 	DST_COLOR                                                  = 0x0306
+	DST_IN_NV                                                  = 0x928B
+	DST_NV                                                     = 0x9287
+	DST_OUT_NV                                                 = 0x928D
+	DST_OVER_NV                                                = 0x9289
+	DUP_FIRST_CUBIC_CURVE_TO_NV                                = 0xF2
+	DUP_LAST_CUBIC_CURVE_TO_NV                                 = 0xF4
 	DYNAMIC_COPY                                               = 0x88EA
 	DYNAMIC_DRAW                                               = 0x88E8
 	DYNAMIC_READ                                               = 0x88E9
 	DYNAMIC_STORAGE_BIT                                        = 0x0100
+	EDGE_FLAG_ARRAY_ADDRESS_NV                                 = 0x8F26
+	EDGE_FLAG_ARRAY_LENGTH_NV                                  = 0x8F30
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
+	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_BARRIER_BIT                                  = 0x00000002
 	ELEMENT_ARRAY_BUFFER                                       = 0x8893
 	ELEMENT_ARRAY_BUFFER_BINDING                               = 0x8895
+	ELEMENT_ARRAY_LENGTH_NV                                    = 0x8F33
+	ELEMENT_ARRAY_UNIFIED_NV                                   = 0x8F1F
 	EQUAL                                                      = 0x0202
 	EQUIV                                                      = 0x1509
+	EXCLUSION_KHR                                              = 0x92A0
+	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXTENSIONS                                                 = 0x1F03
+	FACTOR_MAX_AMD                                             = 0x901D
+	FACTOR_MIN_AMD                                             = 0x901C
 	FALSE                                                      = 0
 	FASTEST                                                    = 0x1101
+	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
+	FIRST_TO_REST_NV                                           = 0x90AF
 	FIRST_VERTEX_CONVENTION                                    = 0x8E4D
 	FIXED                                                      = 0x140C
 	FIXED_ONLY                                                 = 0x891D
 	FLOAT                                                      = 0x1406
+	FLOAT16_NV                                                 = 0x8FF8
+	FLOAT16_VEC2_NV                                            = 0x8FF9
+	FLOAT16_VEC3_NV                                            = 0x8FFA
+	FLOAT16_VEC4_NV                                            = 0x8FFB
 	FLOAT_32_UNSIGNED_INT_24_8_REV                             = 0x8DAD
 	FLOAT_MAT2                                                 = 0x8B5A
 	FLOAT_MAT2x3                                               = 0x8B65
@@ -3346,12 +5678,37 @@ const (
 	FLOAT_VEC2                                                 = 0x8B50
 	FLOAT_VEC3                                                 = 0x8B51
 	FLOAT_VEC4                                                 = 0x8B52
+	FOG_COORD_ARRAY_ADDRESS_NV                                 = 0x8F28
+	FOG_COORD_ARRAY_LENGTH_NV                                  = 0x8F32
+	FONT_ASCENDER_BIT_NV                                       = 0x00200000
+	FONT_DESCENDER_BIT_NV                                      = 0x00400000
+	FONT_GLYPHS_AVAILABLE_NV                                   = 0x9368
+	FONT_HAS_KERNING_BIT_NV                                    = 0x10000000
+	FONT_HEIGHT_BIT_NV                                         = 0x00800000
+	FONT_MAX_ADVANCE_HEIGHT_BIT_NV                             = 0x02000000
+	FONT_MAX_ADVANCE_WIDTH_BIT_NV                              = 0x01000000
+	FONT_NUM_GLYPH_INDICES_BIT_NV                              = 0x20000000
+	FONT_TARGET_UNAVAILABLE_NV                                 = 0x9369
+	FONT_UNAVAILABLE_NV                                        = 0x936A
+	FONT_UNDERLINE_POSITION_BIT_NV                             = 0x04000000
+	FONT_UNDERLINE_THICKNESS_BIT_NV                            = 0x08000000
+	FONT_UNINTELLIGIBLE_NV                                     = 0x936B
+	FONT_UNITS_PER_EM_BIT_NV                                   = 0x00100000
+	FONT_X_MAX_BOUNDS_BIT_NV                                   = 0x00040000
+	FONT_X_MIN_BOUNDS_BIT_NV                                   = 0x00010000
+	FONT_Y_MAX_BOUNDS_BIT_NV                                   = 0x00080000
+	FONT_Y_MIN_BOUNDS_BIT_NV                                   = 0x00020000
 	FRACTIONAL_EVEN                                            = 0x8E7C
 	FRACTIONAL_ODD                                             = 0x8E7B
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
+	FRAGMENT_INPUT_NV                                          = 0x936D
 	FRAGMENT_INTERPOLATION_OFFSET_BITS                         = 0x8E5D
 	FRAGMENT_SHADER                                            = 0x8B30
 	FRAGMENT_SHADER_BIT                                        = 0x00000002
+	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -3364,13 +5721,16 @@ const (
 	FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE                          = 0x8216
 	FRAMEBUFFER_ATTACHMENT_GREEN_SIZE                          = 0x8213
 	FRAMEBUFFER_ATTACHMENT_LAYERED                             = 0x8DA7
+	FRAMEBUFFER_ATTACHMENT_LAYERED_ARB                         = 0x8DA7
 	FRAMEBUFFER_ATTACHMENT_OBJECT_NAME                         = 0x8CD1
 	FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE                         = 0x8CD0
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
 	FRAMEBUFFER_BLEND                                          = 0x828B
@@ -3383,18 +5743,26 @@ const (
 	FRAMEBUFFER_DEFAULT_WIDTH                                  = 0x9310
 	FRAMEBUFFER_INCOMPLETE_ATTACHMENT                          = 0x8CD6
 	FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER                         = 0x8CDB
+	FRAMEBUFFER_INCOMPLETE_LAYER_COUNT_ARB                     = 0x8DA9
 	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS                       = 0x8DA8
+	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS_ARB                   = 0x8DA8
 	FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT                  = 0x8CD7
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE                         = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_UNDEFINED                                      = 0x8219
 	FRAMEBUFFER_UNSUPPORTED                                    = 0x8CDD
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_SUPPORT                                               = 0x82B7
@@ -3402,8 +5770,11 @@ const (
 	FUNC_REVERSE_SUBTRACT                                      = 0x800B
 	FUNC_SUBTRACT                                              = 0x800A
 	GEOMETRY_INPUT_TYPE                                        = 0x8917
+	GEOMETRY_INPUT_TYPE_ARB                                    = 0x8DDB
 	GEOMETRY_OUTPUT_TYPE                                       = 0x8918
+	GEOMETRY_OUTPUT_TYPE_ARB                                   = 0x8DDC
 	GEOMETRY_SHADER                                            = 0x8DD9
+	GEOMETRY_SHADER_ARB                                        = 0x8DD9
 	GEOMETRY_SHADER_BIT                                        = 0x00000004
 	GEOMETRY_SHADER_INVOCATIONS                                = 0x887F
 	GEOMETRY_SHADER_PRIMITIVES_EMITTED_ARB                     = 0x82F3
@@ -3411,18 +5782,42 @@ const (
 	GEOMETRY_SUBROUTINE_UNIFORM                                = 0x92F1
 	GEOMETRY_TEXTURE                                           = 0x829E
 	GEOMETRY_VERTICES_OUT                                      = 0x8916
+	GEOMETRY_VERTICES_OUT_ARB                                  = 0x8DDA
 	GEQUAL                                                     = 0x0206
 	GET_TEXTURE_IMAGE_FORMAT                                   = 0x8291
 	GET_TEXTURE_IMAGE_TYPE                                     = 0x8292
+	GLYPH_HAS_KERNING_BIT_NV                                   = 0x100
+	GLYPH_HEIGHT_BIT_NV                                        = 0x02
+	GLYPH_HORIZONTAL_BEARING_ADVANCE_BIT_NV                    = 0x10
+	GLYPH_HORIZONTAL_BEARING_X_BIT_NV                          = 0x04
+	GLYPH_HORIZONTAL_BEARING_Y_BIT_NV                          = 0x08
+	GLYPH_VERTICAL_BEARING_ADVANCE_BIT_NV                      = 0x80
+	GLYPH_VERTICAL_BEARING_X_BIT_NV                            = 0x20
+	GLYPH_VERTICAL_BEARING_Y_BIT_NV                            = 0x40
+	GLYPH_WIDTH_BIT_NV                                         = 0x01
+	GPU_ADDRESS_NV                                             = 0x8F34
 	GREATER                                                    = 0x0204
 	GREEN                                                      = 0x1904
 	GREEN_INTEGER                                              = 0x8D95
+	GREEN_NV                                                   = 0x1904
 	GUILTY_CONTEXT_RESET                                       = 0x8253
 	GUILTY_CONTEXT_RESET_ARB                                   = 0x8253
 	GUILTY_CONTEXT_RESET_KHR                                   = 0x8253
 	HALF_FLOAT                                                 = 0x140B
+	HARDLIGHT_KHR                                              = 0x929B
+	HARDLIGHT_NV                                               = 0x929B
+	HARDMIX_NV                                                 = 0x92A9
 	HIGH_FLOAT                                                 = 0x8DF2
 	HIGH_INT                                                   = 0x8DF5
+	HORIZONTAL_LINE_TO_NV                                      = 0x06
+	HSL_COLOR_KHR                                              = 0x92AF
+	HSL_COLOR_NV                                               = 0x92AF
+	HSL_HUE_KHR                                                = 0x92AD
+	HSL_HUE_NV                                                 = 0x92AD
+	HSL_LUMINOSITY_KHR                                         = 0x92B0
+	HSL_LUMINOSITY_NV                                          = 0x92B0
+	HSL_SATURATION_KHR                                         = 0x92AE
+	HSL_SATURATION_NV                                          = 0x92AE
 	IMAGE_1D                                                   = 0x904C
 	IMAGE_1D_ARRAY                                             = 0x9052
 	IMAGE_2D                                                   = 0x904D
@@ -3460,13 +5855,32 @@ const (
 	IMAGE_TEXEL_SIZE                                           = 0x82A7
 	IMPLEMENTATION_COLOR_READ_FORMAT                           = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
+	INDEX_ARRAY_ADDRESS_NV                                     = 0x8F24
+	INDEX_ARRAY_LENGTH_NV                                      = 0x8F2E
 	INFO_LOG_LENGTH                                            = 0x8B84
 	INNOCENT_CONTEXT_RESET                                     = 0x8254
 	INNOCENT_CONTEXT_RESET_ARB                                 = 0x8254
 	INNOCENT_CONTEXT_RESET_KHR                                 = 0x8254
 	INT                                                        = 0x1404
+	INT16_NV                                                   = 0x8FE4
+	INT16_VEC2_NV                                              = 0x8FE5
+	INT16_VEC3_NV                                              = 0x8FE6
+	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
+	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
+	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
+	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
+	INT64_VEC4_NV                                              = 0x8FEB
+	INT8_NV                                                    = 0x8FE0
+	INT8_VEC2_NV                                               = 0x8FE1
+	INT8_VEC3_NV                                               = 0x8FE2
+	INT8_VEC4_NV                                               = 0x8FE3
 	INTERLEAVED_ATTRIBS                                        = 0x8C8C
 	INTERNALFORMAT_ALPHA_SIZE                                  = 0x8274
 	INTERNALFORMAT_ALPHA_TYPE                                  = 0x827B
@@ -3516,27 +5930,41 @@ const (
 	INVALID_OPERATION                                          = 0x0502
 	INVALID_VALUE                                              = 0x0501
 	INVERT                                                     = 0x150A
+	INVERT_OVG_NV                                              = 0x92B4
+	INVERT_RGB_NV                                              = 0x92A3
 	ISOLINES                                                   = 0x8E7A
 	IS_PER_PATCH                                               = 0x92E7
 	IS_ROW_MAJOR                                               = 0x9300
+	ITALIC_BIT_NV                                              = 0x02
 	KEEP                                                       = 0x1E00
+	LARGE_CCW_ARC_TO_NV                                        = 0x16
+	LARGE_CW_ARC_TO_NV                                         = 0x18
 	LAST_VERTEX_CONVENTION                                     = 0x8E4E
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LESS                                                       = 0x0201
+	LIGHTEN_KHR                                                = 0x9298
+	LIGHTEN_NV                                                 = 0x9298
 	LINE                                                       = 0x1B01
 	LINEAR                                                     = 0x2601
+	LINEARBURN_NV                                              = 0x92A5
+	LINEARDODGE_NV                                             = 0x92A4
+	LINEARLIGHT_NV                                             = 0x92A7
 	LINEAR_MIPMAP_LINEAR                                       = 0x2703
 	LINEAR_MIPMAP_NEAREST                                      = 0x2701
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
+	LINES_ADJACENCY_ARB                                        = 0x000A
 	LINE_LOOP                                                  = 0x0002
 	LINE_SMOOTH                                                = 0x0B20
 	LINE_SMOOTH_HINT                                           = 0x0C52
 	LINE_STRIP                                                 = 0x0003
 	LINE_STRIP_ADJACENCY                                       = 0x000B
+	LINE_STRIP_ADJACENCY_ARB                                   = 0x000B
+	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -3636,12 +6064,17 @@ const (
 	MAX_GEOMETRY_INPUT_COMPONENTS                              = 0x9123
 	MAX_GEOMETRY_OUTPUT_COMPONENTS                             = 0x9124
 	MAX_GEOMETRY_OUTPUT_VERTICES                               = 0x8DE0
+	MAX_GEOMETRY_OUTPUT_VERTICES_ARB                           = 0x8DE0
 	MAX_GEOMETRY_SHADER_INVOCATIONS                            = 0x8E5A
 	MAX_GEOMETRY_SHADER_STORAGE_BLOCKS                         = 0x90D7
 	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS                           = 0x8C29
+	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS_ARB                       = 0x8C29
 	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS                       = 0x8DE1
+	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS_ARB                   = 0x8DE1
 	MAX_GEOMETRY_UNIFORM_BLOCKS                                = 0x8A2C
 	MAX_GEOMETRY_UNIFORM_COMPONENTS                            = 0x8DDF
+	MAX_GEOMETRY_UNIFORM_COMPONENTS_ARB                        = 0x8DDF
+	MAX_GEOMETRY_VARYING_COMPONENTS_ARB                        = 0x8DDD
 	MAX_HEIGHT                                                 = 0x827F
 	MAX_IMAGE_SAMPLES                                          = 0x906D
 	MAX_IMAGE_UNITS                                            = 0x8F38
@@ -3649,6 +6082,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_MULTISAMPLE_COVERAGE_MODES_NV                          = 0x8E11
 	MAX_NAME_LENGTH                                            = 0x92F6
 	MAX_NUM_ACTIVE_VARIABLES                                   = 0x92F7
 	MAX_NUM_COMPATIBLE_SUBROUTINES                             = 0x92F8
@@ -3657,16 +6091,21 @@ const (
 	MAX_PROGRAM_TEXTURE_GATHER_COMPONENTS_ARB                  = 0x8F9F
 	MAX_PROGRAM_TEXTURE_GATHER_OFFSET                          = 0x8E5F
 	MAX_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5F
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RENDERBUFFER_SIZE                                      = 0x84E8
 	MAX_SAMPLES                                                = 0x8D57
 	MAX_SAMPLE_MASK_WORDS                                      = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
+	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SPARSE_3D_TEXTURE_SIZE_ARB                             = 0x9199
 	MAX_SPARSE_ARRAY_TEXTURE_LAYERS_ARB                        = 0x919A
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -3691,8 +6130,10 @@ const (
 	MAX_TESS_GEN_LEVEL                                         = 0x8E7E
 	MAX_TESS_PATCH_COMPONENTS                                  = 0x8E84
 	MAX_TEXTURE_BUFFER_SIZE                                    = 0x8C2B
+	MAX_TEXTURE_BUFFER_SIZE_ARB                                = 0x8C2B
 	MAX_TEXTURE_IMAGE_UNITS                                    = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TRANSFORM_FEEDBACK_BUFFERS                             = 0x8E70
 	MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS              = 0x8C8A
@@ -3718,13 +6159,18 @@ const (
 	MAX_VERTEX_UNIFORM_BLOCKS                                  = 0x8A2B
 	MAX_VERTEX_UNIFORM_COMPONENTS                              = 0x8B4A
 	MAX_VERTEX_UNIFORM_VECTORS                                 = 0x8DFB
+	MAX_VERTEX_VARYING_COMPONENTS_ARB                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
 	MINOR_VERSION                                              = 0x821C
+	MINUS_CLAMPED_NV                                           = 0x92B3
+	MINUS_NV                                                   = 0x929F
 	MIN_FRAGMENT_INTERPOLATION_OFFSET                          = 0x8E5B
 	MIN_MAP_BUFFER_ALIGNMENT                                   = 0x90BC
 	MIN_PROGRAM_TEXEL_OFFSET                                   = 0x8904
@@ -3732,11 +6178,25 @@ const (
 	MIN_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5E
 	MIN_SAMPLE_SHADING_VALUE                                   = 0x8C37
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
+	MIRRORED_REPEAT_ARB                                        = 0x8370
 	MIRROR_CLAMP_TO_EDGE                                       = 0x8743
+	MITER_REVERT_NV                                            = 0x90A7
+	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
+	MOVE_TO_CONTINUES_NV                                       = 0x90B6
+	MOVE_TO_NV                                                 = 0x02
+	MOVE_TO_RESETS_NV                                          = 0x90B5
+	MULTIPLY_KHR                                               = 0x9294
+	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
+	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	NAMED_STRING_LENGTH_ARB                                    = 0x8DE9
 	NAMED_STRING_TYPE_ARB                                      = 0x8DEA
 	NAME_LENGTH                                                = 0x92F9
@@ -3749,7 +6209,10 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
+	NORMAL_ARRAY_ADDRESS_NV                                    = 0x8F22
+	NORMAL_ARRAY_LENGTH_NV                                     = 0x8F2C
 	NOTEQUAL                                                   = 0x0205
 	NO_ERROR                                                   = 0
 	NO_RESET_NOTIFICATION                                      = 0x8261
@@ -3763,7 +6226,10 @@ const (
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
 	NUM_SHADING_LANGUAGE_VERSIONS                              = 0x82E9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_TYPE                                                = 0x9112
 	OFFSET                                                     = 0x92FC
 	ONE                                                        = 1
@@ -3779,6 +6245,8 @@ const (
 	OR_INVERTED                                                = 0x150D
 	OR_REVERSE                                                 = 0x150B
 	OUT_OF_MEMORY                                              = 0x0505
+	OVERLAY_KHR                                                = 0x9296
+	OVERLAY_NV                                                 = 0x9296
 	PACK_ALIGNMENT                                             = 0x0D05
 	PACK_COMPRESSED_BLOCK_DEPTH                                = 0x912D
 	PACK_COMPRESSED_BLOCK_HEIGHT                               = 0x912C
@@ -3797,11 +6265,90 @@ const (
 	PATCH_DEFAULT_INNER_LEVEL                                  = 0x8E73
 	PATCH_DEFAULT_OUTER_LEVEL                                  = 0x8E74
 	PATCH_VERTICES                                             = 0x8E72
+	PATH_CLIENT_LENGTH_NV                                      = 0x907F
+	PATH_COMMAND_COUNT_NV                                      = 0x909D
+	PATH_COMPUTED_LENGTH_NV                                    = 0x90A0
+	PATH_COORD_COUNT_NV                                        = 0x909E
+	PATH_COVER_DEPTH_FUNC_NV                                   = 0x90BF
+	PATH_DASH_ARRAY_COUNT_NV                                   = 0x909F
+	PATH_DASH_CAPS_NV                                          = 0x907B
+	PATH_DASH_OFFSET_NV                                        = 0x907E
+	PATH_DASH_OFFSET_RESET_NV                                  = 0x90B4
+	PATH_END_CAPS_NV                                           = 0x9076
+	PATH_ERROR_POSITION_NV                                     = 0x90AB
+	PATH_FILL_BOUNDING_BOX_NV                                  = 0x90A1
+	PATH_FILL_COVER_MODE_NV                                    = 0x9082
+	PATH_FILL_MASK_NV                                          = 0x9081
+	PATH_FILL_MODE_NV                                          = 0x9080
+	PATH_FORMAT_PS_NV                                          = 0x9071
+	PATH_FORMAT_SVG_NV                                         = 0x9070
+	PATH_GEN_COEFF_NV                                          = 0x90B1
+	PATH_GEN_COMPONENTS_NV                                     = 0x90B3
+	PATH_GEN_MODE_NV                                           = 0x90B0
+	PATH_INITIAL_DASH_CAP_NV                                   = 0x907C
+	PATH_INITIAL_END_CAP_NV                                    = 0x9077
+	PATH_JOIN_STYLE_NV                                         = 0x9079
+	PATH_MAX_MODELVIEW_STACK_DEPTH_NV                          = 0x0D36
+	PATH_MAX_PROJECTION_STACK_DEPTH_NV                         = 0x0D38
+	PATH_MITER_LIMIT_NV                                        = 0x907A
+	PATH_MODELVIEW_MATRIX_NV                                   = 0x0BA6
+	PATH_MODELVIEW_NV                                          = 0x1700
+	PATH_MODELVIEW_STACK_DEPTH_NV                              = 0x0BA3
+	PATH_OBJECT_BOUNDING_BOX_NV                                = 0x908A
+	PATH_PROJECTION_MATRIX_NV                                  = 0x0BA7
+	PATH_PROJECTION_NV                                         = 0x1701
+	PATH_PROJECTION_STACK_DEPTH_NV                             = 0x0BA4
+	PATH_STENCIL_DEPTH_OFFSET_FACTOR_NV                        = 0x90BD
+	PATH_STENCIL_DEPTH_OFFSET_UNITS_NV                         = 0x90BE
+	PATH_STENCIL_FUNC_NV                                       = 0x90B7
+	PATH_STENCIL_REF_NV                                        = 0x90B8
+	PATH_STENCIL_VALUE_MASK_NV                                 = 0x90B9
+	PATH_STROKE_BOUNDING_BOX_NV                                = 0x90A2
+	PATH_STROKE_COVER_MODE_NV                                  = 0x9083
+	PATH_STROKE_MASK_NV                                        = 0x9084
+	PATH_STROKE_WIDTH_NV                                       = 0x9075
+	PATH_TERMINAL_DASH_CAP_NV                                  = 0x907D
+	PATH_TERMINAL_END_CAP_NV                                   = 0x9078
+	PATH_TRANSPOSE_MODELVIEW_MATRIX_NV                         = 0x84E3
+	PATH_TRANSPOSE_PROJECTION_MATRIX_NV                        = 0x84E4
+	PERCENTAGE_AMD                                             = 0x8BC3
+	PERFMON_RESULT_AMD                                         = 0x8BC6
+	PERFMON_RESULT_AVAILABLE_AMD                               = 0x8BC4
+	PERFMON_RESULT_SIZE_AMD                                    = 0x8BC5
+	PERFQUERY_COUNTER_DATA_BOOL32_INTEL                        = 0x94FC
+	PERFQUERY_COUNTER_DATA_DOUBLE_INTEL                        = 0x94FB
+	PERFQUERY_COUNTER_DATA_FLOAT_INTEL                         = 0x94FA
+	PERFQUERY_COUNTER_DATA_UINT32_INTEL                        = 0x94F8
+	PERFQUERY_COUNTER_DATA_UINT64_INTEL                        = 0x94F9
+	PERFQUERY_COUNTER_DESC_LENGTH_MAX_INTEL                    = 0x94FF
+	PERFQUERY_COUNTER_DURATION_NORM_INTEL                      = 0x94F1
+	PERFQUERY_COUNTER_DURATION_RAW_INTEL                       = 0x94F2
+	PERFQUERY_COUNTER_EVENT_INTEL                              = 0x94F0
+	PERFQUERY_COUNTER_NAME_LENGTH_MAX_INTEL                    = 0x94FE
+	PERFQUERY_COUNTER_RAW_INTEL                                = 0x94F4
+	PERFQUERY_COUNTER_THROUGHPUT_INTEL                         = 0x94F3
+	PERFQUERY_COUNTER_TIMESTAMP_INTEL                          = 0x94F5
+	PERFQUERY_DONOT_FLUSH_INTEL                                = 0x83F9
+	PERFQUERY_FLUSH_INTEL                                      = 0x83FA
+	PERFQUERY_GLOBAL_CONTEXT_INTEL                             = 0x00000001
+	PERFQUERY_GPA_EXTENDED_COUNTERS_INTEL                      = 0x9500
+	PERFQUERY_QUERY_NAME_LENGTH_MAX_INTEL                      = 0x94FD
+	PERFQUERY_SINGLE_CONTEXT_INTEL                             = 0x00000000
+	PERFQUERY_WAIT_INTEL                                       = 0x83FB
+	PINLIGHT_NV                                                = 0x92A8
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_PACK_BUFFER                                          = 0x88EB
+	PIXEL_PACK_BUFFER_ARB                                      = 0x88EB
 	PIXEL_PACK_BUFFER_BINDING                                  = 0x88ED
+	PIXEL_PACK_BUFFER_BINDING_ARB                              = 0x88ED
 	PIXEL_UNPACK_BUFFER                                        = 0x88EC
+	PIXEL_UNPACK_BUFFER_ARB                                    = 0x88EC
 	PIXEL_UNPACK_BUFFER_BINDING                                = 0x88EF
+	PIXEL_UNPACK_BUFFER_BINDING_ARB                            = 0x88EF
+	PLUS_CLAMPED_ALPHA_NV                                      = 0x92B2
+	PLUS_CLAMPED_NV                                            = 0x92B1
+	PLUS_DARKER_NV                                             = 0x9292
+	PLUS_NV                                                    = 0x9291
 	POINT                                                      = 0x1B00
 	POINTS                                                     = 0x0000
 	POINT_FADE_THRESHOLD_SIZE                                  = 0x8128
@@ -3810,6 +6357,9 @@ const (
 	POINT_SIZE_RANGE                                           = 0x0B12
 	POINT_SPRITE_COORD_ORIGIN                                  = 0x8CA0
 	POLYGON_MODE                                               = 0x0B40
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FILL                                        = 0x8037
 	POLYGON_OFFSET_LINE                                        = 0x2A02
@@ -3819,21 +6369,34 @@ const (
 	POLYGON_SMOOTH_HINT                                        = 0x0C53
 	PRIMITIVES_GENERATED                                       = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
 	PRIMITIVE_RESTART_FOR_PATCHES_SUPPORTED                    = 0x8221
 	PRIMITIVE_RESTART_INDEX                                    = 0x8F9E
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_INPUT                                              = 0x92E3
 	PROGRAM_KHR                                                = 0x82E2
+	PROGRAM_MATRIX_EXT                                         = 0x8E2D
+	PROGRAM_MATRIX_STACK_DEPTH_EXT                             = 0x8E2F
+	PROGRAM_OBJECT_EXT                                         = 0x8B40
 	PROGRAM_OUTPUT                                             = 0x92E4
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
+	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
+	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
+	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
 	PROGRAM_SEPARABLE                                          = 0x8258
+	PROGRAM_SEPARABLE_EXT                                      = 0x8258
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROXY_TEXTURE_1D                                           = 0x8063
 	PROXY_TEXTURE_1D_ARRAY                                     = 0x8C19
@@ -3846,6 +6409,7 @@ const (
 	PROXY_TEXTURE_CUBE_MAP_ARRAY                               = 0x900B
 	PROXY_TEXTURE_CUBE_MAP_ARRAY_ARB                           = 0x900B
 	PROXY_TEXTURE_RECTANGLE                                    = 0x84F7
+	QUADRATIC_CURVE_TO_NV                                      = 0x0A
 	QUADS                                                      = 0x0007
 	QUADS_FOLLOW_PROVOKING_VERTEX_CONVENTION                   = 0x8E4C
 	QUERY                                                      = 0x82E3
@@ -3854,18 +6418,23 @@ const (
 	QUERY_BUFFER_BINDING                                       = 0x9193
 	QUERY_BY_REGION_NO_WAIT                                    = 0x8E16
 	QUERY_BY_REGION_NO_WAIT_INVERTED                           = 0x8E1A
+	QUERY_BY_REGION_NO_WAIT_NV                                 = 0x8E16
 	QUERY_BY_REGION_WAIT                                       = 0x8E15
 	QUERY_BY_REGION_WAIT_INVERTED                              = 0x8E19
+	QUERY_BY_REGION_WAIT_NV                                    = 0x8E15
 	QUERY_COUNTER_BITS                                         = 0x8864
 	QUERY_KHR                                                  = 0x82E3
 	QUERY_NO_WAIT                                              = 0x8E14
 	QUERY_NO_WAIT_INVERTED                                     = 0x8E18
+	QUERY_NO_WAIT_NV                                           = 0x8E14
+	QUERY_OBJECT_EXT                                           = 0x9153
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
 	QUERY_RESULT_NO_WAIT                                       = 0x9194
 	QUERY_TARGET                                               = 0x82EA
 	QUERY_WAIT                                                 = 0x8E13
 	QUERY_WAIT_INVERTED                                        = 0x8E17
+	QUERY_WAIT_NV                                              = 0x8E13
 	R11F_G11F_B10F                                             = 0x8C3A
 	R16                                                        = 0x822A
 	R16F                                                       = 0x822D
@@ -3881,6 +6450,9 @@ const (
 	R8UI                                                       = 0x8232
 	R8_SNORM                                                   = 0x8F94
 	RASTERIZER_DISCARD                                         = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -3889,18 +6461,41 @@ const (
 	READ_PIXELS_FORMAT                                         = 0x828D
 	READ_PIXELS_TYPE                                           = 0x828E
 	READ_WRITE                                                 = 0x88BA
+	RECT_NV                                                    = 0xF6
 	RED                                                        = 0x1903
 	RED_INTEGER                                                = 0x8D94
+	RED_NV                                                     = 0x1903
 	REFERENCED_BY_COMPUTE_SHADER                               = 0x930B
 	REFERENCED_BY_FRAGMENT_SHADER                              = 0x930A
 	REFERENCED_BY_GEOMETRY_SHADER                              = 0x9309
 	REFERENCED_BY_TESS_CONTROL_SHADER                          = 0x9307
 	REFERENCED_BY_TESS_EVALUATION_SHADER                       = 0x9308
 	REFERENCED_BY_VERTEX_SHADER                                = 0x9306
+	RELATIVE_ARC_TO_NV                                         = 0xFF
+	RELATIVE_CONIC_CURVE_TO_NV                                 = 0x1B
+	RELATIVE_CUBIC_CURVE_TO_NV                                 = 0x0D
+	RELATIVE_HORIZONTAL_LINE_TO_NV                             = 0x07
+	RELATIVE_LARGE_CCW_ARC_TO_NV                               = 0x17
+	RELATIVE_LARGE_CW_ARC_TO_NV                                = 0x19
+	RELATIVE_LINE_TO_NV                                        = 0x05
+	RELATIVE_MOVE_TO_NV                                        = 0x03
+	RELATIVE_QUADRATIC_CURVE_TO_NV                             = 0x0B
+	RELATIVE_RECT_NV                                           = 0xF7
+	RELATIVE_ROUNDED_RECT2_NV                                  = 0xEB
+	RELATIVE_ROUNDED_RECT4_NV                                  = 0xED
+	RELATIVE_ROUNDED_RECT8_NV                                  = 0xEF
+	RELATIVE_ROUNDED_RECT_NV                                   = 0xE9
+	RELATIVE_SMALL_CCW_ARC_TO_NV                               = 0x13
+	RELATIVE_SMALL_CW_ARC_TO_NV                                = 0x15
+	RELATIVE_SMOOTH_CUBIC_CURVE_TO_NV                          = 0x11
+	RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV                      = 0x0F
+	RELATIVE_VERTICAL_LINE_TO_NV                               = 0x09
 	RENDERBUFFER                                               = 0x8D41
 	RENDERBUFFER_ALPHA_SIZE                                    = 0x8D53
 	RENDERBUFFER_BINDING                                       = 0x8CA7
 	RENDERBUFFER_BLUE_SIZE                                     = 0x8D52
+	RENDERBUFFER_COLOR_SAMPLES_NV                              = 0x8E10
+	RENDERBUFFER_COVERAGE_SAMPLES_NV                           = 0x8CAB
 	RENDERBUFFER_DEPTH_SIZE                                    = 0x8D54
 	RENDERBUFFER_GREEN_SIZE                                    = 0x8D51
 	RENDERBUFFER_HEIGHT                                        = 0x8D43
@@ -3915,6 +6510,7 @@ const (
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
 	RESET_NOTIFICATION_STRATEGY_ARB                            = 0x8256
 	RESET_NOTIFICATION_STRATEGY_KHR                            = 0x8256
+	RESTART_PATH_NV                                            = 0xF0
 	RG                                                         = 0x8227
 	RG16                                                       = 0x822C
 	RG16F                                                      = 0x822F
@@ -3967,9 +6563,16 @@ const (
 	RGBA8UI                                                    = 0x8D7C
 	RGBA8_SNORM                                                = 0x8F97
 	RGBA_INTEGER                                               = 0x8D99
+	RGB_422_APPLE                                              = 0x8A1F
 	RGB_INTEGER                                                = 0x8D98
+	RGB_RAW_422_APPLE                                          = 0x8A51
 	RG_INTEGER                                                 = 0x8228
 	RIGHT                                                      = 0x0407
+	ROUNDED_RECT2_NV                                           = 0xEA
+	ROUNDED_RECT4_NV                                           = 0xEC
+	ROUNDED_RECT8_NV                                           = 0xEE
+	ROUNDED_RECT_NV                                            = 0xE8
+	ROUND_NV                                                   = 0x90A4
 	SAMPLER                                                    = 0x82E6
 	SAMPLER_1D                                                 = 0x8B5D
 	SAMPLER_1D_ARRAY                                           = 0x8DC0
@@ -4001,24 +6604,40 @@ const (
 	SAMPLE_COVERAGE                                            = 0x80A0
 	SAMPLE_COVERAGE_INVERT                                     = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_VALUE                                          = 0x8E52
 	SAMPLE_POSITION                                            = 0x8E50
 	SAMPLE_SHADING                                             = 0x8C36
 	SAMPLE_SHADING_ARB                                         = 0x8C36
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
+	SCREEN_KHR                                                 = 0x9295
+	SCREEN_NV                                                  = 0x9295
+	SECONDARY_COLOR_ARRAY_ADDRESS_NV                           = 0x8F27
+	SECONDARY_COLOR_ARRAY_LENGTH_NV                            = 0x8F31
 	SEPARATE_ATTRIBS                                           = 0x8C8D
 	SET                                                        = 0x150F
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
+	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
 	SHADER_IMAGE_ACCESS_BARRIER_BIT                            = 0x00000020
 	SHADER_IMAGE_ATOMIC                                        = 0x82A6
 	SHADER_IMAGE_LOAD                                          = 0x82A4
 	SHADER_IMAGE_STORE                                         = 0x82A5
 	SHADER_INCLUDE_ARB                                         = 0x8DAE
 	SHADER_KHR                                                 = 0x82E1
+	SHADER_OBJECT_EXT                                          = 0x8B48
 	SHADER_SOURCE_LENGTH                                       = 0x8B88
 	SHADER_STORAGE_BARRIER_BIT                                 = 0x00002000
 	SHADER_STORAGE_BLOCK                                       = 0x92E6
@@ -4029,6 +6648,7 @@ const (
 	SHADER_STORAGE_BUFFER_START                                = 0x90D4
 	SHADER_TYPE                                                = 0x8B4F
 	SHADING_LANGUAGE_VERSION                                   = 0x8B8C
+	SHARED_EDGE_NV                                             = 0xC0
 	SHORT                                                      = 0x1402
 	SIGNALED                                                   = 0x9119
 	SIGNED_NORMALIZED                                          = 0x8F9C
@@ -4036,18 +6656,35 @@ const (
 	SIMULTANEOUS_TEXTURE_AND_DEPTH_WRITE                       = 0x82AE
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_TEST                      = 0x82AD
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_WRITE                     = 0x82AF
+	SKIP_DECODE_EXT                                            = 0x8A4A
+	SKIP_MISSING_GLYPH_NV                                      = 0x90A9
+	SMALL_CCW_ARC_TO_NV                                        = 0x12
+	SMALL_CW_ARC_TO_NV                                         = 0x14
+	SMOOTH_CUBIC_CURVE_TO_NV                                   = 0x10
 	SMOOTH_LINE_WIDTH_GRANULARITY                              = 0x0B23
 	SMOOTH_LINE_WIDTH_RANGE                                    = 0x0B22
 	SMOOTH_POINT_SIZE_GRANULARITY                              = 0x0B13
 	SMOOTH_POINT_SIZE_RANGE                                    = 0x0B12
+	SMOOTH_QUADRATIC_CURVE_TO_NV                               = 0x0E
+	SM_COUNT_NV                                                = 0x933B
+	SOFTLIGHT_KHR                                              = 0x929C
+	SOFTLIGHT_NV                                               = 0x929C
 	SPARSE_BUFFER_PAGE_SIZE_ARB                                = 0x82F8
 	SPARSE_STORAGE_BIT_ARB                                     = 0x0400
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
+	SQUARE_NV                                                  = 0x90A3
 	SRC1_ALPHA                                                 = 0x8589
 	SRC1_COLOR                                                 = 0x88F9
 	SRC_ALPHA                                                  = 0x0302
 	SRC_ALPHA_SATURATE                                         = 0x0308
+	SRC_ATOP_NV                                                = 0x928E
 	SRC_COLOR                                                  = 0x0300
+	SRC_IN_NV                                                  = 0x928A
+	SRC_NV                                                     = 0x9286
+	SRC_OUT_NV                                                 = 0x928C
+	SRC_OVER_NV                                                = 0x9288
 	SRGB                                                       = 0x8C40
 	SRGB8                                                      = 0x8C41
 	SRGB8_ALPHA8                                               = 0x8C43
@@ -4059,6 +6696,8 @@ const (
 	STACK_OVERFLOW_KHR                                         = 0x0503
 	STACK_UNDERFLOW                                            = 0x0504
 	STACK_UNDERFLOW_KHR                                        = 0x0504
+	STANDARD_FONT_FORMAT_NV                                    = 0x936C
+	STANDARD_FONT_NAME_NV                                      = 0x9072
 	STATIC_COPY                                                = 0x88E6
 	STATIC_DRAW                                                = 0x88E4
 	STATIC_READ                                                = 0x88E5
@@ -4084,7 +6723,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_VALUE_MASK                                         = 0x0B93
 	STENCIL_WRITEMASK                                          = 0x0B98
@@ -4093,6 +6734,10 @@ const (
 	STREAM_DRAW                                                = 0x88E0
 	STREAM_READ                                                = 0x88E1
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SYNC_CL_EVENT_ARB                                          = 0x8240
 	SYNC_CL_EVENT_COMPLETE_ARB                                 = 0x8241
 	SYNC_CONDITION                                             = 0x9113
@@ -4101,6 +6746,8 @@ const (
 	SYNC_FLUSH_COMMANDS_BIT                                    = 0x00000001
 	SYNC_GPU_COMMANDS_COMPLETE                                 = 0x9117
 	SYNC_STATUS                                                = 0x9114
+	SYSTEM_FONT_NAME_NV                                        = 0x9073
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
 	TESS_CONTROL_SHADER                                        = 0x8E88
 	TESS_CONTROL_SHADER_BIT                                    = 0x00000008
@@ -4161,7 +6808,6 @@ const (
 	TEXTURE_ALPHA_SIZE                                         = 0x805F
 	TEXTURE_ALPHA_TYPE                                         = 0x8C13
 	TEXTURE_BASE_LEVEL                                         = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_2D                                         = 0x8069
@@ -4170,6 +6816,7 @@ const (
 	TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY                       = 0x9105
 	TEXTURE_BINDING_3D                                         = 0x806A
 	TEXTURE_BINDING_BUFFER                                     = 0x8C2C
+	TEXTURE_BINDING_BUFFER_ARB                                 = 0x8C2C
 	TEXTURE_BINDING_CUBE_MAP                                   = 0x8514
 	TEXTURE_BINDING_CUBE_MAP_ARRAY                             = 0x900A
 	TEXTURE_BINDING_CUBE_MAP_ARRAY_ARB                         = 0x900A
@@ -4178,8 +6825,11 @@ const (
 	TEXTURE_BLUE_TYPE                                          = 0x8C12
 	TEXTURE_BORDER_COLOR                                       = 0x1004
 	TEXTURE_BUFFER                                             = 0x8C2A
+	TEXTURE_BUFFER_ARB                                         = 0x8C2A
 	TEXTURE_BUFFER_BINDING                                     = 0x8C2A
 	TEXTURE_BUFFER_DATA_STORE_BINDING                          = 0x8C2D
+	TEXTURE_BUFFER_DATA_STORE_BINDING_ARB                      = 0x8C2D
+	TEXTURE_BUFFER_FORMAT_ARB                                  = 0x8C2E
 	TEXTURE_BUFFER_OFFSET                                      = 0x919D
 	TEXTURE_BUFFER_OFFSET_ALIGNMENT                            = 0x919F
 	TEXTURE_BUFFER_SIZE                                        = 0x919E
@@ -4191,6 +6841,8 @@ const (
 	TEXTURE_COMPRESSED_BLOCK_WIDTH                             = 0x82B1
 	TEXTURE_COMPRESSED_IMAGE_SIZE                              = 0x86A0
 	TEXTURE_COMPRESSION_HINT                                   = 0x84EF
+	TEXTURE_COORD_ARRAY_ADDRESS_NV                             = 0x8F25
+	TEXTURE_COORD_ARRAY_LENGTH_NV                              = 0x8F2F
 	TEXTURE_CUBE_MAP                                           = 0x8513
 	TEXTURE_CUBE_MAP_ARRAY                                     = 0x9009
 	TEXTURE_CUBE_MAP_ARRAY_ARB                                 = 0x9009
@@ -4218,17 +6870,21 @@ const (
 	TEXTURE_INTERNAL_FORMAT                                    = 0x1003
 	TEXTURE_LOD_BIAS                                           = 0x8501
 	TEXTURE_MAG_FILTER                                         = 0x2800
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_LEVEL                                          = 0x813D
 	TEXTURE_MAX_LOD                                            = 0x813B
 	TEXTURE_MIN_FILTER                                         = 0x2801
 	TEXTURE_MIN_LOD                                            = 0x813A
 	TEXTURE_RECTANGLE                                          = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
 	TEXTURE_SAMPLES                                            = 0x9106
 	TEXTURE_SHADOW                                             = 0x82A1
 	TEXTURE_SHARED_SIZE                                        = 0x8C3F
 	TEXTURE_SPARSE_ARB                                         = 0x91A6
+	TEXTURE_SRGB_DECODE_EXT                                    = 0x8A48
 	TEXTURE_STENCIL_SIZE                                       = 0x88F1
 	TEXTURE_SWIZZLE_A                                          = 0x8E45
 	TEXTURE_SWIZZLE_B                                          = 0x8E44
@@ -4272,15 +6928,27 @@ const (
 	TRANSFORM_FEEDBACK_VARYING                                 = 0x92F4
 	TRANSFORM_FEEDBACK_VARYINGS                                = 0x8C83
 	TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH                      = 0x8C76
+	TRANSLATE_2D_NV                                            = 0x9090
+	TRANSLATE_3D_NV                                            = 0x9091
+	TRANSLATE_X_NV                                             = 0x908E
+	TRANSLATE_Y_NV                                             = 0x908F
+	TRANSPOSE_AFFINE_2D_NV                                     = 0x9096
+	TRANSPOSE_AFFINE_3D_NV                                     = 0x9098
+	TRANSPOSE_PROGRAM_MATRIX_EXT                               = 0x8E2E
 	TRIANGLES                                                  = 0x0004
 	TRIANGLES_ADJACENCY                                        = 0x000C
+	TRIANGLES_ADJACENCY_ARB                                    = 0x000C
 	TRIANGLE_FAN                                               = 0x0006
 	TRIANGLE_STRIP                                             = 0x0005
 	TRIANGLE_STRIP_ADJACENCY                                   = 0x000D
+	TRIANGLE_STRIP_ADJACENCY_ARB                               = 0x000D
+	TRIANGULAR_NV                                              = 0x90A5
 	TRUE                                                       = 1
 	TYPE                                                       = 0x92FA
+	UNCORRELATED_NV                                            = 0x9282
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -4298,10 +6966,13 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -4328,7 +6999,23 @@ const (
 	UNSIGNED_BYTE_2_3_3_REV                                    = 0x8362
 	UNSIGNED_BYTE_3_3_2                                        = 0x8032
 	UNSIGNED_INT                                               = 0x1405
+	UNSIGNED_INT16_NV                                          = 0x8FF0
+	UNSIGNED_INT16_VEC2_NV                                     = 0x8FF1
+	UNSIGNED_INT16_VEC3_NV                                     = 0x8FF2
+	UNSIGNED_INT16_VEC4_NV                                     = 0x8FF3
+	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
+	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
+	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
+	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
+	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
+	UNSIGNED_INT8_NV                                           = 0x8FEC
+	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
+	UNSIGNED_INT8_VEC3_NV                                      = 0x8FEE
+	UNSIGNED_INT8_VEC4_NV                                      = 0x8FEF
 	UNSIGNED_INT_10F_11F_11F_REV                               = 0x8C3B
 	UNSIGNED_INT_10_10_10_2                                    = 0x8036
 	UNSIGNED_INT_24_8                                          = 0x84FA
@@ -4371,24 +7058,36 @@ const (
 	UNSIGNED_SHORT_5_5_5_1                                     = 0x8034
 	UNSIGNED_SHORT_5_6_5                                       = 0x8363
 	UNSIGNED_SHORT_5_6_5_REV                                   = 0x8364
+	UNSIGNED_SHORT_8_8_APPLE                                   = 0x85BA
+	UNSIGNED_SHORT_8_8_REV_APPLE                               = 0x85BB
 	UPPER_LEFT                                                 = 0x8CA2
+	USE_MISSING_GLYPH_NV                                       = 0x90AA
+	UTF16_NV                                                   = 0x909B
+	UTF8_NV                                                    = 0x909A
 	VALIDATE_STATUS                                            = 0x8B83
 	VENDOR                                                     = 0x1F00
 	VERSION                                                    = 0x1F02
 	VERTEX_ARRAY                                               = 0x8074
+	VERTEX_ARRAY_ADDRESS_NV                                    = 0x8F21
 	VERTEX_ARRAY_BINDING                                       = 0x85B5
 	VERTEX_ARRAY_KHR                                           = 0x8074
+	VERTEX_ARRAY_LENGTH_NV                                     = 0x8F2B
+	VERTEX_ARRAY_OBJECT_EXT                                    = 0x9154
+	VERTEX_ATTRIB_ARRAY_ADDRESS_NV                             = 0x8F20
 	VERTEX_ATTRIB_ARRAY_BARRIER_BIT                            = 0x00000001
 	VERTEX_ATTRIB_ARRAY_BUFFER_BINDING                         = 0x889F
 	VERTEX_ATTRIB_ARRAY_DIVISOR                                = 0x88FE
+	VERTEX_ATTRIB_ARRAY_DIVISOR_ARB                            = 0x88FE
 	VERTEX_ATTRIB_ARRAY_ENABLED                                = 0x8622
 	VERTEX_ATTRIB_ARRAY_INTEGER                                = 0x88FD
+	VERTEX_ATTRIB_ARRAY_LENGTH_NV                              = 0x8F2A
 	VERTEX_ATTRIB_ARRAY_LONG                                   = 0x874E
 	VERTEX_ATTRIB_ARRAY_NORMALIZED                             = 0x886A
 	VERTEX_ATTRIB_ARRAY_POINTER                                = 0x8645
 	VERTEX_ATTRIB_ARRAY_SIZE                                   = 0x8623
 	VERTEX_ATTRIB_ARRAY_STRIDE                                 = 0x8624
 	VERTEX_ATTRIB_ARRAY_TYPE                                   = 0x8625
+	VERTEX_ATTRIB_ARRAY_UNIFIED_NV                             = 0x8F1E
 	VERTEX_ATTRIB_BINDING                                      = 0x82D4
 	VERTEX_ATTRIB_RELATIVE_OFFSET                              = 0x82D5
 	VERTEX_BINDING_BUFFER                                      = 0x8F4F
@@ -4398,15 +7097,33 @@ const (
 	VERTEX_PROGRAM_POINT_SIZE                                  = 0x8642
 	VERTEX_SHADER                                              = 0x8B31
 	VERTEX_SHADER_BIT                                          = 0x00000001
+	VERTEX_SHADER_BIT_EXT                                      = 0x00000001
 	VERTEX_SHADER_INVOCATIONS_ARB                              = 0x82F0
 	VERTEX_SUBROUTINE                                          = 0x92E8
 	VERTEX_SUBROUTINE_UNIFORM                                  = 0x92EE
 	VERTEX_TEXTURE                                             = 0x829B
+	VERTICAL_LINE_TO_NV                                        = 0x08
 	VERTICES_SUBMITTED_ARB                                     = 0x82EE
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -4428,723 +7145,1284 @@ const (
 	VIRTUAL_PAGE_SIZE_X_ARB                                    = 0x9195
 	VIRTUAL_PAGE_SIZE_Y_ARB                                    = 0x9196
 	VIRTUAL_PAGE_SIZE_Z_ARB                                    = 0x9197
+	VIVIDLIGHT_NV                                              = 0x92A6
 	WAIT_FAILED                                                = 0x911D
+	WARPS_PER_SM_NV                                            = 0x933A
+	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRITE_ONLY                                                 = 0x88B9
 	XOR                                                        = 0x1506
+	XOR_NV                                                     = 0x1506
 	ZERO                                                       = 0
 	ZERO_TO_ONE                                                = 0x935F
 )
 
 var (
-	gpActiveShaderProgram                         C.GPACTIVESHADERPROGRAM
-	gpActiveTexture                               C.GPACTIVETEXTURE
-	gpAttachShader                                C.GPATTACHSHADER
-	gpBeginConditionalRender                      C.GPBEGINCONDITIONALRENDER
-	gpBeginQuery                                  C.GPBEGINQUERY
-	gpBeginQueryIndexed                           C.GPBEGINQUERYINDEXED
-	gpBeginTransformFeedback                      C.GPBEGINTRANSFORMFEEDBACK
-	gpBindAttribLocation                          C.GPBINDATTRIBLOCATION
-	gpBindBuffer                                  C.GPBINDBUFFER
-	gpBindBufferBase                              C.GPBINDBUFFERBASE
-	gpBindBufferRange                             C.GPBINDBUFFERRANGE
-	gpBindBuffersBase                             C.GPBINDBUFFERSBASE
-	gpBindBuffersRange                            C.GPBINDBUFFERSRANGE
-	gpBindFragDataLocation                        C.GPBINDFRAGDATALOCATION
-	gpBindFragDataLocationIndexed                 C.GPBINDFRAGDATALOCATIONINDEXED
-	gpBindFramebuffer                             C.GPBINDFRAMEBUFFER
-	gpBindImageTexture                            C.GPBINDIMAGETEXTURE
-	gpBindImageTextures                           C.GPBINDIMAGETEXTURES
-	gpBindProgramPipeline                         C.GPBINDPROGRAMPIPELINE
-	gpBindRenderbuffer                            C.GPBINDRENDERBUFFER
-	gpBindSampler                                 C.GPBINDSAMPLER
-	gpBindSamplers                                C.GPBINDSAMPLERS
-	gpBindTexture                                 C.GPBINDTEXTURE
-	gpBindTextureUnit                             C.GPBINDTEXTUREUNIT
-	gpBindTextures                                C.GPBINDTEXTURES
-	gpBindTransformFeedback                       C.GPBINDTRANSFORMFEEDBACK
-	gpBindVertexArray                             C.GPBINDVERTEXARRAY
-	gpBindVertexBuffer                            C.GPBINDVERTEXBUFFER
-	gpBindVertexBuffers                           C.GPBINDVERTEXBUFFERS
-	gpBlendColor                                  C.GPBLENDCOLOR
-	gpBlendEquation                               C.GPBLENDEQUATION
-	gpBlendEquationSeparate                       C.GPBLENDEQUATIONSEPARATE
-	gpBlendEquationSeparatei                      C.GPBLENDEQUATIONSEPARATEI
-	gpBlendEquationSeparateiARB                   C.GPBLENDEQUATIONSEPARATEIARB
-	gpBlendEquationi                              C.GPBLENDEQUATIONI
-	gpBlendEquationiARB                           C.GPBLENDEQUATIONIARB
-	gpBlendFunc                                   C.GPBLENDFUNC
-	gpBlendFuncSeparate                           C.GPBLENDFUNCSEPARATE
-	gpBlendFuncSeparatei                          C.GPBLENDFUNCSEPARATEI
-	gpBlendFuncSeparateiARB                       C.GPBLENDFUNCSEPARATEIARB
-	gpBlendFunci                                  C.GPBLENDFUNCI
-	gpBlendFunciARB                               C.GPBLENDFUNCIARB
-	gpBlitFramebuffer                             C.GPBLITFRAMEBUFFER
-	gpBlitNamedFramebuffer                        C.GPBLITNAMEDFRAMEBUFFER
-	gpBufferData                                  C.GPBUFFERDATA
-	gpBufferPageCommitmentARB                     C.GPBUFFERPAGECOMMITMENTARB
-	gpBufferStorage                               C.GPBUFFERSTORAGE
-	gpBufferSubData                               C.GPBUFFERSUBDATA
-	gpCheckFramebufferStatus                      C.GPCHECKFRAMEBUFFERSTATUS
-	gpCheckNamedFramebufferStatus                 C.GPCHECKNAMEDFRAMEBUFFERSTATUS
-	gpClampColor                                  C.GPCLAMPCOLOR
-	gpClear                                       C.GPCLEAR
-	gpClearBufferData                             C.GPCLEARBUFFERDATA
-	gpClearBufferSubData                          C.GPCLEARBUFFERSUBDATA
-	gpClearBufferfi                               C.GPCLEARBUFFERFI
-	gpClearBufferfv                               C.GPCLEARBUFFERFV
-	gpClearBufferiv                               C.GPCLEARBUFFERIV
-	gpClearBufferuiv                              C.GPCLEARBUFFERUIV
-	gpClearColor                                  C.GPCLEARCOLOR
-	gpClearDepth                                  C.GPCLEARDEPTH
-	gpClearDepthf                                 C.GPCLEARDEPTHF
-	gpClearNamedBufferData                        C.GPCLEARNAMEDBUFFERDATA
-	gpClearNamedBufferSubData                     C.GPCLEARNAMEDBUFFERSUBDATA
-	gpClearNamedFramebufferfi                     C.GPCLEARNAMEDFRAMEBUFFERFI
-	gpClearNamedFramebufferfv                     C.GPCLEARNAMEDFRAMEBUFFERFV
-	gpClearNamedFramebufferiv                     C.GPCLEARNAMEDFRAMEBUFFERIV
-	gpClearNamedFramebufferuiv                    C.GPCLEARNAMEDFRAMEBUFFERUIV
-	gpClearStencil                                C.GPCLEARSTENCIL
-	gpClearTexImage                               C.GPCLEARTEXIMAGE
-	gpClearTexSubImage                            C.GPCLEARTEXSUBIMAGE
-	gpClientWaitSync                              C.GPCLIENTWAITSYNC
-	gpClipControl                                 C.GPCLIPCONTROL
-	gpColorMask                                   C.GPCOLORMASK
-	gpColorMaski                                  C.GPCOLORMASKI
-	gpCompileShader                               C.GPCOMPILESHADER
-	gpCompileShaderIncludeARB                     C.GPCOMPILESHADERINCLUDEARB
-	gpCompressedTexImage1D                        C.GPCOMPRESSEDTEXIMAGE1D
-	gpCompressedTexImage2D                        C.GPCOMPRESSEDTEXIMAGE2D
-	gpCompressedTexImage3D                        C.GPCOMPRESSEDTEXIMAGE3D
-	gpCompressedTexSubImage1D                     C.GPCOMPRESSEDTEXSUBIMAGE1D
-	gpCompressedTexSubImage2D                     C.GPCOMPRESSEDTEXSUBIMAGE2D
-	gpCompressedTexSubImage3D                     C.GPCOMPRESSEDTEXSUBIMAGE3D
-	gpCompressedTextureSubImage1D                 C.GPCOMPRESSEDTEXTURESUBIMAGE1D
-	gpCompressedTextureSubImage2D                 C.GPCOMPRESSEDTEXTURESUBIMAGE2D
-	gpCompressedTextureSubImage3D                 C.GPCOMPRESSEDTEXTURESUBIMAGE3D
-	gpCopyBufferSubData                           C.GPCOPYBUFFERSUBDATA
-	gpCopyImageSubData                            C.GPCOPYIMAGESUBDATA
-	gpCopyNamedBufferSubData                      C.GPCOPYNAMEDBUFFERSUBDATA
-	gpCopyTexImage1D                              C.GPCOPYTEXIMAGE1D
-	gpCopyTexImage2D                              C.GPCOPYTEXIMAGE2D
-	gpCopyTexSubImage1D                           C.GPCOPYTEXSUBIMAGE1D
-	gpCopyTexSubImage2D                           C.GPCOPYTEXSUBIMAGE2D
-	gpCopyTexSubImage3D                           C.GPCOPYTEXSUBIMAGE3D
-	gpCopyTextureSubImage1D                       C.GPCOPYTEXTURESUBIMAGE1D
-	gpCopyTextureSubImage2D                       C.GPCOPYTEXTURESUBIMAGE2D
-	gpCopyTextureSubImage3D                       C.GPCOPYTEXTURESUBIMAGE3D
-	gpCreateBuffers                               C.GPCREATEBUFFERS
-	gpCreateFramebuffers                          C.GPCREATEFRAMEBUFFERS
-	gpCreateProgram                               C.GPCREATEPROGRAM
-	gpCreateProgramPipelines                      C.GPCREATEPROGRAMPIPELINES
-	gpCreateQueries                               C.GPCREATEQUERIES
-	gpCreateRenderbuffers                         C.GPCREATERENDERBUFFERS
-	gpCreateSamplers                              C.GPCREATESAMPLERS
-	gpCreateShader                                C.GPCREATESHADER
-	gpCreateShaderProgramv                        C.GPCREATESHADERPROGRAMV
-	gpCreateSyncFromCLeventARB                    C.GPCREATESYNCFROMCLEVENTARB
-	gpCreateTextures                              C.GPCREATETEXTURES
-	gpCreateTransformFeedbacks                    C.GPCREATETRANSFORMFEEDBACKS
-	gpCreateVertexArrays                          C.GPCREATEVERTEXARRAYS
-	gpCullFace                                    C.GPCULLFACE
-	gpDebugMessageCallback                        C.GPDEBUGMESSAGECALLBACK
-	gpDebugMessageCallbackARB                     C.GPDEBUGMESSAGECALLBACKARB
-	gpDebugMessageCallbackKHR                     C.GPDEBUGMESSAGECALLBACKKHR
-	gpDebugMessageControl                         C.GPDEBUGMESSAGECONTROL
-	gpDebugMessageControlARB                      C.GPDEBUGMESSAGECONTROLARB
-	gpDebugMessageControlKHR                      C.GPDEBUGMESSAGECONTROLKHR
-	gpDebugMessageInsert                          C.GPDEBUGMESSAGEINSERT
-	gpDebugMessageInsertARB                       C.GPDEBUGMESSAGEINSERTARB
-	gpDebugMessageInsertKHR                       C.GPDEBUGMESSAGEINSERTKHR
-	gpDeleteBuffers                               C.GPDELETEBUFFERS
-	gpDeleteFramebuffers                          C.GPDELETEFRAMEBUFFERS
-	gpDeleteNamedStringARB                        C.GPDELETENAMEDSTRINGARB
-	gpDeleteProgram                               C.GPDELETEPROGRAM
-	gpDeleteProgramPipelines                      C.GPDELETEPROGRAMPIPELINES
-	gpDeleteQueries                               C.GPDELETEQUERIES
-	gpDeleteRenderbuffers                         C.GPDELETERENDERBUFFERS
-	gpDeleteSamplers                              C.GPDELETESAMPLERS
-	gpDeleteShader                                C.GPDELETESHADER
-	gpDeleteSync                                  C.GPDELETESYNC
-	gpDeleteTextures                              C.GPDELETETEXTURES
-	gpDeleteTransformFeedbacks                    C.GPDELETETRANSFORMFEEDBACKS
-	gpDeleteVertexArrays                          C.GPDELETEVERTEXARRAYS
-	gpDepthFunc                                   C.GPDEPTHFUNC
-	gpDepthMask                                   C.GPDEPTHMASK
-	gpDepthRange                                  C.GPDEPTHRANGE
-	gpDepthRangeArrayv                            C.GPDEPTHRANGEARRAYV
-	gpDepthRangeIndexed                           C.GPDEPTHRANGEINDEXED
-	gpDepthRangef                                 C.GPDEPTHRANGEF
-	gpDetachShader                                C.GPDETACHSHADER
-	gpDisable                                     C.GPDISABLE
-	gpDisableVertexArrayAttrib                    C.GPDISABLEVERTEXARRAYATTRIB
-	gpDisableVertexAttribArray                    C.GPDISABLEVERTEXATTRIBARRAY
-	gpDisablei                                    C.GPDISABLEI
-	gpDispatchCompute                             C.GPDISPATCHCOMPUTE
-	gpDispatchComputeGroupSizeARB                 C.GPDISPATCHCOMPUTEGROUPSIZEARB
-	gpDispatchComputeIndirect                     C.GPDISPATCHCOMPUTEINDIRECT
-	gpDrawArrays                                  C.GPDRAWARRAYS
-	gpDrawArraysIndirect                          C.GPDRAWARRAYSINDIRECT
-	gpDrawArraysInstanced                         C.GPDRAWARRAYSINSTANCED
-	gpDrawArraysInstancedBaseInstance             C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
-	gpDrawBuffer                                  C.GPDRAWBUFFER
-	gpDrawBuffers                                 C.GPDRAWBUFFERS
-	gpDrawElements                                C.GPDRAWELEMENTS
-	gpDrawElementsBaseVertex                      C.GPDRAWELEMENTSBASEVERTEX
-	gpDrawElementsIndirect                        C.GPDRAWELEMENTSINDIRECT
-	gpDrawElementsInstanced                       C.GPDRAWELEMENTSINSTANCED
-	gpDrawElementsInstancedBaseInstance           C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
-	gpDrawElementsInstancedBaseVertex             C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
-	gpDrawElementsInstancedBaseVertexBaseInstance C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
-	gpDrawRangeElements                           C.GPDRAWRANGEELEMENTS
-	gpDrawRangeElementsBaseVertex                 C.GPDRAWRANGEELEMENTSBASEVERTEX
-	gpDrawTransformFeedback                       C.GPDRAWTRANSFORMFEEDBACK
-	gpDrawTransformFeedbackInstanced              C.GPDRAWTRANSFORMFEEDBACKINSTANCED
-	gpDrawTransformFeedbackStream                 C.GPDRAWTRANSFORMFEEDBACKSTREAM
-	gpDrawTransformFeedbackStreamInstanced        C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
-	gpEnable                                      C.GPENABLE
-	gpEnableVertexArrayAttrib                     C.GPENABLEVERTEXARRAYATTRIB
-	gpEnableVertexAttribArray                     C.GPENABLEVERTEXATTRIBARRAY
-	gpEnablei                                     C.GPENABLEI
-	gpEndConditionalRender                        C.GPENDCONDITIONALRENDER
-	gpEndQuery                                    C.GPENDQUERY
-	gpEndQueryIndexed                             C.GPENDQUERYINDEXED
-	gpEndTransformFeedback                        C.GPENDTRANSFORMFEEDBACK
-	gpFenceSync                                   C.GPFENCESYNC
-	gpFinish                                      C.GPFINISH
-	gpFlush                                       C.GPFLUSH
-	gpFlushMappedBufferRange                      C.GPFLUSHMAPPEDBUFFERRANGE
-	gpFlushMappedNamedBufferRange                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
-	gpFramebufferParameteri                       C.GPFRAMEBUFFERPARAMETERI
-	gpFramebufferRenderbuffer                     C.GPFRAMEBUFFERRENDERBUFFER
-	gpFramebufferTexture                          C.GPFRAMEBUFFERTEXTURE
-	gpFramebufferTexture1D                        C.GPFRAMEBUFFERTEXTURE1D
-	gpFramebufferTexture2D                        C.GPFRAMEBUFFERTEXTURE2D
-	gpFramebufferTexture3D                        C.GPFRAMEBUFFERTEXTURE3D
-	gpFramebufferTextureLayer                     C.GPFRAMEBUFFERTEXTURELAYER
-	gpFrontFace                                   C.GPFRONTFACE
-	gpGenBuffers                                  C.GPGENBUFFERS
-	gpGenFramebuffers                             C.GPGENFRAMEBUFFERS
-	gpGenProgramPipelines                         C.GPGENPROGRAMPIPELINES
-	gpGenQueries                                  C.GPGENQUERIES
-	gpGenRenderbuffers                            C.GPGENRENDERBUFFERS
-	gpGenSamplers                                 C.GPGENSAMPLERS
-	gpGenTextures                                 C.GPGENTEXTURES
-	gpGenTransformFeedbacks                       C.GPGENTRANSFORMFEEDBACKS
-	gpGenVertexArrays                             C.GPGENVERTEXARRAYS
-	gpGenerateMipmap                              C.GPGENERATEMIPMAP
-	gpGenerateTextureMipmap                       C.GPGENERATETEXTUREMIPMAP
-	gpGetActiveAtomicCounterBufferiv              C.GPGETACTIVEATOMICCOUNTERBUFFERIV
-	gpGetActiveAttrib                             C.GPGETACTIVEATTRIB
-	gpGetActiveSubroutineName                     C.GPGETACTIVESUBROUTINENAME
-	gpGetActiveSubroutineUniformName              C.GPGETACTIVESUBROUTINEUNIFORMNAME
-	gpGetActiveSubroutineUniformiv                C.GPGETACTIVESUBROUTINEUNIFORMIV
-	gpGetActiveUniform                            C.GPGETACTIVEUNIFORM
-	gpGetActiveUniformBlockName                   C.GPGETACTIVEUNIFORMBLOCKNAME
-	gpGetActiveUniformBlockiv                     C.GPGETACTIVEUNIFORMBLOCKIV
-	gpGetActiveUniformName                        C.GPGETACTIVEUNIFORMNAME
-	gpGetActiveUniformsiv                         C.GPGETACTIVEUNIFORMSIV
-	gpGetAttachedShaders                          C.GPGETATTACHEDSHADERS
-	gpGetAttribLocation                           C.GPGETATTRIBLOCATION
-	gpGetBooleani_v                               C.GPGETBOOLEANI_V
-	gpGetBooleanv                                 C.GPGETBOOLEANV
-	gpGetBufferParameteri64v                      C.GPGETBUFFERPARAMETERI64V
-	gpGetBufferParameteriv                        C.GPGETBUFFERPARAMETERIV
-	gpGetBufferPointerv                           C.GPGETBUFFERPOINTERV
-	gpGetBufferSubData                            C.GPGETBUFFERSUBDATA
-	gpGetCompressedTexImage                       C.GPGETCOMPRESSEDTEXIMAGE
-	gpGetCompressedTextureImage                   C.GPGETCOMPRESSEDTEXTUREIMAGE
-	gpGetCompressedTextureSubImage                C.GPGETCOMPRESSEDTEXTURESUBIMAGE
-	gpGetDebugMessageLog                          C.GPGETDEBUGMESSAGELOG
-	gpGetDebugMessageLogARB                       C.GPGETDEBUGMESSAGELOGARB
-	gpGetDebugMessageLogKHR                       C.GPGETDEBUGMESSAGELOGKHR
-	gpGetDoublei_v                                C.GPGETDOUBLEI_V
-	gpGetDoublev                                  C.GPGETDOUBLEV
-	gpGetError                                    C.GPGETERROR
-	gpGetFloati_v                                 C.GPGETFLOATI_V
-	gpGetFloatv                                   C.GPGETFLOATV
-	gpGetFragDataIndex                            C.GPGETFRAGDATAINDEX
-	gpGetFragDataLocation                         C.GPGETFRAGDATALOCATION
-	gpGetFramebufferAttachmentParameteriv         C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetFramebufferParameteriv                   C.GPGETFRAMEBUFFERPARAMETERIV
-	gpGetGraphicsResetStatus                      C.GPGETGRAPHICSRESETSTATUS
-	gpGetGraphicsResetStatusARB                   C.GPGETGRAPHICSRESETSTATUSARB
-	gpGetGraphicsResetStatusKHR                   C.GPGETGRAPHICSRESETSTATUSKHR
-	gpGetImageHandleARB                           C.GPGETIMAGEHANDLEARB
-	gpGetInteger64i_v                             C.GPGETINTEGER64I_V
-	gpGetInteger64v                               C.GPGETINTEGER64V
-	gpGetIntegeri_v                               C.GPGETINTEGERI_V
-	gpGetIntegerv                                 C.GPGETINTEGERV
-	gpGetInternalformati64v                       C.GPGETINTERNALFORMATI64V
-	gpGetInternalformativ                         C.GPGETINTERNALFORMATIV
-	gpGetMultisamplefv                            C.GPGETMULTISAMPLEFV
-	gpGetNamedBufferParameteri64v                 C.GPGETNAMEDBUFFERPARAMETERI64V
-	gpGetNamedBufferParameteriv                   C.GPGETNAMEDBUFFERPARAMETERIV
-	gpGetNamedBufferPointerv                      C.GPGETNAMEDBUFFERPOINTERV
-	gpGetNamedBufferSubData                       C.GPGETNAMEDBUFFERSUBDATA
-	gpGetNamedFramebufferAttachmentParameteriv    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetNamedFramebufferParameteriv              C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
-	gpGetNamedRenderbufferParameteriv             C.GPGETNAMEDRENDERBUFFERPARAMETERIV
-	gpGetNamedStringARB                           C.GPGETNAMEDSTRINGARB
-	gpGetNamedStringivARB                         C.GPGETNAMEDSTRINGIVARB
-	gpGetObjectLabel                              C.GPGETOBJECTLABEL
-	gpGetObjectLabelKHR                           C.GPGETOBJECTLABELKHR
-	gpGetObjectPtrLabel                           C.GPGETOBJECTPTRLABEL
-	gpGetObjectPtrLabelKHR                        C.GPGETOBJECTPTRLABELKHR
-	gpGetPointerv                                 C.GPGETPOINTERV
-	gpGetPointervKHR                              C.GPGETPOINTERVKHR
-	gpGetProgramBinary                            C.GPGETPROGRAMBINARY
-	gpGetProgramInfoLog                           C.GPGETPROGRAMINFOLOG
-	gpGetProgramInterfaceiv                       C.GPGETPROGRAMINTERFACEIV
-	gpGetProgramPipelineInfoLog                   C.GPGETPROGRAMPIPELINEINFOLOG
-	gpGetProgramPipelineiv                        C.GPGETPROGRAMPIPELINEIV
-	gpGetProgramResourceIndex                     C.GPGETPROGRAMRESOURCEINDEX
-	gpGetProgramResourceLocation                  C.GPGETPROGRAMRESOURCELOCATION
-	gpGetProgramResourceLocationIndex             C.GPGETPROGRAMRESOURCELOCATIONINDEX
-	gpGetProgramResourceName                      C.GPGETPROGRAMRESOURCENAME
-	gpGetProgramResourceiv                        C.GPGETPROGRAMRESOURCEIV
-	gpGetProgramStageiv                           C.GPGETPROGRAMSTAGEIV
-	gpGetProgramiv                                C.GPGETPROGRAMIV
-	gpGetQueryIndexediv                           C.GPGETQUERYINDEXEDIV
-	gpGetQueryObjecti64v                          C.GPGETQUERYOBJECTI64V
-	gpGetQueryObjectiv                            C.GPGETQUERYOBJECTIV
-	gpGetQueryObjectui64v                         C.GPGETQUERYOBJECTUI64V
-	gpGetQueryObjectuiv                           C.GPGETQUERYOBJECTUIV
-	gpGetQueryiv                                  C.GPGETQUERYIV
-	gpGetRenderbufferParameteriv                  C.GPGETRENDERBUFFERPARAMETERIV
-	gpGetSamplerParameterIiv                      C.GPGETSAMPLERPARAMETERIIV
-	gpGetSamplerParameterIuiv                     C.GPGETSAMPLERPARAMETERIUIV
-	gpGetSamplerParameterfv                       C.GPGETSAMPLERPARAMETERFV
-	gpGetSamplerParameteriv                       C.GPGETSAMPLERPARAMETERIV
-	gpGetShaderInfoLog                            C.GPGETSHADERINFOLOG
-	gpGetShaderPrecisionFormat                    C.GPGETSHADERPRECISIONFORMAT
-	gpGetShaderSource                             C.GPGETSHADERSOURCE
-	gpGetShaderiv                                 C.GPGETSHADERIV
-	gpGetString                                   C.GPGETSTRING
-	gpGetStringi                                  C.GPGETSTRINGI
-	gpGetSubroutineIndex                          C.GPGETSUBROUTINEINDEX
-	gpGetSubroutineUniformLocation                C.GPGETSUBROUTINEUNIFORMLOCATION
-	gpGetSynciv                                   C.GPGETSYNCIV
-	gpGetTexImage                                 C.GPGETTEXIMAGE
-	gpGetTexLevelParameterfv                      C.GPGETTEXLEVELPARAMETERFV
-	gpGetTexLevelParameteriv                      C.GPGETTEXLEVELPARAMETERIV
-	gpGetTexParameterIiv                          C.GPGETTEXPARAMETERIIV
-	gpGetTexParameterIuiv                         C.GPGETTEXPARAMETERIUIV
-	gpGetTexParameterfv                           C.GPGETTEXPARAMETERFV
-	gpGetTexParameteriv                           C.GPGETTEXPARAMETERIV
-	gpGetTextureHandleARB                         C.GPGETTEXTUREHANDLEARB
-	gpGetTextureImage                             C.GPGETTEXTUREIMAGE
-	gpGetTextureLevelParameterfv                  C.GPGETTEXTURELEVELPARAMETERFV
-	gpGetTextureLevelParameteriv                  C.GPGETTEXTURELEVELPARAMETERIV
-	gpGetTextureParameterIiv                      C.GPGETTEXTUREPARAMETERIIV
-	gpGetTextureParameterIuiv                     C.GPGETTEXTUREPARAMETERIUIV
-	gpGetTextureParameterfv                       C.GPGETTEXTUREPARAMETERFV
-	gpGetTextureParameteriv                       C.GPGETTEXTUREPARAMETERIV
-	gpGetTextureSamplerHandleARB                  C.GPGETTEXTURESAMPLERHANDLEARB
-	gpGetTextureSubImage                          C.GPGETTEXTURESUBIMAGE
-	gpGetTransformFeedbackVarying                 C.GPGETTRANSFORMFEEDBACKVARYING
-	gpGetTransformFeedbacki64_v                   C.GPGETTRANSFORMFEEDBACKI64_V
-	gpGetTransformFeedbacki_v                     C.GPGETTRANSFORMFEEDBACKI_V
-	gpGetTransformFeedbackiv                      C.GPGETTRANSFORMFEEDBACKIV
-	gpGetUniformBlockIndex                        C.GPGETUNIFORMBLOCKINDEX
-	gpGetUniformIndices                           C.GPGETUNIFORMINDICES
-	gpGetUniformLocation                          C.GPGETUNIFORMLOCATION
-	gpGetUniformSubroutineuiv                     C.GPGETUNIFORMSUBROUTINEUIV
-	gpGetUniformdv                                C.GPGETUNIFORMDV
-	gpGetUniformfv                                C.GPGETUNIFORMFV
-	gpGetUniformiv                                C.GPGETUNIFORMIV
-	gpGetUniformuiv                               C.GPGETUNIFORMUIV
-	gpGetVertexArrayIndexed64iv                   C.GPGETVERTEXARRAYINDEXED64IV
-	gpGetVertexArrayIndexediv                     C.GPGETVERTEXARRAYINDEXEDIV
-	gpGetVertexArrayiv                            C.GPGETVERTEXARRAYIV
-	gpGetVertexAttribIiv                          C.GPGETVERTEXATTRIBIIV
-	gpGetVertexAttribIuiv                         C.GPGETVERTEXATTRIBIUIV
-	gpGetVertexAttribLdv                          C.GPGETVERTEXATTRIBLDV
-	gpGetVertexAttribLui64vARB                    C.GPGETVERTEXATTRIBLUI64VARB
-	gpGetVertexAttribPointerv                     C.GPGETVERTEXATTRIBPOINTERV
-	gpGetVertexAttribdv                           C.GPGETVERTEXATTRIBDV
-	gpGetVertexAttribfv                           C.GPGETVERTEXATTRIBFV
-	gpGetVertexAttribiv                           C.GPGETVERTEXATTRIBIV
-	gpGetnCompressedTexImageARB                   C.GPGETNCOMPRESSEDTEXIMAGEARB
-	gpGetnTexImageARB                             C.GPGETNTEXIMAGEARB
-	gpGetnUniformdvARB                            C.GPGETNUNIFORMDVARB
-	gpGetnUniformfv                               C.GPGETNUNIFORMFV
-	gpGetnUniformfvARB                            C.GPGETNUNIFORMFVARB
-	gpGetnUniformfvKHR                            C.GPGETNUNIFORMFVKHR
-	gpGetnUniformiv                               C.GPGETNUNIFORMIV
-	gpGetnUniformivARB                            C.GPGETNUNIFORMIVARB
-	gpGetnUniformivKHR                            C.GPGETNUNIFORMIVKHR
-	gpGetnUniformuiv                              C.GPGETNUNIFORMUIV
-	gpGetnUniformuivARB                           C.GPGETNUNIFORMUIVARB
-	gpGetnUniformuivKHR                           C.GPGETNUNIFORMUIVKHR
-	gpHint                                        C.GPHINT
-	gpInvalidateBufferData                        C.GPINVALIDATEBUFFERDATA
-	gpInvalidateBufferSubData                     C.GPINVALIDATEBUFFERSUBDATA
-	gpInvalidateFramebuffer                       C.GPINVALIDATEFRAMEBUFFER
-	gpInvalidateNamedFramebufferData              C.GPINVALIDATENAMEDFRAMEBUFFERDATA
-	gpInvalidateNamedFramebufferSubData           C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
-	gpInvalidateSubFramebuffer                    C.GPINVALIDATESUBFRAMEBUFFER
-	gpInvalidateTexImage                          C.GPINVALIDATETEXIMAGE
-	gpInvalidateTexSubImage                       C.GPINVALIDATETEXSUBIMAGE
-	gpIsBuffer                                    C.GPISBUFFER
-	gpIsEnabled                                   C.GPISENABLED
-	gpIsEnabledi                                  C.GPISENABLEDI
-	gpIsFramebuffer                               C.GPISFRAMEBUFFER
-	gpIsImageHandleResidentARB                    C.GPISIMAGEHANDLERESIDENTARB
-	gpIsNamedStringARB                            C.GPISNAMEDSTRINGARB
-	gpIsProgram                                   C.GPISPROGRAM
-	gpIsProgramPipeline                           C.GPISPROGRAMPIPELINE
-	gpIsQuery                                     C.GPISQUERY
-	gpIsRenderbuffer                              C.GPISRENDERBUFFER
-	gpIsSampler                                   C.GPISSAMPLER
-	gpIsShader                                    C.GPISSHADER
-	gpIsSync                                      C.GPISSYNC
-	gpIsTexture                                   C.GPISTEXTURE
-	gpIsTextureHandleResidentARB                  C.GPISTEXTUREHANDLERESIDENTARB
-	gpIsTransformFeedback                         C.GPISTRANSFORMFEEDBACK
-	gpIsVertexArray                               C.GPISVERTEXARRAY
-	gpLineWidth                                   C.GPLINEWIDTH
-	gpLinkProgram                                 C.GPLINKPROGRAM
-	gpLogicOp                                     C.GPLOGICOP
-	gpMakeImageHandleNonResidentARB               C.GPMAKEIMAGEHANDLENONRESIDENTARB
-	gpMakeImageHandleResidentARB                  C.GPMAKEIMAGEHANDLERESIDENTARB
-	gpMakeTextureHandleNonResidentARB             C.GPMAKETEXTUREHANDLENONRESIDENTARB
-	gpMakeTextureHandleResidentARB                C.GPMAKETEXTUREHANDLERESIDENTARB
-	gpMapBuffer                                   C.GPMAPBUFFER
-	gpMapBufferRange                              C.GPMAPBUFFERRANGE
-	gpMapNamedBuffer                              C.GPMAPNAMEDBUFFER
-	gpMapNamedBufferRange                         C.GPMAPNAMEDBUFFERRANGE
-	gpMemoryBarrier                               C.GPMEMORYBARRIER
-	gpMemoryBarrierByRegion                       C.GPMEMORYBARRIERBYREGION
-	gpMinSampleShading                            C.GPMINSAMPLESHADING
-	gpMinSampleShadingARB                         C.GPMINSAMPLESHADINGARB
-	gpMultiDrawArrays                             C.GPMULTIDRAWARRAYS
-	gpMultiDrawArraysIndirect                     C.GPMULTIDRAWARRAYSINDIRECT
-	gpMultiDrawArraysIndirectCountARB             C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
-	gpMultiDrawElements                           C.GPMULTIDRAWELEMENTS
-	gpMultiDrawElementsBaseVertex                 C.GPMULTIDRAWELEMENTSBASEVERTEX
-	gpMultiDrawElementsIndirect                   C.GPMULTIDRAWELEMENTSINDIRECT
-	gpMultiDrawElementsIndirectCountARB           C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
-	gpNamedBufferData                             C.GPNAMEDBUFFERDATA
-	gpNamedBufferPageCommitmentARB                C.GPNAMEDBUFFERPAGECOMMITMENTARB
-	gpNamedBufferPageCommitmentEXT                C.GPNAMEDBUFFERPAGECOMMITMENTEXT
-	gpNamedBufferStorage                          C.GPNAMEDBUFFERSTORAGE
-	gpNamedBufferSubData                          C.GPNAMEDBUFFERSUBDATA
-	gpNamedFramebufferDrawBuffer                  C.GPNAMEDFRAMEBUFFERDRAWBUFFER
-	gpNamedFramebufferDrawBuffers                 C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
-	gpNamedFramebufferParameteri                  C.GPNAMEDFRAMEBUFFERPARAMETERI
-	gpNamedFramebufferReadBuffer                  C.GPNAMEDFRAMEBUFFERREADBUFFER
-	gpNamedFramebufferRenderbuffer                C.GPNAMEDFRAMEBUFFERRENDERBUFFER
-	gpNamedFramebufferTexture                     C.GPNAMEDFRAMEBUFFERTEXTURE
-	gpNamedFramebufferTextureLayer                C.GPNAMEDFRAMEBUFFERTEXTURELAYER
-	gpNamedRenderbufferStorage                    C.GPNAMEDRENDERBUFFERSTORAGE
-	gpNamedRenderbufferStorageMultisample         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
-	gpNamedStringARB                              C.GPNAMEDSTRINGARB
-	gpObjectLabel                                 C.GPOBJECTLABEL
-	gpObjectLabelKHR                              C.GPOBJECTLABELKHR
-	gpObjectPtrLabel                              C.GPOBJECTPTRLABEL
-	gpObjectPtrLabelKHR                           C.GPOBJECTPTRLABELKHR
-	gpPatchParameterfv                            C.GPPATCHPARAMETERFV
-	gpPatchParameteri                             C.GPPATCHPARAMETERI
-	gpPauseTransformFeedback                      C.GPPAUSETRANSFORMFEEDBACK
-	gpPixelStoref                                 C.GPPIXELSTOREF
-	gpPixelStorei                                 C.GPPIXELSTOREI
-	gpPointParameterf                             C.GPPOINTPARAMETERF
-	gpPointParameterfv                            C.GPPOINTPARAMETERFV
-	gpPointParameteri                             C.GPPOINTPARAMETERI
-	gpPointParameteriv                            C.GPPOINTPARAMETERIV
-	gpPointSize                                   C.GPPOINTSIZE
-	gpPolygonMode                                 C.GPPOLYGONMODE
-	gpPolygonOffset                               C.GPPOLYGONOFFSET
-	gpPopDebugGroup                               C.GPPOPDEBUGGROUP
-	gpPopDebugGroupKHR                            C.GPPOPDEBUGGROUPKHR
-	gpPrimitiveRestartIndex                       C.GPPRIMITIVERESTARTINDEX
-	gpProgramBinary                               C.GPPROGRAMBINARY
-	gpProgramParameteri                           C.GPPROGRAMPARAMETERI
-	gpProgramUniform1d                            C.GPPROGRAMUNIFORM1D
-	gpProgramUniform1dv                           C.GPPROGRAMUNIFORM1DV
-	gpProgramUniform1f                            C.GPPROGRAMUNIFORM1F
-	gpProgramUniform1fv                           C.GPPROGRAMUNIFORM1FV
-	gpProgramUniform1i                            C.GPPROGRAMUNIFORM1I
-	gpProgramUniform1iv                           C.GPPROGRAMUNIFORM1IV
-	gpProgramUniform1ui                           C.GPPROGRAMUNIFORM1UI
-	gpProgramUniform1uiv                          C.GPPROGRAMUNIFORM1UIV
-	gpProgramUniform2d                            C.GPPROGRAMUNIFORM2D
-	gpProgramUniform2dv                           C.GPPROGRAMUNIFORM2DV
-	gpProgramUniform2f                            C.GPPROGRAMUNIFORM2F
-	gpProgramUniform2fv                           C.GPPROGRAMUNIFORM2FV
-	gpProgramUniform2i                            C.GPPROGRAMUNIFORM2I
-	gpProgramUniform2iv                           C.GPPROGRAMUNIFORM2IV
-	gpProgramUniform2ui                           C.GPPROGRAMUNIFORM2UI
-	gpProgramUniform2uiv                          C.GPPROGRAMUNIFORM2UIV
-	gpProgramUniform3d                            C.GPPROGRAMUNIFORM3D
-	gpProgramUniform3dv                           C.GPPROGRAMUNIFORM3DV
-	gpProgramUniform3f                            C.GPPROGRAMUNIFORM3F
-	gpProgramUniform3fv                           C.GPPROGRAMUNIFORM3FV
-	gpProgramUniform3i                            C.GPPROGRAMUNIFORM3I
-	gpProgramUniform3iv                           C.GPPROGRAMUNIFORM3IV
-	gpProgramUniform3ui                           C.GPPROGRAMUNIFORM3UI
-	gpProgramUniform3uiv                          C.GPPROGRAMUNIFORM3UIV
-	gpProgramUniform4d                            C.GPPROGRAMUNIFORM4D
-	gpProgramUniform4dv                           C.GPPROGRAMUNIFORM4DV
-	gpProgramUniform4f                            C.GPPROGRAMUNIFORM4F
-	gpProgramUniform4fv                           C.GPPROGRAMUNIFORM4FV
-	gpProgramUniform4i                            C.GPPROGRAMUNIFORM4I
-	gpProgramUniform4iv                           C.GPPROGRAMUNIFORM4IV
-	gpProgramUniform4ui                           C.GPPROGRAMUNIFORM4UI
-	gpProgramUniform4uiv                          C.GPPROGRAMUNIFORM4UIV
-	gpProgramUniformHandleui64ARB                 C.GPPROGRAMUNIFORMHANDLEUI64ARB
-	gpProgramUniformHandleui64vARB                C.GPPROGRAMUNIFORMHANDLEUI64VARB
-	gpProgramUniformMatrix2dv                     C.GPPROGRAMUNIFORMMATRIX2DV
-	gpProgramUniformMatrix2fv                     C.GPPROGRAMUNIFORMMATRIX2FV
-	gpProgramUniformMatrix2x3dv                   C.GPPROGRAMUNIFORMMATRIX2X3DV
-	gpProgramUniformMatrix2x3fv                   C.GPPROGRAMUNIFORMMATRIX2X3FV
-	gpProgramUniformMatrix2x4dv                   C.GPPROGRAMUNIFORMMATRIX2X4DV
-	gpProgramUniformMatrix2x4fv                   C.GPPROGRAMUNIFORMMATRIX2X4FV
-	gpProgramUniformMatrix3dv                     C.GPPROGRAMUNIFORMMATRIX3DV
-	gpProgramUniformMatrix3fv                     C.GPPROGRAMUNIFORMMATRIX3FV
-	gpProgramUniformMatrix3x2dv                   C.GPPROGRAMUNIFORMMATRIX3X2DV
-	gpProgramUniformMatrix3x2fv                   C.GPPROGRAMUNIFORMMATRIX3X2FV
-	gpProgramUniformMatrix3x4dv                   C.GPPROGRAMUNIFORMMATRIX3X4DV
-	gpProgramUniformMatrix3x4fv                   C.GPPROGRAMUNIFORMMATRIX3X4FV
-	gpProgramUniformMatrix4dv                     C.GPPROGRAMUNIFORMMATRIX4DV
-	gpProgramUniformMatrix4fv                     C.GPPROGRAMUNIFORMMATRIX4FV
-	gpProgramUniformMatrix4x2dv                   C.GPPROGRAMUNIFORMMATRIX4X2DV
-	gpProgramUniformMatrix4x2fv                   C.GPPROGRAMUNIFORMMATRIX4X2FV
-	gpProgramUniformMatrix4x3dv                   C.GPPROGRAMUNIFORMMATRIX4X3DV
-	gpProgramUniformMatrix4x3fv                   C.GPPROGRAMUNIFORMMATRIX4X3FV
-	gpProvokingVertex                             C.GPPROVOKINGVERTEX
-	gpPushDebugGroup                              C.GPPUSHDEBUGGROUP
-	gpPushDebugGroupKHR                           C.GPPUSHDEBUGGROUPKHR
-	gpQueryCounter                                C.GPQUERYCOUNTER
-	gpReadBuffer                                  C.GPREADBUFFER
-	gpReadPixels                                  C.GPREADPIXELS
-	gpReadnPixels                                 C.GPREADNPIXELS
-	gpReadnPixelsARB                              C.GPREADNPIXELSARB
-	gpReadnPixelsKHR                              C.GPREADNPIXELSKHR
-	gpReleaseShaderCompiler                       C.GPRELEASESHADERCOMPILER
-	gpRenderbufferStorage                         C.GPRENDERBUFFERSTORAGE
-	gpRenderbufferStorageMultisample              C.GPRENDERBUFFERSTORAGEMULTISAMPLE
-	gpResumeTransformFeedback                     C.GPRESUMETRANSFORMFEEDBACK
-	gpSampleCoverage                              C.GPSAMPLECOVERAGE
-	gpSampleMaski                                 C.GPSAMPLEMASKI
-	gpSamplerParameterIiv                         C.GPSAMPLERPARAMETERIIV
-	gpSamplerParameterIuiv                        C.GPSAMPLERPARAMETERIUIV
-	gpSamplerParameterf                           C.GPSAMPLERPARAMETERF
-	gpSamplerParameterfv                          C.GPSAMPLERPARAMETERFV
-	gpSamplerParameteri                           C.GPSAMPLERPARAMETERI
-	gpSamplerParameteriv                          C.GPSAMPLERPARAMETERIV
-	gpScissor                                     C.GPSCISSOR
-	gpScissorArrayv                               C.GPSCISSORARRAYV
-	gpScissorIndexed                              C.GPSCISSORINDEXED
-	gpScissorIndexedv                             C.GPSCISSORINDEXEDV
-	gpShaderBinary                                C.GPSHADERBINARY
-	gpShaderSource                                C.GPSHADERSOURCE
-	gpShaderStorageBlockBinding                   C.GPSHADERSTORAGEBLOCKBINDING
-	gpStencilFunc                                 C.GPSTENCILFUNC
-	gpStencilFuncSeparate                         C.GPSTENCILFUNCSEPARATE
-	gpStencilMask                                 C.GPSTENCILMASK
-	gpStencilMaskSeparate                         C.GPSTENCILMASKSEPARATE
-	gpStencilOp                                   C.GPSTENCILOP
-	gpStencilOpSeparate                           C.GPSTENCILOPSEPARATE
-	gpTexBuffer                                   C.GPTEXBUFFER
-	gpTexBufferRange                              C.GPTEXBUFFERRANGE
-	gpTexImage1D                                  C.GPTEXIMAGE1D
-	gpTexImage2D                                  C.GPTEXIMAGE2D
-	gpTexImage2DMultisample                       C.GPTEXIMAGE2DMULTISAMPLE
-	gpTexImage3D                                  C.GPTEXIMAGE3D
-	gpTexImage3DMultisample                       C.GPTEXIMAGE3DMULTISAMPLE
-	gpTexPageCommitmentARB                        C.GPTEXPAGECOMMITMENTARB
-	gpTexParameterIiv                             C.GPTEXPARAMETERIIV
-	gpTexParameterIuiv                            C.GPTEXPARAMETERIUIV
-	gpTexParameterf                               C.GPTEXPARAMETERF
-	gpTexParameterfv                              C.GPTEXPARAMETERFV
-	gpTexParameteri                               C.GPTEXPARAMETERI
-	gpTexParameteriv                              C.GPTEXPARAMETERIV
-	gpTexStorage1D                                C.GPTEXSTORAGE1D
-	gpTexStorage2D                                C.GPTEXSTORAGE2D
-	gpTexStorage2DMultisample                     C.GPTEXSTORAGE2DMULTISAMPLE
-	gpTexStorage3D                                C.GPTEXSTORAGE3D
-	gpTexStorage3DMultisample                     C.GPTEXSTORAGE3DMULTISAMPLE
-	gpTexSubImage1D                               C.GPTEXSUBIMAGE1D
-	gpTexSubImage2D                               C.GPTEXSUBIMAGE2D
-	gpTexSubImage3D                               C.GPTEXSUBIMAGE3D
-	gpTextureBarrier                              C.GPTEXTUREBARRIER
-	gpTextureBuffer                               C.GPTEXTUREBUFFER
-	gpTextureBufferRange                          C.GPTEXTUREBUFFERRANGE
-	gpTextureParameterIiv                         C.GPTEXTUREPARAMETERIIV
-	gpTextureParameterIuiv                        C.GPTEXTUREPARAMETERIUIV
-	gpTextureParameterf                           C.GPTEXTUREPARAMETERF
-	gpTextureParameterfv                          C.GPTEXTUREPARAMETERFV
-	gpTextureParameteri                           C.GPTEXTUREPARAMETERI
-	gpTextureParameteriv                          C.GPTEXTUREPARAMETERIV
-	gpTextureStorage1D                            C.GPTEXTURESTORAGE1D
-	gpTextureStorage2D                            C.GPTEXTURESTORAGE2D
-	gpTextureStorage2DMultisample                 C.GPTEXTURESTORAGE2DMULTISAMPLE
-	gpTextureStorage3D                            C.GPTEXTURESTORAGE3D
-	gpTextureStorage3DMultisample                 C.GPTEXTURESTORAGE3DMULTISAMPLE
-	gpTextureSubImage1D                           C.GPTEXTURESUBIMAGE1D
-	gpTextureSubImage2D                           C.GPTEXTURESUBIMAGE2D
-	gpTextureSubImage3D                           C.GPTEXTURESUBIMAGE3D
-	gpTextureView                                 C.GPTEXTUREVIEW
-	gpTransformFeedbackBufferBase                 C.GPTRANSFORMFEEDBACKBUFFERBASE
-	gpTransformFeedbackBufferRange                C.GPTRANSFORMFEEDBACKBUFFERRANGE
-	gpTransformFeedbackVaryings                   C.GPTRANSFORMFEEDBACKVARYINGS
-	gpUniform1d                                   C.GPUNIFORM1D
-	gpUniform1dv                                  C.GPUNIFORM1DV
-	gpUniform1f                                   C.GPUNIFORM1F
-	gpUniform1fv                                  C.GPUNIFORM1FV
-	gpUniform1i                                   C.GPUNIFORM1I
-	gpUniform1iv                                  C.GPUNIFORM1IV
-	gpUniform1ui                                  C.GPUNIFORM1UI
-	gpUniform1uiv                                 C.GPUNIFORM1UIV
-	gpUniform2d                                   C.GPUNIFORM2D
-	gpUniform2dv                                  C.GPUNIFORM2DV
-	gpUniform2f                                   C.GPUNIFORM2F
-	gpUniform2fv                                  C.GPUNIFORM2FV
-	gpUniform2i                                   C.GPUNIFORM2I
-	gpUniform2iv                                  C.GPUNIFORM2IV
-	gpUniform2ui                                  C.GPUNIFORM2UI
-	gpUniform2uiv                                 C.GPUNIFORM2UIV
-	gpUniform3d                                   C.GPUNIFORM3D
-	gpUniform3dv                                  C.GPUNIFORM3DV
-	gpUniform3f                                   C.GPUNIFORM3F
-	gpUniform3fv                                  C.GPUNIFORM3FV
-	gpUniform3i                                   C.GPUNIFORM3I
-	gpUniform3iv                                  C.GPUNIFORM3IV
-	gpUniform3ui                                  C.GPUNIFORM3UI
-	gpUniform3uiv                                 C.GPUNIFORM3UIV
-	gpUniform4d                                   C.GPUNIFORM4D
-	gpUniform4dv                                  C.GPUNIFORM4DV
-	gpUniform4f                                   C.GPUNIFORM4F
-	gpUniform4fv                                  C.GPUNIFORM4FV
-	gpUniform4i                                   C.GPUNIFORM4I
-	gpUniform4iv                                  C.GPUNIFORM4IV
-	gpUniform4ui                                  C.GPUNIFORM4UI
-	gpUniform4uiv                                 C.GPUNIFORM4UIV
-	gpUniformBlockBinding                         C.GPUNIFORMBLOCKBINDING
-	gpUniformHandleui64ARB                        C.GPUNIFORMHANDLEUI64ARB
-	gpUniformHandleui64vARB                       C.GPUNIFORMHANDLEUI64VARB
-	gpUniformMatrix2dv                            C.GPUNIFORMMATRIX2DV
-	gpUniformMatrix2fv                            C.GPUNIFORMMATRIX2FV
-	gpUniformMatrix2x3dv                          C.GPUNIFORMMATRIX2X3DV
-	gpUniformMatrix2x3fv                          C.GPUNIFORMMATRIX2X3FV
-	gpUniformMatrix2x4dv                          C.GPUNIFORMMATRIX2X4DV
-	gpUniformMatrix2x4fv                          C.GPUNIFORMMATRIX2X4FV
-	gpUniformMatrix3dv                            C.GPUNIFORMMATRIX3DV
-	gpUniformMatrix3fv                            C.GPUNIFORMMATRIX3FV
-	gpUniformMatrix3x2dv                          C.GPUNIFORMMATRIX3X2DV
-	gpUniformMatrix3x2fv                          C.GPUNIFORMMATRIX3X2FV
-	gpUniformMatrix3x4dv                          C.GPUNIFORMMATRIX3X4DV
-	gpUniformMatrix3x4fv                          C.GPUNIFORMMATRIX3X4FV
-	gpUniformMatrix4dv                            C.GPUNIFORMMATRIX4DV
-	gpUniformMatrix4fv                            C.GPUNIFORMMATRIX4FV
-	gpUniformMatrix4x2dv                          C.GPUNIFORMMATRIX4X2DV
-	gpUniformMatrix4x2fv                          C.GPUNIFORMMATRIX4X2FV
-	gpUniformMatrix4x3dv                          C.GPUNIFORMMATRIX4X3DV
-	gpUniformMatrix4x3fv                          C.GPUNIFORMMATRIX4X3FV
-	gpUniformSubroutinesuiv                       C.GPUNIFORMSUBROUTINESUIV
-	gpUnmapBuffer                                 C.GPUNMAPBUFFER
-	gpUnmapNamedBuffer                            C.GPUNMAPNAMEDBUFFER
-	gpUseProgram                                  C.GPUSEPROGRAM
-	gpUseProgramStages                            C.GPUSEPROGRAMSTAGES
-	gpValidateProgram                             C.GPVALIDATEPROGRAM
-	gpValidateProgramPipeline                     C.GPVALIDATEPROGRAMPIPELINE
-	gpVertexArrayAttribBinding                    C.GPVERTEXARRAYATTRIBBINDING
-	gpVertexArrayAttribFormat                     C.GPVERTEXARRAYATTRIBFORMAT
-	gpVertexArrayAttribIFormat                    C.GPVERTEXARRAYATTRIBIFORMAT
-	gpVertexArrayAttribLFormat                    C.GPVERTEXARRAYATTRIBLFORMAT
-	gpVertexArrayBindingDivisor                   C.GPVERTEXARRAYBINDINGDIVISOR
-	gpVertexArrayElementBuffer                    C.GPVERTEXARRAYELEMENTBUFFER
-	gpVertexArrayVertexBuffer                     C.GPVERTEXARRAYVERTEXBUFFER
-	gpVertexArrayVertexBuffers                    C.GPVERTEXARRAYVERTEXBUFFERS
-	gpVertexAttrib1d                              C.GPVERTEXATTRIB1D
-	gpVertexAttrib1dv                             C.GPVERTEXATTRIB1DV
-	gpVertexAttrib1f                              C.GPVERTEXATTRIB1F
-	gpVertexAttrib1fv                             C.GPVERTEXATTRIB1FV
-	gpVertexAttrib1s                              C.GPVERTEXATTRIB1S
-	gpVertexAttrib1sv                             C.GPVERTEXATTRIB1SV
-	gpVertexAttrib2d                              C.GPVERTEXATTRIB2D
-	gpVertexAttrib2dv                             C.GPVERTEXATTRIB2DV
-	gpVertexAttrib2f                              C.GPVERTEXATTRIB2F
-	gpVertexAttrib2fv                             C.GPVERTEXATTRIB2FV
-	gpVertexAttrib2s                              C.GPVERTEXATTRIB2S
-	gpVertexAttrib2sv                             C.GPVERTEXATTRIB2SV
-	gpVertexAttrib3d                              C.GPVERTEXATTRIB3D
-	gpVertexAttrib3dv                             C.GPVERTEXATTRIB3DV
-	gpVertexAttrib3f                              C.GPVERTEXATTRIB3F
-	gpVertexAttrib3fv                             C.GPVERTEXATTRIB3FV
-	gpVertexAttrib3s                              C.GPVERTEXATTRIB3S
-	gpVertexAttrib3sv                             C.GPVERTEXATTRIB3SV
-	gpVertexAttrib4Nbv                            C.GPVERTEXATTRIB4NBV
-	gpVertexAttrib4Niv                            C.GPVERTEXATTRIB4NIV
-	gpVertexAttrib4Nsv                            C.GPVERTEXATTRIB4NSV
-	gpVertexAttrib4Nub                            C.GPVERTEXATTRIB4NUB
-	gpVertexAttrib4Nubv                           C.GPVERTEXATTRIB4NUBV
-	gpVertexAttrib4Nuiv                           C.GPVERTEXATTRIB4NUIV
-	gpVertexAttrib4Nusv                           C.GPVERTEXATTRIB4NUSV
-	gpVertexAttrib4bv                             C.GPVERTEXATTRIB4BV
-	gpVertexAttrib4d                              C.GPVERTEXATTRIB4D
-	gpVertexAttrib4dv                             C.GPVERTEXATTRIB4DV
-	gpVertexAttrib4f                              C.GPVERTEXATTRIB4F
-	gpVertexAttrib4fv                             C.GPVERTEXATTRIB4FV
-	gpVertexAttrib4iv                             C.GPVERTEXATTRIB4IV
-	gpVertexAttrib4s                              C.GPVERTEXATTRIB4S
-	gpVertexAttrib4sv                             C.GPVERTEXATTRIB4SV
-	gpVertexAttrib4ubv                            C.GPVERTEXATTRIB4UBV
-	gpVertexAttrib4uiv                            C.GPVERTEXATTRIB4UIV
-	gpVertexAttrib4usv                            C.GPVERTEXATTRIB4USV
-	gpVertexAttribBinding                         C.GPVERTEXATTRIBBINDING
-	gpVertexAttribDivisor                         C.GPVERTEXATTRIBDIVISOR
-	gpVertexAttribFormat                          C.GPVERTEXATTRIBFORMAT
-	gpVertexAttribI1i                             C.GPVERTEXATTRIBI1I
-	gpVertexAttribI1iv                            C.GPVERTEXATTRIBI1IV
-	gpVertexAttribI1ui                            C.GPVERTEXATTRIBI1UI
-	gpVertexAttribI1uiv                           C.GPVERTEXATTRIBI1UIV
-	gpVertexAttribI2i                             C.GPVERTEXATTRIBI2I
-	gpVertexAttribI2iv                            C.GPVERTEXATTRIBI2IV
-	gpVertexAttribI2ui                            C.GPVERTEXATTRIBI2UI
-	gpVertexAttribI2uiv                           C.GPVERTEXATTRIBI2UIV
-	gpVertexAttribI3i                             C.GPVERTEXATTRIBI3I
-	gpVertexAttribI3iv                            C.GPVERTEXATTRIBI3IV
-	gpVertexAttribI3ui                            C.GPVERTEXATTRIBI3UI
-	gpVertexAttribI3uiv                           C.GPVERTEXATTRIBI3UIV
-	gpVertexAttribI4bv                            C.GPVERTEXATTRIBI4BV
-	gpVertexAttribI4i                             C.GPVERTEXATTRIBI4I
-	gpVertexAttribI4iv                            C.GPVERTEXATTRIBI4IV
-	gpVertexAttribI4sv                            C.GPVERTEXATTRIBI4SV
-	gpVertexAttribI4ubv                           C.GPVERTEXATTRIBI4UBV
-	gpVertexAttribI4ui                            C.GPVERTEXATTRIBI4UI
-	gpVertexAttribI4uiv                           C.GPVERTEXATTRIBI4UIV
-	gpVertexAttribI4usv                           C.GPVERTEXATTRIBI4USV
-	gpVertexAttribIFormat                         C.GPVERTEXATTRIBIFORMAT
-	gpVertexAttribIPointer                        C.GPVERTEXATTRIBIPOINTER
-	gpVertexAttribL1d                             C.GPVERTEXATTRIBL1D
-	gpVertexAttribL1dv                            C.GPVERTEXATTRIBL1DV
-	gpVertexAttribL1ui64ARB                       C.GPVERTEXATTRIBL1UI64ARB
-	gpVertexAttribL1ui64vARB                      C.GPVERTEXATTRIBL1UI64VARB
-	gpVertexAttribL2d                             C.GPVERTEXATTRIBL2D
-	gpVertexAttribL2dv                            C.GPVERTEXATTRIBL2DV
-	gpVertexAttribL3d                             C.GPVERTEXATTRIBL3D
-	gpVertexAttribL3dv                            C.GPVERTEXATTRIBL3DV
-	gpVertexAttribL4d                             C.GPVERTEXATTRIBL4D
-	gpVertexAttribL4dv                            C.GPVERTEXATTRIBL4DV
-	gpVertexAttribLFormat                         C.GPVERTEXATTRIBLFORMAT
-	gpVertexAttribLPointer                        C.GPVERTEXATTRIBLPOINTER
-	gpVertexAttribP1ui                            C.GPVERTEXATTRIBP1UI
-	gpVertexAttribP1uiv                           C.GPVERTEXATTRIBP1UIV
-	gpVertexAttribP2ui                            C.GPVERTEXATTRIBP2UI
-	gpVertexAttribP2uiv                           C.GPVERTEXATTRIBP2UIV
-	gpVertexAttribP3ui                            C.GPVERTEXATTRIBP3UI
-	gpVertexAttribP3uiv                           C.GPVERTEXATTRIBP3UIV
-	gpVertexAttribP4ui                            C.GPVERTEXATTRIBP4UI
-	gpVertexAttribP4uiv                           C.GPVERTEXATTRIBP4UIV
-	gpVertexAttribPointer                         C.GPVERTEXATTRIBPOINTER
-	gpVertexBindingDivisor                        C.GPVERTEXBINDINGDIVISOR
-	gpViewport                                    C.GPVIEWPORT
-	gpViewportArrayv                              C.GPVIEWPORTARRAYV
-	gpViewportIndexedf                            C.GPVIEWPORTINDEXEDF
-	gpViewportIndexedfv                           C.GPVIEWPORTINDEXEDFV
-	gpWaitSync                                    C.GPWAITSYNC
+	gpActiveProgramEXT                               C.GPACTIVEPROGRAMEXT
+	gpActiveShaderProgram                            C.GPACTIVESHADERPROGRAM
+	gpActiveShaderProgramEXT                         C.GPACTIVESHADERPROGRAMEXT
+	gpActiveTexture                                  C.GPACTIVETEXTURE
+	gpApplyFramebufferAttachmentCMAAINTEL            C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
+	gpAttachShader                                   C.GPATTACHSHADER
+	gpBeginConditionalRender                         C.GPBEGINCONDITIONALRENDER
+	gpBeginConditionalRenderNV                       C.GPBEGINCONDITIONALRENDERNV
+	gpBeginPerfMonitorAMD                            C.GPBEGINPERFMONITORAMD
+	gpBeginPerfQueryINTEL                            C.GPBEGINPERFQUERYINTEL
+	gpBeginQuery                                     C.GPBEGINQUERY
+	gpBeginQueryIndexed                              C.GPBEGINQUERYINDEXED
+	gpBeginTransformFeedback                         C.GPBEGINTRANSFORMFEEDBACK
+	gpBindAttribLocation                             C.GPBINDATTRIBLOCATION
+	gpBindBuffer                                     C.GPBINDBUFFER
+	gpBindBufferBase                                 C.GPBINDBUFFERBASE
+	gpBindBufferRange                                C.GPBINDBUFFERRANGE
+	gpBindBuffersBase                                C.GPBINDBUFFERSBASE
+	gpBindBuffersRange                               C.GPBINDBUFFERSRANGE
+	gpBindFragDataLocation                           C.GPBINDFRAGDATALOCATION
+	gpBindFragDataLocationIndexed                    C.GPBINDFRAGDATALOCATIONINDEXED
+	gpBindFramebuffer                                C.GPBINDFRAMEBUFFER
+	gpBindImageTexture                               C.GPBINDIMAGETEXTURE
+	gpBindImageTextures                              C.GPBINDIMAGETEXTURES
+	gpBindMultiTextureEXT                            C.GPBINDMULTITEXTUREEXT
+	gpBindProgramPipeline                            C.GPBINDPROGRAMPIPELINE
+	gpBindProgramPipelineEXT                         C.GPBINDPROGRAMPIPELINEEXT
+	gpBindRenderbuffer                               C.GPBINDRENDERBUFFER
+	gpBindSampler                                    C.GPBINDSAMPLER
+	gpBindSamplers                                   C.GPBINDSAMPLERS
+	gpBindTexture                                    C.GPBINDTEXTURE
+	gpBindTextureUnit                                C.GPBINDTEXTUREUNIT
+	gpBindTextures                                   C.GPBINDTEXTURES
+	gpBindTransformFeedback                          C.GPBINDTRANSFORMFEEDBACK
+	gpBindVertexArray                                C.GPBINDVERTEXARRAY
+	gpBindVertexBuffer                               C.GPBINDVERTEXBUFFER
+	gpBindVertexBuffers                              C.GPBINDVERTEXBUFFERS
+	gpBlendBarrierKHR                                C.GPBLENDBARRIERKHR
+	gpBlendBarrierNV                                 C.GPBLENDBARRIERNV
+	gpBlendColor                                     C.GPBLENDCOLOR
+	gpBlendEquation                                  C.GPBLENDEQUATION
+	gpBlendEquationSeparate                          C.GPBLENDEQUATIONSEPARATE
+	gpBlendEquationSeparatei                         C.GPBLENDEQUATIONSEPARATEI
+	gpBlendEquationSeparateiARB                      C.GPBLENDEQUATIONSEPARATEIARB
+	gpBlendEquationi                                 C.GPBLENDEQUATIONI
+	gpBlendEquationiARB                              C.GPBLENDEQUATIONIARB
+	gpBlendFunc                                      C.GPBLENDFUNC
+	gpBlendFuncSeparate                              C.GPBLENDFUNCSEPARATE
+	gpBlendFuncSeparatei                             C.GPBLENDFUNCSEPARATEI
+	gpBlendFuncSeparateiARB                          C.GPBLENDFUNCSEPARATEIARB
+	gpBlendFunci                                     C.GPBLENDFUNCI
+	gpBlendFunciARB                                  C.GPBLENDFUNCIARB
+	gpBlendParameteriNV                              C.GPBLENDPARAMETERINV
+	gpBlitFramebuffer                                C.GPBLITFRAMEBUFFER
+	gpBlitNamedFramebuffer                           C.GPBLITNAMEDFRAMEBUFFER
+	gpBufferAddressRangeNV                           C.GPBUFFERADDRESSRANGENV
+	gpBufferData                                     C.GPBUFFERDATA
+	gpBufferPageCommitmentARB                        C.GPBUFFERPAGECOMMITMENTARB
+	gpBufferStorage                                  C.GPBUFFERSTORAGE
+	gpBufferSubData                                  C.GPBUFFERSUBDATA
+	gpCallCommandListNV                              C.GPCALLCOMMANDLISTNV
+	gpCheckFramebufferStatus                         C.GPCHECKFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatus                    C.GPCHECKNAMEDFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatusEXT                 C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT
+	gpClampColor                                     C.GPCLAMPCOLOR
+	gpClear                                          C.GPCLEAR
+	gpClearBufferData                                C.GPCLEARBUFFERDATA
+	gpClearBufferSubData                             C.GPCLEARBUFFERSUBDATA
+	gpClearBufferfi                                  C.GPCLEARBUFFERFI
+	gpClearBufferfv                                  C.GPCLEARBUFFERFV
+	gpClearBufferiv                                  C.GPCLEARBUFFERIV
+	gpClearBufferuiv                                 C.GPCLEARBUFFERUIV
+	gpClearColor                                     C.GPCLEARCOLOR
+	gpClearDepth                                     C.GPCLEARDEPTH
+	gpClearDepthf                                    C.GPCLEARDEPTHF
+	gpClearNamedBufferData                           C.GPCLEARNAMEDBUFFERDATA
+	gpClearNamedBufferDataEXT                        C.GPCLEARNAMEDBUFFERDATAEXT
+	gpClearNamedBufferSubData                        C.GPCLEARNAMEDBUFFERSUBDATA
+	gpClearNamedBufferSubDataEXT                     C.GPCLEARNAMEDBUFFERSUBDATAEXT
+	gpClearNamedFramebufferfi                        C.GPCLEARNAMEDFRAMEBUFFERFI
+	gpClearNamedFramebufferfv                        C.GPCLEARNAMEDFRAMEBUFFERFV
+	gpClearNamedFramebufferiv                        C.GPCLEARNAMEDFRAMEBUFFERIV
+	gpClearNamedFramebufferuiv                       C.GPCLEARNAMEDFRAMEBUFFERUIV
+	gpClearStencil                                   C.GPCLEARSTENCIL
+	gpClearTexImage                                  C.GPCLEARTEXIMAGE
+	gpClearTexSubImage                               C.GPCLEARTEXSUBIMAGE
+	gpClientAttribDefaultEXT                         C.GPCLIENTATTRIBDEFAULTEXT
+	gpClientWaitSync                                 C.GPCLIENTWAITSYNC
+	gpClipControl                                    C.GPCLIPCONTROL
+	gpColorFormatNV                                  C.GPCOLORFORMATNV
+	gpColorMask                                      C.GPCOLORMASK
+	gpColorMaski                                     C.GPCOLORMASKI
+	gpCommandListSegmentsNV                          C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                           C.GPCOMPILECOMMANDLISTNV
+	gpCompileShader                                  C.GPCOMPILESHADER
+	gpCompileShaderIncludeARB                        C.GPCOMPILESHADERINCLUDEARB
+	gpCompressedMultiTexImage1DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE1DEXT
+	gpCompressedMultiTexImage2DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE2DEXT
+	gpCompressedMultiTexImage3DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE3DEXT
+	gpCompressedMultiTexSubImage1DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT
+	gpCompressedMultiTexSubImage2DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT
+	gpCompressedMultiTexSubImage3DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT
+	gpCompressedTexImage1D                           C.GPCOMPRESSEDTEXIMAGE1D
+	gpCompressedTexImage2D                           C.GPCOMPRESSEDTEXIMAGE2D
+	gpCompressedTexImage3D                           C.GPCOMPRESSEDTEXIMAGE3D
+	gpCompressedTexSubImage1D                        C.GPCOMPRESSEDTEXSUBIMAGE1D
+	gpCompressedTexSubImage2D                        C.GPCOMPRESSEDTEXSUBIMAGE2D
+	gpCompressedTexSubImage3D                        C.GPCOMPRESSEDTEXSUBIMAGE3D
+	gpCompressedTextureImage1DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE1DEXT
+	gpCompressedTextureImage2DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE2DEXT
+	gpCompressedTextureImage3DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE3DEXT
+	gpCompressedTextureSubImage1D                    C.GPCOMPRESSEDTEXTURESUBIMAGE1D
+	gpCompressedTextureSubImage1DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT
+	gpCompressedTextureSubImage2D                    C.GPCOMPRESSEDTEXTURESUBIMAGE2D
+	gpCompressedTextureSubImage2DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
+	gpCompressedTextureSubImage3D                    C.GPCOMPRESSEDTEXTURESUBIMAGE3D
+	gpCompressedTextureSubImage3DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                 C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                 C.GPCONSERVATIVERASTERPARAMETERINV
+	gpCopyBufferSubData                              C.GPCOPYBUFFERSUBDATA
+	gpCopyImageSubData                               C.GPCOPYIMAGESUBDATA
+	gpCopyMultiTexImage1DEXT                         C.GPCOPYMULTITEXIMAGE1DEXT
+	gpCopyMultiTexImage2DEXT                         C.GPCOPYMULTITEXIMAGE2DEXT
+	gpCopyMultiTexSubImage1DEXT                      C.GPCOPYMULTITEXSUBIMAGE1DEXT
+	gpCopyMultiTexSubImage2DEXT                      C.GPCOPYMULTITEXSUBIMAGE2DEXT
+	gpCopyMultiTexSubImage3DEXT                      C.GPCOPYMULTITEXSUBIMAGE3DEXT
+	gpCopyNamedBufferSubData                         C.GPCOPYNAMEDBUFFERSUBDATA
+	gpCopyPathNV                                     C.GPCOPYPATHNV
+	gpCopyTexImage1D                                 C.GPCOPYTEXIMAGE1D
+	gpCopyTexImage2D                                 C.GPCOPYTEXIMAGE2D
+	gpCopyTexSubImage1D                              C.GPCOPYTEXSUBIMAGE1D
+	gpCopyTexSubImage2D                              C.GPCOPYTEXSUBIMAGE2D
+	gpCopyTexSubImage3D                              C.GPCOPYTEXSUBIMAGE3D
+	gpCopyTextureImage1DEXT                          C.GPCOPYTEXTUREIMAGE1DEXT
+	gpCopyTextureImage2DEXT                          C.GPCOPYTEXTUREIMAGE2DEXT
+	gpCopyTextureSubImage1D                          C.GPCOPYTEXTURESUBIMAGE1D
+	gpCopyTextureSubImage1DEXT                       C.GPCOPYTEXTURESUBIMAGE1DEXT
+	gpCopyTextureSubImage2D                          C.GPCOPYTEXTURESUBIMAGE2D
+	gpCopyTextureSubImage2DEXT                       C.GPCOPYTEXTURESUBIMAGE2DEXT
+	gpCopyTextureSubImage3D                          C.GPCOPYTEXTURESUBIMAGE3D
+	gpCopyTextureSubImage3DEXT                       C.GPCOPYTEXTURESUBIMAGE3DEXT
+	gpCoverFillPathInstancedNV                       C.GPCOVERFILLPATHINSTANCEDNV
+	gpCoverFillPathNV                                C.GPCOVERFILLPATHNV
+	gpCoverStrokePathInstancedNV                     C.GPCOVERSTROKEPATHINSTANCEDNV
+	gpCoverStrokePathNV                              C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                           C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                      C.GPCOVERAGEMODULATIONTABLENV
+	gpCreateBuffers                                  C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                           C.GPCREATECOMMANDLISTSNV
+	gpCreateFramebuffers                             C.GPCREATEFRAMEBUFFERS
+	gpCreatePerfQueryINTEL                           C.GPCREATEPERFQUERYINTEL
+	gpCreateProgram                                  C.GPCREATEPROGRAM
+	gpCreateProgramPipelines                         C.GPCREATEPROGRAMPIPELINES
+	gpCreateQueries                                  C.GPCREATEQUERIES
+	gpCreateRenderbuffers                            C.GPCREATERENDERBUFFERS
+	gpCreateSamplers                                 C.GPCREATESAMPLERS
+	gpCreateShader                                   C.GPCREATESHADER
+	gpCreateShaderProgramEXT                         C.GPCREATESHADERPROGRAMEXT
+	gpCreateShaderProgramv                           C.GPCREATESHADERPROGRAMV
+	gpCreateShaderProgramvEXT                        C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                 C.GPCREATESTATESNV
+	gpCreateSyncFromCLeventARB                       C.GPCREATESYNCFROMCLEVENTARB
+	gpCreateTextures                                 C.GPCREATETEXTURES
+	gpCreateTransformFeedbacks                       C.GPCREATETRANSFORMFEEDBACKS
+	gpCreateVertexArrays                             C.GPCREATEVERTEXARRAYS
+	gpCullFace                                       C.GPCULLFACE
+	gpDebugMessageCallback                           C.GPDEBUGMESSAGECALLBACK
+	gpDebugMessageCallbackARB                        C.GPDEBUGMESSAGECALLBACKARB
+	gpDebugMessageCallbackKHR                        C.GPDEBUGMESSAGECALLBACKKHR
+	gpDebugMessageControl                            C.GPDEBUGMESSAGECONTROL
+	gpDebugMessageControlARB                         C.GPDEBUGMESSAGECONTROLARB
+	gpDebugMessageControlKHR                         C.GPDEBUGMESSAGECONTROLKHR
+	gpDebugMessageInsert                             C.GPDEBUGMESSAGEINSERT
+	gpDebugMessageInsertARB                          C.GPDEBUGMESSAGEINSERTARB
+	gpDebugMessageInsertKHR                          C.GPDEBUGMESSAGEINSERTKHR
+	gpDeleteBuffers                                  C.GPDELETEBUFFERS
+	gpDeleteCommandListsNV                           C.GPDELETECOMMANDLISTSNV
+	gpDeleteFramebuffers                             C.GPDELETEFRAMEBUFFERS
+	gpDeleteNamedStringARB                           C.GPDELETENAMEDSTRINGARB
+	gpDeletePathsNV                                  C.GPDELETEPATHSNV
+	gpDeletePerfMonitorsAMD                          C.GPDELETEPERFMONITORSAMD
+	gpDeletePerfQueryINTEL                           C.GPDELETEPERFQUERYINTEL
+	gpDeleteProgram                                  C.GPDELETEPROGRAM
+	gpDeleteProgramPipelines                         C.GPDELETEPROGRAMPIPELINES
+	gpDeleteProgramPipelinesEXT                      C.GPDELETEPROGRAMPIPELINESEXT
+	gpDeleteQueries                                  C.GPDELETEQUERIES
+	gpDeleteRenderbuffers                            C.GPDELETERENDERBUFFERS
+	gpDeleteSamplers                                 C.GPDELETESAMPLERS
+	gpDeleteShader                                   C.GPDELETESHADER
+	gpDeleteStatesNV                                 C.GPDELETESTATESNV
+	gpDeleteSync                                     C.GPDELETESYNC
+	gpDeleteTextures                                 C.GPDELETETEXTURES
+	gpDeleteTransformFeedbacks                       C.GPDELETETRANSFORMFEEDBACKS
+	gpDeleteVertexArrays                             C.GPDELETEVERTEXARRAYS
+	gpDepthFunc                                      C.GPDEPTHFUNC
+	gpDepthMask                                      C.GPDEPTHMASK
+	gpDepthRange                                     C.GPDEPTHRANGE
+	gpDepthRangeArrayv                               C.GPDEPTHRANGEARRAYV
+	gpDepthRangeIndexed                              C.GPDEPTHRANGEINDEXED
+	gpDepthRangef                                    C.GPDEPTHRANGEF
+	gpDetachShader                                   C.GPDETACHSHADER
+	gpDisable                                        C.GPDISABLE
+	gpDisableClientStateIndexedEXT                   C.GPDISABLECLIENTSTATEINDEXEDEXT
+	gpDisableClientStateiEXT                         C.GPDISABLECLIENTSTATEIEXT
+	gpDisableIndexedEXT                              C.GPDISABLEINDEXEDEXT
+	gpDisableVertexArrayAttrib                       C.GPDISABLEVERTEXARRAYATTRIB
+	gpDisableVertexArrayAttribEXT                    C.GPDISABLEVERTEXARRAYATTRIBEXT
+	gpDisableVertexArrayEXT                          C.GPDISABLEVERTEXARRAYEXT
+	gpDisableVertexAttribArray                       C.GPDISABLEVERTEXATTRIBARRAY
+	gpDisablei                                       C.GPDISABLEI
+	gpDispatchCompute                                C.GPDISPATCHCOMPUTE
+	gpDispatchComputeGroupSizeARB                    C.GPDISPATCHCOMPUTEGROUPSIZEARB
+	gpDispatchComputeIndirect                        C.GPDISPATCHCOMPUTEINDIRECT
+	gpDrawArrays                                     C.GPDRAWARRAYS
+	gpDrawArraysIndirect                             C.GPDRAWARRAYSINDIRECT
+	gpDrawArraysInstanced                            C.GPDRAWARRAYSINSTANCED
+	gpDrawArraysInstancedARB                         C.GPDRAWARRAYSINSTANCEDARB
+	gpDrawArraysInstancedBaseInstance                C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
+	gpDrawArraysInstancedEXT                         C.GPDRAWARRAYSINSTANCEDEXT
+	gpDrawBuffer                                     C.GPDRAWBUFFER
+	gpDrawBuffers                                    C.GPDRAWBUFFERS
+	gpDrawCommandsAddressNV                          C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                 C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                    C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                           C.GPDRAWCOMMANDSSTATESNV
+	gpDrawElements                                   C.GPDRAWELEMENTS
+	gpDrawElementsBaseVertex                         C.GPDRAWELEMENTSBASEVERTEX
+	gpDrawElementsIndirect                           C.GPDRAWELEMENTSINDIRECT
+	gpDrawElementsInstanced                          C.GPDRAWELEMENTSINSTANCED
+	gpDrawElementsInstancedARB                       C.GPDRAWELEMENTSINSTANCEDARB
+	gpDrawElementsInstancedBaseInstance              C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
+	gpDrawElementsInstancedBaseVertex                C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
+	gpDrawElementsInstancedBaseVertexBaseInstance    C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
+	gpDrawElementsInstancedEXT                       C.GPDRAWELEMENTSINSTANCEDEXT
+	gpDrawRangeElements                              C.GPDRAWRANGEELEMENTS
+	gpDrawRangeElementsBaseVertex                    C.GPDRAWRANGEELEMENTSBASEVERTEX
+	gpDrawTransformFeedback                          C.GPDRAWTRANSFORMFEEDBACK
+	gpDrawTransformFeedbackInstanced                 C.GPDRAWTRANSFORMFEEDBACKINSTANCED
+	gpDrawTransformFeedbackStream                    C.GPDRAWTRANSFORMFEEDBACKSTREAM
+	gpDrawTransformFeedbackStreamInstanced           C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                  C.GPDRAWVKIMAGENV
+	gpEdgeFlagFormatNV                               C.GPEDGEFLAGFORMATNV
+	gpEnable                                         C.GPENABLE
+	gpEnableClientStateIndexedEXT                    C.GPENABLECLIENTSTATEINDEXEDEXT
+	gpEnableClientStateiEXT                          C.GPENABLECLIENTSTATEIEXT
+	gpEnableIndexedEXT                               C.GPENABLEINDEXEDEXT
+	gpEnableVertexArrayAttrib                        C.GPENABLEVERTEXARRAYATTRIB
+	gpEnableVertexArrayAttribEXT                     C.GPENABLEVERTEXARRAYATTRIBEXT
+	gpEnableVertexArrayEXT                           C.GPENABLEVERTEXARRAYEXT
+	gpEnableVertexAttribArray                        C.GPENABLEVERTEXATTRIBARRAY
+	gpEnablei                                        C.GPENABLEI
+	gpEndConditionalRender                           C.GPENDCONDITIONALRENDER
+	gpEndConditionalRenderNV                         C.GPENDCONDITIONALRENDERNV
+	gpEndPerfMonitorAMD                              C.GPENDPERFMONITORAMD
+	gpEndPerfQueryINTEL                              C.GPENDPERFQUERYINTEL
+	gpEndQuery                                       C.GPENDQUERY
+	gpEndQueryIndexed                                C.GPENDQUERYINDEXED
+	gpEndTransformFeedback                           C.GPENDTRANSFORMFEEDBACK
+	gpEvaluateDepthValuesARB                         C.GPEVALUATEDEPTHVALUESARB
+	gpFenceSync                                      C.GPFENCESYNC
+	gpFinish                                         C.GPFINISH
+	gpFlush                                          C.GPFLUSH
+	gpFlushMappedBufferRange                         C.GPFLUSHMAPPEDBUFFERRANGE
+	gpFlushMappedNamedBufferRange                    C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
+	gpFlushMappedNamedBufferRangeEXT                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT
+	gpFogCoordFormatNV                               C.GPFOGCOORDFORMATNV
+	gpFragmentCoverageColorNV                        C.GPFRAGMENTCOVERAGECOLORNV
+	gpFramebufferDrawBufferEXT                       C.GPFRAMEBUFFERDRAWBUFFEREXT
+	gpFramebufferDrawBuffersEXT                      C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                     C.GPFRAMEBUFFERFETCHBARRIEREXT
+	gpFramebufferParameteri                          C.GPFRAMEBUFFERPARAMETERI
+	gpFramebufferReadBufferEXT                       C.GPFRAMEBUFFERREADBUFFEREXT
+	gpFramebufferRenderbuffer                        C.GPFRAMEBUFFERRENDERBUFFER
+	gpFramebufferSampleLocationsfvARB                C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                 C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferTexture                             C.GPFRAMEBUFFERTEXTURE
+	gpFramebufferTexture1D                           C.GPFRAMEBUFFERTEXTURE1D
+	gpFramebufferTexture2D                           C.GPFRAMEBUFFERTEXTURE2D
+	gpFramebufferTexture3D                           C.GPFRAMEBUFFERTEXTURE3D
+	gpFramebufferTextureARB                          C.GPFRAMEBUFFERTEXTUREARB
+	gpFramebufferTextureFaceARB                      C.GPFRAMEBUFFERTEXTUREFACEARB
+	gpFramebufferTextureLayer                        C.GPFRAMEBUFFERTEXTURELAYER
+	gpFramebufferTextureLayerARB                     C.GPFRAMEBUFFERTEXTURELAYERARB
+	gpFramebufferTextureMultiviewOVR                 C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
+	gpFrontFace                                      C.GPFRONTFACE
+	gpGenBuffers                                     C.GPGENBUFFERS
+	gpGenFramebuffers                                C.GPGENFRAMEBUFFERS
+	gpGenPathsNV                                     C.GPGENPATHSNV
+	gpGenPerfMonitorsAMD                             C.GPGENPERFMONITORSAMD
+	gpGenProgramPipelines                            C.GPGENPROGRAMPIPELINES
+	gpGenProgramPipelinesEXT                         C.GPGENPROGRAMPIPELINESEXT
+	gpGenQueries                                     C.GPGENQUERIES
+	gpGenRenderbuffers                               C.GPGENRENDERBUFFERS
+	gpGenSamplers                                    C.GPGENSAMPLERS
+	gpGenTextures                                    C.GPGENTEXTURES
+	gpGenTransformFeedbacks                          C.GPGENTRANSFORMFEEDBACKS
+	gpGenVertexArrays                                C.GPGENVERTEXARRAYS
+	gpGenerateMipmap                                 C.GPGENERATEMIPMAP
+	gpGenerateMultiTexMipmapEXT                      C.GPGENERATEMULTITEXMIPMAPEXT
+	gpGenerateTextureMipmap                          C.GPGENERATETEXTUREMIPMAP
+	gpGenerateTextureMipmapEXT                       C.GPGENERATETEXTUREMIPMAPEXT
+	gpGetActiveAtomicCounterBufferiv                 C.GPGETACTIVEATOMICCOUNTERBUFFERIV
+	gpGetActiveAttrib                                C.GPGETACTIVEATTRIB
+	gpGetActiveSubroutineName                        C.GPGETACTIVESUBROUTINENAME
+	gpGetActiveSubroutineUniformName                 C.GPGETACTIVESUBROUTINEUNIFORMNAME
+	gpGetActiveSubroutineUniformiv                   C.GPGETACTIVESUBROUTINEUNIFORMIV
+	gpGetActiveUniform                               C.GPGETACTIVEUNIFORM
+	gpGetActiveUniformBlockName                      C.GPGETACTIVEUNIFORMBLOCKNAME
+	gpGetActiveUniformBlockiv                        C.GPGETACTIVEUNIFORMBLOCKIV
+	gpGetActiveUniformName                           C.GPGETACTIVEUNIFORMNAME
+	gpGetActiveUniformsiv                            C.GPGETACTIVEUNIFORMSIV
+	gpGetAttachedShaders                             C.GPGETATTACHEDSHADERS
+	gpGetAttribLocation                              C.GPGETATTRIBLOCATION
+	gpGetBooleanIndexedvEXT                          C.GPGETBOOLEANINDEXEDVEXT
+	gpGetBooleani_v                                  C.GPGETBOOLEANI_V
+	gpGetBooleanv                                    C.GPGETBOOLEANV
+	gpGetBufferParameteri64v                         C.GPGETBUFFERPARAMETERI64V
+	gpGetBufferParameteriv                           C.GPGETBUFFERPARAMETERIV
+	gpGetBufferParameterui64vNV                      C.GPGETBUFFERPARAMETERUI64VNV
+	gpGetBufferPointerv                              C.GPGETBUFFERPOINTERV
+	gpGetBufferSubData                               C.GPGETBUFFERSUBDATA
+	gpGetCommandHeaderNV                             C.GPGETCOMMANDHEADERNV
+	gpGetCompressedMultiTexImageEXT                  C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
+	gpGetCompressedTexImage                          C.GPGETCOMPRESSEDTEXIMAGE
+	gpGetCompressedTextureImage                      C.GPGETCOMPRESSEDTEXTUREIMAGE
+	gpGetCompressedTextureImageEXT                   C.GPGETCOMPRESSEDTEXTUREIMAGEEXT
+	gpGetCompressedTextureSubImage                   C.GPGETCOMPRESSEDTEXTURESUBIMAGE
+	gpGetCoverageModulationTableNV                   C.GPGETCOVERAGEMODULATIONTABLENV
+	gpGetDebugMessageLog                             C.GPGETDEBUGMESSAGELOG
+	gpGetDebugMessageLogARB                          C.GPGETDEBUGMESSAGELOGARB
+	gpGetDebugMessageLogKHR                          C.GPGETDEBUGMESSAGELOGKHR
+	gpGetDoubleIndexedvEXT                           C.GPGETDOUBLEINDEXEDVEXT
+	gpGetDoublei_v                                   C.GPGETDOUBLEI_V
+	gpGetDoublei_vEXT                                C.GPGETDOUBLEI_VEXT
+	gpGetDoublev                                     C.GPGETDOUBLEV
+	gpGetError                                       C.GPGETERROR
+	gpGetFirstPerfQueryIdINTEL                       C.GPGETFIRSTPERFQUERYIDINTEL
+	gpGetFloatIndexedvEXT                            C.GPGETFLOATINDEXEDVEXT
+	gpGetFloati_v                                    C.GPGETFLOATI_V
+	gpGetFloati_vEXT                                 C.GPGETFLOATI_VEXT
+	gpGetFloatv                                      C.GPGETFLOATV
+	gpGetFragDataIndex                               C.GPGETFRAGDATAINDEX
+	gpGetFragDataLocation                            C.GPGETFRAGDATALOCATION
+	gpGetFramebufferAttachmentParameteriv            C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetFramebufferParameteriv                      C.GPGETFRAMEBUFFERPARAMETERIV
+	gpGetFramebufferParameterivEXT                   C.GPGETFRAMEBUFFERPARAMETERIVEXT
+	gpGetGraphicsResetStatus                         C.GPGETGRAPHICSRESETSTATUS
+	gpGetGraphicsResetStatusARB                      C.GPGETGRAPHICSRESETSTATUSARB
+	gpGetGraphicsResetStatusKHR                      C.GPGETGRAPHICSRESETSTATUSKHR
+	gpGetImageHandleARB                              C.GPGETIMAGEHANDLEARB
+	gpGetImageHandleNV                               C.GPGETIMAGEHANDLENV
+	gpGetInteger64i_v                                C.GPGETINTEGER64I_V
+	gpGetInteger64v                                  C.GPGETINTEGER64V
+	gpGetIntegerIndexedvEXT                          C.GPGETINTEGERINDEXEDVEXT
+	gpGetIntegeri_v                                  C.GPGETINTEGERI_V
+	gpGetIntegerui64i_vNV                            C.GPGETINTEGERUI64I_VNV
+	gpGetIntegerui64vNV                              C.GPGETINTEGERUI64VNV
+	gpGetIntegerv                                    C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                    C.GPGETINTERNALFORMATSAMPLEIVNV
+	gpGetInternalformati64v                          C.GPGETINTERNALFORMATI64V
+	gpGetInternalformativ                            C.GPGETINTERNALFORMATIV
+	gpGetMultiTexEnvfvEXT                            C.GPGETMULTITEXENVFVEXT
+	gpGetMultiTexEnvivEXT                            C.GPGETMULTITEXENVIVEXT
+	gpGetMultiTexGendvEXT                            C.GPGETMULTITEXGENDVEXT
+	gpGetMultiTexGenfvEXT                            C.GPGETMULTITEXGENFVEXT
+	gpGetMultiTexGenivEXT                            C.GPGETMULTITEXGENIVEXT
+	gpGetMultiTexImageEXT                            C.GPGETMULTITEXIMAGEEXT
+	gpGetMultiTexLevelParameterfvEXT                 C.GPGETMULTITEXLEVELPARAMETERFVEXT
+	gpGetMultiTexLevelParameterivEXT                 C.GPGETMULTITEXLEVELPARAMETERIVEXT
+	gpGetMultiTexParameterIivEXT                     C.GPGETMULTITEXPARAMETERIIVEXT
+	gpGetMultiTexParameterIuivEXT                    C.GPGETMULTITEXPARAMETERIUIVEXT
+	gpGetMultiTexParameterfvEXT                      C.GPGETMULTITEXPARAMETERFVEXT
+	gpGetMultiTexParameterivEXT                      C.GPGETMULTITEXPARAMETERIVEXT
+	gpGetMultisamplefv                               C.GPGETMULTISAMPLEFV
+	gpGetNamedBufferParameteri64v                    C.GPGETNAMEDBUFFERPARAMETERI64V
+	gpGetNamedBufferParameteriv                      C.GPGETNAMEDBUFFERPARAMETERIV
+	gpGetNamedBufferParameterivEXT                   C.GPGETNAMEDBUFFERPARAMETERIVEXT
+	gpGetNamedBufferParameterui64vNV                 C.GPGETNAMEDBUFFERPARAMETERUI64VNV
+	gpGetNamedBufferPointerv                         C.GPGETNAMEDBUFFERPOINTERV
+	gpGetNamedBufferPointervEXT                      C.GPGETNAMEDBUFFERPOINTERVEXT
+	gpGetNamedBufferSubData                          C.GPGETNAMEDBUFFERSUBDATA
+	gpGetNamedBufferSubDataEXT                       C.GPGETNAMEDBUFFERSUBDATAEXT
+	gpGetNamedFramebufferAttachmentParameteriv       C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetNamedFramebufferAttachmentParameterivEXT    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameteriv                 C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
+	gpGetNamedFramebufferParameterivEXT              C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
+	gpGetNamedProgramLocalParameterIivEXT            C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
+	gpGetNamedProgramLocalParameterIuivEXT           C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT
+	gpGetNamedProgramLocalParameterdvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT
+	gpGetNamedProgramLocalParameterfvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT
+	gpGetNamedProgramStringEXT                       C.GPGETNAMEDPROGRAMSTRINGEXT
+	gpGetNamedProgramivEXT                           C.GPGETNAMEDPROGRAMIVEXT
+	gpGetNamedRenderbufferParameteriv                C.GPGETNAMEDRENDERBUFFERPARAMETERIV
+	gpGetNamedRenderbufferParameterivEXT             C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT
+	gpGetNamedStringARB                              C.GPGETNAMEDSTRINGARB
+	gpGetNamedStringivARB                            C.GPGETNAMEDSTRINGIVARB
+	gpGetNextPerfQueryIdINTEL                        C.GPGETNEXTPERFQUERYIDINTEL
+	gpGetObjectLabel                                 C.GPGETOBJECTLABEL
+	gpGetObjectLabelEXT                              C.GPGETOBJECTLABELEXT
+	gpGetObjectLabelKHR                              C.GPGETOBJECTLABELKHR
+	gpGetObjectPtrLabel                              C.GPGETOBJECTPTRLABEL
+	gpGetObjectPtrLabelKHR                           C.GPGETOBJECTPTRLABELKHR
+	gpGetPathCommandsNV                              C.GPGETPATHCOMMANDSNV
+	gpGetPathCoordsNV                                C.GPGETPATHCOORDSNV
+	gpGetPathDashArrayNV                             C.GPGETPATHDASHARRAYNV
+	gpGetPathLengthNV                                C.GPGETPATHLENGTHNV
+	gpGetPathMetricRangeNV                           C.GPGETPATHMETRICRANGENV
+	gpGetPathMetricsNV                               C.GPGETPATHMETRICSNV
+	gpGetPathParameterfvNV                           C.GPGETPATHPARAMETERFVNV
+	gpGetPathParameterivNV                           C.GPGETPATHPARAMETERIVNV
+	gpGetPathSpacingNV                               C.GPGETPATHSPACINGNV
+	gpGetPerfCounterInfoINTEL                        C.GPGETPERFCOUNTERINFOINTEL
+	gpGetPerfMonitorCounterDataAMD                   C.GPGETPERFMONITORCOUNTERDATAAMD
+	gpGetPerfMonitorCounterInfoAMD                   C.GPGETPERFMONITORCOUNTERINFOAMD
+	gpGetPerfMonitorCounterStringAMD                 C.GPGETPERFMONITORCOUNTERSTRINGAMD
+	gpGetPerfMonitorCountersAMD                      C.GPGETPERFMONITORCOUNTERSAMD
+	gpGetPerfMonitorGroupStringAMD                   C.GPGETPERFMONITORGROUPSTRINGAMD
+	gpGetPerfMonitorGroupsAMD                        C.GPGETPERFMONITORGROUPSAMD
+	gpGetPerfQueryDataINTEL                          C.GPGETPERFQUERYDATAINTEL
+	gpGetPerfQueryIdByNameINTEL                      C.GPGETPERFQUERYIDBYNAMEINTEL
+	gpGetPerfQueryInfoINTEL                          C.GPGETPERFQUERYINFOINTEL
+	gpGetPointerIndexedvEXT                          C.GPGETPOINTERINDEXEDVEXT
+	gpGetPointeri_vEXT                               C.GPGETPOINTERI_VEXT
+	gpGetPointerv                                    C.GPGETPOINTERV
+	gpGetPointervKHR                                 C.GPGETPOINTERVKHR
+	gpGetProgramBinary                               C.GPGETPROGRAMBINARY
+	gpGetProgramInfoLog                              C.GPGETPROGRAMINFOLOG
+	gpGetProgramInterfaceiv                          C.GPGETPROGRAMINTERFACEIV
+	gpGetProgramPipelineInfoLog                      C.GPGETPROGRAMPIPELINEINFOLOG
+	gpGetProgramPipelineInfoLogEXT                   C.GPGETPROGRAMPIPELINEINFOLOGEXT
+	gpGetProgramPipelineiv                           C.GPGETPROGRAMPIPELINEIV
+	gpGetProgramPipelineivEXT                        C.GPGETPROGRAMPIPELINEIVEXT
+	gpGetProgramResourceIndex                        C.GPGETPROGRAMRESOURCEINDEX
+	gpGetProgramResourceLocation                     C.GPGETPROGRAMRESOURCELOCATION
+	gpGetProgramResourceLocationIndex                C.GPGETPROGRAMRESOURCELOCATIONINDEX
+	gpGetProgramResourceName                         C.GPGETPROGRAMRESOURCENAME
+	gpGetProgramResourcefvNV                         C.GPGETPROGRAMRESOURCEFVNV
+	gpGetProgramResourceiv                           C.GPGETPROGRAMRESOURCEIV
+	gpGetProgramStageiv                              C.GPGETPROGRAMSTAGEIV
+	gpGetProgramiv                                   C.GPGETPROGRAMIV
+	gpGetQueryBufferObjecti64v                       C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                         C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                      C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                        C.GPGETQUERYBUFFEROBJECTUIV
+	gpGetQueryIndexediv                              C.GPGETQUERYINDEXEDIV
+	gpGetQueryObjecti64v                             C.GPGETQUERYOBJECTI64V
+	gpGetQueryObjectiv                               C.GPGETQUERYOBJECTIV
+	gpGetQueryObjectui64v                            C.GPGETQUERYOBJECTUI64V
+	gpGetQueryObjectuiv                              C.GPGETQUERYOBJECTUIV
+	gpGetQueryiv                                     C.GPGETQUERYIV
+	gpGetRenderbufferParameteriv                     C.GPGETRENDERBUFFERPARAMETERIV
+	gpGetSamplerParameterIiv                         C.GPGETSAMPLERPARAMETERIIV
+	gpGetSamplerParameterIuiv                        C.GPGETSAMPLERPARAMETERIUIV
+	gpGetSamplerParameterfv                          C.GPGETSAMPLERPARAMETERFV
+	gpGetSamplerParameteriv                          C.GPGETSAMPLERPARAMETERIV
+	gpGetShaderInfoLog                               C.GPGETSHADERINFOLOG
+	gpGetShaderPrecisionFormat                       C.GPGETSHADERPRECISIONFORMAT
+	gpGetShaderSource                                C.GPGETSHADERSOURCE
+	gpGetShaderiv                                    C.GPGETSHADERIV
+	gpGetStageIndexNV                                C.GPGETSTAGEINDEXNV
+	gpGetString                                      C.GPGETSTRING
+	gpGetStringi                                     C.GPGETSTRINGI
+	gpGetSubroutineIndex                             C.GPGETSUBROUTINEINDEX
+	gpGetSubroutineUniformLocation                   C.GPGETSUBROUTINEUNIFORMLOCATION
+	gpGetSynciv                                      C.GPGETSYNCIV
+	gpGetTexImage                                    C.GPGETTEXIMAGE
+	gpGetTexLevelParameterfv                         C.GPGETTEXLEVELPARAMETERFV
+	gpGetTexLevelParameteriv                         C.GPGETTEXLEVELPARAMETERIV
+	gpGetTexParameterIiv                             C.GPGETTEXPARAMETERIIV
+	gpGetTexParameterIuiv                            C.GPGETTEXPARAMETERIUIV
+	gpGetTexParameterfv                              C.GPGETTEXPARAMETERFV
+	gpGetTexParameteriv                              C.GPGETTEXPARAMETERIV
+	gpGetTextureHandleARB                            C.GPGETTEXTUREHANDLEARB
+	gpGetTextureHandleNV                             C.GPGETTEXTUREHANDLENV
+	gpGetTextureImage                                C.GPGETTEXTUREIMAGE
+	gpGetTextureImageEXT                             C.GPGETTEXTUREIMAGEEXT
+	gpGetTextureLevelParameterfv                     C.GPGETTEXTURELEVELPARAMETERFV
+	gpGetTextureLevelParameterfvEXT                  C.GPGETTEXTURELEVELPARAMETERFVEXT
+	gpGetTextureLevelParameteriv                     C.GPGETTEXTURELEVELPARAMETERIV
+	gpGetTextureLevelParameterivEXT                  C.GPGETTEXTURELEVELPARAMETERIVEXT
+	gpGetTextureParameterIiv                         C.GPGETTEXTUREPARAMETERIIV
+	gpGetTextureParameterIivEXT                      C.GPGETTEXTUREPARAMETERIIVEXT
+	gpGetTextureParameterIuiv                        C.GPGETTEXTUREPARAMETERIUIV
+	gpGetTextureParameterIuivEXT                     C.GPGETTEXTUREPARAMETERIUIVEXT
+	gpGetTextureParameterfv                          C.GPGETTEXTUREPARAMETERFV
+	gpGetTextureParameterfvEXT                       C.GPGETTEXTUREPARAMETERFVEXT
+	gpGetTextureParameteriv                          C.GPGETTEXTUREPARAMETERIV
+	gpGetTextureParameterivEXT                       C.GPGETTEXTUREPARAMETERIVEXT
+	gpGetTextureSamplerHandleARB                     C.GPGETTEXTURESAMPLERHANDLEARB
+	gpGetTextureSamplerHandleNV                      C.GPGETTEXTURESAMPLERHANDLENV
+	gpGetTextureSubImage                             C.GPGETTEXTURESUBIMAGE
+	gpGetTransformFeedbackVarying                    C.GPGETTRANSFORMFEEDBACKVARYING
+	gpGetTransformFeedbacki64_v                      C.GPGETTRANSFORMFEEDBACKI64_V
+	gpGetTransformFeedbacki_v                        C.GPGETTRANSFORMFEEDBACKI_V
+	gpGetTransformFeedbackiv                         C.GPGETTRANSFORMFEEDBACKIV
+	gpGetUniformBlockIndex                           C.GPGETUNIFORMBLOCKINDEX
+	gpGetUniformIndices                              C.GPGETUNIFORMINDICES
+	gpGetUniformLocation                             C.GPGETUNIFORMLOCATION
+	gpGetUniformSubroutineuiv                        C.GPGETUNIFORMSUBROUTINEUIV
+	gpGetUniformdv                                   C.GPGETUNIFORMDV
+	gpGetUniformfv                                   C.GPGETUNIFORMFV
+	gpGetUniformi64vARB                              C.GPGETUNIFORMI64VARB
+	gpGetUniformi64vNV                               C.GPGETUNIFORMI64VNV
+	gpGetUniformiv                                   C.GPGETUNIFORMIV
+	gpGetUniformui64vARB                             C.GPGETUNIFORMUI64VARB
+	gpGetUniformui64vNV                              C.GPGETUNIFORMUI64VNV
+	gpGetUniformuiv                                  C.GPGETUNIFORMUIV
+	gpGetVertexArrayIndexed64iv                      C.GPGETVERTEXARRAYINDEXED64IV
+	gpGetVertexArrayIndexediv                        C.GPGETVERTEXARRAYINDEXEDIV
+	gpGetVertexArrayIntegeri_vEXT                    C.GPGETVERTEXARRAYINTEGERI_VEXT
+	gpGetVertexArrayIntegervEXT                      C.GPGETVERTEXARRAYINTEGERVEXT
+	gpGetVertexArrayPointeri_vEXT                    C.GPGETVERTEXARRAYPOINTERI_VEXT
+	gpGetVertexArrayPointervEXT                      C.GPGETVERTEXARRAYPOINTERVEXT
+	gpGetVertexArrayiv                               C.GPGETVERTEXARRAYIV
+	gpGetVertexAttribIiv                             C.GPGETVERTEXATTRIBIIV
+	gpGetVertexAttribIuiv                            C.GPGETVERTEXATTRIBIUIV
+	gpGetVertexAttribLdv                             C.GPGETVERTEXATTRIBLDV
+	gpGetVertexAttribLi64vNV                         C.GPGETVERTEXATTRIBLI64VNV
+	gpGetVertexAttribLui64vARB                       C.GPGETVERTEXATTRIBLUI64VARB
+	gpGetVertexAttribLui64vNV                        C.GPGETVERTEXATTRIBLUI64VNV
+	gpGetVertexAttribPointerv                        C.GPGETVERTEXATTRIBPOINTERV
+	gpGetVertexAttribdv                              C.GPGETVERTEXATTRIBDV
+	gpGetVertexAttribfv                              C.GPGETVERTEXATTRIBFV
+	gpGetVertexAttribiv                              C.GPGETVERTEXATTRIBIV
+	gpGetVkProcAddrNV                                C.GPGETVKPROCADDRNV
+	gpGetnCompressedTexImageARB                      C.GPGETNCOMPRESSEDTEXIMAGEARB
+	gpGetnTexImageARB                                C.GPGETNTEXIMAGEARB
+	gpGetnUniformdvARB                               C.GPGETNUNIFORMDVARB
+	gpGetnUniformfv                                  C.GPGETNUNIFORMFV
+	gpGetnUniformfvARB                               C.GPGETNUNIFORMFVARB
+	gpGetnUniformfvKHR                               C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                             C.GPGETNUNIFORMI64VARB
+	gpGetnUniformiv                                  C.GPGETNUNIFORMIV
+	gpGetnUniformivARB                               C.GPGETNUNIFORMIVARB
+	gpGetnUniformivKHR                               C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                            C.GPGETNUNIFORMUI64VARB
+	gpGetnUniformuiv                                 C.GPGETNUNIFORMUIV
+	gpGetnUniformuivARB                              C.GPGETNUNIFORMUIVARB
+	gpGetnUniformuivKHR                              C.GPGETNUNIFORMUIVKHR
+	gpHint                                           C.GPHINT
+	gpIndexFormatNV                                  C.GPINDEXFORMATNV
+	gpInsertEventMarkerEXT                           C.GPINSERTEVENTMARKEREXT
+	gpInterpolatePathsNV                             C.GPINTERPOLATEPATHSNV
+	gpInvalidateBufferData                           C.GPINVALIDATEBUFFERDATA
+	gpInvalidateBufferSubData                        C.GPINVALIDATEBUFFERSUBDATA
+	gpInvalidateFramebuffer                          C.GPINVALIDATEFRAMEBUFFER
+	gpInvalidateNamedFramebufferData                 C.GPINVALIDATENAMEDFRAMEBUFFERDATA
+	gpInvalidateNamedFramebufferSubData              C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
+	gpInvalidateSubFramebuffer                       C.GPINVALIDATESUBFRAMEBUFFER
+	gpInvalidateTexImage                             C.GPINVALIDATETEXIMAGE
+	gpInvalidateTexSubImage                          C.GPINVALIDATETEXSUBIMAGE
+	gpIsBuffer                                       C.GPISBUFFER
+	gpIsBufferResidentNV                             C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                C.GPISCOMMANDLISTNV
+	gpIsEnabled                                      C.GPISENABLED
+	gpIsEnabledIndexedEXT                            C.GPISENABLEDINDEXEDEXT
+	gpIsEnabledi                                     C.GPISENABLEDI
+	gpIsFramebuffer                                  C.GPISFRAMEBUFFER
+	gpIsImageHandleResidentARB                       C.GPISIMAGEHANDLERESIDENTARB
+	gpIsImageHandleResidentNV                        C.GPISIMAGEHANDLERESIDENTNV
+	gpIsNamedBufferResidentNV                        C.GPISNAMEDBUFFERRESIDENTNV
+	gpIsNamedStringARB                               C.GPISNAMEDSTRINGARB
+	gpIsPathNV                                       C.GPISPATHNV
+	gpIsPointInFillPathNV                            C.GPISPOINTINFILLPATHNV
+	gpIsPointInStrokePathNV                          C.GPISPOINTINSTROKEPATHNV
+	gpIsProgram                                      C.GPISPROGRAM
+	gpIsProgramPipeline                              C.GPISPROGRAMPIPELINE
+	gpIsProgramPipelineEXT                           C.GPISPROGRAMPIPELINEEXT
+	gpIsQuery                                        C.GPISQUERY
+	gpIsRenderbuffer                                 C.GPISRENDERBUFFER
+	gpIsSampler                                      C.GPISSAMPLER
+	gpIsShader                                       C.GPISSHADER
+	gpIsStateNV                                      C.GPISSTATENV
+	gpIsSync                                         C.GPISSYNC
+	gpIsTexture                                      C.GPISTEXTURE
+	gpIsTextureHandleResidentARB                     C.GPISTEXTUREHANDLERESIDENTARB
+	gpIsTextureHandleResidentNV                      C.GPISTEXTUREHANDLERESIDENTNV
+	gpIsTransformFeedback                            C.GPISTRANSFORMFEEDBACK
+	gpIsVertexArray                                  C.GPISVERTEXARRAY
+	gpLabelObjectEXT                                 C.GPLABELOBJECTEXT
+	gpLineWidth                                      C.GPLINEWIDTH
+	gpLinkProgram                                    C.GPLINKPROGRAM
+	gpListDrawCommandsStatesClientNV                 C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
+	gpLogicOp                                        C.GPLOGICOP
+	gpMakeBufferNonResidentNV                        C.GPMAKEBUFFERNONRESIDENTNV
+	gpMakeBufferResidentNV                           C.GPMAKEBUFFERRESIDENTNV
+	gpMakeImageHandleNonResidentARB                  C.GPMAKEIMAGEHANDLENONRESIDENTARB
+	gpMakeImageHandleNonResidentNV                   C.GPMAKEIMAGEHANDLENONRESIDENTNV
+	gpMakeImageHandleResidentARB                     C.GPMAKEIMAGEHANDLERESIDENTARB
+	gpMakeImageHandleResidentNV                      C.GPMAKEIMAGEHANDLERESIDENTNV
+	gpMakeNamedBufferNonResidentNV                   C.GPMAKENAMEDBUFFERNONRESIDENTNV
+	gpMakeNamedBufferResidentNV                      C.GPMAKENAMEDBUFFERRESIDENTNV
+	gpMakeTextureHandleNonResidentARB                C.GPMAKETEXTUREHANDLENONRESIDENTARB
+	gpMakeTextureHandleNonResidentNV                 C.GPMAKETEXTUREHANDLENONRESIDENTNV
+	gpMakeTextureHandleResidentARB                   C.GPMAKETEXTUREHANDLERESIDENTARB
+	gpMakeTextureHandleResidentNV                    C.GPMAKETEXTUREHANDLERESIDENTNV
+	gpMapBuffer                                      C.GPMAPBUFFER
+	gpMapBufferRange                                 C.GPMAPBUFFERRANGE
+	gpMapNamedBuffer                                 C.GPMAPNAMEDBUFFER
+	gpMapNamedBufferEXT                              C.GPMAPNAMEDBUFFEREXT
+	gpMapNamedBufferRange                            C.GPMAPNAMEDBUFFERRANGE
+	gpMapNamedBufferRangeEXT                         C.GPMAPNAMEDBUFFERRANGEEXT
+	gpMatrixFrustumEXT                               C.GPMATRIXFRUSTUMEXT
+	gpMatrixLoad3x2fNV                               C.GPMATRIXLOAD3X2FNV
+	gpMatrixLoad3x3fNV                               C.GPMATRIXLOAD3X3FNV
+	gpMatrixLoadIdentityEXT                          C.GPMATRIXLOADIDENTITYEXT
+	gpMatrixLoadTranspose3x3fNV                      C.GPMATRIXLOADTRANSPOSE3X3FNV
+	gpMatrixLoadTransposedEXT                        C.GPMATRIXLOADTRANSPOSEDEXT
+	gpMatrixLoadTransposefEXT                        C.GPMATRIXLOADTRANSPOSEFEXT
+	gpMatrixLoaddEXT                                 C.GPMATRIXLOADDEXT
+	gpMatrixLoadfEXT                                 C.GPMATRIXLOADFEXT
+	gpMatrixMult3x2fNV                               C.GPMATRIXMULT3X2FNV
+	gpMatrixMult3x3fNV                               C.GPMATRIXMULT3X3FNV
+	gpMatrixMultTranspose3x3fNV                      C.GPMATRIXMULTTRANSPOSE3X3FNV
+	gpMatrixMultTransposedEXT                        C.GPMATRIXMULTTRANSPOSEDEXT
+	gpMatrixMultTransposefEXT                        C.GPMATRIXMULTTRANSPOSEFEXT
+	gpMatrixMultdEXT                                 C.GPMATRIXMULTDEXT
+	gpMatrixMultfEXT                                 C.GPMATRIXMULTFEXT
+	gpMatrixOrthoEXT                                 C.GPMATRIXORTHOEXT
+	gpMatrixPopEXT                                   C.GPMATRIXPOPEXT
+	gpMatrixPushEXT                                  C.GPMATRIXPUSHEXT
+	gpMatrixRotatedEXT                               C.GPMATRIXROTATEDEXT
+	gpMatrixRotatefEXT                               C.GPMATRIXROTATEFEXT
+	gpMatrixScaledEXT                                C.GPMATRIXSCALEDEXT
+	gpMatrixScalefEXT                                C.GPMATRIXSCALEFEXT
+	gpMatrixTranslatedEXT                            C.GPMATRIXTRANSLATEDEXT
+	gpMatrixTranslatefEXT                            C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                    C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                    C.GPMAXSHADERCOMPILERTHREADSKHR
+	gpMemoryBarrier                                  C.GPMEMORYBARRIER
+	gpMemoryBarrierByRegion                          C.GPMEMORYBARRIERBYREGION
+	gpMinSampleShading                               C.GPMINSAMPLESHADING
+	gpMinSampleShadingARB                            C.GPMINSAMPLESHADINGARB
+	gpMultiDrawArrays                                C.GPMULTIDRAWARRAYS
+	gpMultiDrawArraysIndirect                        C.GPMULTIDRAWARRAYSINDIRECT
+	gpMultiDrawArraysIndirectBindlessCountNV         C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawArraysIndirectBindlessNV              C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV
+	gpMultiDrawArraysIndirectCountARB                C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
+	gpMultiDrawElements                              C.GPMULTIDRAWELEMENTS
+	gpMultiDrawElementsBaseVertex                    C.GPMULTIDRAWELEMENTSBASEVERTEX
+	gpMultiDrawElementsIndirect                      C.GPMULTIDRAWELEMENTSINDIRECT
+	gpMultiDrawElementsIndirectBindlessCountNV       C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawElementsIndirectBindlessNV            C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV
+	gpMultiDrawElementsIndirectCountARB              C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
+	gpMultiTexBufferEXT                              C.GPMULTITEXBUFFEREXT
+	gpMultiTexCoordPointerEXT                        C.GPMULTITEXCOORDPOINTEREXT
+	gpMultiTexEnvfEXT                                C.GPMULTITEXENVFEXT
+	gpMultiTexEnvfvEXT                               C.GPMULTITEXENVFVEXT
+	gpMultiTexEnviEXT                                C.GPMULTITEXENVIEXT
+	gpMultiTexEnvivEXT                               C.GPMULTITEXENVIVEXT
+	gpMultiTexGendEXT                                C.GPMULTITEXGENDEXT
+	gpMultiTexGendvEXT                               C.GPMULTITEXGENDVEXT
+	gpMultiTexGenfEXT                                C.GPMULTITEXGENFEXT
+	gpMultiTexGenfvEXT                               C.GPMULTITEXGENFVEXT
+	gpMultiTexGeniEXT                                C.GPMULTITEXGENIEXT
+	gpMultiTexGenivEXT                               C.GPMULTITEXGENIVEXT
+	gpMultiTexImage1DEXT                             C.GPMULTITEXIMAGE1DEXT
+	gpMultiTexImage2DEXT                             C.GPMULTITEXIMAGE2DEXT
+	gpMultiTexImage3DEXT                             C.GPMULTITEXIMAGE3DEXT
+	gpMultiTexParameterIivEXT                        C.GPMULTITEXPARAMETERIIVEXT
+	gpMultiTexParameterIuivEXT                       C.GPMULTITEXPARAMETERIUIVEXT
+	gpMultiTexParameterfEXT                          C.GPMULTITEXPARAMETERFEXT
+	gpMultiTexParameterfvEXT                         C.GPMULTITEXPARAMETERFVEXT
+	gpMultiTexParameteriEXT                          C.GPMULTITEXPARAMETERIEXT
+	gpMultiTexParameterivEXT                         C.GPMULTITEXPARAMETERIVEXT
+	gpMultiTexRenderbufferEXT                        C.GPMULTITEXRENDERBUFFEREXT
+	gpMultiTexSubImage1DEXT                          C.GPMULTITEXSUBIMAGE1DEXT
+	gpMultiTexSubImage2DEXT                          C.GPMULTITEXSUBIMAGE2DEXT
+	gpMultiTexSubImage3DEXT                          C.GPMULTITEXSUBIMAGE3DEXT
+	gpNamedBufferData                                C.GPNAMEDBUFFERDATA
+	gpNamedBufferDataEXT                             C.GPNAMEDBUFFERDATAEXT
+	gpNamedBufferPageCommitmentARB                   C.GPNAMEDBUFFERPAGECOMMITMENTARB
+	gpNamedBufferPageCommitmentEXT                   C.GPNAMEDBUFFERPAGECOMMITMENTEXT
+	gpNamedBufferStorage                             C.GPNAMEDBUFFERSTORAGE
+	gpNamedBufferStorageEXT                          C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferSubData                             C.GPNAMEDBUFFERSUBDATA
+	gpNamedBufferSubDataEXT                          C.GPNAMEDBUFFERSUBDATAEXT
+	gpNamedCopyBufferSubDataEXT                      C.GPNAMEDCOPYBUFFERSUBDATAEXT
+	gpNamedFramebufferDrawBuffer                     C.GPNAMEDFRAMEBUFFERDRAWBUFFER
+	gpNamedFramebufferDrawBuffers                    C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
+	gpNamedFramebufferParameteri                     C.GPNAMEDFRAMEBUFFERPARAMETERI
+	gpNamedFramebufferParameteriEXT                  C.GPNAMEDFRAMEBUFFERPARAMETERIEXT
+	gpNamedFramebufferReadBuffer                     C.GPNAMEDFRAMEBUFFERREADBUFFER
+	gpNamedFramebufferRenderbuffer                   C.GPNAMEDFRAMEBUFFERRENDERBUFFER
+	gpNamedFramebufferRenderbufferEXT                C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB           C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV            C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferTexture                        C.GPNAMEDFRAMEBUFFERTEXTURE
+	gpNamedFramebufferTexture1DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
+	gpNamedFramebufferTexture2DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
+	gpNamedFramebufferTexture3DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT
+	gpNamedFramebufferTextureEXT                     C.GPNAMEDFRAMEBUFFERTEXTUREEXT
+	gpNamedFramebufferTextureFaceEXT                 C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT
+	gpNamedFramebufferTextureLayer                   C.GPNAMEDFRAMEBUFFERTEXTURELAYER
+	gpNamedFramebufferTextureLayerEXT                C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT
+	gpNamedProgramLocalParameter4dEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT
+	gpNamedProgramLocalParameter4dvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT
+	gpNamedProgramLocalParameter4fEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT
+	gpNamedProgramLocalParameter4fvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT
+	gpNamedProgramLocalParameterI4iEXT               C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT
+	gpNamedProgramLocalParameterI4ivEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT
+	gpNamedProgramLocalParameterI4uiEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT
+	gpNamedProgramLocalParameterI4uivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT
+	gpNamedProgramLocalParameters4fvEXT              C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT
+	gpNamedProgramLocalParametersI4ivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT
+	gpNamedProgramLocalParametersI4uivEXT            C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT
+	gpNamedProgramStringEXT                          C.GPNAMEDPROGRAMSTRINGEXT
+	gpNamedRenderbufferStorage                       C.GPNAMEDRENDERBUFFERSTORAGE
+	gpNamedRenderbufferStorageEXT                    C.GPNAMEDRENDERBUFFERSTORAGEEXT
+	gpNamedRenderbufferStorageMultisample            C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
+	gpNamedRenderbufferStorageMultisampleCoverageEXT C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT
+	gpNamedRenderbufferStorageMultisampleEXT         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT
+	gpNamedStringARB                                 C.GPNAMEDSTRINGARB
+	gpNormalFormatNV                                 C.GPNORMALFORMATNV
+	gpObjectLabel                                    C.GPOBJECTLABEL
+	gpObjectLabelKHR                                 C.GPOBJECTLABELKHR
+	gpObjectPtrLabel                                 C.GPOBJECTPTRLABEL
+	gpObjectPtrLabelKHR                              C.GPOBJECTPTRLABELKHR
+	gpPatchParameterfv                               C.GPPATCHPARAMETERFV
+	gpPatchParameteri                                C.GPPATCHPARAMETERI
+	gpPathCommandsNV                                 C.GPPATHCOMMANDSNV
+	gpPathCoordsNV                                   C.GPPATHCOORDSNV
+	gpPathCoverDepthFuncNV                           C.GPPATHCOVERDEPTHFUNCNV
+	gpPathDashArrayNV                                C.GPPATHDASHARRAYNV
+	gpPathGlyphIndexArrayNV                          C.GPPATHGLYPHINDEXARRAYNV
+	gpPathGlyphIndexRangeNV                          C.GPPATHGLYPHINDEXRANGENV
+	gpPathGlyphRangeNV                               C.GPPATHGLYPHRANGENV
+	gpPathGlyphsNV                                   C.GPPATHGLYPHSNV
+	gpPathMemoryGlyphIndexArrayNV                    C.GPPATHMEMORYGLYPHINDEXARRAYNV
+	gpPathParameterfNV                               C.GPPATHPARAMETERFNV
+	gpPathParameterfvNV                              C.GPPATHPARAMETERFVNV
+	gpPathParameteriNV                               C.GPPATHPARAMETERINV
+	gpPathParameterivNV                              C.GPPATHPARAMETERIVNV
+	gpPathStencilDepthOffsetNV                       C.GPPATHSTENCILDEPTHOFFSETNV
+	gpPathStencilFuncNV                              C.GPPATHSTENCILFUNCNV
+	gpPathStringNV                                   C.GPPATHSTRINGNV
+	gpPathSubCommandsNV                              C.GPPATHSUBCOMMANDSNV
+	gpPathSubCoordsNV                                C.GPPATHSUBCOORDSNV
+	gpPauseTransformFeedback                         C.GPPAUSETRANSFORMFEEDBACK
+	gpPixelStoref                                    C.GPPIXELSTOREF
+	gpPixelStorei                                    C.GPPIXELSTOREI
+	gpPointAlongPathNV                               C.GPPOINTALONGPATHNV
+	gpPointParameterf                                C.GPPOINTPARAMETERF
+	gpPointParameterfv                               C.GPPOINTPARAMETERFV
+	gpPointParameteri                                C.GPPOINTPARAMETERI
+	gpPointParameteriv                               C.GPPOINTPARAMETERIV
+	gpPointSize                                      C.GPPOINTSIZE
+	gpPolygonMode                                    C.GPPOLYGONMODE
+	gpPolygonOffset                                  C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                             C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                          C.GPPOLYGONOFFSETCLAMPEXT
+	gpPopDebugGroup                                  C.GPPOPDEBUGGROUP
+	gpPopDebugGroupKHR                               C.GPPOPDEBUGGROUPKHR
+	gpPopGroupMarkerEXT                              C.GPPOPGROUPMARKEREXT
+	gpPrimitiveBoundingBoxARB                        C.GPPRIMITIVEBOUNDINGBOXARB
+	gpPrimitiveRestartIndex                          C.GPPRIMITIVERESTARTINDEX
+	gpProgramBinary                                  C.GPPROGRAMBINARY
+	gpProgramParameteri                              C.GPPROGRAMPARAMETERI
+	gpProgramParameteriARB                           C.GPPROGRAMPARAMETERIARB
+	gpProgramParameteriEXT                           C.GPPROGRAMPARAMETERIEXT
+	gpProgramPathFragmentInputGenNV                  C.GPPROGRAMPATHFRAGMENTINPUTGENNV
+	gpProgramUniform1d                               C.GPPROGRAMUNIFORM1D
+	gpProgramUniform1dEXT                            C.GPPROGRAMUNIFORM1DEXT
+	gpProgramUniform1dv                              C.GPPROGRAMUNIFORM1DV
+	gpProgramUniform1dvEXT                           C.GPPROGRAMUNIFORM1DVEXT
+	gpProgramUniform1f                               C.GPPROGRAMUNIFORM1F
+	gpProgramUniform1fEXT                            C.GPPROGRAMUNIFORM1FEXT
+	gpProgramUniform1fv                              C.GPPROGRAMUNIFORM1FV
+	gpProgramUniform1fvEXT                           C.GPPROGRAMUNIFORM1FVEXT
+	gpProgramUniform1i                               C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                          C.GPPROGRAMUNIFORM1I64ARB
+	gpProgramUniform1i64NV                           C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                         C.GPPROGRAMUNIFORM1I64VARB
+	gpProgramUniform1i64vNV                          C.GPPROGRAMUNIFORM1I64VNV
+	gpProgramUniform1iEXT                            C.GPPROGRAMUNIFORM1IEXT
+	gpProgramUniform1iv                              C.GPPROGRAMUNIFORM1IV
+	gpProgramUniform1ivEXT                           C.GPPROGRAMUNIFORM1IVEXT
+	gpProgramUniform1ui                              C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                         C.GPPROGRAMUNIFORM1UI64ARB
+	gpProgramUniform1ui64NV                          C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                        C.GPPROGRAMUNIFORM1UI64VARB
+	gpProgramUniform1ui64vNV                         C.GPPROGRAMUNIFORM1UI64VNV
+	gpProgramUniform1uiEXT                           C.GPPROGRAMUNIFORM1UIEXT
+	gpProgramUniform1uiv                             C.GPPROGRAMUNIFORM1UIV
+	gpProgramUniform1uivEXT                          C.GPPROGRAMUNIFORM1UIVEXT
+	gpProgramUniform2d                               C.GPPROGRAMUNIFORM2D
+	gpProgramUniform2dEXT                            C.GPPROGRAMUNIFORM2DEXT
+	gpProgramUniform2dv                              C.GPPROGRAMUNIFORM2DV
+	gpProgramUniform2dvEXT                           C.GPPROGRAMUNIFORM2DVEXT
+	gpProgramUniform2f                               C.GPPROGRAMUNIFORM2F
+	gpProgramUniform2fEXT                            C.GPPROGRAMUNIFORM2FEXT
+	gpProgramUniform2fv                              C.GPPROGRAMUNIFORM2FV
+	gpProgramUniform2fvEXT                           C.GPPROGRAMUNIFORM2FVEXT
+	gpProgramUniform2i                               C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                          C.GPPROGRAMUNIFORM2I64ARB
+	gpProgramUniform2i64NV                           C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                         C.GPPROGRAMUNIFORM2I64VARB
+	gpProgramUniform2i64vNV                          C.GPPROGRAMUNIFORM2I64VNV
+	gpProgramUniform2iEXT                            C.GPPROGRAMUNIFORM2IEXT
+	gpProgramUniform2iv                              C.GPPROGRAMUNIFORM2IV
+	gpProgramUniform2ivEXT                           C.GPPROGRAMUNIFORM2IVEXT
+	gpProgramUniform2ui                              C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                         C.GPPROGRAMUNIFORM2UI64ARB
+	gpProgramUniform2ui64NV                          C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                        C.GPPROGRAMUNIFORM2UI64VARB
+	gpProgramUniform2ui64vNV                         C.GPPROGRAMUNIFORM2UI64VNV
+	gpProgramUniform2uiEXT                           C.GPPROGRAMUNIFORM2UIEXT
+	gpProgramUniform2uiv                             C.GPPROGRAMUNIFORM2UIV
+	gpProgramUniform2uivEXT                          C.GPPROGRAMUNIFORM2UIVEXT
+	gpProgramUniform3d                               C.GPPROGRAMUNIFORM3D
+	gpProgramUniform3dEXT                            C.GPPROGRAMUNIFORM3DEXT
+	gpProgramUniform3dv                              C.GPPROGRAMUNIFORM3DV
+	gpProgramUniform3dvEXT                           C.GPPROGRAMUNIFORM3DVEXT
+	gpProgramUniform3f                               C.GPPROGRAMUNIFORM3F
+	gpProgramUniform3fEXT                            C.GPPROGRAMUNIFORM3FEXT
+	gpProgramUniform3fv                              C.GPPROGRAMUNIFORM3FV
+	gpProgramUniform3fvEXT                           C.GPPROGRAMUNIFORM3FVEXT
+	gpProgramUniform3i                               C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                          C.GPPROGRAMUNIFORM3I64ARB
+	gpProgramUniform3i64NV                           C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                         C.GPPROGRAMUNIFORM3I64VARB
+	gpProgramUniform3i64vNV                          C.GPPROGRAMUNIFORM3I64VNV
+	gpProgramUniform3iEXT                            C.GPPROGRAMUNIFORM3IEXT
+	gpProgramUniform3iv                              C.GPPROGRAMUNIFORM3IV
+	gpProgramUniform3ivEXT                           C.GPPROGRAMUNIFORM3IVEXT
+	gpProgramUniform3ui                              C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                         C.GPPROGRAMUNIFORM3UI64ARB
+	gpProgramUniform3ui64NV                          C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                        C.GPPROGRAMUNIFORM3UI64VARB
+	gpProgramUniform3ui64vNV                         C.GPPROGRAMUNIFORM3UI64VNV
+	gpProgramUniform3uiEXT                           C.GPPROGRAMUNIFORM3UIEXT
+	gpProgramUniform3uiv                             C.GPPROGRAMUNIFORM3UIV
+	gpProgramUniform3uivEXT                          C.GPPROGRAMUNIFORM3UIVEXT
+	gpProgramUniform4d                               C.GPPROGRAMUNIFORM4D
+	gpProgramUniform4dEXT                            C.GPPROGRAMUNIFORM4DEXT
+	gpProgramUniform4dv                              C.GPPROGRAMUNIFORM4DV
+	gpProgramUniform4dvEXT                           C.GPPROGRAMUNIFORM4DVEXT
+	gpProgramUniform4f                               C.GPPROGRAMUNIFORM4F
+	gpProgramUniform4fEXT                            C.GPPROGRAMUNIFORM4FEXT
+	gpProgramUniform4fv                              C.GPPROGRAMUNIFORM4FV
+	gpProgramUniform4fvEXT                           C.GPPROGRAMUNIFORM4FVEXT
+	gpProgramUniform4i                               C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                          C.GPPROGRAMUNIFORM4I64ARB
+	gpProgramUniform4i64NV                           C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                         C.GPPROGRAMUNIFORM4I64VARB
+	gpProgramUniform4i64vNV                          C.GPPROGRAMUNIFORM4I64VNV
+	gpProgramUniform4iEXT                            C.GPPROGRAMUNIFORM4IEXT
+	gpProgramUniform4iv                              C.GPPROGRAMUNIFORM4IV
+	gpProgramUniform4ivEXT                           C.GPPROGRAMUNIFORM4IVEXT
+	gpProgramUniform4ui                              C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                         C.GPPROGRAMUNIFORM4UI64ARB
+	gpProgramUniform4ui64NV                          C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                        C.GPPROGRAMUNIFORM4UI64VARB
+	gpProgramUniform4ui64vNV                         C.GPPROGRAMUNIFORM4UI64VNV
+	gpProgramUniform4uiEXT                           C.GPPROGRAMUNIFORM4UIEXT
+	gpProgramUniform4uiv                             C.GPPROGRAMUNIFORM4UIV
+	gpProgramUniform4uivEXT                          C.GPPROGRAMUNIFORM4UIVEXT
+	gpProgramUniformHandleui64ARB                    C.GPPROGRAMUNIFORMHANDLEUI64ARB
+	gpProgramUniformHandleui64NV                     C.GPPROGRAMUNIFORMHANDLEUI64NV
+	gpProgramUniformHandleui64vARB                   C.GPPROGRAMUNIFORMHANDLEUI64VARB
+	gpProgramUniformHandleui64vNV                    C.GPPROGRAMUNIFORMHANDLEUI64VNV
+	gpProgramUniformMatrix2dv                        C.GPPROGRAMUNIFORMMATRIX2DV
+	gpProgramUniformMatrix2dvEXT                     C.GPPROGRAMUNIFORMMATRIX2DVEXT
+	gpProgramUniformMatrix2fv                        C.GPPROGRAMUNIFORMMATRIX2FV
+	gpProgramUniformMatrix2fvEXT                     C.GPPROGRAMUNIFORMMATRIX2FVEXT
+	gpProgramUniformMatrix2x3dv                      C.GPPROGRAMUNIFORMMATRIX2X3DV
+	gpProgramUniformMatrix2x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3DVEXT
+	gpProgramUniformMatrix2x3fv                      C.GPPROGRAMUNIFORMMATRIX2X3FV
+	gpProgramUniformMatrix2x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3FVEXT
+	gpProgramUniformMatrix2x4dv                      C.GPPROGRAMUNIFORMMATRIX2X4DV
+	gpProgramUniformMatrix2x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4DVEXT
+	gpProgramUniformMatrix2x4fv                      C.GPPROGRAMUNIFORMMATRIX2X4FV
+	gpProgramUniformMatrix2x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4FVEXT
+	gpProgramUniformMatrix3dv                        C.GPPROGRAMUNIFORMMATRIX3DV
+	gpProgramUniformMatrix3dvEXT                     C.GPPROGRAMUNIFORMMATRIX3DVEXT
+	gpProgramUniformMatrix3fv                        C.GPPROGRAMUNIFORMMATRIX3FV
+	gpProgramUniformMatrix3fvEXT                     C.GPPROGRAMUNIFORMMATRIX3FVEXT
+	gpProgramUniformMatrix3x2dv                      C.GPPROGRAMUNIFORMMATRIX3X2DV
+	gpProgramUniformMatrix3x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2DVEXT
+	gpProgramUniformMatrix3x2fv                      C.GPPROGRAMUNIFORMMATRIX3X2FV
+	gpProgramUniformMatrix3x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2FVEXT
+	gpProgramUniformMatrix3x4dv                      C.GPPROGRAMUNIFORMMATRIX3X4DV
+	gpProgramUniformMatrix3x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4DVEXT
+	gpProgramUniformMatrix3x4fv                      C.GPPROGRAMUNIFORMMATRIX3X4FV
+	gpProgramUniformMatrix3x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4FVEXT
+	gpProgramUniformMatrix4dv                        C.GPPROGRAMUNIFORMMATRIX4DV
+	gpProgramUniformMatrix4dvEXT                     C.GPPROGRAMUNIFORMMATRIX4DVEXT
+	gpProgramUniformMatrix4fv                        C.GPPROGRAMUNIFORMMATRIX4FV
+	gpProgramUniformMatrix4fvEXT                     C.GPPROGRAMUNIFORMMATRIX4FVEXT
+	gpProgramUniformMatrix4x2dv                      C.GPPROGRAMUNIFORMMATRIX4X2DV
+	gpProgramUniformMatrix4x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2DVEXT
+	gpProgramUniformMatrix4x2fv                      C.GPPROGRAMUNIFORMMATRIX4X2FV
+	gpProgramUniformMatrix4x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2FVEXT
+	gpProgramUniformMatrix4x3dv                      C.GPPROGRAMUNIFORMMATRIX4X3DV
+	gpProgramUniformMatrix4x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3DVEXT
+	gpProgramUniformMatrix4x3fv                      C.GPPROGRAMUNIFORMMATRIX4X3FV
+	gpProgramUniformMatrix4x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3FVEXT
+	gpProgramUniformui64NV                           C.GPPROGRAMUNIFORMUI64NV
+	gpProgramUniformui64vNV                          C.GPPROGRAMUNIFORMUI64VNV
+	gpProvokingVertex                                C.GPPROVOKINGVERTEX
+	gpPushClientAttribDefaultEXT                     C.GPPUSHCLIENTATTRIBDEFAULTEXT
+	gpPushDebugGroup                                 C.GPPUSHDEBUGGROUP
+	gpPushDebugGroupKHR                              C.GPPUSHDEBUGGROUPKHR
+	gpPushGroupMarkerEXT                             C.GPPUSHGROUPMARKEREXT
+	gpQueryCounter                                   C.GPQUERYCOUNTER
+	gpRasterSamplesEXT                               C.GPRASTERSAMPLESEXT
+	gpReadBuffer                                     C.GPREADBUFFER
+	gpReadPixels                                     C.GPREADPIXELS
+	gpReadnPixels                                    C.GPREADNPIXELS
+	gpReadnPixelsARB                                 C.GPREADNPIXELSARB
+	gpReadnPixelsKHR                                 C.GPREADNPIXELSKHR
+	gpReleaseShaderCompiler                          C.GPRELEASESHADERCOMPILER
+	gpRenderbufferStorage                            C.GPRENDERBUFFERSTORAGE
+	gpRenderbufferStorageMultisample                 C.GPRENDERBUFFERSTORAGEMULTISAMPLE
+	gpRenderbufferStorageMultisampleCoverageNV       C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV
+	gpResolveDepthValuesNV                           C.GPRESOLVEDEPTHVALUESNV
+	gpResumeTransformFeedback                        C.GPRESUMETRANSFORMFEEDBACK
+	gpSampleCoverage                                 C.GPSAMPLECOVERAGE
+	gpSampleMaski                                    C.GPSAMPLEMASKI
+	gpSamplerParameterIiv                            C.GPSAMPLERPARAMETERIIV
+	gpSamplerParameterIuiv                           C.GPSAMPLERPARAMETERIUIV
+	gpSamplerParameterf                              C.GPSAMPLERPARAMETERF
+	gpSamplerParameterfv                             C.GPSAMPLERPARAMETERFV
+	gpSamplerParameteri                              C.GPSAMPLERPARAMETERI
+	gpSamplerParameteriv                             C.GPSAMPLERPARAMETERIV
+	gpScissor                                        C.GPSCISSOR
+	gpScissorArrayv                                  C.GPSCISSORARRAYV
+	gpScissorIndexed                                 C.GPSCISSORINDEXED
+	gpScissorIndexedv                                C.GPSCISSORINDEXEDV
+	gpSecondaryColorFormatNV                         C.GPSECONDARYCOLORFORMATNV
+	gpSelectPerfMonitorCountersAMD                   C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpShaderBinary                                   C.GPSHADERBINARY
+	gpShaderSource                                   C.GPSHADERSOURCE
+	gpShaderStorageBlockBinding                      C.GPSHADERSTORAGEBLOCKBINDING
+	gpSignalVkFenceNV                                C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                            C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                            C.GPSPECIALIZESHADERARB
+	gpStateCaptureNV                                 C.GPSTATECAPTURENV
+	gpStencilFillPathInstancedNV                     C.GPSTENCILFILLPATHINSTANCEDNV
+	gpStencilFillPathNV                              C.GPSTENCILFILLPATHNV
+	gpStencilFunc                                    C.GPSTENCILFUNC
+	gpStencilFuncSeparate                            C.GPSTENCILFUNCSEPARATE
+	gpStencilMask                                    C.GPSTENCILMASK
+	gpStencilMaskSeparate                            C.GPSTENCILMASKSEPARATE
+	gpStencilOp                                      C.GPSTENCILOP
+	gpStencilOpSeparate                              C.GPSTENCILOPSEPARATE
+	gpStencilStrokePathInstancedNV                   C.GPSTENCILSTROKEPATHINSTANCEDNV
+	gpStencilStrokePathNV                            C.GPSTENCILSTROKEPATHNV
+	gpStencilThenCoverFillPathInstancedNV            C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV
+	gpStencilThenCoverFillPathNV                     C.GPSTENCILTHENCOVERFILLPATHNV
+	gpStencilThenCoverStrokePathInstancedNV          C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV
+	gpStencilThenCoverStrokePathNV                   C.GPSTENCILTHENCOVERSTROKEPATHNV
+	gpSubpixelPrecisionBiasNV                        C.GPSUBPIXELPRECISIONBIASNV
+	gpTexBuffer                                      C.GPTEXBUFFER
+	gpTexBufferARB                                   C.GPTEXBUFFERARB
+	gpTexBufferRange                                 C.GPTEXBUFFERRANGE
+	gpTexCoordFormatNV                               C.GPTEXCOORDFORMATNV
+	gpTexImage1D                                     C.GPTEXIMAGE1D
+	gpTexImage2D                                     C.GPTEXIMAGE2D
+	gpTexImage2DMultisample                          C.GPTEXIMAGE2DMULTISAMPLE
+	gpTexImage3D                                     C.GPTEXIMAGE3D
+	gpTexImage3DMultisample                          C.GPTEXIMAGE3DMULTISAMPLE
+	gpTexPageCommitmentARB                           C.GPTEXPAGECOMMITMENTARB
+	gpTexParameterIiv                                C.GPTEXPARAMETERIIV
+	gpTexParameterIuiv                               C.GPTEXPARAMETERIUIV
+	gpTexParameterf                                  C.GPTEXPARAMETERF
+	gpTexParameterfv                                 C.GPTEXPARAMETERFV
+	gpTexParameteri                                  C.GPTEXPARAMETERI
+	gpTexParameteriv                                 C.GPTEXPARAMETERIV
+	gpTexStorage1D                                   C.GPTEXSTORAGE1D
+	gpTexStorage2D                                   C.GPTEXSTORAGE2D
+	gpTexStorage2DMultisample                        C.GPTEXSTORAGE2DMULTISAMPLE
+	gpTexStorage3D                                   C.GPTEXSTORAGE3D
+	gpTexStorage3DMultisample                        C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexSubImage1D                                  C.GPTEXSUBIMAGE1D
+	gpTexSubImage2D                                  C.GPTEXSUBIMAGE2D
+	gpTexSubImage3D                                  C.GPTEXSUBIMAGE3D
+	gpTextureBarrier                                 C.GPTEXTUREBARRIER
+	gpTextureBarrierNV                               C.GPTEXTUREBARRIERNV
+	gpTextureBuffer                                  C.GPTEXTUREBUFFER
+	gpTextureBufferEXT                               C.GPTEXTUREBUFFEREXT
+	gpTextureBufferRange                             C.GPTEXTUREBUFFERRANGE
+	gpTextureBufferRangeEXT                          C.GPTEXTUREBUFFERRANGEEXT
+	gpTextureImage1DEXT                              C.GPTEXTUREIMAGE1DEXT
+	gpTextureImage2DEXT                              C.GPTEXTUREIMAGE2DEXT
+	gpTextureImage3DEXT                              C.GPTEXTUREIMAGE3DEXT
+	gpTexturePageCommitmentEXT                       C.GPTEXTUREPAGECOMMITMENTEXT
+	gpTextureParameterIiv                            C.GPTEXTUREPARAMETERIIV
+	gpTextureParameterIivEXT                         C.GPTEXTUREPARAMETERIIVEXT
+	gpTextureParameterIuiv                           C.GPTEXTUREPARAMETERIUIV
+	gpTextureParameterIuivEXT                        C.GPTEXTUREPARAMETERIUIVEXT
+	gpTextureParameterf                              C.GPTEXTUREPARAMETERF
+	gpTextureParameterfEXT                           C.GPTEXTUREPARAMETERFEXT
+	gpTextureParameterfv                             C.GPTEXTUREPARAMETERFV
+	gpTextureParameterfvEXT                          C.GPTEXTUREPARAMETERFVEXT
+	gpTextureParameteri                              C.GPTEXTUREPARAMETERI
+	gpTextureParameteriEXT                           C.GPTEXTUREPARAMETERIEXT
+	gpTextureParameteriv                             C.GPTEXTUREPARAMETERIV
+	gpTextureParameterivEXT                          C.GPTEXTUREPARAMETERIVEXT
+	gpTextureRenderbufferEXT                         C.GPTEXTURERENDERBUFFEREXT
+	gpTextureStorage1D                               C.GPTEXTURESTORAGE1D
+	gpTextureStorage1DEXT                            C.GPTEXTURESTORAGE1DEXT
+	gpTextureStorage2D                               C.GPTEXTURESTORAGE2D
+	gpTextureStorage2DEXT                            C.GPTEXTURESTORAGE2DEXT
+	gpTextureStorage2DMultisample                    C.GPTEXTURESTORAGE2DMULTISAMPLE
+	gpTextureStorage2DMultisampleEXT                 C.GPTEXTURESTORAGE2DMULTISAMPLEEXT
+	gpTextureStorage3D                               C.GPTEXTURESTORAGE3D
+	gpTextureStorage3DEXT                            C.GPTEXTURESTORAGE3DEXT
+	gpTextureStorage3DMultisample                    C.GPTEXTURESTORAGE3DMULTISAMPLE
+	gpTextureStorage3DMultisampleEXT                 C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureSubImage1D                              C.GPTEXTURESUBIMAGE1D
+	gpTextureSubImage1DEXT                           C.GPTEXTURESUBIMAGE1DEXT
+	gpTextureSubImage2D                              C.GPTEXTURESUBIMAGE2D
+	gpTextureSubImage2DEXT                           C.GPTEXTURESUBIMAGE2DEXT
+	gpTextureSubImage3D                              C.GPTEXTURESUBIMAGE3D
+	gpTextureSubImage3DEXT                           C.GPTEXTURESUBIMAGE3DEXT
+	gpTextureView                                    C.GPTEXTUREVIEW
+	gpTransformFeedbackBufferBase                    C.GPTRANSFORMFEEDBACKBUFFERBASE
+	gpTransformFeedbackBufferRange                   C.GPTRANSFORMFEEDBACKBUFFERRANGE
+	gpTransformFeedbackVaryings                      C.GPTRANSFORMFEEDBACKVARYINGS
+	gpTransformPathNV                                C.GPTRANSFORMPATHNV
+	gpUniform1d                                      C.GPUNIFORM1D
+	gpUniform1dv                                     C.GPUNIFORM1DV
+	gpUniform1f                                      C.GPUNIFORM1F
+	gpUniform1fv                                     C.GPUNIFORM1FV
+	gpUniform1i                                      C.GPUNIFORM1I
+	gpUniform1i64ARB                                 C.GPUNIFORM1I64ARB
+	gpUniform1i64NV                                  C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                C.GPUNIFORM1I64VARB
+	gpUniform1i64vNV                                 C.GPUNIFORM1I64VNV
+	gpUniform1iv                                     C.GPUNIFORM1IV
+	gpUniform1ui                                     C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                C.GPUNIFORM1UI64ARB
+	gpUniform1ui64NV                                 C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                               C.GPUNIFORM1UI64VARB
+	gpUniform1ui64vNV                                C.GPUNIFORM1UI64VNV
+	gpUniform1uiv                                    C.GPUNIFORM1UIV
+	gpUniform2d                                      C.GPUNIFORM2D
+	gpUniform2dv                                     C.GPUNIFORM2DV
+	gpUniform2f                                      C.GPUNIFORM2F
+	gpUniform2fv                                     C.GPUNIFORM2FV
+	gpUniform2i                                      C.GPUNIFORM2I
+	gpUniform2i64ARB                                 C.GPUNIFORM2I64ARB
+	gpUniform2i64NV                                  C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                C.GPUNIFORM2I64VARB
+	gpUniform2i64vNV                                 C.GPUNIFORM2I64VNV
+	gpUniform2iv                                     C.GPUNIFORM2IV
+	gpUniform2ui                                     C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                C.GPUNIFORM2UI64ARB
+	gpUniform2ui64NV                                 C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                               C.GPUNIFORM2UI64VARB
+	gpUniform2ui64vNV                                C.GPUNIFORM2UI64VNV
+	gpUniform2uiv                                    C.GPUNIFORM2UIV
+	gpUniform3d                                      C.GPUNIFORM3D
+	gpUniform3dv                                     C.GPUNIFORM3DV
+	gpUniform3f                                      C.GPUNIFORM3F
+	gpUniform3fv                                     C.GPUNIFORM3FV
+	gpUniform3i                                      C.GPUNIFORM3I
+	gpUniform3i64ARB                                 C.GPUNIFORM3I64ARB
+	gpUniform3i64NV                                  C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                C.GPUNIFORM3I64VARB
+	gpUniform3i64vNV                                 C.GPUNIFORM3I64VNV
+	gpUniform3iv                                     C.GPUNIFORM3IV
+	gpUniform3ui                                     C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                C.GPUNIFORM3UI64ARB
+	gpUniform3ui64NV                                 C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                               C.GPUNIFORM3UI64VARB
+	gpUniform3ui64vNV                                C.GPUNIFORM3UI64VNV
+	gpUniform3uiv                                    C.GPUNIFORM3UIV
+	gpUniform4d                                      C.GPUNIFORM4D
+	gpUniform4dv                                     C.GPUNIFORM4DV
+	gpUniform4f                                      C.GPUNIFORM4F
+	gpUniform4fv                                     C.GPUNIFORM4FV
+	gpUniform4i                                      C.GPUNIFORM4I
+	gpUniform4i64ARB                                 C.GPUNIFORM4I64ARB
+	gpUniform4i64NV                                  C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                C.GPUNIFORM4I64VARB
+	gpUniform4i64vNV                                 C.GPUNIFORM4I64VNV
+	gpUniform4iv                                     C.GPUNIFORM4IV
+	gpUniform4ui                                     C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                C.GPUNIFORM4UI64ARB
+	gpUniform4ui64NV                                 C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                               C.GPUNIFORM4UI64VARB
+	gpUniform4ui64vNV                                C.GPUNIFORM4UI64VNV
+	gpUniform4uiv                                    C.GPUNIFORM4UIV
+	gpUniformBlockBinding                            C.GPUNIFORMBLOCKBINDING
+	gpUniformHandleui64ARB                           C.GPUNIFORMHANDLEUI64ARB
+	gpUniformHandleui64NV                            C.GPUNIFORMHANDLEUI64NV
+	gpUniformHandleui64vARB                          C.GPUNIFORMHANDLEUI64VARB
+	gpUniformHandleui64vNV                           C.GPUNIFORMHANDLEUI64VNV
+	gpUniformMatrix2dv                               C.GPUNIFORMMATRIX2DV
+	gpUniformMatrix2fv                               C.GPUNIFORMMATRIX2FV
+	gpUniformMatrix2x3dv                             C.GPUNIFORMMATRIX2X3DV
+	gpUniformMatrix2x3fv                             C.GPUNIFORMMATRIX2X3FV
+	gpUniformMatrix2x4dv                             C.GPUNIFORMMATRIX2X4DV
+	gpUniformMatrix2x4fv                             C.GPUNIFORMMATRIX2X4FV
+	gpUniformMatrix3dv                               C.GPUNIFORMMATRIX3DV
+	gpUniformMatrix3fv                               C.GPUNIFORMMATRIX3FV
+	gpUniformMatrix3x2dv                             C.GPUNIFORMMATRIX3X2DV
+	gpUniformMatrix3x2fv                             C.GPUNIFORMMATRIX3X2FV
+	gpUniformMatrix3x4dv                             C.GPUNIFORMMATRIX3X4DV
+	gpUniformMatrix3x4fv                             C.GPUNIFORMMATRIX3X4FV
+	gpUniformMatrix4dv                               C.GPUNIFORMMATRIX4DV
+	gpUniformMatrix4fv                               C.GPUNIFORMMATRIX4FV
+	gpUniformMatrix4x2dv                             C.GPUNIFORMMATRIX4X2DV
+	gpUniformMatrix4x2fv                             C.GPUNIFORMMATRIX4X2FV
+	gpUniformMatrix4x3dv                             C.GPUNIFORMMATRIX4X3DV
+	gpUniformMatrix4x3fv                             C.GPUNIFORMMATRIX4X3FV
+	gpUniformSubroutinesuiv                          C.GPUNIFORMSUBROUTINESUIV
+	gpUniformui64NV                                  C.GPUNIFORMUI64NV
+	gpUniformui64vNV                                 C.GPUNIFORMUI64VNV
+	gpUnmapBuffer                                    C.GPUNMAPBUFFER
+	gpUnmapNamedBuffer                               C.GPUNMAPNAMEDBUFFER
+	gpUnmapNamedBufferEXT                            C.GPUNMAPNAMEDBUFFEREXT
+	gpUseProgram                                     C.GPUSEPROGRAM
+	gpUseProgramStages                               C.GPUSEPROGRAMSTAGES
+	gpUseProgramStagesEXT                            C.GPUSEPROGRAMSTAGESEXT
+	gpUseShaderProgramEXT                            C.GPUSESHADERPROGRAMEXT
+	gpValidateProgram                                C.GPVALIDATEPROGRAM
+	gpValidateProgramPipeline                        C.GPVALIDATEPROGRAMPIPELINE
+	gpValidateProgramPipelineEXT                     C.GPVALIDATEPROGRAMPIPELINEEXT
+	gpVertexArrayAttribBinding                       C.GPVERTEXARRAYATTRIBBINDING
+	gpVertexArrayAttribFormat                        C.GPVERTEXARRAYATTRIBFORMAT
+	gpVertexArrayAttribIFormat                       C.GPVERTEXARRAYATTRIBIFORMAT
+	gpVertexArrayAttribLFormat                       C.GPVERTEXARRAYATTRIBLFORMAT
+	gpVertexArrayBindVertexBufferEXT                 C.GPVERTEXARRAYBINDVERTEXBUFFEREXT
+	gpVertexArrayBindingDivisor                      C.GPVERTEXARRAYBINDINGDIVISOR
+	gpVertexArrayColorOffsetEXT                      C.GPVERTEXARRAYCOLOROFFSETEXT
+	gpVertexArrayEdgeFlagOffsetEXT                   C.GPVERTEXARRAYEDGEFLAGOFFSETEXT
+	gpVertexArrayElementBuffer                       C.GPVERTEXARRAYELEMENTBUFFER
+	gpVertexArrayFogCoordOffsetEXT                   C.GPVERTEXARRAYFOGCOORDOFFSETEXT
+	gpVertexArrayIndexOffsetEXT                      C.GPVERTEXARRAYINDEXOFFSETEXT
+	gpVertexArrayMultiTexCoordOffsetEXT              C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT
+	gpVertexArrayNormalOffsetEXT                     C.GPVERTEXARRAYNORMALOFFSETEXT
+	gpVertexArraySecondaryColorOffsetEXT             C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT
+	gpVertexArrayTexCoordOffsetEXT                   C.GPVERTEXARRAYTEXCOORDOFFSETEXT
+	gpVertexArrayVertexAttribBindingEXT              C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT
+	gpVertexArrayVertexAttribDivisorEXT              C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT
+	gpVertexArrayVertexAttribFormatEXT               C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT
+	gpVertexArrayVertexAttribIFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT
+	gpVertexArrayVertexAttribIOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT
+	gpVertexArrayVertexAttribLFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT
+	gpVertexArrayVertexAttribLOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT
+	gpVertexArrayVertexAttribOffsetEXT               C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT
+	gpVertexArrayVertexBindingDivisorEXT             C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT
+	gpVertexArrayVertexBuffer                        C.GPVERTEXARRAYVERTEXBUFFER
+	gpVertexArrayVertexBuffers                       C.GPVERTEXARRAYVERTEXBUFFERS
+	gpVertexArrayVertexOffsetEXT                     C.GPVERTEXARRAYVERTEXOFFSETEXT
+	gpVertexAttrib1d                                 C.GPVERTEXATTRIB1D
+	gpVertexAttrib1dv                                C.GPVERTEXATTRIB1DV
+	gpVertexAttrib1f                                 C.GPVERTEXATTRIB1F
+	gpVertexAttrib1fv                                C.GPVERTEXATTRIB1FV
+	gpVertexAttrib1s                                 C.GPVERTEXATTRIB1S
+	gpVertexAttrib1sv                                C.GPVERTEXATTRIB1SV
+	gpVertexAttrib2d                                 C.GPVERTEXATTRIB2D
+	gpVertexAttrib2dv                                C.GPVERTEXATTRIB2DV
+	gpVertexAttrib2f                                 C.GPVERTEXATTRIB2F
+	gpVertexAttrib2fv                                C.GPVERTEXATTRIB2FV
+	gpVertexAttrib2s                                 C.GPVERTEXATTRIB2S
+	gpVertexAttrib2sv                                C.GPVERTEXATTRIB2SV
+	gpVertexAttrib3d                                 C.GPVERTEXATTRIB3D
+	gpVertexAttrib3dv                                C.GPVERTEXATTRIB3DV
+	gpVertexAttrib3f                                 C.GPVERTEXATTRIB3F
+	gpVertexAttrib3fv                                C.GPVERTEXATTRIB3FV
+	gpVertexAttrib3s                                 C.GPVERTEXATTRIB3S
+	gpVertexAttrib3sv                                C.GPVERTEXATTRIB3SV
+	gpVertexAttrib4Nbv                               C.GPVERTEXATTRIB4NBV
+	gpVertexAttrib4Niv                               C.GPVERTEXATTRIB4NIV
+	gpVertexAttrib4Nsv                               C.GPVERTEXATTRIB4NSV
+	gpVertexAttrib4Nub                               C.GPVERTEXATTRIB4NUB
+	gpVertexAttrib4Nubv                              C.GPVERTEXATTRIB4NUBV
+	gpVertexAttrib4Nuiv                              C.GPVERTEXATTRIB4NUIV
+	gpVertexAttrib4Nusv                              C.GPVERTEXATTRIB4NUSV
+	gpVertexAttrib4bv                                C.GPVERTEXATTRIB4BV
+	gpVertexAttrib4d                                 C.GPVERTEXATTRIB4D
+	gpVertexAttrib4dv                                C.GPVERTEXATTRIB4DV
+	gpVertexAttrib4f                                 C.GPVERTEXATTRIB4F
+	gpVertexAttrib4fv                                C.GPVERTEXATTRIB4FV
+	gpVertexAttrib4iv                                C.GPVERTEXATTRIB4IV
+	gpVertexAttrib4s                                 C.GPVERTEXATTRIB4S
+	gpVertexAttrib4sv                                C.GPVERTEXATTRIB4SV
+	gpVertexAttrib4ubv                               C.GPVERTEXATTRIB4UBV
+	gpVertexAttrib4uiv                               C.GPVERTEXATTRIB4UIV
+	gpVertexAttrib4usv                               C.GPVERTEXATTRIB4USV
+	gpVertexAttribBinding                            C.GPVERTEXATTRIBBINDING
+	gpVertexAttribDivisor                            C.GPVERTEXATTRIBDIVISOR
+	gpVertexAttribDivisorARB                         C.GPVERTEXATTRIBDIVISORARB
+	gpVertexAttribFormat                             C.GPVERTEXATTRIBFORMAT
+	gpVertexAttribFormatNV                           C.GPVERTEXATTRIBFORMATNV
+	gpVertexAttribI1i                                C.GPVERTEXATTRIBI1I
+	gpVertexAttribI1iv                               C.GPVERTEXATTRIBI1IV
+	gpVertexAttribI1ui                               C.GPVERTEXATTRIBI1UI
+	gpVertexAttribI1uiv                              C.GPVERTEXATTRIBI1UIV
+	gpVertexAttribI2i                                C.GPVERTEXATTRIBI2I
+	gpVertexAttribI2iv                               C.GPVERTEXATTRIBI2IV
+	gpVertexAttribI2ui                               C.GPVERTEXATTRIBI2UI
+	gpVertexAttribI2uiv                              C.GPVERTEXATTRIBI2UIV
+	gpVertexAttribI3i                                C.GPVERTEXATTRIBI3I
+	gpVertexAttribI3iv                               C.GPVERTEXATTRIBI3IV
+	gpVertexAttribI3ui                               C.GPVERTEXATTRIBI3UI
+	gpVertexAttribI3uiv                              C.GPVERTEXATTRIBI3UIV
+	gpVertexAttribI4bv                               C.GPVERTEXATTRIBI4BV
+	gpVertexAttribI4i                                C.GPVERTEXATTRIBI4I
+	gpVertexAttribI4iv                               C.GPVERTEXATTRIBI4IV
+	gpVertexAttribI4sv                               C.GPVERTEXATTRIBI4SV
+	gpVertexAttribI4ubv                              C.GPVERTEXATTRIBI4UBV
+	gpVertexAttribI4ui                               C.GPVERTEXATTRIBI4UI
+	gpVertexAttribI4uiv                              C.GPVERTEXATTRIBI4UIV
+	gpVertexAttribI4usv                              C.GPVERTEXATTRIBI4USV
+	gpVertexAttribIFormat                            C.GPVERTEXATTRIBIFORMAT
+	gpVertexAttribIFormatNV                          C.GPVERTEXATTRIBIFORMATNV
+	gpVertexAttribIPointer                           C.GPVERTEXATTRIBIPOINTER
+	gpVertexAttribL1d                                C.GPVERTEXATTRIBL1D
+	gpVertexAttribL1dv                               C.GPVERTEXATTRIBL1DV
+	gpVertexAttribL1i64NV                            C.GPVERTEXATTRIBL1I64NV
+	gpVertexAttribL1i64vNV                           C.GPVERTEXATTRIBL1I64VNV
+	gpVertexAttribL1ui64ARB                          C.GPVERTEXATTRIBL1UI64ARB
+	gpVertexAttribL1ui64NV                           C.GPVERTEXATTRIBL1UI64NV
+	gpVertexAttribL1ui64vARB                         C.GPVERTEXATTRIBL1UI64VARB
+	gpVertexAttribL1ui64vNV                          C.GPVERTEXATTRIBL1UI64VNV
+	gpVertexAttribL2d                                C.GPVERTEXATTRIBL2D
+	gpVertexAttribL2dv                               C.GPVERTEXATTRIBL2DV
+	gpVertexAttribL2i64NV                            C.GPVERTEXATTRIBL2I64NV
+	gpVertexAttribL2i64vNV                           C.GPVERTEXATTRIBL2I64VNV
+	gpVertexAttribL2ui64NV                           C.GPVERTEXATTRIBL2UI64NV
+	gpVertexAttribL2ui64vNV                          C.GPVERTEXATTRIBL2UI64VNV
+	gpVertexAttribL3d                                C.GPVERTEXATTRIBL3D
+	gpVertexAttribL3dv                               C.GPVERTEXATTRIBL3DV
+	gpVertexAttribL3i64NV                            C.GPVERTEXATTRIBL3I64NV
+	gpVertexAttribL3i64vNV                           C.GPVERTEXATTRIBL3I64VNV
+	gpVertexAttribL3ui64NV                           C.GPVERTEXATTRIBL3UI64NV
+	gpVertexAttribL3ui64vNV                          C.GPVERTEXATTRIBL3UI64VNV
+	gpVertexAttribL4d                                C.GPVERTEXATTRIBL4D
+	gpVertexAttribL4dv                               C.GPVERTEXATTRIBL4DV
+	gpVertexAttribL4i64NV                            C.GPVERTEXATTRIBL4I64NV
+	gpVertexAttribL4i64vNV                           C.GPVERTEXATTRIBL4I64VNV
+	gpVertexAttribL4ui64NV                           C.GPVERTEXATTRIBL4UI64NV
+	gpVertexAttribL4ui64vNV                          C.GPVERTEXATTRIBL4UI64VNV
+	gpVertexAttribLFormat                            C.GPVERTEXATTRIBLFORMAT
+	gpVertexAttribLFormatNV                          C.GPVERTEXATTRIBLFORMATNV
+	gpVertexAttribLPointer                           C.GPVERTEXATTRIBLPOINTER
+	gpVertexAttribP1ui                               C.GPVERTEXATTRIBP1UI
+	gpVertexAttribP1uiv                              C.GPVERTEXATTRIBP1UIV
+	gpVertexAttribP2ui                               C.GPVERTEXATTRIBP2UI
+	gpVertexAttribP2uiv                              C.GPVERTEXATTRIBP2UIV
+	gpVertexAttribP3ui                               C.GPVERTEXATTRIBP3UI
+	gpVertexAttribP3uiv                              C.GPVERTEXATTRIBP3UIV
+	gpVertexAttribP4ui                               C.GPVERTEXATTRIBP4UI
+	gpVertexAttribP4uiv                              C.GPVERTEXATTRIBP4UIV
+	gpVertexAttribPointer                            C.GPVERTEXATTRIBPOINTER
+	gpVertexBindingDivisor                           C.GPVERTEXBINDINGDIVISOR
+	gpVertexFormatNV                                 C.GPVERTEXFORMATNV
+	gpViewport                                       C.GPVIEWPORT
+	gpViewportArrayv                                 C.GPVIEWPORTARRAYV
+	gpViewportIndexedf                               C.GPVIEWPORTINDEXEDF
+	gpViewportIndexedfv                              C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                       C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                              C.GPVIEWPORTSWIZZLENV
+	gpWaitSync                                       C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                              C.GPWAITVKSEMAPHORENV
+	gpWeightPathsNV                                  C.GPWEIGHTPATHSNV
+	gpWindowRectanglesEXT                            C.GPWINDOWRECTANGLESEXT
 )
 
 // Helper functions
@@ -5154,15 +8432,24 @@ func boolToInt(b bool) int {
 	}
 	return 0
 }
+func ActiveProgramEXT(program uint32) {
+	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
+}
 
 // set the active program object for a program pipeline object
 func ActiveShaderProgram(pipeline uint32, program uint32) {
 	C.glowActiveShaderProgram(gpActiveShaderProgram, (C.GLuint)(pipeline), (C.GLuint)(program))
 }
+func ActiveShaderProgramEXT(pipeline uint32, program uint32) {
+	C.glowActiveShaderProgramEXT(gpActiveShaderProgramEXT, (C.GLuint)(pipeline), (C.GLuint)(program))
+}
 
 // select active texture unit
 func ActiveTexture(texture uint32) {
 	C.glowActiveTexture(gpActiveTexture, (C.GLenum)(texture))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 
 // Attaches a shader object to a program object
@@ -5173,6 +8460,15 @@ func AttachShader(program uint32, shader uint32) {
 // start conditional rendering
 func BeginConditionalRender(id uint32, mode uint32) {
 	C.glowBeginConditionalRender(gpBeginConditionalRender, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginConditionalRenderNV(id uint32, mode uint32) {
+	C.glowBeginConditionalRenderNV(gpBeginConditionalRenderNV, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginPerfMonitorAMD(monitor uint32) {
+	C.glowBeginPerfMonitorAMD(gpBeginPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func BeginPerfQueryINTEL(queryHandle uint32) {
+	C.glowBeginPerfQueryINTEL(gpBeginPerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // delimit the boundaries of a query object
@@ -5242,10 +8538,16 @@ func BindImageTexture(unit uint32, texture uint32, level int32, layered bool, la
 func BindImageTextures(first uint32, count int32, textures *uint32) {
 	C.glowBindImageTextures(gpBindImageTextures, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(textures)))
 }
+func BindMultiTextureEXT(texunit uint32, target uint32, texture uint32) {
+	C.glowBindMultiTextureEXT(gpBindMultiTextureEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(texture))
+}
 
 // bind a program pipeline to the current context
 func BindProgramPipeline(pipeline uint32) {
 	C.glowBindProgramPipeline(gpBindProgramPipeline, (C.GLuint)(pipeline))
+}
+func BindProgramPipelineEXT(pipeline uint32) {
+	C.glowBindProgramPipelineEXT(gpBindProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 
 // bind a renderbuffer to a renderbuffer target
@@ -5297,6 +8599,12 @@ func BindVertexBuffer(bindingindex uint32, buffer uint32, offset int, stride int
 func BindVertexBuffers(first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowBindVertexBuffers(gpBindVertexBuffers, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
 }
+func BlendBarrierKHR() {
+	C.glowBlendBarrierKHR(gpBlendBarrierKHR)
+}
+func BlendBarrierNV() {
+	C.glowBlendBarrierNV(gpBlendBarrierNV)
+}
 
 // set the blend color
 func BlendColor(red float32, green float32, blue float32, alpha float32) {
@@ -5346,6 +8654,9 @@ func BlendFunci(buf uint32, src uint32, dst uint32) {
 func BlendFunciARB(buf uint32, src uint32, dst uint32) {
 	C.glowBlendFunciARB(gpBlendFunciARB, (C.GLuint)(buf), (C.GLenum)(src), (C.GLenum)(dst))
 }
+func BlendParameteriNV(pname uint32, value int32) {
+	C.glowBlendParameteriNV(gpBlendParameteriNV, (C.GLenum)(pname), (C.GLint)(value))
+}
 
 // copy a block of pixels from one framebuffer object to another
 func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
@@ -5356,13 +8667,16 @@ func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 i
 func BlitNamedFramebuffer(readFramebuffer uint32, drawFramebuffer uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
 	C.glowBlitNamedFramebuffer(gpBlitNamedFramebuffer, (C.GLuint)(readFramebuffer), (C.GLuint)(drawFramebuffer), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
 }
+func BufferAddressRangeNV(pname uint32, index uint32, address uint64, length int) {
+	C.glowBufferAddressRangeNV(gpBufferAddressRangeNV, (C.GLenum)(pname), (C.GLuint)(index), (C.GLuint64EXT)(address), (C.GLsizeiptr)(length))
+}
 
 // creates and initializes a buffer object's data     store
 func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferData(gpBufferData, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
@@ -5374,6 +8688,9 @@ func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubData(gpBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
+}
 
 // check the completeness status of a framebuffer
 func CheckFramebufferStatus(target uint32) uint32 {
@@ -5384,6 +8701,10 @@ func CheckFramebufferStatus(target uint32) uint32 {
 // check the completeness status of a framebuffer
 func CheckNamedFramebufferStatus(framebuffer uint32, target uint32) uint32 {
 	ret := C.glowCheckNamedFramebufferStatus(gpCheckNamedFramebufferStatus, (C.GLuint)(framebuffer), (C.GLenum)(target))
+	return (uint32)(ret)
+}
+func CheckNamedFramebufferStatusEXT(framebuffer uint32, target uint32) uint32 {
+	ret := C.glowCheckNamedFramebufferStatusEXT(gpCheckNamedFramebufferStatusEXT, (C.GLuint)(framebuffer), (C.GLenum)(target))
 	return (uint32)(ret)
 }
 
@@ -5428,6 +8749,8 @@ func ClearColor(red float32, green float32, blue float32, alpha float32) {
 func ClearDepth(depth float64) {
 	C.glowClearDepth(gpClearDepth, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -5436,13 +8759,19 @@ func ClearDepthf(d float32) {
 func ClearNamedBufferData(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferData(gpClearNamedBufferData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferDataEXT(gpClearNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -5468,9 +8797,12 @@ func ClearTexImage(texture uint32, level int32, format uint32, xtype uint32, dat
 func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearTexSubImage(gpClearTexSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClientAttribDefaultEXT(mask uint32) {
+	C.glowClientAttribDefaultEXT(gpClientAttribDefaultEXT, (C.GLbitfield)(mask))
+}
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -5479,11 +8811,20 @@ func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
 func ClipControl(origin uint32, depth uint32) {
 	C.glowClipControl(gpClipControl, (C.GLenum)(origin), (C.GLenum)(depth))
 }
+func ColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowColorFormatNV(gpColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func ColorMask(red bool, green bool, blue bool, alpha bool) {
 	C.glowColorMask(gpColorMask, (C.GLboolean)(boolToInt(red)), (C.GLboolean)(boolToInt(green)), (C.GLboolean)(boolToInt(blue)), (C.GLboolean)(boolToInt(alpha)))
 }
 func ColorMaski(index uint32, r bool, g bool, b bool, a bool) {
 	C.glowColorMaski(gpColorMaski, (C.GLuint)(index), (C.GLboolean)(boolToInt(r)), (C.GLboolean)(boolToInt(g)), (C.GLboolean)(boolToInt(b)), (C.GLboolean)(boolToInt(a)))
+}
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
 }
 
 // Compiles a shader object
@@ -5492,6 +8833,24 @@ func CompileShader(shader uint32) {
 }
 func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
+}
+func CompressedMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage1DEXT(gpCompressedMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage2DEXT(gpCompressedMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage3DEXT(gpCompressedMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage1DEXT(gpCompressedMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage2DEXT(gpCompressedMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage3DEXT(gpCompressedMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a one-dimensional texture image in a compressed format
@@ -5523,20 +8882,44 @@ func CompressedTexSubImage2D(target uint32, level int32, xoffset int32, yoffset 
 func CompressedTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTexSubImage3D(gpCompressedTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage1DEXT(gpCompressedTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage2DEXT(gpCompressedTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage3DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage3DEXT(gpCompressedTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a one-dimensional texture subimage in a compressed     format
 func CompressedTextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage1D(gpCompressedTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage1DEXT(gpCompressedTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a two-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage2D(gpCompressedTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage2DEXT(gpCompressedTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a three-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3D(gpCompressedTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
@@ -5548,10 +8931,28 @@ func CopyBufferSubData(readTarget uint32, writeTarget uint32, readOffset int, wr
 func CopyImageSubData(srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
 	C.glowCopyImageSubData(gpCopyImageSubData, (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
 }
+func CopyMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyMultiTexImage1DEXT(gpCopyMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyMultiTexImage2DEXT(gpCopyMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
+func CopyMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyMultiTexSubImage1DEXT(gpCopyMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage2DEXT(gpCopyMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage3DEXT(gpCopyMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func CopyPathNV(resultPath uint32, srcPath uint32) {
+	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
 }
 
 // copy pixels into a 1D texture image
@@ -5578,30 +8979,69 @@ func CopyTexSubImage2D(target uint32, level int32, xoffset int32, yoffset int32,
 func CopyTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTexSubImage3D(gpCopyTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyTextureImage1DEXT(gpCopyTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyTextureImage2DEXT(gpCopyTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
 
 // copy a one-dimensional texture subimage
 func CopyTextureSubImage1D(texture uint32, level int32, xoffset int32, x int32, y int32, width int32) {
 	C.glowCopyTextureSubImage1D(gpCopyTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyTextureSubImage1DEXT(gpCopyTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
 }
 
 // copy a two-dimensional texture subimage
 func CopyTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage2D(gpCopyTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage2DEXT(gpCopyTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy a three-dimensional texture subimage
 func CopyTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage3D(gpCopyTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage3DEXT(gpCopyTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverFillPathInstancedNV(gpCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverFillPathNV(path uint32, coverMode uint32) {
+	C.glowCoverFillPathNV(gpCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverStrokePathInstancedNV(gpCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverStrokePathNV(path uint32, coverMode uint32) {
+	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
+	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
 }
 
 // Creates a program object
@@ -5635,15 +9075,26 @@ func CreateShader(xtype uint32) uint32 {
 	ret := C.glowCreateShader(gpCreateShader, (C.GLenum)(xtype))
 	return (uint32)(ret)
 }
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
+	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
+	return (uint32)(ret)
+}
 
 // create a stand-alone program from an array of null-terminated source code strings
 func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
+	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
+	return (uint32)(ret)
+}
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -5706,6 +9157,9 @@ func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint
 func DeleteBuffers(n int32, buffers *uint32) {
 	C.glowDeleteBuffers(gpDeleteBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // delete framebuffer objects
 func DeleteFramebuffers(n int32, framebuffers *uint32) {
@@ -5713,6 +9167,15 @@ func DeleteFramebuffers(n int32, framebuffers *uint32) {
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+}
+func DeletePathsNV(path uint32, xrange int32) {
+	C.glowDeletePathsNV(gpDeletePathsNV, (C.GLuint)(path), (C.GLsizei)(xrange))
+}
+func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowDeletePerfMonitorsAMD(gpDeletePerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
+func DeletePerfQueryINTEL(queryHandle uint32) {
+	C.glowDeletePerfQueryINTEL(gpDeletePerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // Deletes a program object
@@ -5723,6 +9186,9 @@ func DeleteProgram(program uint32) {
 // delete program pipeline objects
 func DeleteProgramPipelines(n int32, pipelines *uint32) {
 	C.glowDeleteProgramPipelines(gpDeleteProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func DeleteProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowDeleteProgramPipelinesEXT(gpDeleteProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // delete named query objects
@@ -5744,9 +9210,12 @@ func DeleteSamplers(count int32, samplers *uint32) {
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -5787,6 +9256,8 @@ func DepthRangeArrayv(first uint32, count int32, v *float64) {
 func DepthRangeIndexed(index uint32, n float64, f float64) {
 	C.glowDepthRangeIndexed(gpDepthRangeIndexed, (C.GLuint)(index), (C.GLdouble)(n), (C.GLdouble)(f))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -5798,10 +9269,25 @@ func DetachShader(program uint32, shader uint32) {
 func Disable(cap uint32) {
 	C.glowDisable(gpDisable, (C.GLenum)(cap))
 }
+func DisableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowDisableClientStateIndexedEXT(gpDisableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableClientStateiEXT(array uint32, index uint32) {
+	C.glowDisableClientStateiEXT(gpDisableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableIndexedEXT(target uint32, index uint32) {
+	C.glowDisableIndexedEXT(gpDisableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func DisableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowDisableVertexArrayAttrib(gpDisableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowDisableVertexArrayAttribEXT(gpDisableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowDisableVertexArrayEXT(gpDisableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -5839,10 +9325,16 @@ func DrawArraysIndirect(mode uint32, indirect unsafe.Pointer) {
 func DrawArraysInstanced(mode uint32, first int32, count int32, instancecount int32) {
 	C.glowDrawArraysInstanced(gpDrawArraysInstanced, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount))
 }
+func DrawArraysInstancedARB(mode uint32, first int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedARB(gpDrawArraysInstancedARB, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a range of elements with offset applied to instanced attributes
 func DrawArraysInstancedBaseInstance(mode uint32, first int32, count int32, instancecount int32, baseinstance uint32) {
 	C.glowDrawArraysInstancedBaseInstance(gpDrawArraysInstancedBaseInstance, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount), (C.GLuint)(baseinstance))
+}
+func DrawArraysInstancedEXT(mode uint32, start int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedEXT(gpDrawArraysInstancedEXT, (C.GLenum)(mode), (C.GLint)(start), (C.GLsizei)(count), (C.GLsizei)(primcount))
 }
 
 // specify which color buffers are to be drawn into
@@ -5853,6 +9345,18 @@ func DrawBuffer(buf uint32) {
 // Specifies a list of color buffers to be drawn     into
 func DrawBuffers(n int32, bufs *uint32) {
 	C.glowDrawBuffers(gpDrawBuffers, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 
 // render primitives from array data
@@ -5874,6 +9378,9 @@ func DrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer) {
 func DrawElementsInstanced(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32) {
 	C.glowDrawElementsInstanced(gpDrawElementsInstanced, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount))
 }
+func DrawElementsInstancedARB(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedARB(gpDrawElementsInstancedARB, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a set of elements with offset applied to instanced attributes
 func DrawElementsInstancedBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, baseinstance uint32) {
@@ -5888,6 +9395,9 @@ func DrawElementsInstancedBaseVertex(mode uint32, count int32, xtype uint32, ind
 // render multiple instances of a set of primitives from array data with a per-element offset
 func DrawElementsInstancedBaseVertexBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, basevertex int32, baseinstance uint32) {
 	C.glowDrawElementsInstancedBaseVertexBaseInstance(gpDrawElementsInstancedBaseVertexBaseInstance, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount), (C.GLint)(basevertex), (C.GLuint)(baseinstance))
+}
+func DrawElementsInstancedEXT(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedEXT(gpDrawElementsInstancedEXT, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
 }
 
 // render primitives from array data
@@ -5919,15 +9429,36 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
 }
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
+}
+func EdgeFlagFormatNV(stride int32) {
+	C.glowEdgeFlagFormatNV(gpEdgeFlagFormatNV, (C.GLsizei)(stride))
+}
 
 // enable or disable server-side GL capabilities
 func Enable(cap uint32) {
 	C.glowEnable(gpEnable, (C.GLenum)(cap))
 }
+func EnableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowEnableClientStateIndexedEXT(gpEnableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableClientStateiEXT(array uint32, index uint32) {
+	C.glowEnableClientStateiEXT(gpEnableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableIndexedEXT(target uint32, index uint32) {
+	C.glowEnableIndexedEXT(gpEnableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func EnableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowEnableVertexArrayAttrib(gpEnableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowEnableVertexArrayAttribEXT(gpEnableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowEnableVertexArrayEXT(gpEnableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -5940,6 +9471,15 @@ func Enablei(target uint32, index uint32) {
 func EndConditionalRender() {
 	C.glowEndConditionalRender(gpEndConditionalRender)
 }
+func EndConditionalRenderNV() {
+	C.glowEndConditionalRenderNV(gpEndConditionalRenderNV)
+}
+func EndPerfMonitorAMD(monitor uint32) {
+	C.glowEndPerfMonitorAMD(gpEndPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func EndPerfQueryINTEL(queryHandle uint32) {
+	C.glowEndPerfQueryINTEL(gpEndPerfQueryINTEL, (C.GLuint)(queryHandle))
+}
 func EndQuery(target uint32) {
 	C.glowEndQuery(gpEndQuery, (C.GLenum)(target))
 }
@@ -5949,11 +9489,14 @@ func EndQueryIndexed(target uint32, index uint32) {
 func EndTransformFeedback() {
 	C.glowEndTransformFeedback(gpEndTransformFeedback)
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -5972,18 +9515,45 @@ func FlushMappedBufferRange(target uint32, offset int, length int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FogCoordFormatNV(xtype uint32, stride int32) {
+	C.glowFogCoordFormatNV(gpFogCoordFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
+func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferDrawBufferEXT(gpFramebufferDrawBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
+func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
+	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
 }
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
 	C.glowFramebufferParameteri(gpFramebufferParameteri, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
 }
+func FramebufferReadBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferReadBufferEXT(gpFramebufferReadBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
 
 // attach a renderbuffer as a logical buffer of a framebuffer object
 func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbuffer(gpFramebufferRenderbuffer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
@@ -5993,16 +9563,30 @@ func FramebufferTexture(target uint32, attachment uint32, texture uint32, level 
 func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1D(gpFramebufferTexture1D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
 func FramebufferTexture3D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
 	C.glowFramebufferTexture3D(gpFramebufferTexture3D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
 }
+func FramebufferTextureARB(target uint32, attachment uint32, texture uint32, level int32) {
+	C.glowFramebufferTextureARB(gpFramebufferTextureARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func FramebufferTextureFaceARB(target uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowFramebufferTextureFaceARB(gpFramebufferTextureFaceARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
+}
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func FramebufferTextureLayer(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayer(gpFramebufferTextureLayer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowFramebufferTextureLayerARB(gpFramebufferTextureLayerARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 
 // define front- and back-facing polygons
@@ -6019,10 +9603,20 @@ func GenBuffers(n int32, buffers *uint32) {
 func GenFramebuffers(n int32, framebuffers *uint32) {
 	C.glowGenFramebuffers(gpGenFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
 }
+func GenPathsNV(xrange int32) uint32 {
+	ret := C.glowGenPathsNV(gpGenPathsNV, (C.GLsizei)(xrange))
+	return (uint32)(ret)
+}
+func GenPerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowGenPerfMonitorsAMD(gpGenPerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
 
 // reserve program pipeline object names
 func GenProgramPipelines(n int32, pipelines *uint32) {
 	C.glowGenProgramPipelines(gpGenProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func GenProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowGenProgramPipelinesEXT(gpGenProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // generate query object names
@@ -6059,10 +9653,16 @@ func GenVertexArrays(n int32, arrays *uint32) {
 func GenerateMipmap(target uint32) {
 	C.glowGenerateMipmap(gpGenerateMipmap, (C.GLenum)(target))
 }
+func GenerateMultiTexMipmapEXT(texunit uint32, target uint32) {
+	C.glowGenerateMultiTexMipmapEXT(gpGenerateMultiTexMipmapEXT, (C.GLenum)(texunit), (C.GLenum)(target))
+}
 
 // generate mipmaps for a specified texture object
 func GenerateTextureMipmap(texture uint32) {
 	C.glowGenerateTextureMipmap(gpGenerateTextureMipmap, (C.GLuint)(texture))
+}
+func GenerateTextureMipmapEXT(texture uint32, target uint32) {
+	C.glowGenerateTextureMipmapEXT(gpGenerateTextureMipmapEXT, (C.GLuint)(texture), (C.GLenum)(target))
 }
 
 // retrieve information about the set of active atomic counter buffers for a program
@@ -6097,6 +9697,8 @@ func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6121,6 +9723,9 @@ func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
+func GetBooleanIndexedvEXT(target uint32, index uint32, data *bool) {
+	C.glowGetBooleanIndexedvEXT(gpGetBooleanIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
+}
 func GetBooleani_v(target uint32, index uint32, data *bool) {
 	C.glowGetBooleani_v(gpGetBooleani_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
 }
@@ -6137,6 +9742,9 @@ func GetBufferParameteri64v(target uint32, pname uint32, params *int64) {
 func GetBufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetBufferParameteriv(gpGetBufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetBufferParameterui64vNV(target uint32, pname uint32, params *uint64) {
+	C.glowGetBufferParameterui64vNV(gpGetBufferParameterui64vNV, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
@@ -6146,6 +9754,13 @@ func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
 // returns a subset of a buffer object's data store
 func GetBufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetBufferSubData(gpGetBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
+func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
 
 // return a compressed texture image
@@ -6157,10 +9772,16 @@ func GetCompressedTexImage(target uint32, level int32, img unsafe.Pointer) {
 func GetCompressedTextureImage(texture uint32, level int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureImage(gpGetCompressedTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLsizei)(bufSize), pixels)
 }
+func GetCompressedTextureImageEXT(texture uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedTextureImageEXT(gpGetCompressedTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(lod), img)
+}
 
 // retrieve a sub-region of a compressed texture image from a     compressed texture object
 func GetCompressedTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureSubImage(gpGetCompressedTextureSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(bufSize), pixels)
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -6176,8 +9797,14 @@ func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
+func GetDoubleIndexedvEXT(target uint32, index uint32, data *float64) {
+	C.glowGetDoubleIndexedvEXT(gpGetDoubleIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
 func GetDoublei_v(target uint32, index uint32, data *float64) {
 	C.glowGetDoublei_v(gpGetDoublei_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
+func GetDoublei_vEXT(pname uint32, index uint32, params *float64) {
+	C.glowGetDoublei_vEXT(gpGetDoublei_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
 }
 func GetDoublev(pname uint32, data *float64) {
 	C.glowGetDoublev(gpGetDoublev, (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(data)))
@@ -6188,8 +9815,17 @@ func GetError() uint32 {
 	ret := C.glowGetError(gpGetError)
 	return (uint32)(ret)
 }
+func GetFirstPerfQueryIdINTEL(queryId *uint32) {
+	C.glowGetFirstPerfQueryIdINTEL(gpGetFirstPerfQueryIdINTEL, (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetFloatIndexedvEXT(target uint32, index uint32, data *float32) {
+	C.glowGetFloatIndexedvEXT(gpGetFloatIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
 func GetFloati_v(target uint32, index uint32, data *float32) {
 	C.glowGetFloati_v(gpGetFloati_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
+func GetFloati_vEXT(pname uint32, index uint32, params *float32) {
+	C.glowGetFloati_vEXT(gpGetFloati_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetFloatv(pname uint32, data *float32) {
 	C.glowGetFloatv(gpGetFloatv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(data)))
@@ -6207,14 +9843,17 @@ func GetFragDataLocation(program uint32, name *uint8) int32 {
 	return (int32)(ret)
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetFramebufferParameterivEXT(gpGetFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // check if the rendering context has not been lost due to software or hardware issues
@@ -6234,23 +9873,77 @@ func GetImageHandleARB(texture uint32, level int32, layered bool, layer int32, f
 	ret := C.glowGetImageHandleARB(gpGetImageHandleARB, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
 	return (uint64)(ret)
 }
+func GetImageHandleNV(texture uint32, level int32, layered bool, layer int32, format uint32) uint64 {
+	ret := C.glowGetImageHandleNV(gpGetImageHandleNV, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
+	return (uint64)(ret)
+}
 func GetInteger64i_v(target uint32, index uint32, data *int64) {
 	C.glowGetInteger64i_v(gpGetInteger64i_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint64)(unsafe.Pointer(data)))
 }
 func GetInteger64v(pname uint32, data *int64) {
 	C.glowGetInteger64v(gpGetInteger64v, (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(data)))
 }
+func GetIntegerIndexedvEXT(target uint32, index uint32, data *int32) {
+	C.glowGetIntegerIndexedvEXT(gpGetIntegerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
 func GetIntegeri_v(target uint32, index uint32, data *int32) {
 	C.glowGetIntegeri_v(gpGetIntegeri_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
+func GetIntegerui64i_vNV(value uint32, index uint32, result *uint64) {
+	C.glowGetIntegerui64i_vNV(gpGetIntegerui64i_vNV, (C.GLenum)(value), (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(result)))
+}
+func GetIntegerui64vNV(value uint32, result *uint64) {
+	C.glowGetIntegerui64vNV(gpGetIntegerui64vNV, (C.GLenum)(value), (*C.GLuint64EXT)(unsafe.Pointer(result)))
 }
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexEnvfvEXT(gpGetMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexEnvivEXT(gpGetMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowGetMultiTexGendvEXT(gpGetMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexGenfvEXT(gpGetMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexGenivEXT(gpGetMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexImageEXT(texunit uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetMultiTexImageEXT(gpGetMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func GetMultiTexLevelParameterfvEXT(texunit uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetMultiTexLevelParameterfvEXT(gpGetMultiTexLevelParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexLevelParameterivEXT(texunit uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetMultiTexLevelParameterivEXT(gpGetMultiTexLevelParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterIivEXT(gpGetMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetMultiTexParameterIuivEXT(gpGetMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexParameterfvEXT(gpGetMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterivEXT(gpGetMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // retrieve the location of a sample
@@ -6267,30 +9960,69 @@ func GetNamedBufferParameteri64v(buffer uint32, pname uint32, params *int64) {
 func GetNamedBufferParameteriv(buffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedBufferParameteriv(gpGetNamedBufferParameteriv, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedBufferParameterivEXT(buffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedBufferParameterivEXT(gpGetNamedBufferParameterivEXT, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedBufferParameterui64vNV(buffer uint32, pname uint32, params *uint64) {
+	C.glowGetNamedBufferParameterui64vNV(gpGetNamedBufferParameterui64vNV, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetNamedBufferPointerv(buffer uint32, pname uint32, params *unsafe.Pointer) {
 	C.glowGetNamedBufferPointerv(gpGetNamedBufferPointerv, (C.GLuint)(buffer), (C.GLenum)(pname), params)
 }
+func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Pointer) {
+	C.glowGetNamedBufferPointervEXT(gpGetNamedBufferPointervEXT, (C.GLuint)(buffer), (C.GLenum)(pname), params)
+}
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 
 // retrieve information about attachments of a framebuffer object
 func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameteriv(gpGetNamedFramebufferAttachmentParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a framebuffer object
 func GetNamedFramebufferParameteriv(framebuffer uint32, pname uint32, param *int32) {
 	C.glowGetNamedFramebufferParameteriv(gpGetNamedFramebufferParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
 }
+func GetNamedFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferParameterivEXT(gpGetNamedFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowGetNamedProgramLocalParameterIivEXT(gpGetNamedProgramLocalParameterIivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIuivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowGetNamedProgramLocalParameterIuivEXT(gpGetNamedProgramLocalParameterIuivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterdvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowGetNamedProgramLocalParameterdvEXT(gpGetNamedProgramLocalParameterdvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterfvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowGetNamedProgramLocalParameterfvEXT(gpGetNamedProgramLocalParameterfvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetNamedProgramStringEXT(program uint32, target uint32, pname uint32, xstring unsafe.Pointer) {
+	C.glowGetNamedProgramStringEXT(gpGetNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), xstring)
+}
+func GetNamedProgramivEXT(program uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetNamedProgramivEXT(gpGetNamedProgramivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a renderbuffer object
 func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameteriv(gpGetNamedRenderbufferParameteriv, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedRenderbufferParameterivEXT(renderbuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedRenderbufferParameterivEXT(gpGetNamedRenderbufferParameterivEXT, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
@@ -6298,10 +10030,16 @@ func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int
 func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
+	C.glowGetNextPerfQueryIdINTEL(gpGetNextPerfQueryIdINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(nextQueryId)))
+}
 
 // retrieve the label of a named object identified within a namespace
 func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
+	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
@@ -6313,6 +10051,70 @@ func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *
 }
 func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetPathCommandsNV(path uint32, commands *uint8) {
+	C.glowGetPathCommandsNV(gpGetPathCommandsNV, (C.GLuint)(path), (*C.GLubyte)(unsafe.Pointer(commands)))
+}
+func GetPathCoordsNV(path uint32, coords *float32) {
+	C.glowGetPathCoordsNV(gpGetPathCoordsNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(coords)))
+}
+func GetPathDashArrayNV(path uint32, dashArray *float32) {
+	C.glowGetPathDashArrayNV(gpGetPathDashArrayNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func GetPathLengthNV(path uint32, startSegment int32, numSegments int32) float32 {
+	ret := C.glowGetPathLengthNV(gpGetPathLengthNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments))
+	return (float32)(ret)
+}
+func GetPathMetricRangeNV(metricQueryMask uint32, firstPathName uint32, numPaths int32, stride int32, metrics *float32) {
+	C.glowGetPathMetricRangeNV(gpGetPathMetricRangeNV, (C.GLbitfield)(metricQueryMask), (C.GLuint)(firstPathName), (C.GLsizei)(numPaths), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathMetricsNV(metricQueryMask uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, stride int32, metrics *float32) {
+	C.glowGetPathMetricsNV(gpGetPathMetricsNV, (C.GLbitfield)(metricQueryMask), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowGetPathParameterfvNV(gpGetPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func GetPathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowGetPathParameterivNV(gpGetPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func GetPathSpacingNV(pathListMode uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, advanceScale float32, kerningScale float32, transformType uint32, returnedSpacing *float32) {
+	C.glowGetPathSpacingNV(gpGetPathSpacingNV, (C.GLenum)(pathListMode), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLfloat)(advanceScale), (C.GLfloat)(kerningScale), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(returnedSpacing)))
+}
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
+}
+func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
+	C.glowGetPerfMonitorCounterDataAMD(gpGetPerfMonitorCounterDataAMD, (C.GLuint)(monitor), (C.GLenum)(pname), (C.GLsizei)(dataSize), (*C.GLuint)(unsafe.Pointer(data)), (*C.GLint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
+	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
+}
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
+	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
+}
+func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
+	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
+}
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
+	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
+}
+func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
+	C.glowGetPerfMonitorGroupsAMD(gpGetPerfMonitorGroupsAMD, (*C.GLint)(unsafe.Pointer(numGroups)), (C.GLsizei)(groupsSize), (*C.GLuint)(unsafe.Pointer(groups)))
+}
+func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
+	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
+	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
+}
+func GetPointerIndexedvEXT(target uint32, index uint32, data *unsafe.Pointer) {
+	C.glowGetPointerIndexedvEXT(gpGetPointerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), data)
+}
+func GetPointeri_vEXT(pname uint32, index uint32, params *unsafe.Pointer) {
+	C.glowGetPointeri_vEXT(gpGetPointeri_vEXT, (C.GLenum)(pname), (C.GLuint)(index), params)
 }
 
 // return the address of the specified pointer
@@ -6340,8 +10142,14 @@ func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32
 func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
+	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
+}
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
 	C.glowGetProgramPipelineiv(gpGetProgramPipelineiv, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
+	C.glowGetProgramPipelineivEXT(gpGetProgramPipelineivEXT, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // query the index of a named resource within a program
@@ -6366,6 +10174,9 @@ func GetProgramResourceLocationIndex(program uint32, programInterface uint32, na
 func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
+func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
+	C.glowGetProgramResourcefvNV(gpGetProgramResourcefvNV, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLfloat)(unsafe.Pointer(params)))
+}
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
 	C.glowGetProgramResourceiv(gpGetProgramResourceiv, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6376,6 +10187,18 @@ func GetProgramStageiv(program uint32, shadertype uint32, pname uint32, values *
 // Returns a parameter from a program object
 func GetProgramiv(program uint32, pname uint32, params *int32) {
 	C.glowGetProgramiv(gpGetProgramiv, (C.GLuint)(program), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
 }
 
 // return parameters of an indexed query object target
@@ -6391,6 +10214,8 @@ func GetQueryObjectiv(id uint32, pname uint32, params *int32) {
 func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64v(gpGetQueryObjectui64v, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -6400,7 +10225,7 @@ func GetQueryiv(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryiv(gpGetQueryiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6436,6 +10261,10 @@ func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8)
 func GetShaderiv(shader uint32, pname uint32, params *int32) {
 	C.glowGetShaderiv(gpGetShaderiv, (C.GLuint)(shader), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -6460,7 +10289,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 
@@ -6490,31 +10319,60 @@ func GetTextureHandleARB(texture uint32) uint64 {
 	ret := C.glowGetTextureHandleARB(gpGetTextureHandleARB, (C.GLuint)(texture))
 	return (uint64)(ret)
 }
+func GetTextureHandleNV(texture uint32) uint64 {
+	ret := C.glowGetTextureHandleNV(gpGetTextureHandleNV, (C.GLuint)(texture))
+	return (uint64)(ret)
+}
 
 // return a texture image
 func GetTextureImage(texture uint32, level int32, format uint32, xtype uint32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetTextureImage(gpGetTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), pixels)
 }
+func GetTextureImageEXT(texture uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetTextureImageEXT(gpGetTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 func GetTextureLevelParameterfv(texture uint32, level int32, pname uint32, params *float32) {
 	C.glowGetTextureLevelParameterfv(gpGetTextureLevelParameterfv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureLevelParameterfvEXT(texture uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetTextureLevelParameterfvEXT(gpGetTextureLevelParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureLevelParameteriv(texture uint32, level int32, pname uint32, params *int32) {
 	C.glowGetTextureLevelParameteriv(gpGetTextureLevelParameteriv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureLevelParameterivEXT(texture uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetTextureLevelParameterivEXT(gpGetTextureLevelParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameterIiv(gpGetTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetTextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterIivEXT(gpGetTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetTextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowGetTextureParameterIuiv(gpGetTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetTextureParameterIuivEXT(gpGetTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterfv(texture uint32, pname uint32, params *float32) {
 	C.glowGetTextureParameterfv(gpGetTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetTextureParameterfvEXT(gpGetTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureParameteriv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameteriv(gpGetTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterivEXT(gpGetTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureSamplerHandleARB(texture uint32, sampler uint32) uint64 {
 	ret := C.glowGetTextureSamplerHandleARB(gpGetTextureSamplerHandleARB, (C.GLuint)(texture), (C.GLuint)(sampler))
+	return (uint64)(ret)
+}
+func GetTextureSamplerHandleNV(texture uint32, sampler uint32) uint64 {
+	ret := C.glowGetTextureSamplerHandleNV(gpGetTextureSamplerHandleNV, (C.GLuint)(texture), (C.GLuint)(sampler))
 	return (uint64)(ret)
 }
 
@@ -6566,10 +10424,22 @@ func GetUniformdv(program uint32, location int32, params *float64) {
 func GetUniformfv(program uint32, location int32, params *float32) {
 	C.glowGetUniformfv(gpGetUniformfv, (C.GLuint)(program), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func GetUniformi64vNV(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 
 // Returns the value of a uniform variable
 func GetUniformiv(program uint32, location int32, params *int32) {
 	C.glowGetUniformiv(gpGetUniformiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func GetUniformui64vNV(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 func GetUniformuiv(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuiv(gpGetUniformuiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
@@ -6579,6 +10449,18 @@ func GetVertexArrayIndexed64iv(vaobj uint32, index uint32, pname uint32, param *
 }
 func GetVertexArrayIndexediv(vaobj uint32, index uint32, pname uint32, param *int32) {
 	C.glowGetVertexArrayIndexediv(gpGetVertexArrayIndexediv, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegeri_vEXT(vaobj uint32, index uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegeri_vEXT(gpGetVertexArrayIntegeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegervEXT(vaobj uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegervEXT(gpGetVertexArrayIntegervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayPointeri_vEXT(vaobj uint32, index uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointeri_vEXT(gpGetVertexArrayPointeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), param)
+}
+func GetVertexArrayPointervEXT(vaobj uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointervEXT(gpGetVertexArrayPointervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), param)
 }
 
 // retrieve parameters of a vertex array object
@@ -6600,8 +10482,14 @@ func GetVertexAttribIuiv(index uint32, pname uint32, params *uint32) {
 func GetVertexAttribLdv(index uint32, pname uint32, params *float64) {
 	C.glowGetVertexAttribLdv(gpGetVertexAttribLdv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
 }
+func GetVertexAttribLi64vNV(index uint32, pname uint32, params *int64) {
+	C.glowGetVertexAttribLi64vNV(gpGetVertexAttribLi64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 func GetVertexAttribLui64vARB(index uint32, pname uint32, params *uint64) {
 	C.glowGetVertexAttribLui64vARB(gpGetVertexAttribLui64vARB, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
+func GetVertexAttribLui64vNV(index uint32, pname uint32, params *uint64) {
+	C.glowGetVertexAttribLui64vNV(gpGetVertexAttribLui64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 
 // return the address of the specified generic vertex attribute pointer
@@ -6623,6 +10511,10 @@ func GetVertexAttribfv(index uint32, pname uint32, params *float32) {
 func GetVertexAttribiv(index uint32, pname uint32, params *int32) {
 	C.glowGetVertexAttribiv(gpGetVertexAttribiv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
+}
 func GetnCompressedTexImageARB(target uint32, lod int32, bufSize int32, img unsafe.Pointer) {
 	C.glowGetnCompressedTexImageARB(gpGetnCompressedTexImageARB, (C.GLenum)(target), (C.GLint)(lod), (C.GLsizei)(bufSize), img)
 }
@@ -6641,6 +10533,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6649,6 +10544,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -6663,6 +10561,15 @@ func GetnUniformuivKHR(program uint32, location int32, bufSize int32, params *ui
 // specify implementation-specific hints
 func Hint(target uint32, mode uint32) {
 	C.glowHint(gpHint, (C.GLenum)(target), (C.GLenum)(mode))
+}
+func IndexFormatNV(xtype uint32, stride int32) {
+	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func InsertEventMarkerEXT(length int32, marker *uint8) {
+	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
+func InterpolatePathsNV(resultPath uint32, pathA uint32, pathB uint32, weight float32) {
+	C.glowInterpolatePathsNV(gpInterpolatePathsNV, (C.GLuint)(resultPath), (C.GLuint)(pathA), (C.GLuint)(pathB), (C.GLfloat)(weight))
 }
 
 // invalidate the content of a buffer object's data store
@@ -6710,8 +10617,20 @@ func IsBuffer(buffer uint32) bool {
 	ret := C.glowIsBuffer(gpIsBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func IsBufferResidentNV(target uint32) bool {
+	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
+	return ret == TRUE
+}
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
+	return ret == TRUE
+}
+func IsEnabledIndexedEXT(target uint32, index uint32) bool {
+	ret := C.glowIsEnabledIndexedEXT(gpIsEnabledIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
 	return ret == TRUE
 }
 func IsEnabledi(target uint32, index uint32) bool {
@@ -6728,8 +10647,28 @@ func IsImageHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsImageHandleResidentARB(gpIsImageHandleResidentARB, (C.GLuint64)(handle))
 	return ret == TRUE
 }
+func IsImageHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsImageHandleResidentNV(gpIsImageHandleResidentNV, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsNamedBufferResidentNV(buffer uint32) bool {
+	ret := C.glowIsNamedBufferResidentNV(gpIsNamedBufferResidentNV, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+	return ret == TRUE
+}
+func IsPathNV(path uint32) bool {
+	ret := C.glowIsPathNV(gpIsPathNV, (C.GLuint)(path))
+	return ret == TRUE
+}
+func IsPointInFillPathNV(path uint32, mask uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInFillPathNV(gpIsPointInFillPathNV, (C.GLuint)(path), (C.GLuint)(mask), (C.GLfloat)(x), (C.GLfloat)(y))
+	return ret == TRUE
+}
+func IsPointInStrokePathNV(path uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInStrokePathNV(gpIsPointInStrokePathNV, (C.GLuint)(path), (C.GLfloat)(x), (C.GLfloat)(y))
 	return ret == TRUE
 }
 
@@ -6742,6 +10681,10 @@ func IsProgram(program uint32) bool {
 // determine if a name corresponds to a program pipeline object
 func IsProgramPipeline(pipeline uint32) bool {
 	ret := C.glowIsProgramPipeline(gpIsProgramPipeline, (C.GLuint)(pipeline))
+	return ret == TRUE
+}
+func IsProgramPipelineEXT(pipeline uint32) bool {
+	ret := C.glowIsProgramPipelineEXT(gpIsProgramPipelineEXT, (C.GLuint)(pipeline))
 	return ret == TRUE
 }
 
@@ -6768,9 +10711,13 @@ func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -6782,6 +10729,10 @@ func IsTexture(texture uint32) bool {
 }
 func IsTextureHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsTextureHandleResidentARB(gpIsTextureHandleResidentARB, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsTextureHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsTextureHandleResidentNV(gpIsTextureHandleResidentNV, (C.GLuint64)(handle))
 	return ret == TRUE
 }
 
@@ -6796,6 +10747,9 @@ func IsVertexArray(array uint32) bool {
 	ret := C.glowIsVertexArray(gpIsVertexArray, (C.GLuint)(array))
 	return ret == TRUE
 }
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
+	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
+}
 
 // specify the width of rasterized lines
 func LineWidth(width float32) {
@@ -6806,22 +10760,49 @@ func LineWidth(width float32) {
 func LinkProgram(program uint32) {
 	C.glowLinkProgram(gpLinkProgram, (C.GLuint)(program))
 }
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 
 // specify a logical pixel operation for rendering
 func LogicOp(opcode uint32) {
 	C.glowLogicOp(gpLogicOp, (C.GLenum)(opcode))
 }
+func MakeBufferNonResidentNV(target uint32) {
+	C.glowMakeBufferNonResidentNV(gpMakeBufferNonResidentNV, (C.GLenum)(target))
+}
+func MakeBufferResidentNV(target uint32, access uint32) {
+	C.glowMakeBufferResidentNV(gpMakeBufferResidentNV, (C.GLenum)(target), (C.GLenum)(access))
+}
 func MakeImageHandleNonResidentARB(handle uint64) {
 	C.glowMakeImageHandleNonResidentARB(gpMakeImageHandleNonResidentARB, (C.GLuint64)(handle))
+}
+func MakeImageHandleNonResidentNV(handle uint64) {
+	C.glowMakeImageHandleNonResidentNV(gpMakeImageHandleNonResidentNV, (C.GLuint64)(handle))
 }
 func MakeImageHandleResidentARB(handle uint64, access uint32) {
 	C.glowMakeImageHandleResidentARB(gpMakeImageHandleResidentARB, (C.GLuint64)(handle), (C.GLenum)(access))
 }
+func MakeImageHandleResidentNV(handle uint64, access uint32) {
+	C.glowMakeImageHandleResidentNV(gpMakeImageHandleResidentNV, (C.GLuint64)(handle), (C.GLenum)(access))
+}
+func MakeNamedBufferNonResidentNV(buffer uint32) {
+	C.glowMakeNamedBufferNonResidentNV(gpMakeNamedBufferNonResidentNV, (C.GLuint)(buffer))
+}
+func MakeNamedBufferResidentNV(buffer uint32, access uint32) {
+	C.glowMakeNamedBufferResidentNV(gpMakeNamedBufferResidentNV, (C.GLuint)(buffer), (C.GLenum)(access))
+}
 func MakeTextureHandleNonResidentARB(handle uint64) {
 	C.glowMakeTextureHandleNonResidentARB(gpMakeTextureHandleNonResidentARB, (C.GLuint64)(handle))
 }
+func MakeTextureHandleNonResidentNV(handle uint64) {
+	C.glowMakeTextureHandleNonResidentNV(gpMakeTextureHandleNonResidentNV, (C.GLuint64)(handle))
+}
 func MakeTextureHandleResidentARB(handle uint64) {
 	C.glowMakeTextureHandleResidentARB(gpMakeTextureHandleResidentARB, (C.GLuint64)(handle))
+}
+func MakeTextureHandleResidentNV(handle uint64) {
+	C.glowMakeTextureHandleResidentNV(gpMakeTextureHandleResidentNV, (C.GLuint64)(handle))
 }
 
 // map all of a buffer object's data store into the client's address space
@@ -6841,11 +10822,100 @@ func MapNamedBuffer(buffer uint32, access uint32) unsafe.Pointer {
 	ret := C.glowMapNamedBuffer(gpMapNamedBuffer, (C.GLuint)(buffer), (C.GLenum)(access))
 	return (unsafe.Pointer)(ret)
 }
+func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferEXT(gpMapNamedBufferEXT, (C.GLuint)(buffer), (C.GLenum)(access))
+	return (unsafe.Pointer)(ret)
+}
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
+}
+func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRangeEXT(gpMapNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
+	return (unsafe.Pointer)(ret)
+}
+func MatrixFrustumEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixFrustumEXT(gpMatrixFrustumEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixLoad3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x2fNV(gpMatrixLoad3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoad3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x3fNV(gpMatrixLoad3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadIdentityEXT(mode uint32) {
+	C.glowMatrixLoadIdentityEXT(gpMatrixLoadIdentityEXT, (C.GLenum)(mode))
+}
+func MatrixLoadTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoadTranspose3x3fNV(gpMatrixLoadTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixLoadTransposedEXT(gpMatrixLoadTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadTransposefEXT(gpMatrixLoadTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoaddEXT(mode uint32, m *float64) {
+	C.glowMatrixLoaddEXT(gpMatrixLoaddEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadfEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadfEXT(gpMatrixLoadfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x2fNV(gpMatrixMult3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x3fNV(gpMatrixMult3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMultTranspose3x3fNV(gpMatrixMultTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixMultTransposedEXT(gpMatrixMultTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixMultTransposefEXT(gpMatrixMultTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultdEXT(mode uint32, m *float64) {
+	C.glowMatrixMultdEXT(gpMatrixMultdEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultfEXT(mode uint32, m *float32) {
+	C.glowMatrixMultfEXT(gpMatrixMultfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixOrthoEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixOrthoEXT(gpMatrixOrthoEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixPopEXT(mode uint32) {
+	C.glowMatrixPopEXT(gpMatrixPopEXT, (C.GLenum)(mode))
+}
+func MatrixPushEXT(mode uint32) {
+	C.glowMatrixPushEXT(gpMatrixPushEXT, (C.GLenum)(mode))
+}
+func MatrixRotatedEXT(mode uint32, angle float64, x float64, y float64, z float64) {
+	C.glowMatrixRotatedEXT(gpMatrixRotatedEXT, (C.GLenum)(mode), (C.GLdouble)(angle), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixRotatefEXT(mode uint32, angle float32, x float32, y float32, z float32) {
+	C.glowMatrixRotatefEXT(gpMatrixRotatefEXT, (C.GLenum)(mode), (C.GLfloat)(angle), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixScaledEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixScaledEXT(gpMatrixScaledEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixScalefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixScalefEXT(gpMatrixScalefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixTranslatedEXT(gpMatrixTranslatedEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
 }
 
 // defines a barrier ordering memory transactions
@@ -6873,8 +10943,14 @@ func MultiDrawArrays(mode uint32, first *int32, count *int32, drawcount int32) {
 func MultiDrawArraysIndirect(mode uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawArraysIndirect(gpMultiDrawArraysIndirect, (C.GLenum)(mode), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessCountNV(gpMultiDrawArraysIndirectBindlessCountNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 
 // render multiple sets of primitives by specifying indices of array data elements
@@ -6891,29 +10967,122 @@ func MultiDrawElementsBaseVertex(mode uint32, count *int32, xtype uint32, indice
 func MultiDrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawElementsIndirect(gpMultiDrawElementsIndirect, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessCountNV(gpMultiDrawElementsIndirectBindlessCountNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+}
+func MultiTexBufferEXT(texunit uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowMultiTexBufferEXT(gpMultiTexBufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
+func MultiTexCoordPointerEXT(texunit uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
+	C.glowMultiTexCoordPointerEXT(gpMultiTexCoordPointerEXT, (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
+}
+func MultiTexEnvfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexEnvfEXT(gpMultiTexEnvfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexEnvfvEXT(gpMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexEnviEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexEnviEXT(gpMultiTexEnviEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexEnvivEXT(gpMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexGendEXT(texunit uint32, coord uint32, pname uint32, param float64) {
+	C.glowMultiTexGendEXT(gpMultiTexGendEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLdouble)(param))
+}
+func MultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowMultiTexGendvEXT(gpMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func MultiTexGenfEXT(texunit uint32, coord uint32, pname uint32, param float32) {
+	C.glowMultiTexGenfEXT(gpMultiTexGenfEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowMultiTexGenfvEXT(gpMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexGeniEXT(texunit uint32, coord uint32, pname uint32, param int32) {
+	C.glowMultiTexGeniEXT(gpMultiTexGeniEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowMultiTexGenivEXT(gpMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage1DEXT(gpMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage2DEXT(gpMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage3DEXT(gpMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterIivEXT(gpMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowMultiTexParameterIuivEXT(gpMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexParameterfEXT(gpMultiTexParameterfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexParameterfvEXT(gpMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexParameteriEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexParameteriEXT(gpMultiTexParameteriEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterivEXT(gpMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexRenderbufferEXT(texunit uint32, target uint32, renderbuffer uint32) {
+	C.glowMultiTexRenderbufferEXT(gpMultiTexRenderbufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(renderbuffer))
+}
+func MultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage1DEXT(gpMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage2DEXT(gpMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
+}
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
+}
+func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedCopyBufferSubDataEXT(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowNamedCopyBufferSubDataEXT(gpNamedCopyBufferSubDataEXT, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 
 // specify which color buffers are to be drawn into
@@ -6930,6 +11099,9 @@ func NamedFramebufferDrawBuffers(framebuffer uint32, n int32, bufs *uint32) {
 func NamedFramebufferParameteri(framebuffer uint32, pname uint32, param int32) {
 	C.glowNamedFramebufferParameteri(gpNamedFramebufferParameteri, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
 }
+func NamedFramebufferParameteriEXT(framebuffer uint32, pname uint32, param int32) {
+	C.glowNamedFramebufferParameteriEXT(gpNamedFramebufferParameteriEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // select a color buffer source for pixels
 func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
@@ -6940,26 +11112,101 @@ func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
 func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbuffer(gpNamedFramebufferRenderbuffer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
+	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture1DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture1DEXT(gpNamedFramebufferTexture1DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture2DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture2DEXT(gpNamedFramebufferTexture2DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture3DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
+	C.glowNamedFramebufferTexture3DEXT(gpNamedFramebufferTexture3DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
+}
+func NamedFramebufferTextureEXT(framebuffer uint32, attachment uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTextureEXT(gpNamedFramebufferTextureEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTextureFaceEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowNamedFramebufferTextureFaceEXT(gpNamedFramebufferTextureFaceEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
 }
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func NamedFramebufferTextureLayer(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowNamedFramebufferTextureLayer(gpNamedFramebufferTextureLayer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
 }
+func NamedFramebufferTextureLayerEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowNamedFramebufferTextureLayerEXT(gpNamedFramebufferTextureLayerEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func NamedProgramLocalParameter4dEXT(program uint32, target uint32, index uint32, x float64, y float64, z float64, w float64) {
+	C.glowNamedProgramLocalParameter4dEXT(gpNamedProgramLocalParameter4dEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
+func NamedProgramLocalParameter4dvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowNamedProgramLocalParameter4dvEXT(gpNamedProgramLocalParameter4dvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameter4fEXT(program uint32, target uint32, index uint32, x float32, y float32, z float32, w float32) {
+	C.glowNamedProgramLocalParameter4fEXT(gpNamedProgramLocalParameter4fEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z), (C.GLfloat)(w))
+}
+func NamedProgramLocalParameter4fvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowNamedProgramLocalParameter4fvEXT(gpNamedProgramLocalParameter4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4iEXT(program uint32, target uint32, index uint32, x int32, y int32, z int32, w int32) {
+	C.glowNamedProgramLocalParameterI4iEXT(gpNamedProgramLocalParameterI4iEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLint)(x), (C.GLint)(y), (C.GLint)(z), (C.GLint)(w))
+}
+func NamedProgramLocalParameterI4ivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowNamedProgramLocalParameterI4ivEXT(gpNamedProgramLocalParameterI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4uiEXT(program uint32, target uint32, index uint32, x uint32, y uint32, z uint32, w uint32) {
+	C.glowNamedProgramLocalParameterI4uiEXT(gpNamedProgramLocalParameterI4uiEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(x), (C.GLuint)(y), (C.GLuint)(z), (C.GLuint)(w))
+}
+func NamedProgramLocalParameterI4uivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowNamedProgramLocalParameterI4uivEXT(gpNamedProgramLocalParameterI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameters4fvEXT(program uint32, target uint32, index uint32, count int32, params *float32) {
+	C.glowNamedProgramLocalParameters4fvEXT(gpNamedProgramLocalParameters4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4ivEXT(program uint32, target uint32, index uint32, count int32, params *int32) {
+	C.glowNamedProgramLocalParametersI4ivEXT(gpNamedProgramLocalParametersI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4uivEXT(program uint32, target uint32, index uint32, count int32, params *uint32) {
+	C.glowNamedProgramLocalParametersI4uivEXT(gpNamedProgramLocalParametersI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramStringEXT(program uint32, target uint32, format uint32, len int32, xstring unsafe.Pointer) {
+	C.glowNamedProgramStringEXT(gpNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(format), (C.GLsizei)(len), xstring)
+}
 
 // establish data storage, format and dimensions of a     renderbuffer object's image
 func NamedRenderbufferStorage(renderbuffer uint32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorage(gpNamedRenderbufferStorage, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageEXT(renderbuffer uint32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageEXT(gpNamedRenderbufferStorageEXT, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func NamedRenderbufferStorageMultisample(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisample(gpNamedRenderbufferStorageMultisample, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func NamedRenderbufferStorageMultisampleCoverageEXT(renderbuffer uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleCoverageEXT(gpNamedRenderbufferStorageMultisampleCoverageEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageMultisampleEXT(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleEXT(gpNamedRenderbufferStorageMultisampleEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
+}
+func NormalFormatNV(xtype uint32, stride int32) {
+	C.glowNormalFormatNV(gpNormalFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // label a named object identified within a namespace
@@ -6980,8 +11227,67 @@ func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathCommandsNV(path uint32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCommandsNV(gpPathCommandsNV, (C.GLuint)(path), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoordsNV(path uint32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCoordsNV(gpPathCoordsNV, (C.GLuint)(path), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoverDepthFuncNV(xfunc uint32) {
+	C.glowPathCoverDepthFuncNV(gpPathCoverDepthFuncNV, (C.GLenum)(xfunc))
+}
+func PathDashArrayNV(path uint32, dashCount int32, dashArray *float32) {
+	C.glowPathDashArrayNV(gpPathDashArrayNV, (C.GLuint)(path), (C.GLsizei)(dashCount), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func PathGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathGlyphIndexArrayNV(gpPathGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathGlyphIndexRangeNV(fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, pathParameterTemplate uint32, emScale float32, baseAndCount *uint32) uint32 {
+	ret := C.glowPathGlyphIndexRangeNV(gpPathGlyphIndexRangeNV, (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale), (*C.GLuint)(unsafe.Pointer(baseAndCount)))
+	return (uint32)(ret)
+}
+func PathGlyphRangeNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyph uint32, numGlyphs int32, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphRangeNV(gpPathGlyphRangeNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyph), (C.GLsizei)(numGlyphs), (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathGlyphsNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, numGlyphs int32, xtype uint32, charcodes unsafe.Pointer, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphsNV(gpPathGlyphsNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLsizei)(numGlyphs), (C.GLenum)(xtype), charcodes, (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathMemoryGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontSize int, fontData unsafe.Pointer, faceIndex int32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathMemoryGlyphIndexArrayNV(gpPathMemoryGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), (C.GLsizeiptr)(fontSize), fontData, (C.GLsizei)(faceIndex), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathParameterfNV(path uint32, pname uint32, value float32) {
+	C.glowPathParameterfNV(gpPathParameterfNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func PathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowPathParameterfvNV(gpPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func PathParameteriNV(path uint32, pname uint32, value int32) {
+	C.glowPathParameteriNV(gpPathParameteriNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowPathParameterivNV(gpPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func PathStencilDepthOffsetNV(factor float32, units float32) {
+	C.glowPathStencilDepthOffsetNV(gpPathStencilDepthOffsetNV, (C.GLfloat)(factor), (C.GLfloat)(units))
+}
+func PathStencilFuncNV(xfunc uint32, ref int32, mask uint32) {
+	C.glowPathStencilFuncNV(gpPathStencilFuncNV, (C.GLenum)(xfunc), (C.GLint)(ref), (C.GLuint)(mask))
+}
+func PathStringNV(path uint32, format uint32, length int32, pathString unsafe.Pointer) {
+	C.glowPathStringNV(gpPathStringNV, (C.GLuint)(path), (C.GLenum)(format), (C.GLsizei)(length), pathString)
+}
+func PathSubCommandsNV(path uint32, commandStart int32, commandsToDelete int32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCommandsNV(gpPathSubCommandsNV, (C.GLuint)(path), (C.GLsizei)(commandStart), (C.GLsizei)(commandsToDelete), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathSubCoordsNV(path uint32, coordStart int32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCoordsNV(gpPathSubCoordsNV, (C.GLuint)(path), (C.GLsizei)(coordStart), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
 }
 
 // pause transform feedback operations
@@ -6991,8 +11297,14 @@ func PauseTransformFeedback() {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
+}
+func PointAlongPathNV(path uint32, startSegment int32, numSegments int32, distance float32, x *float32, y *float32, tangentX *float32, tangentY *float32) bool {
+	ret := C.glowPointAlongPathNV(gpPointAlongPathNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments), (C.GLfloat)(distance), (*C.GLfloat)(unsafe.Pointer(x)), (*C.GLfloat)(unsafe.Pointer(y)), (*C.GLfloat)(unsafe.Pointer(tangentX)), (*C.GLfloat)(unsafe.Pointer(tangentY)))
+	return ret == TRUE
 }
 func PointParameterf(pname uint32, param float32) {
 	C.glowPointParameterf(gpPointParameterf, (C.GLenum)(pname), (C.GLfloat)(param))
@@ -7021,6 +11333,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 
 // pop the active debug group
 func PopDebugGroup() {
@@ -7028,6 +11346,12 @@ func PopDebugGroup() {
 }
 func PopDebugGroupKHR() {
 	C.glowPopDebugGroupKHR(gpPopDebugGroupKHR)
+}
+func PopGroupMarkerEXT() {
+	C.glowPopGroupMarkerEXT(gpPopGroupMarkerEXT)
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -7039,235 +11363,507 @@ func PrimitiveRestartIndex(index uint32) {
 func ProgramBinary(program uint32, binaryFormat uint32, binary unsafe.Pointer, length int32) {
 	C.glowProgramBinary(gpProgramBinary, (C.GLuint)(program), (C.GLenum)(binaryFormat), binary, (C.GLsizei)(length))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriARB(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriARB(gpProgramParameteriARB, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriEXT(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriEXT(gpProgramParameteriEXT, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramPathFragmentInputGenNV(program uint32, location int32, genMode uint32, components int32, coeffs *float32) {
+	C.glowProgramPathFragmentInputGenNV(gpProgramPathFragmentInputGenNV, (C.GLuint)(program), (C.GLint)(location), (C.GLenum)(genMode), (C.GLint)(components), (*C.GLfloat)(unsafe.Pointer(coeffs)))
 }
 func ProgramUniform1d(program uint32, location int32, v0 float64) {
 	C.glowProgramUniform1d(gpProgramUniform1d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0))
 }
+func ProgramUniform1dEXT(program uint32, location int32, x float64) {
+	C.glowProgramUniform1dEXT(gpProgramUniform1dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x))
+}
 func ProgramUniform1dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform1dv(gpProgramUniform1dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform1dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform1dvEXT(gpProgramUniform1dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1f(program uint32, location int32, v0 float32) {
 	C.glowProgramUniform1f(gpProgramUniform1f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
 }
+func ProgramUniform1fEXT(program uint32, location int32, v0 float32) {
+	C.glowProgramUniform1fEXT(gpProgramUniform1fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform1fv(gpProgramUniform1fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform1fvEXT(gpProgramUniform1fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
+func ProgramUniform1i64NV(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1iEXT(program uint32, location int32, v0 int32) {
+	C.glowProgramUniform1iEXT(gpProgramUniform1iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform1iv(gpProgramUniform1iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform1ivEXT(gpProgramUniform1ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
+func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1uiEXT(program uint32, location int32, v0 uint32) {
+	C.glowProgramUniform1uiEXT(gpProgramUniform1uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform1uiv(gpProgramUniform1uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform1uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform1uivEXT(gpProgramUniform1uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform2d(program uint32, location int32, v0 float64, v1 float64) {
 	C.glowProgramUniform2d(gpProgramUniform2d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1))
 }
+func ProgramUniform2dEXT(program uint32, location int32, x float64, y float64) {
+	C.glowProgramUniform2dEXT(gpProgramUniform2dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y))
+}
 func ProgramUniform2dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform2dv(gpProgramUniform2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform2dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform2dvEXT(gpProgramUniform2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2f(program uint32, location int32, v0 float32, v1 float32) {
 	C.glowProgramUniform2f(gpProgramUniform2f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
 }
+func ProgramUniform2fEXT(program uint32, location int32, v0 float32, v1 float32) {
+	C.glowProgramUniform2fEXT(gpProgramUniform2fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform2fv(gpProgramUniform2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform2fvEXT(gpProgramUniform2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2iEXT(program uint32, location int32, v0 int32, v1 int32) {
+	C.glowProgramUniform2iEXT(gpProgramUniform2iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform2iv(gpProgramUniform2iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform2ivEXT(gpProgramUniform2ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2uiEXT(program uint32, location int32, v0 uint32, v1 uint32) {
+	C.glowProgramUniform2uiEXT(gpProgramUniform2uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform2uiv(gpProgramUniform2uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform2uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform2uivEXT(gpProgramUniform2uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform3d(program uint32, location int32, v0 float64, v1 float64, v2 float64) {
 	C.glowProgramUniform3d(gpProgramUniform3d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2))
 }
+func ProgramUniform3dEXT(program uint32, location int32, x float64, y float64, z float64) {
+	C.glowProgramUniform3dEXT(gpProgramUniform3dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
 func ProgramUniform3dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform3dv(gpProgramUniform3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform3dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform3dvEXT(gpProgramUniform3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3f(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
 	C.glowProgramUniform3f(gpProgramUniform3f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
 }
+func ProgramUniform3fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
+	C.glowProgramUniform3fEXT(gpProgramUniform3fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform3fv(gpProgramUniform3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform3fvEXT(gpProgramUniform3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
+	C.glowProgramUniform3iEXT(gpProgramUniform3iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform3iv(gpProgramUniform3iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform3ivEXT(gpProgramUniform3ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
+	C.glowProgramUniform3uiEXT(gpProgramUniform3uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform3uiv(gpProgramUniform3uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform3uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform3uivEXT(gpProgramUniform3uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform4d(program uint32, location int32, v0 float64, v1 float64, v2 float64, v3 float64) {
 	C.glowProgramUniform4d(gpProgramUniform4d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2), (C.GLdouble)(v3))
 }
+func ProgramUniform4dEXT(program uint32, location int32, x float64, y float64, z float64, w float64) {
+	C.glowProgramUniform4dEXT(gpProgramUniform4dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
 func ProgramUniform4dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform4dv(gpProgramUniform4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform4dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform4dvEXT(gpProgramUniform4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4f(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
 	C.glowProgramUniform4f(gpProgramUniform4f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
 }
+func ProgramUniform4fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
+	C.glowProgramUniform4fEXT(gpProgramUniform4fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform4fv(gpProgramUniform4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform4fvEXT(gpProgramUniform4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
+	C.glowProgramUniform4iEXT(gpProgramUniform4iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform4iv(gpProgramUniform4iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform4ivEXT(gpProgramUniform4ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
+	C.glowProgramUniform4uiEXT(gpProgramUniform4uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform4uiv(gpProgramUniform4uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform4uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform4uivEXT(gpProgramUniform4uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniformHandleui64ARB(program uint32, location int32, value uint64) {
 	C.glowProgramUniformHandleui64ARB(gpProgramUniformHandleui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
+}
+func ProgramUniformHandleui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformHandleui64NV(gpProgramUniformHandleui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
 }
 func ProgramUniformHandleui64vARB(program uint32, location int32, count int32, values *uint64) {
 	C.glowProgramUniformHandleui64vARB(gpProgramUniformHandleui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
 }
+func ProgramUniformHandleui64vNV(program uint32, location int32, count int32, values *uint64) {
+	C.glowProgramUniformHandleui64vNV(gpProgramUniformHandleui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
+}
 func ProgramUniformMatrix2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2dv(gpProgramUniformMatrix2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2dvEXT(gpProgramUniformMatrix2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2fv(gpProgramUniformMatrix2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2fvEXT(gpProgramUniformMatrix2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x3dv(gpProgramUniformMatrix2x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x3dvEXT(gpProgramUniformMatrix2x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x3fv(gpProgramUniformMatrix2x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x3fvEXT(gpProgramUniformMatrix2x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x4dv(gpProgramUniformMatrix2x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x4dvEXT(gpProgramUniformMatrix2x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x4fv(gpProgramUniformMatrix2x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x4fvEXT(gpProgramUniformMatrix2x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3dv(gpProgramUniformMatrix3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3dvEXT(gpProgramUniformMatrix3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3fv(gpProgramUniformMatrix3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3fvEXT(gpProgramUniformMatrix3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x2dv(gpProgramUniformMatrix3x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x2dvEXT(gpProgramUniformMatrix3x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x2fv(gpProgramUniformMatrix3x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x2fvEXT(gpProgramUniformMatrix3x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x4dv(gpProgramUniformMatrix3x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x4dvEXT(gpProgramUniformMatrix3x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x4fv(gpProgramUniformMatrix3x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x4fvEXT(gpProgramUniformMatrix3x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4dv(gpProgramUniformMatrix4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4dvEXT(gpProgramUniformMatrix4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4fv(gpProgramUniformMatrix4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4fvEXT(gpProgramUniformMatrix4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x2dv(gpProgramUniformMatrix4x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x2dvEXT(gpProgramUniformMatrix4x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x2fv(gpProgramUniformMatrix4x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x2fvEXT(gpProgramUniformMatrix4x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x3dv(gpProgramUniformMatrix4x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x3dvEXT(gpProgramUniformMatrix4x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x3fv(gpProgramUniformMatrix4x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x3fvEXT(gpProgramUniformMatrix4x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniformui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformui64NV(gpProgramUniformui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func ProgramUniformui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniformui64vNV(gpProgramUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // specifiy the vertex to be used as the source of data for flat shaded varyings
 func ProvokingVertex(mode uint32) {
 	C.glowProvokingVertex(gpProvokingVertex, (C.GLenum)(mode))
+}
+func PushClientAttribDefaultEXT(mask uint32) {
+	C.glowPushClientAttribDefaultEXT(gpPushClientAttribDefaultEXT, (C.GLbitfield)(mask))
 }
 
 // push a named debug group into the command stream
@@ -7277,10 +11873,16 @@ func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
+func PushGroupMarkerEXT(length int32, marker *uint8) {
+	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
 
 // record the GL time into a query object after all previous commands have reached the GL server but have not yet necessarily executed.
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
+}
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
 
 // select a color buffer source for pixels
@@ -7317,6 +11919,12 @@ func RenderbufferStorage(target uint32, internalformat uint32, width int32, heig
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func RenderbufferStorageMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowRenderbufferStorageMultisample(gpRenderbufferStorageMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func RenderbufferStorageMultisampleCoverageNV(target uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowRenderbufferStorageMultisampleCoverageNV(gpRenderbufferStorageMultisampleCoverageNV, (C.GLenum)(target), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
 }
 
 // resume transform feedback operations
@@ -7367,6 +11975,12 @@ func ScissorIndexed(index uint32, left int32, bottom int32, width int32, height 
 func ScissorIndexedv(index uint32, v *int32) {
 	C.glowScissorIndexedv(gpScissorIndexedv, (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(v)))
 }
+func SecondaryColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowSecondaryColorFormatNV(gpSecondaryColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
+	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
+}
 
 // load pre-compiled shader binaries
 func ShaderBinary(count int32, shaders *uint32, binaryformat uint32, binary unsafe.Pointer, length int32) {
@@ -7381,6 +11995,24 @@ func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 // change an active shader storage block binding
 func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storageBlockBinding uint32) {
 	C.glowShaderStorageBlockBinding(gpShaderStorageBlockBinding, (C.GLuint)(program), (C.GLuint)(storageBlockIndex), (C.GLuint)(storageBlockBinding))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
+}
+func StencilFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilFillPathInstancedNV(gpStencilFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilFillPathNV(path uint32, fillMode uint32, mask uint32) {
+	C.glowStencilFillPathNV(gpStencilFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask))
 }
 
 // set front and back function and reference value for stencil testing
@@ -7412,15 +12044,42 @@ func StencilOp(fail uint32, zfail uint32, zpass uint32) {
 func StencilOpSeparate(face uint32, sfail uint32, dpfail uint32, dppass uint32) {
 	C.glowStencilOpSeparate(gpStencilOpSeparate, (C.GLenum)(face), (C.GLenum)(sfail), (C.GLenum)(dpfail), (C.GLenum)(dppass))
 }
+func StencilStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilStrokePathInstancedNV(gpStencilStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilStrokePathNV(path uint32, reference int32, mask uint32) {
+	C.glowStencilStrokePathNV(gpStencilStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask))
+}
+func StencilThenCoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverFillPathInstancedNV(gpStencilThenCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverFillPathNV(path uint32, fillMode uint32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverFillPathNV(gpStencilThenCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func StencilThenCoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverStrokePathInstancedNV(gpStencilThenCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverStrokePathNV(path uint32, reference int32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverStrokePathNV(gpStencilThenCoverStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TexBuffer(target uint32, internalformat uint32, buffer uint32) {
 	C.glowTexBuffer(gpTexBuffer, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TexBufferARB(target uint32, internalformat uint32, buffer uint32) {
+	C.glowTexBufferARB(gpTexBufferARB, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
 func TexBufferRange(target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTexBufferRange(gpTexBufferRange, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TexCoordFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowTexCoordFormatNV(gpTexCoordFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // specify a one-dimensional texture image
@@ -7447,8 +12106,8 @@ func TexImage3D(target uint32, level int32, internalformat int32, width int32, h
 func TexImage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexImage3DMultisample(gpTexImage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -7513,73 +12172,139 @@ func TexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zof
 func TextureBarrier() {
 	C.glowTextureBarrier(gpTextureBarrier)
 }
+func TextureBarrierNV() {
+	C.glowTextureBarrierNV(gpTextureBarrierNV)
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TextureBuffer(texture uint32, internalformat uint32, buffer uint32) {
 	C.glowTextureBuffer(gpTextureBuffer, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowTextureBufferEXT(gpTextureBufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureImage1DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage1DEXT(gpTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage2DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage2DEXT(gpTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage3DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage3DEXT(gpTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func TextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterIivEXT(gpTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func TextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowTextureParameterIuiv(gpTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func TextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowTextureParameterIuivEXT(gpTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
 func TextureParameterf(texture uint32, pname uint32, param float32) {
 	C.glowTextureParameterf(gpTextureParameterf, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLfloat)(param))
 }
+func TextureParameterfEXT(texture uint32, target uint32, pname uint32, param float32) {
+	C.glowTextureParameterfEXT(gpTextureParameterfEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
 func TextureParameterfv(texture uint32, pname uint32, param *float32) {
 	C.glowTextureParameterfv(gpTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(param)))
+}
+func TextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowTextureParameterfvEXT(gpTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func TextureParameteri(texture uint32, pname uint32, param int32) {
 	C.glowTextureParameteri(gpTextureParameteri, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLint)(param))
 }
+func TextureParameteriEXT(texture uint32, target uint32, pname uint32, param int32) {
+	C.glowTextureParameteriEXT(gpTextureParameteriEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
 func TextureParameteriv(texture uint32, pname uint32, param *int32) {
 	C.glowTextureParameteriv(gpTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func TextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterivEXT(gpTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func TextureRenderbufferEXT(texture uint32, target uint32, renderbuffer uint32) {
+	C.glowTextureRenderbufferEXT(gpTextureRenderbufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLuint)(renderbuffer))
 }
 
 // simultaneously specify storage for all levels of a one-dimensional texture
 func TextureStorage1D(texture uint32, levels int32, internalformat uint32, width int32) {
 	C.glowTextureStorage1D(gpTextureStorage1D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
 }
+func TextureStorage1DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32) {
+	C.glowTextureStorage1DEXT(gpTextureStorage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
+}
 
 // simultaneously specify storage for all levels of a two-dimensional or one-dimensional array texture
 func TextureStorage2D(texture uint32, levels int32, internalformat uint32, width int32, height int32) {
 	C.glowTextureStorage2D(gpTextureStorage2D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func TextureStorage2DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32) {
+	C.glowTextureStorage2DEXT(gpTextureStorage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // specify storage for a two-dimensional multisample texture
 func TextureStorage2DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
 	C.glowTextureStorage2DMultisample(gpTextureStorage2DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage2DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
+	C.glowTextureStorage2DMultisampleEXT(gpTextureStorage2DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // simultaneously specify storage for all levels of a three-dimensional, two-dimensional array or cube-map array texture
 func TextureStorage3D(texture uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
 	C.glowTextureStorage3D(gpTextureStorage3D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func TextureStorage3DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
+	C.glowTextureStorage3DEXT(gpTextureStorage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
 }
 
 // specify storage for a two-dimensional multisample array texture
 func TextureStorage3DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisample(gpTextureStorage3DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
+	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // specify a one-dimensional texture subimage
 func TextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage1D(gpTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage1DEXT(gpTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // specify a two-dimensional texture subimage
 func TextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage2D(gpTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func TextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage2DEXT(gpTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 
 // specify a three-dimensional texture subimage
 func TextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage3D(gpTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage3DEXT(gpTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // initialize a texture as a data alias of another texture's data store
@@ -7593,13 +12318,16 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 
 // specify values to record in transform feedback buffers
 func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
+}
+func TransformPathNV(resultPath uint32, srcPath uint32, transformType uint32, transformValues *float32) {
+	C.glowTransformPathNV(gpTransformPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
 }
 func Uniform1d(location int32, x float64) {
 	C.glowUniform1d(gpUniform1d, (C.GLint)(location), (C.GLdouble)(x))
@@ -7622,6 +12350,18 @@ func Uniform1fv(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
+func Uniform1i64NV(location int32, x int64) {
+	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform1i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform1iv(location int32, count int32, value *int32) {
@@ -7631,6 +12371,18 @@ func Uniform1iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
+}
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
+func Uniform1ui64NV(location int32, x uint64) {
+	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform1ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7658,6 +12410,18 @@ func Uniform2fv(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func Uniform2i64NV(location int32, x int64, y int64) {
+	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform2i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform2iv(location int32, count int32, value *int32) {
@@ -7667,6 +12431,18 @@ func Uniform2iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func Uniform2ui64NV(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform2ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7694,6 +12470,18 @@ func Uniform3fv(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func Uniform3i64NV(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform3i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform3iv(location int32, count int32, value *int32) {
@@ -7703,6 +12491,18 @@ func Uniform3iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform3ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7730,6 +12530,18 @@ func Uniform4fv(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform4i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform4iv(location int32, count int32, value *int32) {
@@ -7739,6 +12551,18 @@ func Uniform4iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform4ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7753,8 +12577,14 @@ func UniformBlockBinding(program uint32, uniformBlockIndex uint32, uniformBlockB
 func UniformHandleui64ARB(location int32, value uint64) {
 	C.glowUniformHandleui64ARB(gpUniformHandleui64ARB, (C.GLint)(location), (C.GLuint64)(value))
 }
+func UniformHandleui64NV(location int32, value uint64) {
+	C.glowUniformHandleui64NV(gpUniformHandleui64NV, (C.GLint)(location), (C.GLuint64)(value))
+}
 func UniformHandleui64vARB(location int32, count int32, value *uint64) {
 	C.glowUniformHandleui64vARB(gpUniformHandleui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func UniformHandleui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformHandleui64vNV(gpUniformHandleui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func UniformMatrix2dv(location int32, count int32, transpose bool, value *float64) {
 	C.glowUniformMatrix2dv(gpUniformMatrix2dv, (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
@@ -7831,6 +12661,12 @@ func UniformMatrix4x3fv(location int32, count int32, transpose bool, value *floa
 func UniformSubroutinesuiv(shadertype uint32, count int32, indices *uint32) {
 	C.glowUniformSubroutinesuiv(gpUniformSubroutinesuiv, (C.GLenum)(shadertype), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(indices)))
 }
+func Uniformui64NV(location int32, value uint64) {
+	C.glowUniformui64NV(gpUniformui64NV, (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func Uniformui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformui64vNV(gpUniformui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // release the mapping of a buffer object's data store into the client's address space
 func UnmapBuffer(target uint32) bool {
@@ -7843,6 +12679,10 @@ func UnmapNamedBuffer(buffer uint32) bool {
 	ret := C.glowUnmapNamedBuffer(gpUnmapNamedBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func UnmapNamedBufferEXT(buffer uint32) bool {
+	ret := C.glowUnmapNamedBufferEXT(gpUnmapNamedBufferEXT, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 
 // Installs a program object as part of current rendering state
 func UseProgram(program uint32) {
@@ -7853,6 +12693,12 @@ func UseProgram(program uint32) {
 func UseProgramStages(pipeline uint32, stages uint32, program uint32) {
 	C.glowUseProgramStages(gpUseProgramStages, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
 }
+func UseProgramStagesEXT(pipeline uint32, stages uint32, program uint32) {
+	C.glowUseProgramStagesEXT(gpUseProgramStagesEXT, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
+}
+func UseShaderProgramEXT(xtype uint32, program uint32) {
+	C.glowUseShaderProgramEXT(gpUseShaderProgramEXT, (C.GLenum)(xtype), (C.GLuint)(program))
+}
 
 // Validates a program object
 func ValidateProgram(program uint32) {
@@ -7862,6 +12708,9 @@ func ValidateProgram(program uint32) {
 // validate a program pipeline object against current GL state
 func ValidateProgramPipeline(pipeline uint32) {
 	C.glowValidateProgramPipeline(gpValidateProgramPipeline, (C.GLuint)(pipeline))
+}
+func ValidateProgramPipelineEXT(pipeline uint32) {
+	C.glowValidateProgramPipelineEXT(gpValidateProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 func VertexArrayAttribBinding(vaobj uint32, attribindex uint32, bindingindex uint32) {
 	C.glowVertexArrayAttribBinding(gpVertexArrayAttribBinding, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
@@ -7877,15 +12726,69 @@ func VertexArrayAttribIFormat(vaobj uint32, attribindex uint32, size int32, xtyp
 func VertexArrayAttribLFormat(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexArrayAttribLFormat(gpVertexArrayAttribLFormat, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexArrayBindVertexBufferEXT(vaobj uint32, bindingindex uint32, buffer uint32, offset int, stride int32) {
+	C.glowVertexArrayBindVertexBufferEXT(gpVertexArrayBindVertexBufferEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(stride))
+}
 
 // modify the rate at which generic vertex attributes     advance
 func VertexArrayBindingDivisor(vaobj uint32, bindingindex uint32, divisor uint32) {
 	C.glowVertexArrayBindingDivisor(gpVertexArrayBindingDivisor, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexArrayColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayColorOffsetEXT(gpVertexArrayColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayEdgeFlagOffsetEXT(vaobj uint32, buffer uint32, stride int32, offset int) {
+	C.glowVertexArrayEdgeFlagOffsetEXT(gpVertexArrayEdgeFlagOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
 
 // configures element array buffer binding of a vertex array object
 func VertexArrayElementBuffer(vaobj uint32, buffer uint32) {
 	C.glowVertexArrayElementBuffer(gpVertexArrayElementBuffer, (C.GLuint)(vaobj), (C.GLuint)(buffer))
+}
+func VertexArrayFogCoordOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayFogCoordOffsetEXT(gpVertexArrayFogCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayIndexOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayIndexOffsetEXT(gpVertexArrayIndexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayMultiTexCoordOffsetEXT(vaobj uint32, buffer uint32, texunit uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayMultiTexCoordOffsetEXT(gpVertexArrayMultiTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayNormalOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayNormalOffsetEXT(gpVertexArrayNormalOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArraySecondaryColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArraySecondaryColorOffsetEXT(gpVertexArraySecondaryColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayTexCoordOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayTexCoordOffsetEXT(gpVertexArrayTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribBindingEXT(vaobj uint32, attribindex uint32, bindingindex uint32) {
+	C.glowVertexArrayVertexAttribBindingEXT(gpVertexArrayVertexAttribBindingEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
+}
+func VertexArrayVertexAttribDivisorEXT(vaobj uint32, index uint32, divisor uint32) {
+	C.glowVertexArrayVertexAttribDivisorEXT(gpVertexArrayVertexAttribDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLuint)(divisor))
+}
+func VertexArrayVertexAttribFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribFormatEXT(gpVertexArrayVertexAttribFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribIFormatEXT(gpVertexArrayVertexAttribIFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribIOffsetEXT(gpVertexArrayVertexAttribIOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribLFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribLFormatEXT(gpVertexArrayVertexAttribLFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribLOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribLOffsetEXT(gpVertexArrayVertexAttribLOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, normalized bool, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribOffsetEXT(gpVertexArrayVertexAttribOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexBindingDivisorEXT(vaobj uint32, bindingindex uint32, divisor uint32) {
+	C.glowVertexArrayVertexBindingDivisorEXT(gpVertexArrayVertexBindingDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
 
 // bind a buffer to a vertex buffer bind point
@@ -7896,6 +12799,9 @@ func VertexArrayVertexBuffer(vaobj uint32, bindingindex uint32, buffer uint32, o
 // attach multiple buffer objects to a vertex array object
 func VertexArrayVertexBuffers(vaobj uint32, first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowVertexArrayVertexBuffers(gpVertexArrayVertexBuffers, (C.GLuint)(vaobj), (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
+}
+func VertexArrayVertexOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexOffsetEXT(gpVertexArrayVertexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
 }
 func VertexAttrib1d(index uint32, x float64) {
 	C.glowVertexAttrib1d(gpVertexAttrib1d, (C.GLuint)(index), (C.GLdouble)(x))
@@ -8015,10 +12921,16 @@ func VertexAttribBinding(attribindex uint32, bindingindex uint32) {
 func VertexAttribDivisor(index uint32, divisor uint32) {
 	C.glowVertexAttribDivisor(gpVertexAttribDivisor, (C.GLuint)(index), (C.GLuint)(divisor))
 }
+func VertexAttribDivisorARB(index uint32, divisor uint32) {
+	C.glowVertexAttribDivisorARB(gpVertexAttribDivisorARB, (C.GLuint)(index), (C.GLuint)(divisor))
+}
 
 // specify the organization of vertex arrays
 func VertexAttribFormat(attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
 	C.glowVertexAttribFormat(gpVertexAttribFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexAttribFormatNV(index uint32, size int32, xtype uint32, normalized bool, stride int32) {
+	C.glowVertexAttribFormatNV(gpVertexAttribFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride))
 }
 func VertexAttribI1i(index uint32, x int32) {
 	C.glowVertexAttribI1i(gpVertexAttribI1i, (C.GLuint)(index), (C.GLint)(x))
@@ -8083,6 +12995,9 @@ func VertexAttribI4usv(index uint32, v *uint16) {
 func VertexAttribIFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribIFormat(gpVertexAttribIFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexAttribIFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribIFormatNV(gpVertexAttribIFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func VertexAttribIPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribIPointer(gpVertexAttribIPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
 }
@@ -8092,11 +13007,23 @@ func VertexAttribL1d(index uint32, x float64) {
 func VertexAttribL1dv(index uint32, v *float64) {
 	C.glowVertexAttribL1dv(gpVertexAttribL1dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL1i64NV(index uint32, x int64) {
+	C.glowVertexAttribL1i64NV(gpVertexAttribL1i64NV, (C.GLuint)(index), (C.GLint64EXT)(x))
+}
+func VertexAttribL1i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL1i64vNV(gpVertexAttribL1i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL1ui64ARB(index uint32, x uint64) {
 	C.glowVertexAttribL1ui64ARB(gpVertexAttribL1ui64ARB, (C.GLuint)(index), (C.GLuint64EXT)(x))
 }
+func VertexAttribL1ui64NV(index uint32, x uint64) {
+	C.glowVertexAttribL1ui64NV(gpVertexAttribL1ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x))
+}
 func VertexAttribL1ui64vARB(index uint32, v *uint64) {
 	C.glowVertexAttribL1ui64vARB(gpVertexAttribL1ui64vARB, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL1ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL1ui64vNV(gpVertexAttribL1ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL2d(index uint32, x float64, y float64) {
 	C.glowVertexAttribL2d(gpVertexAttribL2d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y))
@@ -8104,11 +13031,35 @@ func VertexAttribL2d(index uint32, x float64, y float64) {
 func VertexAttribL2dv(index uint32, v *float64) {
 	C.glowVertexAttribL2dv(gpVertexAttribL2dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL2i64NV(index uint32, x int64, y int64) {
+	C.glowVertexAttribL2i64NV(gpVertexAttribL2i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func VertexAttribL2i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL2i64vNV(gpVertexAttribL2i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL2ui64NV(index uint32, x uint64, y uint64) {
+	C.glowVertexAttribL2ui64NV(gpVertexAttribL2ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func VertexAttribL2ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL2ui64vNV(gpVertexAttribL2ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL3d(index uint32, x float64, y float64, z float64) {
 	C.glowVertexAttribL3d(gpVertexAttribL3d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
 }
 func VertexAttribL3dv(index uint32, v *float64) {
 	C.glowVertexAttribL3dv(gpVertexAttribL3dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
+}
+func VertexAttribL3i64NV(index uint32, x int64, y int64, z int64) {
+	C.glowVertexAttribL3i64NV(gpVertexAttribL3i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func VertexAttribL3i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL3i64vNV(gpVertexAttribL3i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL3ui64NV(index uint32, x uint64, y uint64, z uint64) {
+	C.glowVertexAttribL3ui64NV(gpVertexAttribL3ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func VertexAttribL3ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL3ui64vNV(gpVertexAttribL3ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 	C.glowVertexAttribL4d(gpVertexAttribL4d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
@@ -8116,8 +13067,23 @@ func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 func VertexAttribL4dv(index uint32, v *float64) {
 	C.glowVertexAttribL4dv(gpVertexAttribL4dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL4i64NV(index uint32, x int64, y int64, z int64, w int64) {
+	C.glowVertexAttribL4i64NV(gpVertexAttribL4i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func VertexAttribL4i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL4i64vNV(gpVertexAttribL4i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL4ui64NV(index uint32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowVertexAttribL4ui64NV(gpVertexAttribL4ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func VertexAttribL4ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL4ui64vNV(gpVertexAttribL4ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribLFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribLFormat(gpVertexAttribLFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexAttribLFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribLFormatNV(gpVertexAttribLFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 func VertexAttribLPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribLPointer(gpVertexAttribLPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
@@ -8156,6 +13122,9 @@ func VertexAttribPointer(index uint32, size int32, xtype uint32, normalized bool
 func VertexBindingDivisor(bindingindex uint32, divisor uint32) {
 	C.glowVertexBindingDivisor(gpVertexBindingDivisor, (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowVertexFormatNV(gpVertexFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 
 // set the viewport
 func Viewport(x int32, y int32, width int32, height int32) {
@@ -8170,10 +13139,25 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
+	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
+}
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
 }
 
 // Init initializes the OpenGL bindings by loading the function pointers (for
@@ -8203,14 +13187,17 @@ func Init() error {
 // function pointer loading function. For more cases Init should be used
 // instead.
 func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
+	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
 	if gpActiveShaderProgram == nil {
 		return errors.New("glActiveShaderProgram")
 	}
+	gpActiveShaderProgramEXT = (C.GPACTIVESHADERPROGRAMEXT)(getProcAddr("glActiveShaderProgramEXT"))
 	gpActiveTexture = (C.GPACTIVETEXTURE)(getProcAddr("glActiveTexture"))
 	if gpActiveTexture == nil {
 		return errors.New("glActiveTexture")
 	}
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpAttachShader = (C.GPATTACHSHADER)(getProcAddr("glAttachShader"))
 	if gpAttachShader == nil {
 		return errors.New("glAttachShader")
@@ -8219,6 +13206,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBeginConditionalRender == nil {
 		return errors.New("glBeginConditionalRender")
 	}
+	gpBeginConditionalRenderNV = (C.GPBEGINCONDITIONALRENDERNV)(getProcAddr("glBeginConditionalRenderNV"))
+	gpBeginPerfMonitorAMD = (C.GPBEGINPERFMONITORAMD)(getProcAddr("glBeginPerfMonitorAMD"))
+	gpBeginPerfQueryINTEL = (C.GPBEGINPERFQUERYINTEL)(getProcAddr("glBeginPerfQueryINTEL"))
 	gpBeginQuery = (C.GPBEGINQUERY)(getProcAddr("glBeginQuery"))
 	if gpBeginQuery == nil {
 		return errors.New("glBeginQuery")
@@ -8275,10 +13265,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBindImageTextures == nil {
 		return errors.New("glBindImageTextures")
 	}
+	gpBindMultiTextureEXT = (C.GPBINDMULTITEXTUREEXT)(getProcAddr("glBindMultiTextureEXT"))
 	gpBindProgramPipeline = (C.GPBINDPROGRAMPIPELINE)(getProcAddr("glBindProgramPipeline"))
 	if gpBindProgramPipeline == nil {
 		return errors.New("glBindProgramPipeline")
 	}
+	gpBindProgramPipelineEXT = (C.GPBINDPROGRAMPIPELINEEXT)(getProcAddr("glBindProgramPipelineEXT"))
 	gpBindRenderbuffer = (C.GPBINDRENDERBUFFER)(getProcAddr("glBindRenderbuffer"))
 	if gpBindRenderbuffer == nil {
 		return errors.New("glBindRenderbuffer")
@@ -8316,6 +13308,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBindVertexBuffers == nil {
 		return errors.New("glBindVertexBuffers")
 	}
+	gpBlendBarrierKHR = (C.GPBLENDBARRIERKHR)(getProcAddr("glBlendBarrierKHR"))
+	gpBlendBarrierNV = (C.GPBLENDBARRIERNV)(getProcAddr("glBlendBarrierNV"))
 	gpBlendColor = (C.GPBLENDCOLOR)(getProcAddr("glBlendColor"))
 	if gpBlendColor == nil {
 		return errors.New("glBlendColor")
@@ -8356,11 +13350,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glBlendFunci")
 	}
 	gpBlendFunciARB = (C.GPBLENDFUNCIARB)(getProcAddr("glBlendFunciARB"))
+	gpBlendParameteriNV = (C.GPBLENDPARAMETERINV)(getProcAddr("glBlendParameteriNV"))
 	gpBlitFramebuffer = (C.GPBLITFRAMEBUFFER)(getProcAddr("glBlitFramebuffer"))
 	if gpBlitFramebuffer == nil {
 		return errors.New("glBlitFramebuffer")
 	}
 	gpBlitNamedFramebuffer = (C.GPBLITNAMEDFRAMEBUFFER)(getProcAddr("glBlitNamedFramebuffer"))
+	gpBufferAddressRangeNV = (C.GPBUFFERADDRESSRANGENV)(getProcAddr("glBufferAddressRangeNV"))
 	gpBufferData = (C.GPBUFFERDATA)(getProcAddr("glBufferData"))
 	if gpBufferData == nil {
 		return errors.New("glBufferData")
@@ -8374,11 +13370,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCheckFramebufferStatus = (C.GPCHECKFRAMEBUFFERSTATUS)(getProcAddr("glCheckFramebufferStatus"))
 	if gpCheckFramebufferStatus == nil {
 		return errors.New("glCheckFramebufferStatus")
 	}
 	gpCheckNamedFramebufferStatus = (C.GPCHECKNAMEDFRAMEBUFFERSTATUS)(getProcAddr("glCheckNamedFramebufferStatus"))
+	gpCheckNamedFramebufferStatusEXT = (C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(getProcAddr("glCheckNamedFramebufferStatusEXT"))
 	gpClampColor = (C.GPCLAMPCOLOR)(getProcAddr("glClampColor"))
 	if gpClampColor == nil {
 		return errors.New("glClampColor")
@@ -8424,7 +13422,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glClearDepthf")
 	}
 	gpClearNamedBufferData = (C.GPCLEARNAMEDBUFFERDATA)(getProcAddr("glClearNamedBufferData"))
+	gpClearNamedBufferDataEXT = (C.GPCLEARNAMEDBUFFERDATAEXT)(getProcAddr("glClearNamedBufferDataEXT"))
 	gpClearNamedBufferSubData = (C.GPCLEARNAMEDBUFFERSUBDATA)(getProcAddr("glClearNamedBufferSubData"))
+	gpClearNamedBufferSubDataEXT = (C.GPCLEARNAMEDBUFFERSUBDATAEXT)(getProcAddr("glClearNamedBufferSubDataEXT"))
 	gpClearNamedFramebufferfi = (C.GPCLEARNAMEDFRAMEBUFFERFI)(getProcAddr("glClearNamedFramebufferfi"))
 	gpClearNamedFramebufferfv = (C.GPCLEARNAMEDFRAMEBUFFERFV)(getProcAddr("glClearNamedFramebufferfv"))
 	gpClearNamedFramebufferiv = (C.GPCLEARNAMEDFRAMEBUFFERIV)(getProcAddr("glClearNamedFramebufferiv"))
@@ -8441,11 +13441,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpClearTexSubImage == nil {
 		return errors.New("glClearTexSubImage")
 	}
+	gpClientAttribDefaultEXT = (C.GPCLIENTATTRIBDEFAULTEXT)(getProcAddr("glClientAttribDefaultEXT"))
 	gpClientWaitSync = (C.GPCLIENTWAITSYNC)(getProcAddr("glClientWaitSync"))
 	if gpClientWaitSync == nil {
 		return errors.New("glClientWaitSync")
 	}
 	gpClipControl = (C.GPCLIPCONTROL)(getProcAddr("glClipControl"))
+	gpColorFormatNV = (C.GPCOLORFORMATNV)(getProcAddr("glColorFormatNV"))
 	gpColorMask = (C.GPCOLORMASK)(getProcAddr("glColorMask"))
 	if gpColorMask == nil {
 		return errors.New("glColorMask")
@@ -8454,11 +13456,19 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpColorMaski == nil {
 		return errors.New("glColorMaski")
 	}
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
 	}
 	gpCompileShaderIncludeARB = (C.GPCOMPILESHADERINCLUDEARB)(getProcAddr("glCompileShaderIncludeARB"))
+	gpCompressedMultiTexImage1DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE1DEXT)(getProcAddr("glCompressedMultiTexImage1DEXT"))
+	gpCompressedMultiTexImage2DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE2DEXT)(getProcAddr("glCompressedMultiTexImage2DEXT"))
+	gpCompressedMultiTexImage3DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE3DEXT)(getProcAddr("glCompressedMultiTexImage3DEXT"))
+	gpCompressedMultiTexSubImage1DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCompressedMultiTexSubImage1DEXT"))
+	gpCompressedMultiTexSubImage2DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCompressedMultiTexSubImage2DEXT"))
+	gpCompressedMultiTexSubImage3DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCompressedMultiTexSubImage3DEXT"))
 	gpCompressedTexImage1D = (C.GPCOMPRESSEDTEXIMAGE1D)(getProcAddr("glCompressedTexImage1D"))
 	if gpCompressedTexImage1D == nil {
 		return errors.New("glCompressedTexImage1D")
@@ -8483,9 +13493,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCompressedTexSubImage3D == nil {
 		return errors.New("glCompressedTexSubImage3D")
 	}
+	gpCompressedTextureImage1DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE1DEXT)(getProcAddr("glCompressedTextureImage1DEXT"))
+	gpCompressedTextureImage2DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE2DEXT)(getProcAddr("glCompressedTextureImage2DEXT"))
+	gpCompressedTextureImage3DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE3DEXT)(getProcAddr("glCompressedTextureImage3DEXT"))
 	gpCompressedTextureSubImage1D = (C.GPCOMPRESSEDTEXTURESUBIMAGE1D)(getProcAddr("glCompressedTextureSubImage1D"))
+	gpCompressedTextureSubImage1DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(getProcAddr("glCompressedTextureSubImage1DEXT"))
 	gpCompressedTextureSubImage2D = (C.GPCOMPRESSEDTEXTURESUBIMAGE2D)(getProcAddr("glCompressedTextureSubImage2D"))
+	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
+	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpCopyBufferSubData = (C.GPCOPYBUFFERSUBDATA)(getProcAddr("glCopyBufferSubData"))
 	if gpCopyBufferSubData == nil {
 		return errors.New("glCopyBufferSubData")
@@ -8494,7 +13512,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCopyImageSubData == nil {
 		return errors.New("glCopyImageSubData")
 	}
+	gpCopyMultiTexImage1DEXT = (C.GPCOPYMULTITEXIMAGE1DEXT)(getProcAddr("glCopyMultiTexImage1DEXT"))
+	gpCopyMultiTexImage2DEXT = (C.GPCOPYMULTITEXIMAGE2DEXT)(getProcAddr("glCopyMultiTexImage2DEXT"))
+	gpCopyMultiTexSubImage1DEXT = (C.GPCOPYMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCopyMultiTexSubImage1DEXT"))
+	gpCopyMultiTexSubImage2DEXT = (C.GPCOPYMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCopyMultiTexSubImage2DEXT"))
+	gpCopyMultiTexSubImage3DEXT = (C.GPCOPYMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCopyMultiTexSubImage3DEXT"))
 	gpCopyNamedBufferSubData = (C.GPCOPYNAMEDBUFFERSUBDATA)(getProcAddr("glCopyNamedBufferSubData"))
+	gpCopyPathNV = (C.GPCOPYPATHNV)(getProcAddr("glCopyPathNV"))
 	gpCopyTexImage1D = (C.GPCOPYTEXIMAGE1D)(getProcAddr("glCopyTexImage1D"))
 	if gpCopyTexImage1D == nil {
 		return errors.New("glCopyTexImage1D")
@@ -8515,11 +13539,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCopyTexSubImage3D == nil {
 		return errors.New("glCopyTexSubImage3D")
 	}
+	gpCopyTextureImage1DEXT = (C.GPCOPYTEXTUREIMAGE1DEXT)(getProcAddr("glCopyTextureImage1DEXT"))
+	gpCopyTextureImage2DEXT = (C.GPCOPYTEXTUREIMAGE2DEXT)(getProcAddr("glCopyTextureImage2DEXT"))
 	gpCopyTextureSubImage1D = (C.GPCOPYTEXTURESUBIMAGE1D)(getProcAddr("glCopyTextureSubImage1D"))
+	gpCopyTextureSubImage1DEXT = (C.GPCOPYTEXTURESUBIMAGE1DEXT)(getProcAddr("glCopyTextureSubImage1DEXT"))
 	gpCopyTextureSubImage2D = (C.GPCOPYTEXTURESUBIMAGE2D)(getProcAddr("glCopyTextureSubImage2D"))
+	gpCopyTextureSubImage2DEXT = (C.GPCOPYTEXTURESUBIMAGE2DEXT)(getProcAddr("glCopyTextureSubImage2DEXT"))
 	gpCopyTextureSubImage3D = (C.GPCOPYTEXTURESUBIMAGE3D)(getProcAddr("glCopyTextureSubImage3D"))
+	gpCopyTextureSubImage3DEXT = (C.GPCOPYTEXTURESUBIMAGE3DEXT)(getProcAddr("glCopyTextureSubImage3DEXT"))
+	gpCoverFillPathInstancedNV = (C.GPCOVERFILLPATHINSTANCEDNV)(getProcAddr("glCoverFillPathInstancedNV"))
+	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
+	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
+	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
+	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
 		return errors.New("glCreateProgram")
@@ -8532,10 +13569,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCreateShader == nil {
 		return errors.New("glCreateShader")
 	}
+	gpCreateShaderProgramEXT = (C.GPCREATESHADERPROGRAMEXT)(getProcAddr("glCreateShaderProgramEXT"))
 	gpCreateShaderProgramv = (C.GPCREATESHADERPROGRAMV)(getProcAddr("glCreateShaderProgramv"))
 	if gpCreateShaderProgramv == nil {
 		return errors.New("glCreateShaderProgramv")
 	}
+	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	gpCreateTransformFeedbacks = (C.GPCREATETRANSFORMFEEDBACKS)(getProcAddr("glCreateTransformFeedbacks"))
@@ -8566,11 +13606,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteBuffers == nil {
 		return errors.New("glDeleteBuffers")
 	}
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFramebuffers = (C.GPDELETEFRAMEBUFFERS)(getProcAddr("glDeleteFramebuffers"))
 	if gpDeleteFramebuffers == nil {
 		return errors.New("glDeleteFramebuffers")
 	}
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
+	gpDeletePathsNV = (C.GPDELETEPATHSNV)(getProcAddr("glDeletePathsNV"))
+	gpDeletePerfMonitorsAMD = (C.GPDELETEPERFMONITORSAMD)(getProcAddr("glDeletePerfMonitorsAMD"))
+	gpDeletePerfQueryINTEL = (C.GPDELETEPERFQUERYINTEL)(getProcAddr("glDeletePerfQueryINTEL"))
 	gpDeleteProgram = (C.GPDELETEPROGRAM)(getProcAddr("glDeleteProgram"))
 	if gpDeleteProgram == nil {
 		return errors.New("glDeleteProgram")
@@ -8579,6 +13623,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteProgramPipelines == nil {
 		return errors.New("glDeleteProgramPipelines")
 	}
+	gpDeleteProgramPipelinesEXT = (C.GPDELETEPROGRAMPIPELINESEXT)(getProcAddr("glDeleteProgramPipelinesEXT"))
 	gpDeleteQueries = (C.GPDELETEQUERIES)(getProcAddr("glDeleteQueries"))
 	if gpDeleteQueries == nil {
 		return errors.New("glDeleteQueries")
@@ -8595,6 +13640,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	if gpDeleteSync == nil {
 		return errors.New("glDeleteSync")
@@ -8643,7 +13689,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDisable == nil {
 		return errors.New("glDisable")
 	}
+	gpDisableClientStateIndexedEXT = (C.GPDISABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glDisableClientStateIndexedEXT"))
+	gpDisableClientStateiEXT = (C.GPDISABLECLIENTSTATEIEXT)(getProcAddr("glDisableClientStateiEXT"))
+	gpDisableIndexedEXT = (C.GPDISABLEINDEXEDEXT)(getProcAddr("glDisableIndexedEXT"))
 	gpDisableVertexArrayAttrib = (C.GPDISABLEVERTEXARRAYATTRIB)(getProcAddr("glDisableVertexArrayAttrib"))
+	gpDisableVertexArrayAttribEXT = (C.GPDISABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glDisableVertexArrayAttribEXT"))
+	gpDisableVertexArrayEXT = (C.GPDISABLEVERTEXARRAYEXT)(getProcAddr("glDisableVertexArrayEXT"))
 	gpDisableVertexAttribArray = (C.GPDISABLEVERTEXATTRIBARRAY)(getProcAddr("glDisableVertexAttribArray"))
 	if gpDisableVertexAttribArray == nil {
 		return errors.New("glDisableVertexAttribArray")
@@ -8673,10 +13724,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawArraysInstanced == nil {
 		return errors.New("glDrawArraysInstanced")
 	}
+	gpDrawArraysInstancedARB = (C.GPDRAWARRAYSINSTANCEDARB)(getProcAddr("glDrawArraysInstancedARB"))
 	gpDrawArraysInstancedBaseInstance = (C.GPDRAWARRAYSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawArraysInstancedBaseInstance"))
 	if gpDrawArraysInstancedBaseInstance == nil {
 		return errors.New("glDrawArraysInstancedBaseInstance")
 	}
+	gpDrawArraysInstancedEXT = (C.GPDRAWARRAYSINSTANCEDEXT)(getProcAddr("glDrawArraysInstancedEXT"))
 	gpDrawBuffer = (C.GPDRAWBUFFER)(getProcAddr("glDrawBuffer"))
 	if gpDrawBuffer == nil {
 		return errors.New("glDrawBuffer")
@@ -8685,6 +13738,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawBuffers == nil {
 		return errors.New("glDrawBuffers")
 	}
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
 	if gpDrawElements == nil {
 		return errors.New("glDrawElements")
@@ -8701,6 +13758,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawElementsInstanced == nil {
 		return errors.New("glDrawElementsInstanced")
 	}
+	gpDrawElementsInstancedARB = (C.GPDRAWELEMENTSINSTANCEDARB)(getProcAddr("glDrawElementsInstancedARB"))
 	gpDrawElementsInstancedBaseInstance = (C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawElementsInstancedBaseInstance"))
 	if gpDrawElementsInstancedBaseInstance == nil {
 		return errors.New("glDrawElementsInstancedBaseInstance")
@@ -8713,6 +13771,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawElementsInstancedBaseVertexBaseInstance == nil {
 		return errors.New("glDrawElementsInstancedBaseVertexBaseInstance")
 	}
+	gpDrawElementsInstancedEXT = (C.GPDRAWELEMENTSINSTANCEDEXT)(getProcAddr("glDrawElementsInstancedEXT"))
 	gpDrawRangeElements = (C.GPDRAWRANGEELEMENTS)(getProcAddr("glDrawRangeElements"))
 	if gpDrawRangeElements == nil {
 		return errors.New("glDrawRangeElements")
@@ -8737,11 +13796,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawTransformFeedbackStreamInstanced == nil {
 		return errors.New("glDrawTransformFeedbackStreamInstanced")
 	}
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
+	gpEdgeFlagFormatNV = (C.GPEDGEFLAGFORMATNV)(getProcAddr("glEdgeFlagFormatNV"))
 	gpEnable = (C.GPENABLE)(getProcAddr("glEnable"))
 	if gpEnable == nil {
 		return errors.New("glEnable")
 	}
+	gpEnableClientStateIndexedEXT = (C.GPENABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glEnableClientStateIndexedEXT"))
+	gpEnableClientStateiEXT = (C.GPENABLECLIENTSTATEIEXT)(getProcAddr("glEnableClientStateiEXT"))
+	gpEnableIndexedEXT = (C.GPENABLEINDEXEDEXT)(getProcAddr("glEnableIndexedEXT"))
 	gpEnableVertexArrayAttrib = (C.GPENABLEVERTEXARRAYATTRIB)(getProcAddr("glEnableVertexArrayAttrib"))
+	gpEnableVertexArrayAttribEXT = (C.GPENABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glEnableVertexArrayAttribEXT"))
+	gpEnableVertexArrayEXT = (C.GPENABLEVERTEXARRAYEXT)(getProcAddr("glEnableVertexArrayEXT"))
 	gpEnableVertexAttribArray = (C.GPENABLEVERTEXATTRIBARRAY)(getProcAddr("glEnableVertexAttribArray"))
 	if gpEnableVertexAttribArray == nil {
 		return errors.New("glEnableVertexAttribArray")
@@ -8754,6 +13820,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEndConditionalRender == nil {
 		return errors.New("glEndConditionalRender")
 	}
+	gpEndConditionalRenderNV = (C.GPENDCONDITIONALRENDERNV)(getProcAddr("glEndConditionalRenderNV"))
+	gpEndPerfMonitorAMD = (C.GPENDPERFMONITORAMD)(getProcAddr("glEndPerfMonitorAMD"))
+	gpEndPerfQueryINTEL = (C.GPENDPERFQUERYINTEL)(getProcAddr("glEndPerfQueryINTEL"))
 	gpEndQuery = (C.GPENDQUERY)(getProcAddr("glEndQuery"))
 	if gpEndQuery == nil {
 		return errors.New("glEndQuery")
@@ -8766,6 +13835,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEndTransformFeedback == nil {
 		return errors.New("glEndTransformFeedback")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpFenceSync = (C.GPFENCESYNC)(getProcAddr("glFenceSync"))
 	if gpFenceSync == nil {
 		return errors.New("glFenceSync")
@@ -8783,14 +13853,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glFlushMappedBufferRange")
 	}
 	gpFlushMappedNamedBufferRange = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGE)(getProcAddr("glFlushMappedNamedBufferRange"))
+	gpFlushMappedNamedBufferRangeEXT = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(getProcAddr("glFlushMappedNamedBufferRangeEXT"))
+	gpFogCoordFormatNV = (C.GPFOGCOORDFORMATNV)(getProcAddr("glFogCoordFormatNV"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
+	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
+	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
 	if gpFramebufferParameteri == nil {
 		return errors.New("glFramebufferParameteri")
 	}
+	gpFramebufferReadBufferEXT = (C.GPFRAMEBUFFERREADBUFFEREXT)(getProcAddr("glFramebufferReadBufferEXT"))
 	gpFramebufferRenderbuffer = (C.GPFRAMEBUFFERRENDERBUFFER)(getProcAddr("glFramebufferRenderbuffer"))
 	if gpFramebufferRenderbuffer == nil {
 		return errors.New("glFramebufferRenderbuffer")
 	}
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	if gpFramebufferTexture == nil {
 		return errors.New("glFramebufferTexture")
@@ -8807,10 +13886,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpFramebufferTexture3D == nil {
 		return errors.New("glFramebufferTexture3D")
 	}
+	gpFramebufferTextureARB = (C.GPFRAMEBUFFERTEXTUREARB)(getProcAddr("glFramebufferTextureARB"))
+	gpFramebufferTextureFaceARB = (C.GPFRAMEBUFFERTEXTUREFACEARB)(getProcAddr("glFramebufferTextureFaceARB"))
 	gpFramebufferTextureLayer = (C.GPFRAMEBUFFERTEXTURELAYER)(getProcAddr("glFramebufferTextureLayer"))
 	if gpFramebufferTextureLayer == nil {
 		return errors.New("glFramebufferTextureLayer")
 	}
+	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
 		return errors.New("glFrontFace")
@@ -8823,10 +13906,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenFramebuffers == nil {
 		return errors.New("glGenFramebuffers")
 	}
+	gpGenPathsNV = (C.GPGENPATHSNV)(getProcAddr("glGenPathsNV"))
+	gpGenPerfMonitorsAMD = (C.GPGENPERFMONITORSAMD)(getProcAddr("glGenPerfMonitorsAMD"))
 	gpGenProgramPipelines = (C.GPGENPROGRAMPIPELINES)(getProcAddr("glGenProgramPipelines"))
 	if gpGenProgramPipelines == nil {
 		return errors.New("glGenProgramPipelines")
 	}
+	gpGenProgramPipelinesEXT = (C.GPGENPROGRAMPIPELINESEXT)(getProcAddr("glGenProgramPipelinesEXT"))
 	gpGenQueries = (C.GPGENQUERIES)(getProcAddr("glGenQueries"))
 	if gpGenQueries == nil {
 		return errors.New("glGenQueries")
@@ -8855,7 +13941,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenerateMipmap == nil {
 		return errors.New("glGenerateMipmap")
 	}
+	gpGenerateMultiTexMipmapEXT = (C.GPGENERATEMULTITEXMIPMAPEXT)(getProcAddr("glGenerateMultiTexMipmapEXT"))
 	gpGenerateTextureMipmap = (C.GPGENERATETEXTUREMIPMAP)(getProcAddr("glGenerateTextureMipmap"))
+	gpGenerateTextureMipmapEXT = (C.GPGENERATETEXTUREMIPMAPEXT)(getProcAddr("glGenerateTextureMipmapEXT"))
 	gpGetActiveAtomicCounterBufferiv = (C.GPGETACTIVEATOMICCOUNTERBUFFERIV)(getProcAddr("glGetActiveAtomicCounterBufferiv"))
 	if gpGetActiveAtomicCounterBufferiv == nil {
 		return errors.New("glGetActiveAtomicCounterBufferiv")
@@ -8904,6 +13992,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetAttribLocation == nil {
 		return errors.New("glGetAttribLocation")
 	}
+	gpGetBooleanIndexedvEXT = (C.GPGETBOOLEANINDEXEDVEXT)(getProcAddr("glGetBooleanIndexedvEXT"))
 	gpGetBooleani_v = (C.GPGETBOOLEANI_V)(getProcAddr("glGetBooleani_v"))
 	if gpGetBooleani_v == nil {
 		return errors.New("glGetBooleani_v")
@@ -8920,6 +14009,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetBufferParameteriv == nil {
 		return errors.New("glGetBufferParameteriv")
 	}
+	gpGetBufferParameterui64vNV = (C.GPGETBUFFERPARAMETERUI64VNV)(getProcAddr("glGetBufferParameterui64vNV"))
 	gpGetBufferPointerv = (C.GPGETBUFFERPOINTERV)(getProcAddr("glGetBufferPointerv"))
 	if gpGetBufferPointerv == nil {
 		return errors.New("glGetBufferPointerv")
@@ -8928,22 +14018,28 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetBufferSubData == nil {
 		return errors.New("glGetBufferSubData")
 	}
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
+	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
 		return errors.New("glGetCompressedTexImage")
 	}
 	gpGetCompressedTextureImage = (C.GPGETCOMPRESSEDTEXTUREIMAGE)(getProcAddr("glGetCompressedTextureImage"))
+	gpGetCompressedTextureImageEXT = (C.GPGETCOMPRESSEDTEXTUREIMAGEEXT)(getProcAddr("glGetCompressedTextureImageEXT"))
 	gpGetCompressedTextureSubImage = (C.GPGETCOMPRESSEDTEXTURESUBIMAGE)(getProcAddr("glGetCompressedTextureSubImage"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	if gpGetDebugMessageLog == nil {
 		return errors.New("glGetDebugMessageLog")
 	}
 	gpGetDebugMessageLogARB = (C.GPGETDEBUGMESSAGELOGARB)(getProcAddr("glGetDebugMessageLogARB"))
 	gpGetDebugMessageLogKHR = (C.GPGETDEBUGMESSAGELOGKHR)(getProcAddr("glGetDebugMessageLogKHR"))
+	gpGetDoubleIndexedvEXT = (C.GPGETDOUBLEINDEXEDVEXT)(getProcAddr("glGetDoubleIndexedvEXT"))
 	gpGetDoublei_v = (C.GPGETDOUBLEI_V)(getProcAddr("glGetDoublei_v"))
 	if gpGetDoublei_v == nil {
 		return errors.New("glGetDoublei_v")
 	}
+	gpGetDoublei_vEXT = (C.GPGETDOUBLEI_VEXT)(getProcAddr("glGetDoublei_vEXT"))
 	gpGetDoublev = (C.GPGETDOUBLEV)(getProcAddr("glGetDoublev"))
 	if gpGetDoublev == nil {
 		return errors.New("glGetDoublev")
@@ -8952,10 +14048,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetError == nil {
 		return errors.New("glGetError")
 	}
+	gpGetFirstPerfQueryIdINTEL = (C.GPGETFIRSTPERFQUERYIDINTEL)(getProcAddr("glGetFirstPerfQueryIdINTEL"))
+	gpGetFloatIndexedvEXT = (C.GPGETFLOATINDEXEDVEXT)(getProcAddr("glGetFloatIndexedvEXT"))
 	gpGetFloati_v = (C.GPGETFLOATI_V)(getProcAddr("glGetFloati_v"))
 	if gpGetFloati_v == nil {
 		return errors.New("glGetFloati_v")
 	}
+	gpGetFloati_vEXT = (C.GPGETFLOATI_VEXT)(getProcAddr("glGetFloati_vEXT"))
 	gpGetFloatv = (C.GPGETFLOATV)(getProcAddr("glGetFloatv"))
 	if gpGetFloatv == nil {
 		return errors.New("glGetFloatv")
@@ -8976,10 +14075,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetFramebufferParameteriv == nil {
 		return errors.New("glGetFramebufferParameteriv")
 	}
+	gpGetFramebufferParameterivEXT = (C.GPGETFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetFramebufferParameterivEXT"))
 	gpGetGraphicsResetStatus = (C.GPGETGRAPHICSRESETSTATUS)(getProcAddr("glGetGraphicsResetStatus"))
 	gpGetGraphicsResetStatusARB = (C.GPGETGRAPHICSRESETSTATUSARB)(getProcAddr("glGetGraphicsResetStatusARB"))
 	gpGetGraphicsResetStatusKHR = (C.GPGETGRAPHICSRESETSTATUSKHR)(getProcAddr("glGetGraphicsResetStatusKHR"))
 	gpGetImageHandleARB = (C.GPGETIMAGEHANDLEARB)(getProcAddr("glGetImageHandleARB"))
+	gpGetImageHandleNV = (C.GPGETIMAGEHANDLENV)(getProcAddr("glGetImageHandleNV"))
 	gpGetInteger64i_v = (C.GPGETINTEGER64I_V)(getProcAddr("glGetInteger64i_v"))
 	if gpGetInteger64i_v == nil {
 		return errors.New("glGetInteger64i_v")
@@ -8988,14 +14089,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetInteger64v == nil {
 		return errors.New("glGetInteger64v")
 	}
+	gpGetIntegerIndexedvEXT = (C.GPGETINTEGERINDEXEDVEXT)(getProcAddr("glGetIntegerIndexedvEXT"))
 	gpGetIntegeri_v = (C.GPGETINTEGERI_V)(getProcAddr("glGetIntegeri_v"))
 	if gpGetIntegeri_v == nil {
 		return errors.New("glGetIntegeri_v")
 	}
+	gpGetIntegerui64i_vNV = (C.GPGETINTEGERUI64I_VNV)(getProcAddr("glGetIntegerui64i_vNV"))
+	gpGetIntegerui64vNV = (C.GPGETINTEGERUI64VNV)(getProcAddr("glGetIntegerui64vNV"))
 	gpGetIntegerv = (C.GPGETINTEGERV)(getProcAddr("glGetIntegerv"))
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	if gpGetInternalformati64v == nil {
 		return errors.New("glGetInternalformati64v")
@@ -9004,29 +14109,77 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetInternalformativ == nil {
 		return errors.New("glGetInternalformativ")
 	}
+	gpGetMultiTexEnvfvEXT = (C.GPGETMULTITEXENVFVEXT)(getProcAddr("glGetMultiTexEnvfvEXT"))
+	gpGetMultiTexEnvivEXT = (C.GPGETMULTITEXENVIVEXT)(getProcAddr("glGetMultiTexEnvivEXT"))
+	gpGetMultiTexGendvEXT = (C.GPGETMULTITEXGENDVEXT)(getProcAddr("glGetMultiTexGendvEXT"))
+	gpGetMultiTexGenfvEXT = (C.GPGETMULTITEXGENFVEXT)(getProcAddr("glGetMultiTexGenfvEXT"))
+	gpGetMultiTexGenivEXT = (C.GPGETMULTITEXGENIVEXT)(getProcAddr("glGetMultiTexGenivEXT"))
+	gpGetMultiTexImageEXT = (C.GPGETMULTITEXIMAGEEXT)(getProcAddr("glGetMultiTexImageEXT"))
+	gpGetMultiTexLevelParameterfvEXT = (C.GPGETMULTITEXLEVELPARAMETERFVEXT)(getProcAddr("glGetMultiTexLevelParameterfvEXT"))
+	gpGetMultiTexLevelParameterivEXT = (C.GPGETMULTITEXLEVELPARAMETERIVEXT)(getProcAddr("glGetMultiTexLevelParameterivEXT"))
+	gpGetMultiTexParameterIivEXT = (C.GPGETMULTITEXPARAMETERIIVEXT)(getProcAddr("glGetMultiTexParameterIivEXT"))
+	gpGetMultiTexParameterIuivEXT = (C.GPGETMULTITEXPARAMETERIUIVEXT)(getProcAddr("glGetMultiTexParameterIuivEXT"))
+	gpGetMultiTexParameterfvEXT = (C.GPGETMULTITEXPARAMETERFVEXT)(getProcAddr("glGetMultiTexParameterfvEXT"))
+	gpGetMultiTexParameterivEXT = (C.GPGETMULTITEXPARAMETERIVEXT)(getProcAddr("glGetMultiTexParameterivEXT"))
 	gpGetMultisamplefv = (C.GPGETMULTISAMPLEFV)(getProcAddr("glGetMultisamplefv"))
 	if gpGetMultisamplefv == nil {
 		return errors.New("glGetMultisamplefv")
 	}
 	gpGetNamedBufferParameteri64v = (C.GPGETNAMEDBUFFERPARAMETERI64V)(getProcAddr("glGetNamedBufferParameteri64v"))
 	gpGetNamedBufferParameteriv = (C.GPGETNAMEDBUFFERPARAMETERIV)(getProcAddr("glGetNamedBufferParameteriv"))
+	gpGetNamedBufferParameterivEXT = (C.GPGETNAMEDBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedBufferParameterivEXT"))
+	gpGetNamedBufferParameterui64vNV = (C.GPGETNAMEDBUFFERPARAMETERUI64VNV)(getProcAddr("glGetNamedBufferParameterui64vNV"))
 	gpGetNamedBufferPointerv = (C.GPGETNAMEDBUFFERPOINTERV)(getProcAddr("glGetNamedBufferPointerv"))
+	gpGetNamedBufferPointervEXT = (C.GPGETNAMEDBUFFERPOINTERVEXT)(getProcAddr("glGetNamedBufferPointervEXT"))
 	gpGetNamedBufferSubData = (C.GPGETNAMEDBUFFERSUBDATA)(getProcAddr("glGetNamedBufferSubData"))
+	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
+	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
+	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
+	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
+	gpGetNamedProgramLocalParameterIuivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIuivEXT"))
+	gpGetNamedProgramLocalParameterdvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(getProcAddr("glGetNamedProgramLocalParameterdvEXT"))
+	gpGetNamedProgramLocalParameterfvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(getProcAddr("glGetNamedProgramLocalParameterfvEXT"))
+	gpGetNamedProgramStringEXT = (C.GPGETNAMEDPROGRAMSTRINGEXT)(getProcAddr("glGetNamedProgramStringEXT"))
+	gpGetNamedProgramivEXT = (C.GPGETNAMEDPROGRAMIVEXT)(getProcAddr("glGetNamedProgramivEXT"))
 	gpGetNamedRenderbufferParameteriv = (C.GPGETNAMEDRENDERBUFFERPARAMETERIV)(getProcAddr("glGetNamedRenderbufferParameteriv"))
+	gpGetNamedRenderbufferParameterivEXT = (C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedRenderbufferParameterivEXT"))
 	gpGetNamedStringARB = (C.GPGETNAMEDSTRINGARB)(getProcAddr("glGetNamedStringARB"))
 	gpGetNamedStringivARB = (C.GPGETNAMEDSTRINGIVARB)(getProcAddr("glGetNamedStringivARB"))
+	gpGetNextPerfQueryIdINTEL = (C.GPGETNEXTPERFQUERYIDINTEL)(getProcAddr("glGetNextPerfQueryIdINTEL"))
 	gpGetObjectLabel = (C.GPGETOBJECTLABEL)(getProcAddr("glGetObjectLabel"))
 	if gpGetObjectLabel == nil {
 		return errors.New("glGetObjectLabel")
 	}
+	gpGetObjectLabelEXT = (C.GPGETOBJECTLABELEXT)(getProcAddr("glGetObjectLabelEXT"))
 	gpGetObjectLabelKHR = (C.GPGETOBJECTLABELKHR)(getProcAddr("glGetObjectLabelKHR"))
 	gpGetObjectPtrLabel = (C.GPGETOBJECTPTRLABEL)(getProcAddr("glGetObjectPtrLabel"))
 	if gpGetObjectPtrLabel == nil {
 		return errors.New("glGetObjectPtrLabel")
 	}
 	gpGetObjectPtrLabelKHR = (C.GPGETOBJECTPTRLABELKHR)(getProcAddr("glGetObjectPtrLabelKHR"))
+	gpGetPathCommandsNV = (C.GPGETPATHCOMMANDSNV)(getProcAddr("glGetPathCommandsNV"))
+	gpGetPathCoordsNV = (C.GPGETPATHCOORDSNV)(getProcAddr("glGetPathCoordsNV"))
+	gpGetPathDashArrayNV = (C.GPGETPATHDASHARRAYNV)(getProcAddr("glGetPathDashArrayNV"))
+	gpGetPathLengthNV = (C.GPGETPATHLENGTHNV)(getProcAddr("glGetPathLengthNV"))
+	gpGetPathMetricRangeNV = (C.GPGETPATHMETRICRANGENV)(getProcAddr("glGetPathMetricRangeNV"))
+	gpGetPathMetricsNV = (C.GPGETPATHMETRICSNV)(getProcAddr("glGetPathMetricsNV"))
+	gpGetPathParameterfvNV = (C.GPGETPATHPARAMETERFVNV)(getProcAddr("glGetPathParameterfvNV"))
+	gpGetPathParameterivNV = (C.GPGETPATHPARAMETERIVNV)(getProcAddr("glGetPathParameterivNV"))
+	gpGetPathSpacingNV = (C.GPGETPATHSPACINGNV)(getProcAddr("glGetPathSpacingNV"))
+	gpGetPerfCounterInfoINTEL = (C.GPGETPERFCOUNTERINFOINTEL)(getProcAddr("glGetPerfCounterInfoINTEL"))
+	gpGetPerfMonitorCounterDataAMD = (C.GPGETPERFMONITORCOUNTERDATAAMD)(getProcAddr("glGetPerfMonitorCounterDataAMD"))
+	gpGetPerfMonitorCounterInfoAMD = (C.GPGETPERFMONITORCOUNTERINFOAMD)(getProcAddr("glGetPerfMonitorCounterInfoAMD"))
+	gpGetPerfMonitorCounterStringAMD = (C.GPGETPERFMONITORCOUNTERSTRINGAMD)(getProcAddr("glGetPerfMonitorCounterStringAMD"))
+	gpGetPerfMonitorCountersAMD = (C.GPGETPERFMONITORCOUNTERSAMD)(getProcAddr("glGetPerfMonitorCountersAMD"))
+	gpGetPerfMonitorGroupStringAMD = (C.GPGETPERFMONITORGROUPSTRINGAMD)(getProcAddr("glGetPerfMonitorGroupStringAMD"))
+	gpGetPerfMonitorGroupsAMD = (C.GPGETPERFMONITORGROUPSAMD)(getProcAddr("glGetPerfMonitorGroupsAMD"))
+	gpGetPerfQueryDataINTEL = (C.GPGETPERFQUERYDATAINTEL)(getProcAddr("glGetPerfQueryDataINTEL"))
+	gpGetPerfQueryIdByNameINTEL = (C.GPGETPERFQUERYIDBYNAMEINTEL)(getProcAddr("glGetPerfQueryIdByNameINTEL"))
+	gpGetPerfQueryInfoINTEL = (C.GPGETPERFQUERYINFOINTEL)(getProcAddr("glGetPerfQueryInfoINTEL"))
+	gpGetPointerIndexedvEXT = (C.GPGETPOINTERINDEXEDVEXT)(getProcAddr("glGetPointerIndexedvEXT"))
+	gpGetPointeri_vEXT = (C.GPGETPOINTERI_VEXT)(getProcAddr("glGetPointeri_vEXT"))
 	gpGetPointerv = (C.GPGETPOINTERV)(getProcAddr("glGetPointerv"))
 	if gpGetPointerv == nil {
 		return errors.New("glGetPointerv")
@@ -9048,10 +14201,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetProgramPipelineInfoLog == nil {
 		return errors.New("glGetProgramPipelineInfoLog")
 	}
+	gpGetProgramPipelineInfoLogEXT = (C.GPGETPROGRAMPIPELINEINFOLOGEXT)(getProcAddr("glGetProgramPipelineInfoLogEXT"))
 	gpGetProgramPipelineiv = (C.GPGETPROGRAMPIPELINEIV)(getProcAddr("glGetProgramPipelineiv"))
 	if gpGetProgramPipelineiv == nil {
 		return errors.New("glGetProgramPipelineiv")
 	}
+	gpGetProgramPipelineivEXT = (C.GPGETPROGRAMPIPELINEIVEXT)(getProcAddr("glGetProgramPipelineivEXT"))
 	gpGetProgramResourceIndex = (C.GPGETPROGRAMRESOURCEINDEX)(getProcAddr("glGetProgramResourceIndex"))
 	if gpGetProgramResourceIndex == nil {
 		return errors.New("glGetProgramResourceIndex")
@@ -9068,6 +14223,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetProgramResourceName == nil {
 		return errors.New("glGetProgramResourceName")
 	}
+	gpGetProgramResourcefvNV = (C.GPGETPROGRAMRESOURCEFVNV)(getProcAddr("glGetProgramResourcefvNV"))
 	gpGetProgramResourceiv = (C.GPGETPROGRAMRESOURCEIV)(getProcAddr("glGetProgramResourceiv"))
 	if gpGetProgramResourceiv == nil {
 		return errors.New("glGetProgramResourceiv")
@@ -9080,6 +14236,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetProgramiv == nil {
 		return errors.New("glGetProgramiv")
 	}
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	if gpGetQueryIndexediv == nil {
 		return errors.New("glGetQueryIndexediv")
@@ -9140,6 +14300,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetShaderiv == nil {
 		return errors.New("glGetShaderiv")
 	}
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -9189,14 +14350,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetTexParameteriv")
 	}
 	gpGetTextureHandleARB = (C.GPGETTEXTUREHANDLEARB)(getProcAddr("glGetTextureHandleARB"))
+	gpGetTextureHandleNV = (C.GPGETTEXTUREHANDLENV)(getProcAddr("glGetTextureHandleNV"))
 	gpGetTextureImage = (C.GPGETTEXTUREIMAGE)(getProcAddr("glGetTextureImage"))
+	gpGetTextureImageEXT = (C.GPGETTEXTUREIMAGEEXT)(getProcAddr("glGetTextureImageEXT"))
 	gpGetTextureLevelParameterfv = (C.GPGETTEXTURELEVELPARAMETERFV)(getProcAddr("glGetTextureLevelParameterfv"))
+	gpGetTextureLevelParameterfvEXT = (C.GPGETTEXTURELEVELPARAMETERFVEXT)(getProcAddr("glGetTextureLevelParameterfvEXT"))
 	gpGetTextureLevelParameteriv = (C.GPGETTEXTURELEVELPARAMETERIV)(getProcAddr("glGetTextureLevelParameteriv"))
+	gpGetTextureLevelParameterivEXT = (C.GPGETTEXTURELEVELPARAMETERIVEXT)(getProcAddr("glGetTextureLevelParameterivEXT"))
 	gpGetTextureParameterIiv = (C.GPGETTEXTUREPARAMETERIIV)(getProcAddr("glGetTextureParameterIiv"))
+	gpGetTextureParameterIivEXT = (C.GPGETTEXTUREPARAMETERIIVEXT)(getProcAddr("glGetTextureParameterIivEXT"))
 	gpGetTextureParameterIuiv = (C.GPGETTEXTUREPARAMETERIUIV)(getProcAddr("glGetTextureParameterIuiv"))
+	gpGetTextureParameterIuivEXT = (C.GPGETTEXTUREPARAMETERIUIVEXT)(getProcAddr("glGetTextureParameterIuivEXT"))
 	gpGetTextureParameterfv = (C.GPGETTEXTUREPARAMETERFV)(getProcAddr("glGetTextureParameterfv"))
+	gpGetTextureParameterfvEXT = (C.GPGETTEXTUREPARAMETERFVEXT)(getProcAddr("glGetTextureParameterfvEXT"))
 	gpGetTextureParameteriv = (C.GPGETTEXTUREPARAMETERIV)(getProcAddr("glGetTextureParameteriv"))
+	gpGetTextureParameterivEXT = (C.GPGETTEXTUREPARAMETERIVEXT)(getProcAddr("glGetTextureParameterivEXT"))
 	gpGetTextureSamplerHandleARB = (C.GPGETTEXTURESAMPLERHANDLEARB)(getProcAddr("glGetTextureSamplerHandleARB"))
+	gpGetTextureSamplerHandleNV = (C.GPGETTEXTURESAMPLERHANDLENV)(getProcAddr("glGetTextureSamplerHandleNV"))
 	gpGetTextureSubImage = (C.GPGETTEXTURESUBIMAGE)(getProcAddr("glGetTextureSubImage"))
 	gpGetTransformFeedbackVarying = (C.GPGETTRANSFORMFEEDBACKVARYING)(getProcAddr("glGetTransformFeedbackVarying"))
 	if gpGetTransformFeedbackVarying == nil {
@@ -9229,16 +14399,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetUniformfv == nil {
 		return errors.New("glGetUniformfv")
 	}
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
+	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
+	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
 	}
 	gpGetVertexArrayIndexed64iv = (C.GPGETVERTEXARRAYINDEXED64IV)(getProcAddr("glGetVertexArrayIndexed64iv"))
 	gpGetVertexArrayIndexediv = (C.GPGETVERTEXARRAYINDEXEDIV)(getProcAddr("glGetVertexArrayIndexediv"))
+	gpGetVertexArrayIntegeri_vEXT = (C.GPGETVERTEXARRAYINTEGERI_VEXT)(getProcAddr("glGetVertexArrayIntegeri_vEXT"))
+	gpGetVertexArrayIntegervEXT = (C.GPGETVERTEXARRAYINTEGERVEXT)(getProcAddr("glGetVertexArrayIntegervEXT"))
+	gpGetVertexArrayPointeri_vEXT = (C.GPGETVERTEXARRAYPOINTERI_VEXT)(getProcAddr("glGetVertexArrayPointeri_vEXT"))
+	gpGetVertexArrayPointervEXT = (C.GPGETVERTEXARRAYPOINTERVEXT)(getProcAddr("glGetVertexArrayPointervEXT"))
 	gpGetVertexArrayiv = (C.GPGETVERTEXARRAYIV)(getProcAddr("glGetVertexArrayiv"))
 	gpGetVertexAttribIiv = (C.GPGETVERTEXATTRIBIIV)(getProcAddr("glGetVertexAttribIiv"))
 	if gpGetVertexAttribIiv == nil {
@@ -9252,7 +14430,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetVertexAttribLdv == nil {
 		return errors.New("glGetVertexAttribLdv")
 	}
+	gpGetVertexAttribLi64vNV = (C.GPGETVERTEXATTRIBLI64VNV)(getProcAddr("glGetVertexAttribLi64vNV"))
 	gpGetVertexAttribLui64vARB = (C.GPGETVERTEXATTRIBLUI64VARB)(getProcAddr("glGetVertexAttribLui64vARB"))
+	gpGetVertexAttribLui64vNV = (C.GPGETVERTEXATTRIBLUI64VNV)(getProcAddr("glGetVertexAttribLui64vNV"))
 	gpGetVertexAttribPointerv = (C.GPGETVERTEXATTRIBPOINTERV)(getProcAddr("glGetVertexAttribPointerv"))
 	if gpGetVertexAttribPointerv == nil {
 		return errors.New("glGetVertexAttribPointerv")
@@ -9269,15 +14449,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetVertexAttribiv == nil {
 		return errors.New("glGetVertexAttribiv")
 	}
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnCompressedTexImageARB = (C.GPGETNCOMPRESSEDTEXIMAGEARB)(getProcAddr("glGetnCompressedTexImageARB"))
 	gpGetnTexImageARB = (C.GPGETNTEXIMAGEARB)(getProcAddr("glGetnTexImageARB"))
 	gpGetnUniformdvARB = (C.GPGETNUNIFORMDVARB)(getProcAddr("glGetnUniformdvARB"))
 	gpGetnUniformfv = (C.GPGETNUNIFORMFV)(getProcAddr("glGetnUniformfv"))
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	gpGetnUniformuivARB = (C.GPGETNUNIFORMUIVARB)(getProcAddr("glGetnUniformuivARB"))
 	gpGetnUniformuivKHR = (C.GPGETNUNIFORMUIVKHR)(getProcAddr("glGetnUniformuivKHR"))
@@ -9285,6 +14468,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpHint == nil {
 		return errors.New("glHint")
 	}
+	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
+	gpInsertEventMarkerEXT = (C.GPINSERTEVENTMARKEREXT)(getProcAddr("glInsertEventMarkerEXT"))
+	gpInterpolatePathsNV = (C.GPINTERPOLATEPATHSNV)(getProcAddr("glInterpolatePathsNV"))
 	gpInvalidateBufferData = (C.GPINVALIDATEBUFFERDATA)(getProcAddr("glInvalidateBufferData"))
 	if gpInvalidateBufferData == nil {
 		return errors.New("glInvalidateBufferData")
@@ -9315,10 +14501,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsBuffer == nil {
 		return errors.New("glIsBuffer")
 	}
+	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
 	}
+	gpIsEnabledIndexedEXT = (C.GPISENABLEDINDEXEDEXT)(getProcAddr("glIsEnabledIndexedEXT"))
 	gpIsEnabledi = (C.GPISENABLEDI)(getProcAddr("glIsEnabledi"))
 	if gpIsEnabledi == nil {
 		return errors.New("glIsEnabledi")
@@ -9328,7 +14517,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsFramebuffer")
 	}
 	gpIsImageHandleResidentARB = (C.GPISIMAGEHANDLERESIDENTARB)(getProcAddr("glIsImageHandleResidentARB"))
+	gpIsImageHandleResidentNV = (C.GPISIMAGEHANDLERESIDENTNV)(getProcAddr("glIsImageHandleResidentNV"))
+	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
+	gpIsPathNV = (C.GPISPATHNV)(getProcAddr("glIsPathNV"))
+	gpIsPointInFillPathNV = (C.GPISPOINTINFILLPATHNV)(getProcAddr("glIsPointInFillPathNV"))
+	gpIsPointInStrokePathNV = (C.GPISPOINTINSTROKEPATHNV)(getProcAddr("glIsPointInStrokePathNV"))
 	gpIsProgram = (C.GPISPROGRAM)(getProcAddr("glIsProgram"))
 	if gpIsProgram == nil {
 		return errors.New("glIsProgram")
@@ -9337,6 +14531,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsProgramPipeline == nil {
 		return errors.New("glIsProgramPipeline")
 	}
+	gpIsProgramPipelineEXT = (C.GPISPROGRAMPIPELINEEXT)(getProcAddr("glIsProgramPipelineEXT"))
 	gpIsQuery = (C.GPISQUERY)(getProcAddr("glIsQuery"))
 	if gpIsQuery == nil {
 		return errors.New("glIsQuery")
@@ -9353,6 +14548,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	if gpIsSync == nil {
 		return errors.New("glIsSync")
@@ -9362,6 +14558,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsTexture")
 	}
 	gpIsTextureHandleResidentARB = (C.GPISTEXTUREHANDLERESIDENTARB)(getProcAddr("glIsTextureHandleResidentARB"))
+	gpIsTextureHandleResidentNV = (C.GPISTEXTUREHANDLERESIDENTNV)(getProcAddr("glIsTextureHandleResidentNV"))
 	gpIsTransformFeedback = (C.GPISTRANSFORMFEEDBACK)(getProcAddr("glIsTransformFeedback"))
 	if gpIsTransformFeedback == nil {
 		return errors.New("glIsTransformFeedback")
@@ -9370,6 +14567,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsVertexArray == nil {
 		return errors.New("glIsVertexArray")
 	}
+	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLineWidth = (C.GPLINEWIDTH)(getProcAddr("glLineWidth"))
 	if gpLineWidth == nil {
 		return errors.New("glLineWidth")
@@ -9378,14 +14576,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpLinkProgram == nil {
 		return errors.New("glLinkProgram")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpLogicOp = (C.GPLOGICOP)(getProcAddr("glLogicOp"))
 	if gpLogicOp == nil {
 		return errors.New("glLogicOp")
 	}
+	gpMakeBufferNonResidentNV = (C.GPMAKEBUFFERNONRESIDENTNV)(getProcAddr("glMakeBufferNonResidentNV"))
+	gpMakeBufferResidentNV = (C.GPMAKEBUFFERRESIDENTNV)(getProcAddr("glMakeBufferResidentNV"))
 	gpMakeImageHandleNonResidentARB = (C.GPMAKEIMAGEHANDLENONRESIDENTARB)(getProcAddr("glMakeImageHandleNonResidentARB"))
+	gpMakeImageHandleNonResidentNV = (C.GPMAKEIMAGEHANDLENONRESIDENTNV)(getProcAddr("glMakeImageHandleNonResidentNV"))
 	gpMakeImageHandleResidentARB = (C.GPMAKEIMAGEHANDLERESIDENTARB)(getProcAddr("glMakeImageHandleResidentARB"))
+	gpMakeImageHandleResidentNV = (C.GPMAKEIMAGEHANDLERESIDENTNV)(getProcAddr("glMakeImageHandleResidentNV"))
+	gpMakeNamedBufferNonResidentNV = (C.GPMAKENAMEDBUFFERNONRESIDENTNV)(getProcAddr("glMakeNamedBufferNonResidentNV"))
+	gpMakeNamedBufferResidentNV = (C.GPMAKENAMEDBUFFERRESIDENTNV)(getProcAddr("glMakeNamedBufferResidentNV"))
 	gpMakeTextureHandleNonResidentARB = (C.GPMAKETEXTUREHANDLENONRESIDENTARB)(getProcAddr("glMakeTextureHandleNonResidentARB"))
+	gpMakeTextureHandleNonResidentNV = (C.GPMAKETEXTUREHANDLENONRESIDENTNV)(getProcAddr("glMakeTextureHandleNonResidentNV"))
 	gpMakeTextureHandleResidentARB = (C.GPMAKETEXTUREHANDLERESIDENTARB)(getProcAddr("glMakeTextureHandleResidentARB"))
+	gpMakeTextureHandleResidentNV = (C.GPMAKETEXTUREHANDLERESIDENTNV)(getProcAddr("glMakeTextureHandleResidentNV"))
 	gpMapBuffer = (C.GPMAPBUFFER)(getProcAddr("glMapBuffer"))
 	if gpMapBuffer == nil {
 		return errors.New("glMapBuffer")
@@ -9395,7 +14602,36 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMapBufferRange")
 	}
 	gpMapNamedBuffer = (C.GPMAPNAMEDBUFFER)(getProcAddr("glMapNamedBuffer"))
+	gpMapNamedBufferEXT = (C.GPMAPNAMEDBUFFEREXT)(getProcAddr("glMapNamedBufferEXT"))
 	gpMapNamedBufferRange = (C.GPMAPNAMEDBUFFERRANGE)(getProcAddr("glMapNamedBufferRange"))
+	gpMapNamedBufferRangeEXT = (C.GPMAPNAMEDBUFFERRANGEEXT)(getProcAddr("glMapNamedBufferRangeEXT"))
+	gpMatrixFrustumEXT = (C.GPMATRIXFRUSTUMEXT)(getProcAddr("glMatrixFrustumEXT"))
+	gpMatrixLoad3x2fNV = (C.GPMATRIXLOAD3X2FNV)(getProcAddr("glMatrixLoad3x2fNV"))
+	gpMatrixLoad3x3fNV = (C.GPMATRIXLOAD3X3FNV)(getProcAddr("glMatrixLoad3x3fNV"))
+	gpMatrixLoadIdentityEXT = (C.GPMATRIXLOADIDENTITYEXT)(getProcAddr("glMatrixLoadIdentityEXT"))
+	gpMatrixLoadTranspose3x3fNV = (C.GPMATRIXLOADTRANSPOSE3X3FNV)(getProcAddr("glMatrixLoadTranspose3x3fNV"))
+	gpMatrixLoadTransposedEXT = (C.GPMATRIXLOADTRANSPOSEDEXT)(getProcAddr("glMatrixLoadTransposedEXT"))
+	gpMatrixLoadTransposefEXT = (C.GPMATRIXLOADTRANSPOSEFEXT)(getProcAddr("glMatrixLoadTransposefEXT"))
+	gpMatrixLoaddEXT = (C.GPMATRIXLOADDEXT)(getProcAddr("glMatrixLoaddEXT"))
+	gpMatrixLoadfEXT = (C.GPMATRIXLOADFEXT)(getProcAddr("glMatrixLoadfEXT"))
+	gpMatrixMult3x2fNV = (C.GPMATRIXMULT3X2FNV)(getProcAddr("glMatrixMult3x2fNV"))
+	gpMatrixMult3x3fNV = (C.GPMATRIXMULT3X3FNV)(getProcAddr("glMatrixMult3x3fNV"))
+	gpMatrixMultTranspose3x3fNV = (C.GPMATRIXMULTTRANSPOSE3X3FNV)(getProcAddr("glMatrixMultTranspose3x3fNV"))
+	gpMatrixMultTransposedEXT = (C.GPMATRIXMULTTRANSPOSEDEXT)(getProcAddr("glMatrixMultTransposedEXT"))
+	gpMatrixMultTransposefEXT = (C.GPMATRIXMULTTRANSPOSEFEXT)(getProcAddr("glMatrixMultTransposefEXT"))
+	gpMatrixMultdEXT = (C.GPMATRIXMULTDEXT)(getProcAddr("glMatrixMultdEXT"))
+	gpMatrixMultfEXT = (C.GPMATRIXMULTFEXT)(getProcAddr("glMatrixMultfEXT"))
+	gpMatrixOrthoEXT = (C.GPMATRIXORTHOEXT)(getProcAddr("glMatrixOrthoEXT"))
+	gpMatrixPopEXT = (C.GPMATRIXPOPEXT)(getProcAddr("glMatrixPopEXT"))
+	gpMatrixPushEXT = (C.GPMATRIXPUSHEXT)(getProcAddr("glMatrixPushEXT"))
+	gpMatrixRotatedEXT = (C.GPMATRIXROTATEDEXT)(getProcAddr("glMatrixRotatedEXT"))
+	gpMatrixRotatefEXT = (C.GPMATRIXROTATEFEXT)(getProcAddr("glMatrixRotatefEXT"))
+	gpMatrixScaledEXT = (C.GPMATRIXSCALEDEXT)(getProcAddr("glMatrixScaledEXT"))
+	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
+	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
+	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	if gpMemoryBarrier == nil {
 		return errors.New("glMemoryBarrier")
@@ -9414,6 +14650,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpMultiDrawArraysIndirect == nil {
 		return errors.New("glMultiDrawArraysIndirect")
 	}
+	gpMultiDrawArraysIndirectBindlessCountNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawArraysIndirectBindlessCountNV"))
+	gpMultiDrawArraysIndirectBindlessNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawArraysIndirectBindlessNV"))
 	gpMultiDrawArraysIndirectCountARB = (C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawArraysIndirectCountARB"))
 	gpMultiDrawElements = (C.GPMULTIDRAWELEMENTS)(getProcAddr("glMultiDrawElements"))
 	if gpMultiDrawElements == nil {
@@ -9427,22 +14665,79 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpMultiDrawElementsIndirect == nil {
 		return errors.New("glMultiDrawElementsIndirect")
 	}
+	gpMultiDrawElementsIndirectBindlessCountNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawElementsIndirectBindlessCountNV"))
+	gpMultiDrawElementsIndirectBindlessNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawElementsIndirectBindlessNV"))
 	gpMultiDrawElementsIndirectCountARB = (C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawElementsIndirectCountARB"))
+	gpMultiTexBufferEXT = (C.GPMULTITEXBUFFEREXT)(getProcAddr("glMultiTexBufferEXT"))
+	gpMultiTexCoordPointerEXT = (C.GPMULTITEXCOORDPOINTEREXT)(getProcAddr("glMultiTexCoordPointerEXT"))
+	gpMultiTexEnvfEXT = (C.GPMULTITEXENVFEXT)(getProcAddr("glMultiTexEnvfEXT"))
+	gpMultiTexEnvfvEXT = (C.GPMULTITEXENVFVEXT)(getProcAddr("glMultiTexEnvfvEXT"))
+	gpMultiTexEnviEXT = (C.GPMULTITEXENVIEXT)(getProcAddr("glMultiTexEnviEXT"))
+	gpMultiTexEnvivEXT = (C.GPMULTITEXENVIVEXT)(getProcAddr("glMultiTexEnvivEXT"))
+	gpMultiTexGendEXT = (C.GPMULTITEXGENDEXT)(getProcAddr("glMultiTexGendEXT"))
+	gpMultiTexGendvEXT = (C.GPMULTITEXGENDVEXT)(getProcAddr("glMultiTexGendvEXT"))
+	gpMultiTexGenfEXT = (C.GPMULTITEXGENFEXT)(getProcAddr("glMultiTexGenfEXT"))
+	gpMultiTexGenfvEXT = (C.GPMULTITEXGENFVEXT)(getProcAddr("glMultiTexGenfvEXT"))
+	gpMultiTexGeniEXT = (C.GPMULTITEXGENIEXT)(getProcAddr("glMultiTexGeniEXT"))
+	gpMultiTexGenivEXT = (C.GPMULTITEXGENIVEXT)(getProcAddr("glMultiTexGenivEXT"))
+	gpMultiTexImage1DEXT = (C.GPMULTITEXIMAGE1DEXT)(getProcAddr("glMultiTexImage1DEXT"))
+	gpMultiTexImage2DEXT = (C.GPMULTITEXIMAGE2DEXT)(getProcAddr("glMultiTexImage2DEXT"))
+	gpMultiTexImage3DEXT = (C.GPMULTITEXIMAGE3DEXT)(getProcAddr("glMultiTexImage3DEXT"))
+	gpMultiTexParameterIivEXT = (C.GPMULTITEXPARAMETERIIVEXT)(getProcAddr("glMultiTexParameterIivEXT"))
+	gpMultiTexParameterIuivEXT = (C.GPMULTITEXPARAMETERIUIVEXT)(getProcAddr("glMultiTexParameterIuivEXT"))
+	gpMultiTexParameterfEXT = (C.GPMULTITEXPARAMETERFEXT)(getProcAddr("glMultiTexParameterfEXT"))
+	gpMultiTexParameterfvEXT = (C.GPMULTITEXPARAMETERFVEXT)(getProcAddr("glMultiTexParameterfvEXT"))
+	gpMultiTexParameteriEXT = (C.GPMULTITEXPARAMETERIEXT)(getProcAddr("glMultiTexParameteriEXT"))
+	gpMultiTexParameterivEXT = (C.GPMULTITEXPARAMETERIVEXT)(getProcAddr("glMultiTexParameterivEXT"))
+	gpMultiTexRenderbufferEXT = (C.GPMULTITEXRENDERBUFFEREXT)(getProcAddr("glMultiTexRenderbufferEXT"))
+	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
+	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
+	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
+	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
+	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
+	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
+	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
 	gpNamedFramebufferDrawBuffer = (C.GPNAMEDFRAMEBUFFERDRAWBUFFER)(getProcAddr("glNamedFramebufferDrawBuffer"))
 	gpNamedFramebufferDrawBuffers = (C.GPNAMEDFRAMEBUFFERDRAWBUFFERS)(getProcAddr("glNamedFramebufferDrawBuffers"))
 	gpNamedFramebufferParameteri = (C.GPNAMEDFRAMEBUFFERPARAMETERI)(getProcAddr("glNamedFramebufferParameteri"))
+	gpNamedFramebufferParameteriEXT = (C.GPNAMEDFRAMEBUFFERPARAMETERIEXT)(getProcAddr("glNamedFramebufferParameteriEXT"))
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	gpNamedFramebufferRenderbuffer = (C.GPNAMEDFRAMEBUFFERRENDERBUFFER)(getProcAddr("glNamedFramebufferRenderbuffer"))
+	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
+	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
+	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
+	gpNamedFramebufferTexture3DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(getProcAddr("glNamedFramebufferTexture3DEXT"))
+	gpNamedFramebufferTextureEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREEXT)(getProcAddr("glNamedFramebufferTextureEXT"))
+	gpNamedFramebufferTextureFaceEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(getProcAddr("glNamedFramebufferTextureFaceEXT"))
 	gpNamedFramebufferTextureLayer = (C.GPNAMEDFRAMEBUFFERTEXTURELAYER)(getProcAddr("glNamedFramebufferTextureLayer"))
+	gpNamedFramebufferTextureLayerEXT = (C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glNamedFramebufferTextureLayerEXT"))
+	gpNamedProgramLocalParameter4dEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(getProcAddr("glNamedProgramLocalParameter4dEXT"))
+	gpNamedProgramLocalParameter4dvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(getProcAddr("glNamedProgramLocalParameter4dvEXT"))
+	gpNamedProgramLocalParameter4fEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(getProcAddr("glNamedProgramLocalParameter4fEXT"))
+	gpNamedProgramLocalParameter4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(getProcAddr("glNamedProgramLocalParameter4fvEXT"))
+	gpNamedProgramLocalParameterI4iEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(getProcAddr("glNamedProgramLocalParameterI4iEXT"))
+	gpNamedProgramLocalParameterI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(getProcAddr("glNamedProgramLocalParameterI4ivEXT"))
+	gpNamedProgramLocalParameterI4uiEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(getProcAddr("glNamedProgramLocalParameterI4uiEXT"))
+	gpNamedProgramLocalParameterI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(getProcAddr("glNamedProgramLocalParameterI4uivEXT"))
+	gpNamedProgramLocalParameters4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(getProcAddr("glNamedProgramLocalParameters4fvEXT"))
+	gpNamedProgramLocalParametersI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(getProcAddr("glNamedProgramLocalParametersI4ivEXT"))
+	gpNamedProgramLocalParametersI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(getProcAddr("glNamedProgramLocalParametersI4uivEXT"))
+	gpNamedProgramStringEXT = (C.GPNAMEDPROGRAMSTRINGEXT)(getProcAddr("glNamedProgramStringEXT"))
 	gpNamedRenderbufferStorage = (C.GPNAMEDRENDERBUFFERSTORAGE)(getProcAddr("glNamedRenderbufferStorage"))
+	gpNamedRenderbufferStorageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEEXT)(getProcAddr("glNamedRenderbufferStorageEXT"))
 	gpNamedRenderbufferStorageMultisample = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(getProcAddr("glNamedRenderbufferStorageMultisample"))
+	gpNamedRenderbufferStorageMultisampleCoverageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleCoverageEXT"))
+	gpNamedRenderbufferStorageMultisampleEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleEXT"))
 	gpNamedStringARB = (C.GPNAMEDSTRINGARB)(getProcAddr("glNamedStringARB"))
+	gpNormalFormatNV = (C.GPNORMALFORMATNV)(getProcAddr("glNormalFormatNV"))
 	gpObjectLabel = (C.GPOBJECTLABEL)(getProcAddr("glObjectLabel"))
 	if gpObjectLabel == nil {
 		return errors.New("glObjectLabel")
@@ -9461,6 +14756,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPatchParameteri == nil {
 		return errors.New("glPatchParameteri")
 	}
+	gpPathCommandsNV = (C.GPPATHCOMMANDSNV)(getProcAddr("glPathCommandsNV"))
+	gpPathCoordsNV = (C.GPPATHCOORDSNV)(getProcAddr("glPathCoordsNV"))
+	gpPathCoverDepthFuncNV = (C.GPPATHCOVERDEPTHFUNCNV)(getProcAddr("glPathCoverDepthFuncNV"))
+	gpPathDashArrayNV = (C.GPPATHDASHARRAYNV)(getProcAddr("glPathDashArrayNV"))
+	gpPathGlyphIndexArrayNV = (C.GPPATHGLYPHINDEXARRAYNV)(getProcAddr("glPathGlyphIndexArrayNV"))
+	gpPathGlyphIndexRangeNV = (C.GPPATHGLYPHINDEXRANGENV)(getProcAddr("glPathGlyphIndexRangeNV"))
+	gpPathGlyphRangeNV = (C.GPPATHGLYPHRANGENV)(getProcAddr("glPathGlyphRangeNV"))
+	gpPathGlyphsNV = (C.GPPATHGLYPHSNV)(getProcAddr("glPathGlyphsNV"))
+	gpPathMemoryGlyphIndexArrayNV = (C.GPPATHMEMORYGLYPHINDEXARRAYNV)(getProcAddr("glPathMemoryGlyphIndexArrayNV"))
+	gpPathParameterfNV = (C.GPPATHPARAMETERFNV)(getProcAddr("glPathParameterfNV"))
+	gpPathParameterfvNV = (C.GPPATHPARAMETERFVNV)(getProcAddr("glPathParameterfvNV"))
+	gpPathParameteriNV = (C.GPPATHPARAMETERINV)(getProcAddr("glPathParameteriNV"))
+	gpPathParameterivNV = (C.GPPATHPARAMETERIVNV)(getProcAddr("glPathParameterivNV"))
+	gpPathStencilDepthOffsetNV = (C.GPPATHSTENCILDEPTHOFFSETNV)(getProcAddr("glPathStencilDepthOffsetNV"))
+	gpPathStencilFuncNV = (C.GPPATHSTENCILFUNCNV)(getProcAddr("glPathStencilFuncNV"))
+	gpPathStringNV = (C.GPPATHSTRINGNV)(getProcAddr("glPathStringNV"))
+	gpPathSubCommandsNV = (C.GPPATHSUBCOMMANDSNV)(getProcAddr("glPathSubCommandsNV"))
+	gpPathSubCoordsNV = (C.GPPATHSUBCOORDSNV)(getProcAddr("glPathSubCoordsNV"))
 	gpPauseTransformFeedback = (C.GPPAUSETRANSFORMFEEDBACK)(getProcAddr("glPauseTransformFeedback"))
 	if gpPauseTransformFeedback == nil {
 		return errors.New("glPauseTransformFeedback")
@@ -9473,6 +14786,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPixelStorei == nil {
 		return errors.New("glPixelStorei")
 	}
+	gpPointAlongPathNV = (C.GPPOINTALONGPATHNV)(getProcAddr("glPointAlongPathNV"))
 	gpPointParameterf = (C.GPPOINTPARAMETERF)(getProcAddr("glPointParameterf"))
 	if gpPointParameterf == nil {
 		return errors.New("glPointParameterf")
@@ -9501,11 +14815,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPopDebugGroup = (C.GPPOPDEBUGGROUP)(getProcAddr("glPopDebugGroup"))
 	if gpPopDebugGroup == nil {
 		return errors.New("glPopDebugGroup")
 	}
 	gpPopDebugGroupKHR = (C.GPPOPDEBUGGROUPKHR)(getProcAddr("glPopDebugGroupKHR"))
+	gpPopGroupMarkerEXT = (C.GPPOPGROUPMARKEREXT)(getProcAddr("glPopGroupMarkerEXT"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	if gpPrimitiveRestartIndex == nil {
 		return errors.New("glPrimitiveRestartIndex")
@@ -9518,221 +14836,313 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramParameteri == nil {
 		return errors.New("glProgramParameteri")
 	}
+	gpProgramParameteriARB = (C.GPPROGRAMPARAMETERIARB)(getProcAddr("glProgramParameteriARB"))
+	gpProgramParameteriEXT = (C.GPPROGRAMPARAMETERIEXT)(getProcAddr("glProgramParameteriEXT"))
+	gpProgramPathFragmentInputGenNV = (C.GPPROGRAMPATHFRAGMENTINPUTGENNV)(getProcAddr("glProgramPathFragmentInputGenNV"))
 	gpProgramUniform1d = (C.GPPROGRAMUNIFORM1D)(getProcAddr("glProgramUniform1d"))
 	if gpProgramUniform1d == nil {
 		return errors.New("glProgramUniform1d")
 	}
+	gpProgramUniform1dEXT = (C.GPPROGRAMUNIFORM1DEXT)(getProcAddr("glProgramUniform1dEXT"))
 	gpProgramUniform1dv = (C.GPPROGRAMUNIFORM1DV)(getProcAddr("glProgramUniform1dv"))
 	if gpProgramUniform1dv == nil {
 		return errors.New("glProgramUniform1dv")
 	}
+	gpProgramUniform1dvEXT = (C.GPPROGRAMUNIFORM1DVEXT)(getProcAddr("glProgramUniform1dvEXT"))
 	gpProgramUniform1f = (C.GPPROGRAMUNIFORM1F)(getProcAddr("glProgramUniform1f"))
 	if gpProgramUniform1f == nil {
 		return errors.New("glProgramUniform1f")
 	}
+	gpProgramUniform1fEXT = (C.GPPROGRAMUNIFORM1FEXT)(getProcAddr("glProgramUniform1fEXT"))
 	gpProgramUniform1fv = (C.GPPROGRAMUNIFORM1FV)(getProcAddr("glProgramUniform1fv"))
 	if gpProgramUniform1fv == nil {
 		return errors.New("glProgramUniform1fv")
 	}
+	gpProgramUniform1fvEXT = (C.GPPROGRAMUNIFORM1FVEXT)(getProcAddr("glProgramUniform1fvEXT"))
 	gpProgramUniform1i = (C.GPPROGRAMUNIFORM1I)(getProcAddr("glProgramUniform1i"))
 	if gpProgramUniform1i == nil {
 		return errors.New("glProgramUniform1i")
 	}
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
+	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
+	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
+	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
 	if gpProgramUniform1iv == nil {
 		return errors.New("glProgramUniform1iv")
 	}
+	gpProgramUniform1ivEXT = (C.GPPROGRAMUNIFORM1IVEXT)(getProcAddr("glProgramUniform1ivEXT"))
 	gpProgramUniform1ui = (C.GPPROGRAMUNIFORM1UI)(getProcAddr("glProgramUniform1ui"))
 	if gpProgramUniform1ui == nil {
 		return errors.New("glProgramUniform1ui")
 	}
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
+	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
+	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
+	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
 	if gpProgramUniform1uiv == nil {
 		return errors.New("glProgramUniform1uiv")
 	}
+	gpProgramUniform1uivEXT = (C.GPPROGRAMUNIFORM1UIVEXT)(getProcAddr("glProgramUniform1uivEXT"))
 	gpProgramUniform2d = (C.GPPROGRAMUNIFORM2D)(getProcAddr("glProgramUniform2d"))
 	if gpProgramUniform2d == nil {
 		return errors.New("glProgramUniform2d")
 	}
+	gpProgramUniform2dEXT = (C.GPPROGRAMUNIFORM2DEXT)(getProcAddr("glProgramUniform2dEXT"))
 	gpProgramUniform2dv = (C.GPPROGRAMUNIFORM2DV)(getProcAddr("glProgramUniform2dv"))
 	if gpProgramUniform2dv == nil {
 		return errors.New("glProgramUniform2dv")
 	}
+	gpProgramUniform2dvEXT = (C.GPPROGRAMUNIFORM2DVEXT)(getProcAddr("glProgramUniform2dvEXT"))
 	gpProgramUniform2f = (C.GPPROGRAMUNIFORM2F)(getProcAddr("glProgramUniform2f"))
 	if gpProgramUniform2f == nil {
 		return errors.New("glProgramUniform2f")
 	}
+	gpProgramUniform2fEXT = (C.GPPROGRAMUNIFORM2FEXT)(getProcAddr("glProgramUniform2fEXT"))
 	gpProgramUniform2fv = (C.GPPROGRAMUNIFORM2FV)(getProcAddr("glProgramUniform2fv"))
 	if gpProgramUniform2fv == nil {
 		return errors.New("glProgramUniform2fv")
 	}
+	gpProgramUniform2fvEXT = (C.GPPROGRAMUNIFORM2FVEXT)(getProcAddr("glProgramUniform2fvEXT"))
 	gpProgramUniform2i = (C.GPPROGRAMUNIFORM2I)(getProcAddr("glProgramUniform2i"))
 	if gpProgramUniform2i == nil {
 		return errors.New("glProgramUniform2i")
 	}
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
+	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
+	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
+	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
 	if gpProgramUniform2iv == nil {
 		return errors.New("glProgramUniform2iv")
 	}
+	gpProgramUniform2ivEXT = (C.GPPROGRAMUNIFORM2IVEXT)(getProcAddr("glProgramUniform2ivEXT"))
 	gpProgramUniform2ui = (C.GPPROGRAMUNIFORM2UI)(getProcAddr("glProgramUniform2ui"))
 	if gpProgramUniform2ui == nil {
 		return errors.New("glProgramUniform2ui")
 	}
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
+	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
+	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
+	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
 	if gpProgramUniform2uiv == nil {
 		return errors.New("glProgramUniform2uiv")
 	}
+	gpProgramUniform2uivEXT = (C.GPPROGRAMUNIFORM2UIVEXT)(getProcAddr("glProgramUniform2uivEXT"))
 	gpProgramUniform3d = (C.GPPROGRAMUNIFORM3D)(getProcAddr("glProgramUniform3d"))
 	if gpProgramUniform3d == nil {
 		return errors.New("glProgramUniform3d")
 	}
+	gpProgramUniform3dEXT = (C.GPPROGRAMUNIFORM3DEXT)(getProcAddr("glProgramUniform3dEXT"))
 	gpProgramUniform3dv = (C.GPPROGRAMUNIFORM3DV)(getProcAddr("glProgramUniform3dv"))
 	if gpProgramUniform3dv == nil {
 		return errors.New("glProgramUniform3dv")
 	}
+	gpProgramUniform3dvEXT = (C.GPPROGRAMUNIFORM3DVEXT)(getProcAddr("glProgramUniform3dvEXT"))
 	gpProgramUniform3f = (C.GPPROGRAMUNIFORM3F)(getProcAddr("glProgramUniform3f"))
 	if gpProgramUniform3f == nil {
 		return errors.New("glProgramUniform3f")
 	}
+	gpProgramUniform3fEXT = (C.GPPROGRAMUNIFORM3FEXT)(getProcAddr("glProgramUniform3fEXT"))
 	gpProgramUniform3fv = (C.GPPROGRAMUNIFORM3FV)(getProcAddr("glProgramUniform3fv"))
 	if gpProgramUniform3fv == nil {
 		return errors.New("glProgramUniform3fv")
 	}
+	gpProgramUniform3fvEXT = (C.GPPROGRAMUNIFORM3FVEXT)(getProcAddr("glProgramUniform3fvEXT"))
 	gpProgramUniform3i = (C.GPPROGRAMUNIFORM3I)(getProcAddr("glProgramUniform3i"))
 	if gpProgramUniform3i == nil {
 		return errors.New("glProgramUniform3i")
 	}
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
+	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
+	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
+	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
 	if gpProgramUniform3iv == nil {
 		return errors.New("glProgramUniform3iv")
 	}
+	gpProgramUniform3ivEXT = (C.GPPROGRAMUNIFORM3IVEXT)(getProcAddr("glProgramUniform3ivEXT"))
 	gpProgramUniform3ui = (C.GPPROGRAMUNIFORM3UI)(getProcAddr("glProgramUniform3ui"))
 	if gpProgramUniform3ui == nil {
 		return errors.New("glProgramUniform3ui")
 	}
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
+	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
+	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
+	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
 	if gpProgramUniform3uiv == nil {
 		return errors.New("glProgramUniform3uiv")
 	}
+	gpProgramUniform3uivEXT = (C.GPPROGRAMUNIFORM3UIVEXT)(getProcAddr("glProgramUniform3uivEXT"))
 	gpProgramUniform4d = (C.GPPROGRAMUNIFORM4D)(getProcAddr("glProgramUniform4d"))
 	if gpProgramUniform4d == nil {
 		return errors.New("glProgramUniform4d")
 	}
+	gpProgramUniform4dEXT = (C.GPPROGRAMUNIFORM4DEXT)(getProcAddr("glProgramUniform4dEXT"))
 	gpProgramUniform4dv = (C.GPPROGRAMUNIFORM4DV)(getProcAddr("glProgramUniform4dv"))
 	if gpProgramUniform4dv == nil {
 		return errors.New("glProgramUniform4dv")
 	}
+	gpProgramUniform4dvEXT = (C.GPPROGRAMUNIFORM4DVEXT)(getProcAddr("glProgramUniform4dvEXT"))
 	gpProgramUniform4f = (C.GPPROGRAMUNIFORM4F)(getProcAddr("glProgramUniform4f"))
 	if gpProgramUniform4f == nil {
 		return errors.New("glProgramUniform4f")
 	}
+	gpProgramUniform4fEXT = (C.GPPROGRAMUNIFORM4FEXT)(getProcAddr("glProgramUniform4fEXT"))
 	gpProgramUniform4fv = (C.GPPROGRAMUNIFORM4FV)(getProcAddr("glProgramUniform4fv"))
 	if gpProgramUniform4fv == nil {
 		return errors.New("glProgramUniform4fv")
 	}
+	gpProgramUniform4fvEXT = (C.GPPROGRAMUNIFORM4FVEXT)(getProcAddr("glProgramUniform4fvEXT"))
 	gpProgramUniform4i = (C.GPPROGRAMUNIFORM4I)(getProcAddr("glProgramUniform4i"))
 	if gpProgramUniform4i == nil {
 		return errors.New("glProgramUniform4i")
 	}
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
+	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
+	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
+	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
 	if gpProgramUniform4iv == nil {
 		return errors.New("glProgramUniform4iv")
 	}
+	gpProgramUniform4ivEXT = (C.GPPROGRAMUNIFORM4IVEXT)(getProcAddr("glProgramUniform4ivEXT"))
 	gpProgramUniform4ui = (C.GPPROGRAMUNIFORM4UI)(getProcAddr("glProgramUniform4ui"))
 	if gpProgramUniform4ui == nil {
 		return errors.New("glProgramUniform4ui")
 	}
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
+	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
+	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
+	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
 	if gpProgramUniform4uiv == nil {
 		return errors.New("glProgramUniform4uiv")
 	}
+	gpProgramUniform4uivEXT = (C.GPPROGRAMUNIFORM4UIVEXT)(getProcAddr("glProgramUniform4uivEXT"))
 	gpProgramUniformHandleui64ARB = (C.GPPROGRAMUNIFORMHANDLEUI64ARB)(getProcAddr("glProgramUniformHandleui64ARB"))
+	gpProgramUniformHandleui64NV = (C.GPPROGRAMUNIFORMHANDLEUI64NV)(getProcAddr("glProgramUniformHandleui64NV"))
 	gpProgramUniformHandleui64vARB = (C.GPPROGRAMUNIFORMHANDLEUI64VARB)(getProcAddr("glProgramUniformHandleui64vARB"))
+	gpProgramUniformHandleui64vNV = (C.GPPROGRAMUNIFORMHANDLEUI64VNV)(getProcAddr("glProgramUniformHandleui64vNV"))
 	gpProgramUniformMatrix2dv = (C.GPPROGRAMUNIFORMMATRIX2DV)(getProcAddr("glProgramUniformMatrix2dv"))
 	if gpProgramUniformMatrix2dv == nil {
 		return errors.New("glProgramUniformMatrix2dv")
 	}
+	gpProgramUniformMatrix2dvEXT = (C.GPPROGRAMUNIFORMMATRIX2DVEXT)(getProcAddr("glProgramUniformMatrix2dvEXT"))
 	gpProgramUniformMatrix2fv = (C.GPPROGRAMUNIFORMMATRIX2FV)(getProcAddr("glProgramUniformMatrix2fv"))
 	if gpProgramUniformMatrix2fv == nil {
 		return errors.New("glProgramUniformMatrix2fv")
 	}
+	gpProgramUniformMatrix2fvEXT = (C.GPPROGRAMUNIFORMMATRIX2FVEXT)(getProcAddr("glProgramUniformMatrix2fvEXT"))
 	gpProgramUniformMatrix2x3dv = (C.GPPROGRAMUNIFORMMATRIX2X3DV)(getProcAddr("glProgramUniformMatrix2x3dv"))
 	if gpProgramUniformMatrix2x3dv == nil {
 		return errors.New("glProgramUniformMatrix2x3dv")
 	}
+	gpProgramUniformMatrix2x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3DVEXT)(getProcAddr("glProgramUniformMatrix2x3dvEXT"))
 	gpProgramUniformMatrix2x3fv = (C.GPPROGRAMUNIFORMMATRIX2X3FV)(getProcAddr("glProgramUniformMatrix2x3fv"))
 	if gpProgramUniformMatrix2x3fv == nil {
 		return errors.New("glProgramUniformMatrix2x3fv")
 	}
+	gpProgramUniformMatrix2x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3FVEXT)(getProcAddr("glProgramUniformMatrix2x3fvEXT"))
 	gpProgramUniformMatrix2x4dv = (C.GPPROGRAMUNIFORMMATRIX2X4DV)(getProcAddr("glProgramUniformMatrix2x4dv"))
 	if gpProgramUniformMatrix2x4dv == nil {
 		return errors.New("glProgramUniformMatrix2x4dv")
 	}
+	gpProgramUniformMatrix2x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4DVEXT)(getProcAddr("glProgramUniformMatrix2x4dvEXT"))
 	gpProgramUniformMatrix2x4fv = (C.GPPROGRAMUNIFORMMATRIX2X4FV)(getProcAddr("glProgramUniformMatrix2x4fv"))
 	if gpProgramUniformMatrix2x4fv == nil {
 		return errors.New("glProgramUniformMatrix2x4fv")
 	}
+	gpProgramUniformMatrix2x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4FVEXT)(getProcAddr("glProgramUniformMatrix2x4fvEXT"))
 	gpProgramUniformMatrix3dv = (C.GPPROGRAMUNIFORMMATRIX3DV)(getProcAddr("glProgramUniformMatrix3dv"))
 	if gpProgramUniformMatrix3dv == nil {
 		return errors.New("glProgramUniformMatrix3dv")
 	}
+	gpProgramUniformMatrix3dvEXT = (C.GPPROGRAMUNIFORMMATRIX3DVEXT)(getProcAddr("glProgramUniformMatrix3dvEXT"))
 	gpProgramUniformMatrix3fv = (C.GPPROGRAMUNIFORMMATRIX3FV)(getProcAddr("glProgramUniformMatrix3fv"))
 	if gpProgramUniformMatrix3fv == nil {
 		return errors.New("glProgramUniformMatrix3fv")
 	}
+	gpProgramUniformMatrix3fvEXT = (C.GPPROGRAMUNIFORMMATRIX3FVEXT)(getProcAddr("glProgramUniformMatrix3fvEXT"))
 	gpProgramUniformMatrix3x2dv = (C.GPPROGRAMUNIFORMMATRIX3X2DV)(getProcAddr("glProgramUniformMatrix3x2dv"))
 	if gpProgramUniformMatrix3x2dv == nil {
 		return errors.New("glProgramUniformMatrix3x2dv")
 	}
+	gpProgramUniformMatrix3x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2DVEXT)(getProcAddr("glProgramUniformMatrix3x2dvEXT"))
 	gpProgramUniformMatrix3x2fv = (C.GPPROGRAMUNIFORMMATRIX3X2FV)(getProcAddr("glProgramUniformMatrix3x2fv"))
 	if gpProgramUniformMatrix3x2fv == nil {
 		return errors.New("glProgramUniformMatrix3x2fv")
 	}
+	gpProgramUniformMatrix3x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2FVEXT)(getProcAddr("glProgramUniformMatrix3x2fvEXT"))
 	gpProgramUniformMatrix3x4dv = (C.GPPROGRAMUNIFORMMATRIX3X4DV)(getProcAddr("glProgramUniformMatrix3x4dv"))
 	if gpProgramUniformMatrix3x4dv == nil {
 		return errors.New("glProgramUniformMatrix3x4dv")
 	}
+	gpProgramUniformMatrix3x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4DVEXT)(getProcAddr("glProgramUniformMatrix3x4dvEXT"))
 	gpProgramUniformMatrix3x4fv = (C.GPPROGRAMUNIFORMMATRIX3X4FV)(getProcAddr("glProgramUniformMatrix3x4fv"))
 	if gpProgramUniformMatrix3x4fv == nil {
 		return errors.New("glProgramUniformMatrix3x4fv")
 	}
+	gpProgramUniformMatrix3x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4FVEXT)(getProcAddr("glProgramUniformMatrix3x4fvEXT"))
 	gpProgramUniformMatrix4dv = (C.GPPROGRAMUNIFORMMATRIX4DV)(getProcAddr("glProgramUniformMatrix4dv"))
 	if gpProgramUniformMatrix4dv == nil {
 		return errors.New("glProgramUniformMatrix4dv")
 	}
+	gpProgramUniformMatrix4dvEXT = (C.GPPROGRAMUNIFORMMATRIX4DVEXT)(getProcAddr("glProgramUniformMatrix4dvEXT"))
 	gpProgramUniformMatrix4fv = (C.GPPROGRAMUNIFORMMATRIX4FV)(getProcAddr("glProgramUniformMatrix4fv"))
 	if gpProgramUniformMatrix4fv == nil {
 		return errors.New("glProgramUniformMatrix4fv")
 	}
+	gpProgramUniformMatrix4fvEXT = (C.GPPROGRAMUNIFORMMATRIX4FVEXT)(getProcAddr("glProgramUniformMatrix4fvEXT"))
 	gpProgramUniformMatrix4x2dv = (C.GPPROGRAMUNIFORMMATRIX4X2DV)(getProcAddr("glProgramUniformMatrix4x2dv"))
 	if gpProgramUniformMatrix4x2dv == nil {
 		return errors.New("glProgramUniformMatrix4x2dv")
 	}
+	gpProgramUniformMatrix4x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2DVEXT)(getProcAddr("glProgramUniformMatrix4x2dvEXT"))
 	gpProgramUniformMatrix4x2fv = (C.GPPROGRAMUNIFORMMATRIX4X2FV)(getProcAddr("glProgramUniformMatrix4x2fv"))
 	if gpProgramUniformMatrix4x2fv == nil {
 		return errors.New("glProgramUniformMatrix4x2fv")
 	}
+	gpProgramUniformMatrix4x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2FVEXT)(getProcAddr("glProgramUniformMatrix4x2fvEXT"))
 	gpProgramUniformMatrix4x3dv = (C.GPPROGRAMUNIFORMMATRIX4X3DV)(getProcAddr("glProgramUniformMatrix4x3dv"))
 	if gpProgramUniformMatrix4x3dv == nil {
 		return errors.New("glProgramUniformMatrix4x3dv")
 	}
+	gpProgramUniformMatrix4x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3DVEXT)(getProcAddr("glProgramUniformMatrix4x3dvEXT"))
 	gpProgramUniformMatrix4x3fv = (C.GPPROGRAMUNIFORMMATRIX4X3FV)(getProcAddr("glProgramUniformMatrix4x3fv"))
 	if gpProgramUniformMatrix4x3fv == nil {
 		return errors.New("glProgramUniformMatrix4x3fv")
 	}
+	gpProgramUniformMatrix4x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3FVEXT)(getProcAddr("glProgramUniformMatrix4x3fvEXT"))
+	gpProgramUniformui64NV = (C.GPPROGRAMUNIFORMUI64NV)(getProcAddr("glProgramUniformui64NV"))
+	gpProgramUniformui64vNV = (C.GPPROGRAMUNIFORMUI64VNV)(getProcAddr("glProgramUniformui64vNV"))
 	gpProvokingVertex = (C.GPPROVOKINGVERTEX)(getProcAddr("glProvokingVertex"))
 	if gpProvokingVertex == nil {
 		return errors.New("glProvokingVertex")
 	}
+	gpPushClientAttribDefaultEXT = (C.GPPUSHCLIENTATTRIBDEFAULTEXT)(getProcAddr("glPushClientAttribDefaultEXT"))
 	gpPushDebugGroup = (C.GPPUSHDEBUGGROUP)(getProcAddr("glPushDebugGroup"))
 	if gpPushDebugGroup == nil {
 		return errors.New("glPushDebugGroup")
 	}
 	gpPushDebugGroupKHR = (C.GPPUSHDEBUGGROUPKHR)(getProcAddr("glPushDebugGroupKHR"))
+	gpPushGroupMarkerEXT = (C.GPPUSHGROUPMARKEREXT)(getProcAddr("glPushGroupMarkerEXT"))
 	gpQueryCounter = (C.GPQUERYCOUNTER)(getProcAddr("glQueryCounter"))
 	if gpQueryCounter == nil {
 		return errors.New("glQueryCounter")
 	}
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -9756,6 +15166,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpRenderbufferStorageMultisample == nil {
 		return errors.New("glRenderbufferStorageMultisample")
 	}
+	gpRenderbufferStorageMultisampleCoverageNV = (C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(getProcAddr("glRenderbufferStorageMultisampleCoverageNV"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	if gpResumeTransformFeedback == nil {
 		return errors.New("glResumeTransformFeedback")
@@ -9808,6 +15220,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpScissorIndexedv == nil {
 		return errors.New("glScissorIndexedv")
 	}
+	gpSecondaryColorFormatNV = (C.GPSECONDARYCOLORFORMATNV)(getProcAddr("glSecondaryColorFormatNV"))
+	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
 	gpShaderBinary = (C.GPSHADERBINARY)(getProcAddr("glShaderBinary"))
 	if gpShaderBinary == nil {
 		return errors.New("glShaderBinary")
@@ -9820,6 +15234,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpShaderStorageBlockBinding == nil {
 		return errors.New("glShaderStorageBlockBinding")
 	}
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
+	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
+	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
 	gpStencilFunc = (C.GPSTENCILFUNC)(getProcAddr("glStencilFunc"))
 	if gpStencilFunc == nil {
 		return errors.New("glStencilFunc")
@@ -9844,14 +15264,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpStencilOpSeparate == nil {
 		return errors.New("glStencilOpSeparate")
 	}
+	gpStencilStrokePathInstancedNV = (C.GPSTENCILSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilStrokePathInstancedNV"))
+	gpStencilStrokePathNV = (C.GPSTENCILSTROKEPATHNV)(getProcAddr("glStencilStrokePathNV"))
+	gpStencilThenCoverFillPathInstancedNV = (C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverFillPathInstancedNV"))
+	gpStencilThenCoverFillPathNV = (C.GPSTENCILTHENCOVERFILLPATHNV)(getProcAddr("glStencilThenCoverFillPathNV"))
+	gpStencilThenCoverStrokePathInstancedNV = (C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverStrokePathInstancedNV"))
+	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpTexBuffer = (C.GPTEXBUFFER)(getProcAddr("glTexBuffer"))
 	if gpTexBuffer == nil {
 		return errors.New("glTexBuffer")
 	}
+	gpTexBufferARB = (C.GPTEXBUFFERARB)(getProcAddr("glTexBufferARB"))
 	gpTexBufferRange = (C.GPTEXBUFFERRANGE)(getProcAddr("glTexBufferRange"))
 	if gpTexBufferRange == nil {
 		return errors.New("glTexBufferRange")
 	}
+	gpTexCoordFormatNV = (C.GPTEXCOORDFORMATNV)(getProcAddr("glTexCoordFormatNV"))
 	gpTexImage1D = (C.GPTEXIMAGE1D)(getProcAddr("glTexImage1D"))
 	if gpTexImage1D == nil {
 		return errors.New("glTexImage1D")
@@ -9930,22 +15359,44 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glTexSubImage3D")
 	}
 	gpTextureBarrier = (C.GPTEXTUREBARRIER)(getProcAddr("glTextureBarrier"))
+	gpTextureBarrierNV = (C.GPTEXTUREBARRIERNV)(getProcAddr("glTextureBarrierNV"))
 	gpTextureBuffer = (C.GPTEXTUREBUFFER)(getProcAddr("glTextureBuffer"))
+	gpTextureBufferEXT = (C.GPTEXTUREBUFFEREXT)(getProcAddr("glTextureBufferEXT"))
 	gpTextureBufferRange = (C.GPTEXTUREBUFFERRANGE)(getProcAddr("glTextureBufferRange"))
+	gpTextureBufferRangeEXT = (C.GPTEXTUREBUFFERRANGEEXT)(getProcAddr("glTextureBufferRangeEXT"))
+	gpTextureImage1DEXT = (C.GPTEXTUREIMAGE1DEXT)(getProcAddr("glTextureImage1DEXT"))
+	gpTextureImage2DEXT = (C.GPTEXTUREIMAGE2DEXT)(getProcAddr("glTextureImage2DEXT"))
+	gpTextureImage3DEXT = (C.GPTEXTUREIMAGE3DEXT)(getProcAddr("glTextureImage3DEXT"))
+	gpTexturePageCommitmentEXT = (C.GPTEXTUREPAGECOMMITMENTEXT)(getProcAddr("glTexturePageCommitmentEXT"))
 	gpTextureParameterIiv = (C.GPTEXTUREPARAMETERIIV)(getProcAddr("glTextureParameterIiv"))
+	gpTextureParameterIivEXT = (C.GPTEXTUREPARAMETERIIVEXT)(getProcAddr("glTextureParameterIivEXT"))
 	gpTextureParameterIuiv = (C.GPTEXTUREPARAMETERIUIV)(getProcAddr("glTextureParameterIuiv"))
+	gpTextureParameterIuivEXT = (C.GPTEXTUREPARAMETERIUIVEXT)(getProcAddr("glTextureParameterIuivEXT"))
 	gpTextureParameterf = (C.GPTEXTUREPARAMETERF)(getProcAddr("glTextureParameterf"))
+	gpTextureParameterfEXT = (C.GPTEXTUREPARAMETERFEXT)(getProcAddr("glTextureParameterfEXT"))
 	gpTextureParameterfv = (C.GPTEXTUREPARAMETERFV)(getProcAddr("glTextureParameterfv"))
+	gpTextureParameterfvEXT = (C.GPTEXTUREPARAMETERFVEXT)(getProcAddr("glTextureParameterfvEXT"))
 	gpTextureParameteri = (C.GPTEXTUREPARAMETERI)(getProcAddr("glTextureParameteri"))
+	gpTextureParameteriEXT = (C.GPTEXTUREPARAMETERIEXT)(getProcAddr("glTextureParameteriEXT"))
 	gpTextureParameteriv = (C.GPTEXTUREPARAMETERIV)(getProcAddr("glTextureParameteriv"))
+	gpTextureParameterivEXT = (C.GPTEXTUREPARAMETERIVEXT)(getProcAddr("glTextureParameterivEXT"))
+	gpTextureRenderbufferEXT = (C.GPTEXTURERENDERBUFFEREXT)(getProcAddr("glTextureRenderbufferEXT"))
 	gpTextureStorage1D = (C.GPTEXTURESTORAGE1D)(getProcAddr("glTextureStorage1D"))
+	gpTextureStorage1DEXT = (C.GPTEXTURESTORAGE1DEXT)(getProcAddr("glTextureStorage1DEXT"))
 	gpTextureStorage2D = (C.GPTEXTURESTORAGE2D)(getProcAddr("glTextureStorage2D"))
+	gpTextureStorage2DEXT = (C.GPTEXTURESTORAGE2DEXT)(getProcAddr("glTextureStorage2DEXT"))
 	gpTextureStorage2DMultisample = (C.GPTEXTURESTORAGE2DMULTISAMPLE)(getProcAddr("glTextureStorage2DMultisample"))
+	gpTextureStorage2DMultisampleEXT = (C.GPTEXTURESTORAGE2DMULTISAMPLEEXT)(getProcAddr("glTextureStorage2DMultisampleEXT"))
 	gpTextureStorage3D = (C.GPTEXTURESTORAGE3D)(getProcAddr("glTextureStorage3D"))
+	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
+	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
+	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
 	gpTextureSubImage2D = (C.GPTEXTURESUBIMAGE2D)(getProcAddr("glTextureSubImage2D"))
+	gpTextureSubImage2DEXT = (C.GPTEXTURESUBIMAGE2DEXT)(getProcAddr("glTextureSubImage2DEXT"))
 	gpTextureSubImage3D = (C.GPTEXTURESUBIMAGE3D)(getProcAddr("glTextureSubImage3D"))
+	gpTextureSubImage3DEXT = (C.GPTEXTURESUBIMAGE3DEXT)(getProcAddr("glTextureSubImage3DEXT"))
 	gpTextureView = (C.GPTEXTUREVIEW)(getProcAddr("glTextureView"))
 	if gpTextureView == nil {
 		return errors.New("glTextureView")
@@ -9956,6 +15407,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpTransformFeedbackVaryings == nil {
 		return errors.New("glTransformFeedbackVaryings")
 	}
+	gpTransformPathNV = (C.GPTRANSFORMPATHNV)(getProcAddr("glTransformPathNV"))
 	gpUniform1d = (C.GPUNIFORM1D)(getProcAddr("glUniform1d"))
 	if gpUniform1d == nil {
 		return errors.New("glUniform1d")
@@ -9976,6 +15428,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
+	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
+	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
 	if gpUniform1iv == nil {
 		return errors.New("glUniform1iv")
@@ -9984,6 +15440,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
+	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
+	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
 	if gpUniform1uiv == nil {
 		return errors.New("glUniform1uiv")
@@ -10008,6 +15468,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
+	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
+	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
 	if gpUniform2iv == nil {
 		return errors.New("glUniform2iv")
@@ -10016,6 +15480,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
+	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
+	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
 	if gpUniform2uiv == nil {
 		return errors.New("glUniform2uiv")
@@ -10040,6 +15508,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
+	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
+	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
 	if gpUniform3iv == nil {
 		return errors.New("glUniform3iv")
@@ -10048,6 +15520,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
+	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
+	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
 	if gpUniform3uiv == nil {
 		return errors.New("glUniform3uiv")
@@ -10072,6 +15548,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
+	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
+	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
 	if gpUniform4iv == nil {
 		return errors.New("glUniform4iv")
@@ -10080,6 +15560,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
+	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
+	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
 	if gpUniform4uiv == nil {
 		return errors.New("glUniform4uiv")
@@ -10089,7 +15573,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glUniformBlockBinding")
 	}
 	gpUniformHandleui64ARB = (C.GPUNIFORMHANDLEUI64ARB)(getProcAddr("glUniformHandleui64ARB"))
+	gpUniformHandleui64NV = (C.GPUNIFORMHANDLEUI64NV)(getProcAddr("glUniformHandleui64NV"))
 	gpUniformHandleui64vARB = (C.GPUNIFORMHANDLEUI64VARB)(getProcAddr("glUniformHandleui64vARB"))
+	gpUniformHandleui64vNV = (C.GPUNIFORMHANDLEUI64VNV)(getProcAddr("glUniformHandleui64vNV"))
 	gpUniformMatrix2dv = (C.GPUNIFORMMATRIX2DV)(getProcAddr("glUniformMatrix2dv"))
 	if gpUniformMatrix2dv == nil {
 		return errors.New("glUniformMatrix2dv")
@@ -10166,11 +15652,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniformSubroutinesuiv == nil {
 		return errors.New("glUniformSubroutinesuiv")
 	}
+	gpUniformui64NV = (C.GPUNIFORMUI64NV)(getProcAddr("glUniformui64NV"))
+	gpUniformui64vNV = (C.GPUNIFORMUI64VNV)(getProcAddr("glUniformui64vNV"))
 	gpUnmapBuffer = (C.GPUNMAPBUFFER)(getProcAddr("glUnmapBuffer"))
 	if gpUnmapBuffer == nil {
 		return errors.New("glUnmapBuffer")
 	}
 	gpUnmapNamedBuffer = (C.GPUNMAPNAMEDBUFFER)(getProcAddr("glUnmapNamedBuffer"))
+	gpUnmapNamedBufferEXT = (C.GPUNMAPNAMEDBUFFEREXT)(getProcAddr("glUnmapNamedBufferEXT"))
 	gpUseProgram = (C.GPUSEPROGRAM)(getProcAddr("glUseProgram"))
 	if gpUseProgram == nil {
 		return errors.New("glUseProgram")
@@ -10179,6 +15668,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUseProgramStages == nil {
 		return errors.New("glUseProgramStages")
 	}
+	gpUseProgramStagesEXT = (C.GPUSEPROGRAMSTAGESEXT)(getProcAddr("glUseProgramStagesEXT"))
+	gpUseShaderProgramEXT = (C.GPUSESHADERPROGRAMEXT)(getProcAddr("glUseShaderProgramEXT"))
 	gpValidateProgram = (C.GPVALIDATEPROGRAM)(getProcAddr("glValidateProgram"))
 	if gpValidateProgram == nil {
 		return errors.New("glValidateProgram")
@@ -10187,14 +15678,34 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpValidateProgramPipeline == nil {
 		return errors.New("glValidateProgramPipeline")
 	}
+	gpValidateProgramPipelineEXT = (C.GPVALIDATEPROGRAMPIPELINEEXT)(getProcAddr("glValidateProgramPipelineEXT"))
 	gpVertexArrayAttribBinding = (C.GPVERTEXARRAYATTRIBBINDING)(getProcAddr("glVertexArrayAttribBinding"))
 	gpVertexArrayAttribFormat = (C.GPVERTEXARRAYATTRIBFORMAT)(getProcAddr("glVertexArrayAttribFormat"))
 	gpVertexArrayAttribIFormat = (C.GPVERTEXARRAYATTRIBIFORMAT)(getProcAddr("glVertexArrayAttribIFormat"))
 	gpVertexArrayAttribLFormat = (C.GPVERTEXARRAYATTRIBLFORMAT)(getProcAddr("glVertexArrayAttribLFormat"))
+	gpVertexArrayBindVertexBufferEXT = (C.GPVERTEXARRAYBINDVERTEXBUFFEREXT)(getProcAddr("glVertexArrayBindVertexBufferEXT"))
 	gpVertexArrayBindingDivisor = (C.GPVERTEXARRAYBINDINGDIVISOR)(getProcAddr("glVertexArrayBindingDivisor"))
+	gpVertexArrayColorOffsetEXT = (C.GPVERTEXARRAYCOLOROFFSETEXT)(getProcAddr("glVertexArrayColorOffsetEXT"))
+	gpVertexArrayEdgeFlagOffsetEXT = (C.GPVERTEXARRAYEDGEFLAGOFFSETEXT)(getProcAddr("glVertexArrayEdgeFlagOffsetEXT"))
 	gpVertexArrayElementBuffer = (C.GPVERTEXARRAYELEMENTBUFFER)(getProcAddr("glVertexArrayElementBuffer"))
+	gpVertexArrayFogCoordOffsetEXT = (C.GPVERTEXARRAYFOGCOORDOFFSETEXT)(getProcAddr("glVertexArrayFogCoordOffsetEXT"))
+	gpVertexArrayIndexOffsetEXT = (C.GPVERTEXARRAYINDEXOFFSETEXT)(getProcAddr("glVertexArrayIndexOffsetEXT"))
+	gpVertexArrayMultiTexCoordOffsetEXT = (C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayMultiTexCoordOffsetEXT"))
+	gpVertexArrayNormalOffsetEXT = (C.GPVERTEXARRAYNORMALOFFSETEXT)(getProcAddr("glVertexArrayNormalOffsetEXT"))
+	gpVertexArraySecondaryColorOffsetEXT = (C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(getProcAddr("glVertexArraySecondaryColorOffsetEXT"))
+	gpVertexArrayTexCoordOffsetEXT = (C.GPVERTEXARRAYTEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayTexCoordOffsetEXT"))
+	gpVertexArrayVertexAttribBindingEXT = (C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(getProcAddr("glVertexArrayVertexAttribBindingEXT"))
+	gpVertexArrayVertexAttribDivisorEXT = (C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(getProcAddr("glVertexArrayVertexAttribDivisorEXT"))
+	gpVertexArrayVertexAttribFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(getProcAddr("glVertexArrayVertexAttribFormatEXT"))
+	gpVertexArrayVertexAttribIFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(getProcAddr("glVertexArrayVertexAttribIFormatEXT"))
+	gpVertexArrayVertexAttribIOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribIOffsetEXT"))
+	gpVertexArrayVertexAttribLFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(getProcAddr("glVertexArrayVertexAttribLFormatEXT"))
+	gpVertexArrayVertexAttribLOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribLOffsetEXT"))
+	gpVertexArrayVertexAttribOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribOffsetEXT"))
+	gpVertexArrayVertexBindingDivisorEXT = (C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(getProcAddr("glVertexArrayVertexBindingDivisorEXT"))
 	gpVertexArrayVertexBuffer = (C.GPVERTEXARRAYVERTEXBUFFER)(getProcAddr("glVertexArrayVertexBuffer"))
 	gpVertexArrayVertexBuffers = (C.GPVERTEXARRAYVERTEXBUFFERS)(getProcAddr("glVertexArrayVertexBuffers"))
+	gpVertexArrayVertexOffsetEXT = (C.GPVERTEXARRAYVERTEXOFFSETEXT)(getProcAddr("glVertexArrayVertexOffsetEXT"))
 	gpVertexAttrib1d = (C.GPVERTEXATTRIB1D)(getProcAddr("glVertexAttrib1d"))
 	if gpVertexAttrib1d == nil {
 		return errors.New("glVertexAttrib1d")
@@ -10347,10 +15858,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribDivisor == nil {
 		return errors.New("glVertexAttribDivisor")
 	}
+	gpVertexAttribDivisorARB = (C.GPVERTEXATTRIBDIVISORARB)(getProcAddr("glVertexAttribDivisorARB"))
 	gpVertexAttribFormat = (C.GPVERTEXATTRIBFORMAT)(getProcAddr("glVertexAttribFormat"))
 	if gpVertexAttribFormat == nil {
 		return errors.New("glVertexAttribFormat")
 	}
+	gpVertexAttribFormatNV = (C.GPVERTEXATTRIBFORMATNV)(getProcAddr("glVertexAttribFormatNV"))
 	gpVertexAttribI1i = (C.GPVERTEXATTRIBI1I)(getProcAddr("glVertexAttribI1i"))
 	if gpVertexAttribI1i == nil {
 		return errors.New("glVertexAttribI1i")
@@ -10435,6 +15948,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribIFormat == nil {
 		return errors.New("glVertexAttribIFormat")
 	}
+	gpVertexAttribIFormatNV = (C.GPVERTEXATTRIBIFORMATNV)(getProcAddr("glVertexAttribIFormatNV"))
 	gpVertexAttribIPointer = (C.GPVERTEXATTRIBIPOINTER)(getProcAddr("glVertexAttribIPointer"))
 	if gpVertexAttribIPointer == nil {
 		return errors.New("glVertexAttribIPointer")
@@ -10447,8 +15961,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL1dv == nil {
 		return errors.New("glVertexAttribL1dv")
 	}
+	gpVertexAttribL1i64NV = (C.GPVERTEXATTRIBL1I64NV)(getProcAddr("glVertexAttribL1i64NV"))
+	gpVertexAttribL1i64vNV = (C.GPVERTEXATTRIBL1I64VNV)(getProcAddr("glVertexAttribL1i64vNV"))
 	gpVertexAttribL1ui64ARB = (C.GPVERTEXATTRIBL1UI64ARB)(getProcAddr("glVertexAttribL1ui64ARB"))
+	gpVertexAttribL1ui64NV = (C.GPVERTEXATTRIBL1UI64NV)(getProcAddr("glVertexAttribL1ui64NV"))
 	gpVertexAttribL1ui64vARB = (C.GPVERTEXATTRIBL1UI64VARB)(getProcAddr("glVertexAttribL1ui64vARB"))
+	gpVertexAttribL1ui64vNV = (C.GPVERTEXATTRIBL1UI64VNV)(getProcAddr("glVertexAttribL1ui64vNV"))
 	gpVertexAttribL2d = (C.GPVERTEXATTRIBL2D)(getProcAddr("glVertexAttribL2d"))
 	if gpVertexAttribL2d == nil {
 		return errors.New("glVertexAttribL2d")
@@ -10457,6 +15975,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL2dv == nil {
 		return errors.New("glVertexAttribL2dv")
 	}
+	gpVertexAttribL2i64NV = (C.GPVERTEXATTRIBL2I64NV)(getProcAddr("glVertexAttribL2i64NV"))
+	gpVertexAttribL2i64vNV = (C.GPVERTEXATTRIBL2I64VNV)(getProcAddr("glVertexAttribL2i64vNV"))
+	gpVertexAttribL2ui64NV = (C.GPVERTEXATTRIBL2UI64NV)(getProcAddr("glVertexAttribL2ui64NV"))
+	gpVertexAttribL2ui64vNV = (C.GPVERTEXATTRIBL2UI64VNV)(getProcAddr("glVertexAttribL2ui64vNV"))
 	gpVertexAttribL3d = (C.GPVERTEXATTRIBL3D)(getProcAddr("glVertexAttribL3d"))
 	if gpVertexAttribL3d == nil {
 		return errors.New("glVertexAttribL3d")
@@ -10465,6 +15987,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL3dv == nil {
 		return errors.New("glVertexAttribL3dv")
 	}
+	gpVertexAttribL3i64NV = (C.GPVERTEXATTRIBL3I64NV)(getProcAddr("glVertexAttribL3i64NV"))
+	gpVertexAttribL3i64vNV = (C.GPVERTEXATTRIBL3I64VNV)(getProcAddr("glVertexAttribL3i64vNV"))
+	gpVertexAttribL3ui64NV = (C.GPVERTEXATTRIBL3UI64NV)(getProcAddr("glVertexAttribL3ui64NV"))
+	gpVertexAttribL3ui64vNV = (C.GPVERTEXATTRIBL3UI64VNV)(getProcAddr("glVertexAttribL3ui64vNV"))
 	gpVertexAttribL4d = (C.GPVERTEXATTRIBL4D)(getProcAddr("glVertexAttribL4d"))
 	if gpVertexAttribL4d == nil {
 		return errors.New("glVertexAttribL4d")
@@ -10473,10 +15999,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL4dv == nil {
 		return errors.New("glVertexAttribL4dv")
 	}
+	gpVertexAttribL4i64NV = (C.GPVERTEXATTRIBL4I64NV)(getProcAddr("glVertexAttribL4i64NV"))
+	gpVertexAttribL4i64vNV = (C.GPVERTEXATTRIBL4I64VNV)(getProcAddr("glVertexAttribL4i64vNV"))
+	gpVertexAttribL4ui64NV = (C.GPVERTEXATTRIBL4UI64NV)(getProcAddr("glVertexAttribL4ui64NV"))
+	gpVertexAttribL4ui64vNV = (C.GPVERTEXATTRIBL4UI64VNV)(getProcAddr("glVertexAttribL4ui64vNV"))
 	gpVertexAttribLFormat = (C.GPVERTEXATTRIBLFORMAT)(getProcAddr("glVertexAttribLFormat"))
 	if gpVertexAttribLFormat == nil {
 		return errors.New("glVertexAttribLFormat")
 	}
+	gpVertexAttribLFormatNV = (C.GPVERTEXATTRIBLFORMATNV)(getProcAddr("glVertexAttribLFormatNV"))
 	gpVertexAttribLPointer = (C.GPVERTEXATTRIBLPOINTER)(getProcAddr("glVertexAttribLPointer"))
 	if gpVertexAttribLPointer == nil {
 		return errors.New("glVertexAttribLPointer")
@@ -10521,6 +16052,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexBindingDivisor == nil {
 		return errors.New("glVertexBindingDivisor")
 	}
+	gpVertexFormatNV = (C.GPVERTEXFORMATNV)(getProcAddr("glVertexFormatNV"))
 	gpViewport = (C.GPVIEWPORT)(getProcAddr("glViewport"))
 	if gpViewport == nil {
 		return errors.New("glViewport")
@@ -10537,9 +16069,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpViewportIndexedfv == nil {
 		return errors.New("glViewportIndexedfv")
 	}
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
+	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	return nil
 }

--- a/v4.4-core/gl/procaddr.go
+++ b/v4.4-core/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcore44(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v4.5-compatibility/gl/package.go
+++ b/v4.5-compatibility/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -75,7 +73,6 @@ package gl
 // typedef unsigned int GLenum;
 // typedef unsigned char GLboolean;
 // typedef unsigned int GLbitfield;
-// typedef void GLvoid;
 // typedef signed char GLbyte;
 // typedef short GLshort;
 // typedef int GLint;
@@ -88,6 +85,7 @@ package gl
 // typedef float GLclampf;
 // typedef double GLdouble;
 // typedef double GLclampd;
+// typedef void *GLeglClientBufferEXT;
 // typedef char GLchar;
 // typedef char GLcharARB;
 // #ifdef __APPLE__
@@ -104,7 +102,7 @@ package gl
 // typedef ptrdiff_t GLsizeiptrARB;
 // typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
@@ -113,12 +111,14 @@ package gl
 // typedef void (APIENTRY *GLDEBUGPROCAMD)(GLuint id,GLenum category,GLenum severity,GLsizei length,const GLchar *message,void *userParam);
 // typedef unsigned short GLhalfNV;
 // typedef GLintptr GLvdpauSurfaceNV;
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcompatibility45(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcompatibility45(source, type, id, severity, length, message, userParam);
 // }
 // typedef void  (APIENTRYP GPACCUM)(GLenum  op, GLfloat  value);
 // typedef void  (APIENTRYP GPACCUMXOES)(GLenum  op, GLfixed  value);
+// typedef GLboolean  (APIENTRYP GPACQUIREKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key, GLuint  timeout);
 // typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
@@ -131,6 +131,8 @@ package gl
 // typedef void  (APIENTRYP GPALPHAFRAGMENTOP3ATI)(GLenum  op, GLuint  dst, GLuint  dstMod, GLuint  arg1, GLuint  arg1Rep, GLuint  arg1Mod, GLuint  arg2, GLuint  arg2Rep, GLuint  arg2Mod, GLuint  arg3, GLuint  arg3Rep, GLuint  arg3Mod);
 // typedef void  (APIENTRYP GPALPHAFUNC)(GLenum  func, GLfloat  ref);
 // typedef void  (APIENTRYP GPALPHAFUNCXOES)(GLenum  func, GLfixed  ref);
+// typedef void  (APIENTRYP GPALPHATOCOVERAGEDITHERCONTROLNV)(GLenum  mode);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPAPPLYTEXTUREEXT)(GLenum  mode);
 // typedef GLboolean  (APIENTRYP GPAREPROGRAMSRESIDENTNV)(GLsizei  n, const GLuint * programs, GLboolean * residences);
 // typedef GLboolean  (APIENTRYP GPARETEXTURESRESIDENT)(GLsizei  n, const GLuint * textures, GLboolean * residences);
@@ -252,11 +254,14 @@ package gl
 // typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPBUFFERDATAARB)(GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERPARAMETERIAPPLE)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEEXTERNALEXT)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPBUFFERSTORAGEMEMEXT)(GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPBUFFERSUBDATAARB)(GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLIST)(GLuint  list);
 // typedef void  (APIENTRYP GPCALLLISTS)(GLsizei  n, GLenum  type, const void * lists);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
@@ -286,9 +291,9 @@ package gl
 // typedef void  (APIENTRYP GPCLEARINDEX)(GLfloat  c);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
@@ -384,6 +389,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOMBINERPARAMETERIVNV)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERARB)(GLhandleARB  shaderObj);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
@@ -414,6 +421,8 @@ package gl
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER1DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image);
 // typedef void  (APIENTRYP GPCONVOLUTIONFILTER2D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * image);
@@ -444,7 +453,7 @@ package gl
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  type);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
@@ -469,8 +478,12 @@ package gl
 // typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEMEMORYOBJECTSEXT)(GLsizei  n, GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef GLhandleARB  (APIENTRYP GPCREATEPROGRAMOBJECTARB)();
@@ -483,6 +496,7 @@ package gl
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -509,12 +523,14 @@ package gl
 // typedef void  (APIENTRYP GPDELETEASYNCMARKERSSGIX)(GLuint  marker, GLsizei  range);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
 // typedef void  (APIENTRYP GPDELETEBUFFERSARB)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFENCESAPPLE)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFENCESNV)(GLsizei  n, const GLuint * fences);
 // typedef void  (APIENTRYP GPDELETEFRAGMENTSHADERATI)(GLuint  id);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERSEXT)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETELISTS)(GLuint  list, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEMEMORYOBJECTSEXT)(GLsizei  n, const GLuint * memoryObjects);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
 // typedef void  (APIENTRYP GPDELETENAMESAMD)(GLenum  identifier, GLuint  num, const GLuint * names);
 // typedef void  (APIENTRYP GPDELETEOBJECTARB)(GLhandleARB  obj);
@@ -529,10 +545,13 @@ package gl
 // typedef void  (APIENTRYP GPDELETEPROGRAMSNV)(GLsizei  n, const GLuint * programs);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETEQUERIESARB)(GLsizei  n, const GLuint * ids);
+// typedef void  (APIENTRYP GPDELETEQUERYRESOURCETAGNV)(GLsizei  n, const GLint * tagIds);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERSEXT)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
+// typedef void  (APIENTRYP GPDELETESEMAPHORESEXT)(GLsizei  n, const GLuint * semaphores);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETEXTURESEXT)(GLsizei  n, const GLuint * textures);
@@ -582,6 +601,10 @@ package gl
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSARB)(GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPDRAWBUFFERSATI)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYAPPLE)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTARRAYATI)(GLenum  mode, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
@@ -606,6 +629,7 @@ package gl
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKNV)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
 // typedef void  (APIENTRYP GPEDGEFLAG)(GLboolean  flag);
 // typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPEDGEFLAGPOINTER)(GLsizei  stride, const void * pointer);
@@ -661,6 +685,7 @@ package gl
 // typedef void  (APIENTRYP GPEVALMESH2)(GLenum  mode, GLint  i1, GLint  i2, GLint  j1, GLint  j2);
 // typedef void  (APIENTRYP GPEVALPOINT1)(GLint  i);
 // typedef void  (APIENTRYP GPEVALPOINT2)(GLint  i, GLint  j);
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef void  (APIENTRYP GPEXECUTEPROGRAMNV)(GLenum  target, GLuint  id, const GLfloat * params);
 // typedef void  (APIENTRYP GPEXTRACTCOMPONENTEXT)(GLuint  res, GLuint  src, GLuint  num);
 // typedef void  (APIENTRYP GPFEEDBACKBUFFER)(GLsizei  size, GLenum  type, GLfloat * buffer);
@@ -676,7 +701,7 @@ package gl
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGEAPPLE)(GLenum  target, GLintptr  offset, GLsizeiptr  size);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPFLUSHPIXELDATARANGENV)(GLenum  target);
 // typedef void  (APIENTRYP GPFLUSHRASTERSGIX)();
@@ -705,6 +730,7 @@ package gl
 // typedef void  (APIENTRYP GPFOGXOES)(GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPFOGXVOES)(GLenum  pname, const GLfixed * param);
 // typedef void  (APIENTRYP GPFRAGMENTCOLORMATERIALSGIX)(GLenum  face, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPFRAGMENTLIGHTMODELISGIX)(GLenum  pname, GLint  param);
@@ -721,10 +747,14 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEZOOMSGIX)(GLint  factor);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFEREXT)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1DEXT)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -739,6 +769,7 @@ package gl
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYEREXT)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFREEOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPFRUSTUM)(GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
@@ -763,9 +794,11 @@ package gl
 // typedef void  (APIENTRYP GPGENPROGRAMSNV)(GLsizei  n, GLuint * programs);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENQUERIESARB)(GLsizei  n, GLuint * ids);
+// typedef void  (APIENTRYP GPGENQUERYRESOURCETAGNV)(GLsizei  n, GLint * tagIds);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERSEXT)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
+// typedef void  (APIENTRYP GPGENSEMAPHORESEXT)(GLsizei  n, GLuint * semaphores);
 // typedef GLuint  (APIENTRYP GPGENSYMBOLSEXT)(GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components);
 // typedef void  (APIENTRYP GPGENTEXTURES)(GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPGENTEXTURESEXT)(GLsizei  n, GLuint * textures);
@@ -826,6 +859,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERFVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETCOMBINEROUTPUTPARAMETERIVNV)(GLenum  stage, GLenum  portion, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCOMBINERSTAGEPARAMETERFVNV)(GLenum  stage, GLenum  pname, GLfloat * params);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  level, void * img);
@@ -839,6 +873,7 @@ package gl
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERIVEXT)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETCONVOLUTIONPARAMETERXVOES)(GLenum  target, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGAMD)(GLuint  count, GLsizei  bufsize, GLenum * categories, GLuint * severities, GLuint * ids, GLsizei * lengths, GLchar * message);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
@@ -868,6 +903,7 @@ package gl
 // typedef void  (APIENTRYP GPGETFRAGMENTMATERIALIVSGIX)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERFVAMD)(GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
@@ -894,6 +930,7 @@ package gl
 // typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -921,6 +958,7 @@ package gl
 // typedef void  (APIENTRYP GPGETMATERIALIV)(GLenum  face, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMATERIALXOES)(GLenum  face, GLenum  pname, GLfixed  param);
 // typedef void  (APIENTRYP GPGETMATERIALXVOES)(GLenum  face, GLenum  pname, GLfixed * params);
+// typedef void  (APIENTRYP GPGETMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMINMAX)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXEXT)(GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values);
 // typedef void  (APIENTRYP GPGETMINMAXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
@@ -947,10 +985,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
@@ -996,7 +1035,7 @@ package gl
 // typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
 // typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
-// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
 // typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
 // typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
 // typedef void  (APIENTRYP GPGETPIXELMAPFV)(GLenum  map, GLfloat * values);
@@ -1045,6 +1084,10 @@ package gl
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVARB)(GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMIVNV)(GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64VEXT)(GLuint  id, GLenum  pname, GLint64 * params);
@@ -1062,6 +1105,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIUIV)(GLuint  sampler, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERFV)(GLuint  sampler, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETSAMPLERPARAMETERIV)(GLuint  sampler, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTER)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSEPARABLEFILTEREXT)(GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span);
 // typedef void  (APIENTRYP GPGETSHADERINFOLOG)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
@@ -1070,6 +1114,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERSOURCEARB)(GLhandleARB  obj, GLsizei  maxLength, GLsizei * length, GLcharARB * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETSHARPENTEXFUNCSGIS)(GLenum  target, GLfloat * points);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -1133,12 +1178,16 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFVARB)(GLhandleARB  programObj, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIVARB)(GLhandleARB  programObj, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIVEXT)(GLuint  program, GLint  location, GLuint * params);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEI_VEXT)(GLenum  target, GLuint  index, GLubyte * data);
+// typedef void  (APIENTRYP GPGETUNSIGNEDBYTEVEXT)(GLenum  pname, GLubyte * data);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTFVATI)(GLuint  id, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVARIANTARRAYOBJECTIVATI)(GLuint  id, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVARIANTBOOLEANVEXT)(GLuint  id, GLenum  value, GLboolean * data);
@@ -1184,6 +1233,7 @@ package gl
 // typedef void  (APIENTRYP GPGETVIDEOIVNV)(GLuint  video_slot, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVIDEOUI64VNV)(GLuint  video_slot, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVIDEOUIVNV)(GLuint  video_slot, GLenum  pname, GLuint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOLORTABLE)(GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table);
 // typedef void  (APIENTRYP GPGETNCOLORTABLEARB)(GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  lod, GLsizei  bufSize, void * pixels);
@@ -1217,9 +1267,11 @@ package gl
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
@@ -1240,6 +1292,12 @@ package gl
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERFVHP)(GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIHP)(GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPIMAGETRANSFORMPARAMETERIVHP)(GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPIMPORTMEMORYFDEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32HANDLEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTMEMORYWIN32NAMEEXT)(GLuint  memory, GLuint64  size, GLenum  handleType, const void * name);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREFDEXT)(GLuint  semaphore, GLenum  handleType, GLint  fd);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32HANDLEEXT)(GLuint  semaphore, GLenum  handleType, void * handle);
+// typedef void  (APIENTRYP GPIMPORTSEMAPHOREWIN32NAMEEXT)(GLuint  semaphore, GLenum  handleType, const void * name);
 // typedef GLsync  (APIENTRYP GPIMPORTSYNCEXT)(GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags);
 // typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPINDEXFUNCEXT)(GLenum  func, GLclampf  ref);
@@ -1278,6 +1336,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERARB)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
 // typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
@@ -1288,6 +1347,7 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISLIST)(GLuint  list);
+// typedef GLboolean  (APIENTRYP GPISMEMORYOBJECTEXT)(GLuint  memoryObject);
 // typedef GLboolean  (APIENTRYP GPISNAMEAMD)(GLenum  identifier, GLuint  name);
 // typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
@@ -1306,7 +1366,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFEREXT)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
+// typedef GLboolean  (APIENTRYP GPISSEMAPHOREEXT)(GLuint  semaphore);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREEXT)(GLuint  texture);
@@ -1318,6 +1380,9 @@ package gl
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAYAPPLE)(GLuint  array);
 // typedef GLboolean  (APIENTRYP GPISVERTEXATTRIBENABLEDAPPLE)(GLuint  index, GLenum  pname);
+// typedef void  (APIENTRYP GPLGPUCOPYIMAGESUBDATANVX)(GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPLGPUINTERLOCKNVX)();
+// typedef void  (APIENTRYP GPLGPUNAMEDBUFFERSUBDATANVX)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLIGHTENVISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPLIGHTMODELF)(GLenum  pname, GLfloat  param);
@@ -1338,6 +1403,7 @@ package gl
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPLINKPROGRAMARB)(GLhandleARB  programObj);
 // typedef void  (APIENTRYP GPLISTBASE)(GLuint  base);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLISTPARAMETERFSGIX)(GLuint  list, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPLISTPARAMETERFVSGIX)(GLuint  list, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPLISTPARAMETERISGIX)(GLuint  list, GLenum  pname, GLint  param);
@@ -1386,7 +1452,7 @@ package gl
 // typedef void  (APIENTRYP GPMAPGRID2XOES)(GLint  n, GLfixed  u1, GLfixed  u2, GLfixed  v1, GLfixed  v2);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPOBJECTBUFFERATI)(GLuint  buffer);
 // typedef void  (APIENTRYP GPMAPPARAMETERFVNV)(GLenum  target, GLenum  pname, const GLfloat * params);
@@ -1432,9 +1498,12 @@ package gl
 // typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIEREXT)(GLbitfield  barriers);
+// typedef void  (APIENTRYP GPMEMORYOBJECTPARAMETERIVEXT)(GLuint  memoryObject, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPMINSAMPLESHADING)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINMAX)(GLenum  target, GLenum  internalformat, GLboolean  sink);
@@ -1453,7 +1522,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTAMD)(GLenum  mode, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTARRAYAPPLE)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
@@ -1462,7 +1531,7 @@ package gl
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTAMD)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  primcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWRANGEELEMENTARRAYAPPLE)(GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWARRAYSIBM)(const GLenum * mode, const GLint * first, const GLsizei * count, GLsizei  primcount, GLint  modestride);
 // typedef void  (APIENTRYP GPMULTIMODEDRAWELEMENTSIBM)(const GLenum * mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  primcount, GLint  modestride);
@@ -1587,13 +1656,26 @@ package gl
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPMULTICASTBARRIERNV)();
+// typedef void  (APIENTRYP GPMULTICASTBLITFRAMEBUFFERNV)(GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPMULTICASTBUFFERSUBDATANV)(GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPMULTICASTCOPYBUFFERSUBDATANV)(GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPMULTICASTCOPYIMAGESUBDATANV)(GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
+// typedef void  (APIENTRYP GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUI64VNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params);
+// typedef void  (APIENTRYP GPMULTICASTGETQUERYOBJECTUIVNV)(GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPMULTICASTWAITSYNCNV)(GLuint  signalGpu, GLbitfield  waitGpuMask);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
 // typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXTERNALEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEMEMEXT)(GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
 // typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
@@ -1603,6 +1685,9 @@ package gl
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
@@ -1746,6 +1831,8 @@ package gl
 // typedef GLint  (APIENTRYP GPPOLLINSTRUMENTSSGIX)(GLint * marker_p);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETEXT)(GLfloat  factor, GLfloat  bias);
 // typedef void  (APIENTRYP GPPOLYGONOFFSETXOES)(GLfixed  factor, GLfixed  units);
 // typedef void  (APIENTRYP GPPOLYGONSTIPPLE)(const GLubyte * mask);
@@ -1758,6 +1845,7 @@ package gl
 // typedef void  (APIENTRYP GPPOPNAME)();
 // typedef void  (APIENTRYP GPPRESENTFRAMEDUALFILLNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLenum  target1, GLuint  fill1, GLenum  target2, GLuint  fill2, GLenum  target3, GLuint  fill3);
 // typedef void  (APIENTRYP GPPRESENTFRAMEKEYEDNV)(GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1);
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEXNV)(GLuint  index);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTNV)();
@@ -1815,13 +1903,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1835,13 +1927,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1855,13 +1951,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1875,13 +1975,17 @@ package gl
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
@@ -1942,6 +2046,8 @@ package gl
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
 // typedef GLbitfield  (APIENTRYP GPQUERYMATRIXXOES)(GLfixed * mantissa, GLint * exponent);
 // typedef void  (APIENTRYP GPQUERYOBJECTPARAMETERUIAMD)(GLenum  target, GLuint  id, GLenum  pname, GLuint  param);
+// typedef GLint  (APIENTRYP GPQUERYRESOURCENV)(GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer);
+// typedef void  (APIENTRYP GPQUERYRESOURCETAGNV)(GLint  tagId, const GLchar * tagString);
 // typedef void  (APIENTRYP GPRASTERPOS2D)(GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPRASTERPOS2DV)(const GLdouble * v);
 // typedef void  (APIENTRYP GPRASTERPOS2F)(GLfloat  x, GLfloat  y);
@@ -1972,6 +2078,7 @@ package gl
 // typedef void  (APIENTRYP GPRASTERPOS4SV)(const GLshort * v);
 // typedef void  (APIENTRYP GPRASTERPOS4XOES)(GLfixed  x, GLfixed  y, GLfixed  z, GLfixed  w);
 // typedef void  (APIENTRYP GPRASTERPOS4XVOES)(const GLfixed * coords);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
@@ -1989,7 +2096,9 @@ package gl
 // typedef void  (APIENTRYP GPRECTXOES)(GLfixed  x1, GLfixed  y1, GLfixed  x2, GLfixed  y2);
 // typedef void  (APIENTRYP GPRECTXVOES)(const GLfixed * v1, const GLfixed * v2);
 // typedef void  (APIENTRYP GPREFERENCEPLANESGIX)(const GLdouble * equation);
+// typedef GLboolean  (APIENTRYP GPRELEASEKEYEDMUTEXWIN32EXT)(GLuint  memory, GLuint64  key);
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
+// typedef void  (APIENTRYP GPRENDERGPUMASKNV)(GLbitfield  mask);
 // typedef GLint  (APIENTRYP GPRENDERMODE)(GLenum  mode);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
@@ -2025,6 +2134,7 @@ package gl
 // typedef void  (APIENTRYP GPRESETMINMAX)(GLenum  target);
 // typedef void  (APIENTRYP GPRESETMINMAXEXT)(GLenum  target);
 // typedef void  (APIENTRYP GPRESIZEBUFFERSMESA)();
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACKNV)();
 // typedef void  (APIENTRYP GPROTATED)(GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
@@ -2032,7 +2142,6 @@ package gl
 // typedef void  (APIENTRYP GPROTATEXOES)(GLfixed  angle, GLfixed  x, GLfixed  y, GLfixed  z);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEARB)(GLfloat  value, GLboolean  invert);
-// typedef void  (APIENTRYP GPSAMPLECOVERAGEOES)(GLfixed  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLECOVERAGEXOES)(GLclampx  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMAPATI)(GLuint  dst, GLuint  interp, GLenum  swizzle);
 // typedef void  (APIENTRYP GPSAMPLEMASKEXT)(GLclampf  value, GLboolean  invert);
@@ -2096,6 +2205,7 @@ package gl
 // typedef void  (APIENTRYP GPSECONDARYCOLORPOINTERLISTIBM)(GLint  size, GLenum  type, GLint  stride, const void ** pointer, GLint  ptrstride);
 // typedef void  (APIENTRYP GPSELECTBUFFER)(GLsizei  size, GLuint * buffer);
 // typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
+// typedef void  (APIENTRYP GPSEMAPHOREPARAMETERUI64VEXT)(GLuint  semaphore, GLenum  pname, const GLuint64 * params);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2D)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSEPARABLEFILTER2DEXT)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column);
 // typedef void  (APIENTRYP GPSETFENCEAPPLE)(GLuint  fence);
@@ -2113,11 +2223,16 @@ package gl
 // typedef void  (APIENTRYP GPSHADERSOURCEARB)(GLhandleARB  shaderObj, GLsizei  count, const GLcharARB ** string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
 // typedef void  (APIENTRYP GPSHARPENTEXFUNCSGIS)(GLenum  target, GLsizei  n, const GLfloat * points);
+// typedef void  (APIENTRYP GPSIGNALSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFSGIX)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERFVSGIX)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERISGIX)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPSPRITEPARAMETERIVSGIX)(GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPSTARTINSTRUMENTSSGIX)();
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
 // typedef void  (APIENTRYP GPSTENCILCLEARTAGEXT)(GLsizei  stencilTagBits, GLuint  stencilClearTag);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
@@ -2138,6 +2253,7 @@ package gl
 // typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
 // typedef void  (APIENTRYP GPSTOPINSTRUMENTSSGIX)(GLint  marker);
 // typedef void  (APIENTRYP GPSTRINGMARKERGREMEDY)(GLsizei  len, const void * string);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPSWIZZLEEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // typedef void  (APIENTRYP GPSYNCTEXTUREINTEL)(GLuint  texture);
 // typedef void  (APIENTRYP GPTAGSAMPLEBUFFERSGIX)();
@@ -2271,7 +2387,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLint  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations);
 // typedef void  (APIENTRYP GPTEXIMAGE4DSGIS)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIVEXT)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
@@ -2288,6 +2404,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXSTORAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXSTORAGE3D)(GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXSTORAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM1DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DEXT)(GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXSTORAGESPARSEAMD)(GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE1DEXT)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2300,7 +2421,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTEXTURECOLORMASKSGIS)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
@@ -2313,7 +2434,7 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURELIGHTEXT)(GLenum  pname);
 // typedef void  (APIENTRYP GPTEXTUREMATERIALEXT)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPTEXTURENORMALEXT)(GLenum  mode);
-// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
@@ -2338,6 +2459,11 @@ package gl
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM1DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DEXT)(GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset);
+// typedef void  (APIENTRYP GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset);
 // typedef void  (APIENTRYP GPTEXTURESTORAGESPARSEAMD)(GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
@@ -2349,7 +2475,7 @@ package gl
 // typedef void  (APIENTRYP GPTRACKMATRIXNV)(GLenum  target, GLuint  address, GLenum  matrix, GLenum  transform);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKATTRIBSNV)(GLsizei  count, const GLint * attribs, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKSTREAMATTRIBSNV)(GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGSEXT)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
@@ -2365,13 +2491,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IARB)(GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
 // typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIEXT)(GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2383,13 +2513,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IARB)(GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
 // typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIEXT)(GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2401,13 +2535,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
 // typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2419,13 +2557,17 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4FVARB)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IARB)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4IVARB)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
 // typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIEXT)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
@@ -2852,7 +2994,11 @@ package gl
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
+// typedef void  (APIENTRYP GPWAITSEMAPHOREEXT)(GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
 // typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
 // typedef void  (APIENTRYP GPWEIGHTPOINTERARB)(GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPWEIGHTBVARB)(GLint  size, const GLbyte * weights);
@@ -2919,12 +3065,16 @@ package gl
 // typedef void  (APIENTRYP GPWINDOWPOS4IVMESA)(const GLint * v);
 // typedef void  (APIENTRYP GPWINDOWPOS4SMESA)(GLshort  x, GLshort  y, GLshort  z, GLshort  w);
 // typedef void  (APIENTRYP GPWINDOWPOS4SVMESA)(const GLshort * v);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
 // typedef void  (APIENTRYP GPWRITEMASKEXT)(GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW);
 // static void  glowAccum(GPACCUM fnptr, GLenum  op, GLfloat  value) {
 //   (*fnptr)(op, value);
 // }
 // static void  glowAccumxOES(GPACCUMXOES fnptr, GLenum  op, GLfixed  value) {
 //   (*fnptr)(op, value);
+// }
+// static GLboolean  glowAcquireKeyedMutexWin32EXT(GPACQUIREKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key, GLuint  timeout) {
+//   return (*fnptr)(memory, key, timeout);
 // }
 // static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
 //   (*fnptr)(program);
@@ -2961,6 +3111,12 @@ package gl
 // }
 // static void  glowAlphaFuncxOES(GPALPHAFUNCXOES fnptr, GLenum  func, GLfixed  ref) {
 //   (*fnptr)(func, ref);
+// }
+// static void  glowAlphaToCoverageDitherControlNV(GPALPHATOCOVERAGEDITHERCONTROLNV fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowApplyTextureEXT(GPAPPLYTEXTUREEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -3325,7 +3481,7 @@ package gl
 // static void  glowBufferDataARB(GPBUFFERDATAARB fnptr, GLenum  target, GLsizeiptrARB  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferParameteriAPPLE(GPBUFFERPARAMETERIAPPLE fnptr, GLenum  target, GLenum  pname, GLint  param) {
@@ -3334,11 +3490,20 @@ package gl
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(target, size, data, flags);
 // }
+// static void  glowBufferStorageExternalEXT(GPBUFFERSTORAGEEXTERNALEXT fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(target, offset, size, clientBuffer, flags);
+// }
+// static void  glowBufferStorageMemEXT(GPBUFFERSTORAGEMEMEXT fnptr, GLenum  target, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, size, memory, offset);
+// }
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
 // static void  glowBufferSubDataARB(GPBUFFERSUBDATAARB fnptr, GLenum  target, GLintptrARB  offset, GLsizeiptrARB  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
 // }
 // static void  glowCallList(GPCALLLIST fnptr, GLuint  list) {
 //   (*fnptr)(list);
@@ -3427,14 +3592,14 @@ package gl
 // static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
 // static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -3721,6 +3886,12 @@ package gl
 // static void  glowCombinerStageParameterfvNV(GPCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, const GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
@@ -3810,6 +3981,12 @@ package gl
 // }
 // static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
 //   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowConvolutionFilter1D(GPCONVOLUTIONFILTER1D fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLenum  format, GLenum  type, const void * image) {
 //   (*fnptr)(target, internalformat, width, format, type, image);
@@ -3901,7 +4078,7 @@ package gl
 // static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
@@ -3976,11 +4153,23 @@ package gl
 // static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
 //   (*fnptr)(path, coverMode);
 // }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
+// }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreateMemoryObjectsEXT(GPCREATEMEMORYOBJECTSEXT fnptr, GLsizei  n, GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
 //   (*fnptr)(queryId, queryHandle);
@@ -4017,6 +4206,9 @@ package gl
 // }
 // static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -4096,6 +4288,9 @@ package gl
 // static void  glowDeleteBuffersARB(GPDELETEBUFFERSARB fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFencesAPPLE(GPDELETEFENCESAPPLE fnptr, GLsizei  n, const GLuint * fences) {
 //   (*fnptr)(n, fences);
 // }
@@ -4113,6 +4308,9 @@ package gl
 // }
 // static void  glowDeleteLists(GPDELETELISTS fnptr, GLuint  list, GLsizei  range) {
 //   (*fnptr)(list, range);
+// }
+// static void  glowDeleteMemoryObjectsEXT(GPDELETEMEMORYOBJECTSEXT fnptr, GLsizei  n, const GLuint * memoryObjects) {
+//   (*fnptr)(n, memoryObjects);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
@@ -4156,6 +4354,9 @@ package gl
 // static void  glowDeleteQueriesARB(GPDELETEQUERIESARB fnptr, GLsizei  n, const GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowDeleteQueryResourceTagNV(GPDELETEQUERYRESOURCETAGNV fnptr, GLsizei  n, const GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowDeleteRenderbuffers(GPDELETERENDERBUFFERS fnptr, GLsizei  n, const GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4165,8 +4366,14 @@ package gl
 // static void  glowDeleteSamplers(GPDELETESAMPLERS fnptr, GLsizei  count, const GLuint * samplers) {
 //   (*fnptr)(count, samplers);
 // }
+// static void  glowDeleteSemaphoresEXT(GPDELETESEMAPHORESEXT fnptr, GLsizei  n, const GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
+// }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -4315,6 +4522,18 @@ package gl
 // static void  glowDrawBuffersATI(GPDRAWBUFFERSATI fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
 // }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
+// }
 // static void  glowDrawElementArrayAPPLE(GPDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, GLint  first, GLsizei  count) {
 //   (*fnptr)(mode, first, count);
 // }
@@ -4386,6 +4605,9 @@ package gl
 // }
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
+// }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
 // }
 // static void  glowEdgeFlag(GPEDGEFLAG fnptr, GLboolean  flag) {
 //   (*fnptr)(flag);
@@ -4552,6 +4774,9 @@ package gl
 // static void  glowEvalPoint2(GPEVALPOINT2 fnptr, GLint  i, GLint  j) {
 //   (*fnptr)(i, j);
 // }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowExecuteProgramNV(GPEXECUTEPROGRAMNV fnptr, GLenum  target, GLuint  id, const GLfloat * params) {
 //   (*fnptr)(target, id, params);
 // }
@@ -4597,7 +4822,7 @@ package gl
 // static void  glowFlushMappedBufferRangeAPPLE(GPFLUSHMAPPEDBUFFERRANGEAPPLE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, offset, size);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
 // }
 // static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
@@ -4684,6 +4909,9 @@ package gl
 // static void  glowFragmentColorMaterialSGIX(GPFRAGMENTCOLORMATERIALSGIX fnptr, GLenum  face, GLenum  mode) {
 //   (*fnptr)(face, mode);
 // }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
 // static void  glowFragmentLightModelfSGIX(GPFRAGMENTLIGHTMODELFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -4732,6 +4960,9 @@ package gl
 // static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(framebuffer, n, bufs);
 // }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
@@ -4743,6 +4974,15 @@ package gl
 // }
 // static void  glowFramebufferRenderbufferEXT(GPFRAMEBUFFERRENDERBUFFEREXT fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSamplePositionsfvAMD(GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLenum  target, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(target, numsamples, pixelindex, values);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -4785,6 +5025,9 @@ package gl
 // }
 // static void  glowFramebufferTextureLayerEXT(GPFRAMEBUFFERTEXTURELAYEREXT fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFreeObjectBufferATI(GPFREEOBJECTBUFFERATI fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -4858,6 +5101,9 @@ package gl
 // static void  glowGenQueriesARB(GPGENQUERIESARB fnptr, GLsizei  n, GLuint * ids) {
 //   (*fnptr)(n, ids);
 // }
+// static void  glowGenQueryResourceTagNV(GPGENQUERYRESOURCETAGNV fnptr, GLsizei  n, GLint * tagIds) {
+//   (*fnptr)(n, tagIds);
+// }
 // static void  glowGenRenderbuffers(GPGENRENDERBUFFERS fnptr, GLsizei  n, GLuint * renderbuffers) {
 //   (*fnptr)(n, renderbuffers);
 // }
@@ -4866,6 +5112,9 @@ package gl
 // }
 // static void  glowGenSamplers(GPGENSAMPLERS fnptr, GLsizei  count, GLuint * samplers) {
 //   (*fnptr)(count, samplers);
+// }
+// static void  glowGenSemaphoresEXT(GPGENSEMAPHORESEXT fnptr, GLsizei  n, GLuint * semaphores) {
+//   (*fnptr)(n, semaphores);
 // }
 // static GLuint  glowGenSymbolsEXT(GPGENSYMBOLSEXT fnptr, GLenum  datatype, GLenum  storagetype, GLenum  range, GLuint  components) {
 //   return (*fnptr)(datatype, storagetype, range, components);
@@ -5047,6 +5296,9 @@ package gl
 // static void  glowGetCombinerStageParameterfvNV(GPGETCOMBINERSTAGEPARAMETERFVNV fnptr, GLenum  stage, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(stage, pname, params);
 // }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
 // static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
 //   (*fnptr)(texunit, target, lod, img);
 // }
@@ -5085,6 +5337,9 @@ package gl
 // }
 // static void  glowGetConvolutionParameterxvOES(GPGETCONVOLUTIONPARAMETERXVOES fnptr, GLenum  target, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -5173,6 +5428,9 @@ package gl
 // static void  glowGetFramebufferAttachmentParameterivEXT(GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLenum  target, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, attachment, pname, params);
 // }
+// static void  glowGetFramebufferParameterfvAMD(GPGETFRAMEBUFFERPARAMETERFVAMD fnptr, GLenum  target, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(target, pname, numsamples, pixelindex, size, values);
+// }
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
@@ -5250,6 +5508,9 @@ package gl
 // }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
@@ -5332,6 +5593,9 @@ package gl
 // static void  glowGetMaterialxvOES(GPGETMATERIALXVOES fnptr, GLenum  face, GLenum  pname, GLfixed * params) {
 //   (*fnptr)(face, pname, params);
 // }
+// static void  glowGetMemoryObjectParameterivEXT(GPGETMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
+// }
 // static void  glowGetMinmax(GPGETMINMAX fnptr, GLenum  target, GLboolean  reset, GLenum  format, GLenum  type, void * values) {
 //   (*fnptr)(target, reset, format, type, values);
 // }
@@ -5410,7 +5674,7 @@ package gl
 // static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
@@ -5421,6 +5685,9 @@ package gl
 // }
 // static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
+// }
+// static void  glowGetNamedFramebufferParameterfvAMD(GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD fnptr, GLuint  framebuffer, GLenum  pname, GLuint  numsamples, GLuint  pixelindex, GLsizei  size, GLfloat * values) {
+//   (*fnptr)(framebuffer, pname, numsamples, pixelindex, size, values);
 // }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
@@ -5557,7 +5824,7 @@ package gl
 // static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
 //   (*fnptr)(numGroups, groupsSize, groups);
 // }
-// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, GLvoid * data, GLuint * bytesWritten) {
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
 //   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
 // }
 // static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
@@ -5704,6 +5971,18 @@ package gl
 // static void  glowGetProgramivNV(GPGETPROGRAMIVNV fnptr, GLuint  id, GLenum  pname, GLint * params) {
 //   (*fnptr)(id, pname, params);
 // }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
 // }
@@ -5755,6 +6034,9 @@ package gl
 // static void  glowGetSamplerParameteriv(GPGETSAMPLERPARAMETERIV fnptr, GLuint  sampler, GLenum  pname, GLint * params) {
 //   (*fnptr)(sampler, pname, params);
 // }
+// static void  glowGetSemaphoreParameterui64vEXT(GPGETSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowGetSeparableFilter(GPGETSEPARABLEFILTER fnptr, GLenum  target, GLenum  format, GLenum  type, void * row, void * column, void * span) {
 //   (*fnptr)(target, format, type, row, column, span);
 // }
@@ -5778,6 +6060,9 @@ package gl
 // }
 // static void  glowGetSharpenTexFuncSGIS(GPGETSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLfloat * points) {
 //   (*fnptr)(target, points);
+// }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
 // }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
@@ -5968,6 +6253,9 @@ package gl
 // static void  glowGetUniformfvARB(GPGETUNIFORMFVARB fnptr, GLhandleARB  programObj, GLint  location, GLfloat * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5977,6 +6265,9 @@ package gl
 // static void  glowGetUniformivARB(GPGETUNIFORMIVARB fnptr, GLhandleARB  programObj, GLint  location, GLint * params) {
 //   (*fnptr)(programObj, location, params);
 // }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
@@ -5985,6 +6276,12 @@ package gl
 // }
 // static void  glowGetUniformuivEXT(GPGETUNIFORMUIVEXT fnptr, GLuint  program, GLint  location, GLuint * params) {
 //   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUnsignedBytei_vEXT(GPGETUNSIGNEDBYTEI_VEXT fnptr, GLenum  target, GLuint  index, GLubyte * data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetUnsignedBytevEXT(GPGETUNSIGNEDBYTEVEXT fnptr, GLenum  pname, GLubyte * data) {
+//   (*fnptr)(pname, data);
 // }
 // static void  glowGetVariantArrayObjectfvATI(GPGETVARIANTARRAYOBJECTFVATI fnptr, GLuint  id, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(id, pname, params);
@@ -6121,6 +6418,9 @@ package gl
 // static void  glowGetVideouivNV(GPGETVIDEOUIVNV fnptr, GLuint  video_slot, GLenum  pname, GLuint * params) {
 //   (*fnptr)(video_slot, pname, params);
 // }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
+// }
 // static void  glowGetnColorTable(GPGETNCOLORTABLE fnptr, GLenum  target, GLenum  format, GLenum  type, GLsizei  bufSize, void * table) {
 //   (*fnptr)(target, format, type, bufSize, table);
 // }
@@ -6220,6 +6520,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -6227,6 +6530,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -6288,6 +6594,24 @@ package gl
 // }
 // static void  glowImageTransformParameterivHP(GPIMAGETRANSFORMPARAMETERIVHP fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
+// }
+// static void  glowImportMemoryFdEXT(GPIMPORTMEMORYFDEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(memory, size, handleType, fd);
+// }
+// static void  glowImportMemoryWin32HandleEXT(GPIMPORTMEMORYWIN32HANDLEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, void * handle) {
+//   (*fnptr)(memory, size, handleType, handle);
+// }
+// static void  glowImportMemoryWin32NameEXT(GPIMPORTMEMORYWIN32NAMEEXT fnptr, GLuint  memory, GLuint64  size, GLenum  handleType, const void * name) {
+//   (*fnptr)(memory, size, handleType, name);
+// }
+// static void  glowImportSemaphoreFdEXT(GPIMPORTSEMAPHOREFDEXT fnptr, GLuint  semaphore, GLenum  handleType, GLint  fd) {
+//   (*fnptr)(semaphore, handleType, fd);
+// }
+// static void  glowImportSemaphoreWin32HandleEXT(GPIMPORTSEMAPHOREWIN32HANDLEEXT fnptr, GLuint  semaphore, GLenum  handleType, void * handle) {
+//   (*fnptr)(semaphore, handleType, handle);
+// }
+// static void  glowImportSemaphoreWin32NameEXT(GPIMPORTSEMAPHOREWIN32NAMEEXT fnptr, GLuint  semaphore, GLenum  handleType, const void * name) {
+//   (*fnptr)(semaphore, handleType, name);
 // }
 // static GLsync  glowImportSyncEXT(GPIMPORTSYNCEXT fnptr, GLenum  external_sync_type, GLintptr  external_sync, GLbitfield  flags) {
 //   return (*fnptr)(external_sync_type, external_sync, flags);
@@ -6403,6 +6727,9 @@ package gl
 // static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
 // }
@@ -6432,6 +6759,9 @@ package gl
 // }
 // static GLboolean  glowIsList(GPISLIST fnptr, GLuint  list) {
 //   return (*fnptr)(list);
+// }
+// static GLboolean  glowIsMemoryObjectEXT(GPISMEMORYOBJECTEXT fnptr, GLuint  memoryObject) {
+//   return (*fnptr)(memoryObject);
 // }
 // static GLboolean  glowIsNameAMD(GPISNAMEAMD fnptr, GLenum  identifier, GLuint  name) {
 //   return (*fnptr)(identifier, name);
@@ -6487,8 +6817,14 @@ package gl
 // static GLboolean  glowIsSampler(GPISSAMPLER fnptr, GLuint  sampler) {
 //   return (*fnptr)(sampler);
 // }
+// static GLboolean  glowIsSemaphoreEXT(GPISSEMAPHOREEXT fnptr, GLuint  semaphore) {
+//   return (*fnptr)(semaphore);
+// }
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
+// }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
 // }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
@@ -6522,6 +6858,15 @@ package gl
 // }
 // static GLboolean  glowIsVertexAttribEnabledAPPLE(GPISVERTEXATTRIBENABLEDAPPLE fnptr, GLuint  index, GLenum  pname) {
 //   return (*fnptr)(index, pname);
+// }
+// static void  glowLGPUCopyImageSubDataNVX(GPLGPUCOPYIMAGESUBDATANVX fnptr, GLuint  sourceGpu, GLbitfield  destinationGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srxY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(sourceGpu, destinationGpuMask, srcName, srcTarget, srcLevel, srcX, srxY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, width, height, depth);
+// }
+// static void  glowLGPUInterlockNVX(GPLGPUINTERLOCKNVX fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowLGPUNamedBufferSubDataNVX(GPLGPUNAMEDBUFFERSUBDATANVX fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
 // }
 // static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(type, object, length, label);
@@ -6582,6 +6927,9 @@ package gl
 // }
 // static void  glowListBase(GPLISTBASE fnptr, GLuint  base) {
 //   (*fnptr)(base);
+// }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
 // }
 // static void  glowListParameterfSGIX(GPLISTPARAMETERFSGIX fnptr, GLuint  list, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(list, pname, param);
@@ -6727,7 +7075,7 @@ package gl
 // static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
 // }
 // static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
@@ -6865,6 +7213,12 @@ package gl
 // static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
 //   (*fnptr)(mode, x, y, z);
 // }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
 // }
@@ -6873,6 +7227,9 @@ package gl
 // }
 // static void  glowMemoryBarrierEXT(GPMEMORYBARRIEREXT fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
+// }
+// static void  glowMemoryObjectParameterivEXT(GPMEMORYOBJECTPARAMETERIVEXT fnptr, GLuint  memoryObject, GLenum  pname, const GLint * params) {
+//   (*fnptr)(memoryObject, pname, params);
 // }
 // static void  glowMinSampleShading(GPMINSAMPLESHADING fnptr, GLfloat  value) {
 //   (*fnptr)(value);
@@ -6928,7 +7285,7 @@ package gl
 // static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElementArrayAPPLE(GPMULTIDRAWELEMENTARRAYAPPLE fnptr, GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -6955,7 +7312,7 @@ package gl
 // static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
 //   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawRangeElementArrayAPPLE(GPMULTIDRAWRANGEELEMENTARRAYAPPLE fnptr, GLenum  mode, GLuint  start, GLuint  end, const GLint * first, const GLsizei * count, GLsizei  primcount) {
@@ -7330,25 +7687,64 @@ package gl
 // static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMulticastBarrierNV(GPMULTICASTBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowMulticastBlitFramebufferNV(GPMULTICASTBLITFRAMEBUFFERNV fnptr, GLuint  srcGpu, GLuint  dstGpu, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
+//   (*fnptr)(srcGpu, dstGpu, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+// }
+// static void  glowMulticastBufferSubDataNV(GPMULTICASTBUFFERSUBDATANV fnptr, GLbitfield  gpuMask, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(gpuMask, buffer, offset, size, data);
+// }
+// static void  glowMulticastCopyBufferSubDataNV(GPMULTICASTCOPYBUFFERSUBDATANV fnptr, GLuint  readGpu, GLbitfield  writeGpuMask, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readGpu, writeGpuMask, readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowMulticastCopyImageSubDataNV(GPMULTICASTCOPYIMAGESUBDATANV fnptr, GLuint  srcGpu, GLbitfield  dstGpuMask, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
+//   (*fnptr)(srcGpu, dstGpuMask, srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
+// }
+// static void  glowMulticastFramebufferSampleLocationsfvNV(GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  gpu, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(gpu, framebuffer, start, count, v);
+// }
+// static void  glowMulticastGetQueryObjecti64vNV(GPMULTICASTGETQUERYOBJECTI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectivNV(GPMULTICASTGETQUERYOBJECTIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectui64vNV(GPMULTICASTGETQUERYOBJECTUI64VNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint64 * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastGetQueryObjectuivNV(GPMULTICASTGETQUERYOBJECTUIVNV fnptr, GLuint  gpu, GLuint  id, GLenum  pname, GLuint * params) {
+//   (*fnptr)(gpu, id, pname, params);
+// }
+// static void  glowMulticastWaitSyncNV(GPMULTICASTWAITSYNCNV fnptr, GLuint  signalGpu, GLbitfield  waitGpuMask) {
+//   (*fnptr)(signalGpu, waitGpuMask);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
 // static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
 // static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageExternalEXT(GPNAMEDBUFFERSTORAGEEXTERNALEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLeglClientBufferEXT  clientBuffer, GLbitfield  flags) {
+//   (*fnptr)(buffer, offset, size, clientBuffer, flags);
+// }
+// static void  glowNamedBufferStorageMemEXT(GPNAMEDBUFFERSTORAGEMEMEXT fnptr, GLuint  buffer, GLsizeiptr  size, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(buffer, size, memory, offset);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
@@ -7377,6 +7773,15 @@ package gl
 // }
 // static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSamplePositionsfvAMD(GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD fnptr, GLuint  framebuffer, GLuint  numsamples, GLuint  pixelindex, const GLfloat * values) {
+//   (*fnptr)(framebuffer, numsamples, pixelindex, values);
 // }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
@@ -7807,6 +8212,12 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPolygonOffsetEXT(GPPOLYGONOFFSETEXT fnptr, GLfloat  factor, GLfloat  bias) {
 //   (*fnptr)(factor, bias);
 // }
@@ -7842,6 +8253,9 @@ package gl
 // }
 // static void  glowPresentFrameKeyedNV(GPPRESENTFRAMEKEYEDNV fnptr, GLuint  video_slot, GLuint64EXT  minPresentTime, GLuint  beginPresentTimeId, GLuint  presentDurationId, GLenum  type, GLenum  target0, GLuint  fill0, GLuint  key0, GLenum  target1, GLuint  fill1, GLuint  key1) {
 //   (*fnptr)(video_slot, minPresentTime, beginPresentTimeId, presentDurationId, type, target0, fill0, key0, target1, fill1, key1);
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -8014,8 +8428,14 @@ package gl
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8032,8 +8452,14 @@ package gl
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8074,8 +8500,14 @@ package gl
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8092,8 +8524,14 @@ package gl
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8134,8 +8572,14 @@ package gl
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8152,8 +8596,14 @@ package gl
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8194,8 +8644,14 @@ package gl
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8212,8 +8668,14 @@ package gl
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(program, location, count, value);
@@ -8395,6 +8857,12 @@ package gl
 // static void  glowQueryObjectParameteruiAMD(GPQUERYOBJECTPARAMETERUIAMD fnptr, GLenum  target, GLuint  id, GLenum  pname, GLuint  param) {
 //   (*fnptr)(target, id, pname, param);
 // }
+// static GLint  glowQueryResourceNV(GPQUERYRESOURCENV fnptr, GLenum  queryType, GLint  tagId, GLuint  bufSize, GLint * buffer) {
+//   return (*fnptr)(queryType, tagId, bufSize, buffer);
+// }
+// static void  glowQueryResourceTagNV(GPQUERYRESOURCETAGNV fnptr, GLint  tagId, const GLchar * tagString) {
+//   (*fnptr)(tagId, tagString);
+// }
 // static void  glowRasterPos2d(GPRASTERPOS2D fnptr, GLdouble  x, GLdouble  y) {
 //   (*fnptr)(x, y);
 // }
@@ -8485,6 +8953,9 @@ package gl
 // static void  glowRasterPos4xvOES(GPRASTERPOS4XVOES fnptr, const GLfixed * coords) {
 //   (*fnptr)(coords);
 // }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
+// }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
 // }
@@ -8536,8 +9007,14 @@ package gl
 // static void  glowReferencePlaneSGIX(GPREFERENCEPLANESGIX fnptr, const GLdouble * equation) {
 //   (*fnptr)(equation);
 // }
+// static GLboolean  glowReleaseKeyedMutexWin32EXT(GPRELEASEKEYEDMUTEXWIN32EXT fnptr, GLuint  memory, GLuint64  key) {
+//   return (*fnptr)(memory, key);
+// }
 // static void  glowReleaseShaderCompiler(GPRELEASESHADERCOMPILER fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowRenderGpuMaskNV(GPRENDERGPUMASKNV fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static GLint  glowRenderMode(GPRENDERMODE fnptr, GLenum  mode) {
 //   return (*fnptr)(mode);
@@ -8644,6 +9121,9 @@ package gl
 // static void  glowResizeBuffersMESA(GPRESIZEBUFFERSMESA fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -8663,9 +9143,6 @@ package gl
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoverageARB(GPSAMPLECOVERAGEARB fnptr, GLfloat  value, GLboolean  invert) {
-//   (*fnptr)(value, invert);
-// }
-// static void  glowSampleCoverageOES(GPSAMPLECOVERAGEOES fnptr, GLfixed  value, GLboolean  invert) {
 //   (*fnptr)(value, invert);
 // }
 // static void  glowSampleCoveragexOES(GPSAMPLECOVERAGEXOES fnptr, GLclampx  value, GLboolean  invert) {
@@ -8857,6 +9334,9 @@ package gl
 // static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
 //   (*fnptr)(monitor, enable, group, numCounters, counterList);
 // }
+// static void  glowSemaphoreParameterui64vEXT(GPSEMAPHOREPARAMETERUI64VEXT fnptr, GLuint  semaphore, GLenum  pname, const GLuint64 * params) {
+//   (*fnptr)(semaphore, pname, params);
+// }
 // static void  glowSeparableFilter2D(GPSEPARABLEFILTER2D fnptr, GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * row, const void * column) {
 //   (*fnptr)(target, internalformat, width, height, format, type, row, column);
 // }
@@ -8908,6 +9388,18 @@ package gl
 // static void  glowSharpenTexFuncSGIS(GPSHARPENTEXFUNCSGIS fnptr, GLenum  target, GLsizei  n, const GLfloat * points) {
 //   (*fnptr)(target, n, points);
 // }
+// static void  glowSignalSemaphoreEXT(GPSIGNALSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * dstLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, dstLayouts);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
 // static void  glowSpriteParameterfSGIX(GPSPRITEPARAMETERFSGIX fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
 // }
@@ -8922,6 +9414,9 @@ package gl
 // }
 // static void  glowStartInstrumentsSGIX(GPSTARTINSTRUMENTSSGIX fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
 // }
 // static void  glowStencilClearTagEXT(GPSTENCILCLEARTAGEXT fnptr, GLsizei  stencilTagBits, GLuint  stencilClearTag) {
 //   (*fnptr)(stencilTagBits, stencilClearTag);
@@ -8982,6 +9477,9 @@ package gl
 // }
 // static void  glowStringMarkerGREMEDY(GPSTRINGMARKERGREMEDY fnptr, GLsizei  len, const void * string) {
 //   (*fnptr)(len, string);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
 // }
 // static void  glowSwizzleEXT(GPSWIZZLEEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
@@ -9382,8 +9880,8 @@ package gl
 // static void  glowTexImage4DSGIS(GPTEXIMAGE4DSGIS fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  size4d, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, height, depth, size4d, border, format, type, pixels);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -9433,6 +9931,21 @@ package gl
 // static void  glowTexStorage3DMultisample(GPTEXSTORAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTexStorageMem1DEXT(GPTEXSTORAGEMEM1DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTexStorageMem2DEXT(GPTEXSTORAGEMEM2DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTexStorageMem2DMultisampleEXT(GPTEXSTORAGEMEM2DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTexStorageMem3DEXT(GPTEXSTORAGEMEM3DEXT fnptr, GLenum  target, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTexStorageMem3DMultisampleEXT(GPTEXSTORAGEMEM3DMULTISAMPLEEXT fnptr, GLenum  target, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTexStorageSparseAMD(GPTEXSTORAGESPARSEAMD fnptr, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9469,7 +9982,7 @@ package gl
 // static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, target, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
 // }
 // static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
@@ -9508,8 +10021,8 @@ package gl
 // static void  glowTextureNormalEXT(GPTEXTURENORMALEXT fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
 // }
-// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
@@ -9583,6 +10096,21 @@ package gl
 // static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorageMem1DEXT(GPTEXTURESTORAGEMEM1DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, memory, offset);
+// }
+// static void  glowTextureStorageMem2DEXT(GPTEXTURESTORAGEMEM2DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, memory, offset);
+// }
+// static void  glowTextureStorageMem2DMultisampleEXT(GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+// }
+// static void  glowTextureStorageMem3DEXT(GPTEXTURESTORAGEMEM3DEXT fnptr, GLuint  texture, GLsizei  levels, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, levels, internalFormat, width, height, depth, memory, offset);
+// }
+// static void  glowTextureStorageMem3DMultisampleEXT(GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT fnptr, GLuint  texture, GLsizei  samples, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedSampleLocations, GLuint  memory, GLuint64  offset) {
+//   (*fnptr)(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+// }
 // static void  glowTextureStorageSparseAMD(GPTEXTURESTORAGESPARSEAMD fnptr, GLuint  texture, GLenum  target, GLenum  internalFormat, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  layers, GLbitfield  flags) {
 //   (*fnptr)(texture, target, internalFormat, width, height, depth, layers, flags);
 // }
@@ -9616,7 +10144,7 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackStreamAttribsNV(GPTRANSFORMFEEDBACKSTREAMATTRIBSNV fnptr, GLsizei  count, const GLint * attribs, GLsizei  nbuffers, const GLint * bufstreams, GLenum  bufferMode) {
@@ -9664,8 +10192,14 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9682,8 +10216,14 @@ package gl
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
 // static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
 //   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9718,8 +10258,14 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9736,8 +10282,14 @@ package gl
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
 // static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
 //   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9772,8 +10324,14 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9790,8 +10348,14 @@ package gl
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
 // static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
 //   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9826,8 +10390,14 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -9844,8 +10414,14 @@ package gl
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
 // static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
 //   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
 //   (*fnptr)(location, count, value);
@@ -11125,8 +11701,20 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
+// static void  glowWaitSemaphoreEXT(GPWAITSEMAPHOREEXT fnptr, GLuint  semaphore, GLuint  numBufferBarriers, const GLuint * buffers, GLuint  numTextureBarriers, const GLuint * textures, const GLenum * srcLayouts) {
+//   (*fnptr)(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, srcLayouts);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
 // }
 // static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
 //   (*fnptr)(resultPath, numPaths, paths, weights);
@@ -11326,6 +11914,9 @@ package gl
 // static void  glowWindowPos4svMESA(GPWINDOWPOS4SVMESA fnptr, const GLshort * v) {
 //   (*fnptr)(v);
 // }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
+// }
 // static void  glowWriteMaskEXT(GPWRITEMASKEXT fnptr, GLuint  res, GLuint  in, GLenum  outX, GLenum  outY, GLenum  outZ, GLenum  outW) {
 //   (*fnptr)(res, in, outX, outY, outZ, outW);
 // }
@@ -11417,6 +12008,7 @@ const (
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_BARRIER_BITS_EXT                                       = 0xFFFFFFFF
 	ALL_COMPLETED_NV                                           = 0x84F2
+	ALL_PIXELS_AMD                                             = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
 	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALL_STATIC_DATA_IBM                                        = 103060
@@ -11451,11 +12043,16 @@ const (
 	ALPHA_MAX_SGIX                                             = 0x8321
 	ALPHA_MIN_CLAMP_INGR                                       = 0x8563
 	ALPHA_MIN_SGIX                                             = 0x8320
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALPHA_SCALE                                                = 0x0D1C
 	ALPHA_SNORM                                                = 0x9010
 	ALPHA_TEST                                                 = 0x0BC0
 	ALPHA_TEST_FUNC                                            = 0x0BC1
 	ALPHA_TEST_REF                                             = 0x0BC2
+	ALPHA_TO_COVERAGE_DITHER_DEFAULT_NV                        = 0x934D
+	ALPHA_TO_COVERAGE_DITHER_DISABLE_NV                        = 0x934F
+	ALPHA_TO_COVERAGE_DITHER_ENABLE_NV                         = 0x934E
+	ALPHA_TO_COVERAGE_DITHER_MODE_NV                           = 0x92BF
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	ALWAYS_FAST_HINT_PGI                                       = 0x1A20C
@@ -11501,6 +12098,7 @@ const (
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
 	ATTENUATION_EXT                                            = 0x834D
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	ATTRIB_ARRAY_POINTER_NV                                    = 0x8645
 	ATTRIB_ARRAY_SIZE_NV                                       = 0x8623
 	ATTRIB_ARRAY_STRIDE_NV                                     = 0x8624
@@ -11543,6 +12141,7 @@ const (
 	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
 	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_COLOR_EXT                                            = 0x8005
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
@@ -11720,10 +12319,26 @@ const (
 	COLOR_ATTACHMENT14_EXT                                     = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
 	COLOR_ATTACHMENT15_EXT                                     = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT1_EXT                                      = 0x8CE1
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT2_EXT                                      = 0x8CE2
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT3_EXT                                      = 0x8CE3
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT4_EXT                                      = 0x8CE4
@@ -11827,6 +12442,8 @@ const (
 	COMPILE                                                    = 0x1300
 	COMPILE_AND_EXECUTE                                        = 0x1301
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_ALPHA                                           = 0x84E9
 	COMPRESSED_ALPHA_ARB                                       = 0x84E9
 	COMPRESSED_INTENSITY                                       = 0x84EC
@@ -11930,8 +12547,18 @@ const (
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	COMP_BIT_ATI                                               = 0x00000002
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
 	CONIC_CURVE_TO_NV                                          = 0x1A
 	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSERVE_MEMORY_HINT_PGI                                   = 0x1A1FD
 	CONSTANT                                                   = 0x8576
 	CONSTANT_ALPHA                                             = 0x8003
@@ -11953,6 +12580,7 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT                             = 0x00000004
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
@@ -12032,6 +12660,9 @@ const (
 	COUNTER_TYPE_AMD                                           = 0x8BC0
 	COUNT_DOWN_NV                                              = 0x9089
 	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
 	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CUBIC_EXT                                                  = 0x8334
 	CUBIC_HP                                                   = 0x815F
@@ -12081,6 +12712,7 @@ const (
 	CURRENT_VERTEX_WEIGHT_EXT                                  = 0x850B
 	CURRENT_WEIGHT_ARB                                         = 0x86A8
 	CW                                                         = 0x0900
+	D3D12_FENCE_VALUE_EXT                                      = 0x9595
 	DARKEN_KHR                                                 = 0x9297
 	DARKEN_NV                                                  = 0x9297
 	DATA_BUFFER_AMD                                            = 0x9151
@@ -12173,6 +12805,7 @@ const (
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DECR_WRAP_EXT                                              = 0x8508
+	DEDICATED_MEMORY_OBJECT_EXT                                = 0x9581
 	DEFORMATIONS_MASK_SGIX                                     = 0x8196
 	DELETE_STATUS                                              = 0x8B80
 	DEPENDENT_AR_TEXTURE_2D_NV                                 = 0x86E9
@@ -12214,6 +12847,7 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_SCALE                                                = 0x0D1E
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
@@ -12231,6 +12865,9 @@ const (
 	DETAIL_TEXTURE_FUNC_POINTS_SGIS                            = 0x809C
 	DETAIL_TEXTURE_LEVEL_SGIS                                  = 0x809A
 	DETAIL_TEXTURE_MODE_SGIS                                   = 0x809B
+	DEVICE_LUID_EXT                                            = 0x9599
+	DEVICE_NODE_MASK_EXT                                       = 0x959A
+	DEVICE_UUID_EXT                                            = 0x9597
 	DIFFERENCE_KHR                                             = 0x929E
 	DIFFERENCE_NV                                              = 0x929E
 	DIFFUSE                                                    = 0x1201
@@ -12293,6 +12930,9 @@ const (
 	DOUBLE_VEC3_EXT                                            = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
 	DOUBLE_VEC4_EXT                                            = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER0_ARB                                           = 0x8825
@@ -12342,6 +12982,9 @@ const (
 	DRAW_BUFFER9                                               = 0x882E
 	DRAW_BUFFER9_ARB                                           = 0x882E
 	DRAW_BUFFER9_ATI                                           = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
 	DRAW_FRAMEBUFFER_BINDING_EXT                               = 0x8CA6
@@ -12353,6 +12996,7 @@ const (
 	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DRAW_PIXELS_APPLE                                          = 0x8A0A
 	DRAW_PIXEL_TOKEN                                           = 0x0705
+	DRIVER_UUID_EXT                                            = 0x9598
 	DSDT8_MAG8_INTENSITY8_NV                                   = 0x870B
 	DSDT8_MAG8_NV                                              = 0x870A
 	DSDT8_NV                                                   = 0x8709
@@ -12413,7 +13057,9 @@ const (
 	EDGE_FLAG_ARRAY_POINTER_EXT                                = 0x8093
 	EDGE_FLAG_ARRAY_STRIDE                                     = 0x808C
 	EDGE_FLAG_ARRAY_STRIDE_EXT                                 = 0x808C
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
 	EIGHTH_BIT_ATI                                             = 0x00000020
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
 	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_APPLE                                        = 0x8A0C
 	ELEMENT_ARRAY_ATI                                          = 0x8768
@@ -12458,6 +13104,7 @@ const (
 	EVAL_VERTEX_ATTRIB9_NV                                     = 0x86CF
 	EXCLUSION_KHR                                              = 0x92A0
 	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXP                                                        = 0x0800
 	EXP2                                                       = 0x0801
 	EXPAND_NEGATE_NV                                           = 0x8539
@@ -12491,6 +13138,7 @@ const (
 	FIELD_UPPER_NV                                             = 0x9022
 	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
 	FILTER4_SGIS                                               = 0x8146
 	FIRST_TO_REST_NV                                           = 0x90AF
@@ -12502,6 +13150,15 @@ const (
 	FIXED_ONLY_ARB                                             = 0x891D
 	FLAT                                                       = 0x1D00
 	FLOAT                                                      = 0x1406
+	FLOAT16_MAT2_AMD                                           = 0x91C5
+	FLOAT16_MAT2x3_AMD                                         = 0x91C8
+	FLOAT16_MAT2x4_AMD                                         = 0x91C9
+	FLOAT16_MAT3_AMD                                           = 0x91C6
+	FLOAT16_MAT3x2_AMD                                         = 0x91CA
+	FLOAT16_MAT3x4_AMD                                         = 0x91CB
+	FLOAT16_MAT4_AMD                                           = 0x91C7
+	FLOAT16_MAT4x2_AMD                                         = 0x91CC
+	FLOAT16_MAT4x3_AMD                                         = 0x91CD
 	FLOAT16_NV                                                 = 0x8FF8
 	FLOAT16_VEC2_NV                                            = 0x8FF9
 	FLOAT16_VEC3_NV                                            = 0x8FFA
@@ -12607,6 +13264,8 @@ const (
 	FRAGMENT_COLOR_MATERIAL_FACE_SGIX                          = 0x8402
 	FRAGMENT_COLOR_MATERIAL_PARAMETER_SGIX                     = 0x8403
 	FRAGMENT_COLOR_MATERIAL_SGIX                               = 0x8401
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
 	FRAGMENT_DEPTH                                             = 0x8452
 	FRAGMENT_DEPTH_EXT                                         = 0x8452
 	FRAGMENT_INPUT_NV                                          = 0x936D
@@ -12638,6 +13297,7 @@ const (
 	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
 	FRAGMENT_SHADER_DERIVATIVE_HINT_ARB                        = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -12659,12 +13319,14 @@ const (
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_3D_ZOFFSET_EXT              = 0x8CD4
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE_EXT           = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER_EXT                   = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL_EXT                   = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BARRIER_BIT_EXT                                = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
@@ -12696,8 +13358,13 @@ const (
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_EXT                     = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER_EXT                     = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_SRGB_CAPABLE_EXT                               = 0x8DBA
 	FRAMEBUFFER_SRGB_EXT                                       = 0x8DB9
@@ -12710,6 +13377,7 @@ const (
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_RANGE_EXT                                             = 0x87E1
@@ -12789,6 +13457,14 @@ const (
 	HALF_FLOAT                                                 = 0x140B
 	HALF_FLOAT_ARB                                             = 0x140B
 	HALF_FLOAT_NV                                              = 0x140B
+	HANDLE_TYPE_D3D11_IMAGE_EXT                                = 0x958B
+	HANDLE_TYPE_D3D11_IMAGE_KMT_EXT                            = 0x958C
+	HANDLE_TYPE_D3D12_FENCE_EXT                                = 0x9594
+	HANDLE_TYPE_D3D12_RESOURCE_EXT                             = 0x958A
+	HANDLE_TYPE_D3D12_TILEPOOL_EXT                             = 0x9589
+	HANDLE_TYPE_OPAQUE_FD_EXT                                  = 0x9586
+	HANDLE_TYPE_OPAQUE_WIN32_EXT                               = 0x9587
+	HANDLE_TYPE_OPAQUE_WIN32_KMT_EXT                           = 0x9588
 	HARDLIGHT_KHR                                              = 0x929B
 	HARDLIGHT_NV                                               = 0x929B
 	HARDMIX_NV                                                 = 0x92A9
@@ -12896,6 +13572,7 @@ const (
 	IMPLEMENTATION_COLOR_READ_FORMAT_OES                       = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
 	IMPLEMENTATION_COLOR_READ_TYPE_OES                         = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
 	INCR_WRAP_EXT                                              = 0x8507
@@ -12940,9 +13617,13 @@ const (
 	INT16_VEC2_NV                                              = 0x8FE5
 	INT16_VEC3_NV                                              = 0x8FE6
 	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
 	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
 	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
 	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
 	INT64_VEC4_NV                                              = 0x8FEB
 	INT8_NV                                                    = 0x8FE0
 	INT8_VEC2_NV                                               = 0x8FE1
@@ -13081,13 +13762,23 @@ const (
 	LAST_VIDEO_CAPTURE_STATUS_NV                               = 0x9027
 	LAYER_NV                                                   = 0x8DAA
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
+	LAYOUT_COLOR_ATTACHMENT_EXT                                = 0x958E
 	LAYOUT_DEFAULT_INTEL                                       = 0
+	LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT              = 0x9531
+	LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT              = 0x9530
+	LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT                        = 0x958F
+	LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT                         = 0x9590
+	LAYOUT_GENERAL_EXT                                         = 0x958D
 	LAYOUT_LINEAR_CPU_CACHED_INTEL                             = 2
 	LAYOUT_LINEAR_INTEL                                        = 1
+	LAYOUT_SHADER_READ_ONLY_EXT                                = 0x9591
+	LAYOUT_TRANSFER_DST_EXT                                    = 0x9593
+	LAYOUT_TRANSFER_SRC_EXT                                    = 0x9592
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LERP_ATI                                                   = 0x8969
 	LESS                                                       = 0x0201
+	LGPU_SEPARATE_STORAGE_BIT_NVX                              = 0x0800
 	LIGHT0                                                     = 0x4000
 	LIGHT1                                                     = 0x4001
 	LIGHT2                                                     = 0x4002
@@ -13123,6 +13814,7 @@ const (
 	LINEAR_SHARPEN_ALPHA_SGIS                                  = 0x80AE
 	LINEAR_SHARPEN_COLOR_SGIS                                  = 0x80AF
 	LINEAR_SHARPEN_SGIS                                        = 0x80AD
+	LINEAR_TILING_EXT                                          = 0x9585
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
 	LINES_ADJACENCY_ARB                                        = 0x000A
@@ -13142,6 +13834,7 @@ const (
 	LINE_TOKEN                                                 = 0x0702
 	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -13168,6 +13861,7 @@ const (
 	LOW_INT                                                    = 0x8DF3
 	LO_BIAS_NV                                                 = 0x8715
 	LO_SCALE_NV                                                = 0x870F
+	LUID_SIZE_EXT                                              = 8
 	LUMINANCE                                                  = 0x1909
 	LUMINANCE12                                                = 0x8041
 	LUMINANCE12_ALPHA12                                        = 0x8047
@@ -13501,6 +14195,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_LGPU_GPUS_NVX                                          = 0x92BA
 	MAX_LIGHTS                                                 = 0x0D31
 	MAX_LIST_NESTING                                           = 0x0B31
 	MAX_MAP_TESSELLATION_NV                                    = 0x86D6
@@ -13565,6 +14260,7 @@ const (
 	MAX_PROGRAM_TEX_INSTRUCTIONS_ARB                           = 0x880C
 	MAX_PROGRAM_TOTAL_OUTPUT_COMPONENTS_NV                     = 0x8C28
 	MAX_PROJECTION_STACK_DEPTH                                 = 0x0D38
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RATIONAL_EVAL_ORDER_NV                                 = 0x86D7
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RECTANGLE_TEXTURE_SIZE_ARB                             = 0x84F8
@@ -13577,6 +14273,8 @@ const (
 	MAX_SAMPLE_MASK_WORDS_NV                                   = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
 	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SHININESS_NV                                           = 0x8504
@@ -13587,6 +14285,7 @@ const (
 	MAX_SPARSE_TEXTURE_SIZE_AMD                                = 0x9198
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
 	MAX_SPOT_EXPONENT_NV                                       = 0x8505
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -13621,6 +14320,7 @@ const (
 	MAX_TEXTURE_IMAGE_UNITS_NV                                 = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
 	MAX_TEXTURE_LOD_BIAS_EXT                                   = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_MAX_ANISOTROPY_EXT                             = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TEXTURE_STACK_DEPTH                                    = 0x0D39
@@ -13677,7 +14377,9 @@ const (
 	MAX_VERTEX_VARYING_COMPONENTS_EXT                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
@@ -13704,7 +14406,6 @@ const (
 	MIN_SAMPLE_SHADING_VALUE                                   = 0x8C37
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
 	MIN_SPARSE_LEVEL_AMD                                       = 0x919B
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
 	MIRRORED_REPEAT_ARB                                        = 0x8370
@@ -13717,6 +14418,8 @@ const (
 	MIRROR_CLAMP_TO_EDGE_EXT                                   = 0x8743
 	MITER_REVERT_NV                                            = 0x90A7
 	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
 	MODELVIEW                                                  = 0x1700
 	MODELVIEW0_ARB                                             = 0x1700
 	MODELVIEW0_EXT                                             = 0x1700
@@ -13768,9 +14471,12 @@ const (
 	MOVE_TO_RESETS_NV                                          = 0x90B5
 	MOV_ATI                                                    = 0x8961
 	MULT                                                       = 0x0103
+	MULTICAST_GPUS_NV                                          = 0x92BA
+	MULTICAST_PROGRAMMABLE_SAMPLE_LOCATION_NV                  = 0x9549
 	MULTIPLY_KHR                                               = 0x9294
 	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
 	MULTISAMPLE_3DFX                                           = 0x86B2
 	MULTISAMPLE_ARB                                            = 0x809D
 	MULTISAMPLE_BIT                                            = 0x20000000
@@ -13780,6 +14486,9 @@ const (
 	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
 	MULTISAMPLE_EXT                                            = 0x809D
 	MULTISAMPLE_FILTER_HINT_NV                                 = 0x8534
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	MULTISAMPLE_SGIS                                           = 0x809D
 	MUL_ATI                                                    = 0x8964
 	MVP_MATRIX_EXT                                             = 0x87E3
@@ -13810,6 +14519,7 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
 	NORMALIZE                                                  = 0x0BA1
 	NORMALIZED_RANGE_EXT                                       = 0x87E0
@@ -13843,6 +14553,7 @@ const (
 	NUM_COMPATIBLE_SUBROUTINES                                 = 0x8E4A
 	NUM_COMPRESSED_TEXTURE_FORMATS                             = 0x86A2
 	NUM_COMPRESSED_TEXTURE_FORMATS_ARB                         = 0x86A2
+	NUM_DEVICE_UUIDS_EXT                                       = 0x9596
 	NUM_EXTENSIONS                                             = 0x821D
 	NUM_FILL_STREAMS_NV                                        = 0x8E29
 	NUM_FRAGMENT_CONSTANTS_ATI                                 = 0x896F
@@ -13857,8 +14568,12 @@ const (
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
 	NUM_SHADING_LANGUAGE_VERSIONS                              = 0x82E9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
+	NUM_TILING_TYPES_EXT                                       = 0x9582
 	NUM_VIDEO_CAPTURE_STREAMS_NV                               = 0x9024
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_ACTIVE_ATTRIBUTES_ARB                               = 0x8B89
 	OBJECT_ACTIVE_ATTRIBUTE_MAX_LENGTH_ARB                     = 0x8B8A
 	OBJECT_ACTIVE_UNIFORMS_ARB                                 = 0x8B86
@@ -13935,6 +14650,7 @@ const (
 	OPERAND2_RGB_EXT                                           = 0x8592
 	OPERAND3_ALPHA_NV                                          = 0x859B
 	OPERAND3_RGB_NV                                            = 0x8593
+	OPTIMAL_TILING_EXT                                         = 0x9584
 	OP_ADD_EXT                                                 = 0x8787
 	OP_CLAMP_EXT                                               = 0x878E
 	OP_CROSS_PRODUCT_EXT                                       = 0x8797
@@ -14014,7 +14730,7 @@ const (
 	PACK_INVERT_MESA                                           = 0x8758
 	PACK_LSB_FIRST                                             = 0x0D01
 	PACK_RESAMPLE_OML                                          = 0x8984
-	PACK_RESAMPLE_SGIX                                         = 0x842C
+	PACK_RESAMPLE_SGIX                                         = 0x842E
 	PACK_ROW_BYTES_APPLE                                       = 0x8A15
 	PACK_ROW_LENGTH                                            = 0x0D02
 	PACK_SKIP_IMAGES                                           = 0x806B
@@ -14119,10 +14835,14 @@ const (
 	PERFQUERY_WAIT_INTEL                                       = 0x83FB
 	PERSPECTIVE_CORRECTION_HINT                                = 0x0C50
 	PERTURB_EXT                                                = 0x85AE
+	PER_GPU_STORAGE_BIT_NV                                     = 0x0800
+	PER_GPU_STORAGE_NV                                         = 0x9548
 	PER_STAGE_CONSTANTS_NV                                     = 0x8535
 	PHONG_HINT_WIN                                             = 0x80EB
 	PHONG_WIN                                                  = 0x80EA
 	PINLIGHT_NV                                                = 0x92A8
+	PIXELS_PER_SAMPLE_PATTERN_X_AMD                            = 0x91AE
+	PIXELS_PER_SAMPLE_PATTERN_Y_AMD                            = 0x91AF
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_BUFFER_BARRIER_BIT_EXT                               = 0x00000080
 	PIXEL_COUNTER_BITS_NV                                      = 0x8864
@@ -14228,6 +14948,9 @@ const (
 	POLYGON_BIT                                                = 0x00000008
 	POLYGON_MODE                                               = 0x0B40
 	POLYGON_OFFSET_BIAS_EXT                                    = 0x8039
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_EXT                                         = 0x8037
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FACTOR_EXT                                  = 0x8038
@@ -14298,6 +15021,7 @@ const (
 	PRIMITIVES_GENERATED_EXT                                   = 0x8C87
 	PRIMITIVES_GENERATED_NV                                    = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_ID_NV                                            = 0x8C7C
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
@@ -14306,11 +15030,16 @@ const (
 	PRIMITIVE_RESTART_INDEX_NV                                 = 0x8559
 	PRIMITIVE_RESTART_NV                                       = 0x8558
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_ADDRESS_REGISTERS_ARB                              = 0x88B0
 	PROGRAM_ALU_INSTRUCTIONS_ARB                               = 0x8805
 	PROGRAM_ATTRIBS_ARB                                        = 0x88AC
 	PROGRAM_ATTRIB_COMPONENTS_NV                               = 0x8906
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
+	PROGRAM_BINARY_FORMAT_MESA                                 = 0x875F
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_BINDING_ARB                                        = 0x8677
@@ -14343,6 +15072,7 @@ const (
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
 	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
 	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
 	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
@@ -14361,6 +15091,7 @@ const (
 	PROJECTION                                                 = 0x1701
 	PROJECTION_MATRIX                                          = 0x0BA7
 	PROJECTION_STACK_DEPTH                                     = 0x0BA4
+	PROTECTED_MEMORY_OBJECT_EXT                                = 0x959B
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROVOKING_VERTEX_EXT                                       = 0x8E4F
 	PROXY_COLOR_TABLE                                          = 0x80D3
@@ -14397,6 +15128,7 @@ const (
 	PROXY_TEXTURE_RECTANGLE_ARB                                = 0x84F7
 	PROXY_TEXTURE_RECTANGLE_NV                                 = 0x84F7
 	PURGEABLE_APPLE                                            = 0x8A1D
+	PURGED_CONTEXT_RESET_NV                                    = 0x92BB
 	Q                                                          = 0x2003
 	QUADRATIC_ATTENUATION                                      = 0x1209
 	QUADRATIC_CURVE_TO_NV                                      = 0x0A
@@ -14437,6 +15169,12 @@ const (
 	QUERY_NO_WAIT_NV                                           = 0x8E14
 	QUERY_OBJECT_AMD                                           = 0x9153
 	QUERY_OBJECT_EXT                                           = 0x9153
+	QUERY_RESOURCE_BUFFEROBJECT_NV                             = 0x9547
+	QUERY_RESOURCE_MEMTYPE_VIDMEM_NV                           = 0x9542
+	QUERY_RESOURCE_RENDERBUFFER_NV                             = 0x9546
+	QUERY_RESOURCE_SYS_RESERVED_NV                             = 0x9544
+	QUERY_RESOURCE_TEXTURE_NV                                  = 0x9545
+	QUERY_RESOURCE_TYPE_VIDMEM_ALLOC_NV                        = 0x9540
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_ARB                                           = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
@@ -14475,7 +15213,10 @@ const (
 	RASTERIZER_DISCARD                                         = 0x8C89
 	RASTERIZER_DISCARD_EXT                                     = 0x8C89
 	RASTERIZER_DISCARD_NV                                      = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
 	RASTER_POSITION_UNCLIPPED_IBM                              = 0x19262
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -14600,6 +15341,7 @@ const (
 	RENDERBUFFER_WIDTH                                         = 0x8D42
 	RENDERBUFFER_WIDTH_EXT                                     = 0x8D42
 	RENDERER                                                   = 0x1F01
+	RENDER_GPU_MASK_NV                                         = 0x9558
 	RENDER_MODE                                                = 0x0C40
 	REPEAT                                                     = 0x2901
 	REPLACE                                                    = 0x1E01
@@ -14618,9 +15360,9 @@ const (
 	RESAMPLE_DECIMATE_OML                                      = 0x8989
 	RESAMPLE_DECIMATE_SGIX                                     = 0x8430
 	RESAMPLE_REPLICATE_OML                                     = 0x8986
-	RESAMPLE_REPLICATE_SGIX                                    = 0x842E
+	RESAMPLE_REPLICATE_SGIX                                    = 0x8433
 	RESAMPLE_ZERO_FILL_OML                                     = 0x8987
-	RESAMPLE_ZERO_FILL_SGIX                                    = 0x842F
+	RESAMPLE_ZERO_FILL_SGIX                                    = 0x8434
 	RESCALE_NORMAL                                             = 0x803A
 	RESCALE_NORMAL_EXT                                         = 0x803A
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
@@ -14818,6 +15560,14 @@ const (
 	SAMPLE_COVERAGE_INVERT_ARB                                 = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
 	SAMPLE_COVERAGE_VALUE_ARB                                  = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_EXT                                            = 0x80A0
 	SAMPLE_MASK_INVERT_EXT                                     = 0x80AB
@@ -14844,6 +15594,7 @@ const (
 	SCALE_BY_TWO_NV                                            = 0x853E
 	SCISSOR_BIT                                                = 0x00080000
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
 	SCREEN_COORDINATES_REND                                    = 0x8490
 	SCREEN_KHR                                                 = 0x9295
@@ -14880,6 +15631,7 @@ const (
 	SET_AMD                                                    = 0x874A
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
 	SHADER_CONSISTENT_NV                                       = 0x86DD
 	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
@@ -14907,6 +15659,7 @@ const (
 	SHADING_LANGUAGE_VERSION_ARB                               = 0x8B8C
 	SHADOW_AMBIENT_SGIX                                        = 0x80BF
 	SHADOW_ATTENUATION_EXT                                     = 0x834E
+	SHARED_EDGE_NV                                             = 0xC0
 	SHARED_TEXTURE_PALETTE_EXT                                 = 0x81FB
 	SHARPEN_TEXTURE_FUNC_POINTS_SGIS                           = 0x80B0
 	SHININESS                                                  = 0x1601
@@ -14993,6 +15746,8 @@ const (
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
 	SPECULAR                                                   = 0x1202
 	SPHERE_MAP                                                 = 0x2402
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
 	SPOT_CUTOFF                                                = 0x1206
 	SPOT_DIRECTION                                             = 0x1204
 	SPOT_EXPONENT                                              = 0x1205
@@ -15079,7 +15834,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TAG_BITS_EXT                                       = 0x88F2
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_TEST_TWO_SIDE_EXT                                  = 0x8910
@@ -15101,11 +15858,15 @@ const (
 	STRICT_LIGHTING_HINT_PGI                                   = 0x1A217
 	STRICT_SCISSOR_HINT_PGI                                    = 0x1A218
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
 	SUBSAMPLE_DISTANCE_AMD                                     = 0x883F
 	SUBTRACT                                                   = 0x84E7
 	SUBTRACT_ARB                                               = 0x84E7
 	SUB_ATI                                                    = 0x8965
 	SUCCESS_NV                                                 = 0x902F
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SURFACE_MAPPED_NV                                          = 0x8700
 	SURFACE_REGISTERED_NV                                      = 0x86FD
 	SURFACE_STATE_NV                                           = 0x86EB
@@ -15143,6 +15904,7 @@ const (
 	TANGENT_ARRAY_POINTER_EXT                                  = 0x8442
 	TANGENT_ARRAY_STRIDE_EXT                                   = 0x843F
 	TANGENT_ARRAY_TYPE_EXT                                     = 0x843E
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESSELLATION_FACTOR_AMD                                    = 0x9005
 	TESSELLATION_MODE_AMD                                      = 0x9004
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
@@ -15262,7 +16024,6 @@ const (
 	TEXTURE_APPLICATION_MODE_EXT                               = 0x834F
 	TEXTURE_BASE_LEVEL                                         = 0x813C
 	TEXTURE_BASE_LEVEL_SGIS                                    = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_1D_ARRAY_EXT                               = 0x8C1C
@@ -15439,6 +16200,7 @@ const (
 	TEXTURE_MATERIAL_FACE_EXT                                  = 0x8351
 	TEXTURE_MATERIAL_PARAMETER_EXT                             = 0x8352
 	TEXTURE_MATRIX                                             = 0x0BA8
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_ANISOTROPY_EXT                                 = 0x84FE
 	TEXTURE_MAX_CLAMP_R_SGIX                                   = 0x836B
 	TEXTURE_MAX_CLAMP_S_SGIX                                   = 0x8369
@@ -15462,6 +16224,8 @@ const (
 	TEXTURE_RECTANGLE                                          = 0x84F5
 	TEXTURE_RECTANGLE_ARB                                      = 0x84F5
 	TEXTURE_RECTANGLE_NV                                       = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_SIZE_EXT                                       = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
@@ -15493,6 +16257,7 @@ const (
 	TEXTURE_SWIZZLE_RGBA_EXT                                   = 0x8E46
 	TEXTURE_SWIZZLE_R_EXT                                      = 0x8E42
 	TEXTURE_TARGET                                             = 0x1006
+	TEXTURE_TILING_EXT                                         = 0x9580
 	TEXTURE_TOO_LARGE_EXT                                      = 0x8065
 	TEXTURE_UNSIGNED_REMAP_MODE_NV                             = 0x888F
 	TEXTURE_UPDATE_BARRIER_BIT                                 = 0x00000100
@@ -15509,6 +16274,10 @@ const (
 	TEXTURE_WRAP_S                                             = 0x2802
 	TEXTURE_WRAP_T                                             = 0x2803
 	TEXT_FRAGMENT_SHADER_ATI                                   = 0x8200
+	TILE_RASTER_ORDER_FIXED_MESA                               = 0x8BB8
+	TILE_RASTER_ORDER_INCREASING_X_MESA                        = 0x8BB9
+	TILE_RASTER_ORDER_INCREASING_Y_MESA                        = 0x8BBA
+	TILING_TYPES_EXT                                           = 0x9583
 	TIMEOUT_EXPIRED                                            = 0x911B
 	TIMEOUT_IGNORED                                            = 0xFFFFFFFFFFFFFFFF
 	TIMESTAMP                                                  = 0x8E28
@@ -15597,6 +16366,7 @@ const (
 	UNDEFINED_APPLE                                            = 0x8A1C
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -15615,12 +16385,15 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
 	UNIFORM_BUFFER_BINDING_EXT                                 = 0x8DEF
 	UNIFORM_BUFFER_EXT                                         = 0x8DEE
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -15643,7 +16416,7 @@ const (
 	UNPACK_IMAGE_HEIGHT_EXT                                    = 0x806E
 	UNPACK_LSB_FIRST                                           = 0x0CF1
 	UNPACK_RESAMPLE_OML                                        = 0x8985
-	UNPACK_RESAMPLE_SGIX                                       = 0x842D
+	UNPACK_RESAMPLE_SGIX                                       = 0x842F
 	UNPACK_ROW_BYTES_APPLE                                     = 0x8A16
 	UNPACK_ROW_LENGTH                                          = 0x0CF2
 	UNPACK_SKIP_IMAGES                                         = 0x806D
@@ -15667,8 +16440,11 @@ const (
 	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
 	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
 	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
 	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
 	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
 	UNSIGNED_INT8_NV                                           = 0x8FEC
 	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
@@ -15760,6 +16536,7 @@ const (
 	USE_MISSING_GLYPH_NV                                       = 0x90AA
 	UTF16_NV                                                   = 0x909B
 	UTF8_NV                                                    = 0x909A
+	UUID_SIZE_EXT                                              = 16
 	V2F                                                        = 0x2A20
 	V3F                                                        = 0x2A21
 	VALIDATE_STATUS                                            = 0x8B83
@@ -15943,8 +16720,24 @@ const (
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BIT                                               = 0x00000800
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -15974,6 +16767,8 @@ const (
 	WAIT_FAILED                                                = 0x911D
 	WARPS_PER_SM_NV                                            = 0x933A
 	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
 	WEIGHT_ARRAY_ARB                                           = 0x86AD
 	WEIGHT_ARRAY_BUFFER_BINDING                                = 0x889E
 	WEIGHT_ARRAY_BUFFER_BINDING_ARB                            = 0x889E
@@ -15983,6 +16778,8 @@ const (
 	WEIGHT_ARRAY_TYPE_ARB                                      = 0x86A9
 	WEIGHT_SUM_UNITY_ARB                                       = 0x86A6
 	WIDE_LINE_HINT_PGI                                         = 0x1A222
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRAP_BORDER_SUN                                            = 0x81D4
 	WRITE_DISCARD_NV                                           = 0x88BE
 	WRITE_ONLY                                                 = 0x88B9
@@ -16019,6 +16816,7 @@ const (
 var (
 	gpAccum                                                  C.GPACCUM
 	gpAccumxOES                                              C.GPACCUMXOES
+	gpAcquireKeyedMutexWin32EXT                              C.GPACQUIREKEYEDMUTEXWIN32EXT
 	gpActiveProgramEXT                                       C.GPACTIVEPROGRAMEXT
 	gpActiveShaderProgram                                    C.GPACTIVESHADERPROGRAM
 	gpActiveShaderProgramEXT                                 C.GPACTIVESHADERPROGRAMEXT
@@ -16031,6 +16829,8 @@ var (
 	gpAlphaFragmentOp3ATI                                    C.GPALPHAFRAGMENTOP3ATI
 	gpAlphaFunc                                              C.GPALPHAFUNC
 	gpAlphaFuncxOES                                          C.GPALPHAFUNCXOES
+	gpAlphaToCoverageDitherControlNV                         C.GPALPHATOCOVERAGEDITHERCONTROLNV
+	gpApplyFramebufferAttachmentCMAAINTEL                    C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
 	gpApplyTextureEXT                                        C.GPAPPLYTEXTUREEXT
 	gpAreProgramsResidentNV                                  C.GPAREPROGRAMSRESIDENTNV
 	gpAreTexturesResident                                    C.GPARETEXTURESRESIDENT
@@ -16155,8 +16955,11 @@ var (
 	gpBufferPageCommitmentARB                                C.GPBUFFERPAGECOMMITMENTARB
 	gpBufferParameteriAPPLE                                  C.GPBUFFERPARAMETERIAPPLE
 	gpBufferStorage                                          C.GPBUFFERSTORAGE
+	gpBufferStorageExternalEXT                               C.GPBUFFERSTORAGEEXTERNALEXT
+	gpBufferStorageMemEXT                                    C.GPBUFFERSTORAGEMEMEXT
 	gpBufferSubData                                          C.GPBUFFERSUBDATA
 	gpBufferSubDataARB                                       C.GPBUFFERSUBDATAARB
+	gpCallCommandListNV                                      C.GPCALLCOMMANDLISTNV
 	gpCallList                                               C.GPCALLLIST
 	gpCallLists                                              C.GPCALLLISTS
 	gpCheckFramebufferStatus                                 C.GPCHECKFRAMEBUFFERSTATUS
@@ -16284,6 +17087,8 @@ var (
 	gpCombinerParameteriNV                                   C.GPCOMBINERPARAMETERINV
 	gpCombinerParameterivNV                                  C.GPCOMBINERPARAMETERIVNV
 	gpCombinerStageParameterfvNV                             C.GPCOMBINERSTAGEPARAMETERFVNV
+	gpCommandListSegmentsNV                                  C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                                   C.GPCOMPILECOMMANDLISTNV
 	gpCompileShader                                          C.GPCOMPILESHADER
 	gpCompileShaderARB                                       C.GPCOMPILESHADERARB
 	gpCompileShaderIncludeARB                                C.GPCOMPILESHADERINCLUDEARB
@@ -16314,6 +17119,8 @@ var (
 	gpCompressedTextureSubImage2DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
 	gpCompressedTextureSubImage3D                            C.GPCOMPRESSEDTEXTURESUBIMAGE3D
 	gpCompressedTextureSubImage3DEXT                         C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                         C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                         C.GPCONSERVATIVERASTERPARAMETERINV
 	gpConvolutionFilter1D                                    C.GPCONVOLUTIONFILTER1D
 	gpConvolutionFilter1DEXT                                 C.GPCONVOLUTIONFILTER1DEXT
 	gpConvolutionFilter2D                                    C.GPCONVOLUTIONFILTER2D
@@ -16369,8 +17176,12 @@ var (
 	gpCoverFillPathNV                                        C.GPCOVERFILLPATHNV
 	gpCoverStrokePathInstancedNV                             C.GPCOVERSTROKEPATHINSTANCEDNV
 	gpCoverStrokePathNV                                      C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                                   C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                              C.GPCOVERAGEMODULATIONTABLENV
 	gpCreateBuffers                                          C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                                   C.GPCREATECOMMANDLISTSNV
 	gpCreateFramebuffers                                     C.GPCREATEFRAMEBUFFERS
+	gpCreateMemoryObjectsEXT                                 C.GPCREATEMEMORYOBJECTSEXT
 	gpCreatePerfQueryINTEL                                   C.GPCREATEPERFQUERYINTEL
 	gpCreateProgram                                          C.GPCREATEPROGRAM
 	gpCreateProgramObjectARB                                 C.GPCREATEPROGRAMOBJECTARB
@@ -16383,6 +17194,7 @@ var (
 	gpCreateShaderProgramEXT                                 C.GPCREATESHADERPROGRAMEXT
 	gpCreateShaderProgramv                                   C.GPCREATESHADERPROGRAMV
 	gpCreateShaderProgramvEXT                                C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                         C.GPCREATESTATESNV
 	gpCreateSyncFromCLeventARB                               C.GPCREATESYNCFROMCLEVENTARB
 	gpCreateTextures                                         C.GPCREATETEXTURES
 	gpCreateTransformFeedbacks                               C.GPCREATETRANSFORMFEEDBACKS
@@ -16409,12 +17221,14 @@ var (
 	gpDeleteAsyncMarkersSGIX                                 C.GPDELETEASYNCMARKERSSGIX
 	gpDeleteBuffers                                          C.GPDELETEBUFFERS
 	gpDeleteBuffersARB                                       C.GPDELETEBUFFERSARB
+	gpDeleteCommandListsNV                                   C.GPDELETECOMMANDLISTSNV
 	gpDeleteFencesAPPLE                                      C.GPDELETEFENCESAPPLE
 	gpDeleteFencesNV                                         C.GPDELETEFENCESNV
 	gpDeleteFragmentShaderATI                                C.GPDELETEFRAGMENTSHADERATI
 	gpDeleteFramebuffers                                     C.GPDELETEFRAMEBUFFERS
 	gpDeleteFramebuffersEXT                                  C.GPDELETEFRAMEBUFFERSEXT
 	gpDeleteLists                                            C.GPDELETELISTS
+	gpDeleteMemoryObjectsEXT                                 C.GPDELETEMEMORYOBJECTSEXT
 	gpDeleteNamedStringARB                                   C.GPDELETENAMEDSTRINGARB
 	gpDeleteNamesAMD                                         C.GPDELETENAMESAMD
 	gpDeleteObjectARB                                        C.GPDELETEOBJECTARB
@@ -16429,10 +17243,13 @@ var (
 	gpDeleteProgramsNV                                       C.GPDELETEPROGRAMSNV
 	gpDeleteQueries                                          C.GPDELETEQUERIES
 	gpDeleteQueriesARB                                       C.GPDELETEQUERIESARB
+	gpDeleteQueryResourceTagNV                               C.GPDELETEQUERYRESOURCETAGNV
 	gpDeleteRenderbuffers                                    C.GPDELETERENDERBUFFERS
 	gpDeleteRenderbuffersEXT                                 C.GPDELETERENDERBUFFERSEXT
 	gpDeleteSamplers                                         C.GPDELETESAMPLERS
+	gpDeleteSemaphoresEXT                                    C.GPDELETESEMAPHORESEXT
 	gpDeleteShader                                           C.GPDELETESHADER
+	gpDeleteStatesNV                                         C.GPDELETESTATESNV
 	gpDeleteSync                                             C.GPDELETESYNC
 	gpDeleteTextures                                         C.GPDELETETEXTURES
 	gpDeleteTexturesEXT                                      C.GPDELETETEXTURESEXT
@@ -16482,6 +17299,10 @@ var (
 	gpDrawBuffers                                            C.GPDRAWBUFFERS
 	gpDrawBuffersARB                                         C.GPDRAWBUFFERSARB
 	gpDrawBuffersATI                                         C.GPDRAWBUFFERSATI
+	gpDrawCommandsAddressNV                                  C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                         C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                            C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                                   C.GPDRAWCOMMANDSSTATESNV
 	gpDrawElementArrayAPPLE                                  C.GPDRAWELEMENTARRAYAPPLE
 	gpDrawElementArrayATI                                    C.GPDRAWELEMENTARRAYATI
 	gpDrawElements                                           C.GPDRAWELEMENTS
@@ -16506,6 +17327,7 @@ var (
 	gpDrawTransformFeedbackNV                                C.GPDRAWTRANSFORMFEEDBACKNV
 	gpDrawTransformFeedbackStream                            C.GPDRAWTRANSFORMFEEDBACKSTREAM
 	gpDrawTransformFeedbackStreamInstanced                   C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                          C.GPDRAWVKIMAGENV
 	gpEdgeFlag                                               C.GPEDGEFLAG
 	gpEdgeFlagFormatNV                                       C.GPEDGEFLAGFORMATNV
 	gpEdgeFlagPointer                                        C.GPEDGEFLAGPOINTER
@@ -16561,6 +17383,7 @@ var (
 	gpEvalMesh2                                              C.GPEVALMESH2
 	gpEvalPoint1                                             C.GPEVALPOINT1
 	gpEvalPoint2                                             C.GPEVALPOINT2
+	gpEvaluateDepthValuesARB                                 C.GPEVALUATEDEPTHVALUESARB
 	gpExecuteProgramNV                                       C.GPEXECUTEPROGRAMNV
 	gpExtractComponentEXT                                    C.GPEXTRACTCOMPONENTEXT
 	gpFeedbackBuffer                                         C.GPFEEDBACKBUFFER
@@ -16605,6 +17428,7 @@ var (
 	gpFogxOES                                                C.GPFOGXOES
 	gpFogxvOES                                               C.GPFOGXVOES
 	gpFragmentColorMaterialSGIX                              C.GPFRAGMENTCOLORMATERIALSGIX
+	gpFragmentCoverageColorNV                                C.GPFRAGMENTCOVERAGECOLORNV
 	gpFragmentLightModelfSGIX                                C.GPFRAGMENTLIGHTMODELFSGIX
 	gpFragmentLightModelfvSGIX                               C.GPFRAGMENTLIGHTMODELFVSGIX
 	gpFragmentLightModeliSGIX                                C.GPFRAGMENTLIGHTMODELISGIX
@@ -16621,10 +17445,14 @@ var (
 	gpFrameZoomSGIX                                          C.GPFRAMEZOOMSGIX
 	gpFramebufferDrawBufferEXT                               C.GPFRAMEBUFFERDRAWBUFFEREXT
 	gpFramebufferDrawBuffersEXT                              C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                             C.GPFRAMEBUFFERFETCHBARRIEREXT
 	gpFramebufferParameteri                                  C.GPFRAMEBUFFERPARAMETERI
 	gpFramebufferReadBufferEXT                               C.GPFRAMEBUFFERREADBUFFEREXT
 	gpFramebufferRenderbuffer                                C.GPFRAMEBUFFERRENDERBUFFER
 	gpFramebufferRenderbufferEXT                             C.GPFRAMEBUFFERRENDERBUFFEREXT
+	gpFramebufferSampleLocationsfvARB                        C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                         C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferSamplePositionsfvAMD                        C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpFramebufferTexture                                     C.GPFRAMEBUFFERTEXTURE
 	gpFramebufferTexture1D                                   C.GPFRAMEBUFFERTEXTURE1D
 	gpFramebufferTexture1DEXT                                C.GPFRAMEBUFFERTEXTURE1DEXT
@@ -16639,6 +17467,7 @@ var (
 	gpFramebufferTextureLayer                                C.GPFRAMEBUFFERTEXTURELAYER
 	gpFramebufferTextureLayerARB                             C.GPFRAMEBUFFERTEXTURELAYERARB
 	gpFramebufferTextureLayerEXT                             C.GPFRAMEBUFFERTEXTURELAYEREXT
+	gpFramebufferTextureMultiviewOVR                         C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
 	gpFreeObjectBufferATI                                    C.GPFREEOBJECTBUFFERATI
 	gpFrontFace                                              C.GPFRONTFACE
 	gpFrustum                                                C.GPFRUSTUM
@@ -16663,9 +17492,11 @@ var (
 	gpGenProgramsNV                                          C.GPGENPROGRAMSNV
 	gpGenQueries                                             C.GPGENQUERIES
 	gpGenQueriesARB                                          C.GPGENQUERIESARB
+	gpGenQueryResourceTagNV                                  C.GPGENQUERYRESOURCETAGNV
 	gpGenRenderbuffers                                       C.GPGENRENDERBUFFERS
 	gpGenRenderbuffersEXT                                    C.GPGENRENDERBUFFERSEXT
 	gpGenSamplers                                            C.GPGENSAMPLERS
+	gpGenSemaphoresEXT                                       C.GPGENSEMAPHORESEXT
 	gpGenSymbolsEXT                                          C.GPGENSYMBOLSEXT
 	gpGenTextures                                            C.GPGENTEXTURES
 	gpGenTexturesEXT                                         C.GPGENTEXTURESEXT
@@ -16726,6 +17557,7 @@ var (
 	gpGetCombinerOutputParameterfvNV                         C.GPGETCOMBINEROUTPUTPARAMETERFVNV
 	gpGetCombinerOutputParameterivNV                         C.GPGETCOMBINEROUTPUTPARAMETERIVNV
 	gpGetCombinerStageParameterfvNV                          C.GPGETCOMBINERSTAGEPARAMETERFVNV
+	gpGetCommandHeaderNV                                     C.GPGETCOMMANDHEADERNV
 	gpGetCompressedMultiTexImageEXT                          C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
 	gpGetCompressedTexImage                                  C.GPGETCOMPRESSEDTEXIMAGE
 	gpGetCompressedTexImageARB                               C.GPGETCOMPRESSEDTEXIMAGEARB
@@ -16739,6 +17571,7 @@ var (
 	gpGetConvolutionParameteriv                              C.GPGETCONVOLUTIONPARAMETERIV
 	gpGetConvolutionParameterivEXT                           C.GPGETCONVOLUTIONPARAMETERIVEXT
 	gpGetConvolutionParameterxvOES                           C.GPGETCONVOLUTIONPARAMETERXVOES
+	gpGetCoverageModulationTableNV                           C.GPGETCOVERAGEMODULATIONTABLENV
 	gpGetDebugMessageLog                                     C.GPGETDEBUGMESSAGELOG
 	gpGetDebugMessageLogAMD                                  C.GPGETDEBUGMESSAGELOGAMD
 	gpGetDebugMessageLogARB                                  C.GPGETDEBUGMESSAGELOGARB
@@ -16768,6 +17601,7 @@ var (
 	gpGetFragmentMaterialivSGIX                              C.GPGETFRAGMENTMATERIALIVSGIX
 	gpGetFramebufferAttachmentParameteriv                    C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetFramebufferAttachmentParameterivEXT                 C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetFramebufferParameterfvAMD                           C.GPGETFRAMEBUFFERPARAMETERFVAMD
 	gpGetFramebufferParameteriv                              C.GPGETFRAMEBUFFERPARAMETERIV
 	gpGetFramebufferParameterivEXT                           C.GPGETFRAMEBUFFERPARAMETERIVEXT
 	gpGetGraphicsResetStatus                                 C.GPGETGRAPHICSRESETSTATUS
@@ -16794,6 +17628,7 @@ var (
 	gpGetIntegerui64i_vNV                                    C.GPGETINTEGERUI64I_VNV
 	gpGetIntegerui64vNV                                      C.GPGETINTEGERUI64VNV
 	gpGetIntegerv                                            C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                            C.GPGETINTERNALFORMATSAMPLEIVNV
 	gpGetInternalformati64v                                  C.GPGETINTERNALFORMATI64V
 	gpGetInternalformativ                                    C.GPGETINTERNALFORMATIV
 	gpGetInvariantBooleanvEXT                                C.GPGETINVARIANTBOOLEANVEXT
@@ -16821,6 +17656,7 @@ var (
 	gpGetMaterialiv                                          C.GPGETMATERIALIV
 	gpGetMaterialxOES                                        C.GPGETMATERIALXOES
 	gpGetMaterialxvOES                                       C.GPGETMATERIALXVOES
+	gpGetMemoryObjectParameterivEXT                          C.GPGETMEMORYOBJECTPARAMETERIVEXT
 	gpGetMinmax                                              C.GPGETMINMAX
 	gpGetMinmaxEXT                                           C.GPGETMINMAXEXT
 	gpGetMinmaxParameterfv                                   C.GPGETMINMAXPARAMETERFV
@@ -16851,6 +17687,7 @@ var (
 	gpGetNamedBufferSubDataEXT                               C.GPGETNAMEDBUFFERSUBDATAEXT
 	gpGetNamedFramebufferAttachmentParameteriv               C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
 	gpGetNamedFramebufferAttachmentParameterivEXT            C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameterfvAMD                      C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD
 	gpGetNamedFramebufferParameteriv                         C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
 	gpGetNamedFramebufferParameterivEXT                      C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
 	gpGetNamedProgramLocalParameterIivEXT                    C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
@@ -16945,6 +17782,10 @@ var (
 	gpGetProgramiv                                           C.GPGETPROGRAMIV
 	gpGetProgramivARB                                        C.GPGETPROGRAMIVARB
 	gpGetProgramivNV                                         C.GPGETPROGRAMIVNV
+	gpGetQueryBufferObjecti64v                               C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                                 C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                              C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                                C.GPGETQUERYBUFFEROBJECTUIV
 	gpGetQueryIndexediv                                      C.GPGETQUERYINDEXEDIV
 	gpGetQueryObjecti64v                                     C.GPGETQUERYOBJECTI64V
 	gpGetQueryObjecti64vEXT                                  C.GPGETQUERYOBJECTI64VEXT
@@ -16962,6 +17803,7 @@ var (
 	gpGetSamplerParameterIuiv                                C.GPGETSAMPLERPARAMETERIUIV
 	gpGetSamplerParameterfv                                  C.GPGETSAMPLERPARAMETERFV
 	gpGetSamplerParameteriv                                  C.GPGETSAMPLERPARAMETERIV
+	gpGetSemaphoreParameterui64vEXT                          C.GPGETSEMAPHOREPARAMETERUI64VEXT
 	gpGetSeparableFilter                                     C.GPGETSEPARABLEFILTER
 	gpGetSeparableFilterEXT                                  C.GPGETSEPARABLEFILTEREXT
 	gpGetShaderInfoLog                                       C.GPGETSHADERINFOLOG
@@ -16970,6 +17812,7 @@ var (
 	gpGetShaderSourceARB                                     C.GPGETSHADERSOURCEARB
 	gpGetShaderiv                                            C.GPGETSHADERIV
 	gpGetSharpenTexFuncSGIS                                  C.GPGETSHARPENTEXFUNCSGIS
+	gpGetStageIndexNV                                        C.GPGETSTAGEINDEXNV
 	gpGetString                                              C.GPGETSTRING
 	gpGetStringi                                             C.GPGETSTRINGI
 	gpGetSubroutineIndex                                     C.GPGETSUBROUTINEINDEX
@@ -17033,12 +17876,16 @@ var (
 	gpGetUniformdv                                           C.GPGETUNIFORMDV
 	gpGetUniformfv                                           C.GPGETUNIFORMFV
 	gpGetUniformfvARB                                        C.GPGETUNIFORMFVARB
+	gpGetUniformi64vARB                                      C.GPGETUNIFORMI64VARB
 	gpGetUniformi64vNV                                       C.GPGETUNIFORMI64VNV
 	gpGetUniformiv                                           C.GPGETUNIFORMIV
 	gpGetUniformivARB                                        C.GPGETUNIFORMIVARB
+	gpGetUniformui64vARB                                     C.GPGETUNIFORMUI64VARB
 	gpGetUniformui64vNV                                      C.GPGETUNIFORMUI64VNV
 	gpGetUniformuiv                                          C.GPGETUNIFORMUIV
 	gpGetUniformuivEXT                                       C.GPGETUNIFORMUIVEXT
+	gpGetUnsignedBytei_vEXT                                  C.GPGETUNSIGNEDBYTEI_VEXT
+	gpGetUnsignedBytevEXT                                    C.GPGETUNSIGNEDBYTEVEXT
 	gpGetVariantArrayObjectfvATI                             C.GPGETVARIANTARRAYOBJECTFVATI
 	gpGetVariantArrayObjectivATI                             C.GPGETVARIANTARRAYOBJECTIVATI
 	gpGetVariantBooleanvEXT                                  C.GPGETVARIANTBOOLEANVEXT
@@ -17084,6 +17931,7 @@ var (
 	gpGetVideoivNV                                           C.GPGETVIDEOIVNV
 	gpGetVideoui64vNV                                        C.GPGETVIDEOUI64VNV
 	gpGetVideouivNV                                          C.GPGETVIDEOUIVNV
+	gpGetVkProcAddrNV                                        C.GPGETVKPROCADDRNV
 	gpGetnColorTable                                         C.GPGETNCOLORTABLE
 	gpGetnColorTableARB                                      C.GPGETNCOLORTABLEARB
 	gpGetnCompressedTexImage                                 C.GPGETNCOMPRESSEDTEXIMAGE
@@ -17117,9 +17965,11 @@ var (
 	gpGetnUniformfv                                          C.GPGETNUNIFORMFV
 	gpGetnUniformfvARB                                       C.GPGETNUNIFORMFVARB
 	gpGetnUniformfvKHR                                       C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                                     C.GPGETNUNIFORMI64VARB
 	gpGetnUniformiv                                          C.GPGETNUNIFORMIV
 	gpGetnUniformivARB                                       C.GPGETNUNIFORMIVARB
 	gpGetnUniformivKHR                                       C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                                    C.GPGETNUNIFORMUI64VARB
 	gpGetnUniformuiv                                         C.GPGETNUNIFORMUIV
 	gpGetnUniformuivARB                                      C.GPGETNUNIFORMUIVARB
 	gpGetnUniformuivKHR                                      C.GPGETNUNIFORMUIVKHR
@@ -17140,6 +17990,12 @@ var (
 	gpImageTransformParameterfvHP                            C.GPIMAGETRANSFORMPARAMETERFVHP
 	gpImageTransformParameteriHP                             C.GPIMAGETRANSFORMPARAMETERIHP
 	gpImageTransformParameterivHP                            C.GPIMAGETRANSFORMPARAMETERIVHP
+	gpImportMemoryFdEXT                                      C.GPIMPORTMEMORYFDEXT
+	gpImportMemoryWin32HandleEXT                             C.GPIMPORTMEMORYWIN32HANDLEEXT
+	gpImportMemoryWin32NameEXT                               C.GPIMPORTMEMORYWIN32NAMEEXT
+	gpImportSemaphoreFdEXT                                   C.GPIMPORTSEMAPHOREFDEXT
+	gpImportSemaphoreWin32HandleEXT                          C.GPIMPORTSEMAPHOREWIN32HANDLEEXT
+	gpImportSemaphoreWin32NameEXT                            C.GPIMPORTSEMAPHOREWIN32NAMEEXT
 	gpImportSyncEXT                                          C.GPIMPORTSYNCEXT
 	gpIndexFormatNV                                          C.GPINDEXFORMATNV
 	gpIndexFuncEXT                                           C.GPINDEXFUNCEXT
@@ -17178,6 +18034,7 @@ var (
 	gpIsBuffer                                               C.GPISBUFFER
 	gpIsBufferARB                                            C.GPISBUFFERARB
 	gpIsBufferResidentNV                                     C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                        C.GPISCOMMANDLISTNV
 	gpIsEnabled                                              C.GPISENABLED
 	gpIsEnabledIndexedEXT                                    C.GPISENABLEDINDEXEDEXT
 	gpIsEnabledi                                             C.GPISENABLEDI
@@ -17188,6 +18045,7 @@ var (
 	gpIsImageHandleResidentARB                               C.GPISIMAGEHANDLERESIDENTARB
 	gpIsImageHandleResidentNV                                C.GPISIMAGEHANDLERESIDENTNV
 	gpIsList                                                 C.GPISLIST
+	gpIsMemoryObjectEXT                                      C.GPISMEMORYOBJECTEXT
 	gpIsNameAMD                                              C.GPISNAMEAMD
 	gpIsNamedBufferResidentNV                                C.GPISNAMEDBUFFERRESIDENTNV
 	gpIsNamedStringARB                                       C.GPISNAMEDSTRINGARB
@@ -17206,7 +18064,9 @@ var (
 	gpIsRenderbuffer                                         C.GPISRENDERBUFFER
 	gpIsRenderbufferEXT                                      C.GPISRENDERBUFFEREXT
 	gpIsSampler                                              C.GPISSAMPLER
+	gpIsSemaphoreEXT                                         C.GPISSEMAPHOREEXT
 	gpIsShader                                               C.GPISSHADER
+	gpIsStateNV                                              C.GPISSTATENV
 	gpIsSync                                                 C.GPISSYNC
 	gpIsTexture                                              C.GPISTEXTURE
 	gpIsTextureEXT                                           C.GPISTEXTUREEXT
@@ -17218,6 +18078,9 @@ var (
 	gpIsVertexArray                                          C.GPISVERTEXARRAY
 	gpIsVertexArrayAPPLE                                     C.GPISVERTEXARRAYAPPLE
 	gpIsVertexAttribEnabledAPPLE                             C.GPISVERTEXATTRIBENABLEDAPPLE
+	gpLGPUCopyImageSubDataNVX                                C.GPLGPUCOPYIMAGESUBDATANVX
+	gpLGPUInterlockNVX                                       C.GPLGPUINTERLOCKNVX
+	gpLGPUNamedBufferSubDataNVX                              C.GPLGPUNAMEDBUFFERSUBDATANVX
 	gpLabelObjectEXT                                         C.GPLABELOBJECTEXT
 	gpLightEnviSGIX                                          C.GPLIGHTENVISGIX
 	gpLightModelf                                            C.GPLIGHTMODELF
@@ -17238,6 +18101,7 @@ var (
 	gpLinkProgram                                            C.GPLINKPROGRAM
 	gpLinkProgramARB                                         C.GPLINKPROGRAMARB
 	gpListBase                                               C.GPLISTBASE
+	gpListDrawCommandsStatesClientNV                         C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
 	gpListParameterfSGIX                                     C.GPLISTPARAMETERFSGIX
 	gpListParameterfvSGIX                                    C.GPLISTPARAMETERFVSGIX
 	gpListParameteriSGIX                                     C.GPLISTPARAMETERISGIX
@@ -17332,9 +18196,12 @@ var (
 	gpMatrixScalefEXT                                        C.GPMATRIXSCALEFEXT
 	gpMatrixTranslatedEXT                                    C.GPMATRIXTRANSLATEDEXT
 	gpMatrixTranslatefEXT                                    C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                            C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                            C.GPMAXSHADERCOMPILERTHREADSKHR
 	gpMemoryBarrier                                          C.GPMEMORYBARRIER
 	gpMemoryBarrierByRegion                                  C.GPMEMORYBARRIERBYREGION
 	gpMemoryBarrierEXT                                       C.GPMEMORYBARRIEREXT
+	gpMemoryObjectParameterivEXT                             C.GPMEMORYOBJECTPARAMETERIVEXT
 	gpMinSampleShading                                       C.GPMINSAMPLESHADING
 	gpMinSampleShadingARB                                    C.GPMINSAMPLESHADINGARB
 	gpMinmax                                                 C.GPMINMAX
@@ -17487,12 +18354,25 @@ var (
 	gpMultiTexSubImage1DEXT                                  C.GPMULTITEXSUBIMAGE1DEXT
 	gpMultiTexSubImage2DEXT                                  C.GPMULTITEXSUBIMAGE2DEXT
 	gpMultiTexSubImage3DEXT                                  C.GPMULTITEXSUBIMAGE3DEXT
+	gpMulticastBarrierNV                                     C.GPMULTICASTBARRIERNV
+	gpMulticastBlitFramebufferNV                             C.GPMULTICASTBLITFRAMEBUFFERNV
+	gpMulticastBufferSubDataNV                               C.GPMULTICASTBUFFERSUBDATANV
+	gpMulticastCopyBufferSubDataNV                           C.GPMULTICASTCOPYBUFFERSUBDATANV
+	gpMulticastCopyImageSubDataNV                            C.GPMULTICASTCOPYIMAGESUBDATANV
+	gpMulticastFramebufferSampleLocationsfvNV                C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpMulticastGetQueryObjecti64vNV                          C.GPMULTICASTGETQUERYOBJECTI64VNV
+	gpMulticastGetQueryObjectivNV                            C.GPMULTICASTGETQUERYOBJECTIVNV
+	gpMulticastGetQueryObjectui64vNV                         C.GPMULTICASTGETQUERYOBJECTUI64VNV
+	gpMulticastGetQueryObjectuivNV                           C.GPMULTICASTGETQUERYOBJECTUIVNV
+	gpMulticastWaitSyncNV                                    C.GPMULTICASTWAITSYNCNV
 	gpNamedBufferData                                        C.GPNAMEDBUFFERDATA
 	gpNamedBufferDataEXT                                     C.GPNAMEDBUFFERDATAEXT
 	gpNamedBufferPageCommitmentARB                           C.GPNAMEDBUFFERPAGECOMMITMENTARB
 	gpNamedBufferPageCommitmentEXT                           C.GPNAMEDBUFFERPAGECOMMITMENTEXT
 	gpNamedBufferStorage                                     C.GPNAMEDBUFFERSTORAGE
 	gpNamedBufferStorageEXT                                  C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferStorageExternalEXT                          C.GPNAMEDBUFFERSTORAGEEXTERNALEXT
+	gpNamedBufferStorageMemEXT                               C.GPNAMEDBUFFERSTORAGEMEMEXT
 	gpNamedBufferSubData                                     C.GPNAMEDBUFFERSUBDATA
 	gpNamedBufferSubDataEXT                                  C.GPNAMEDBUFFERSUBDATAEXT
 	gpNamedCopyBufferSubDataEXT                              C.GPNAMEDCOPYBUFFERSUBDATAEXT
@@ -17503,6 +18383,9 @@ var (
 	gpNamedFramebufferReadBuffer                             C.GPNAMEDFRAMEBUFFERREADBUFFER
 	gpNamedFramebufferRenderbuffer                           C.GPNAMEDFRAMEBUFFERRENDERBUFFER
 	gpNamedFramebufferRenderbufferEXT                        C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB                   C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV                    C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferSamplePositionsfvAMD                   C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD
 	gpNamedFramebufferTexture                                C.GPNAMEDFRAMEBUFFERTEXTURE
 	gpNamedFramebufferTexture1DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
 	gpNamedFramebufferTexture2DEXT                           C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
@@ -17646,6 +18529,8 @@ var (
 	gpPollInstrumentsSGIX                                    C.GPPOLLINSTRUMENTSSGIX
 	gpPolygonMode                                            C.GPPOLYGONMODE
 	gpPolygonOffset                                          C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                                     C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                                  C.GPPOLYGONOFFSETCLAMPEXT
 	gpPolygonOffsetEXT                                       C.GPPOLYGONOFFSETEXT
 	gpPolygonOffsetxOES                                      C.GPPOLYGONOFFSETXOES
 	gpPolygonStipple                                         C.GPPOLYGONSTIPPLE
@@ -17658,6 +18543,7 @@ var (
 	gpPopName                                                C.GPPOPNAME
 	gpPresentFrameDualFillNV                                 C.GPPRESENTFRAMEDUALFILLNV
 	gpPresentFrameKeyedNV                                    C.GPPRESENTFRAMEKEYEDNV
+	gpPrimitiveBoundingBoxARB                                C.GPPRIMITIVEBOUNDINGBOXARB
 	gpPrimitiveRestartIndex                                  C.GPPRIMITIVERESTARTINDEX
 	gpPrimitiveRestartIndexNV                                C.GPPRIMITIVERESTARTINDEXNV
 	gpPrimitiveRestartNV                                     C.GPPRIMITIVERESTARTNV
@@ -17715,13 +18601,17 @@ var (
 	gpProgramUniform1fv                                      C.GPPROGRAMUNIFORM1FV
 	gpProgramUniform1fvEXT                                   C.GPPROGRAMUNIFORM1FVEXT
 	gpProgramUniform1i                                       C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                                  C.GPPROGRAMUNIFORM1I64ARB
 	gpProgramUniform1i64NV                                   C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                                 C.GPPROGRAMUNIFORM1I64VARB
 	gpProgramUniform1i64vNV                                  C.GPPROGRAMUNIFORM1I64VNV
 	gpProgramUniform1iEXT                                    C.GPPROGRAMUNIFORM1IEXT
 	gpProgramUniform1iv                                      C.GPPROGRAMUNIFORM1IV
 	gpProgramUniform1ivEXT                                   C.GPPROGRAMUNIFORM1IVEXT
 	gpProgramUniform1ui                                      C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                                 C.GPPROGRAMUNIFORM1UI64ARB
 	gpProgramUniform1ui64NV                                  C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                                C.GPPROGRAMUNIFORM1UI64VARB
 	gpProgramUniform1ui64vNV                                 C.GPPROGRAMUNIFORM1UI64VNV
 	gpProgramUniform1uiEXT                                   C.GPPROGRAMUNIFORM1UIEXT
 	gpProgramUniform1uiv                                     C.GPPROGRAMUNIFORM1UIV
@@ -17735,13 +18625,17 @@ var (
 	gpProgramUniform2fv                                      C.GPPROGRAMUNIFORM2FV
 	gpProgramUniform2fvEXT                                   C.GPPROGRAMUNIFORM2FVEXT
 	gpProgramUniform2i                                       C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                                  C.GPPROGRAMUNIFORM2I64ARB
 	gpProgramUniform2i64NV                                   C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                                 C.GPPROGRAMUNIFORM2I64VARB
 	gpProgramUniform2i64vNV                                  C.GPPROGRAMUNIFORM2I64VNV
 	gpProgramUniform2iEXT                                    C.GPPROGRAMUNIFORM2IEXT
 	gpProgramUniform2iv                                      C.GPPROGRAMUNIFORM2IV
 	gpProgramUniform2ivEXT                                   C.GPPROGRAMUNIFORM2IVEXT
 	gpProgramUniform2ui                                      C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                                 C.GPPROGRAMUNIFORM2UI64ARB
 	gpProgramUniform2ui64NV                                  C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                                C.GPPROGRAMUNIFORM2UI64VARB
 	gpProgramUniform2ui64vNV                                 C.GPPROGRAMUNIFORM2UI64VNV
 	gpProgramUniform2uiEXT                                   C.GPPROGRAMUNIFORM2UIEXT
 	gpProgramUniform2uiv                                     C.GPPROGRAMUNIFORM2UIV
@@ -17755,13 +18649,17 @@ var (
 	gpProgramUniform3fv                                      C.GPPROGRAMUNIFORM3FV
 	gpProgramUniform3fvEXT                                   C.GPPROGRAMUNIFORM3FVEXT
 	gpProgramUniform3i                                       C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                                  C.GPPROGRAMUNIFORM3I64ARB
 	gpProgramUniform3i64NV                                   C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                                 C.GPPROGRAMUNIFORM3I64VARB
 	gpProgramUniform3i64vNV                                  C.GPPROGRAMUNIFORM3I64VNV
 	gpProgramUniform3iEXT                                    C.GPPROGRAMUNIFORM3IEXT
 	gpProgramUniform3iv                                      C.GPPROGRAMUNIFORM3IV
 	gpProgramUniform3ivEXT                                   C.GPPROGRAMUNIFORM3IVEXT
 	gpProgramUniform3ui                                      C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                                 C.GPPROGRAMUNIFORM3UI64ARB
 	gpProgramUniform3ui64NV                                  C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                                C.GPPROGRAMUNIFORM3UI64VARB
 	gpProgramUniform3ui64vNV                                 C.GPPROGRAMUNIFORM3UI64VNV
 	gpProgramUniform3uiEXT                                   C.GPPROGRAMUNIFORM3UIEXT
 	gpProgramUniform3uiv                                     C.GPPROGRAMUNIFORM3UIV
@@ -17775,13 +18673,17 @@ var (
 	gpProgramUniform4fv                                      C.GPPROGRAMUNIFORM4FV
 	gpProgramUniform4fvEXT                                   C.GPPROGRAMUNIFORM4FVEXT
 	gpProgramUniform4i                                       C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                                  C.GPPROGRAMUNIFORM4I64ARB
 	gpProgramUniform4i64NV                                   C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                                 C.GPPROGRAMUNIFORM4I64VARB
 	gpProgramUniform4i64vNV                                  C.GPPROGRAMUNIFORM4I64VNV
 	gpProgramUniform4iEXT                                    C.GPPROGRAMUNIFORM4IEXT
 	gpProgramUniform4iv                                      C.GPPROGRAMUNIFORM4IV
 	gpProgramUniform4ivEXT                                   C.GPPROGRAMUNIFORM4IVEXT
 	gpProgramUniform4ui                                      C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                                 C.GPPROGRAMUNIFORM4UI64ARB
 	gpProgramUniform4ui64NV                                  C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                                C.GPPROGRAMUNIFORM4UI64VARB
 	gpProgramUniform4ui64vNV                                 C.GPPROGRAMUNIFORM4UI64VNV
 	gpProgramUniform4uiEXT                                   C.GPPROGRAMUNIFORM4UIEXT
 	gpProgramUniform4uiv                                     C.GPPROGRAMUNIFORM4UIV
@@ -17842,6 +18744,8 @@ var (
 	gpQueryCounter                                           C.GPQUERYCOUNTER
 	gpQueryMatrixxOES                                        C.GPQUERYMATRIXXOES
 	gpQueryObjectParameteruiAMD                              C.GPQUERYOBJECTPARAMETERUIAMD
+	gpQueryResourceNV                                        C.GPQUERYRESOURCENV
+	gpQueryResourceTagNV                                     C.GPQUERYRESOURCETAGNV
 	gpRasterPos2d                                            C.GPRASTERPOS2D
 	gpRasterPos2dv                                           C.GPRASTERPOS2DV
 	gpRasterPos2f                                            C.GPRASTERPOS2F
@@ -17872,6 +18776,7 @@ var (
 	gpRasterPos4sv                                           C.GPRASTERPOS4SV
 	gpRasterPos4xOES                                         C.GPRASTERPOS4XOES
 	gpRasterPos4xvOES                                        C.GPRASTERPOS4XVOES
+	gpRasterSamplesEXT                                       C.GPRASTERSAMPLESEXT
 	gpReadBuffer                                             C.GPREADBUFFER
 	gpReadInstrumentsSGIX                                    C.GPREADINSTRUMENTSSGIX
 	gpReadPixels                                             C.GPREADPIXELS
@@ -17889,7 +18794,9 @@ var (
 	gpRectxOES                                               C.GPRECTXOES
 	gpRectxvOES                                              C.GPRECTXVOES
 	gpReferencePlaneSGIX                                     C.GPREFERENCEPLANESGIX
+	gpReleaseKeyedMutexWin32EXT                              C.GPRELEASEKEYEDMUTEXWIN32EXT
 	gpReleaseShaderCompiler                                  C.GPRELEASESHADERCOMPILER
+	gpRenderGpuMaskNV                                        C.GPRENDERGPUMASKNV
 	gpRenderMode                                             C.GPRENDERMODE
 	gpRenderbufferStorage                                    C.GPRENDERBUFFERSTORAGE
 	gpRenderbufferStorageEXT                                 C.GPRENDERBUFFERSTORAGEEXT
@@ -17925,6 +18832,7 @@ var (
 	gpResetMinmax                                            C.GPRESETMINMAX
 	gpResetMinmaxEXT                                         C.GPRESETMINMAXEXT
 	gpResizeBuffersMESA                                      C.GPRESIZEBUFFERSMESA
+	gpResolveDepthValuesNV                                   C.GPRESOLVEDEPTHVALUESNV
 	gpResumeTransformFeedback                                C.GPRESUMETRANSFORMFEEDBACK
 	gpResumeTransformFeedbackNV                              C.GPRESUMETRANSFORMFEEDBACKNV
 	gpRotated                                                C.GPROTATED
@@ -17932,7 +18840,6 @@ var (
 	gpRotatexOES                                             C.GPROTATEXOES
 	gpSampleCoverage                                         C.GPSAMPLECOVERAGE
 	gpSampleCoverageARB                                      C.GPSAMPLECOVERAGEARB
-	gpSampleCoverageOES                                      C.GPSAMPLECOVERAGEOES
 	gpSampleCoveragexOES                                     C.GPSAMPLECOVERAGEXOES
 	gpSampleMapATI                                           C.GPSAMPLEMAPATI
 	gpSampleMaskEXT                                          C.GPSAMPLEMASKEXT
@@ -17996,6 +18903,7 @@ var (
 	gpSecondaryColorPointerListIBM                           C.GPSECONDARYCOLORPOINTERLISTIBM
 	gpSelectBuffer                                           C.GPSELECTBUFFER
 	gpSelectPerfMonitorCountersAMD                           C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpSemaphoreParameterui64vEXT                             C.GPSEMAPHOREPARAMETERUI64VEXT
 	gpSeparableFilter2D                                      C.GPSEPARABLEFILTER2D
 	gpSeparableFilter2DEXT                                   C.GPSEPARABLEFILTER2DEXT
 	gpSetFenceAPPLE                                          C.GPSETFENCEAPPLE
@@ -18013,11 +18921,16 @@ var (
 	gpShaderSourceARB                                        C.GPSHADERSOURCEARB
 	gpShaderStorageBlockBinding                              C.GPSHADERSTORAGEBLOCKBINDING
 	gpSharpenTexFuncSGIS                                     C.GPSHARPENTEXFUNCSGIS
+	gpSignalSemaphoreEXT                                     C.GPSIGNALSEMAPHOREEXT
+	gpSignalVkFenceNV                                        C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                                    C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                                    C.GPSPECIALIZESHADERARB
 	gpSpriteParameterfSGIX                                   C.GPSPRITEPARAMETERFSGIX
 	gpSpriteParameterfvSGIX                                  C.GPSPRITEPARAMETERFVSGIX
 	gpSpriteParameteriSGIX                                   C.GPSPRITEPARAMETERISGIX
 	gpSpriteParameterivSGIX                                  C.GPSPRITEPARAMETERIVSGIX
 	gpStartInstrumentsSGIX                                   C.GPSTARTINSTRUMENTSSGIX
+	gpStateCaptureNV                                         C.GPSTATECAPTURENV
 	gpStencilClearTagEXT                                     C.GPSTENCILCLEARTAGEXT
 	gpStencilFillPathInstancedNV                             C.GPSTENCILFILLPATHINSTANCEDNV
 	gpStencilFillPathNV                                      C.GPSTENCILFILLPATHNV
@@ -18038,6 +18951,7 @@ var (
 	gpStencilThenCoverStrokePathNV                           C.GPSTENCILTHENCOVERSTROKEPATHNV
 	gpStopInstrumentsSGIX                                    C.GPSTOPINSTRUMENTSSGIX
 	gpStringMarkerGREMEDY                                    C.GPSTRINGMARKERGREMEDY
+	gpSubpixelPrecisionBiasNV                                C.GPSUBPIXELPRECISIONBIASNV
 	gpSwizzleEXT                                             C.GPSWIZZLEEXT
 	gpSyncTextureINTEL                                       C.GPSYNCTEXTUREINTEL
 	gpTagSampleBufferSGIX                                    C.GPTAGSAMPLEBUFFERSGIX
@@ -18188,6 +19102,11 @@ var (
 	gpTexStorage2DMultisample                                C.GPTEXSTORAGE2DMULTISAMPLE
 	gpTexStorage3D                                           C.GPTEXSTORAGE3D
 	gpTexStorage3DMultisample                                C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexStorageMem1DEXT                                     C.GPTEXSTORAGEMEM1DEXT
+	gpTexStorageMem2DEXT                                     C.GPTEXSTORAGEMEM2DEXT
+	gpTexStorageMem2DMultisampleEXT                          C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT
+	gpTexStorageMem3DEXT                                     C.GPTEXSTORAGEMEM3DEXT
+	gpTexStorageMem3DMultisampleEXT                          C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT
 	gpTexStorageSparseAMD                                    C.GPTEXSTORAGESPARSEAMD
 	gpTexSubImage1D                                          C.GPTEXSUBIMAGE1D
 	gpTexSubImage1DEXT                                       C.GPTEXSUBIMAGE1DEXT
@@ -18238,6 +19157,11 @@ var (
 	gpTextureStorage3DEXT                                    C.GPTEXTURESTORAGE3DEXT
 	gpTextureStorage3DMultisample                            C.GPTEXTURESTORAGE3DMULTISAMPLE
 	gpTextureStorage3DMultisampleEXT                         C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureStorageMem1DEXT                                 C.GPTEXTURESTORAGEMEM1DEXT
+	gpTextureStorageMem2DEXT                                 C.GPTEXTURESTORAGEMEM2DEXT
+	gpTextureStorageMem2DMultisampleEXT                      C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT
+	gpTextureStorageMem3DEXT                                 C.GPTEXTURESTORAGEMEM3DEXT
+	gpTextureStorageMem3DMultisampleEXT                      C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT
 	gpTextureStorageSparseAMD                                C.GPTEXTURESTORAGESPARSEAMD
 	gpTextureSubImage1D                                      C.GPTEXTURESUBIMAGE1D
 	gpTextureSubImage1DEXT                                   C.GPTEXTURESUBIMAGE1DEXT
@@ -18265,13 +19189,17 @@ var (
 	gpUniform1fv                                             C.GPUNIFORM1FV
 	gpUniform1fvARB                                          C.GPUNIFORM1FVARB
 	gpUniform1i                                              C.GPUNIFORM1I
+	gpUniform1i64ARB                                         C.GPUNIFORM1I64ARB
 	gpUniform1i64NV                                          C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                        C.GPUNIFORM1I64VARB
 	gpUniform1i64vNV                                         C.GPUNIFORM1I64VNV
 	gpUniform1iARB                                           C.GPUNIFORM1IARB
 	gpUniform1iv                                             C.GPUNIFORM1IV
 	gpUniform1ivARB                                          C.GPUNIFORM1IVARB
 	gpUniform1ui                                             C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                        C.GPUNIFORM1UI64ARB
 	gpUniform1ui64NV                                         C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                                       C.GPUNIFORM1UI64VARB
 	gpUniform1ui64vNV                                        C.GPUNIFORM1UI64VNV
 	gpUniform1uiEXT                                          C.GPUNIFORM1UIEXT
 	gpUniform1uiv                                            C.GPUNIFORM1UIV
@@ -18283,13 +19211,17 @@ var (
 	gpUniform2fv                                             C.GPUNIFORM2FV
 	gpUniform2fvARB                                          C.GPUNIFORM2FVARB
 	gpUniform2i                                              C.GPUNIFORM2I
+	gpUniform2i64ARB                                         C.GPUNIFORM2I64ARB
 	gpUniform2i64NV                                          C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                        C.GPUNIFORM2I64VARB
 	gpUniform2i64vNV                                         C.GPUNIFORM2I64VNV
 	gpUniform2iARB                                           C.GPUNIFORM2IARB
 	gpUniform2iv                                             C.GPUNIFORM2IV
 	gpUniform2ivARB                                          C.GPUNIFORM2IVARB
 	gpUniform2ui                                             C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                        C.GPUNIFORM2UI64ARB
 	gpUniform2ui64NV                                         C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                                       C.GPUNIFORM2UI64VARB
 	gpUniform2ui64vNV                                        C.GPUNIFORM2UI64VNV
 	gpUniform2uiEXT                                          C.GPUNIFORM2UIEXT
 	gpUniform2uiv                                            C.GPUNIFORM2UIV
@@ -18301,13 +19233,17 @@ var (
 	gpUniform3fv                                             C.GPUNIFORM3FV
 	gpUniform3fvARB                                          C.GPUNIFORM3FVARB
 	gpUniform3i                                              C.GPUNIFORM3I
+	gpUniform3i64ARB                                         C.GPUNIFORM3I64ARB
 	gpUniform3i64NV                                          C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                        C.GPUNIFORM3I64VARB
 	gpUniform3i64vNV                                         C.GPUNIFORM3I64VNV
 	gpUniform3iARB                                           C.GPUNIFORM3IARB
 	gpUniform3iv                                             C.GPUNIFORM3IV
 	gpUniform3ivARB                                          C.GPUNIFORM3IVARB
 	gpUniform3ui                                             C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                        C.GPUNIFORM3UI64ARB
 	gpUniform3ui64NV                                         C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                                       C.GPUNIFORM3UI64VARB
 	gpUniform3ui64vNV                                        C.GPUNIFORM3UI64VNV
 	gpUniform3uiEXT                                          C.GPUNIFORM3UIEXT
 	gpUniform3uiv                                            C.GPUNIFORM3UIV
@@ -18319,13 +19255,17 @@ var (
 	gpUniform4fv                                             C.GPUNIFORM4FV
 	gpUniform4fvARB                                          C.GPUNIFORM4FVARB
 	gpUniform4i                                              C.GPUNIFORM4I
+	gpUniform4i64ARB                                         C.GPUNIFORM4I64ARB
 	gpUniform4i64NV                                          C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                        C.GPUNIFORM4I64VARB
 	gpUniform4i64vNV                                         C.GPUNIFORM4I64VNV
 	gpUniform4iARB                                           C.GPUNIFORM4IARB
 	gpUniform4iv                                             C.GPUNIFORM4IV
 	gpUniform4ivARB                                          C.GPUNIFORM4IVARB
 	gpUniform4ui                                             C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                        C.GPUNIFORM4UI64ARB
 	gpUniform4ui64NV                                         C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                                       C.GPUNIFORM4UI64VARB
 	gpUniform4ui64vNV                                        C.GPUNIFORM4UI64VNV
 	gpUniform4uiEXT                                          C.GPUNIFORM4UIEXT
 	gpUniform4uiv                                            C.GPUNIFORM4UIV
@@ -18752,7 +19692,11 @@ var (
 	gpViewportArrayv                                         C.GPVIEWPORTARRAYV
 	gpViewportIndexedf                                       C.GPVIEWPORTINDEXEDF
 	gpViewportIndexedfv                                      C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                               C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                                      C.GPVIEWPORTSWIZZLENV
+	gpWaitSemaphoreEXT                                       C.GPWAITSEMAPHOREEXT
 	gpWaitSync                                               C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                                      C.GPWAITVKSEMAPHORENV
 	gpWeightPathsNV                                          C.GPWEIGHTPATHSNV
 	gpWeightPointerARB                                       C.GPWEIGHTPOINTERARB
 	gpWeightbvARB                                            C.GPWEIGHTBVARB
@@ -18819,6 +19763,7 @@ var (
 	gpWindowPos4ivMESA                                       C.GPWINDOWPOS4IVMESA
 	gpWindowPos4sMESA                                        C.GPWINDOWPOS4SMESA
 	gpWindowPos4svMESA                                       C.GPWINDOWPOS4SVMESA
+	gpWindowRectanglesEXT                                    C.GPWINDOWRECTANGLESEXT
 	gpWriteMaskEXT                                           C.GPWRITEMASKEXT
 )
 
@@ -18836,6 +19781,10 @@ func Accum(op uint32, value float32) {
 }
 func AccumxOES(op uint32, value int32) {
 	C.glowAccumxOES(gpAccumxOES, (C.GLenum)(op), (C.GLfixed)(value))
+}
+func AcquireKeyedMutexWin32EXT(memory uint32, key uint64, timeout uint32) bool {
+	ret := C.glowAcquireKeyedMutexWin32EXT(gpAcquireKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key), (C.GLuint)(timeout))
+	return ret == TRUE
 }
 func ActiveProgramEXT(program uint32) {
 	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
@@ -18878,6 +19827,12 @@ func AlphaFunc(xfunc uint32, ref float32) {
 }
 func AlphaFuncxOES(xfunc uint32, ref int32) {
 	C.glowAlphaFuncxOES(gpAlphaFuncxOES, (C.GLenum)(xfunc), (C.GLfixed)(ref))
+}
+func AlphaToCoverageDitherControlNV(mode uint32) {
+	C.glowAlphaToCoverageDitherControlNV(gpAlphaToCoverageDitherControlNV, (C.GLenum)(mode))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 func ApplyTextureEXT(mode uint32) {
 	C.glowApplyTextureEXT(gpApplyTextureEXT, (C.GLenum)(mode))
@@ -19326,8 +20281,8 @@ func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 func BufferDataARB(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferDataARB(gpBufferDataARB, (C.GLenum)(target), (C.GLsizeiptrARB)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 	C.glowBufferParameteriAPPLE(gpBufferParameteriAPPLE, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
@@ -19337,6 +20292,12 @@ func BufferParameteriAPPLE(target uint32, pname uint32, param int32) {
 func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowBufferStorage(gpBufferStorage, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func BufferStorageExternalEXT(target uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowBufferStorageExternalEXT(gpBufferStorageExternalEXT, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func BufferStorageMemEXT(target uint32, size int, memory uint32, offset uint64) {
+	C.glowBufferStorageMemEXT(gpBufferStorageMemEXT, (C.GLenum)(target), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
@@ -19344,6 +20305,9 @@ func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 }
 func BufferSubDataARB(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubDataARB(gpBufferSubDataARB, (C.GLenum)(target), (C.GLintptrARB)(offset), (C.GLsizeiptrARB)(size), data)
+}
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
 }
 
 // execute a display list
@@ -19440,6 +20404,8 @@ func ClearDepth(depth float64) {
 func ClearDepthdNV(depth float64) {
 	C.glowClearDepthdNV(gpClearDepthdNV, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -19464,14 +20430,14 @@ func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32
 }
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
 func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -19513,7 +20479,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -19781,6 +20747,12 @@ func CombinerParameterivNV(pname uint32, params *int32) {
 func CombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowCombinerStageParameterfvNV(gpCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
+}
 
 // Compiles a shader object
 func CompileShader(shader uint32) {
@@ -19891,6 +20863,12 @@ func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yof
 func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // define a one-dimensional convolution filter
 func ConvolutionFilter1D(target uint32, internalformat uint32, width int32, format uint32, xtype uint32, image unsafe.Pointer) {
@@ -19999,8 +20977,8 @@ func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffs
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 func CopyPathNV(resultPath uint32, srcPath uint32) {
 	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
@@ -20092,15 +21070,27 @@ func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsaf
 func CoverStrokePathNV(path uint32, coverMode uint32) {
 	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
 }
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreateMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowCreateMemoryObjectsEXT(gpCreateMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
 	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
@@ -20159,9 +21149,12 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -20257,6 +21250,9 @@ func DeleteBuffers(n int32, buffers *uint32) {
 func DeleteBuffersARB(n int32, buffers *uint32) {
 	C.glowDeleteBuffersARB(gpDeleteBuffersARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 func DeleteFencesAPPLE(n int32, fences *uint32) {
 	C.glowDeleteFencesAPPLE(gpDeleteFencesAPPLE, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(fences)))
 }
@@ -20278,6 +21274,9 @@ func DeleteFramebuffersEXT(n int32, framebuffers *uint32) {
 // delete a contiguous group of display lists
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
+}
+func DeleteMemoryObjectsEXT(n int32, memoryObjects *uint32) {
+	C.glowDeleteMemoryObjectsEXT(gpDeleteMemoryObjectsEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(memoryObjects)))
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
@@ -20327,6 +21326,9 @@ func DeleteQueries(n int32, ids *uint32) {
 func DeleteQueriesARB(n int32, ids *uint32) {
 	C.glowDeleteQueriesARB(gpDeleteQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func DeleteQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowDeleteQueryResourceTagNV(gpDeleteQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // delete renderbuffer objects
 func DeleteRenderbuffers(n int32, renderbuffers *uint32) {
@@ -20340,14 +21342,20 @@ func DeleteRenderbuffersEXT(n int32, renderbuffers *uint32) {
 func DeleteSamplers(count int32, samplers *uint32) {
 	C.glowDeleteSamplers(gpDeleteSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
 }
+func DeleteSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowDeleteSemaphoresEXT(gpDeleteSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
+}
 
 // Deletes a shader object
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -20409,6 +21417,8 @@ func DepthRangeIndexed(index uint32, n float64, f float64) {
 func DepthRangedNV(zNear float64, zFar float64) {
 	C.glowDepthRangedNV(gpDepthRangedNV, (C.GLdouble)(zNear), (C.GLdouble)(zFar))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -20530,6 +21540,18 @@ func DrawBuffersARB(n int32, bufs *uint32) {
 func DrawBuffersATI(n int32, bufs *uint32) {
 	C.glowDrawBuffersATI(gpDrawBuffersATI, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 func DrawElementArrayAPPLE(mode uint32, first int32, count int32) {
 	C.glowDrawElementArrayAPPLE(gpDrawElementArrayAPPLE, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count))
 }
@@ -20629,6 +21651,9 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 // render multiple instances of primitives using a count derived from a specifed stream of a transform feedback object
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
+}
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
 }
 
 // flag edges as either boundary or nonboundary
@@ -20807,6 +21832,9 @@ func EvalPoint1(i int32) {
 func EvalPoint2(i int32, j int32) {
 	C.glowEvalPoint2(gpEvalPoint2, (C.GLint)(i), (C.GLint)(j))
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 func ExecuteProgramNV(target uint32, id uint32, params *float32) {
 	C.glowExecuteProgramNV(gpExecuteProgramNV, (C.GLenum)(target), (C.GLuint)(id), (*C.GLfloat)(unsafe.Pointer(params)))
 }
@@ -20823,9 +21851,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -20866,8 +21894,8 @@ func FlushMappedBufferRangeAPPLE(target uint32, offset int, size int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
 }
 func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
 	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
@@ -20955,6 +21983,9 @@ func FogxvOES(pname uint32, param *int32) {
 func FragmentColorMaterialSGIX(face uint32, mode uint32) {
 	C.glowFragmentColorMaterialSGIX(gpFragmentColorMaterialSGIX, (C.GLenum)(face), (C.GLenum)(mode))
 }
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
 func FragmentLightModelfSGIX(pname uint32, param float32) {
 	C.glowFragmentLightModelfSGIX(gpFragmentLightModelfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -21003,6 +22034,9 @@ func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
 func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
 	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
 }
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
+}
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
@@ -21019,6 +22053,15 @@ func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarge
 func FramebufferRenderbufferEXT(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbufferEXT(gpFramebufferRenderbufferEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSamplePositionsfvAMD(target uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowFramebufferSamplePositionsfvAMD(gpFramebufferSamplePositionsfvAMD, (C.GLenum)(target), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
 func FramebufferTexture(target uint32, attachment uint32, texture uint32, level int32) {
@@ -21030,6 +22073,8 @@ func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, te
 func FramebufferTexture1DEXT(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1DEXT(gpFramebufferTexture1DEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
@@ -21064,6 +22109,9 @@ func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32
 }
 func FramebufferTextureLayerEXT(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayerEXT(gpFramebufferTextureLayerEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 func FreeObjectBufferATI(buffer uint32) {
 	C.glowFreeObjectBufferATI(gpFreeObjectBufferATI, (C.GLuint)(buffer))
@@ -21155,6 +22203,9 @@ func GenQueries(n int32, ids *uint32) {
 func GenQueriesARB(n int32, ids *uint32) {
 	C.glowGenQueriesARB(gpGenQueriesARB, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(ids)))
 }
+func GenQueryResourceTagNV(n int32, tagIds *int32) {
+	C.glowGenQueryResourceTagNV(gpGenQueryResourceTagNV, (C.GLsizei)(n), (*C.GLint)(unsafe.Pointer(tagIds)))
+}
 
 // generate renderbuffer object names
 func GenRenderbuffers(n int32, renderbuffers *uint32) {
@@ -21167,6 +22218,9 @@ func GenRenderbuffersEXT(n int32, renderbuffers *uint32) {
 // generate sampler object names
 func GenSamplers(count int32, samplers *uint32) {
 	C.glowGenSamplers(gpGenSamplers, (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(samplers)))
+}
+func GenSemaphoresEXT(n int32, semaphores *uint32) {
+	C.glowGenSemaphoresEXT(gpGenSemaphoresEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(semaphores)))
 }
 func GenSymbolsEXT(datatype uint32, storagetype uint32, xrange uint32, components uint32) uint32 {
 	ret := C.glowGenSymbolsEXT(gpGenSymbolsEXT, (C.GLenum)(datatype), (C.GLenum)(storagetype), (C.GLenum)(xrange), (C.GLuint)(components))
@@ -21258,6 +22312,8 @@ func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, leng
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21394,6 +22450,10 @@ func GetCombinerOutputParameterivNV(stage uint32, portion uint32, pname uint32, 
 func GetCombinerStageParameterfvNV(stage uint32, pname uint32, params *float32) {
 	C.glowGetCombinerStageParameterfvNV(gpGetCombinerStageParameterfvNV, (C.GLenum)(stage), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
 func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
 	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
@@ -21440,6 +22500,9 @@ func GetConvolutionParameterivEXT(target uint32, pname uint32, params *int32) {
 }
 func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 	C.glowGetConvolutionParameterxvOES(gpGetConvolutionParameterxvOES, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -21539,15 +22602,18 @@ func GetFragmentMaterialivSGIX(face uint32, pname uint32, params *int32) {
 	C.glowGetFragmentMaterialivSGIX(gpGetFragmentMaterialivSGIX, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetFramebufferAttachmentParameterivEXT(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameterivEXT(gpGetFramebufferAttachmentParameterivEXT, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetFramebufferParameterfvAMD(target uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetFramebufferParameterfvAMD(gpGetFramebufferParameterfvAMD, (C.GLenum)(target), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
+}
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21637,9 +22703,14 @@ func GetIntegerui64vNV(value uint32, result *uint64) {
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -21717,6 +22788,9 @@ func GetMaterialxOES(face uint32, pname uint32, param int32) {
 }
 func GetMaterialxvOES(face uint32, pname uint32, params *int32) {
 	C.glowGetMaterialxvOES(gpGetMaterialxvOES, (C.GLenum)(face), (C.GLenum)(pname), (*C.GLfixed)(unsafe.Pointer(params)))
+}
+func GetMemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowGetMemoryObjectParameterivEXT(gpGetMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // get minimum and maximum pixel values
@@ -21808,8 +22882,8 @@ func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Point
 }
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -21821,6 +22895,9 @@ func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uin
 }
 func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedFramebufferParameterfvAMD(framebuffer uint32, pname uint32, numsamples uint32, pixelindex uint32, size int32, values *float32) {
+	C.glowGetNamedFramebufferParameterfvAMD(gpGetNamedFramebufferParameterfvAMD, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (C.GLsizei)(size), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 
 // query a named parameter of a framebuffer object
@@ -22136,6 +23213,18 @@ func GetProgramivARB(target uint32, pname uint32, params *int32) {
 func GetProgramivNV(id uint32, pname uint32, params *int32) {
 	C.glowGetProgramivNV(gpGetProgramivNV, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
 
 // return parameters of an indexed query object target
 func GetQueryIndexediv(target uint32, index uint32, pname uint32, params *int32) {
@@ -22159,6 +23248,8 @@ func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 func GetQueryObjectui64vEXT(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64vEXT(gpGetQueryObjectui64vEXT, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -22174,7 +23265,7 @@ func GetQueryivARB(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryivARB(gpGetQueryivARB, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -22192,6 +23283,9 @@ func GetSamplerParameterfv(sampler uint32, pname uint32, params *float32) {
 }
 func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 	C.glowGetSamplerParameteriv(gpGetSamplerParameteriv, (C.GLuint)(sampler), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetSemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowGetSemaphoreParameterui64vEXT(gpGetSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 
 // get separable convolution filter kernel images
@@ -22227,6 +23321,10 @@ func GetShaderiv(shader uint32, pname uint32, params *int32) {
 func GetSharpenTexFuncSGIS(target uint32, points *float32) {
 	C.glowGetSharpenTexFuncSGIS(gpGetSharpenTexFuncSGIS, (C.GLenum)(target), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -22251,7 +23349,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -22455,6 +23553,9 @@ func GetUniformfv(program uint32, location int32, params *float32) {
 func GetUniformfvARB(programObj uintptr, location int32, params *float32) {
 	C.glowGetUniformfvARB(gpGetUniformfvARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetUniformi64vNV(program uint32, location int32, params *int64) {
 	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
 }
@@ -22466,6 +23567,9 @@ func GetUniformiv(program uint32, location int32, params *int32) {
 func GetUniformivARB(programObj uintptr, location int32, params *int32) {
 	C.glowGetUniformivARB(gpGetUniformivARB, (C.GLhandleARB)(programObj), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 func GetUniformui64vNV(program uint32, location int32, params *uint64) {
 	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
@@ -22474,6 +23578,12 @@ func GetUniformuiv(program uint32, location int32, params *uint32) {
 }
 func GetUniformuivEXT(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuivEXT(gpGetUniformuivEXT, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetUnsignedBytei_vEXT(target uint32, index uint32, data *uint8) {
+	C.glowGetUnsignedBytei_vEXT(gpGetUnsignedBytei_vEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLubyte)(unsafe.Pointer(data)))
+}
+func GetUnsignedBytevEXT(pname uint32, data *uint8) {
+	C.glowGetUnsignedBytevEXT(gpGetUnsignedBytevEXT, (C.GLenum)(pname), (*C.GLubyte)(unsafe.Pointer(data)))
 }
 func GetVariantArrayObjectfvATI(id uint32, pname uint32, params *float32) {
 	C.glowGetVariantArrayObjectfvATI(gpGetVariantArrayObjectfvATI, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
@@ -22627,6 +23737,10 @@ func GetVideoui64vNV(video_slot uint32, pname uint32, params *uint64) {
 func GetVideouivNV(video_slot uint32, pname uint32, params *uint32) {
 	C.glowGetVideouivNV(gpGetVideouivNV, (C.GLuint)(video_slot), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
+}
 func GetnColorTable(target uint32, format uint32, xtype uint32, bufSize int32, table unsafe.Pointer) {
 	C.glowGetnColorTable(gpGetnColorTable, (C.GLenum)(target), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), table)
 }
@@ -22730,6 +23844,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -22738,6 +23855,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -22803,9 +23923,27 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportMemoryFdEXT(memory uint32, size uint64, handleType uint32, fd int32) {
+	C.glowImportMemoryFdEXT(gpImportMemoryFdEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportMemoryWin32HandleEXT(memory uint32, size uint64, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportMemoryWin32HandleEXT(gpImportMemoryWin32HandleEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), handle)
+}
+func ImportMemoryWin32NameEXT(memory uint32, size uint64, handleType uint32, name unsafe.Pointer) {
+	C.glowImportMemoryWin32NameEXT(gpImportMemoryWin32NameEXT, (C.GLuint)(memory), (C.GLuint64)(size), (C.GLenum)(handleType), name)
+}
+func ImportSemaphoreFdEXT(semaphore uint32, handleType uint32, fd int32) {
+	C.glowImportSemaphoreFdEXT(gpImportSemaphoreFdEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), (C.GLint)(fd))
+}
+func ImportSemaphoreWin32HandleEXT(semaphore uint32, handleType uint32, handle unsafe.Pointer) {
+	C.glowImportSemaphoreWin32HandleEXT(gpImportSemaphoreWin32HandleEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), handle)
+}
+func ImportSemaphoreWin32NameEXT(semaphore uint32, handleType uint32, name unsafe.Pointer) {
+	C.glowImportSemaphoreWin32NameEXT(gpImportSemaphoreWin32NameEXT, (C.GLuint)(semaphore), (C.GLenum)(handleType), name)
+}
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -22948,6 +24086,10 @@ func IsBufferResidentNV(target uint32) bool {
 	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
 	return ret == TRUE
 }
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
 	return ret == TRUE
@@ -22990,6 +24132,10 @@ func IsImageHandleResidentNV(handle uint64) bool {
 // determine if a name corresponds to a display list
 func IsList(list uint32) bool {
 	ret := C.glowIsList(gpIsList, (C.GLuint)(list))
+	return ret == TRUE
+}
+func IsMemoryObjectEXT(memoryObject uint32) bool {
+	ret := C.glowIsMemoryObjectEXT(gpIsMemoryObjectEXT, (C.GLuint)(memoryObject))
 	return ret == TRUE
 }
 func IsNameAMD(identifier uint32, name uint32) bool {
@@ -23074,15 +24220,23 @@ func IsSampler(sampler uint32) bool {
 	ret := C.glowIsSampler(gpIsSampler, (C.GLuint)(sampler))
 	return ret == TRUE
 }
+func IsSemaphoreEXT(semaphore uint32) bool {
+	ret := C.glowIsSemaphoreEXT(gpIsSemaphoreEXT, (C.GLuint)(semaphore))
+	return ret == TRUE
+}
 
 // Determines if a name corresponds to a shader object
 func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -23131,6 +24285,15 @@ func IsVertexArrayAPPLE(array uint32) bool {
 func IsVertexAttribEnabledAPPLE(index uint32, pname uint32) bool {
 	ret := C.glowIsVertexAttribEnabledAPPLE(gpIsVertexAttribEnabledAPPLE, (C.GLuint)(index), (C.GLenum)(pname))
 	return ret == TRUE
+}
+func LGPUCopyImageSubDataNVX(sourceGpu uint32, destinationGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srxY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, width int32, height int32, depth int32) {
+	C.glowLGPUCopyImageSubDataNVX(gpLGPUCopyImageSubDataNVX, (C.GLuint)(sourceGpu), (C.GLbitfield)(destinationGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srxY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func LGPUInterlockNVX() {
+	C.glowLGPUInterlockNVX(gpLGPUInterlockNVX)
+}
+func LGPUNamedBufferSubDataNVX(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowLGPUNamedBufferSubDataNVX(gpLGPUNamedBufferSubDataNVX, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
@@ -23199,6 +24362,9 @@ func LinkProgramARB(programObj uintptr) {
 // set the display-list base for
 func ListBase(base uint32) {
 	C.glowListBase(gpListBase, (C.GLuint)(base))
+}
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 func ListParameterfSGIX(list uint32, pname uint32, param float32) {
 	C.glowListParameterfSGIX(gpListParameterfSGIX, (C.GLuint)(list), (C.GLenum)(pname), (C.GLfloat)(param))
@@ -23363,8 +24529,8 @@ func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
 }
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
 }
 func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
@@ -23507,6 +24673,12 @@ func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
 func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
 	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
 }
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
+}
 
 // defines a barrier ordering memory transactions
 func MemoryBarrier(barriers uint32) {
@@ -23517,6 +24689,9 @@ func MemoryBarrierByRegion(barriers uint32) {
 }
 func MemoryBarrierEXT(barriers uint32) {
 	C.glowMemoryBarrierEXT(gpMemoryBarrierEXT, (C.GLbitfield)(barriers))
+}
+func MemoryObjectParameterivEXT(memoryObject uint32, pname uint32, params *int32) {
+	C.glowMemoryObjectParameterivEXT(gpMemoryObjectParameterivEXT, (C.GLuint)(memoryObject), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // specifies minimum rate at which sample shaing takes place
@@ -23580,8 +24755,8 @@ func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer
 func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawElementArrayAPPLE(mode uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawElementArrayAPPLE(gpMultiDrawElementArrayAPPLE, (C.GLenum)(mode), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -23613,8 +24788,8 @@ func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirec
 func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
 	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 func MultiDrawRangeElementArrayAPPLE(mode uint32, start uint32, end uint32, first *int32, count *int32, primcount int32) {
 	C.glowMultiDrawRangeElementArrayAPPLE(gpMultiDrawRangeElementArrayAPPLE, (C.GLenum)(mode), (C.GLuint)(start), (C.GLuint)(end), (*C.GLint)(unsafe.Pointer(first)), (*C.GLsizei)(unsafe.Pointer(count)), (C.GLsizei)(primcount))
@@ -23988,32 +25163,71 @@ func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset i
 func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func MulticastBarrierNV() {
+	C.glowMulticastBarrierNV(gpMulticastBarrierNV)
+}
+func MulticastBlitFramebufferNV(srcGpu uint32, dstGpu uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
+	C.glowMulticastBlitFramebufferNV(gpMulticastBlitFramebufferNV, (C.GLuint)(srcGpu), (C.GLuint)(dstGpu), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
+}
+func MulticastBufferSubDataNV(gpuMask uint32, buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowMulticastBufferSubDataNV(gpMulticastBufferSubDataNV, (C.GLbitfield)(gpuMask), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func MulticastCopyBufferSubDataNV(readGpu uint32, writeGpuMask uint32, readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowMulticastCopyBufferSubDataNV(gpMulticastCopyBufferSubDataNV, (C.GLuint)(readGpu), (C.GLbitfield)(writeGpuMask), (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func MulticastCopyImageSubDataNV(srcGpu uint32, dstGpuMask uint32, srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
+	C.glowMulticastCopyImageSubDataNV(gpMulticastCopyImageSubDataNV, (C.GLuint)(srcGpu), (C.GLbitfield)(dstGpuMask), (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
+}
+func MulticastFramebufferSampleLocationsfvNV(gpu uint32, framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowMulticastFramebufferSampleLocationsfvNV(gpMulticastFramebufferSampleLocationsfvNV, (C.GLuint)(gpu), (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func MulticastGetQueryObjecti64vNV(gpu uint32, id uint32, pname uint32, params *int64) {
+	C.glowMulticastGetQueryObjecti64vNV(gpMulticastGetQueryObjecti64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectivNV(gpu uint32, id uint32, pname uint32, params *int32) {
+	C.glowMulticastGetQueryObjectivNV(gpMulticastGetQueryObjectivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectui64vNV(gpu uint32, id uint32, pname uint32, params *uint64) {
+	C.glowMulticastGetQueryObjectui64vNV(gpMulticastGetQueryObjectui64vNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func MulticastGetQueryObjectuivNV(gpu uint32, id uint32, pname uint32, params *uint32) {
+	C.glowMulticastGetQueryObjectuivNV(gpMulticastGetQueryObjectuivNV, (C.GLuint)(gpu), (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MulticastWaitSyncNV(signalGpu uint32, waitGpuMask uint32) {
+	C.glowMulticastWaitSyncNV(gpMulticastWaitSyncNV, (C.GLuint)(signalGpu), (C.GLbitfield)(waitGpuMask))
+}
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
 func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
 	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
+func NamedBufferStorageExternalEXT(buffer uint32, offset int, size int, clientBuffer C.GLeglClientBufferEXT, flags uint32) {
+	C.glowNamedBufferStorageExternalEXT(gpNamedBufferStorageExternalEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLeglClientBufferEXT)(clientBuffer), (C.GLbitfield)(flags))
+}
+func NamedBufferStorageMemEXT(buffer uint32, size int, memory uint32, offset uint64) {
+	C.glowNamedBufferStorageMemEXT(gpNamedBufferStorageMemEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
@@ -24051,6 +25265,15 @@ func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderb
 }
 func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSamplePositionsfvAMD(framebuffer uint32, numsamples uint32, pixelindex uint32, values *float32) {
+	C.glowNamedFramebufferSamplePositionsfvAMD(gpNamedFramebufferSamplePositionsfvAMD, (C.GLuint)(framebuffer), (C.GLuint)(numsamples), (C.GLuint)(pixelindex), (*C.GLfloat)(unsafe.Pointer(values)))
 }
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
@@ -24301,6 +25524,8 @@ func PassThroughxOES(token int32) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -24396,6 +25621,8 @@ func PixelMapx(xmap uint32, size int32, values *int32) {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
 }
@@ -24518,6 +25745,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 func PolygonOffsetEXT(factor float32, bias float32) {
 	C.glowPolygonOffsetEXT(gpPolygonOffsetEXT, (C.GLfloat)(factor), (C.GLfloat)(bias))
 }
@@ -24557,6 +25790,9 @@ func PresentFrameDualFillNV(video_slot uint32, minPresentTime uint64, beginPrese
 }
 func PresentFrameKeyedNV(video_slot uint32, minPresentTime uint64, beginPresentTimeId uint32, presentDurationId uint32, xtype uint32, target0 uint32, fill0 uint32, key0 uint32, target1 uint32, fill1 uint32, key1 uint32) {
 	C.glowPresentFrameKeyedNV(gpPresentFrameKeyedNV, (C.GLuint)(video_slot), (C.GLuint64EXT)(minPresentTime), (C.GLuint)(beginPresentTimeId), (C.GLuint)(presentDurationId), (C.GLenum)(xtype), (C.GLenum)(target0), (C.GLuint)(fill0), (C.GLuint)(key0), (C.GLenum)(target1), (C.GLuint)(fill1), (C.GLuint)(key1))
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -24684,6 +25920,8 @@ func ProgramParameter4fNV(target uint32, index uint32, x float32, y float32, z f
 func ProgramParameter4fvNV(target uint32, index uint32, v *float32) {
 	C.glowProgramParameter4fvNV(gpProgramParameter4fvNV, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
 }
@@ -24741,8 +25979,14 @@ func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
 func ProgramUniform1i64NV(program uint32, location int32, x int64) {
 	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24763,8 +26007,14 @@ func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
 func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
 	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24813,8 +26063,14 @@ func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
 	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24835,8 +26091,14 @@ func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
 	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24885,8 +26147,14 @@ func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
 	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24907,8 +26175,14 @@ func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
 	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -24957,8 +26231,14 @@ func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *fl
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
 	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
 	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -24979,8 +26259,14 @@ func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *in
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
 	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -25190,12 +26476,21 @@ func PushName(name uint32) {
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
 }
+
+// return the values of the current matrix
 func QueryMatrixxOES(mantissa *int32, exponent *int32) uint32 {
 	ret := C.glowQueryMatrixxOES(gpQueryMatrixxOES, (*C.GLfixed)(unsafe.Pointer(mantissa)), (*C.GLint)(unsafe.Pointer(exponent)))
 	return (uint32)(ret)
 }
 func QueryObjectParameteruiAMD(target uint32, id uint32, pname uint32, param uint32) {
 	C.glowQueryObjectParameteruiAMD(gpQueryObjectParameteruiAMD, (C.GLenum)(target), (C.GLuint)(id), (C.GLenum)(pname), (C.GLuint)(param))
+}
+func QueryResourceNV(queryType uint32, tagId int32, bufSize uint32, buffer *int32) int32 {
+	ret := C.glowQueryResourceNV(gpQueryResourceNV, (C.GLenum)(queryType), (C.GLint)(tagId), (C.GLuint)(bufSize), (*C.GLint)(unsafe.Pointer(buffer)))
+	return (int32)(ret)
+}
+func QueryResourceTagNV(tagId int32, tagString *uint8) {
+	C.glowQueryResourceTagNV(gpQueryResourceTagNV, (C.GLint)(tagId), (*C.GLchar)(unsafe.Pointer(tagString)))
 }
 func RasterPos2d(x float64, y float64) {
 	C.glowRasterPos2d(gpRasterPos2d, (C.GLdouble)(x), (C.GLdouble)(y))
@@ -25287,6 +26582,9 @@ func RasterPos4xOES(x int32, y int32, z int32, w int32) {
 func RasterPos4xvOES(coords *int32) {
 	C.glowRasterPos4xvOES(gpRasterPos4xvOES, (*C.GLfixed)(unsafe.Pointer(coords)))
 }
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // select a color buffer source for pixels
 func ReadBuffer(src uint32) {
@@ -25344,10 +26642,17 @@ func RectxvOES(v1 *int32, v2 *int32) {
 func ReferencePlaneSGIX(equation *float64) {
 	C.glowReferencePlaneSGIX(gpReferencePlaneSGIX, (*C.GLdouble)(unsafe.Pointer(equation)))
 }
+func ReleaseKeyedMutexWin32EXT(memory uint32, key uint64) bool {
+	ret := C.glowReleaseKeyedMutexWin32EXT(gpReleaseKeyedMutexWin32EXT, (C.GLuint)(memory), (C.GLuint64)(key))
+	return ret == TRUE
+}
 
 // release resources consumed by the implementation's shader compiler
 func ReleaseShaderCompiler() {
 	C.glowReleaseShaderCompiler(gpReleaseShaderCompiler)
+}
+func RenderGpuMaskNV(mask uint32) {
+	C.glowRenderGpuMaskNV(gpRenderGpuMaskNV, (C.GLbitfield)(mask))
 }
 
 // set rasterization mode
@@ -25465,6 +26770,9 @@ func ResetMinmaxEXT(target uint32) {
 func ResizeBuffersMESA() {
 	C.glowResizeBuffersMESA(gpResizeBuffersMESA)
 }
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
+}
 
 // resume transform feedback operations
 func ResumeTransformFeedback() {
@@ -25489,9 +26797,6 @@ func SampleCoverage(value float32, invert bool) {
 }
 func SampleCoverageARB(value float32, invert bool) {
 	C.glowSampleCoverageARB(gpSampleCoverageARB, (C.GLfloat)(value), (C.GLboolean)(boolToInt(invert)))
-}
-func SampleCoverageOES(value int32, invert bool) {
-	C.glowSampleCoverageOES(gpSampleCoverageOES, (C.GLfixed)(value), (C.GLboolean)(boolToInt(invert)))
 }
 func SampleCoveragexOES(value int32, invert bool) {
 	C.glowSampleCoveragexOES(gpSampleCoveragexOES, (C.GLclampx)(value), (C.GLboolean)(boolToInt(invert)))
@@ -25692,6 +26997,9 @@ func SelectBuffer(size int32, buffer *uint32) {
 func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
 	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
 }
+func SemaphoreParameterui64vEXT(semaphore uint32, pname uint32, params *uint64) {
+	C.glowSemaphoreParameterui64vEXT(gpSemaphoreParameterui64vEXT, (C.GLuint)(semaphore), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
+}
 
 // define a separable two-dimensional convolution filter
 func SeparableFilter2D(target uint32, internalformat uint32, width int32, height int32, format uint32, xtype uint32, row unsafe.Pointer, column unsafe.Pointer) {
@@ -25753,6 +27061,18 @@ func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storage
 func SharpenTexFuncSGIS(target uint32, n int32, points *float32) {
 	C.glowSharpenTexFuncSGIS(gpSharpenTexFuncSGIS, (C.GLenum)(target), (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(points)))
 }
+func SignalSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, dstLayouts *uint32) {
+	C.glowSignalSemaphoreEXT(gpSignalSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(dstLayouts)))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
 func SpriteParameterfSGIX(pname uint32, param float32) {
 	C.glowSpriteParameterfSGIX(gpSpriteParameterfSGIX, (C.GLenum)(pname), (C.GLfloat)(param))
 }
@@ -25767,6 +27087,9 @@ func SpriteParameterivSGIX(pname uint32, params *int32) {
 }
 func StartInstrumentsSGIX() {
 	C.glowStartInstrumentsSGIX(gpStartInstrumentsSGIX)
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
 }
 func StencilClearTagEXT(stencilTagBits int32, stencilClearTag uint32) {
 	C.glowStencilClearTagEXT(gpStencilClearTagEXT, (C.GLsizei)(stencilTagBits), (C.GLuint)(stencilClearTag))
@@ -25839,6 +27162,9 @@ func StopInstrumentsSGIX(marker int32) {
 }
 func StringMarkerGREMEDY(len int32, xstring unsafe.Pointer) {
 	C.glowStringMarkerGREMEDY(gpStringMarkerGREMEDY, (C.GLsizei)(len), xstring)
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
 }
 func SwizzleEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowSwizzleEXT(gpSwizzleEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
@@ -26258,8 +27584,8 @@ func TexImage3DMultisampleCoverageNV(target uint32, coverageSamples int32, color
 func TexImage4DSGIS(target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, size4d int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTexImage4DSGIS(gpTexImage4DSGIS, (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(size4d), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -26319,6 +27645,21 @@ func TexStorage3D(target uint32, levels int32, internalformat uint32, width int3
 func TexStorage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexStorage3DMultisample(gpTexStorage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TexStorageMem1DEXT(target uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem1DEXT(gpTexStorageMem1DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DEXT(gpTexStorageMem2DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem2DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem2DMultisampleEXT(gpTexStorageMem2DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DEXT(target uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DEXT(gpTexStorageMem3DEXT, (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TexStorageMem3DMultisampleEXT(target uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTexStorageMem3DMultisampleEXT(gpTexStorageMem3DMultisampleEXT, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TexStorageSparseAMD(target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTexStorageSparseAMD(gpTexStorageSparseAMD, (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -26367,8 +27708,8 @@ func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buff
 }
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
@@ -26406,8 +27747,8 @@ func TextureMaterialEXT(face uint32, mode uint32) {
 func TextureNormalEXT(mode uint32) {
 	C.glowTextureNormalEXT(gpTextureNormalEXT, (C.GLenum)(mode))
 }
-func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -26491,6 +27832,21 @@ func TextureStorage3DMultisample(texture uint32, samples int32, internalformat u
 func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorageMem1DEXT(texture uint32, levels int32, internalFormat uint32, width int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem1DEXT(gpTextureStorageMem1DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DEXT(gpTextureStorageMem2DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem2DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem2DMultisampleEXT(gpTextureStorageMem2DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DEXT(texture uint32, levels int32, internalFormat uint32, width int32, height int32, depth int32, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DEXT(gpTextureStorageMem3DEXT, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
+func TextureStorageMem3DMultisampleEXT(texture uint32, samples int32, internalFormat uint32, width int32, height int32, depth int32, fixedSampleLocations bool, memory uint32, offset uint64) {
+	C.glowTextureStorageMem3DMultisampleEXT(gpTextureStorageMem3DMultisampleEXT, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedSampleLocations)), (C.GLuint)(memory), (C.GLuint64)(offset))
+}
 func TextureStorageSparseAMD(texture uint32, target uint32, internalFormat uint32, width int32, height int32, depth int32, layers int32, flags uint32) {
 	C.glowTextureStorageSparseAMD(gpTextureStorageSparseAMD, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalFormat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(layers), (C.GLbitfield)(flags))
 }
@@ -26536,8 +27892,8 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 func TransformFeedbackStreamAttribsNV(count int32, attribs *int32, nbuffers int32, bufstreams *int32, bufferMode uint32) {
 	C.glowTransformFeedbackStreamAttribsNV(gpTransformFeedbackStreamAttribsNV, (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(attribs)), (C.GLsizei)(nbuffers), (*C.GLint)(unsafe.Pointer(bufstreams)), (C.GLenum)(bufferMode))
@@ -26592,8 +27948,14 @@ func Uniform1fvARB(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
 func Uniform1i64NV(location int32, x int64) {
 	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform1i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26614,8 +27976,14 @@ func Uniform1ivARB(location int32, count int32, value *int32) {
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
 }
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
 func Uniform1ui64NV(location int32, x uint64) {
 	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform1ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26658,8 +28026,14 @@ func Uniform2fvARB(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
 func Uniform2i64NV(location int32, x int64, y int64) {
 	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform2i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26680,8 +28054,14 @@ func Uniform2ivARB(location int32, count int32, value *int32) {
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
 func Uniform2ui64NV(location int32, x uint64, y uint64) {
 	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform2ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26724,8 +28104,14 @@ func Uniform3fvARB(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
 func Uniform3i64NV(location int32, x int64, y int64, z int64) {
 	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform3i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26746,8 +28132,14 @@ func Uniform3ivARB(location int32, count int32, value *int32) {
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
 func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
 	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform3ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -26790,8 +28182,14 @@ func Uniform4fvARB(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
 func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
 	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
 }
 func Uniform4i64vNV(location int32, count int32, value *int64) {
 	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
@@ -26812,8 +28210,14 @@ func Uniform4ivARB(location int32, count int32, value *int32) {
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
 func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
 	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func Uniform4ui64vNV(location int32, count int32, value *uint64) {
 	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
@@ -28159,10 +29563,22 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
+func WaitSemaphoreEXT(semaphore uint32, numBufferBarriers uint32, buffers *uint32, numTextureBarriers uint32, textures *uint32, srcLayouts *uint32) {
+	C.glowWaitSemaphoreEXT(gpWaitSemaphoreEXT, (C.GLuint)(semaphore), (C.GLuint)(numBufferBarriers), (*C.GLuint)(unsafe.Pointer(buffers)), (C.GLuint)(numTextureBarriers), (*C.GLuint)(unsafe.Pointer(textures)), (*C.GLenum)(unsafe.Pointer(srcLayouts)))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
 	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
@@ -28362,6 +29778,9 @@ func WindowPos4sMESA(x int16, y int16, z int16, w int16) {
 func WindowPos4svMESA(v *int16) {
 	C.glowWindowPos4svMESA(gpWindowPos4svMESA, (*C.GLshort)(unsafe.Pointer(v)))
 }
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
+}
 func WriteMaskEXT(res uint32, in uint32, outX uint32, outY uint32, outZ uint32, outW uint32) {
 	C.glowWriteMaskEXT(gpWriteMaskEXT, (C.GLuint)(res), (C.GLuint)(in), (C.GLenum)(outX), (C.GLenum)(outY), (C.GLenum)(outZ), (C.GLenum)(outW))
 }
@@ -28398,6 +29817,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAccum")
 	}
 	gpAccumxOES = (C.GPACCUMXOES)(getProcAddr("glAccumxOES"))
+	gpAcquireKeyedMutexWin32EXT = (C.GPACQUIREKEYEDMUTEXWIN32EXT)(getProcAddr("glAcquireKeyedMutexWin32EXT"))
 	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
 	if gpActiveShaderProgram == nil {
@@ -28419,6 +29839,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glAlphaFunc")
 	}
 	gpAlphaFuncxOES = (C.GPALPHAFUNCXOES)(getProcAddr("glAlphaFuncxOES"))
+	gpAlphaToCoverageDitherControlNV = (C.GPALPHATOCOVERAGEDITHERCONTROLNV)(getProcAddr("glAlphaToCoverageDitherControlNV"))
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpApplyTextureEXT = (C.GPAPPLYTEXTUREEXT)(getProcAddr("glApplyTextureEXT"))
 	gpAreProgramsResidentNV = (C.GPAREPROGRAMSRESIDENTNV)(getProcAddr("glAreProgramsResidentNV"))
 	gpAreTexturesResident = (C.GPARETEXTURESRESIDENT)(getProcAddr("glAreTexturesResident"))
@@ -28675,11 +30097,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBufferStorage == nil {
 		return errors.New("glBufferStorage")
 	}
+	gpBufferStorageExternalEXT = (C.GPBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glBufferStorageExternalEXT"))
+	gpBufferStorageMemEXT = (C.GPBUFFERSTORAGEMEMEXT)(getProcAddr("glBufferStorageMemEXT"))
 	gpBufferSubData = (C.GPBUFFERSUBDATA)(getProcAddr("glBufferSubData"))
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
 	gpBufferSubDataARB = (C.GPBUFFERSUBDATAARB)(getProcAddr("glBufferSubDataARB"))
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCallList = (C.GPCALLLIST)(getProcAddr("glCallList"))
 	if gpCallList == nil {
 		return errors.New("glCallList")
@@ -29017,6 +30442,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCombinerParameteriNV = (C.GPCOMBINERPARAMETERINV)(getProcAddr("glCombinerParameteriNV"))
 	gpCombinerParameterivNV = (C.GPCOMBINERPARAMETERIVNV)(getProcAddr("glCombinerParameterivNV"))
 	gpCombinerStageParameterfvNV = (C.GPCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glCombinerStageParameterfvNV"))
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
@@ -29077,6 +30504,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glCompressedTextureSubImage3D")
 	}
 	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpConvolutionFilter1D = (C.GPCONVOLUTIONFILTER1D)(getProcAddr("glConvolutionFilter1D"))
 	gpConvolutionFilter1DEXT = (C.GPCONVOLUTIONFILTER1DEXT)(getProcAddr("glConvolutionFilter1DEXT"))
 	gpConvolutionFilter2D = (C.GPCONVOLUTIONFILTER2D)(getProcAddr("glConvolutionFilter2D"))
@@ -29168,14 +30597,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
 	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
 	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
 	if gpCreateBuffers == nil {
 		return errors.New("glCreateBuffers")
 	}
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
 	if gpCreateFramebuffers == nil {
 		return errors.New("glCreateFramebuffers")
 	}
+	gpCreateMemoryObjectsEXT = (C.GPCREATEMEMORYOBJECTSEXT)(getProcAddr("glCreateMemoryObjectsEXT"))
 	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
@@ -29209,6 +30642,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glCreateShaderProgramv")
 	}
 	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	if gpCreateTextures == nil {
@@ -29259,6 +30693,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteBuffers")
 	}
 	gpDeleteBuffersARB = (C.GPDELETEBUFFERSARB)(getProcAddr("glDeleteBuffersARB"))
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFencesAPPLE = (C.GPDELETEFENCESAPPLE)(getProcAddr("glDeleteFencesAPPLE"))
 	gpDeleteFencesNV = (C.GPDELETEFENCESNV)(getProcAddr("glDeleteFencesNV"))
 	gpDeleteFragmentShaderATI = (C.GPDELETEFRAGMENTSHADERATI)(getProcAddr("glDeleteFragmentShaderATI"))
@@ -29271,6 +30706,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteLists == nil {
 		return errors.New("glDeleteLists")
 	}
+	gpDeleteMemoryObjectsEXT = (C.GPDELETEMEMORYOBJECTSEXT)(getProcAddr("glDeleteMemoryObjectsEXT"))
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
 	gpDeleteNamesAMD = (C.GPDELETENAMESAMD)(getProcAddr("glDeleteNamesAMD"))
 	gpDeleteObjectARB = (C.GPDELETEOBJECTARB)(getProcAddr("glDeleteObjectARB"))
@@ -29294,6 +30730,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glDeleteQueries")
 	}
 	gpDeleteQueriesARB = (C.GPDELETEQUERIESARB)(getProcAddr("glDeleteQueriesARB"))
+	gpDeleteQueryResourceTagNV = (C.GPDELETEQUERYRESOURCETAGNV)(getProcAddr("glDeleteQueryResourceTagNV"))
 	gpDeleteRenderbuffers = (C.GPDELETERENDERBUFFERS)(getProcAddr("glDeleteRenderbuffers"))
 	if gpDeleteRenderbuffers == nil {
 		return errors.New("glDeleteRenderbuffers")
@@ -29303,10 +30740,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteSamplers == nil {
 		return errors.New("glDeleteSamplers")
 	}
+	gpDeleteSemaphoresEXT = (C.GPDELETESEMAPHORESEXT)(getProcAddr("glDeleteSemaphoresEXT"))
 	gpDeleteShader = (C.GPDELETESHADER)(getProcAddr("glDeleteShader"))
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	if gpDeleteSync == nil {
 		return errors.New("glDeleteSync")
@@ -29428,6 +30867,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpDrawBuffersARB = (C.GPDRAWBUFFERSARB)(getProcAddr("glDrawBuffersARB"))
 	gpDrawBuffersATI = (C.GPDRAWBUFFERSATI)(getProcAddr("glDrawBuffersATI"))
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElementArrayAPPLE = (C.GPDRAWELEMENTARRAYAPPLE)(getProcAddr("glDrawElementArrayAPPLE"))
 	gpDrawElementArrayATI = (C.GPDRAWELEMENTARRAYATI)(getProcAddr("glDrawElementArrayATI"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
@@ -29494,6 +30937,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawTransformFeedbackStreamInstanced == nil {
 		return errors.New("glDrawTransformFeedbackStreamInstanced")
 	}
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
 	gpEdgeFlag = (C.GPEDGEFLAG)(getProcAddr("glEdgeFlag"))
 	if gpEdgeFlag == nil {
 		return errors.New("glEdgeFlag")
@@ -29627,6 +31071,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEvalPoint2 == nil {
 		return errors.New("glEvalPoint2")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpExecuteProgramNV = (C.GPEXECUTEPROGRAMNV)(getProcAddr("glExecuteProgramNV"))
 	gpExtractComponentEXT = (C.GPEXTRACTCOMPONENTEXT)(getProcAddr("glExtractComponentEXT"))
 	gpFeedbackBuffer = (C.GPFEEDBACKBUFFER)(getProcAddr("glFeedbackBuffer"))
@@ -29716,6 +31161,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFogxOES = (C.GPFOGXOES)(getProcAddr("glFogxOES"))
 	gpFogxvOES = (C.GPFOGXVOES)(getProcAddr("glFogxvOES"))
 	gpFragmentColorMaterialSGIX = (C.GPFRAGMENTCOLORMATERIALSGIX)(getProcAddr("glFragmentColorMaterialSGIX"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
 	gpFragmentLightModelfSGIX = (C.GPFRAGMENTLIGHTMODELFSGIX)(getProcAddr("glFragmentLightModelfSGIX"))
 	gpFragmentLightModelfvSGIX = (C.GPFRAGMENTLIGHTMODELFVSGIX)(getProcAddr("glFragmentLightModelfvSGIX"))
 	gpFragmentLightModeliSGIX = (C.GPFRAGMENTLIGHTMODELISGIX)(getProcAddr("glFragmentLightModeliSGIX"))
@@ -29732,6 +31178,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpFrameZoomSGIX = (C.GPFRAMEZOOMSGIX)(getProcAddr("glFrameZoomSGIX"))
 	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
 	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
 	if gpFramebufferParameteri == nil {
 		return errors.New("glFramebufferParameteri")
@@ -29742,6 +31189,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glFramebufferRenderbuffer")
 	}
 	gpFramebufferRenderbufferEXT = (C.GPFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glFramebufferRenderbufferEXT"))
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
+	gpFramebufferSamplePositionsfvAMD = (C.GPFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glFramebufferSamplePositionsfvAMD"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	if gpFramebufferTexture == nil {
 		return errors.New("glFramebufferTexture")
@@ -29771,6 +31221,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
 	gpFramebufferTextureLayerEXT = (C.GPFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glFramebufferTextureLayerEXT"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFreeObjectBufferATI = (C.GPFREEOBJECTBUFFERATI)(getProcAddr("glFreeObjectBufferATI"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
@@ -29816,6 +31267,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGenQueries")
 	}
 	gpGenQueriesARB = (C.GPGENQUERIESARB)(getProcAddr("glGenQueriesARB"))
+	gpGenQueryResourceTagNV = (C.GPGENQUERYRESOURCETAGNV)(getProcAddr("glGenQueryResourceTagNV"))
 	gpGenRenderbuffers = (C.GPGENRENDERBUFFERS)(getProcAddr("glGenRenderbuffers"))
 	if gpGenRenderbuffers == nil {
 		return errors.New("glGenRenderbuffers")
@@ -29825,6 +31277,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenSamplers == nil {
 		return errors.New("glGenSamplers")
 	}
+	gpGenSemaphoresEXT = (C.GPGENSEMAPHORESEXT)(getProcAddr("glGenSemaphoresEXT"))
 	gpGenSymbolsEXT = (C.GPGENSYMBOLSEXT)(getProcAddr("glGenSymbolsEXT"))
 	gpGenTextures = (C.GPGENTEXTURES)(getProcAddr("glGenTextures"))
 	if gpGenTextures == nil {
@@ -29957,6 +31410,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetCombinerOutputParameterfvNV = (C.GPGETCOMBINEROUTPUTPARAMETERFVNV)(getProcAddr("glGetCombinerOutputParameterfvNV"))
 	gpGetCombinerOutputParameterivNV = (C.GPGETCOMBINEROUTPUTPARAMETERIVNV)(getProcAddr("glGetCombinerOutputParameterivNV"))
 	gpGetCombinerStageParameterfvNV = (C.GPGETCOMBINERSTAGEPARAMETERFVNV)(getProcAddr("glGetCombinerStageParameterfvNV"))
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
 	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
@@ -29979,6 +31433,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetConvolutionParameteriv = (C.GPGETCONVOLUTIONPARAMETERIV)(getProcAddr("glGetConvolutionParameteriv"))
 	gpGetConvolutionParameterivEXT = (C.GPGETCONVOLUTIONPARAMETERIVEXT)(getProcAddr("glGetConvolutionParameterivEXT"))
 	gpGetConvolutionParameterxvOES = (C.GPGETCONVOLUTIONPARAMETERXVOES)(getProcAddr("glGetConvolutionParameterxvOES"))
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	if gpGetDebugMessageLog == nil {
 		return errors.New("glGetDebugMessageLog")
@@ -30035,6 +31490,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetFramebufferAttachmentParameteriv")
 	}
 	gpGetFramebufferAttachmentParameterivEXT = (C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetFramebufferAttachmentParameterivEXT"))
+	gpGetFramebufferParameterfvAMD = (C.GPGETFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetFramebufferParameterfvAMD"))
 	gpGetFramebufferParameteriv = (C.GPGETFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetFramebufferParameteriv"))
 	if gpGetFramebufferParameteriv == nil {
 		return errors.New("glGetFramebufferParameteriv")
@@ -30079,6 +31535,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	if gpGetInternalformati64v == nil {
 		return errors.New("glGetInternalformati64v")
@@ -30133,6 +31590,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetMaterialxOES = (C.GPGETMATERIALXOES)(getProcAddr("glGetMaterialxOES"))
 	gpGetMaterialxvOES = (C.GPGETMATERIALXVOES)(getProcAddr("glGetMaterialxvOES"))
+	gpGetMemoryObjectParameterivEXT = (C.GPGETMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glGetMemoryObjectParameterivEXT"))
 	gpGetMinmax = (C.GPGETMINMAX)(getProcAddr("glGetMinmax"))
 	gpGetMinmaxEXT = (C.GPGETMINMAXEXT)(getProcAddr("glGetMinmaxEXT"))
 	gpGetMinmaxParameterfv = (C.GPGETMINMAXPARAMETERFV)(getProcAddr("glGetMinmaxParameterfv"))
@@ -30181,6 +31639,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetNamedFramebufferAttachmentParameteriv")
 	}
 	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
+	gpGetNamedFramebufferParameterfvAMD = (C.GPGETNAMEDFRAMEBUFFERPARAMETERFVAMD)(getProcAddr("glGetNamedFramebufferParameterfvAMD"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
 	if gpGetNamedFramebufferParameteriv == nil {
 		return errors.New("glGetNamedFramebufferParameteriv")
@@ -30338,6 +31797,22 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetProgramivARB = (C.GPGETPROGRAMIVARB)(getProcAddr("glGetProgramivARB"))
 	gpGetProgramivNV = (C.GPGETPROGRAMIVNV)(getProcAddr("glGetProgramivNV"))
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	if gpGetQueryBufferObjecti64v == nil {
+		return errors.New("glGetQueryBufferObjecti64v")
+	}
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	if gpGetQueryBufferObjectiv == nil {
+		return errors.New("glGetQueryBufferObjectiv")
+	}
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	if gpGetQueryBufferObjectui64v == nil {
+		return errors.New("glGetQueryBufferObjectui64v")
+	}
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
+	if gpGetQueryBufferObjectuiv == nil {
+		return errors.New("glGetQueryBufferObjectuiv")
+	}
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	if gpGetQueryIndexediv == nil {
 		return errors.New("glGetQueryIndexediv")
@@ -30388,6 +31863,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetSamplerParameteriv == nil {
 		return errors.New("glGetSamplerParameteriv")
 	}
+	gpGetSemaphoreParameterui64vEXT = (C.GPGETSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glGetSemaphoreParameterui64vEXT"))
 	gpGetSeparableFilter = (C.GPGETSEPARABLEFILTER)(getProcAddr("glGetSeparableFilter"))
 	gpGetSeparableFilterEXT = (C.GPGETSEPARABLEFILTEREXT)(getProcAddr("glGetSeparableFilterEXT"))
 	gpGetShaderInfoLog = (C.GPGETSHADERINFOLOG)(getProcAddr("glGetShaderInfoLog"))
@@ -30408,6 +31884,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetShaderiv")
 	}
 	gpGetSharpenTexFuncSGIS = (C.GPGETSHARPENTEXFUNCSGIS)(getProcAddr("glGetSharpenTexFuncSGIS"))
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -30576,18 +32053,22 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetUniformfv")
 	}
 	gpGetUniformfvARB = (C.GPGETUNIFORMFVARB)(getProcAddr("glGetUniformfvARB"))
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
 	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
 	gpGetUniformivARB = (C.GPGETUNIFORMIVARB)(getProcAddr("glGetUniformivARB"))
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
 	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
 	}
 	gpGetUniformuivEXT = (C.GPGETUNIFORMUIVEXT)(getProcAddr("glGetUniformuivEXT"))
+	gpGetUnsignedBytei_vEXT = (C.GPGETUNSIGNEDBYTEI_VEXT)(getProcAddr("glGetUnsignedBytei_vEXT"))
+	gpGetUnsignedBytevEXT = (C.GPGETUNSIGNEDBYTEVEXT)(getProcAddr("glGetUnsignedBytevEXT"))
 	gpGetVariantArrayObjectfvATI = (C.GPGETVARIANTARRAYOBJECTFVATI)(getProcAddr("glGetVariantArrayObjectfvATI"))
 	gpGetVariantArrayObjectivATI = (C.GPGETVARIANTARRAYOBJECTIVATI)(getProcAddr("glGetVariantArrayObjectivATI"))
 	gpGetVariantBooleanvEXT = (C.GPGETVARIANTBOOLEANVEXT)(getProcAddr("glGetVariantBooleanvEXT"))
@@ -30663,6 +32144,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetVideoivNV = (C.GPGETVIDEOIVNV)(getProcAddr("glGetVideoivNV"))
 	gpGetVideoui64vNV = (C.GPGETVIDEOUI64VNV)(getProcAddr("glGetVideoui64vNV"))
 	gpGetVideouivNV = (C.GPGETVIDEOUIVNV)(getProcAddr("glGetVideouivNV"))
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnColorTable = (C.GPGETNCOLORTABLE)(getProcAddr("glGetnColorTable"))
 	if gpGetnColorTable == nil {
 		return errors.New("glGetnColorTable")
@@ -30744,12 +32226,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	if gpGetnUniformiv == nil {
 		return errors.New("glGetnUniformiv")
 	}
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	if gpGetnUniformuiv == nil {
 		return errors.New("glGetnUniformuiv")
@@ -30776,6 +32260,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpImageTransformParameterfvHP = (C.GPIMAGETRANSFORMPARAMETERFVHP)(getProcAddr("glImageTransformParameterfvHP"))
 	gpImageTransformParameteriHP = (C.GPIMAGETRANSFORMPARAMETERIHP)(getProcAddr("glImageTransformParameteriHP"))
 	gpImageTransformParameterivHP = (C.GPIMAGETRANSFORMPARAMETERIVHP)(getProcAddr("glImageTransformParameterivHP"))
+	gpImportMemoryFdEXT = (C.GPIMPORTMEMORYFDEXT)(getProcAddr("glImportMemoryFdEXT"))
+	gpImportMemoryWin32HandleEXT = (C.GPIMPORTMEMORYWIN32HANDLEEXT)(getProcAddr("glImportMemoryWin32HandleEXT"))
+	gpImportMemoryWin32NameEXT = (C.GPIMPORTMEMORYWIN32NAMEEXT)(getProcAddr("glImportMemoryWin32NameEXT"))
+	gpImportSemaphoreFdEXT = (C.GPIMPORTSEMAPHOREFDEXT)(getProcAddr("glImportSemaphoreFdEXT"))
+	gpImportSemaphoreWin32HandleEXT = (C.GPIMPORTSEMAPHOREWIN32HANDLEEXT)(getProcAddr("glImportSemaphoreWin32HandleEXT"))
+	gpImportSemaphoreWin32NameEXT = (C.GPIMPORTSEMAPHOREWIN32NAMEEXT)(getProcAddr("glImportSemaphoreWin32NameEXT"))
 	gpImportSyncEXT = (C.GPIMPORTSYNCEXT)(getProcAddr("glImportSyncEXT"))
 	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
 	gpIndexFuncEXT = (C.GPINDEXFUNCEXT)(getProcAddr("glIndexFuncEXT"))
@@ -30883,6 +32373,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsBufferARB = (C.GPISBUFFERARB)(getProcAddr("glIsBufferARB"))
 	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
@@ -30905,6 +32396,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsList == nil {
 		return errors.New("glIsList")
 	}
+	gpIsMemoryObjectEXT = (C.GPISMEMORYOBJECTEXT)(getProcAddr("glIsMemoryObjectEXT"))
 	gpIsNameAMD = (C.GPISNAMEAMD)(getProcAddr("glIsNameAMD"))
 	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
@@ -30938,10 +32430,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsSampler == nil {
 		return errors.New("glIsSampler")
 	}
+	gpIsSemaphoreEXT = (C.GPISSEMAPHOREEXT)(getProcAddr("glIsSemaphoreEXT"))
 	gpIsShader = (C.GPISSHADER)(getProcAddr("glIsShader"))
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	if gpIsSync == nil {
 		return errors.New("glIsSync")
@@ -30965,6 +32459,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpIsVertexArrayAPPLE = (C.GPISVERTEXARRAYAPPLE)(getProcAddr("glIsVertexArrayAPPLE"))
 	gpIsVertexAttribEnabledAPPLE = (C.GPISVERTEXATTRIBENABLEDAPPLE)(getProcAddr("glIsVertexAttribEnabledAPPLE"))
+	gpLGPUCopyImageSubDataNVX = (C.GPLGPUCOPYIMAGESUBDATANVX)(getProcAddr("glLGPUCopyImageSubDataNVX"))
+	gpLGPUInterlockNVX = (C.GPLGPUINTERLOCKNVX)(getProcAddr("glLGPUInterlockNVX"))
+	gpLGPUNamedBufferSubDataNVX = (C.GPLGPUNAMEDBUFFERSUBDATANVX)(getProcAddr("glLGPUNamedBufferSubDataNVX"))
 	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLightEnviSGIX = (C.GPLIGHTENVISGIX)(getProcAddr("glLightEnviSGIX"))
 	gpLightModelf = (C.GPLIGHTMODELF)(getProcAddr("glLightModelf"))
@@ -31021,6 +32518,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpListBase == nil {
 		return errors.New("glListBase")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpListParameterfSGIX = (C.GPLISTPARAMETERFSGIX)(getProcAddr("glListParameterfSGIX"))
 	gpListParameterfvSGIX = (C.GPLISTPARAMETERFVSGIX)(getProcAddr("glListParameterfvSGIX"))
 	gpListParameteriSGIX = (C.GPLISTPARAMETERISGIX)(getProcAddr("glListParameteriSGIX"))
@@ -31187,6 +32685,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
 	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
 	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	if gpMemoryBarrier == nil {
 		return errors.New("glMemoryBarrier")
@@ -31196,6 +32696,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glMemoryBarrierByRegion")
 	}
 	gpMemoryBarrierEXT = (C.GPMEMORYBARRIEREXT)(getProcAddr("glMemoryBarrierEXT"))
+	gpMemoryObjectParameterivEXT = (C.GPMEMORYOBJECTPARAMETERIVEXT)(getProcAddr("glMemoryObjectParameterivEXT"))
 	gpMinSampleShading = (C.GPMINSAMPLESHADING)(getProcAddr("glMinSampleShading"))
 	if gpMinSampleShading == nil {
 		return errors.New("glMinSampleShading")
@@ -31498,6 +32999,17 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
 	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
 	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
+	gpMulticastBarrierNV = (C.GPMULTICASTBARRIERNV)(getProcAddr("glMulticastBarrierNV"))
+	gpMulticastBlitFramebufferNV = (C.GPMULTICASTBLITFRAMEBUFFERNV)(getProcAddr("glMulticastBlitFramebufferNV"))
+	gpMulticastBufferSubDataNV = (C.GPMULTICASTBUFFERSUBDATANV)(getProcAddr("glMulticastBufferSubDataNV"))
+	gpMulticastCopyBufferSubDataNV = (C.GPMULTICASTCOPYBUFFERSUBDATANV)(getProcAddr("glMulticastCopyBufferSubDataNV"))
+	gpMulticastCopyImageSubDataNV = (C.GPMULTICASTCOPYIMAGESUBDATANV)(getProcAddr("glMulticastCopyImageSubDataNV"))
+	gpMulticastFramebufferSampleLocationsfvNV = (C.GPMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glMulticastFramebufferSampleLocationsfvNV"))
+	gpMulticastGetQueryObjecti64vNV = (C.GPMULTICASTGETQUERYOBJECTI64VNV)(getProcAddr("glMulticastGetQueryObjecti64vNV"))
+	gpMulticastGetQueryObjectivNV = (C.GPMULTICASTGETQUERYOBJECTIVNV)(getProcAddr("glMulticastGetQueryObjectivNV"))
+	gpMulticastGetQueryObjectui64vNV = (C.GPMULTICASTGETQUERYOBJECTUI64VNV)(getProcAddr("glMulticastGetQueryObjectui64vNV"))
+	gpMulticastGetQueryObjectuivNV = (C.GPMULTICASTGETQUERYOBJECTUIVNV)(getProcAddr("glMulticastGetQueryObjectuivNV"))
+	gpMulticastWaitSyncNV = (C.GPMULTICASTWAITSYNCNV)(getProcAddr("glMulticastWaitSyncNV"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
 	if gpNamedBufferData == nil {
 		return errors.New("glNamedBufferData")
@@ -31510,6 +33022,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glNamedBufferStorage")
 	}
 	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
+	gpNamedBufferStorageExternalEXT = (C.GPNAMEDBUFFERSTORAGEEXTERNALEXT)(getProcAddr("glNamedBufferStorageExternalEXT"))
+	gpNamedBufferStorageMemEXT = (C.GPNAMEDBUFFERSTORAGEMEMEXT)(getProcAddr("glNamedBufferStorageMemEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
 	if gpNamedBufferSubData == nil {
 		return errors.New("glNamedBufferSubData")
@@ -31538,6 +33052,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glNamedFramebufferRenderbuffer")
 	}
 	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
+	gpNamedFramebufferSamplePositionsfvAMD = (C.GPNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMD)(getProcAddr("glNamedFramebufferSamplePositionsfvAMD"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
 	if gpNamedFramebufferTexture == nil {
 		return errors.New("glNamedFramebufferTexture")
@@ -31801,6 +33318,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPolygonOffsetEXT = (C.GPPOLYGONOFFSETEXT)(getProcAddr("glPolygonOffsetEXT"))
 	gpPolygonOffsetxOES = (C.GPPOLYGONOFFSETXOES)(getProcAddr("glPolygonOffsetxOES"))
 	gpPolygonStipple = (C.GPPOLYGONSTIPPLE)(getProcAddr("glPolygonStipple"))
@@ -31831,6 +33350,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpPresentFrameDualFillNV = (C.GPPRESENTFRAMEDUALFILLNV)(getProcAddr("glPresentFrameDualFillNV"))
 	gpPresentFrameKeyedNV = (C.GPPRESENTFRAMEKEYEDNV)(getProcAddr("glPresentFrameKeyedNV"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	if gpPrimitiveRestartIndex == nil {
 		return errors.New("glPrimitiveRestartIndex")
@@ -31915,7 +33435,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform1i == nil {
 		return errors.New("glProgramUniform1i")
 	}
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
 	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
 	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
 	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
@@ -31927,7 +33449,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform1ui == nil {
 		return errors.New("glProgramUniform1ui")
 	}
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
 	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
 	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
 	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
@@ -31959,7 +33483,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform2i == nil {
 		return errors.New("glProgramUniform2i")
 	}
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
 	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
 	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
 	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
@@ -31971,7 +33497,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform2ui == nil {
 		return errors.New("glProgramUniform2ui")
 	}
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
 	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
 	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
 	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
@@ -32003,7 +33531,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform3i == nil {
 		return errors.New("glProgramUniform3i")
 	}
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
 	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
 	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
 	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
@@ -32015,7 +33545,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform3ui == nil {
 		return errors.New("glProgramUniform3ui")
 	}
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
 	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
 	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
 	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
@@ -32047,7 +33579,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform4i == nil {
 		return errors.New("glProgramUniform4i")
 	}
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
 	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
 	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
 	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
@@ -32059,7 +33593,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramUniform4ui == nil {
 		return errors.New("glProgramUniform4ui")
 	}
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
 	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
 	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
 	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
@@ -32198,6 +33734,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpQueryMatrixxOES = (C.GPQUERYMATRIXXOES)(getProcAddr("glQueryMatrixxOES"))
 	gpQueryObjectParameteruiAMD = (C.GPQUERYOBJECTPARAMETERUIAMD)(getProcAddr("glQueryObjectParameteruiAMD"))
+	gpQueryResourceNV = (C.GPQUERYRESOURCENV)(getProcAddr("glQueryResourceNV"))
+	gpQueryResourceTagNV = (C.GPQUERYRESOURCETAGNV)(getProcAddr("glQueryResourceTagNV"))
 	gpRasterPos2d = (C.GPRASTERPOS2D)(getProcAddr("glRasterPos2d"))
 	if gpRasterPos2d == nil {
 		return errors.New("glRasterPos2d")
@@ -32300,6 +33838,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpRasterPos4xOES = (C.GPRASTERPOS4XOES)(getProcAddr("glRasterPos4xOES"))
 	gpRasterPos4xvOES = (C.GPRASTERPOS4XVOES)(getProcAddr("glRasterPos4xvOES"))
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -32350,10 +33889,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpRectxOES = (C.GPRECTXOES)(getProcAddr("glRectxOES"))
 	gpRectxvOES = (C.GPRECTXVOES)(getProcAddr("glRectxvOES"))
 	gpReferencePlaneSGIX = (C.GPREFERENCEPLANESGIX)(getProcAddr("glReferencePlaneSGIX"))
+	gpReleaseKeyedMutexWin32EXT = (C.GPRELEASEKEYEDMUTEXWIN32EXT)(getProcAddr("glReleaseKeyedMutexWin32EXT"))
 	gpReleaseShaderCompiler = (C.GPRELEASESHADERCOMPILER)(getProcAddr("glReleaseShaderCompiler"))
 	if gpReleaseShaderCompiler == nil {
 		return errors.New("glReleaseShaderCompiler")
 	}
+	gpRenderGpuMaskNV = (C.GPRENDERGPUMASKNV)(getProcAddr("glRenderGpuMaskNV"))
 	gpRenderMode = (C.GPRENDERMODE)(getProcAddr("glRenderMode"))
 	if gpRenderMode == nil {
 		return errors.New("glRenderMode")
@@ -32398,6 +33939,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpResetMinmax = (C.GPRESETMINMAX)(getProcAddr("glResetMinmax"))
 	gpResetMinmaxEXT = (C.GPRESETMINMAXEXT)(getProcAddr("glResetMinmaxEXT"))
 	gpResizeBuffersMESA = (C.GPRESIZEBUFFERSMESA)(getProcAddr("glResizeBuffersMESA"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	if gpResumeTransformFeedback == nil {
 		return errors.New("glResumeTransformFeedback")
@@ -32417,7 +33959,6 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSampleCoverage")
 	}
 	gpSampleCoverageARB = (C.GPSAMPLECOVERAGEARB)(getProcAddr("glSampleCoverageARB"))
-	gpSampleCoverageOES = (C.GPSAMPLECOVERAGEOES)(getProcAddr("glSampleCoverageOES"))
 	gpSampleCoveragexOES = (C.GPSAMPLECOVERAGEXOES)(getProcAddr("glSampleCoveragexOES"))
 	gpSampleMapATI = (C.GPSAMPLEMAPATI)(getProcAddr("glSampleMapATI"))
 	gpSampleMaskEXT = (C.GPSAMPLEMASKEXT)(getProcAddr("glSampleMaskEXT"))
@@ -32580,6 +34121,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glSelectBuffer")
 	}
 	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
+	gpSemaphoreParameterui64vEXT = (C.GPSEMAPHOREPARAMETERUI64VEXT)(getProcAddr("glSemaphoreParameterui64vEXT"))
 	gpSeparableFilter2D = (C.GPSEPARABLEFILTER2D)(getProcAddr("glSeparableFilter2D"))
 	gpSeparableFilter2DEXT = (C.GPSEPARABLEFILTER2DEXT)(getProcAddr("glSeparableFilter2DEXT"))
 	gpSetFenceAPPLE = (C.GPSETFENCEAPPLE)(getProcAddr("glSetFenceAPPLE"))
@@ -32609,11 +34151,16 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glShaderStorageBlockBinding")
 	}
 	gpSharpenTexFuncSGIS = (C.GPSHARPENTEXFUNCSGIS)(getProcAddr("glSharpenTexFuncSGIS"))
+	gpSignalSemaphoreEXT = (C.GPSIGNALSEMAPHOREEXT)(getProcAddr("glSignalSemaphoreEXT"))
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
 	gpSpriteParameterfSGIX = (C.GPSPRITEPARAMETERFSGIX)(getProcAddr("glSpriteParameterfSGIX"))
 	gpSpriteParameterfvSGIX = (C.GPSPRITEPARAMETERFVSGIX)(getProcAddr("glSpriteParameterfvSGIX"))
 	gpSpriteParameteriSGIX = (C.GPSPRITEPARAMETERISGIX)(getProcAddr("glSpriteParameteriSGIX"))
 	gpSpriteParameterivSGIX = (C.GPSPRITEPARAMETERIVSGIX)(getProcAddr("glSpriteParameterivSGIX"))
 	gpStartInstrumentsSGIX = (C.GPSTARTINSTRUMENTSSGIX)(getProcAddr("glStartInstrumentsSGIX"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
 	gpStencilClearTagEXT = (C.GPSTENCILCLEARTAGEXT)(getProcAddr("glStencilClearTagEXT"))
 	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
 	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
@@ -32652,6 +34199,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
 	gpStopInstrumentsSGIX = (C.GPSTOPINSTRUMENTSSGIX)(getProcAddr("glStopInstrumentsSGIX"))
 	gpStringMarkerGREMEDY = (C.GPSTRINGMARKERGREMEDY)(getProcAddr("glStringMarkerGREMEDY"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpSwizzleEXT = (C.GPSWIZZLEEXT)(getProcAddr("glSwizzleEXT"))
 	gpSyncTextureINTEL = (C.GPSYNCTEXTUREINTEL)(getProcAddr("glSyncTextureINTEL"))
 	gpTagSampleBufferSGIX = (C.GPTAGSAMPLEBUFFERSGIX)(getProcAddr("glTagSampleBufferSGIX"))
@@ -33009,6 +34557,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpTexStorage3DMultisample == nil {
 		return errors.New("glTexStorage3DMultisample")
 	}
+	gpTexStorageMem1DEXT = (C.GPTEXSTORAGEMEM1DEXT)(getProcAddr("glTexStorageMem1DEXT"))
+	gpTexStorageMem2DEXT = (C.GPTEXSTORAGEMEM2DEXT)(getProcAddr("glTexStorageMem2DEXT"))
+	gpTexStorageMem2DMultisampleEXT = (C.GPTEXSTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem2DMultisampleEXT"))
+	gpTexStorageMem3DEXT = (C.GPTEXSTORAGEMEM3DEXT)(getProcAddr("glTexStorageMem3DEXT"))
+	gpTexStorageMem3DMultisampleEXT = (C.GPTEXSTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTexStorageMem3DMultisampleEXT"))
 	gpTexStorageSparseAMD = (C.GPTEXSTORAGESPARSEAMD)(getProcAddr("glTexStorageSparseAMD"))
 	gpTexSubImage1D = (C.GPTEXSUBIMAGE1D)(getProcAddr("glTexSubImage1D"))
 	if gpTexSubImage1D == nil {
@@ -33110,6 +34663,11 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glTextureStorage3DMultisample")
 	}
 	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
+	gpTextureStorageMem1DEXT = (C.GPTEXTURESTORAGEMEM1DEXT)(getProcAddr("glTextureStorageMem1DEXT"))
+	gpTextureStorageMem2DEXT = (C.GPTEXTURESTORAGEMEM2DEXT)(getProcAddr("glTextureStorageMem2DEXT"))
+	gpTextureStorageMem2DMultisampleEXT = (C.GPTEXTURESTORAGEMEM2DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem2DMultisampleEXT"))
+	gpTextureStorageMem3DEXT = (C.GPTEXTURESTORAGEMEM3DEXT)(getProcAddr("glTextureStorageMem3DEXT"))
+	gpTextureStorageMem3DMultisampleEXT = (C.GPTEXTURESTORAGEMEM3DMULTISAMPLEEXT)(getProcAddr("glTextureStorageMem3DMultisampleEXT"))
 	gpTextureStorageSparseAMD = (C.GPTEXTURESTORAGESPARSEAMD)(getProcAddr("glTextureStorageSparseAMD"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
 	if gpTextureSubImage1D == nil {
@@ -33179,7 +34737,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
 	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
 	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iARB = (C.GPUNIFORM1IARB)(getProcAddr("glUniform1iARB"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
@@ -33191,7 +34751,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
 	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
 	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiEXT = (C.GPUNIFORM1UIEXT)(getProcAddr("glUniform1uiEXT"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
@@ -33221,7 +34783,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
 	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
 	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iARB = (C.GPUNIFORM2IARB)(getProcAddr("glUniform2iARB"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
@@ -33233,7 +34797,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
 	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
 	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiEXT = (C.GPUNIFORM2UIEXT)(getProcAddr("glUniform2uiEXT"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
@@ -33263,7 +34829,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
 	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
 	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iARB = (C.GPUNIFORM3IARB)(getProcAddr("glUniform3iARB"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
@@ -33275,7 +34843,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
 	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
 	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiEXT = (C.GPUNIFORM3UIEXT)(getProcAddr("glUniform3uiEXT"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
@@ -33305,7 +34875,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
 	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
 	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iARB = (C.GPUNIFORM4IARB)(getProcAddr("glUniform4iARB"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
@@ -33317,7 +34889,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
 	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
 	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiEXT = (C.GPUNIFORM4UIEXT)(getProcAddr("glUniform4uiEXT"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
@@ -34197,10 +35771,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpViewportIndexedfv == nil {
 		return errors.New("glViewportIndexedfv")
 	}
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
+	gpWaitSemaphoreEXT = (C.GPWAITSEMAPHOREEXT)(getProcAddr("glWaitSemaphoreEXT"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
 	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
 	gpWeightPointerARB = (C.GPWEIGHTPOINTERARB)(getProcAddr("glWeightPointerARB"))
 	gpWeightbvARB = (C.GPWEIGHTBVARB)(getProcAddr("glWeightbvARB"))
@@ -34315,6 +35893,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpWindowPos4ivMESA = (C.GPWINDOWPOS4IVMESA)(getProcAddr("glWindowPos4ivMESA"))
 	gpWindowPos4sMESA = (C.GPWINDOWPOS4SMESA)(getProcAddr("glWindowPos4sMESA"))
 	gpWindowPos4svMESA = (C.GPWINDOWPOS4SVMESA)(getProcAddr("glWindowPos4svMESA"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	gpWriteMaskEXT = (C.GPWRITEMASKEXT)(getProcAddr("glWriteMaskEXT"))
 	return nil
 }

--- a/v4.5-compatibility/gl/procaddr.go
+++ b/v4.5-compatibility/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcompatibility45(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */

--- a/v4.5-core/gl/package.go
+++ b/v4.5-core/gl/package.go
@@ -12,8 +12,6 @@
 // This package was automatically generated using Glow:
 //  http://github.com/go-gl/glow
 //
-// Generated based on the OpenGL XML specification:
-//  SVN revision 27695
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
@@ -89,21 +87,29 @@ package gl
 // typedef ptrdiff_t GLsizeiptr;
 // typedef int64_t GLint64;
 // typedef uint64_t GLuint64;
+// typedef int64_t GLint64EXT;
 // typedef uint64_t GLuint64EXT;
-// typedef struct __GLsync *GLsync;
+// typedef uintptr_t GLsync;
 // struct _cl_context;
 // struct _cl_event;
 // typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCARB)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
 // typedef void (APIENTRY *GLDEBUGPROCKHR)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
+// typedef void (APIENTRY *GLVULKANPROCNV)(void);
 // extern void glowDebugCallback_glcore45(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 // static void APIENTRY glowCDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
 //   glowDebugCallback_glcore45(source, type, id, severity, length, message, userParam);
 // }
+// typedef void  (APIENTRYP GPACTIVEPROGRAMEXT)(GLuint  program);
 // typedef void  (APIENTRYP GPACTIVESHADERPROGRAM)(GLuint  pipeline, GLuint  program);
+// typedef void  (APIENTRYP GPACTIVESHADERPROGRAMEXT)(GLuint  pipeline, GLuint  program);
 // typedef void  (APIENTRYP GPACTIVETEXTURE)(GLenum  texture);
+// typedef void  (APIENTRYP GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)();
 // typedef void  (APIENTRYP GPATTACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPBEGINCONDITIONALRENDER)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINCONDITIONALRENDERNV)(GLuint  id, GLenum  mode);
+// typedef void  (APIENTRYP GPBEGINPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPBEGINPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPBEGINQUERY)(GLenum  target, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINQUERYINDEXED)(GLenum  target, GLuint  index, GLuint  id);
 // typedef void  (APIENTRYP GPBEGINTRANSFORMFEEDBACK)(GLenum  primitiveMode);
@@ -118,7 +124,9 @@ package gl
 // typedef void  (APIENTRYP GPBINDFRAMEBUFFER)(GLenum  target, GLuint  framebuffer);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURE)(GLuint  unit, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  access, GLenum  format);
 // typedef void  (APIENTRYP GPBINDIMAGETEXTURES)(GLuint  first, GLsizei  count, const GLuint * textures);
+// typedef void  (APIENTRYP GPBINDMULTITEXTUREEXT)(GLenum  texunit, GLenum  target, GLuint  texture);
 // typedef void  (APIENTRYP GPBINDPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPBINDPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPBINDRENDERBUFFER)(GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPBINDSAMPLER)(GLuint  unit, GLuint  sampler);
 // typedef void  (APIENTRYP GPBINDSAMPLERS)(GLuint  first, GLsizei  count, const GLuint * samplers);
@@ -129,6 +137,8 @@ package gl
 // typedef void  (APIENTRYP GPBINDVERTEXARRAY)(GLuint  array);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFER)(GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPBINDVERTEXBUFFERS)(GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPBLENDBARRIERKHR)();
+// typedef void  (APIENTRYP GPBLENDBARRIERNV)();
 // typedef void  (APIENTRYP GPBLENDCOLOR)(GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha);
 // typedef void  (APIENTRYP GPBLENDEQUATION)(GLenum  mode);
 // typedef void  (APIENTRYP GPBLENDEQUATIONSEPARATE)(GLenum  modeRGB, GLenum  modeAlpha);
@@ -142,14 +152,18 @@ package gl
 // typedef void  (APIENTRYP GPBLENDFUNCSEPARATEIARB)(GLuint  buf, GLenum  srcRGB, GLenum  dstRGB, GLenum  srcAlpha, GLenum  dstAlpha);
 // typedef void  (APIENTRYP GPBLENDFUNCI)(GLuint  buf, GLenum  src, GLenum  dst);
 // typedef void  (APIENTRYP GPBLENDFUNCIARB)(GLuint  buf, GLenum  src, GLenum  dst);
+// typedef void  (APIENTRYP GPBLENDPARAMETERINV)(GLenum  pname, GLint  value);
 // typedef void  (APIENTRYP GPBLITFRAMEBUFFER)(GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
 // typedef void  (APIENTRYP GPBLITNAMEDFRAMEBUFFER)(GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter);
+// typedef void  (APIENTRYP GPBUFFERADDRESSRANGENV)(GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPBUFFERDATA)(GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPBUFFERPAGECOMMITMENTARB)(GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
 // typedef void  (APIENTRYP GPBUFFERSTORAGE)(GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags);
 // typedef void  (APIENTRYP GPBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPCALLCOMMANDLISTNV)(GLuint  list);
 // typedef GLenum  (APIENTRYP GPCHECKFRAMEBUFFERSTATUS)(GLenum  target);
 // typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUS)(GLuint  framebuffer, GLenum  target);
+// typedef GLenum  (APIENTRYP GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(GLuint  framebuffer, GLenum  target);
 // typedef void  (APIENTRYP GPCLAMPCOLOR)(GLenum  target, GLenum  clamp);
 // typedef void  (APIENTRYP GPCLEAR)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPCLEARBUFFERDATA)(GLenum  target, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
@@ -162,49 +176,91 @@ package gl
 // typedef void  (APIENTRYP GPCLEARDEPTH)(GLdouble  depth);
 // typedef void  (APIENTRYP GPCLEARDEPTHF)(GLfloat  d);
 // typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATA)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data);
-// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERDATAEXT)(GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATA)(GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFI)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERFV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLint * value);
 // typedef void  (APIENTRYP GPCLEARNAMEDFRAMEBUFFERUIV)(GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLuint * value);
 // typedef void  (APIENTRYP GPCLEARSTENCIL)(GLint  s);
 // typedef void  (APIENTRYP GPCLEARTEXIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, const void * data);
 // typedef void  (APIENTRYP GPCLEARTEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data);
+// typedef void  (APIENTRYP GPCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef GLenum  (APIENTRYP GPCLIENTWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
 // typedef void  (APIENTRYP GPCLIPCONTROL)(GLenum  origin, GLenum  depth);
+// typedef void  (APIENTRYP GPCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPCOLORMASK)(GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha);
 // typedef void  (APIENTRYP GPCOLORMASKI)(GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a);
+// typedef void  (APIENTRYP GPCOMMANDLISTSEGMENTSNV)(GLuint  list, GLuint  segments);
+// typedef void  (APIENTRYP GPCOMPILECOMMANDLISTNV)(GLuint  list);
 // typedef void  (APIENTRYP GPCOMPILESHADER)(GLuint  shader);
 // typedef void  (APIENTRYP GPCOMPILESHADERINCLUDEARB)(GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXIMAGE3D)(GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits);
 // typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data);
+// typedef void  (APIENTRYP GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERFNV)(GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPCONSERVATIVERASTERPARAMETERINV)(GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPCOPYBUFFERSUBDATA)(GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPCOPYIMAGESUBDATA)(GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth);
-// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYNAMEDBUFFERSUBDATA)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPCOPYPATHNV)(GLuint  resultPath, GLuint  srcPath);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE1D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXIMAGE2D)(GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE1D)(GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border);
+// typedef void  (APIENTRYP GPCOPYTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOPYTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERFILLPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPCOVERSTROKEPATHNV)(GLuint  path, GLenum  coverMode);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONNV)(GLenum  components);
+// typedef void  (APIENTRYP GPCOVERAGEMODULATIONTABLENV)(GLsizei  n, const GLfloat * v);
 // typedef void  (APIENTRYP GPCREATEBUFFERS)(GLsizei  n, GLuint * buffers);
+// typedef void  (APIENTRYP GPCREATECOMMANDLISTSNV)(GLsizei  n, GLuint * lists);
 // typedef void  (APIENTRYP GPCREATEFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef void  (APIENTRYP GPCREATEPERFQUERYINTEL)(GLuint  queryId, GLuint * queryHandle);
 // typedef GLuint  (APIENTRYP GPCREATEPROGRAM)();
 // typedef void  (APIENTRYP GPCREATEPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPCREATEQUERIES)(GLenum  target, GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPCREATERENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPCREATESAMPLERS)(GLsizei  n, GLuint * samplers);
 // typedef GLuint  (APIENTRYP GPCREATESHADER)(GLenum  type);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMEXT)(GLenum  type, const GLchar * string);
 // typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMV)(GLenum  type, GLsizei  count, const GLchar *const* strings);
+// typedef GLuint  (APIENTRYP GPCREATESHADERPROGRAMVEXT)(GLenum  type, GLsizei  count, const GLchar ** strings);
+// typedef void  (APIENTRYP GPCREATESTATESNV)(GLsizei  n, GLuint * states);
 // typedef GLsync  (APIENTRYP GPCREATESYNCFROMCLEVENTARB)(struct _cl_context * context, struct _cl_event * event, GLbitfield  flags);
 // typedef void  (APIENTRYP GPCREATETEXTURES)(GLenum  target, GLsizei  n, GLuint * textures);
 // typedef void  (APIENTRYP GPCREATETRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
@@ -220,14 +276,20 @@ package gl
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTARB)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDEBUGMESSAGEINSERTKHR)(GLenum  source, GLenum  type, GLuint  id, GLenum  severity, GLsizei  length, const GLchar * buf);
 // typedef void  (APIENTRYP GPDELETEBUFFERS)(GLsizei  n, const GLuint * buffers);
+// typedef void  (APIENTRYP GPDELETECOMMANDLISTSNV)(GLsizei  n, const GLuint * lists);
 // typedef void  (APIENTRYP GPDELETEFRAMEBUFFERS)(GLsizei  n, const GLuint * framebuffers);
 // typedef void  (APIENTRYP GPDELETENAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef void  (APIENTRYP GPDELETEPATHSNV)(GLuint  path, GLsizei  range);
+// typedef void  (APIENTRYP GPDELETEPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
+// typedef void  (APIENTRYP GPDELETEPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPDELETEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINES)(GLsizei  n, const GLuint * pipelines);
+// typedef void  (APIENTRYP GPDELETEPROGRAMPIPELINESEXT)(GLsizei  n, const GLuint * pipelines);
 // typedef void  (APIENTRYP GPDELETEQUERIES)(GLsizei  n, const GLuint * ids);
 // typedef void  (APIENTRYP GPDELETERENDERBUFFERS)(GLsizei  n, const GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPDELETESAMPLERS)(GLsizei  count, const GLuint * samplers);
 // typedef void  (APIENTRYP GPDELETESHADER)(GLuint  shader);
+// typedef void  (APIENTRYP GPDELETESTATESNV)(GLsizei  n, const GLuint * states);
 // typedef void  (APIENTRYP GPDELETESYNC)(GLsync  sync);
 // typedef void  (APIENTRYP GPDELETETEXTURES)(GLsizei  n, const GLuint * textures);
 // typedef void  (APIENTRYP GPDELETETRANSFORMFEEDBACKS)(GLsizei  n, const GLuint * ids);
@@ -240,7 +302,12 @@ package gl
 // typedef void  (APIENTRYP GPDEPTHRANGEF)(GLfloat  n, GLfloat  f);
 // typedef void  (APIENTRYP GPDETACHSHADER)(GLuint  program, GLuint  shader);
 // typedef void  (APIENTRYP GPDISABLE)(GLenum  cap);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPDISABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPDISABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPDISABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPDISPATCHCOMPUTE)(GLuint  num_groups_x, GLuint  num_groups_y, GLuint  num_groups_z);
@@ -249,46 +316,81 @@ package gl
 // typedef void  (APIENTRYP GPDRAWARRAYS)(GLenum  mode, GLint  first, GLsizei  count);
 // typedef void  (APIENTRYP GPDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCED)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDARB)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDBASEINSTANCE)(GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWARRAYSINSTANCEDEXT)(GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWBUFFER)(GLenum  buf);
 // typedef void  (APIENTRYP GPDRAWBUFFERS)(GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSADDRESSNV)(GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSNV)(GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESADDRESSNV)(const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
+// typedef void  (APIENTRYP GPDRAWCOMMANDSSTATESNV)(GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPDRAWELEMENTS)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWELEMENTSBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCED)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDARB)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEX)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance);
+// typedef void  (APIENTRYP GPDRAWELEMENTSINSTANCEDEXT)(GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTS)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices);
 // typedef void  (APIENTRYP GPDRAWRANGEELEMENTSBASEVERTEX)(GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices, GLint  basevertex);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACK)(GLenum  mode, GLuint  id);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKINSTANCED)(GLenum  mode, GLuint  id, GLsizei  instancecount);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAM)(GLenum  mode, GLuint  id, GLuint  stream);
 // typedef void  (APIENTRYP GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED)(GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount);
+// typedef void  (APIENTRYP GPDRAWVKIMAGENV)(GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1);
+// typedef void  (APIENTRYP GPEDGEFLAGFORMATNV)(GLsizei  stride);
 // typedef void  (APIENTRYP GPENABLE)(GLenum  cap);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEINDEXEDEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLECLIENTSTATEIEXT)(GLenum  array, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIB)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYATTRIBEXT)(GLuint  vaobj, GLuint  index);
+// typedef void  (APIENTRYP GPENABLEVERTEXARRAYEXT)(GLuint  vaobj, GLenum  array);
 // typedef void  (APIENTRYP GPENABLEVERTEXATTRIBARRAY)(GLuint  index);
 // typedef void  (APIENTRYP GPENABLEI)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDCONDITIONALRENDER)();
+// typedef void  (APIENTRYP GPENDCONDITIONALRENDERNV)();
+// typedef void  (APIENTRYP GPENDPERFMONITORAMD)(GLuint  monitor);
+// typedef void  (APIENTRYP GPENDPERFQUERYINTEL)(GLuint  queryHandle);
 // typedef void  (APIENTRYP GPENDQUERY)(GLenum  target);
 // typedef void  (APIENTRYP GPENDQUERYINDEXED)(GLenum  target, GLuint  index);
 // typedef void  (APIENTRYP GPENDTRANSFORMFEEDBACK)();
+// typedef void  (APIENTRYP GPEVALUATEDEPTHVALUESARB)();
 // typedef GLsync  (APIENTRYP GPFENCESYNC)(GLenum  condition, GLbitfield  flags);
 // typedef void  (APIENTRYP GPFINISH)();
 // typedef void  (APIENTRYP GPFLUSH)();
 // typedef void  (APIENTRYP GPFLUSHMAPPEDBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length);
-// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
+// typedef void  (APIENTRYP GPFOGCOORDFORMATNV)(GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPFRAGMENTCOVERAGECOLORNV)(GLuint  color);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
+// typedef void  (APIENTRYP GPFRAMEBUFFERDRAWBUFFERSEXT)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
+// typedef void  (APIENTRYP GPFRAMEBUFFERFETCHBARRIEREXT)();
 // typedef void  (APIENTRYP GPFRAMEBUFFERPARAMETERI)(GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPFRAMEBUFFERREADBUFFEREXT)(GLuint  framebuffer, GLenum  mode);
 // typedef void  (APIENTRYP GPFRAMEBUFFERRENDERBUFFER)(GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE1D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE2D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURE3D)(GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREFACEARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYER)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTURELAYERARB)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews);
 // typedef void  (APIENTRYP GPFRONTFACE)(GLenum  mode);
 // typedef void  (APIENTRYP GPGENBUFFERS)(GLsizei  n, GLuint * buffers);
 // typedef void  (APIENTRYP GPGENFRAMEBUFFERS)(GLsizei  n, GLuint * framebuffers);
+// typedef GLuint  (APIENTRYP GPGENPATHSNV)(GLsizei  range);
+// typedef void  (APIENTRYP GPGENPERFMONITORSAMD)(GLsizei  n, GLuint * monitors);
 // typedef void  (APIENTRYP GPGENPROGRAMPIPELINES)(GLsizei  n, GLuint * pipelines);
+// typedef void  (APIENTRYP GPGENPROGRAMPIPELINESEXT)(GLsizei  n, GLuint * pipelines);
 // typedef void  (APIENTRYP GPGENQUERIES)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENRENDERBUFFERS)(GLsizei  n, GLuint * renderbuffers);
 // typedef void  (APIENTRYP GPGENSAMPLERS)(GLsizei  count, GLuint * samplers);
@@ -296,7 +398,9 @@ package gl
 // typedef void  (APIENTRYP GPGENTRANSFORMFEEDBACKS)(GLsizei  n, GLuint * ids);
 // typedef void  (APIENTRYP GPGENVERTEXARRAYS)(GLsizei  n, GLuint * arrays);
 // typedef void  (APIENTRYP GPGENERATEMIPMAP)(GLenum  target);
+// typedef void  (APIENTRYP GPGENERATEMULTITEXMIPMAPEXT)(GLenum  texunit, GLenum  target);
 // typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAP)(GLuint  texture);
+// typedef void  (APIENTRYP GPGENERATETEXTUREMIPMAPEXT)(GLuint  texture, GLenum  target);
 // typedef void  (APIENTRYP GPGETACTIVEATOMICCOUNTERBUFFERIV)(GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETACTIVEATTRIB)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLint * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETACTIVESUBROUTINENAME)(GLuint  program, GLenum  shadertype, GLuint  index, GLsizei  bufsize, GLsizei * length, GLchar * name);
@@ -309,65 +413,137 @@ package gl
 // typedef void  (APIENTRYP GPGETACTIVEUNIFORMSIV)(GLuint  program, GLsizei  uniformCount, const GLuint * uniformIndices, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETATTACHEDSHADERS)(GLuint  program, GLsizei  maxCount, GLsizei * count, GLuint * shaders);
 // typedef GLint  (APIENTRYP GPGETATTRIBLOCATION)(GLuint  program, const GLchar * name);
+// typedef void  (APIENTRYP GPGETBOOLEANINDEXEDVEXT)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANI_V)(GLenum  target, GLuint  index, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBOOLEANV)(GLenum  pname, GLboolean * data);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERI64V)(GLenum  target, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETBUFFERPARAMETERUI64VNV)(GLenum  target, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETBUFFERPOINTERV)(GLenum  target, GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETBUFFERSUBDATA)(GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef GLuint  (APIENTRYP GPGETCOMMANDHEADERNV)(GLenum  tokenID, GLuint  size);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  level, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGE)(GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  lod, void * img);
 // typedef void  (APIENTRYP GPGETCOMPRESSEDTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETCOVERAGEMODULATIONTABLENV)(GLsizei  bufsize, GLfloat * v);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOG)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGARB)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
 // typedef GLuint  (APIENTRYP GPGETDEBUGMESSAGELOGKHR)(GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog);
+// typedef void  (APIENTRYP GPGETDOUBLEINDEXEDVEXT)(GLenum  target, GLuint  index, GLdouble * data);
 // typedef void  (APIENTRYP GPGETDOUBLEI_V)(GLenum  target, GLuint  index, GLdouble * data);
+// typedef void  (APIENTRYP GPGETDOUBLEI_VEXT)(GLenum  pname, GLuint  index, GLdouble * params);
 // typedef void  (APIENTRYP GPGETDOUBLEV)(GLenum  pname, GLdouble * data);
 // typedef GLenum  (APIENTRYP GPGETERROR)();
+// typedef void  (APIENTRYP GPGETFIRSTPERFQUERYIDINTEL)(GLuint * queryId);
+// typedef void  (APIENTRYP GPGETFLOATINDEXEDVEXT)(GLenum  target, GLuint  index, GLfloat * data);
 // typedef void  (APIENTRYP GPGETFLOATI_V)(GLenum  target, GLuint  index, GLfloat * data);
+// typedef void  (APIENTRYP GPGETFLOATI_VEXT)(GLenum  pname, GLuint  index, GLfloat * params);
 // typedef void  (APIENTRYP GPGETFLOATV)(GLenum  pname, GLfloat * data);
 // typedef GLint  (APIENTRYP GPGETFRAGDATAINDEX)(GLuint  program, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETFRAGDATALOCATION)(GLuint  program, const GLchar * name);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERATTACHMENTPARAMETERIV)(GLenum  target, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUS)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSARB)();
 // typedef GLenum  (APIENTRYP GPGETGRAPHICSRESETSTATUSKHR)();
 // typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLEARB)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
+// typedef GLuint64  (APIENTRYP GPGETIMAGEHANDLENV)(GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format);
 // typedef void  (APIENTRYP GPGETINTEGER64I_V)(GLenum  target, GLuint  index, GLint64 * data);
 // typedef void  (APIENTRYP GPGETINTEGER64V)(GLenum  pname, GLint64 * data);
+// typedef void  (APIENTRYP GPGETINTEGERINDEXEDVEXT)(GLenum  target, GLuint  index, GLint * data);
 // typedef void  (APIENTRYP GPGETINTEGERI_V)(GLenum  target, GLuint  index, GLint * data);
+// typedef void  (APIENTRYP GPGETINTEGERUI64I_VNV)(GLenum  value, GLuint  index, GLuint64EXT * result);
+// typedef void  (APIENTRYP GPGETINTEGERUI64VNV)(GLenum  value, GLuint64EXT * result);
 // typedef void  (APIENTRYP GPGETINTEGERV)(GLenum  pname, GLint * data);
+// typedef void  (APIENTRYP GPGETINTERNALFORMATSAMPLEIVNV)(GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATI64V)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETINTERNALFORMATIV)(GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXIMAGEEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXLEVELPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETMULTISAMPLEFV)(GLenum  pname, GLuint  index, GLfloat * val);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERI64V)(GLuint  buffer, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIV)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERIVEXT)(GLuint  buffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPARAMETERUI64VNV)(GLuint  buffer, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERV)(GLuint  buffer, GLenum  pname, void ** params);
-// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERPOINTERVEXT)(GLuint  buffer, GLenum  pname, void ** params);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
+// typedef void  (APIENTRYP GPGETNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIV)(GLuint  framebuffer, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(GLuint  framebuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  pname, void * string);
+// typedef void  (APIENTRYP GPGETNAMEDPROGRAMIVEXT)(GLuint  program, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIV)(GLuint  renderbuffer, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(GLuint  renderbuffer, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGARB)(GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string);
 // typedef void  (APIENTRYP GPGETNAMEDSTRINGIVARB)(GLint  namelen, const GLchar * name, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETNEXTPERFQUERYIDINTEL)(GLuint  queryId, GLuint * nextQueryId);
 // typedef void  (APIENTRYP GPGETOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETOBJECTLABELEXT)(GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABEL)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
 // typedef void  (APIENTRYP GPGETOBJECTPTRLABELKHR)(const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label);
+// typedef void  (APIENTRYP GPGETPATHCOMMANDSNV)(GLuint  path, GLubyte * commands);
+// typedef void  (APIENTRYP GPGETPATHCOORDSNV)(GLuint  path, GLfloat * coords);
+// typedef void  (APIENTRYP GPGETPATHDASHARRAYNV)(GLuint  path, GLfloat * dashArray);
+// typedef GLfloat  (APIENTRYP GPGETPATHLENGTHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments);
+// typedef void  (APIENTRYP GPGETPATHMETRICRANGENV)(GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHMETRICSNV)(GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, GLfloat * value);
+// typedef void  (APIENTRYP GPGETPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, GLint * value);
+// typedef void  (APIENTRYP GPGETPATHSPACINGNV)(GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing);
+// typedef void  (APIENTRYP GPGETPERFCOUNTERINFOINTEL)(GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERDATAAMD)(GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERINFOAMD)(GLuint  group, GLuint  counter, GLenum  pname, void * data);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSTRINGAMD)(GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString);
+// typedef void  (APIENTRYP GPGETPERFMONITORCOUNTERSAMD)(GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSTRINGAMD)(GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString);
+// typedef void  (APIENTRYP GPGETPERFMONITORGROUPSAMD)(GLint * numGroups, GLsizei  groupsSize, GLuint * groups);
+// typedef void  (APIENTRYP GPGETPERFQUERYDATAINTEL)(GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten);
+// typedef void  (APIENTRYP GPGETPERFQUERYIDBYNAMEINTEL)(GLchar * queryName, GLuint * queryId);
+// typedef void  (APIENTRYP GPGETPERFQUERYINFOINTEL)(GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask);
+// typedef void  (APIENTRYP GPGETPOINTERINDEXEDVEXT)(GLenum  target, GLuint  index, void ** data);
+// typedef void  (APIENTRYP GPGETPOINTERI_VEXT)(GLenum  pname, GLuint  index, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERV)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPOINTERVKHR)(GLenum  pname, void ** params);
 // typedef void  (APIENTRYP GPGETPROGRAMBINARY)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLenum * binaryFormat, void * binary);
 // typedef void  (APIENTRYP GPGETPROGRAMINFOLOG)(GLuint  program, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMINTERFACEIV)(GLuint  program, GLenum  programInterface, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOG)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEINFOLOGEXT)(GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog);
 // typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIV)(GLuint  pipeline, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETPROGRAMPIPELINEIVEXT)(GLuint  pipeline, GLenum  pname, GLint * params);
 // typedef GLuint  (APIENTRYP GPGETPROGRAMRESOURCEINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATION)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef GLint  (APIENTRYP GPGETPROGRAMRESOURCELOCATIONINDEX)(GLuint  program, GLenum  programInterface, const GLchar * name);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCENAME)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name);
+// typedef void  (APIENTRYP GPGETPROGRAMRESOURCEFVNV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params);
 // typedef void  (APIENTRYP GPGETPROGRAMRESOURCEIV)(GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params);
 // typedef void  (APIENTRYP GPGETPROGRAMSTAGEIV)(GLuint  program, GLenum  shadertype, GLenum  pname, GLint * values);
 // typedef void  (APIENTRYP GPGETPROGRAMIV)(GLuint  program, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUI64V)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
+// typedef void  (APIENTRYP GPGETQUERYBUFFEROBJECTUIV)(GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset);
 // typedef void  (APIENTRYP GPGETQUERYINDEXEDIV)(GLenum  target, GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTI64V)(GLuint  id, GLenum  pname, GLint64 * params);
 // typedef void  (APIENTRYP GPGETQUERYOBJECTIV)(GLuint  id, GLenum  pname, GLint * params);
@@ -383,6 +559,7 @@ package gl
 // typedef void  (APIENTRYP GPGETSHADERPRECISIONFORMAT)(GLenum  shadertype, GLenum  precisiontype, GLint * range, GLint * precision);
 // typedef void  (APIENTRYP GPGETSHADERSOURCE)(GLuint  shader, GLsizei  bufSize, GLsizei * length, GLchar * source);
 // typedef void  (APIENTRYP GPGETSHADERIV)(GLuint  shader, GLenum  pname, GLint * params);
+// typedef GLushort  (APIENTRYP GPGETSTAGEINDEXNV)(GLenum  shadertype);
 // typedef const GLubyte * (APIENTRYP GPGETSTRING)(GLenum  name);
 // typedef const GLubyte * (APIENTRYP GPGETSTRINGI)(GLenum  name, GLuint  index);
 // typedef GLuint  (APIENTRYP GPGETSUBROUTINEINDEX)(GLuint  program, GLenum  shadertype, const GLchar * name);
@@ -396,14 +573,23 @@ package gl
 // typedef void  (APIENTRYP GPGETTEXPARAMETERFV)(GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXPARAMETERIV)(GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLEARB)(GLuint  texture);
+// typedef GLuint64  (APIENTRYP GPGETTEXTUREHANDLENV)(GLuint  texture);
 // typedef void  (APIENTRYP GPGETTEXTUREIMAGE)(GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
+// typedef void  (APIENTRYP GPGETTEXTUREIMAGEEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFV)(GLuint  texture, GLint  level, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIV)(GLuint  texture, GLint  level, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTURELEVELPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, GLuint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, GLfloat * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, GLint * params);
+// typedef void  (APIENTRYP GPGETTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint * params);
 // typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLEARB)(GLuint  texture, GLuint  sampler);
+// typedef GLuint64  (APIENTRYP GPGETTEXTURESAMPLERHANDLENV)(GLuint  texture, GLuint  sampler);
 // typedef void  (APIENTRYP GPGETTEXTURESUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKVARYING)(GLuint  program, GLuint  index, GLsizei  bufSize, GLsizei * length, GLsizei * size, GLenum * type, GLchar * name);
 // typedef void  (APIENTRYP GPGETTRANSFORMFEEDBACKI64_V)(GLuint  xfb, GLenum  pname, GLuint  index, GLint64 * param);
@@ -415,19 +601,30 @@ package gl
 // typedef void  (APIENTRYP GPGETUNIFORMSUBROUTINEUIV)(GLenum  shadertype, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETUNIFORMDV)(GLuint  program, GLint  location, GLdouble * params);
 // typedef void  (APIENTRYP GPGETUNIFORMFV)(GLuint  program, GLint  location, GLfloat * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VARB)(GLuint  program, GLint  location, GLint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMI64VNV)(GLuint  program, GLint  location, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMIV)(GLuint  program, GLint  location, GLint * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VARB)(GLuint  program, GLint  location, GLuint64 * params);
+// typedef void  (APIENTRYP GPGETUNIFORMUI64VNV)(GLuint  program, GLint  location, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETUNIFORMUIV)(GLuint  program, GLint  location, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXED64IV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint64 * param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYINDEXEDIV)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYINTEGERVEXT)(GLuint  vaobj, GLenum  pname, GLint * param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERI_VEXT)(GLuint  vaobj, GLuint  index, GLenum  pname, void ** param);
+// typedef void  (APIENTRYP GPGETVERTEXARRAYPOINTERVEXT)(GLuint  vaobj, GLenum  pname, void ** param);
 // typedef void  (APIENTRYP GPGETVERTEXARRAYIV)(GLuint  vaobj, GLenum  pname, GLint * param);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIIV)(GLuint  index, GLenum  pname, GLint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIUIV)(GLuint  index, GLenum  pname, GLuint * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLDV)(GLuint  index, GLenum  pname, GLdouble * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLI64VNV)(GLuint  index, GLenum  pname, GLint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VARB)(GLuint  index, GLenum  pname, GLuint64EXT * params);
+// typedef void  (APIENTRYP GPGETVERTEXATTRIBLUI64VNV)(GLuint  index, GLenum  pname, GLuint64EXT * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBPOINTERV)(GLuint  index, GLenum  pname, void ** pointer);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBDV)(GLuint  index, GLenum  pname, GLdouble * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBFV)(GLuint  index, GLenum  pname, GLfloat * params);
 // typedef void  (APIENTRYP GPGETVERTEXATTRIBIV)(GLuint  index, GLenum  pname, GLint * params);
+// typedef GLVULKANPROCNV  (APIENTRYP GPGETVKPROCADDRNV)(const GLchar * name);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGE)(GLenum  target, GLint  lod, GLsizei  bufSize, void * pixels);
 // typedef void  (APIENTRYP GPGETNCOMPRESSEDTEXIMAGEARB)(GLenum  target, GLint  lod, GLsizei  bufSize, void * img);
 // typedef void  (APIENTRYP GPGETNTEXIMAGE)(GLenum  target, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels);
@@ -437,13 +634,18 @@ package gl
 // typedef void  (APIENTRYP GPGETNUNIFORMFV)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMFVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLint * params);
+// typedef void  (APIENTRYP GPGETNUNIFORMUI64VARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIV)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVARB)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPGETNUNIFORMUIVKHR)(GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params);
 // typedef void  (APIENTRYP GPHINT)(GLenum  target, GLenum  mode);
+// typedef void  (APIENTRYP GPINDEXFORMATNV)(GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPINSERTEVENTMARKEREXT)(GLsizei  length, const GLchar * marker);
+// typedef void  (APIENTRYP GPINTERPOLATEPATHSNV)(GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERDATA)(GLuint  buffer);
 // typedef void  (APIENTRYP GPINVALIDATEBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length);
 // typedef void  (APIENTRYP GPINVALIDATEFRAMEBUFFER)(GLenum  target, GLsizei  numAttachments, const GLenum * attachments);
@@ -453,68 +655,196 @@ package gl
 // typedef void  (APIENTRYP GPINVALIDATETEXIMAGE)(GLuint  texture, GLint  level);
 // typedef void  (APIENTRYP GPINVALIDATETEXSUBIMAGE)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef GLboolean  (APIENTRYP GPISBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPISBUFFERRESIDENTNV)(GLenum  target);
+// typedef GLboolean  (APIENTRYP GPISCOMMANDLISTNV)(GLuint  list);
 // typedef GLboolean  (APIENTRYP GPISENABLED)(GLenum  cap);
+// typedef GLboolean  (APIENTRYP GPISENABLEDINDEXEDEXT)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISENABLEDI)(GLenum  target, GLuint  index);
 // typedef GLboolean  (APIENTRYP GPISFRAMEBUFFER)(GLuint  framebuffer);
 // typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISIMAGEHANDLERESIDENTNV)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISNAMEDBUFFERRESIDENTNV)(GLuint  buffer);
 // typedef GLboolean  (APIENTRYP GPISNAMEDSTRINGARB)(GLint  namelen, const GLchar * name);
+// typedef GLboolean  (APIENTRYP GPISPATHNV)(GLuint  path);
+// typedef GLboolean  (APIENTRYP GPISPOINTINFILLPATHNV)(GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y);
+// typedef GLboolean  (APIENTRYP GPISPOINTINSTROKEPATHNV)(GLuint  path, GLfloat  x, GLfloat  y);
 // typedef GLboolean  (APIENTRYP GPISPROGRAM)(GLuint  program);
 // typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef GLboolean  (APIENTRYP GPISPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef GLboolean  (APIENTRYP GPISQUERY)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISRENDERBUFFER)(GLuint  renderbuffer);
 // typedef GLboolean  (APIENTRYP GPISSAMPLER)(GLuint  sampler);
 // typedef GLboolean  (APIENTRYP GPISSHADER)(GLuint  shader);
+// typedef GLboolean  (APIENTRYP GPISSTATENV)(GLuint  state);
 // typedef GLboolean  (APIENTRYP GPISSYNC)(GLsync  sync);
 // typedef GLboolean  (APIENTRYP GPISTEXTURE)(GLuint  texture);
 // typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef GLboolean  (APIENTRYP GPISTEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef GLboolean  (APIENTRYP GPISTRANSFORMFEEDBACK)(GLuint  id);
 // typedef GLboolean  (APIENTRYP GPISVERTEXARRAY)(GLuint  array);
+// typedef void  (APIENTRYP GPLABELOBJECTEXT)(GLenum  type, GLuint  object, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPLINEWIDTH)(GLfloat  width);
 // typedef void  (APIENTRYP GPLINKPROGRAM)(GLuint  program);
+// typedef void  (APIENTRYP GPLISTDRAWCOMMANDSSTATESCLIENTNV)(GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count);
 // typedef void  (APIENTRYP GPLOGICOP)(GLenum  opcode);
+// typedef void  (APIENTRYP GPMAKEBUFFERNONRESIDENTNV)(GLenum  target);
+// typedef void  (APIENTRYP GPMAKEBUFFERRESIDENTNV)(GLenum  target, GLenum  access);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTARB)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKEIMAGEHANDLERESIDENTNV)(GLuint64  handle, GLenum  access);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERNONRESIDENTNV)(GLuint  buffer);
+// typedef void  (APIENTRYP GPMAKENAMEDBUFFERRESIDENTNV)(GLuint  buffer, GLenum  access);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLENONRESIDENTNV)(GLuint64  handle);
 // typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTARB)(GLuint64  handle);
+// typedef void  (APIENTRYP GPMAKETEXTUREHANDLERESIDENTNV)(GLuint64  handle);
 // typedef void * (APIENTRYP GPMAPBUFFER)(GLenum  target, GLenum  access);
 // typedef void * (APIENTRYP GPMAPBUFFERRANGE)(GLenum  target, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
 // typedef void * (APIENTRYP GPMAPNAMEDBUFFER)(GLuint  buffer, GLenum  access);
-// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFEREXT)(GLuint  buffer, GLenum  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGE)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void * (APIENTRYP GPMAPNAMEDBUFFERRANGEEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access);
+// typedef void  (APIENTRYP GPMATRIXFRUSTUMEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOAD3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADIDENTITYEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXLOADDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXLOADFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X2FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULT3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSE3X3FNV)(GLenum  matrixMode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTTRANSPOSEFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXMULTDEXT)(GLenum  mode, const GLdouble * m);
+// typedef void  (APIENTRYP GPMATRIXMULTFEXT)(GLenum  mode, const GLfloat * m);
+// typedef void  (APIENTRYP GPMATRIXORTHOEXT)(GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar);
+// typedef void  (APIENTRYP GPMATRIXPOPEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXPUSHEXT)(GLenum  mode);
+// typedef void  (APIENTRYP GPMATRIXROTATEDEXT)(GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXROTATEFEXT)(GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXSCALEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEDEXT)(GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z);
+// typedef void  (APIENTRYP GPMATRIXTRANSLATEFEXT)(GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSARB)(GLuint  count);
+// typedef void  (APIENTRYP GPMAXSHADERCOMPILERTHREADSKHR)(GLuint  count);
 // typedef void  (APIENTRYP GPMEMORYBARRIER)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMEMORYBARRIERBYREGION)(GLbitfield  barriers);
 // typedef void  (APIENTRYP GPMINSAMPLESHADING)(GLfloat  value);
 // typedef void  (APIENTRYP GPMINSAMPLESHADINGARB)(GLfloat  value);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYS)(GLenum  mode, const GLint * first, const GLsizei * count, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECT)(GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTS)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSBASEVERTEX)(GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount, const GLint * basevertex);
 // typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECT)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
-// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizei  size, const void * data, GLenum  usage);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags);
-// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount);
+// typedef void  (APIENTRYP GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride);
+// typedef void  (APIENTRYP GPMULTITEXBUFFEREXT)(GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPMULTITEXCOORDPOINTEREXT)(GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
+// typedef void  (APIENTRYP GPMULTITEXENVFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXENVFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXENVIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXENVIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXGENDEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param);
+// typedef void  (APIENTRYP GPMULTITEXGENDVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params);
+// typedef void  (APIENTRYP GPMULTITEXGENFEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXGENFVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXGENIEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXGENIVEXT)(GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIUIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERFVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIEXT)(GLenum  texunit, GLenum  target, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPMULTITEXPARAMETERIVEXT)(GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPMULTITEXRENDERBUFFEREXT)(GLenum  texunit, GLenum  target, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE1DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE2DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPMULTITEXSUBIMAGE3DEXT)(GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATA)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERDATAEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTARB)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERPAGECOMMITMENTEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGE)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSTORAGEEXT)(GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATA)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDBUFFERSUBDATAEXT)(GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data);
+// typedef void  (APIENTRYP GPNAMEDCOPYBUFFERSUBDATAEXT)(GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFER)(GLuint  framebuffer, GLenum  buf);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERDRAWBUFFERS)(GLuint  framebuffer, GLsizei  n, const GLenum * bufs);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERI)(GLuint  framebuffer, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERPARAMETERIEXT)(GLuint  framebuffer, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERREADBUFFER)(GLuint  framebuffer, GLenum  src);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFER)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face);
 // typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYER)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLdouble * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params);
+// typedef void  (APIENTRYP GPNAMEDPROGRAMSTRINGEXT)(GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGE)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEEXT)(GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPNAMEDSTRINGARB)(GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string);
+// typedef void  (APIENTRYP GPNORMALFORMATNV)(GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPOBJECTLABEL)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTLABELKHR)(GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABEL)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPOBJECTPTRLABELKHR)(const void * ptr, GLsizei  length, const GLchar * label);
 // typedef void  (APIENTRYP GPPATCHPARAMETERFV)(GLenum  pname, const GLfloat * values);
 // typedef void  (APIENTRYP GPPATCHPARAMETERI)(GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHCOMMANDSNV)(GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOORDSNV)(GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHCOVERDEPTHFUNCNV)(GLenum  func);
+// typedef void  (APIENTRYP GPPATHDASHARRAYNV)(GLuint  path, GLsizei  dashCount, const GLfloat * dashArray);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHGLYPHINDEXRANGENV)(GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount);
+// typedef void  (APIENTRYP GPPATHGLYPHRANGENV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHGLYPHSNV)(GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef GLenum  (APIENTRYP GPPATHMEMORYGLYPHINDEXARRAYNV)(GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale);
+// typedef void  (APIENTRYP GPPATHPARAMETERFNV)(GLuint  path, GLenum  pname, GLfloat  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERFVNV)(GLuint  path, GLenum  pname, const GLfloat * value);
+// typedef void  (APIENTRYP GPPATHPARAMETERINV)(GLuint  path, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPATHPARAMETERIVNV)(GLuint  path, GLenum  pname, const GLint * value);
+// typedef void  (APIENTRYP GPPATHSTENCILDEPTHOFFSETNV)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPATHSTENCILFUNCNV)(GLenum  func, GLint  ref, GLuint  mask);
+// typedef void  (APIENTRYP GPPATHSTRINGNV)(GLuint  path, GLenum  format, GLsizei  length, const void * pathString);
+// typedef void  (APIENTRYP GPPATHSUBCOMMANDSNV)(GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords);
+// typedef void  (APIENTRYP GPPATHSUBCOORDSNV)(GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords);
 // typedef void  (APIENTRYP GPPAUSETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPPIXELSTOREF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPIXELSTOREI)(GLenum  pname, GLint  param);
+// typedef GLboolean  (APIENTRYP GPPOINTALONGPATHNV)(GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY);
 // typedef void  (APIENTRYP GPPOINTPARAMETERF)(GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPPOINTPARAMETERFV)(GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPPOINTPARAMETERI)(GLenum  pname, GLint  param);
@@ -522,67 +852,163 @@ package gl
 // typedef void  (APIENTRYP GPPOINTSIZE)(GLfloat  size);
 // typedef void  (APIENTRYP GPPOLYGONMODE)(GLenum  face, GLenum  mode);
 // typedef void  (APIENTRYP GPPOLYGONOFFSET)(GLfloat  factor, GLfloat  units);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMP)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
+// typedef void  (APIENTRYP GPPOLYGONOFFSETCLAMPEXT)(GLfloat  factor, GLfloat  units, GLfloat  clamp);
 // typedef void  (APIENTRYP GPPOPDEBUGGROUP)();
 // typedef void  (APIENTRYP GPPOPDEBUGGROUPKHR)();
+// typedef void  (APIENTRYP GPPOPGROUPMARKEREXT)();
+// typedef void  (APIENTRYP GPPRIMITIVEBOUNDINGBOXARB)(GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW);
 // typedef void  (APIENTRYP GPPRIMITIVERESTARTINDEX)(GLuint  index);
 // typedef void  (APIENTRYP GPPROGRAMBINARY)(GLuint  program, GLenum  binaryFormat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPPROGRAMPARAMETERI)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIARB)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPARAMETERIEXT)(GLuint  program, GLenum  pname, GLint  value);
+// typedef void  (APIENTRYP GPPROGRAMPATHFRAGMENTINPUTGENNV)(GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1D)(GLuint  program, GLint  location, GLdouble  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DEXT)(GLuint  program, GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1F)(GLuint  program, GLint  location, GLfloat  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FEXT)(GLuint  program, GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1I)(GLuint  program, GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64ARB)(GLuint  program, GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64NV)(GLuint  program, GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IEXT)(GLuint  program, GLint  location, GLint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI)(GLuint  program, GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64ARB)(GLuint  program, GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIEXT)(GLuint  program, GLint  location, GLuint  v0);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM1UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2I)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM2UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM3UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4D)(GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DEXT)(GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4DV)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4DVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4F)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FEXT)(GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4FV)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4FVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4I)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64ARB)(GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64NV)(GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4I64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IEXT)(GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4IV)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4IVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64ARB)(GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64NV)(GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIEXT)(GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIV)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORM4UIVEXT)(GLuint  program, GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64ARB)(GLuint  program, GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64NV)(GLuint  program, GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VARB)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMHANDLEUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX2X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX3X4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X2FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3DVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FV)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMMATRIX4X3FVEXT)(GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64NV)(GLuint  program, GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPPROGRAMUNIFORMUI64VNV)(GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPPROVOKINGVERTEX)(GLenum  mode);
+// typedef void  (APIENTRYP GPPUSHCLIENTATTRIBDEFAULTEXT)(GLbitfield  mask);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUP)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
 // typedef void  (APIENTRYP GPPUSHDEBUGGROUPKHR)(GLenum  source, GLuint  id, GLsizei  length, const GLchar * message);
+// typedef void  (APIENTRYP GPPUSHGROUPMARKEREXT)(GLsizei  length, const GLchar * marker);
 // typedef void  (APIENTRYP GPQUERYCOUNTER)(GLuint  id, GLenum  target);
+// typedef void  (APIENTRYP GPRASTERSAMPLESEXT)(GLuint  samples, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPREADBUFFER)(GLenum  src);
 // typedef void  (APIENTRYP GPREADPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, void * pixels);
 // typedef void  (APIENTRYP GPREADNPIXELS)(GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, GLsizei  bufSize, void * data);
@@ -591,6 +1017,8 @@ package gl
 // typedef void  (APIENTRYP GPRELEASESHADERCOMPILER)();
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGE)(GLenum  target, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPRESOLVEDEPTHVALUESNV)();
 // typedef void  (APIENTRYP GPRESUMETRANSFORMFEEDBACK)();
 // typedef void  (APIENTRYP GPSAMPLECOVERAGE)(GLfloat  value, GLboolean  invert);
 // typedef void  (APIENTRYP GPSAMPLEMASKI)(GLuint  maskNumber, GLbitfield  mask);
@@ -604,23 +1032,40 @@ package gl
 // typedef void  (APIENTRYP GPSCISSORARRAYV)(GLuint  first, GLsizei  count, const GLint * v);
 // typedef void  (APIENTRYP GPSCISSORINDEXED)(GLuint  index, GLint  left, GLint  bottom, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPSCISSORINDEXEDV)(GLuint  index, const GLint * v);
+// typedef void  (APIENTRYP GPSECONDARYCOLORFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
+// typedef void  (APIENTRYP GPSELECTPERFMONITORCOUNTERSAMD)(GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList);
 // typedef void  (APIENTRYP GPSHADERBINARY)(GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length);
 // typedef void  (APIENTRYP GPSHADERSOURCE)(GLuint  shader, GLsizei  count, const GLchar *const* string, const GLint * length);
 // typedef void  (APIENTRYP GPSHADERSTORAGEBLOCKBINDING)(GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding);
+// typedef void  (APIENTRYP GPSIGNALVKFENCENV)(GLuint64  vkFence);
+// typedef void  (APIENTRYP GPSIGNALVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPSPECIALIZESHADERARB)(GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue);
+// typedef void  (APIENTRYP GPSTATECAPTURENV)(GLuint  state, GLenum  mode);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNC)(GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILFUNCSEPARATE)(GLenum  face, GLenum  func, GLint  ref, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASK)(GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILMASKSEPARATE)(GLenum  face, GLuint  mask);
 // typedef void  (APIENTRYP GPSTENCILOP)(GLenum  fail, GLenum  zfail, GLenum  zpass);
 // typedef void  (APIENTRYP GPSTENCILOPSEPARATE)(GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERFILLPATHNV)(GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues);
+// typedef void  (APIENTRYP GPSTENCILTHENCOVERSTROKEPATHNV)(GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode);
+// typedef void  (APIENTRYP GPSUBPIXELPRECISIONBIASNV)(GLuint  xbits, GLuint  ybits);
 // typedef void  (APIENTRYP GPTEXBUFFER)(GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXBUFFERARB)(GLenum  target, GLenum  internalformat, GLuint  buffer);
 // typedef void  (APIENTRYP GPTEXBUFFERRANGE)(GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXCOORDFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPTEXIMAGE1D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE2D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE2DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXIMAGE3D)(GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXIMAGE3DMULTISAMPLE)(GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
-// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident);
+// typedef void  (APIENTRYP GPTEXPAGECOMMITMENTARB)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXPARAMETERIIV)(GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERIUIV)(GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXPARAMETERF)(GLenum  target, GLenum  pname, GLfloat  param);
@@ -636,61 +1081,118 @@ package gl
 // typedef void  (APIENTRYP GPTEXSUBIMAGE2D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXSUBIMAGE3D)(GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREBARRIER)();
+// typedef void  (APIENTRYP GPTEXTUREBARRIERNV)();
 // typedef void  (APIENTRYP GPTEXTUREBUFFER)(GLuint  texture, GLenum  internalformat, GLuint  buffer);
-// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFEREXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGE)(GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREBUFFERRANGEEXT)(GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTUREPAGECOMMITMENTEXT)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIIV)(GLuint  texture, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIV)(GLuint  texture, GLenum  pname, const GLuint * params);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIUIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERF)(GLuint  texture, GLenum  pname, GLfloat  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERFV)(GLuint  texture, GLenum  pname, const GLfloat * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERFVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERI)(GLuint  texture, GLenum  pname, GLint  param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIEXT)(GLuint  texture, GLenum  target, GLenum  pname, GLint  param);
 // typedef void  (APIENTRYP GPTEXTUREPARAMETERIV)(GLuint  texture, GLenum  pname, const GLint * param);
+// typedef void  (APIENTRYP GPTEXTUREPARAMETERIVEXT)(GLuint  texture, GLenum  target, GLenum  pname, const GLint * params);
+// typedef void  (APIENTRYP GPTEXTURERENDERBUFFEREXT)(GLuint  texture, GLenum  target, GLuint  renderbuffer);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE1D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE1DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE2DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3D)(GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DEXT)(GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth);
 // typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLE)(GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
+// typedef void  (APIENTRYP GPTEXTURESTORAGE3DMULTISAMPLEEXT)(GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE1D)(GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE1DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE2D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE2DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTURESUBIMAGE3D)(GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
+// typedef void  (APIENTRYP GPTEXTURESUBIMAGE3DEXT)(GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels);
 // typedef void  (APIENTRYP GPTEXTUREVIEW)(GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERBASE)(GLuint  xfb, GLuint  index, GLuint  buffer);
-// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size);
+// typedef void  (APIENTRYP GPTRANSFORMFEEDBACKBUFFERRANGE)(GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size);
 // typedef void  (APIENTRYP GPTRANSFORMFEEDBACKVARYINGS)(GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode);
+// typedef void  (APIENTRYP GPTRANSFORMPATHNV)(GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues);
 // typedef void  (APIENTRYP GPUNIFORM1D)(GLint  location, GLdouble  x);
 // typedef void  (APIENTRYP GPUNIFORM1DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM1F)(GLint  location, GLfloat  v0);
 // typedef void  (APIENTRYP GPUNIFORM1FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM1I)(GLint  location, GLint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1I64ARB)(GLint  location, GLint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64NV)(GLint  location, GLint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM1UI)(GLint  location, GLuint  v0);
+// typedef void  (APIENTRYP GPUNIFORM1UI64ARB)(GLint  location, GLuint64  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64NV)(GLint  location, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM1UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM1UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM2D)(GLint  location, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPUNIFORM2DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM2F)(GLint  location, GLfloat  v0, GLfloat  v1);
 // typedef void  (APIENTRYP GPUNIFORM2FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM2I)(GLint  location, GLint  v0, GLint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2I64ARB)(GLint  location, GLint64  x, GLint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM2UI)(GLint  location, GLuint  v0, GLuint  v1);
+// typedef void  (APIENTRYP GPUNIFORM2UI64ARB)(GLint  location, GLuint64  x, GLuint64  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM2UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM2UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM3D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPUNIFORM3DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM3F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2);
 // typedef void  (APIENTRYP GPUNIFORM3FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM3I)(GLint  location, GLint  v0, GLint  v1, GLint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM3UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2);
+// typedef void  (APIENTRYP GPUNIFORM3UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM3UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM3UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORM4D)(GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPUNIFORM4DV)(GLint  location, GLsizei  count, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORM4F)(GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3);
 // typedef void  (APIENTRYP GPUNIFORM4FV)(GLint  location, GLsizei  count, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORM4I)(GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4I64ARB)(GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64NV)(GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4I64VARB)(GLint  location, GLsizei  count, const GLint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4I64VNV)(GLint  location, GLsizei  count, const GLint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4IV)(GLint  location, GLsizei  count, const GLint * value);
 // typedef void  (APIENTRYP GPUNIFORM4UI)(GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3);
+// typedef void  (APIENTRYP GPUNIFORM4UI64ARB)(GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64NV)(GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORM4UI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef void  (APIENTRYP GPUNIFORM4UIV)(GLint  location, GLsizei  count, const GLuint * value);
 // typedef void  (APIENTRYP GPUNIFORMBLOCKBINDING)(GLuint  program, GLuint  uniformBlockIndex, GLuint  uniformBlockBinding);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64ARB)(GLint  location, GLuint64  value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64NV)(GLint  location, GLuint64  value);
 // typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VARB)(GLint  location, GLsizei  count, const GLuint64 * value);
+// typedef void  (APIENTRYP GPUNIFORMHANDLEUI64VNV)(GLint  location, GLsizei  count, const GLuint64 * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX2X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
@@ -710,20 +1212,45 @@ package gl
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3DV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value);
 // typedef void  (APIENTRYP GPUNIFORMMATRIX4X3FV)(GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value);
 // typedef void  (APIENTRYP GPUNIFORMSUBROUTINESUIV)(GLenum  shadertype, GLsizei  count, const GLuint * indices);
+// typedef void  (APIENTRYP GPUNIFORMUI64NV)(GLint  location, GLuint64EXT  value);
+// typedef void  (APIENTRYP GPUNIFORMUI64VNV)(GLint  location, GLsizei  count, const GLuint64EXT * value);
 // typedef GLboolean  (APIENTRYP GPUNMAPBUFFER)(GLenum  target);
 // typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFER)(GLuint  buffer);
+// typedef GLboolean  (APIENTRYP GPUNMAPNAMEDBUFFEREXT)(GLuint  buffer);
 // typedef void  (APIENTRYP GPUSEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPUSEPROGRAMSTAGES)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSEPROGRAMSTAGESEXT)(GLuint  pipeline, GLbitfield  stages, GLuint  program);
+// typedef void  (APIENTRYP GPUSESHADERPROGRAMEXT)(GLenum  type, GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAM)(GLuint  program);
 // typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINE)(GLuint  pipeline);
+// typedef void  (APIENTRYP GPVALIDATEPROGRAMPIPELINEEXT)(GLuint  pipeline);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBBINDING)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBIFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
 // typedef void  (APIENTRYP GPVERTEXARRAYATTRIBLFORMAT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYBINDVERTEXBUFFEREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYBINDINGDIVISOR)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYEDGEFLAGOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXARRAYELEMENTBUFFER)(GLuint  vaobj, GLuint  buffer);
+// typedef void  (APIENTRYP GPVERTEXARRAYFOGCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYINDEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYNORMALOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYTEXCOORDOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(GLuint  vaobj, GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(GLuint  vaobj, GLuint  bindingindex, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFER)(GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXARRAYVERTEXBUFFERS)(GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides);
+// typedef void  (APIENTRYP GPVERTEXARRAYVERTEXOFFSETEXT)(GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1DV)(GLuint  index, const GLdouble * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIB1F)(GLuint  index, GLfloat  x);
@@ -762,7 +1289,9 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIB4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBBINDING)(GLuint  attribindex, GLuint  bindingindex);
 // typedef void  (APIENTRYP GPVERTEXATTRIBDIVISOR)(GLuint  index, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXATTRIBDIVISORARB)(GLuint  index, GLuint  divisor);
 // typedef void  (APIENTRYP GPVERTEXATTRIBFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1I)(GLuint  index, GLint  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1IV)(GLuint  index, const GLint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI1UI)(GLuint  index, GLuint  x);
@@ -784,18 +1313,36 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4UIV)(GLuint  index, const GLuint * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBI4USV)(GLuint  index, const GLushort * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBIFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBIPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1D)(GLuint  index, GLdouble  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64NV)(GLuint  index, GLint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1I64VNV)(GLuint  index, const GLint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64ARB)(GLuint  index, GLuint64EXT  x);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64NV)(GLuint  index, GLuint64EXT  x);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VARB)(GLuint  index, const GLuint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL1UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2D)(GLuint  index, GLdouble  x, GLdouble  y);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL2DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL2UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL3DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL3UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4D)(GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w);
 // typedef void  (APIENTRYP GPVERTEXATTRIBL4DV)(GLuint  index, const GLdouble * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64NV)(GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4I64VNV)(GLuint  index, const GLint64EXT * v);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64NV)(GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w);
+// typedef void  (APIENTRYP GPVERTEXATTRIBL4UI64VNV)(GLuint  index, const GLuint64EXT * v);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLFORMAT)(GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset);
+// typedef void  (APIENTRYP GPVERTEXATTRIBLFORMATNV)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVERTEXATTRIBLPOINTER)(GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UI)(GLuint  index, GLenum  type, GLboolean  normalized, GLuint  value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBP1UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
@@ -807,22 +1354,46 @@ package gl
 // typedef void  (APIENTRYP GPVERTEXATTRIBP4UIV)(GLuint  index, GLenum  type, GLboolean  normalized, const GLuint * value);
 // typedef void  (APIENTRYP GPVERTEXATTRIBPOINTER)(GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, const void * pointer);
 // typedef void  (APIENTRYP GPVERTEXBINDINGDIVISOR)(GLuint  bindingindex, GLuint  divisor);
+// typedef void  (APIENTRYP GPVERTEXFORMATNV)(GLint  size, GLenum  type, GLsizei  stride);
 // typedef void  (APIENTRYP GPVIEWPORT)(GLint  x, GLint  y, GLsizei  width, GLsizei  height);
 // typedef void  (APIENTRYP GPVIEWPORTARRAYV)(GLuint  first, GLsizei  count, const GLfloat * v);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDF)(GLuint  index, GLfloat  x, GLfloat  y, GLfloat  w, GLfloat  h);
 // typedef void  (APIENTRYP GPVIEWPORTINDEXEDFV)(GLuint  index, const GLfloat * v);
+// typedef void  (APIENTRYP GPVIEWPORTPOSITIONWSCALENV)(GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff);
+// typedef void  (APIENTRYP GPVIEWPORTSWIZZLENV)(GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew);
 // typedef void  (APIENTRYP GPWAITSYNC)(GLsync  sync, GLbitfield  flags, GLuint64  timeout);
+// typedef void  (APIENTRYP GPWAITVKSEMAPHORENV)(GLuint64  vkSemaphore);
+// typedef void  (APIENTRYP GPWEIGHTPATHSNV)(GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights);
+// typedef void  (APIENTRYP GPWINDOWRECTANGLESEXT)(GLenum  mode, GLsizei  count, const GLint * box);
+// static void  glowActiveProgramEXT(GPACTIVEPROGRAMEXT fnptr, GLuint  program) {
+//   (*fnptr)(program);
+// }
 // static void  glowActiveShaderProgram(GPACTIVESHADERPROGRAM fnptr, GLuint  pipeline, GLuint  program) {
+//   (*fnptr)(pipeline, program);
+// }
+// static void  glowActiveShaderProgramEXT(GPACTIVESHADERPROGRAMEXT fnptr, GLuint  pipeline, GLuint  program) {
 //   (*fnptr)(pipeline, program);
 // }
 // static void  glowActiveTexture(GPACTIVETEXTURE fnptr, GLenum  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowApplyFramebufferAttachmentCMAAINTEL(GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowAttachShader(GPATTACHSHADER fnptr, GLuint  program, GLuint  shader) {
 //   (*fnptr)(program, shader);
 // }
 // static void  glowBeginConditionalRender(GPBEGINCONDITIONALRENDER fnptr, GLuint  id, GLenum  mode) {
 //   (*fnptr)(id, mode);
+// }
+// static void  glowBeginConditionalRenderNV(GPBEGINCONDITIONALRENDERNV fnptr, GLuint  id, GLenum  mode) {
+//   (*fnptr)(id, mode);
+// }
+// static void  glowBeginPerfMonitorAMD(GPBEGINPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowBeginPerfQueryINTEL(GPBEGINPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
 // }
 // static void  glowBeginQuery(GPBEGINQUERY fnptr, GLenum  target, GLuint  id) {
 //   (*fnptr)(target, id);
@@ -866,7 +1437,13 @@ package gl
 // static void  glowBindImageTextures(GPBINDIMAGETEXTURES fnptr, GLuint  first, GLsizei  count, const GLuint * textures) {
 //   (*fnptr)(first, count, textures);
 // }
+// static void  glowBindMultiTextureEXT(GPBINDMULTITEXTUREEXT fnptr, GLenum  texunit, GLenum  target, GLuint  texture) {
+//   (*fnptr)(texunit, target, texture);
+// }
 // static void  glowBindProgramPipeline(GPBINDPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowBindProgramPipelineEXT(GPBINDPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowBindRenderbuffer(GPBINDRENDERBUFFER fnptr, GLenum  target, GLuint  renderbuffer) {
@@ -898,6 +1475,12 @@ package gl
 // }
 // static void  glowBindVertexBuffers(GPBINDVERTEXBUFFERS fnptr, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(first, count, buffers, offsets, strides);
+// }
+// static void  glowBlendBarrierKHR(GPBLENDBARRIERKHR fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowBlendBarrierNV(GPBLENDBARRIERNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowBlendColor(GPBLENDCOLOR fnptr, GLfloat  red, GLfloat  green, GLfloat  blue, GLfloat  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
@@ -938,16 +1521,22 @@ package gl
 // static void  glowBlendFunciARB(GPBLENDFUNCIARB fnptr, GLuint  buf, GLenum  src, GLenum  dst) {
 //   (*fnptr)(buf, src, dst);
 // }
+// static void  glowBlendParameteriNV(GPBLENDPARAMETERINV fnptr, GLenum  pname, GLint  value) {
+//   (*fnptr)(pname, value);
+// }
 // static void  glowBlitFramebuffer(GPBLITFRAMEBUFFER fnptr, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
 // static void  glowBlitNamedFramebuffer(GPBLITNAMEDFRAMEBUFFER fnptr, GLuint  readFramebuffer, GLuint  drawFramebuffer, GLint  srcX0, GLint  srcY0, GLint  srcX1, GLint  srcY1, GLint  dstX0, GLint  dstY0, GLint  dstX1, GLint  dstY1, GLbitfield  mask, GLenum  filter) {
 //   (*fnptr)(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 // }
+// static void  glowBufferAddressRangeNV(GPBUFFERADDRESSRANGENV fnptr, GLenum  pname, GLuint  index, GLuint64EXT  address, GLsizeiptr  length) {
+//   (*fnptr)(pname, index, address, length);
+// }
 // static void  glowBufferData(GPBUFFERDATA fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(target, size, data, usage);
 // }
-// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowBufferPageCommitmentARB(GPBUFFERPAGECOMMITMENTARB fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(target, offset, size, commit);
 // }
 // static void  glowBufferStorage(GPBUFFERSTORAGE fnptr, GLenum  target, GLsizeiptr  size, const void * data, GLbitfield  flags) {
@@ -956,10 +1545,16 @@ package gl
 // static void  glowBufferSubData(GPBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(target, offset, size, data);
 // }
+// static void  glowCallCommandListNV(GPCALLCOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static GLenum  glowCheckFramebufferStatus(GPCHECKFRAMEBUFFERSTATUS fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLenum  glowCheckNamedFramebufferStatus(GPCHECKNAMEDFRAMEBUFFERSTATUS fnptr, GLuint  framebuffer, GLenum  target) {
+//   return (*fnptr)(framebuffer, target);
+// }
+// static GLenum  glowCheckNamedFramebufferStatusEXT(GPCHECKNAMEDFRAMEBUFFERSTATUSEXT fnptr, GLuint  framebuffer, GLenum  target) {
 //   return (*fnptr)(framebuffer, target);
 // }
 // static void  glowClampColor(GPCLAMPCOLOR fnptr, GLenum  target, GLenum  clamp) {
@@ -998,11 +1593,17 @@ package gl
 // static void  glowClearNamedBufferData(GPCLEARNAMEDBUFFERDATA fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, format, type, data);
 // }
-// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizei  size, GLenum  format, GLenum  type, const void * data) {
+// static void  glowClearNamedBufferDataEXT(GPCLEARNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, format, type, data);
+// }
+// static void  glowClearNamedBufferSubData(GPCLEARNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLenum  internalformat, GLintptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
 // }
-// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, const GLfloat  depth, GLint  stencil) {
-//   (*fnptr)(framebuffer, buffer, depth, stencil);
+// static void  glowClearNamedBufferSubDataEXT(GPCLEARNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLenum  internalformat, GLsizeiptr  offset, GLsizeiptr  size, GLenum  format, GLenum  type, const void * data) {
+//   (*fnptr)(buffer, internalformat, offset, size, format, type, data);
+// }
+// static void  glowClearNamedFramebufferfi(GPCLEARNAMEDFRAMEBUFFERFI fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, GLfloat  depth, GLint  stencil) {
+//   (*fnptr)(framebuffer, buffer, drawbuffer, depth, stencil);
 // }
 // static void  glowClearNamedFramebufferfv(GPCLEARNAMEDFRAMEBUFFERFV fnptr, GLuint  framebuffer, GLenum  buffer, GLint  drawbuffer, const GLfloat * value) {
 //   (*fnptr)(framebuffer, buffer, drawbuffer, value);
@@ -1022,11 +1623,17 @@ package gl
 // static void  glowClearTexSubImage(GPCLEARTEXSUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data);
 // }
+// static void  glowClientAttribDefaultEXT(GPCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
+// }
 // static GLenum  glowClientWaitSync(GPCLIENTWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   return (*fnptr)(sync, flags, timeout);
 // }
 // static void  glowClipControl(GPCLIPCONTROL fnptr, GLenum  origin, GLenum  depth) {
 //   (*fnptr)(origin, depth);
+// }
+// static void  glowColorFormatNV(GPCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
 // }
 // static void  glowColorMask(GPCOLORMASK fnptr, GLboolean  red, GLboolean  green, GLboolean  blue, GLboolean  alpha) {
 //   (*fnptr)(red, green, blue, alpha);
@@ -1034,11 +1641,35 @@ package gl
 // static void  glowColorMaski(GPCOLORMASKI fnptr, GLuint  index, GLboolean  r, GLboolean  g, GLboolean  b, GLboolean  a) {
 //   (*fnptr)(index, r, g, b, a);
 // }
+// static void  glowCommandListSegmentsNV(GPCOMMANDLISTSEGMENTSNV fnptr, GLuint  list, GLuint  segments) {
+//   (*fnptr)(list, segments);
+// }
+// static void  glowCompileCommandListNV(GPCOMPILECOMMANDLISTNV fnptr, GLuint  list) {
+//   (*fnptr)(list);
+// }
 // static void  glowCompileShader(GPCOMPILESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
 // }
 // static void  glowCompileShaderIncludeARB(GPCOMPILESHADERINCLUDEARB fnptr, GLuint  shader, GLsizei  count, const GLchar *const* path, const GLint * length) {
 //   (*fnptr)(shader, count, path, length);
+// }
+// static void  glowCompressedMultiTexImage1DEXT(GPCOMPRESSEDMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage2DEXT(GPCOMPRESSEDMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexImage3DEXT(GPCOMPRESSEDMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage1DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage2DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
+// static void  glowCompressedMultiTexSubImage3DEXT(GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
 // }
 // static void  glowCompressedTexImage1D(GPCOMPRESSEDTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, internalformat, width, border, imageSize, data);
@@ -1058,14 +1689,38 @@ package gl
 // static void  glowCompressedTexSubImage3D(GPCOMPRESSEDTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
 // }
+// static void  glowCompressedTextureImage1DEXT(GPCOMPRESSEDTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage2DEXT(GPCOMPRESSEDTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, imageSize, bits);
+// }
+// static void  glowCompressedTextureImage3DEXT(GPCOMPRESSEDTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage1D(GPCOMPRESSEDTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, width, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage1DEXT(GPCOMPRESSEDTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, imageSize, bits);
 // }
 // static void  glowCompressedTextureSubImage2D(GPCOMPRESSEDTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, imageSize, data);
 // }
+// static void  glowCompressedTextureSubImage2DEXT(GPCOMPRESSEDTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, imageSize, bits);
+// }
 // static void  glowCompressedTextureSubImage3D(GPCOMPRESSEDTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * data) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
+// }
+// static void  glowCompressedTextureSubImage3DEXT(GPCOMPRESSEDTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLsizei  imageSize, const void * bits) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits);
+// }
+// static void  glowConservativeRasterParameterfNV(GPCONSERVATIVERASTERPARAMETERFNV fnptr, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(pname, value);
+// }
+// static void  glowConservativeRasterParameteriNV(GPCONSERVATIVERASTERPARAMETERINV fnptr, GLenum  pname, GLint  param) {
+//   (*fnptr)(pname, param);
 // }
 // static void  glowCopyBufferSubData(GPCOPYBUFFERSUBDATA fnptr, GLenum  readTarget, GLenum  writeTarget, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readTarget, writeTarget, readOffset, writeOffset, size);
@@ -1073,8 +1728,26 @@ package gl
 // static void  glowCopyImageSubData(GPCOPYIMAGESUBDATA fnptr, GLuint  srcName, GLenum  srcTarget, GLint  srcLevel, GLint  srcX, GLint  srcY, GLint  srcZ, GLuint  dstName, GLenum  dstTarget, GLint  dstLevel, GLint  dstX, GLint  dstY, GLint  dstZ, GLsizei  srcWidth, GLsizei  srcHeight, GLsizei  srcDepth) {
 //   (*fnptr)(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
 // }
-// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizei  size) {
+// static void  glowCopyMultiTexImage1DEXT(GPCOPYMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyMultiTexImage2DEXT(GPCOPYMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texunit, target, level, internalformat, x, y, width, height, border);
+// }
+// static void  glowCopyMultiTexSubImage1DEXT(GPCOPYMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texunit, target, level, xoffset, x, y, width);
+// }
+// static void  glowCopyMultiTexSubImage2DEXT(GPCOPYMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, x, y, width, height);
+// }
+// static void  glowCopyMultiTexSubImage3DEXT(GPCOPYMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyNamedBufferSubData(GPCOPYNAMEDBUFFERSUBDATA fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
 //   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
+// }
+// static void  glowCopyPathNV(GPCOPYPATHNV fnptr, GLuint  resultPath, GLuint  srcPath) {
+//   (*fnptr)(resultPath, srcPath);
 // }
 // static void  glowCopyTexImage1D(GPCOPYTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
 //   (*fnptr)(target, level, internalformat, x, y, width, border);
@@ -1091,20 +1764,59 @@ package gl
 // static void  glowCopyTexSubImage3D(GPCOPYTEXSUBIMAGE3D fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, level, xoffset, yoffset, zoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureImage1DEXT(GPCOPYTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, border);
+// }
+// static void  glowCopyTextureImage2DEXT(GPCOPYTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  internalformat, GLint  x, GLint  y, GLsizei  width, GLsizei  height, GLint  border) {
+//   (*fnptr)(texture, target, level, internalformat, x, y, width, height, border);
+// }
 // static void  glowCopyTextureSubImage1D(GPCOPYTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
 //   (*fnptr)(texture, level, xoffset, x, y, width);
+// }
+// static void  glowCopyTextureSubImage1DEXT(GPCOPYTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  x, GLint  y, GLsizei  width) {
+//   (*fnptr)(texture, target, level, xoffset, x, y, width);
 // }
 // static void  glowCopyTextureSubImage2D(GPCOPYTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, x, y, width, height);
 // }
+// static void  glowCopyTextureSubImage2DEXT(GPCOPYTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, x, y, width, height);
+// }
 // static void  glowCopyTextureSubImage3D(GPCOPYTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCopyTextureSubImage3DEXT(GPCOPYTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, x, y, width, height);
+// }
+// static void  glowCoverFillPathInstancedNV(GPCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverFillPathNV(GPCOVERFILLPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverStrokePathInstancedNV(GPCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, coverMode, transformType, transformValues);
+// }
+// static void  glowCoverStrokePathNV(GPCOVERSTROKEPATHNV fnptr, GLuint  path, GLenum  coverMode) {
+//   (*fnptr)(path, coverMode);
+// }
+// static void  glowCoverageModulationNV(GPCOVERAGEMODULATIONNV fnptr, GLenum  components) {
+//   (*fnptr)(components);
+// }
+// static void  glowCoverageModulationTableNV(GPCOVERAGEMODULATIONTABLENV fnptr, GLsizei  n, const GLfloat * v) {
+//   (*fnptr)(n, v);
 // }
 // static void  glowCreateBuffers(GPCREATEBUFFERS fnptr, GLsizei  n, GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowCreateCommandListsNV(GPCREATECOMMANDLISTSNV fnptr, GLsizei  n, GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowCreateFramebuffers(GPCREATEFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
+// }
+// static void  glowCreatePerfQueryINTEL(GPCREATEPERFQUERYINTEL fnptr, GLuint  queryId, GLuint * queryHandle) {
+//   (*fnptr)(queryId, queryHandle);
 // }
 // static GLuint  glowCreateProgram(GPCREATEPROGRAM fnptr) {
 //   return (*fnptr)();
@@ -1124,8 +1836,17 @@ package gl
 // static GLuint  glowCreateShader(GPCREATESHADER fnptr, GLenum  type) {
 //   return (*fnptr)(type);
 // }
+// static GLuint  glowCreateShaderProgramEXT(GPCREATESHADERPROGRAMEXT fnptr, GLenum  type, const GLchar * string) {
+//   return (*fnptr)(type, string);
+// }
 // static GLuint  glowCreateShaderProgramv(GPCREATESHADERPROGRAMV fnptr, GLenum  type, GLsizei  count, const GLchar *const* strings) {
 //   return (*fnptr)(type, count, strings);
+// }
+// static GLuint  glowCreateShaderProgramvEXT(GPCREATESHADERPROGRAMVEXT fnptr, GLenum  type, GLsizei  count, const GLchar ** strings) {
+//   return (*fnptr)(type, count, strings);
+// }
+// static void  glowCreateStatesNV(GPCREATESTATESNV fnptr, GLsizei  n, GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static GLsync  glowCreateSyncFromCLeventARB(GPCREATESYNCFROMCLEVENTARB fnptr, struct _cl_context * context, struct _cl_event * event, GLbitfield  flags) {
 //   return (*fnptr)(context, event, flags);
@@ -1172,16 +1893,31 @@ package gl
 // static void  glowDeleteBuffers(GPDELETEBUFFERS fnptr, GLsizei  n, const GLuint * buffers) {
 //   (*fnptr)(n, buffers);
 // }
+// static void  glowDeleteCommandListsNV(GPDELETECOMMANDLISTSNV fnptr, GLsizei  n, const GLuint * lists) {
+//   (*fnptr)(n, lists);
+// }
 // static void  glowDeleteFramebuffers(GPDELETEFRAMEBUFFERS fnptr, GLsizei  n, const GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
 // static void  glowDeleteNamedStringARB(GPDELETENAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   (*fnptr)(namelen, name);
 // }
+// static void  glowDeletePathsNV(GPDELETEPATHSNV fnptr, GLuint  path, GLsizei  range) {
+//   (*fnptr)(path, range);
+// }
+// static void  glowDeletePerfMonitorsAMD(GPDELETEPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
+// static void  glowDeletePerfQueryINTEL(GPDELETEPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowDeleteProgram(GPDELETEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowDeleteProgramPipelines(GPDELETEPROGRAMPIPELINES fnptr, GLsizei  n, const GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowDeleteProgramPipelinesEXT(GPDELETEPROGRAMPIPELINESEXT fnptr, GLsizei  n, const GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowDeleteQueries(GPDELETEQUERIES fnptr, GLsizei  n, const GLuint * ids) {
@@ -1195,6 +1931,9 @@ package gl
 // }
 // static void  glowDeleteShader(GPDELETESHADER fnptr, GLuint  shader) {
 //   (*fnptr)(shader);
+// }
+// static void  glowDeleteStatesNV(GPDELETESTATESNV fnptr, GLsizei  n, const GLuint * states) {
+//   (*fnptr)(n, states);
 // }
 // static void  glowDeleteSync(GPDELETESYNC fnptr, GLsync  sync) {
 //   (*fnptr)(sync);
@@ -1232,8 +1971,23 @@ package gl
 // static void  glowDisable(GPDISABLE fnptr, GLenum  cap) {
 //   (*fnptr)(cap);
 // }
+// static void  glowDisableClientStateIndexedEXT(GPDISABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableClientStateiEXT(GPDISABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowDisableIndexedEXT(GPDISABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowDisableVertexArrayAttrib(GPDISABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayAttribEXT(GPDISABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowDisableVertexArrayEXT(GPDISABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowDisableVertexAttribArray(GPDISABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1259,14 +2013,32 @@ package gl
 // static void  glowDrawArraysInstanced(GPDRAWARRAYSINSTANCED fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount) {
 //   (*fnptr)(mode, first, count, instancecount);
 // }
+// static void  glowDrawArraysInstancedARB(GPDRAWARRAYSINSTANCEDARB fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, first, count, primcount);
+// }
 // static void  glowDrawArraysInstancedBaseInstance(GPDRAWARRAYSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLint  first, GLsizei  count, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, first, count, instancecount, baseinstance);
+// }
+// static void  glowDrawArraysInstancedEXT(GPDRAWARRAYSINSTANCEDEXT fnptr, GLenum  mode, GLint  start, GLsizei  count, GLsizei  primcount) {
+//   (*fnptr)(mode, start, count, primcount);
 // }
 // static void  glowDrawBuffer(GPDRAWBUFFER fnptr, GLenum  buf) {
 //   (*fnptr)(buf);
 // }
 // static void  glowDrawBuffers(GPDRAWBUFFERS fnptr, GLsizei  n, const GLenum * bufs) {
 //   (*fnptr)(n, bufs);
+// }
+// static void  glowDrawCommandsAddressNV(GPDRAWCOMMANDSADDRESSNV fnptr, GLenum  primitiveMode, const GLuint64 * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsNV(GPDRAWCOMMANDSNV fnptr, GLenum  primitiveMode, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, GLuint  count) {
+//   (*fnptr)(primitiveMode, buffer, indirects, sizes, count);
+// }
+// static void  glowDrawCommandsStatesAddressNV(GPDRAWCOMMANDSSTATESADDRESSNV fnptr, const GLuint64 * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(indirects, sizes, states, fbos, count);
+// }
+// static void  glowDrawCommandsStatesNV(GPDRAWCOMMANDSSTATESNV fnptr, GLuint  buffer, const GLintptr * indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(buffer, indirects, sizes, states, fbos, count);
 // }
 // static void  glowDrawElements(GPDRAWELEMENTS fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, count, type, indices);
@@ -1280,6 +2052,9 @@ package gl
 // static void  glowDrawElementsInstanced(GPDRAWELEMENTSINSTANCED fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount) {
 //   (*fnptr)(mode, count, type, indices, instancecount);
 // }
+// static void  glowDrawElementsInstancedARB(GPDRAWELEMENTSINSTANCEDARB fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
+// }
 // static void  glowDrawElementsInstancedBaseInstance(GPDRAWELEMENTSINSTANCEDBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, baseinstance);
 // }
@@ -1288,6 +2063,9 @@ package gl
 // }
 // static void  glowDrawElementsInstancedBaseVertexBaseInstance(GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  instancecount, GLint  basevertex, GLuint  baseinstance) {
 //   (*fnptr)(mode, count, type, indices, instancecount, basevertex, baseinstance);
+// }
+// static void  glowDrawElementsInstancedEXT(GPDRAWELEMENTSINSTANCEDEXT fnptr, GLenum  mode, GLsizei  count, GLenum  type, const void * indices, GLsizei  primcount) {
+//   (*fnptr)(mode, count, type, indices, primcount);
 // }
 // static void  glowDrawRangeElements(GPDRAWRANGEELEMENTS fnptr, GLenum  mode, GLuint  start, GLuint  end, GLsizei  count, GLenum  type, const void * indices) {
 //   (*fnptr)(mode, start, end, count, type, indices);
@@ -1307,11 +2085,32 @@ package gl
 // static void  glowDrawTransformFeedbackStreamInstanced(GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED fnptr, GLenum  mode, GLuint  id, GLuint  stream, GLsizei  instancecount) {
 //   (*fnptr)(mode, id, stream, instancecount);
 // }
+// static void  glowDrawVkImageNV(GPDRAWVKIMAGENV fnptr, GLuint64  vkImage, GLuint  sampler, GLfloat  x0, GLfloat  y0, GLfloat  x1, GLfloat  y1, GLfloat  z, GLfloat  s0, GLfloat  t0, GLfloat  s1, GLfloat  t1) {
+//   (*fnptr)(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
+// }
+// static void  glowEdgeFlagFormatNV(GPEDGEFLAGFORMATNV fnptr, GLsizei  stride) {
+//   (*fnptr)(stride);
+// }
 // static void  glowEnable(GPENABLE fnptr, GLenum  cap) {
 //   (*fnptr)(cap);
 // }
+// static void  glowEnableClientStateIndexedEXT(GPENABLECLIENTSTATEINDEXEDEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableClientStateiEXT(GPENABLECLIENTSTATEIEXT fnptr, GLenum  array, GLuint  index) {
+//   (*fnptr)(array, index);
+// }
+// static void  glowEnableIndexedEXT(GPENABLEINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   (*fnptr)(target, index);
+// }
 // static void  glowEnableVertexArrayAttrib(GPENABLEVERTEXARRAYATTRIB fnptr, GLuint  vaobj, GLuint  index) {
 //   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayAttribEXT(GPENABLEVERTEXARRAYATTRIBEXT fnptr, GLuint  vaobj, GLuint  index) {
+//   (*fnptr)(vaobj, index);
+// }
+// static void  glowEnableVertexArrayEXT(GPENABLEVERTEXARRAYEXT fnptr, GLuint  vaobj, GLenum  array) {
+//   (*fnptr)(vaobj, array);
 // }
 // static void  glowEnableVertexAttribArray(GPENABLEVERTEXATTRIBARRAY fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -1322,6 +2121,15 @@ package gl
 // static void  glowEndConditionalRender(GPENDCONDITIONALRENDER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowEndConditionalRenderNV(GPENDCONDITIONALRENDERNV fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowEndPerfMonitorAMD(GPENDPERFMONITORAMD fnptr, GLuint  monitor) {
+//   (*fnptr)(monitor);
+// }
+// static void  glowEndPerfQueryINTEL(GPENDPERFQUERYINTEL fnptr, GLuint  queryHandle) {
+//   (*fnptr)(queryHandle);
+// }
 // static void  glowEndQuery(GPENDQUERY fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
@@ -1329,6 +2137,9 @@ package gl
 //   (*fnptr)(target, index);
 // }
 // static void  glowEndTransformFeedback(GPENDTRANSFORMFEEDBACK fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowEvaluateDepthValuesARB(GPEVALUATEDEPTHVALUESARB fnptr) {
 //   (*fnptr)();
 // }
 // static GLsync  glowFenceSync(GPFENCESYNC fnptr, GLenum  condition, GLbitfield  flags) {
@@ -1343,14 +2154,41 @@ package gl
 // static void  glowFlushMappedBufferRange(GPFLUSHMAPPEDBUFFERRANGE fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(target, offset, length);
 // }
-// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length) {
+// static void  glowFlushMappedNamedBufferRange(GPFLUSHMAPPEDNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
 //   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFlushMappedNamedBufferRangeEXT(GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length) {
+//   (*fnptr)(buffer, offset, length);
+// }
+// static void  glowFogCoordFormatNV(GPFOGCOORDFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
+// static void  glowFragmentCoverageColorNV(GPFRAGMENTCOVERAGECOLORNV fnptr, GLuint  color) {
+//   (*fnptr)(color);
+// }
+// static void  glowFramebufferDrawBufferEXT(GPFRAMEBUFFERDRAWBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
+// static void  glowFramebufferDrawBuffersEXT(GPFRAMEBUFFERDRAWBUFFERSEXT fnptr, GLuint  framebuffer, GLsizei  n, const GLenum * bufs) {
+//   (*fnptr)(framebuffer, n, bufs);
+// }
+// static void  glowFramebufferFetchBarrierEXT(GPFRAMEBUFFERFETCHBARRIEREXT fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowFramebufferParameteri(GPFRAMEBUFFERPARAMETERI fnptr, GLenum  target, GLenum  pname, GLint  param) {
 //   (*fnptr)(target, pname, param);
 // }
+// static void  glowFramebufferReadBufferEXT(GPFRAMEBUFFERREADBUFFEREXT fnptr, GLuint  framebuffer, GLenum  mode) {
+//   (*fnptr)(framebuffer, mode);
+// }
 // static void  glowFramebufferRenderbuffer(GPFRAMEBUFFERRENDERBUFFER fnptr, GLenum  target, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(target, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowFramebufferSampleLocationsfvARB(GPFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
+// }
+// static void  glowFramebufferSampleLocationsfvNV(GPFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLenum  target, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(target, start, count, v);
 // }
 // static void  glowFramebufferTexture(GPFRAMEBUFFERTEXTURE fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(target, attachment, texture, level);
@@ -1364,8 +2202,20 @@ package gl
 // static void  glowFramebufferTexture3D(GPFRAMEBUFFERTEXTURE3D fnptr, GLenum  target, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
 //   (*fnptr)(target, attachment, textarget, texture, level, zoffset);
 // }
+// static void  glowFramebufferTextureARB(GPFRAMEBUFFERTEXTUREARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(target, attachment, texture, level);
+// }
+// static void  glowFramebufferTextureFaceARB(GPFRAMEBUFFERTEXTUREFACEARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(target, attachment, texture, level, face);
+// }
 // static void  glowFramebufferTextureLayer(GPFRAMEBUFFERTEXTURELAYER fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureLayerARB(GPFRAMEBUFFERTEXTURELAYERARB fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(target, attachment, texture, level, layer);
+// }
+// static void  glowFramebufferTextureMultiviewOVR(GPFRAMEBUFFERTEXTUREMULTIVIEWOVR fnptr, GLenum  target, GLenum  attachment, GLuint  texture, GLint  level, GLint  baseViewIndex, GLsizei  numViews) {
+//   (*fnptr)(target, attachment, texture, level, baseViewIndex, numViews);
 // }
 // static void  glowFrontFace(GPFRONTFACE fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
@@ -1376,7 +2226,16 @@ package gl
 // static void  glowGenFramebuffers(GPGENFRAMEBUFFERS fnptr, GLsizei  n, GLuint * framebuffers) {
 //   (*fnptr)(n, framebuffers);
 // }
+// static GLuint  glowGenPathsNV(GPGENPATHSNV fnptr, GLsizei  range) {
+//   return (*fnptr)(range);
+// }
+// static void  glowGenPerfMonitorsAMD(GPGENPERFMONITORSAMD fnptr, GLsizei  n, GLuint * monitors) {
+//   (*fnptr)(n, monitors);
+// }
 // static void  glowGenProgramPipelines(GPGENPROGRAMPIPELINES fnptr, GLsizei  n, GLuint * pipelines) {
+//   (*fnptr)(n, pipelines);
+// }
+// static void  glowGenProgramPipelinesEXT(GPGENPROGRAMPIPELINESEXT fnptr, GLsizei  n, GLuint * pipelines) {
 //   (*fnptr)(n, pipelines);
 // }
 // static void  glowGenQueries(GPGENQUERIES fnptr, GLsizei  n, GLuint * ids) {
@@ -1400,8 +2259,14 @@ package gl
 // static void  glowGenerateMipmap(GPGENERATEMIPMAP fnptr, GLenum  target) {
 //   (*fnptr)(target);
 // }
+// static void  glowGenerateMultiTexMipmapEXT(GPGENERATEMULTITEXMIPMAPEXT fnptr, GLenum  texunit, GLenum  target) {
+//   (*fnptr)(texunit, target);
+// }
 // static void  glowGenerateTextureMipmap(GPGENERATETEXTUREMIPMAP fnptr, GLuint  texture) {
 //   (*fnptr)(texture);
+// }
+// static void  glowGenerateTextureMipmapEXT(GPGENERATETEXTUREMIPMAPEXT fnptr, GLuint  texture, GLenum  target) {
+//   (*fnptr)(texture, target);
 // }
 // static void  glowGetActiveAtomicCounterBufferiv(GPGETACTIVEATOMICCOUNTERBUFFERIV fnptr, GLuint  program, GLuint  bufferIndex, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, bufferIndex, pname, params);
@@ -1439,6 +2304,9 @@ package gl
 // static GLint  glowGetAttribLocation(GPGETATTRIBLOCATION fnptr, GLuint  program, const GLchar * name) {
 //   return (*fnptr)(program, name);
 // }
+// static void  glowGetBooleanIndexedvEXT(GPGETBOOLEANINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLboolean * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetBooleani_v(GPGETBOOLEANI_V fnptr, GLenum  target, GLuint  index, GLboolean * data) {
 //   (*fnptr)(target, index, data);
 // }
@@ -1451,11 +2319,20 @@ package gl
 // static void  glowGetBufferParameteriv(GPGETBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetBufferParameterui64vNV(GPGETBUFFERPARAMETERUI64VNV fnptr, GLenum  target, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(target, pname, params);
+// }
 // static void  glowGetBufferPointerv(GPGETBUFFERPOINTERV fnptr, GLenum  target, GLenum  pname, void ** params) {
 //   (*fnptr)(target, pname, params);
 // }
 // static void  glowGetBufferSubData(GPGETBUFFERSUBDATA fnptr, GLenum  target, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(target, offset, size, data);
+// }
+// static GLuint  glowGetCommandHeaderNV(GPGETCOMMANDHEADERNV fnptr, GLenum  tokenID, GLuint  size) {
+//   return (*fnptr)(tokenID, size);
+// }
+// static void  glowGetCompressedMultiTexImageEXT(GPGETCOMPRESSEDMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texunit, target, lod, img);
 // }
 // static void  glowGetCompressedTexImage(GPGETCOMPRESSEDTEXIMAGE fnptr, GLenum  target, GLint  level, void * img) {
 //   (*fnptr)(target, level, img);
@@ -1463,8 +2340,14 @@ package gl
 // static void  glowGetCompressedTextureImage(GPGETCOMPRESSEDTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, bufSize, pixels);
 // }
+// static void  glowGetCompressedTextureImageEXT(GPGETCOMPRESSEDTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  lod, void * img) {
+//   (*fnptr)(texture, target, lod, img);
+// }
 // static void  glowGetCompressedTextureSubImage(GPGETCOMPRESSEDTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
+// }
+// static void  glowGetCoverageModulationTableNV(GPGETCOVERAGEMODULATIONTABLENV fnptr, GLsizei  bufsize, GLfloat * v) {
+//   (*fnptr)(bufsize, v);
 // }
 // static GLuint  glowGetDebugMessageLog(GPGETDEBUGMESSAGELOG fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
@@ -1475,8 +2358,14 @@ package gl
 // static GLuint  glowGetDebugMessageLogKHR(GPGETDEBUGMESSAGELOGKHR fnptr, GLuint  count, GLsizei  bufSize, GLenum * sources, GLenum * types, GLuint * ids, GLenum * severities, GLsizei * lengths, GLchar * messageLog) {
 //   return (*fnptr)(count, bufSize, sources, types, ids, severities, lengths, messageLog);
 // }
+// static void  glowGetDoubleIndexedvEXT(GPGETDOUBLEINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLdouble * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetDoublei_v(GPGETDOUBLEI_V fnptr, GLenum  target, GLuint  index, GLdouble * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetDoublei_vEXT(GPGETDOUBLEI_VEXT fnptr, GLenum  pname, GLuint  index, GLdouble * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetDoublev(GPGETDOUBLEV fnptr, GLenum  pname, GLdouble * data) {
 //   (*fnptr)(pname, data);
@@ -1484,8 +2373,17 @@ package gl
 // static GLenum  glowGetError(GPGETERROR fnptr) {
 //   return (*fnptr)();
 // }
+// static void  glowGetFirstPerfQueryIdINTEL(GPGETFIRSTPERFQUERYIDINTEL fnptr, GLuint * queryId) {
+//   (*fnptr)(queryId);
+// }
+// static void  glowGetFloatIndexedvEXT(GPGETFLOATINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLfloat * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetFloati_v(GPGETFLOATI_V fnptr, GLenum  target, GLuint  index, GLfloat * data) {
 //   (*fnptr)(target, index, data);
+// }
+// static void  glowGetFloati_vEXT(GPGETFLOATI_VEXT fnptr, GLenum  pname, GLuint  index, GLfloat * params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetFloatv(GPGETFLOATV fnptr, GLenum  pname, GLfloat * data) {
 //   (*fnptr)(pname, data);
@@ -1502,6 +2400,9 @@ package gl
 // static void  glowGetFramebufferParameteriv(GPGETFRAMEBUFFERPARAMETERIV fnptr, GLenum  target, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, pname, params);
 // }
+// static void  glowGetFramebufferParameterivEXT(GPGETFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
 // static GLenum  glowGetGraphicsResetStatus(GPGETGRAPHICSRESETSTATUS fnptr) {
 //   return (*fnptr)();
 // }
@@ -1514,23 +2415,74 @@ package gl
 // static GLuint64  glowGetImageHandleARB(GPGETIMAGEHANDLEARB fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
 //   return (*fnptr)(texture, level, layered, layer, format);
 // }
+// static GLuint64  glowGetImageHandleNV(GPGETIMAGEHANDLENV fnptr, GLuint  texture, GLint  level, GLboolean  layered, GLint  layer, GLenum  format) {
+//   return (*fnptr)(texture, level, layered, layer, format);
+// }
 // static void  glowGetInteger64i_v(GPGETINTEGER64I_V fnptr, GLenum  target, GLuint  index, GLint64 * data) {
 //   (*fnptr)(target, index, data);
 // }
 // static void  glowGetInteger64v(GPGETINTEGER64V fnptr, GLenum  pname, GLint64 * data) {
 //   (*fnptr)(pname, data);
 // }
+// static void  glowGetIntegerIndexedvEXT(GPGETINTEGERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, GLint * data) {
+//   (*fnptr)(target, index, data);
+// }
 // static void  glowGetIntegeri_v(GPGETINTEGERI_V fnptr, GLenum  target, GLuint  index, GLint * data) {
 //   (*fnptr)(target, index, data);
 // }
+// static void  glowGetIntegerui64i_vNV(GPGETINTEGERUI64I_VNV fnptr, GLenum  value, GLuint  index, GLuint64EXT * result) {
+//   (*fnptr)(value, index, result);
+// }
+// static void  glowGetIntegerui64vNV(GPGETINTEGERUI64VNV fnptr, GLenum  value, GLuint64EXT * result) {
+//   (*fnptr)(value, result);
+// }
 // static void  glowGetIntegerv(GPGETINTEGERV fnptr, GLenum  pname, GLint * data) {
 //   (*fnptr)(pname, data);
+// }
+// static void  glowGetInternalformatSampleivNV(GPGETINTERNALFORMATSAMPLEIVNV fnptr, GLenum  target, GLenum  internalformat, GLsizei  samples, GLenum  pname, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(target, internalformat, samples, pname, bufSize, params);
 // }
 // static void  glowGetInternalformati64v(GPGETINTERNALFORMATI64V fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint64 * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
 // }
 // static void  glowGetInternalformativ(GPGETINTERNALFORMATIV fnptr, GLenum  target, GLenum  internalformat, GLenum  pname, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(target, internalformat, pname, bufSize, params);
+// }
+// static void  glowGetMultiTexEnvfvEXT(GPGETMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexEnvivEXT(GPGETMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexGendvEXT(GPGETMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenfvEXT(GPGETMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexGenivEXT(GPGETMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowGetMultiTexImageEXT(GPGETMULTITEXIMAGEEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texunit, target, level, format, type, pixels);
+// }
+// static void  glowGetMultiTexLevelParameterfvEXT(GPGETMULTITEXLEVELPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexLevelParameterivEXT(GPGETMULTITEXLEVELPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, level, pname, params);
+// }
+// static void  glowGetMultiTexParameterIivEXT(GPGETMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterIuivEXT(GPGETMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterfvEXT(GPGETMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowGetMultiTexParameterivEXT(GPGETMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
 // }
 // static void  glowGetMultisamplefv(GPGETMULTISAMPLEFV fnptr, GLenum  pname, GLuint  index, GLfloat * val) {
 //   (*fnptr)(pname, index, val);
@@ -1541,19 +2493,58 @@ package gl
 // static void  glowGetNamedBufferParameteriv(GPGETNAMEDBUFFERPARAMETERIV fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(buffer, pname, params);
 // }
+// static void  glowGetNamedBufferParameterivEXT(GPGETNAMEDBUFFERPARAMETERIVEXT fnptr, GLuint  buffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferParameterui64vNV(GPGETNAMEDBUFFERPARAMETERUI64VNV fnptr, GLuint  buffer, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(buffer, pname, params);
+// }
 // static void  glowGetNamedBufferPointerv(GPGETNAMEDBUFFERPOINTERV fnptr, GLuint  buffer, GLenum  pname, void ** params) {
 //   (*fnptr)(buffer, pname, params);
 // }
-// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, void * data) {
+// static void  glowGetNamedBufferPointervEXT(GPGETNAMEDBUFFERPOINTERVEXT fnptr, GLuint  buffer, GLenum  pname, void ** params) {
+//   (*fnptr)(buffer, pname, params);
+// }
+// static void  glowGetNamedBufferSubData(GPGETNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowGetNamedBufferSubDataEXT(GPGETNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, void * data) {
 //   (*fnptr)(buffer, offset, size, data);
 // }
 // static void  glowGetNamedFramebufferAttachmentParameteriv(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
 //   (*fnptr)(framebuffer, attachment, pname, params);
 // }
+// static void  glowGetNamedFramebufferAttachmentParameterivEXT(GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, attachment, pname, params);
+// }
 // static void  glowGetNamedFramebufferParameteriv(GPGETNAMEDFRAMEBUFFERPARAMETERIV fnptr, GLuint  framebuffer, GLenum  pname, GLint * param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowGetNamedFramebufferParameterivEXT(GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(framebuffer, pname, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterIuivEXT(GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterdvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramLocalParameterfvEXT(GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowGetNamedProgramStringEXT(GPGETNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, void * string) {
+//   (*fnptr)(program, target, pname, string);
+// }
+// static void  glowGetNamedProgramivEXT(GPGETNAMEDPROGRAMIVEXT fnptr, GLuint  program, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(program, target, pname, params);
+// }
 // static void  glowGetNamedRenderbufferParameteriv(GPGETNAMEDRENDERBUFFERPARAMETERIV fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
+//   (*fnptr)(renderbuffer, pname, params);
+// }
+// static void  glowGetNamedRenderbufferParameterivEXT(GPGETNAMEDRENDERBUFFERPARAMETERIVEXT fnptr, GLuint  renderbuffer, GLenum  pname, GLint * params) {
 //   (*fnptr)(renderbuffer, pname, params);
 // }
 // static void  glowGetNamedStringARB(GPGETNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name, GLsizei  bufSize, GLint * stringlen, GLchar * string) {
@@ -1562,8 +2553,14 @@ package gl
 // static void  glowGetNamedStringivARB(GPGETNAMEDSTRINGIVARB fnptr, GLint  namelen, const GLchar * name, GLenum  pname, GLint * params) {
 //   (*fnptr)(namelen, name, pname, params);
 // }
+// static void  glowGetNextPerfQueryIdINTEL(GPGETNEXTPERFQUERYIDINTEL fnptr, GLuint  queryId, GLuint * nextQueryId) {
+//   (*fnptr)(queryId, nextQueryId);
+// }
 // static void  glowGetObjectLabel(GPGETOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
+// }
+// static void  glowGetObjectLabelEXT(GPGETOBJECTLABELEXT fnptr, GLenum  type, GLuint  object, GLsizei  bufSize, GLsizei * length, GLchar * label) {
+//   (*fnptr)(type, object, bufSize, length, label);
 // }
 // static void  glowGetObjectLabelKHR(GPGETOBJECTLABELKHR fnptr, GLenum  identifier, GLuint  name, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(identifier, name, bufSize, length, label);
@@ -1573,6 +2570,69 @@ package gl
 // }
 // static void  glowGetObjectPtrLabelKHR(GPGETOBJECTPTRLABELKHR fnptr, const void * ptr, GLsizei  bufSize, GLsizei * length, GLchar * label) {
 //   (*fnptr)(ptr, bufSize, length, label);
+// }
+// static void  glowGetPathCommandsNV(GPGETPATHCOMMANDSNV fnptr, GLuint  path, GLubyte * commands) {
+//   (*fnptr)(path, commands);
+// }
+// static void  glowGetPathCoordsNV(GPGETPATHCOORDSNV fnptr, GLuint  path, GLfloat * coords) {
+//   (*fnptr)(path, coords);
+// }
+// static void  glowGetPathDashArrayNV(GPGETPATHDASHARRAYNV fnptr, GLuint  path, GLfloat * dashArray) {
+//   (*fnptr)(path, dashArray);
+// }
+// static GLfloat  glowGetPathLengthNV(GPGETPATHLENGTHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments) {
+//   return (*fnptr)(path, startSegment, numSegments);
+// }
+// static void  glowGetPathMetricRangeNV(GPGETPATHMETRICRANGENV fnptr, GLbitfield  metricQueryMask, GLuint  firstPathName, GLsizei  numPaths, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, firstPathName, numPaths, stride, metrics);
+// }
+// static void  glowGetPathMetricsNV(GPGETPATHMETRICSNV fnptr, GLbitfield  metricQueryMask, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLsizei  stride, GLfloat * metrics) {
+//   (*fnptr)(metricQueryMask, numPaths, pathNameType, paths, pathBase, stride, metrics);
+// }
+// static void  glowGetPathParameterfvNV(GPGETPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathParameterivNV(GPGETPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowGetPathSpacingNV(GPGETPATHSPACINGNV fnptr, GLenum  pathListMode, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLfloat  advanceScale, GLfloat  kerningScale, GLenum  transformType, GLfloat * returnedSpacing) {
+//   (*fnptr)(pathListMode, numPaths, pathNameType, paths, pathBase, advanceScale, kerningScale, transformType, returnedSpacing);
+// }
+// static void  glowGetPerfCounterInfoINTEL(GPGETPERFCOUNTERINFOINTEL fnptr, GLuint  queryId, GLuint  counterId, GLuint  counterNameLength, GLchar * counterName, GLuint  counterDescLength, GLchar * counterDesc, GLuint * counterOffset, GLuint * counterDataSize, GLuint * counterTypeEnum, GLuint * counterDataTypeEnum, GLuint64 * rawCounterMaxValue) {
+//   (*fnptr)(queryId, counterId, counterNameLength, counterName, counterDescLength, counterDesc, counterOffset, counterDataSize, counterTypeEnum, counterDataTypeEnum, rawCounterMaxValue);
+// }
+// static void  glowGetPerfMonitorCounterDataAMD(GPGETPERFMONITORCOUNTERDATAAMD fnptr, GLuint  monitor, GLenum  pname, GLsizei  dataSize, GLuint * data, GLint * bytesWritten) {
+//   (*fnptr)(monitor, pname, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfMonitorCounterInfoAMD(GPGETPERFMONITORCOUNTERINFOAMD fnptr, GLuint  group, GLuint  counter, GLenum  pname, void * data) {
+//   (*fnptr)(group, counter, pname, data);
+// }
+// static void  glowGetPerfMonitorCounterStringAMD(GPGETPERFMONITORCOUNTERSTRINGAMD fnptr, GLuint  group, GLuint  counter, GLsizei  bufSize, GLsizei * length, GLchar * counterString) {
+//   (*fnptr)(group, counter, bufSize, length, counterString);
+// }
+// static void  glowGetPerfMonitorCountersAMD(GPGETPERFMONITORCOUNTERSAMD fnptr, GLuint  group, GLint * numCounters, GLint * maxActiveCounters, GLsizei  counterSize, GLuint * counters) {
+//   (*fnptr)(group, numCounters, maxActiveCounters, counterSize, counters);
+// }
+// static void  glowGetPerfMonitorGroupStringAMD(GPGETPERFMONITORGROUPSTRINGAMD fnptr, GLuint  group, GLsizei  bufSize, GLsizei * length, GLchar * groupString) {
+//   (*fnptr)(group, bufSize, length, groupString);
+// }
+// static void  glowGetPerfMonitorGroupsAMD(GPGETPERFMONITORGROUPSAMD fnptr, GLint * numGroups, GLsizei  groupsSize, GLuint * groups) {
+//   (*fnptr)(numGroups, groupsSize, groups);
+// }
+// static void  glowGetPerfQueryDataINTEL(GPGETPERFQUERYDATAINTEL fnptr, GLuint  queryHandle, GLuint  flags, GLsizei  dataSize, void * data, GLuint * bytesWritten) {
+//   (*fnptr)(queryHandle, flags, dataSize, data, bytesWritten);
+// }
+// static void  glowGetPerfQueryIdByNameINTEL(GPGETPERFQUERYIDBYNAMEINTEL fnptr, GLchar * queryName, GLuint * queryId) {
+//   (*fnptr)(queryName, queryId);
+// }
+// static void  glowGetPerfQueryInfoINTEL(GPGETPERFQUERYINFOINTEL fnptr, GLuint  queryId, GLuint  queryNameLength, GLchar * queryName, GLuint * dataSize, GLuint * noCounters, GLuint * noInstances, GLuint * capsMask) {
+//   (*fnptr)(queryId, queryNameLength, queryName, dataSize, noCounters, noInstances, capsMask);
+// }
+// static void  glowGetPointerIndexedvEXT(GPGETPOINTERINDEXEDVEXT fnptr, GLenum  target, GLuint  index, void ** data) {
+//   (*fnptr)(target, index, data);
+// }
+// static void  glowGetPointeri_vEXT(GPGETPOINTERI_VEXT fnptr, GLenum  pname, GLuint  index, void ** params) {
+//   (*fnptr)(pname, index, params);
 // }
 // static void  glowGetPointerv(GPGETPOINTERV fnptr, GLenum  pname, void ** params) {
 //   (*fnptr)(pname, params);
@@ -1592,7 +2652,13 @@ package gl
 // static void  glowGetProgramPipelineInfoLog(GPGETPROGRAMPIPELINEINFOLOG fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
 //   (*fnptr)(pipeline, bufSize, length, infoLog);
 // }
+// static void  glowGetProgramPipelineInfoLogEXT(GPGETPROGRAMPIPELINEINFOLOGEXT fnptr, GLuint  pipeline, GLsizei  bufSize, GLsizei * length, GLchar * infoLog) {
+//   (*fnptr)(pipeline, bufSize, length, infoLog);
+// }
 // static void  glowGetProgramPipelineiv(GPGETPROGRAMPIPELINEIV fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
+//   (*fnptr)(pipeline, pname, params);
+// }
+// static void  glowGetProgramPipelineivEXT(GPGETPROGRAMPIPELINEIVEXT fnptr, GLuint  pipeline, GLenum  pname, GLint * params) {
 //   (*fnptr)(pipeline, pname, params);
 // }
 // static GLuint  glowGetProgramResourceIndex(GPGETPROGRAMRESOURCEINDEX fnptr, GLuint  program, GLenum  programInterface, const GLchar * name) {
@@ -1607,6 +2673,9 @@ package gl
 // static void  glowGetProgramResourceName(GPGETPROGRAMRESOURCENAME fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  bufSize, GLsizei * length, GLchar * name) {
 //   (*fnptr)(program, programInterface, index, bufSize, length, name);
 // }
+// static void  glowGetProgramResourcefvNV(GPGETPROGRAMRESOURCEFVNV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLfloat * params) {
+//   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
+// }
 // static void  glowGetProgramResourceiv(GPGETPROGRAMRESOURCEIV fnptr, GLuint  program, GLenum  programInterface, GLuint  index, GLsizei  propCount, const GLenum * props, GLsizei  bufSize, GLsizei * length, GLint * params) {
 //   (*fnptr)(program, programInterface, index, propCount, props, bufSize, length, params);
 // }
@@ -1615,6 +2684,18 @@ package gl
 // }
 // static void  glowGetProgramiv(GPGETPROGRAMIV fnptr, GLuint  program, GLenum  pname, GLint * params) {
 //   (*fnptr)(program, pname, params);
+// }
+// static void  glowGetQueryBufferObjecti64v(GPGETQUERYBUFFEROBJECTI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectiv(GPGETQUERYBUFFEROBJECTIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectui64v(GPGETQUERYBUFFEROBJECTUI64V fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
+// }
+// static void  glowGetQueryBufferObjectuiv(GPGETQUERYBUFFEROBJECTUIV fnptr, GLuint  id, GLuint  buffer, GLenum  pname, GLintptr  offset) {
+//   (*fnptr)(id, buffer, pname, offset);
 // }
 // static void  glowGetQueryIndexediv(GPGETQUERYINDEXEDIV fnptr, GLenum  target, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(target, index, pname, params);
@@ -1661,6 +2742,9 @@ package gl
 // static void  glowGetShaderiv(GPGETSHADERIV fnptr, GLuint  shader, GLenum  pname, GLint * params) {
 //   (*fnptr)(shader, pname, params);
 // }
+// static GLushort  glowGetStageIndexNV(GPGETSTAGEINDEXNV fnptr, GLenum  shadertype) {
+//   return (*fnptr)(shadertype);
+// }
 // static const GLubyte * glowGetString(GPGETSTRING fnptr, GLenum  name) {
 //   return (*fnptr)(name);
 // }
@@ -1700,28 +2784,55 @@ package gl
 // static GLuint64  glowGetTextureHandleARB(GPGETTEXTUREHANDLEARB fnptr, GLuint  texture) {
 //   return (*fnptr)(texture);
 // }
+// static GLuint64  glowGetTextureHandleNV(GPGETTEXTUREHANDLENV fnptr, GLuint  texture) {
+//   return (*fnptr)(texture);
+// }
 // static void  glowGetTextureImage(GPGETTEXTUREIMAGE fnptr, GLuint  texture, GLint  level, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(texture, level, format, type, bufSize, pixels);
+// }
+// static void  glowGetTextureImageEXT(GPGETTEXTUREIMAGEEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  format, GLenum  type, void * pixels) {
+//   (*fnptr)(texture, target, level, format, type, pixels);
 // }
 // static void  glowGetTextureLevelParameterfv(GPGETTEXTURELEVELPARAMETERFV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, level, pname, params);
 // }
+// static void  glowGetTextureLevelParameterfvEXT(GPGETTEXTURELEVELPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, level, pname, params);
+// }
 // static void  glowGetTextureLevelParameteriv(GPGETTEXTURELEVELPARAMETERIV fnptr, GLuint  texture, GLint  level, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, level, pname, params);
+// }
+// static void  glowGetTextureLevelParameterivEXT(GPGETTEXTURELEVELPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, level, pname, params);
 // }
 // static void  glowGetTextureParameterIiv(GPGETTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterIivEXT(GPGETTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameterIuiv(GPGETTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowGetTextureParameterIuivEXT(GPGETTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowGetTextureParameterfv(GPGETTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, GLfloat * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterfvEXT(GPGETTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowGetTextureParameteriv(GPGETTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowGetTextureParameterivEXT(GPGETTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static GLuint64  glowGetTextureSamplerHandleARB(GPGETTEXTURESAMPLERHANDLEARB fnptr, GLuint  texture, GLuint  sampler) {
+//   return (*fnptr)(texture, sampler);
+// }
+// static GLuint64  glowGetTextureSamplerHandleNV(GPGETTEXTURESAMPLERHANDLENV fnptr, GLuint  texture, GLuint  sampler) {
 //   return (*fnptr)(texture, sampler);
 // }
 // static void  glowGetTextureSubImage(GPGETTEXTURESUBIMAGE fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, GLsizei  bufSize, void * pixels) {
@@ -1757,7 +2868,19 @@ package gl
 // static void  glowGetUniformfv(GPGETUNIFORMFV fnptr, GLuint  program, GLint  location, GLfloat * params) {
 //   (*fnptr)(program, location, params);
 // }
+// static void  glowGetUniformi64vARB(GPGETUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformi64vNV(GPGETUNIFORMI64VNV fnptr, GLuint  program, GLint  location, GLint64EXT * params) {
+//   (*fnptr)(program, location, params);
+// }
 // static void  glowGetUniformiv(GPGETUNIFORMIV fnptr, GLuint  program, GLint  location, GLint * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vARB(GPGETUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLuint64 * params) {
+//   (*fnptr)(program, location, params);
+// }
+// static void  glowGetUniformui64vNV(GPGETUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLuint64EXT * params) {
 //   (*fnptr)(program, location, params);
 // }
 // static void  glowGetUniformuiv(GPGETUNIFORMUIV fnptr, GLuint  program, GLint  location, GLuint * params) {
@@ -1768,6 +2891,18 @@ package gl
 // }
 // static void  glowGetVertexArrayIndexediv(GPGETVERTEXARRAYINDEXEDIV fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegeri_vEXT(GPGETVERTEXARRAYINTEGERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayIntegervEXT(GPGETVERTEXARRAYINTEGERVEXT fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
+//   (*fnptr)(vaobj, pname, param);
+// }
+// static void  glowGetVertexArrayPointeri_vEXT(GPGETVERTEXARRAYPOINTERI_VEXT fnptr, GLuint  vaobj, GLuint  index, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, index, pname, param);
+// }
+// static void  glowGetVertexArrayPointervEXT(GPGETVERTEXARRAYPOINTERVEXT fnptr, GLuint  vaobj, GLenum  pname, void ** param) {
+//   (*fnptr)(vaobj, pname, param);
 // }
 // static void  glowGetVertexArrayiv(GPGETVERTEXARRAYIV fnptr, GLuint  vaobj, GLenum  pname, GLint * param) {
 //   (*fnptr)(vaobj, pname, param);
@@ -1781,7 +2916,13 @@ package gl
 // static void  glowGetVertexAttribLdv(GPGETVERTEXATTRIBLDV fnptr, GLuint  index, GLenum  pname, GLdouble * params) {
 //   (*fnptr)(index, pname, params);
 // }
+// static void  glowGetVertexAttribLi64vNV(GPGETVERTEXATTRIBLI64VNV fnptr, GLuint  index, GLenum  pname, GLint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
 // static void  glowGetVertexAttribLui64vARB(GPGETVERTEXATTRIBLUI64VARB fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
+//   (*fnptr)(index, pname, params);
+// }
+// static void  glowGetVertexAttribLui64vNV(GPGETVERTEXATTRIBLUI64VNV fnptr, GLuint  index, GLenum  pname, GLuint64EXT * params) {
 //   (*fnptr)(index, pname, params);
 // }
 // static void  glowGetVertexAttribPointerv(GPGETVERTEXATTRIBPOINTERV fnptr, GLuint  index, GLenum  pname, void ** pointer) {
@@ -1795,6 +2936,9 @@ package gl
 // }
 // static void  glowGetVertexAttribiv(GPGETVERTEXATTRIBIV fnptr, GLuint  index, GLenum  pname, GLint * params) {
 //   (*fnptr)(index, pname, params);
+// }
+// static GLVULKANPROCNV  glowGetVkProcAddrNV(GPGETVKPROCADDRNV fnptr, const GLchar * name) {
+//   return (*fnptr)(name);
 // }
 // static void  glowGetnCompressedTexImage(GPGETNCOMPRESSEDTEXIMAGE fnptr, GLenum  target, GLint  lod, GLsizei  bufSize, void * pixels) {
 //   (*fnptr)(target, lod, bufSize, pixels);
@@ -1823,6 +2967,9 @@ package gl
 // static void  glowGetnUniformfvKHR(GPGETNUNIFORMFVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLfloat * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
+// static void  glowGetnUniformi64vARB(GPGETNUNIFORMI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint64 * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
 // static void  glowGetnUniformiv(GPGETNUNIFORMIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
@@ -1830,6 +2977,9 @@ package gl
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformivKHR(GPGETNUNIFORMIVKHR fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLint * params) {
+//   (*fnptr)(program, location, bufSize, params);
+// }
+// static void  glowGetnUniformui64vARB(GPGETNUNIFORMUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint64 * params) {
 //   (*fnptr)(program, location, bufSize, params);
 // }
 // static void  glowGetnUniformuiv(GPGETNUNIFORMUIV fnptr, GLuint  program, GLint  location, GLsizei  bufSize, GLuint * params) {
@@ -1843,6 +2993,15 @@ package gl
 // }
 // static void  glowHint(GPHINT fnptr, GLenum  target, GLenum  mode) {
 //   (*fnptr)(target, mode);
+// }
+// static void  glowIndexFormatNV(GPINDEXFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
+// }
+// static void  glowInsertEventMarkerEXT(GPINSERTEVENTMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
+// static void  glowInterpolatePathsNV(GPINTERPOLATEPATHSNV fnptr, GLuint  resultPath, GLuint  pathA, GLuint  pathB, GLfloat  weight) {
+//   (*fnptr)(resultPath, pathA, pathB, weight);
 // }
 // static void  glowInvalidateBufferData(GPINVALIDATEBUFFERDATA fnptr, GLuint  buffer) {
 //   (*fnptr)(buffer);
@@ -1871,8 +3030,17 @@ package gl
 // static GLboolean  glowIsBuffer(GPISBUFFER fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
+// static GLboolean  glowIsBufferResidentNV(GPISBUFFERRESIDENTNV fnptr, GLenum  target) {
+//   return (*fnptr)(target);
+// }
+// static GLboolean  glowIsCommandListNV(GPISCOMMANDLISTNV fnptr, GLuint  list) {
+//   return (*fnptr)(list);
+// }
 // static GLboolean  glowIsEnabled(GPISENABLED fnptr, GLenum  cap) {
 //   return (*fnptr)(cap);
+// }
+// static GLboolean  glowIsEnabledIndexedEXT(GPISENABLEDINDEXEDEXT fnptr, GLenum  target, GLuint  index) {
+//   return (*fnptr)(target, index);
 // }
 // static GLboolean  glowIsEnabledi(GPISENABLEDI fnptr, GLenum  target, GLuint  index) {
 //   return (*fnptr)(target, index);
@@ -1883,13 +3051,31 @@ package gl
 // static GLboolean  glowIsImageHandleResidentARB(GPISIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsImageHandleResidentNV(GPISIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
+// static GLboolean  glowIsNamedBufferResidentNV(GPISNAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
 // static GLboolean  glowIsNamedStringARB(GPISNAMEDSTRINGARB fnptr, GLint  namelen, const GLchar * name) {
 //   return (*fnptr)(namelen, name);
+// }
+// static GLboolean  glowIsPathNV(GPISPATHNV fnptr, GLuint  path) {
+//   return (*fnptr)(path);
+// }
+// static GLboolean  glowIsPointInFillPathNV(GPISPOINTINFILLPATHNV fnptr, GLuint  path, GLuint  mask, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, mask, x, y);
+// }
+// static GLboolean  glowIsPointInStrokePathNV(GPISPOINTINSTROKEPATHNV fnptr, GLuint  path, GLfloat  x, GLfloat  y) {
+//   return (*fnptr)(path, x, y);
 // }
 // static GLboolean  glowIsProgram(GPISPROGRAM fnptr, GLuint  program) {
 //   return (*fnptr)(program);
 // }
 // static GLboolean  glowIsProgramPipeline(GPISPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   return (*fnptr)(pipeline);
+// }
+// static GLboolean  glowIsProgramPipelineEXT(GPISPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   return (*fnptr)(pipeline);
 // }
 // static GLboolean  glowIsQuery(GPISQUERY fnptr, GLuint  id) {
@@ -1904,6 +3090,9 @@ package gl
 // static GLboolean  glowIsShader(GPISSHADER fnptr, GLuint  shader) {
 //   return (*fnptr)(shader);
 // }
+// static GLboolean  glowIsStateNV(GPISSTATENV fnptr, GLuint  state) {
+//   return (*fnptr)(state);
+// }
 // static GLboolean  glowIsSync(GPISSYNC fnptr, GLsync  sync) {
 //   return (*fnptr)(sync);
 // }
@@ -1913,11 +3102,17 @@ package gl
 // static GLboolean  glowIsTextureHandleResidentARB(GPISTEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
 //   return (*fnptr)(handle);
 // }
+// static GLboolean  glowIsTextureHandleResidentNV(GPISTEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
+//   return (*fnptr)(handle);
+// }
 // static GLboolean  glowIsTransformFeedback(GPISTRANSFORMFEEDBACK fnptr, GLuint  id) {
 //   return (*fnptr)(id);
 // }
 // static GLboolean  glowIsVertexArray(GPISVERTEXARRAY fnptr, GLuint  array) {
 //   return (*fnptr)(array);
+// }
+// static void  glowLabelObjectEXT(GPLABELOBJECTEXT fnptr, GLenum  type, GLuint  object, GLsizei  length, const GLchar * label) {
+//   (*fnptr)(type, object, length, label);
 // }
 // static void  glowLineWidth(GPLINEWIDTH fnptr, GLfloat  width) {
 //   (*fnptr)(width);
@@ -1925,19 +3120,46 @@ package gl
 // static void  glowLinkProgram(GPLINKPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
+// static void  glowListDrawCommandsStatesClientNV(GPLISTDRAWCOMMANDSSTATESCLIENTNV fnptr, GLuint  list, GLuint  segment, const void ** indirects, const GLsizei * sizes, const GLuint * states, const GLuint * fbos, GLuint  count) {
+//   (*fnptr)(list, segment, indirects, sizes, states, fbos, count);
+// }
 // static void  glowLogicOp(GPLOGICOP fnptr, GLenum  opcode) {
 //   (*fnptr)(opcode);
 // }
+// static void  glowMakeBufferNonResidentNV(GPMAKEBUFFERNONRESIDENTNV fnptr, GLenum  target) {
+//   (*fnptr)(target);
+// }
+// static void  glowMakeBufferResidentNV(GPMAKEBUFFERRESIDENTNV fnptr, GLenum  target, GLenum  access) {
+//   (*fnptr)(target, access);
+// }
 // static void  glowMakeImageHandleNonResidentARB(GPMAKEIMAGEHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeImageHandleNonResidentNV(GPMAKEIMAGEHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void  glowMakeImageHandleResidentARB(GPMAKEIMAGEHANDLERESIDENTARB fnptr, GLuint64  handle, GLenum  access) {
 //   (*fnptr)(handle, access);
 // }
+// static void  glowMakeImageHandleResidentNV(GPMAKEIMAGEHANDLERESIDENTNV fnptr, GLuint64  handle, GLenum  access) {
+//   (*fnptr)(handle, access);
+// }
+// static void  glowMakeNamedBufferNonResidentNV(GPMAKENAMEDBUFFERNONRESIDENTNV fnptr, GLuint  buffer) {
+//   (*fnptr)(buffer);
+// }
+// static void  glowMakeNamedBufferResidentNV(GPMAKENAMEDBUFFERRESIDENTNV fnptr, GLuint  buffer, GLenum  access) {
+//   (*fnptr)(buffer, access);
+// }
 // static void  glowMakeTextureHandleNonResidentARB(GPMAKETEXTUREHANDLENONRESIDENTARB fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
+// static void  glowMakeTextureHandleNonResidentNV(GPMAKETEXTUREHANDLENONRESIDENTNV fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
 // static void  glowMakeTextureHandleResidentARB(GPMAKETEXTUREHANDLERESIDENTARB fnptr, GLuint64  handle) {
+//   (*fnptr)(handle);
+// }
+// static void  glowMakeTextureHandleResidentNV(GPMAKETEXTUREHANDLERESIDENTNV fnptr, GLuint64  handle) {
 //   (*fnptr)(handle);
 // }
 // static void * glowMapBuffer(GPMAPBUFFER fnptr, GLenum  target, GLenum  access) {
@@ -1949,8 +3171,95 @@ package gl
 // static void * glowMapNamedBuffer(GPMAPNAMEDBUFFER fnptr, GLuint  buffer, GLenum  access) {
 //   return (*fnptr)(buffer, access);
 // }
-// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizei  length, GLbitfield  access) {
+// static void * glowMapNamedBufferEXT(GPMAPNAMEDBUFFEREXT fnptr, GLuint  buffer, GLenum  access) {
+//   return (*fnptr)(buffer, access);
+// }
+// static void * glowMapNamedBufferRange(GPMAPNAMEDBUFFERRANGE fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
 //   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void * glowMapNamedBufferRangeEXT(GPMAPNAMEDBUFFERRANGEEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  length, GLbitfield  access) {
+//   return (*fnptr)(buffer, offset, length, access);
+// }
+// static void  glowMatrixFrustumEXT(GPMATRIXFRUSTUMEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixLoad3x2fNV(GPMATRIXLOAD3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoad3x3fNV(GPMATRIXLOAD3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadIdentityEXT(GPMATRIXLOADIDENTITYEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixLoadTranspose3x3fNV(GPMATRIXLOADTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixLoadTransposedEXT(GPMATRIXLOADTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadTransposefEXT(GPMATRIXLOADTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoaddEXT(GPMATRIXLOADDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixLoadfEXT(GPMATRIXLOADFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMult3x2fNV(GPMATRIXMULT3X2FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMult3x3fNV(GPMATRIXMULT3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTranspose3x3fNV(GPMATRIXMULTTRANSPOSE3X3FNV fnptr, GLenum  matrixMode, const GLfloat * m) {
+//   (*fnptr)(matrixMode, m);
+// }
+// static void  glowMatrixMultTransposedEXT(GPMATRIXMULTTRANSPOSEDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultTransposefEXT(GPMATRIXMULTTRANSPOSEFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultdEXT(GPMATRIXMULTDEXT fnptr, GLenum  mode, const GLdouble * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixMultfEXT(GPMATRIXMULTFEXT fnptr, GLenum  mode, const GLfloat * m) {
+//   (*fnptr)(mode, m);
+// }
+// static void  glowMatrixOrthoEXT(GPMATRIXORTHOEXT fnptr, GLenum  mode, GLdouble  left, GLdouble  right, GLdouble  bottom, GLdouble  top, GLdouble  zNear, GLdouble  zFar) {
+//   (*fnptr)(mode, left, right, bottom, top, zNear, zFar);
+// }
+// static void  glowMatrixPopEXT(GPMATRIXPOPEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixPushEXT(GPMATRIXPUSHEXT fnptr, GLenum  mode) {
+//   (*fnptr)(mode);
+// }
+// static void  glowMatrixRotatedEXT(GPMATRIXROTATEDEXT fnptr, GLenum  mode, GLdouble  angle, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixRotatefEXT(GPMATRIXROTATEFEXT fnptr, GLenum  mode, GLfloat  angle, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, angle, x, y, z);
+// }
+// static void  glowMatrixScaledEXT(GPMATRIXSCALEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixScalefEXT(GPMATRIXSCALEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatedEXT(GPMATRIXTRANSLATEDEXT fnptr, GLenum  mode, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMatrixTranslatefEXT(GPMATRIXTRANSLATEFEXT fnptr, GLenum  mode, GLfloat  x, GLfloat  y, GLfloat  z) {
+//   (*fnptr)(mode, x, y, z);
+// }
+// static void  glowMaxShaderCompilerThreadsARB(GPMAXSHADERCOMPILERTHREADSARB fnptr, GLuint  count) {
+//   (*fnptr)(count);
+// }
+// static void  glowMaxShaderCompilerThreadsKHR(GPMAXSHADERCOMPILERTHREADSKHR fnptr, GLuint  count) {
+//   (*fnptr)(count);
 // }
 // static void  glowMemoryBarrier(GPMEMORYBARRIER fnptr, GLbitfield  barriers) {
 //   (*fnptr)(barriers);
@@ -1970,7 +3279,13 @@ package gl
 // static void  glowMultiDrawArraysIndirect(GPMULTIDRAWARRAYSINDIRECT fnptr, GLenum  mode, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawArraysIndirectBindlessCountNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectBindlessNV(GPMULTIDRAWARRAYSINDIRECTBINDLESSNV fnptr, GLenum  mode, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawArraysIndirectCountARB(GPMULTIDRAWARRAYSINDIRECTCOUNTARB fnptr, GLenum  mode, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, indirect, drawcount, maxdrawcount, stride);
 // }
 // static void  glowMultiDrawElements(GPMULTIDRAWELEMENTS fnptr, GLenum  mode, const GLsizei * count, GLenum  type, const void *const* indices, GLsizei  drawcount) {
@@ -1982,23 +3297,116 @@ package gl
 // static void  glowMultiDrawElementsIndirect(GPMULTIDRAWELEMENTSINDIRECT fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, stride);
 // }
-// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, GLintptr  indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
+// static void  glowMultiDrawElementsIndirectBindlessCountNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  maxDrawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, maxDrawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectBindlessNV(GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV fnptr, GLenum  mode, GLenum  type, const void * indirect, GLsizei  drawCount, GLsizei  stride, GLint  vertexBufferCount) {
+//   (*fnptr)(mode, type, indirect, drawCount, stride, vertexBufferCount);
+// }
+// static void  glowMultiDrawElementsIndirectCountARB(GPMULTIDRAWELEMENTSINDIRECTCOUNTARB fnptr, GLenum  mode, GLenum  type, const void * indirect, GLintptr  drawcount, GLsizei  maxdrawcount, GLsizei  stride) {
 //   (*fnptr)(mode, type, indirect, drawcount, maxdrawcount, stride);
 // }
-// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizei  size, const void * data, GLenum  usage) {
+// static void  glowMultiTexBufferEXT(GPMULTITEXBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texunit, target, internalformat, buffer);
+// }
+// static void  glowMultiTexCoordPointerEXT(GPMULTITEXCOORDPOINTEREXT fnptr, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
+//   (*fnptr)(texunit, size, type, stride, pointer);
+// }
+// static void  glowMultiTexEnvfEXT(GPMULTITEXENVFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvfvEXT(GPMULTITEXENVFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexEnviEXT(GPMULTITEXENVIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexEnvivEXT(GPMULTITEXENVIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexGendEXT(GPMULTITEXGENDEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLdouble  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGendvEXT(GPMULTITEXGENDVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLdouble * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGenfEXT(GPMULTITEXGENFEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenfvEXT(GPMULTITEXGENFVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexGeniEXT(GPMULTITEXGENIEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, coord, pname, param);
+// }
+// static void  glowMultiTexGenivEXT(GPMULTITEXGENIVEXT fnptr, GLenum  texunit, GLenum  coord, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, coord, pname, params);
+// }
+// static void  glowMultiTexImage1DEXT(GPMULTITEXIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage2DEXT(GPMULTITEXIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowMultiTexImage3DEXT(GPMULTITEXIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowMultiTexParameterIivEXT(GPMULTITEXPARAMETERIIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterIuivEXT(GPMULTITEXPARAMETERIUIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameterfEXT(GPMULTITEXPARAMETERFEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterfvEXT(GPMULTITEXPARAMETERFVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexParameteriEXT(GPMULTITEXPARAMETERIEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texunit, target, pname, param);
+// }
+// static void  glowMultiTexParameterivEXT(GPMULTITEXPARAMETERIVEXT fnptr, GLenum  texunit, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texunit, target, pname, params);
+// }
+// static void  glowMultiTexRenderbufferEXT(GPMULTITEXRENDERBUFFEREXT fnptr, GLenum  texunit, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texunit, target, renderbuffer);
+// }
+// static void  glowMultiTexSubImage1DEXT(GPMULTITEXSUBIMAGE1DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage2DEXT(GPMULTITEXSUBIMAGE2DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
+// static void  glowMultiTexSubImage3DEXT(GPMULTITEXSUBIMAGE3DEXT fnptr, GLenum  texunit, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texunit, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowNamedBufferData(GPNAMEDBUFFERDATA fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
 //   (*fnptr)(buffer, size, data, usage);
 // }
-// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferDataEXT(GPNAMEDBUFFERDATAEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLenum  usage) {
+//   (*fnptr)(buffer, size, data, usage);
+// }
+// static void  glowNamedBufferPageCommitmentARB(GPNAMEDBUFFERPAGECOMMITMENTARB fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, GLboolean  commit) {
+// static void  glowNamedBufferPageCommitmentEXT(GPNAMEDBUFFERPAGECOMMITMENTEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, GLboolean  commit) {
 //   (*fnptr)(buffer, offset, size, commit);
 // }
-// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizei  size, const void * data, GLbitfield  flags) {
+// static void  glowNamedBufferStorage(GPNAMEDBUFFERSTORAGE fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
 //   (*fnptr)(buffer, size, data, flags);
 // }
-// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizei  size, const void * data) {
+// static void  glowNamedBufferStorageEXT(GPNAMEDBUFFERSTORAGEEXT fnptr, GLuint  buffer, GLsizeiptr  size, const void * data, GLbitfield  flags) {
+//   (*fnptr)(buffer, size, data, flags);
+// }
+// static void  glowNamedBufferSubData(GPNAMEDBUFFERSUBDATA fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
 //   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedBufferSubDataEXT(GPNAMEDBUFFERSUBDATAEXT fnptr, GLuint  buffer, GLintptr  offset, GLsizeiptr  size, const void * data) {
+//   (*fnptr)(buffer, offset, size, data);
+// }
+// static void  glowNamedCopyBufferSubDataEXT(GPNAMEDCOPYBUFFERSUBDATAEXT fnptr, GLuint  readBuffer, GLuint  writeBuffer, GLintptr  readOffset, GLintptr  writeOffset, GLsizeiptr  size) {
+//   (*fnptr)(readBuffer, writeBuffer, readOffset, writeOffset, size);
 // }
 // static void  glowNamedFramebufferDrawBuffer(GPNAMEDFRAMEBUFFERDRAWBUFFER fnptr, GLuint  framebuffer, GLenum  buf) {
 //   (*fnptr)(framebuffer, buf);
@@ -2009,26 +3417,104 @@ package gl
 // static void  glowNamedFramebufferParameteri(GPNAMEDFRAMEBUFFERPARAMETERI fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
 //   (*fnptr)(framebuffer, pname, param);
 // }
+// static void  glowNamedFramebufferParameteriEXT(GPNAMEDFRAMEBUFFERPARAMETERIEXT fnptr, GLuint  framebuffer, GLenum  pname, GLint  param) {
+//   (*fnptr)(framebuffer, pname, param);
+// }
 // static void  glowNamedFramebufferReadBuffer(GPNAMEDFRAMEBUFFERREADBUFFER fnptr, GLuint  framebuffer, GLenum  src) {
 //   (*fnptr)(framebuffer, src);
 // }
 // static void  glowNamedFramebufferRenderbuffer(GPNAMEDFRAMEBUFFERRENDERBUFFER fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
 //   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
 // }
+// static void  glowNamedFramebufferRenderbufferEXT(GPNAMEDFRAMEBUFFERRENDERBUFFEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  renderbuffertarget, GLuint  renderbuffer) {
+//   (*fnptr)(framebuffer, attachment, renderbuffertarget, renderbuffer);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvARB(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
+// static void  glowNamedFramebufferSampleLocationsfvNV(GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV fnptr, GLuint  framebuffer, GLuint  start, GLsizei  count, const GLfloat * v) {
+//   (*fnptr)(framebuffer, start, count, v);
+// }
 // static void  glowNamedFramebufferTexture(GPNAMEDFRAMEBUFFERTEXTURE fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
 //   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTexture1DEXT(GPNAMEDFRAMEBUFFERTEXTURE1DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture2DEXT(GPNAMEDFRAMEBUFFERTEXTURE2DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level);
+// }
+// static void  glowNamedFramebufferTexture3DEXT(GPNAMEDFRAMEBUFFERTEXTURE3DEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLenum  textarget, GLuint  texture, GLint  level, GLint  zoffset) {
+//   (*fnptr)(framebuffer, attachment, textarget, texture, level, zoffset);
+// }
+// static void  glowNamedFramebufferTextureEXT(GPNAMEDFRAMEBUFFERTEXTUREEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level) {
+//   (*fnptr)(framebuffer, attachment, texture, level);
+// }
+// static void  glowNamedFramebufferTextureFaceEXT(GPNAMEDFRAMEBUFFERTEXTUREFACEEXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLenum  face) {
+//   (*fnptr)(framebuffer, attachment, texture, level, face);
 // }
 // static void  glowNamedFramebufferTextureLayer(GPNAMEDFRAMEBUFFERTEXTURELAYER fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
 //   (*fnptr)(framebuffer, attachment, texture, level, layer);
 // }
+// static void  glowNamedFramebufferTextureLayerEXT(GPNAMEDFRAMEBUFFERTEXTURELAYEREXT fnptr, GLuint  framebuffer, GLenum  attachment, GLuint  texture, GLint  level, GLint  layer) {
+//   (*fnptr)(framebuffer, attachment, texture, level, layer);
+// }
+// static void  glowNamedProgramLocalParameter4dEXT(GPNAMEDPROGRAMLOCALPARAMETER4DEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4dvEXT(GPNAMEDPROGRAMLOCALPARAMETER4DVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLdouble * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameter4fEXT(GPNAMEDPROGRAMLOCALPARAMETER4FEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLfloat  x, GLfloat  y, GLfloat  z, GLfloat  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameter4fvEXT(GPNAMEDPROGRAMLOCALPARAMETER4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLfloat * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4iEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLint  x, GLint  y, GLint  z, GLint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameterI4uiEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLuint  x, GLuint  y, GLuint  z, GLuint  w) {
+//   (*fnptr)(program, target, index, x, y, z, w);
+// }
+// static void  glowNamedProgramLocalParameterI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, const GLuint * params) {
+//   (*fnptr)(program, target, index, params);
+// }
+// static void  glowNamedProgramLocalParameters4fvEXT(GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLfloat * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4ivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramLocalParametersI4uivEXT(GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT fnptr, GLuint  program, GLenum  target, GLuint  index, GLsizei  count, const GLuint * params) {
+//   (*fnptr)(program, target, index, count, params);
+// }
+// static void  glowNamedProgramStringEXT(GPNAMEDPROGRAMSTRINGEXT fnptr, GLuint  program, GLenum  target, GLenum  format, GLsizei  len, const void * string) {
+//   (*fnptr)(program, target, format, len, string);
+// }
 // static void  glowNamedRenderbufferStorage(GPNAMEDRENDERBUFFERSTORAGE fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageEXT(GPNAMEDRENDERBUFFERSTORAGEEXT fnptr, GLuint  renderbuffer, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, internalformat, width, height);
 // }
 // static void  glowNamedRenderbufferStorageMultisample(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(renderbuffer, samples, internalformat, width, height);
 // }
+// static void  glowNamedRenderbufferStorageMultisampleCoverageEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT fnptr, GLuint  renderbuffer, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowNamedRenderbufferStorageMultisampleEXT(GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT fnptr, GLuint  renderbuffer, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(renderbuffer, samples, internalformat, width, height);
+// }
 // static void  glowNamedStringARB(GPNAMEDSTRINGARB fnptr, GLenum  type, GLint  namelen, const GLchar * name, GLint  stringlen, const GLchar * string) {
 //   (*fnptr)(type, namelen, name, stringlen, string);
+// }
+// static void  glowNormalFormatNV(GPNORMALFORMATNV fnptr, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(type, stride);
 // }
 // static void  glowObjectLabel(GPOBJECTLABEL fnptr, GLenum  identifier, GLuint  name, GLsizei  length, const GLchar * label) {
 //   (*fnptr)(identifier, name, length, label);
@@ -2048,6 +3534,60 @@ package gl
 // static void  glowPatchParameteri(GPPATCHPARAMETERI fnptr, GLenum  pname, GLint  value) {
 //   (*fnptr)(pname, value);
 // }
+// static void  glowPathCommandsNV(GPPATHCOMMANDSNV fnptr, GLuint  path, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathCoordsNV(GPPATHCOORDSNV fnptr, GLuint  path, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, numCoords, coordType, coords);
+// }
+// static void  glowPathCoverDepthFuncNV(GPPATHCOVERDEPTHFUNCNV fnptr, GLenum  func) {
+//   (*fnptr)(func);
+// }
+// static void  glowPathDashArrayNV(GPPATHDASHARRAYNV fnptr, GLuint  path, GLsizei  dashCount, const GLfloat * dashArray) {
+//   (*fnptr)(path, dashCount, dashArray);
+// }
+// static GLenum  glowPathGlyphIndexArrayNV(GPPATHGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathGlyphIndexRangeNV(GPPATHGLYPHINDEXRANGENV fnptr, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  pathParameterTemplate, GLfloat  emScale, GLuint * baseAndCount) {
+//   return (*fnptr)(fontTarget, fontName, fontStyle, pathParameterTemplate, emScale, baseAndCount);
+// }
+// static void  glowPathGlyphRangeNV(GPPATHGLYPHRANGENV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLuint  firstGlyph, GLsizei  numGlyphs, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, firstGlyph, numGlyphs, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathGlyphsNV(GPPATHGLYPHSNV fnptr, GLuint  firstPathName, GLenum  fontTarget, const void * fontName, GLbitfield  fontStyle, GLsizei  numGlyphs, GLenum  type, const void * charcodes, GLenum  handleMissingGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   (*fnptr)(firstPathName, fontTarget, fontName, fontStyle, numGlyphs, type, charcodes, handleMissingGlyphs, pathParameterTemplate, emScale);
+// }
+// static GLenum  glowPathMemoryGlyphIndexArrayNV(GPPATHMEMORYGLYPHINDEXARRAYNV fnptr, GLuint  firstPathName, GLenum  fontTarget, GLsizeiptr  fontSize, const void * fontData, GLsizei  faceIndex, GLuint  firstGlyphIndex, GLsizei  numGlyphs, GLuint  pathParameterTemplate, GLfloat  emScale) {
+//   return (*fnptr)(firstPathName, fontTarget, fontSize, fontData, faceIndex, firstGlyphIndex, numGlyphs, pathParameterTemplate, emScale);
+// }
+// static void  glowPathParameterfNV(GPPATHPARAMETERFNV fnptr, GLuint  path, GLenum  pname, GLfloat  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterfvNV(GPPATHPARAMETERFVNV fnptr, GLuint  path, GLenum  pname, const GLfloat * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameteriNV(GPPATHPARAMETERINV fnptr, GLuint  path, GLenum  pname, GLint  value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathParameterivNV(GPPATHPARAMETERIVNV fnptr, GLuint  path, GLenum  pname, const GLint * value) {
+//   (*fnptr)(path, pname, value);
+// }
+// static void  glowPathStencilDepthOffsetNV(GPPATHSTENCILDEPTHOFFSETNV fnptr, GLfloat  factor, GLfloat  units) {
+//   (*fnptr)(factor, units);
+// }
+// static void  glowPathStencilFuncNV(GPPATHSTENCILFUNCNV fnptr, GLenum  func, GLint  ref, GLuint  mask) {
+//   (*fnptr)(func, ref, mask);
+// }
+// static void  glowPathStringNV(GPPATHSTRINGNV fnptr, GLuint  path, GLenum  format, GLsizei  length, const void * pathString) {
+//   (*fnptr)(path, format, length, pathString);
+// }
+// static void  glowPathSubCommandsNV(GPPATHSUBCOMMANDSNV fnptr, GLuint  path, GLsizei  commandStart, GLsizei  commandsToDelete, GLsizei  numCommands, const GLubyte * commands, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, commandStart, commandsToDelete, numCommands, commands, numCoords, coordType, coords);
+// }
+// static void  glowPathSubCoordsNV(GPPATHSUBCOORDSNV fnptr, GLuint  path, GLsizei  coordStart, GLsizei  numCoords, GLenum  coordType, const void * coords) {
+//   (*fnptr)(path, coordStart, numCoords, coordType, coords);
+// }
 // static void  glowPauseTransformFeedback(GPPAUSETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
 // }
@@ -2056,6 +3596,9 @@ package gl
 // }
 // static void  glowPixelStorei(GPPIXELSTOREI fnptr, GLenum  pname, GLint  param) {
 //   (*fnptr)(pname, param);
+// }
+// static GLboolean  glowPointAlongPathNV(GPPOINTALONGPATHNV fnptr, GLuint  path, GLsizei  startSegment, GLsizei  numSegments, GLfloat  distance, GLfloat * x, GLfloat * y, GLfloat * tangentX, GLfloat * tangentY) {
+//   return (*fnptr)(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
 // }
 // static void  glowPointParameterf(GPPOINTPARAMETERF fnptr, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(pname, param);
@@ -2078,11 +3621,23 @@ package gl
 // static void  glowPolygonOffset(GPPOLYGONOFFSET fnptr, GLfloat  factor, GLfloat  units) {
 //   (*fnptr)(factor, units);
 // }
+// static void  glowPolygonOffsetClamp(GPPOLYGONOFFSETCLAMP fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
+// static void  glowPolygonOffsetClampEXT(GPPOLYGONOFFSETCLAMPEXT fnptr, GLfloat  factor, GLfloat  units, GLfloat  clamp) {
+//   (*fnptr)(factor, units, clamp);
+// }
 // static void  glowPopDebugGroup(GPPOPDEBUGGROUP fnptr) {
 //   (*fnptr)();
 // }
 // static void  glowPopDebugGroupKHR(GPPOPDEBUGGROUPKHR fnptr) {
 //   (*fnptr)();
+// }
+// static void  glowPopGroupMarkerEXT(GPPOPGROUPMARKEREXT fnptr) {
+//   (*fnptr)();
+// }
+// static void  glowPrimitiveBoundingBoxARB(GPPRIMITIVEBOUNDINGBOXARB fnptr, GLfloat  minX, GLfloat  minY, GLfloat  minZ, GLfloat  minW, GLfloat  maxX, GLfloat  maxY, GLfloat  maxZ, GLfloat  maxW) {
+//   (*fnptr)(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
 // }
 // static void  glowPrimitiveRestartIndex(GPPRIMITIVERESTARTINDEX fnptr, GLuint  index) {
 //   (*fnptr)(index);
@@ -2093,164 +3648,434 @@ package gl
 // static void  glowProgramParameteri(GPPROGRAMPARAMETERI fnptr, GLuint  program, GLenum  pname, GLint  value) {
 //   (*fnptr)(program, pname, value);
 // }
+// static void  glowProgramParameteriARB(GPPROGRAMPARAMETERIARB fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramParameteriEXT(GPPROGRAMPARAMETERIEXT fnptr, GLuint  program, GLenum  pname, GLint  value) {
+//   (*fnptr)(program, pname, value);
+// }
+// static void  glowProgramPathFragmentInputGenNV(GPPROGRAMPATHFRAGMENTINPUTGENNV fnptr, GLuint  program, GLint  location, GLenum  genMode, GLint  components, const GLfloat * coeffs) {
+//   (*fnptr)(program, location, genMode, components, coeffs);
+// }
 // static void  glowProgramUniform1d(GPPROGRAMUNIFORM1D fnptr, GLuint  program, GLint  location, GLdouble  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1dEXT(GPPROGRAMUNIFORM1DEXT fnptr, GLuint  program, GLint  location, GLdouble  x) {
+//   (*fnptr)(program, location, x);
+// }
 // static void  glowProgramUniform1dv(GPPROGRAMUNIFORM1DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1dvEXT(GPPROGRAMUNIFORM1DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1f(GPPROGRAMUNIFORM1F fnptr, GLuint  program, GLint  location, GLfloat  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1fEXT(GPPROGRAMUNIFORM1FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1fv(GPPROGRAMUNIFORM1FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1fvEXT(GPPROGRAMUNIFORM1FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1i(GPPROGRAMUNIFORM1I fnptr, GLuint  program, GLint  location, GLint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1i64ARB(GPPROGRAMUNIFORM1I64ARB fnptr, GLuint  program, GLint  location, GLint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64NV(GPPROGRAMUNIFORM1I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1i64vARB(GPPROGRAMUNIFORM1I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1i64vNV(GPPROGRAMUNIFORM1I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1iEXT(GPPROGRAMUNIFORM1IEXT fnptr, GLuint  program, GLint  location, GLint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1iv(GPPROGRAMUNIFORM1IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ivEXT(GPPROGRAMUNIFORM1IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform1ui(GPPROGRAMUNIFORM1UI fnptr, GLuint  program, GLint  location, GLuint  v0) {
 //   (*fnptr)(program, location, v0);
 // }
+// static void  glowProgramUniform1ui64ARB(GPPROGRAMUNIFORM1UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64NV(GPPROGRAMUNIFORM1UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(program, location, x);
+// }
+// static void  glowProgramUniform1ui64vARB(GPPROGRAMUNIFORM1UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1ui64vNV(GPPROGRAMUNIFORM1UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uiEXT(GPPROGRAMUNIFORM1UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0) {
+//   (*fnptr)(program, location, v0);
+// }
 // static void  glowProgramUniform1uiv(GPPROGRAMUNIFORM1UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform1uivEXT(GPPROGRAMUNIFORM1UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2d(GPPROGRAMUNIFORM2D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2dEXT(GPPROGRAMUNIFORM2DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y) {
+//   (*fnptr)(program, location, x, y);
+// }
 // static void  glowProgramUniform2dv(GPPROGRAMUNIFORM2DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2dvEXT(GPPROGRAMUNIFORM2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2f(GPPROGRAMUNIFORM2F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2fEXT(GPPROGRAMUNIFORM2FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2fv(GPPROGRAMUNIFORM2FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2fvEXT(GPPROGRAMUNIFORM2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2i(GPPROGRAMUNIFORM2I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2i64ARB(GPPROGRAMUNIFORM2I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64NV(GPPROGRAMUNIFORM2I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2i64vARB(GPPROGRAMUNIFORM2I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2i64vNV(GPPROGRAMUNIFORM2I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2iEXT(GPPROGRAMUNIFORM2IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2iv(GPPROGRAMUNIFORM2IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ivEXT(GPPROGRAMUNIFORM2IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform2ui(GPPROGRAMUNIFORM2UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(program, location, v0, v1);
 // }
+// static void  glowProgramUniform2ui64ARB(GPPROGRAMUNIFORM2UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64NV(GPPROGRAMUNIFORM2UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(program, location, x, y);
+// }
+// static void  glowProgramUniform2ui64vARB(GPPROGRAMUNIFORM2UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2ui64vNV(GPPROGRAMUNIFORM2UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uiEXT(GPPROGRAMUNIFORM2UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1) {
+//   (*fnptr)(program, location, v0, v1);
+// }
 // static void  glowProgramUniform2uiv(GPPROGRAMUNIFORM2UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform2uivEXT(GPPROGRAMUNIFORM2UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3d(GPPROGRAMUNIFORM3D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3dEXT(GPPROGRAMUNIFORM3DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
 // static void  glowProgramUniform3dv(GPPROGRAMUNIFORM3DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3dvEXT(GPPROGRAMUNIFORM3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3f(GPPROGRAMUNIFORM3F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3fEXT(GPPROGRAMUNIFORM3FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3fv(GPPROGRAMUNIFORM3FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3fvEXT(GPPROGRAMUNIFORM3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3i(GPPROGRAMUNIFORM3I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3i64ARB(GPPROGRAMUNIFORM3I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64NV(GPPROGRAMUNIFORM3I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3i64vARB(GPPROGRAMUNIFORM3I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3i64vNV(GPPROGRAMUNIFORM3I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3iEXT(GPPROGRAMUNIFORM3IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3iv(GPPROGRAMUNIFORM3IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ivEXT(GPPROGRAMUNIFORM3IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform3ui(GPPROGRAMUNIFORM3UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(program, location, v0, v1, v2);
 // }
+// static void  glowProgramUniform3ui64ARB(GPPROGRAMUNIFORM3UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64NV(GPPROGRAMUNIFORM3UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(program, location, x, y, z);
+// }
+// static void  glowProgramUniform3ui64vARB(GPPROGRAMUNIFORM3UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3ui64vNV(GPPROGRAMUNIFORM3UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uiEXT(GPPROGRAMUNIFORM3UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
+//   (*fnptr)(program, location, v0, v1, v2);
+// }
 // static void  glowProgramUniform3uiv(GPPROGRAMUNIFORM3UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform3uivEXT(GPPROGRAMUNIFORM3UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4d(GPPROGRAMUNIFORM4D fnptr, GLuint  program, GLint  location, GLdouble  v0, GLdouble  v1, GLdouble  v2, GLdouble  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4dEXT(GPPROGRAMUNIFORM4DEXT fnptr, GLuint  program, GLint  location, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
 // static void  glowProgramUniform4dv(GPPROGRAMUNIFORM4DV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4dvEXT(GPPROGRAMUNIFORM4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLdouble * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4f(GPPROGRAMUNIFORM4F fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4fEXT(GPPROGRAMUNIFORM4FEXT fnptr, GLuint  program, GLint  location, GLfloat  v0, GLfloat  v1, GLfloat  v2, GLfloat  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4fv(GPPROGRAMUNIFORM4FV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4fvEXT(GPPROGRAMUNIFORM4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLfloat * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4i(GPPROGRAMUNIFORM4I fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4i64ARB(GPPROGRAMUNIFORM4I64ARB fnptr, GLuint  program, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64NV(GPPROGRAMUNIFORM4I64NV fnptr, GLuint  program, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4i64vARB(GPPROGRAMUNIFORM4I64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4i64vNV(GPPROGRAMUNIFORM4I64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4iEXT(GPPROGRAMUNIFORM4IEXT fnptr, GLuint  program, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4iv(GPPROGRAMUNIFORM4IV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ivEXT(GPPROGRAMUNIFORM4IVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniform4ui(GPPROGRAMUNIFORM4UI fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(program, location, v0, v1, v2, v3);
 // }
+// static void  glowProgramUniform4ui64ARB(GPPROGRAMUNIFORM4UI64ARB fnptr, GLuint  program, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64NV(GPPROGRAMUNIFORM4UI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(program, location, x, y, z, w);
+// }
+// static void  glowProgramUniform4ui64vARB(GPPROGRAMUNIFORM4UI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4ui64vNV(GPPROGRAMUNIFORM4UI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uiEXT(GPPROGRAMUNIFORM4UIEXT fnptr, GLuint  program, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
+//   (*fnptr)(program, location, v0, v1, v2, v3);
+// }
 // static void  glowProgramUniform4uiv(GPPROGRAMUNIFORM4UIV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
+//   (*fnptr)(program, location, count, value);
+// }
+// static void  glowProgramUniform4uivEXT(GPPROGRAMUNIFORM4UIVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(program, location, count, value);
 // }
 // static void  glowProgramUniformHandleui64ARB(GPPROGRAMUNIFORMHANDLEUI64ARB fnptr, GLuint  program, GLint  location, GLuint64  value) {
 //   (*fnptr)(program, location, value);
 // }
+// static void  glowProgramUniformHandleui64NV(GPPROGRAMUNIFORMHANDLEUI64NV fnptr, GLuint  program, GLint  location, GLuint64  value) {
+//   (*fnptr)(program, location, value);
+// }
 // static void  glowProgramUniformHandleui64vARB(GPPROGRAMUNIFORMHANDLEUI64VARB fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
+//   (*fnptr)(program, location, count, values);
+// }
+// static void  glowProgramUniformHandleui64vNV(GPPROGRAMUNIFORMHANDLEUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64 * values) {
 //   (*fnptr)(program, location, count, values);
 // }
 // static void  glowProgramUniformMatrix2dv(GPPROGRAMUNIFORMMATRIX2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2dvEXT(GPPROGRAMUNIFORMMATRIX2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2fv(GPPROGRAMUNIFORMMATRIX2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2fvEXT(GPPROGRAMUNIFORMMATRIX2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x3dv(GPPROGRAMUNIFORMMATRIX2X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x3dvEXT(GPPROGRAMUNIFORMMATRIX2X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x3fv(GPPROGRAMUNIFORMMATRIX2X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x3fvEXT(GPPROGRAMUNIFORMMATRIX2X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix2x4dv(GPPROGRAMUNIFORMMATRIX2X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix2x4dvEXT(GPPROGRAMUNIFORMMATRIX2X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix2x4fv(GPPROGRAMUNIFORMMATRIX2X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix2x4fvEXT(GPPROGRAMUNIFORMMATRIX2X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3dv(GPPROGRAMUNIFORMMATRIX3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3dvEXT(GPPROGRAMUNIFORMMATRIX3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3fv(GPPROGRAMUNIFORMMATRIX3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3fvEXT(GPPROGRAMUNIFORMMATRIX3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x2dv(GPPROGRAMUNIFORMMATRIX3X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x2dvEXT(GPPROGRAMUNIFORMMATRIX3X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x2fv(GPPROGRAMUNIFORMMATRIX3X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x2fvEXT(GPPROGRAMUNIFORMMATRIX3X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix3x4dv(GPPROGRAMUNIFORMMATRIX3X4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix3x4dvEXT(GPPROGRAMUNIFORMMATRIX3X4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix3x4fv(GPPROGRAMUNIFORMMATRIX3X4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix3x4fvEXT(GPPROGRAMUNIFORMMATRIX3X4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4dv(GPPROGRAMUNIFORMMATRIX4DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4dvEXT(GPPROGRAMUNIFORMMATRIX4DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4fv(GPPROGRAMUNIFORMMATRIX4FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4fvEXT(GPPROGRAMUNIFORMMATRIX4FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x2dv(GPPROGRAMUNIFORMMATRIX4X2DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x2dvEXT(GPPROGRAMUNIFORMMATRIX4X2DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x2fv(GPPROGRAMUNIFORMMATRIX4X2FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformMatrix4x2fvEXT(GPPROGRAMUNIFORMMATRIX4X2FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
 // static void  glowProgramUniformMatrix4x3dv(GPPROGRAMUNIFORMMATRIX4X3DV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3dvEXT(GPPROGRAMUNIFORMMATRIX4X3DVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
 // static void  glowProgramUniformMatrix4x3fv(GPPROGRAMUNIFORMMATRIX4X3FV fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
 //   (*fnptr)(program, location, count, transpose, value);
 // }
+// static void  glowProgramUniformMatrix4x3fvEXT(GPPROGRAMUNIFORMMATRIX4X3FVEXT fnptr, GLuint  program, GLint  location, GLsizei  count, GLboolean  transpose, const GLfloat * value) {
+//   (*fnptr)(program, location, count, transpose, value);
+// }
+// static void  glowProgramUniformui64NV(GPPROGRAMUNIFORMUI64NV fnptr, GLuint  program, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(program, location, value);
+// }
+// static void  glowProgramUniformui64vNV(GPPROGRAMUNIFORMUI64VNV fnptr, GLuint  program, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(program, location, count, value);
+// }
 // static void  glowProvokingVertex(GPPROVOKINGVERTEX fnptr, GLenum  mode) {
 //   (*fnptr)(mode);
+// }
+// static void  glowPushClientAttribDefaultEXT(GPPUSHCLIENTATTRIBDEFAULTEXT fnptr, GLbitfield  mask) {
+//   (*fnptr)(mask);
 // }
 // static void  glowPushDebugGroup(GPPUSHDEBUGGROUP fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
@@ -2258,8 +4083,14 @@ package gl
 // static void  glowPushDebugGroupKHR(GPPUSHDEBUGGROUPKHR fnptr, GLenum  source, GLuint  id, GLsizei  length, const GLchar * message) {
 //   (*fnptr)(source, id, length, message);
 // }
+// static void  glowPushGroupMarkerEXT(GPPUSHGROUPMARKEREXT fnptr, GLsizei  length, const GLchar * marker) {
+//   (*fnptr)(length, marker);
+// }
 // static void  glowQueryCounter(GPQUERYCOUNTER fnptr, GLuint  id, GLenum  target) {
 //   (*fnptr)(id, target);
+// }
+// static void  glowRasterSamplesEXT(GPRASTERSAMPLESEXT fnptr, GLuint  samples, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(samples, fixedsamplelocations);
 // }
 // static void  glowReadBuffer(GPREADBUFFER fnptr, GLenum  src) {
 //   (*fnptr)(src);
@@ -2284,6 +4115,12 @@ package gl
 // }
 // static void  glowRenderbufferStorageMultisample(GPRENDERBUFFERSTORAGEMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(target, samples, internalformat, width, height);
+// }
+// static void  glowRenderbufferStorageMultisampleCoverageNV(GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV fnptr, GLenum  target, GLsizei  coverageSamples, GLsizei  colorSamples, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(target, coverageSamples, colorSamples, internalformat, width, height);
+// }
+// static void  glowResolveDepthValuesNV(GPRESOLVEDEPTHVALUESNV fnptr) {
+//   (*fnptr)();
 // }
 // static void  glowResumeTransformFeedback(GPRESUMETRANSFORMFEEDBACK fnptr) {
 //   (*fnptr)();
@@ -2324,6 +4161,12 @@ package gl
 // static void  glowScissorIndexedv(GPSCISSORINDEXEDV fnptr, GLuint  index, const GLint * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowSecondaryColorFormatNV(GPSECONDARYCOLORFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
+// static void  glowSelectPerfMonitorCountersAMD(GPSELECTPERFMONITORCOUNTERSAMD fnptr, GLuint  monitor, GLboolean  enable, GLuint  group, GLint  numCounters, GLuint * counterList) {
+//   (*fnptr)(monitor, enable, group, numCounters, counterList);
+// }
 // static void  glowShaderBinary(GPSHADERBINARY fnptr, GLsizei  count, const GLuint * shaders, GLenum  binaryformat, const void * binary, GLsizei  length) {
 //   (*fnptr)(count, shaders, binaryformat, binary, length);
 // }
@@ -2332,6 +4175,24 @@ package gl
 // }
 // static void  glowShaderStorageBlockBinding(GPSHADERSTORAGEBLOCKBINDING fnptr, GLuint  program, GLuint  storageBlockIndex, GLuint  storageBlockBinding) {
 //   (*fnptr)(program, storageBlockIndex, storageBlockBinding);
+// }
+// static void  glowSignalVkFenceNV(GPSIGNALVKFENCENV fnptr, GLuint64  vkFence) {
+//   (*fnptr)(vkFence);
+// }
+// static void  glowSignalVkSemaphoreNV(GPSIGNALVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowSpecializeShaderARB(GPSPECIALIZESHADERARB fnptr, GLuint  shader, const GLchar * pEntryPoint, GLuint  numSpecializationConstants, const GLuint * pConstantIndex, const GLuint * pConstantValue) {
+//   (*fnptr)(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+// }
+// static void  glowStateCaptureNV(GPSTATECAPTURENV fnptr, GLuint  state, GLenum  mode) {
+//   (*fnptr)(state, mode);
+// }
+// static void  glowStencilFillPathInstancedNV(GPSTENCILFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, transformType, transformValues);
+// }
+// static void  glowStencilFillPathNV(GPSTENCILFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask) {
+//   (*fnptr)(path, fillMode, mask);
 // }
 // static void  glowStencilFunc(GPSTENCILFUNC fnptr, GLenum  func, GLint  ref, GLuint  mask) {
 //   (*fnptr)(func, ref, mask);
@@ -2351,11 +4212,38 @@ package gl
 // static void  glowStencilOpSeparate(GPSTENCILOPSEPARATE fnptr, GLenum  face, GLenum  sfail, GLenum  dpfail, GLenum  dppass) {
 //   (*fnptr)(face, sfail, dpfail, dppass);
 // }
+// static void  glowStencilStrokePathInstancedNV(GPSTENCILSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, transformType, transformValues);
+// }
+// static void  glowStencilStrokePathNV(GPSTENCILSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask) {
+//   (*fnptr)(path, reference, mask);
+// }
+// static void  glowStencilThenCoverFillPathInstancedNV(GPSTENCILTHENCOVERFILLPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLenum  fillMode, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, fillMode, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverFillPathNV(GPSTENCILTHENCOVERFILLPATHNV fnptr, GLuint  path, GLenum  fillMode, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, fillMode, mask, coverMode);
+// }
+// static void  glowStencilThenCoverStrokePathInstancedNV(GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV fnptr, GLsizei  numPaths, GLenum  pathNameType, const void * paths, GLuint  pathBase, GLint  reference, GLuint  mask, GLenum  coverMode, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(numPaths, pathNameType, paths, pathBase, reference, mask, coverMode, transformType, transformValues);
+// }
+// static void  glowStencilThenCoverStrokePathNV(GPSTENCILTHENCOVERSTROKEPATHNV fnptr, GLuint  path, GLint  reference, GLuint  mask, GLenum  coverMode) {
+//   (*fnptr)(path, reference, mask, coverMode);
+// }
+// static void  glowSubpixelPrecisionBiasNV(GPSUBPIXELPRECISIONBIASNV fnptr, GLuint  xbits, GLuint  ybits) {
+//   (*fnptr)(xbits, ybits);
+// }
 // static void  glowTexBuffer(GPTEXBUFFER fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(target, internalformat, buffer);
+// }
+// static void  glowTexBufferARB(GPTEXBUFFERARB fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(target, internalformat, buffer);
 // }
 // static void  glowTexBufferRange(GPTEXBUFFERRANGE fnptr, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(target, internalformat, buffer, offset, size);
+// }
+// static void  glowTexCoordFormatNV(GPTEXCOORDFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
 // }
 // static void  glowTexImage1D(GPTEXIMAGE1D fnptr, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(target, level, internalformat, width, border, format, type, pixels);
@@ -2372,8 +4260,8 @@ package gl
 // static void  glowTexImage3DMultisample(GPTEXIMAGE3DMULTISAMPLE fnptr, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(target, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
-// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  resident) {
-//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, resident);
+// static void  glowTexPageCommitmentARB(GPTEXPAGECOMMITMENTARB fnptr, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTexParameterIiv(GPTEXPARAMETERIIV fnptr, GLenum  target, GLenum  pname, const GLint * params) {
 //   (*fnptr)(target, pname, params);
@@ -2420,53 +4308,119 @@ package gl
 // static void  glowTextureBarrier(GPTEXTUREBARRIER fnptr) {
 //   (*fnptr)();
 // }
+// static void  glowTextureBarrierNV(GPTEXTUREBARRIERNV fnptr) {
+//   (*fnptr)();
+// }
 // static void  glowTextureBuffer(GPTEXTUREBUFFER fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer) {
 //   (*fnptr)(texture, internalformat, buffer);
 // }
-// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTextureBufferEXT(GPTEXTUREBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer) {
+//   (*fnptr)(texture, target, internalformat, buffer);
+// }
+// static void  glowTextureBufferRange(GPTEXTUREBUFFERRANGE fnptr, GLuint  texture, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(texture, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureBufferRangeEXT(GPTEXTUREBUFFERRANGEEXT fnptr, GLuint  texture, GLenum  target, GLenum  internalformat, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
+//   (*fnptr)(texture, target, internalformat, buffer, offset, size);
+// }
+// static void  glowTextureImage1DEXT(GPTEXTUREIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, border, format, type, pixels);
+// }
+// static void  glowTextureImage2DEXT(GPTEXTUREIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, border, format, type, pixels);
+// }
+// static void  glowTextureImage3DEXT(GPTEXTUREIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLint  border, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, internalformat, width, height, depth, border, format, type, pixels);
+// }
+// static void  glowTexturePageCommitmentEXT(GPTEXTUREPAGECOMMITMENTEXT fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  commit) {
+//   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
 // }
 // static void  glowTextureParameterIiv(GPTEXTUREPARAMETERIIV fnptr, GLuint  texture, GLenum  pname, const GLint * params) {
 //   (*fnptr)(texture, pname, params);
 // }
+// static void  glowTextureParameterIivEXT(GPTEXTUREPARAMETERIIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
 // static void  glowTextureParameterIuiv(GPTEXTUREPARAMETERIUIV fnptr, GLuint  texture, GLenum  pname, const GLuint * params) {
 //   (*fnptr)(texture, pname, params);
+// }
+// static void  glowTextureParameterIuivEXT(GPTEXTUREPARAMETERIUIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLuint * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameterf(GPTEXTUREPARAMETERF fnptr, GLuint  texture, GLenum  pname, GLfloat  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameterfEXT(GPTEXTUREPARAMETERFEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLfloat  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameterfv(GPTEXTUREPARAMETERFV fnptr, GLuint  texture, GLenum  pname, const GLfloat * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterfvEXT(GPTEXTUREPARAMETERFVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLfloat * params) {
+//   (*fnptr)(texture, target, pname, params);
 // }
 // static void  glowTextureParameteri(GPTEXTUREPARAMETERI fnptr, GLuint  texture, GLenum  pname, GLint  param) {
 //   (*fnptr)(texture, pname, param);
 // }
+// static void  glowTextureParameteriEXT(GPTEXTUREPARAMETERIEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, GLint  param) {
+//   (*fnptr)(texture, target, pname, param);
+// }
 // static void  glowTextureParameteriv(GPTEXTUREPARAMETERIV fnptr, GLuint  texture, GLenum  pname, const GLint * param) {
 //   (*fnptr)(texture, pname, param);
+// }
+// static void  glowTextureParameterivEXT(GPTEXTUREPARAMETERIVEXT fnptr, GLuint  texture, GLenum  target, GLenum  pname, const GLint * params) {
+//   (*fnptr)(texture, target, pname, params);
+// }
+// static void  glowTextureRenderbufferEXT(GPTEXTURERENDERBUFFEREXT fnptr, GLuint  texture, GLenum  target, GLuint  renderbuffer) {
+//   (*fnptr)(texture, target, renderbuffer);
 // }
 // static void  glowTextureStorage1D(GPTEXTURESTORAGE1D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
 //   (*fnptr)(texture, levels, internalformat, width);
 // }
+// static void  glowTextureStorage1DEXT(GPTEXTURESTORAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width) {
+//   (*fnptr)(texture, target, levels, internalformat, width);
+// }
 // static void  glowTextureStorage2D(GPTEXTURESTORAGE2D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(texture, levels, internalformat, width, height);
+// }
+// static void  glowTextureStorage2DEXT(GPTEXTURESTORAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height);
 // }
 // static void  glowTextureStorage2DMultisample(GPTEXTURESTORAGE2DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, fixedsamplelocations);
 // }
+// static void  glowTextureStorage2DMultisampleEXT(GPTEXTURESTORAGE2DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, fixedsamplelocations);
+// }
 // static void  glowTextureStorage3D(GPTEXTURESTORAGE3D fnptr, GLuint  texture, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
 //   (*fnptr)(texture, levels, internalformat, width, height, depth);
+// }
+// static void  glowTextureStorage3DEXT(GPTEXTURESTORAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLsizei  levels, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth) {
+//   (*fnptr)(texture, target, levels, internalformat, width, height, depth);
 // }
 // static void  glowTextureStorage3DMultisample(GPTEXTURESTORAGE3DMULTISAMPLE fnptr, GLuint  texture, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
 //   (*fnptr)(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
 // }
+// static void  glowTextureStorage3DMultisampleEXT(GPTEXTURESTORAGE3DMULTISAMPLEEXT fnptr, GLuint  texture, GLenum  target, GLsizei  samples, GLenum  internalformat, GLsizei  width, GLsizei  height, GLsizei  depth, GLboolean  fixedsamplelocations) {
+//   (*fnptr)(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
+// }
 // static void  glowTextureSubImage1D(GPTEXTURESUBIMAGE1D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, width, format, type, pixels);
+// }
+// static void  glowTextureSubImage1DEXT(GPTEXTURESUBIMAGE1DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLsizei  width, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, width, format, type, pixels);
 // }
 // static void  glowTextureSubImage2D(GPTEXTURESUBIMAGE2D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, width, height, format, type, pixels);
 // }
+// static void  glowTextureSubImage2DEXT(GPTEXTURESUBIMAGE2DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLsizei  width, GLsizei  height, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, width, height, format, type, pixels);
+// }
 // static void  glowTextureSubImage3D(GPTEXTURESUBIMAGE3D fnptr, GLuint  texture, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
 //   (*fnptr)(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+// }
+// static void  glowTextureSubImage3DEXT(GPTEXTURESUBIMAGE3DEXT fnptr, GLuint  texture, GLenum  target, GLint  level, GLint  xoffset, GLint  yoffset, GLint  zoffset, GLsizei  width, GLsizei  height, GLsizei  depth, GLenum  format, GLenum  type, const void * pixels) {
+//   (*fnptr)(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 // }
 // static void  glowTextureView(GPTEXTUREVIEW fnptr, GLuint  texture, GLenum  target, GLuint  origtexture, GLenum  internalformat, GLuint  minlevel, GLuint  numlevels, GLuint  minlayer, GLuint  numlayers) {
 //   (*fnptr)(texture, target, origtexture, internalformat, minlevel, numlevels, minlayer, numlayers);
@@ -2474,11 +4428,14 @@ package gl
 // static void  glowTransformFeedbackBufferBase(GPTRANSFORMFEEDBACKBUFFERBASE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer) {
 //   (*fnptr)(xfb, index, buffer);
 // }
-// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizei  size) {
+// static void  glowTransformFeedbackBufferRange(GPTRANSFORMFEEDBACKBUFFERRANGE fnptr, GLuint  xfb, GLuint  index, GLuint  buffer, GLintptr  offset, GLsizeiptr  size) {
 //   (*fnptr)(xfb, index, buffer, offset, size);
 // }
 // static void  glowTransformFeedbackVaryings(GPTRANSFORMFEEDBACKVARYINGS fnptr, GLuint  program, GLsizei  count, const GLchar *const* varyings, GLenum  bufferMode) {
 //   (*fnptr)(program, count, varyings, bufferMode);
+// }
+// static void  glowTransformPathNV(GPTRANSFORMPATHNV fnptr, GLuint  resultPath, GLuint  srcPath, GLenum  transformType, const GLfloat * transformValues) {
+//   (*fnptr)(resultPath, srcPath, transformType, transformValues);
 // }
 // static void  glowUniform1d(GPUNIFORM1D fnptr, GLint  location, GLdouble  x) {
 //   (*fnptr)(location, x);
@@ -2495,11 +4452,35 @@ package gl
 // static void  glowUniform1i(GPUNIFORM1I fnptr, GLint  location, GLint  v0) {
 //   (*fnptr)(location, v0);
 // }
+// static void  glowUniform1i64ARB(GPUNIFORM1I64ARB fnptr, GLint  location, GLint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64NV(GPUNIFORM1I64NV fnptr, GLint  location, GLint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1i64vARB(GPUNIFORM1I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1i64vNV(GPUNIFORM1I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform1iv(GPUNIFORM1IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1ui(GPUNIFORM1UI fnptr, GLint  location, GLuint  v0) {
 //   (*fnptr)(location, v0);
+// }
+// static void  glowUniform1ui64ARB(GPUNIFORM1UI64ARB fnptr, GLint  location, GLuint64  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64NV(GPUNIFORM1UI64NV fnptr, GLint  location, GLuint64EXT  x) {
+//   (*fnptr)(location, x);
+// }
+// static void  glowUniform1ui64vARB(GPUNIFORM1UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform1ui64vNV(GPUNIFORM1UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform1uiv(GPUNIFORM1UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2519,11 +4500,35 @@ package gl
 // static void  glowUniform2i(GPUNIFORM2I fnptr, GLint  location, GLint  v0, GLint  v1) {
 //   (*fnptr)(location, v0, v1);
 // }
+// static void  glowUniform2i64ARB(GPUNIFORM2I64ARB fnptr, GLint  location, GLint64  x, GLint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64NV(GPUNIFORM2I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2i64vARB(GPUNIFORM2I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2i64vNV(GPUNIFORM2I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform2iv(GPUNIFORM2IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2ui(GPUNIFORM2UI fnptr, GLint  location, GLuint  v0, GLuint  v1) {
 //   (*fnptr)(location, v0, v1);
+// }
+// static void  glowUniform2ui64ARB(GPUNIFORM2UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64NV(GPUNIFORM2UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(location, x, y);
+// }
+// static void  glowUniform2ui64vARB(GPUNIFORM2UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform2ui64vNV(GPUNIFORM2UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform2uiv(GPUNIFORM2UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2543,11 +4548,35 @@ package gl
 // static void  glowUniform3i(GPUNIFORM3I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
 // }
+// static void  glowUniform3i64ARB(GPUNIFORM3I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64NV(GPUNIFORM3I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3i64vARB(GPUNIFORM3I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3i64vNV(GPUNIFORM3I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform3iv(GPUNIFORM3IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3ui(GPUNIFORM3UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2) {
 //   (*fnptr)(location, v0, v1, v2);
+// }
+// static void  glowUniform3ui64ARB(GPUNIFORM3UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64NV(GPUNIFORM3UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(location, x, y, z);
+// }
+// static void  glowUniform3ui64vARB(GPUNIFORM3UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform3ui64vNV(GPUNIFORM3UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform3uiv(GPUNIFORM3UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2567,11 +4596,35 @@ package gl
 // static void  glowUniform4i(GPUNIFORM4I fnptr, GLint  location, GLint  v0, GLint  v1, GLint  v2, GLint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
 // }
+// static void  glowUniform4i64ARB(GPUNIFORM4I64ARB fnptr, GLint  location, GLint64  x, GLint64  y, GLint64  z, GLint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64NV(GPUNIFORM4I64NV fnptr, GLint  location, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4i64vARB(GPUNIFORM4I64VARB fnptr, GLint  location, GLsizei  count, const GLint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4i64vNV(GPUNIFORM4I64VNV fnptr, GLint  location, GLsizei  count, const GLint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static void  glowUniform4iv(GPUNIFORM4IV fnptr, GLint  location, GLsizei  count, const GLint * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4ui(GPUNIFORM4UI fnptr, GLint  location, GLuint  v0, GLuint  v1, GLuint  v2, GLuint  v3) {
 //   (*fnptr)(location, v0, v1, v2, v3);
+// }
+// static void  glowUniform4ui64ARB(GPUNIFORM4UI64ARB fnptr, GLint  location, GLuint64  x, GLuint64  y, GLuint64  z, GLuint64  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64NV(GPUNIFORM4UI64NV fnptr, GLint  location, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(location, x, y, z, w);
+// }
+// static void  glowUniform4ui64vARB(GPUNIFORM4UI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniform4ui64vNV(GPUNIFORM4UI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
 // }
 // static void  glowUniform4uiv(GPUNIFORM4UIV fnptr, GLint  location, GLsizei  count, const GLuint * value) {
 //   (*fnptr)(location, count, value);
@@ -2582,7 +4635,13 @@ package gl
 // static void  glowUniformHandleui64ARB(GPUNIFORMHANDLEUI64ARB fnptr, GLint  location, GLuint64  value) {
 //   (*fnptr)(location, value);
 // }
+// static void  glowUniformHandleui64NV(GPUNIFORMHANDLEUI64NV fnptr, GLint  location, GLuint64  value) {
+//   (*fnptr)(location, value);
+// }
 // static void  glowUniformHandleui64vARB(GPUNIFORMHANDLEUI64VARB fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
+//   (*fnptr)(location, count, value);
+// }
+// static void  glowUniformHandleui64vNV(GPUNIFORMHANDLEUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64 * value) {
 //   (*fnptr)(location, count, value);
 // }
 // static void  glowUniformMatrix2dv(GPUNIFORMMATRIX2DV fnptr, GLint  location, GLsizei  count, GLboolean  transpose, const GLdouble * value) {
@@ -2642,10 +4701,19 @@ package gl
 // static void  glowUniformSubroutinesuiv(GPUNIFORMSUBROUTINESUIV fnptr, GLenum  shadertype, GLsizei  count, const GLuint * indices) {
 //   (*fnptr)(shadertype, count, indices);
 // }
+// static void  glowUniformui64NV(GPUNIFORMUI64NV fnptr, GLint  location, GLuint64EXT  value) {
+//   (*fnptr)(location, value);
+// }
+// static void  glowUniformui64vNV(GPUNIFORMUI64VNV fnptr, GLint  location, GLsizei  count, const GLuint64EXT * value) {
+//   (*fnptr)(location, count, value);
+// }
 // static GLboolean  glowUnmapBuffer(GPUNMAPBUFFER fnptr, GLenum  target) {
 //   return (*fnptr)(target);
 // }
 // static GLboolean  glowUnmapNamedBuffer(GPUNMAPNAMEDBUFFER fnptr, GLuint  buffer) {
+//   return (*fnptr)(buffer);
+// }
+// static GLboolean  glowUnmapNamedBufferEXT(GPUNMAPNAMEDBUFFEREXT fnptr, GLuint  buffer) {
 //   return (*fnptr)(buffer);
 // }
 // static void  glowUseProgram(GPUSEPROGRAM fnptr, GLuint  program) {
@@ -2654,10 +4722,19 @@ package gl
 // static void  glowUseProgramStages(GPUSEPROGRAMSTAGES fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
 //   (*fnptr)(pipeline, stages, program);
 // }
+// static void  glowUseProgramStagesEXT(GPUSEPROGRAMSTAGESEXT fnptr, GLuint  pipeline, GLbitfield  stages, GLuint  program) {
+//   (*fnptr)(pipeline, stages, program);
+// }
+// static void  glowUseShaderProgramEXT(GPUSESHADERPROGRAMEXT fnptr, GLenum  type, GLuint  program) {
+//   (*fnptr)(type, program);
+// }
 // static void  glowValidateProgram(GPVALIDATEPROGRAM fnptr, GLuint  program) {
 //   (*fnptr)(program);
 // }
 // static void  glowValidateProgramPipeline(GPVALIDATEPROGRAMPIPELINE fnptr, GLuint  pipeline) {
+//   (*fnptr)(pipeline);
+// }
+// static void  glowValidateProgramPipelineEXT(GPVALIDATEPROGRAMPIPELINEEXT fnptr, GLuint  pipeline) {
 //   (*fnptr)(pipeline);
 // }
 // static void  glowVertexArrayAttribBinding(GPVERTEXARRAYATTRIBBINDING fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
@@ -2672,17 +4749,74 @@ package gl
 // static void  glowVertexArrayAttribLFormat(GPVERTEXARRAYATTRIBLFORMAT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexArrayBindVertexBufferEXT(GPVERTEXARRAYBINDVERTEXBUFFEREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
+//   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
+// }
 // static void  glowVertexArrayBindingDivisor(GPVERTEXARRAYBINDINGDIVISOR fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(vaobj, bindingindex, divisor);
 // }
+// static void  glowVertexArrayColorOffsetEXT(GPVERTEXARRAYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayEdgeFlagOffsetEXT(GPVERTEXARRAYEDGEFLAGOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, stride, offset);
+// }
 // static void  glowVertexArrayElementBuffer(GPVERTEXARRAYELEMENTBUFFER fnptr, GLuint  vaobj, GLuint  buffer) {
 //   (*fnptr)(vaobj, buffer);
+// }
+// static void  glowVertexArrayFogCoordOffsetEXT(GPVERTEXARRAYFOGCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayIndexOffsetEXT(GPVERTEXARRAYINDEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArrayMultiTexCoordOffsetEXT(GPVERTEXARRAYMULTITEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  texunit, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, texunit, size, type, stride, offset);
+// }
+// static void  glowVertexArrayNormalOffsetEXT(GPVERTEXARRAYNORMALOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, type, stride, offset);
+// }
+// static void  glowVertexArraySecondaryColorOffsetEXT(GPVERTEXARRAYSECONDARYCOLOROFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayTexCoordOffsetEXT(GPVERTEXARRAYTEXCOORDOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribBindingEXT(GPVERTEXARRAYVERTEXATTRIBBINDINGEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLuint  bindingindex) {
+//   (*fnptr)(vaobj, attribindex, bindingindex);
+// }
+// static void  glowVertexArrayVertexAttribDivisorEXT(GPVERTEXARRAYVERTEXATTRIBDIVISOREXT fnptr, GLuint  vaobj, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(vaobj, index, divisor);
+// }
+// static void  glowVertexArrayVertexAttribFormatEXT(GPVERTEXARRAYVERTEXATTRIBFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIFormatEXT(GPVERTEXARRAYVERTEXATTRIBIFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribIOffsetEXT(GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribLFormatEXT(GPVERTEXARRAYVERTEXATTRIBLFORMATEXT fnptr, GLuint  vaobj, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
+//   (*fnptr)(vaobj, attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexArrayVertexAttribLOffsetEXT(GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, stride, offset);
+// }
+// static void  glowVertexArrayVertexAttribOffsetEXT(GPVERTEXARRAYVERTEXATTRIBOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, index, size, type, normalized, stride, offset);
+// }
+// static void  glowVertexArrayVertexBindingDivisorEXT(GPVERTEXARRAYVERTEXBINDINGDIVISOREXT fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  divisor) {
+//   (*fnptr)(vaobj, bindingindex, divisor);
 // }
 // static void  glowVertexArrayVertexBuffer(GPVERTEXARRAYVERTEXBUFFER fnptr, GLuint  vaobj, GLuint  bindingindex, GLuint  buffer, GLintptr  offset, GLsizei  stride) {
 //   (*fnptr)(vaobj, bindingindex, buffer, offset, stride);
 // }
 // static void  glowVertexArrayVertexBuffers(GPVERTEXARRAYVERTEXBUFFERS fnptr, GLuint  vaobj, GLuint  first, GLsizei  count, const GLuint * buffers, const GLintptr * offsets, const GLsizei * strides) {
 //   (*fnptr)(vaobj, first, count, buffers, offsets, strides);
+// }
+// static void  glowVertexArrayVertexOffsetEXT(GPVERTEXARRAYVERTEXOFFSETEXT fnptr, GLuint  vaobj, GLuint  buffer, GLint  size, GLenum  type, GLsizei  stride, GLintptr  offset) {
+//   (*fnptr)(vaobj, buffer, size, type, stride, offset);
 // }
 // static void  glowVertexAttrib1d(GPVERTEXATTRIB1D fnptr, GLuint  index, GLdouble  x) {
 //   (*fnptr)(index, x);
@@ -2798,8 +4932,14 @@ package gl
 // static void  glowVertexAttribDivisor(GPVERTEXATTRIBDIVISOR fnptr, GLuint  index, GLuint  divisor) {
 //   (*fnptr)(index, divisor);
 // }
+// static void  glowVertexAttribDivisorARB(GPVERTEXATTRIBDIVISORARB fnptr, GLuint  index, GLuint  divisor) {
+//   (*fnptr)(index, divisor);
+// }
 // static void  glowVertexAttribFormat(GPVERTEXATTRIBFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLboolean  normalized, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, normalized, relativeoffset);
+// }
+// static void  glowVertexAttribFormatNV(GPVERTEXATTRIBFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride) {
+//   (*fnptr)(index, size, type, normalized, stride);
 // }
 // static void  glowVertexAttribI1i(GPVERTEXATTRIBI1I fnptr, GLuint  index, GLint  x) {
 //   (*fnptr)(index, x);
@@ -2864,6 +5004,9 @@ package gl
 // static void  glowVertexAttribIFormat(GPVERTEXATTRIBIFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
 // }
+// static void  glowVertexAttribIFormatNV(GPVERTEXATTRIBIFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
+// }
 // static void  glowVertexAttribIPointer(GPVERTEXATTRIBIPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
 // }
@@ -2873,10 +5016,22 @@ package gl
 // static void  glowVertexAttribL1dv(GPVERTEXATTRIBL1DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL1i64NV(GPVERTEXATTRIBL1I64NV fnptr, GLuint  index, GLint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
+// static void  glowVertexAttribL1i64vNV(GPVERTEXATTRIBL1I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL1ui64ARB(GPVERTEXATTRIBL1UI64ARB fnptr, GLuint  index, GLuint64EXT  x) {
 //   (*fnptr)(index, x);
 // }
+// static void  glowVertexAttribL1ui64NV(GPVERTEXATTRIBL1UI64NV fnptr, GLuint  index, GLuint64EXT  x) {
+//   (*fnptr)(index, x);
+// }
 // static void  glowVertexAttribL1ui64vARB(GPVERTEXATTRIBL1UI64VARB fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL1ui64vNV(GPVERTEXATTRIBL1UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL2d(GPVERTEXATTRIBL2D fnptr, GLuint  index, GLdouble  x, GLdouble  y) {
@@ -2885,10 +5040,34 @@ package gl
 // static void  glowVertexAttribL2dv(GPVERTEXATTRIBL2DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL2i64NV(GPVERTEXATTRIBL2I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2i64vNV(GPVERTEXATTRIBL2I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL2ui64NV(GPVERTEXATTRIBL2UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y) {
+//   (*fnptr)(index, x, y);
+// }
+// static void  glowVertexAttribL2ui64vNV(GPVERTEXATTRIBL2UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribL3d(GPVERTEXATTRIBL3D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z) {
 //   (*fnptr)(index, x, y, z);
 // }
 // static void  glowVertexAttribL3dv(GPVERTEXATTRIBL3DV fnptr, GLuint  index, const GLdouble * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3i64NV(GPVERTEXATTRIBL3I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3i64vNV(GPVERTEXATTRIBL3I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL3ui64NV(GPVERTEXATTRIBL3UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z) {
+//   (*fnptr)(index, x, y, z);
+// }
+// static void  glowVertexAttribL3ui64vNV(GPVERTEXATTRIBL3UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
 //   (*fnptr)(index, v);
 // }
 // static void  glowVertexAttribL4d(GPVERTEXATTRIBL4D fnptr, GLuint  index, GLdouble  x, GLdouble  y, GLdouble  z, GLdouble  w) {
@@ -2897,8 +5076,23 @@ package gl
 // static void  glowVertexAttribL4dv(GPVERTEXATTRIBL4DV fnptr, GLuint  index, const GLdouble * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowVertexAttribL4i64NV(GPVERTEXATTRIBL4I64NV fnptr, GLuint  index, GLint64EXT  x, GLint64EXT  y, GLint64EXT  z, GLint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4i64vNV(GPVERTEXATTRIBL4I64VNV fnptr, GLuint  index, const GLint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
+// static void  glowVertexAttribL4ui64NV(GPVERTEXATTRIBL4UI64NV fnptr, GLuint  index, GLuint64EXT  x, GLuint64EXT  y, GLuint64EXT  z, GLuint64EXT  w) {
+//   (*fnptr)(index, x, y, z, w);
+// }
+// static void  glowVertexAttribL4ui64vNV(GPVERTEXATTRIBL4UI64VNV fnptr, GLuint  index, const GLuint64EXT * v) {
+//   (*fnptr)(index, v);
+// }
 // static void  glowVertexAttribLFormat(GPVERTEXATTRIBLFORMAT fnptr, GLuint  attribindex, GLint  size, GLenum  type, GLuint  relativeoffset) {
 //   (*fnptr)(attribindex, size, type, relativeoffset);
+// }
+// static void  glowVertexAttribLFormatNV(GPVERTEXATTRIBLFORMATNV fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(index, size, type, stride);
 // }
 // static void  glowVertexAttribLPointer(GPVERTEXATTRIBLPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLsizei  stride, const void * pointer) {
 //   (*fnptr)(index, size, type, stride, pointer);
@@ -2933,6 +5127,9 @@ package gl
 // static void  glowVertexBindingDivisor(GPVERTEXBINDINGDIVISOR fnptr, GLuint  bindingindex, GLuint  divisor) {
 //   (*fnptr)(bindingindex, divisor);
 // }
+// static void  glowVertexFormatNV(GPVERTEXFORMATNV fnptr, GLint  size, GLenum  type, GLsizei  stride) {
+//   (*fnptr)(size, type, stride);
+// }
 // static void  glowViewport(GPVIEWPORT fnptr, GLint  x, GLint  y, GLsizei  width, GLsizei  height) {
 //   (*fnptr)(x, y, width, height);
 // }
@@ -2945,8 +5142,23 @@ package gl
 // static void  glowViewportIndexedfv(GPVIEWPORTINDEXEDFV fnptr, GLuint  index, const GLfloat * v) {
 //   (*fnptr)(index, v);
 // }
+// static void  glowViewportPositionWScaleNV(GPVIEWPORTPOSITIONWSCALENV fnptr, GLuint  index, GLfloat  xcoeff, GLfloat  ycoeff) {
+//   (*fnptr)(index, xcoeff, ycoeff);
+// }
+// static void  glowViewportSwizzleNV(GPVIEWPORTSWIZZLENV fnptr, GLuint  index, GLenum  swizzlex, GLenum  swizzley, GLenum  swizzlez, GLenum  swizzlew) {
+//   (*fnptr)(index, swizzlex, swizzley, swizzlez, swizzlew);
+// }
 // static void  glowWaitSync(GPWAITSYNC fnptr, GLsync  sync, GLbitfield  flags, GLuint64  timeout) {
 //   (*fnptr)(sync, flags, timeout);
+// }
+// static void  glowWaitVkSemaphoreNV(GPWAITVKSEMAPHORENV fnptr, GLuint64  vkSemaphore) {
+//   (*fnptr)(vkSemaphore);
+// }
+// static void  glowWeightPathsNV(GPWEIGHTPATHSNV fnptr, GLuint  resultPath, GLsizei  numPaths, const GLuint * paths, const GLfloat * weights) {
+//   (*fnptr)(resultPath, numPaths, paths, weights);
+// }
+// static void  glowWindowRectanglesEXT(GPWINDOWRECTANGLESEXT fnptr, GLenum  mode, GLsizei  count, const GLint * box) {
+//   (*fnptr)(mode, count, box);
 // }
 import "C"
 import (
@@ -2955,10 +5167,12 @@ import (
 )
 
 const (
+	ACCUM_ADJACENT_PAIRS_NV                                    = 0x90AD
 	ACTIVE_ATOMIC_COUNTER_BUFFERS                              = 0x92D9
 	ACTIVE_ATTRIBUTES                                          = 0x8B89
 	ACTIVE_ATTRIBUTE_MAX_LENGTH                                = 0x8B8A
 	ACTIVE_PROGRAM                                             = 0x8259
+	ACTIVE_PROGRAM_EXT                                         = 0x8B8D
 	ACTIVE_RESOURCES                                           = 0x92F5
 	ACTIVE_SUBROUTINES                                         = 0x8DE5
 	ACTIVE_SUBROUTINE_MAX_LENGTH                               = 0x8E48
@@ -2971,10 +5185,15 @@ const (
 	ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH                       = 0x8A35
 	ACTIVE_UNIFORM_MAX_LENGTH                                  = 0x8B87
 	ACTIVE_VARIABLES                                           = 0x9305
+	ADJACENT_PAIRS_NV                                          = 0x90AE
+	AFFINE_2D_NV                                               = 0x9092
+	AFFINE_3D_NV                                               = 0x9094
 	ALIASED_LINE_WIDTH_RANGE                                   = 0x846E
 	ALL_BARRIER_BITS                                           = 0xFFFFFFFF
 	ALL_SHADER_BITS                                            = 0xFFFFFFFF
+	ALL_SHADER_BITS_EXT                                        = 0xFFFFFFFF
 	ALPHA                                                      = 0x1906
+	ALPHA_REF_COMMAND_NV                                       = 0x000F
 	ALREADY_SIGNALED                                           = 0x911A
 	ALWAYS                                                     = 0x0207
 	AND                                                        = 0x1501
@@ -2982,6 +5201,7 @@ const (
 	AND_REVERSE                                                = 0x1502
 	ANY_SAMPLES_PASSED                                         = 0x8C2F
 	ANY_SAMPLES_PASSED_CONSERVATIVE                            = 0x8D6A
+	ARC_TO_NV                                                  = 0xFE
 	ARRAY_BUFFER                                               = 0x8892
 	ARRAY_BUFFER_BINDING                                       = 0x8894
 	ARRAY_SIZE                                                 = 0x92FB
@@ -3002,43 +5222,56 @@ const (
 	ATOMIC_COUNTER_BUFFER_SIZE                                 = 0x92C3
 	ATOMIC_COUNTER_BUFFER_START                                = 0x92C2
 	ATTACHED_SHADERS                                           = 0x8B85
+	ATTRIBUTE_ADDRESS_COMMAND_NV                               = 0x0009
 	AUTO_GENERATE_MIPMAP                                       = 0x8295
 	BACK                                                       = 0x0405
 	BACK_LEFT                                                  = 0x0402
 	BACK_RIGHT                                                 = 0x0403
+	BEVEL_NV                                                   = 0x90A6
 	BGR                                                        = 0x80E0
 	BGRA                                                       = 0x80E1
 	BGRA_INTEGER                                               = 0x8D9B
 	BGR_INTEGER                                                = 0x8D9A
 	BLEND                                                      = 0x0BE2
+	BLEND_ADVANCED_COHERENT_KHR                                = 0x9285
+	BLEND_ADVANCED_COHERENT_NV                                 = 0x9285
 	BLEND_COLOR                                                = 0x8005
+	BLEND_COLOR_COMMAND_NV                                     = 0x000B
 	BLEND_DST                                                  = 0x0BE0
 	BLEND_DST_ALPHA                                            = 0x80CA
 	BLEND_DST_RGB                                              = 0x80C8
 	BLEND_EQUATION                                             = 0x8009
 	BLEND_EQUATION_ALPHA                                       = 0x883D
 	BLEND_EQUATION_RGB                                         = 0x8009
+	BLEND_OVERLAP_NV                                           = 0x9281
+	BLEND_PREMULTIPLIED_SRC_NV                                 = 0x9280
 	BLEND_SRC                                                  = 0x0BE1
 	BLEND_SRC_ALPHA                                            = 0x80CB
 	BLEND_SRC_RGB                                              = 0x80C9
 	BLOCK_INDEX                                                = 0x92FD
 	BLUE                                                       = 0x1905
 	BLUE_INTEGER                                               = 0x8D96
+	BLUE_NV                                                    = 0x1905
+	BOLD_BIT_NV                                                = 0x01
 	BOOL                                                       = 0x8B56
 	BOOL_VEC2                                                  = 0x8B57
 	BOOL_VEC3                                                  = 0x8B58
 	BOOL_VEC4                                                  = 0x8B59
+	BOUNDING_BOX_NV                                            = 0x908D
+	BOUNDING_BOX_OF_BOUNDING_BOXES_NV                          = 0x909C
 	BUFFER                                                     = 0x82E0
 	BUFFER_ACCESS                                              = 0x88BB
 	BUFFER_ACCESS_FLAGS                                        = 0x911F
 	BUFFER_BINDING                                             = 0x9302
 	BUFFER_DATA_SIZE                                           = 0x9303
+	BUFFER_GPU_ADDRESS_NV                                      = 0x8F1D
 	BUFFER_IMMUTABLE_STORAGE                                   = 0x821F
 	BUFFER_KHR                                                 = 0x82E0
 	BUFFER_MAPPED                                              = 0x88BC
 	BUFFER_MAP_LENGTH                                          = 0x9120
 	BUFFER_MAP_OFFSET                                          = 0x9121
 	BUFFER_MAP_POINTER                                         = 0x88BD
+	BUFFER_OBJECT_EXT                                          = 0x9151
 	BUFFER_SIZE                                                = 0x8764
 	BUFFER_STORAGE_FLAGS                                       = 0x8220
 	BUFFER_UPDATE_BARRIER_BIT                                  = 0x00000200
@@ -3047,8 +5280,12 @@ const (
 	BYTE                                                       = 0x1400
 	CAVEAT_SUPPORT                                             = 0x82B8
 	CCW                                                        = 0x0901
+	CIRCULAR_CCW_ARC_TO_NV                                     = 0xF8
+	CIRCULAR_CW_ARC_TO_NV                                      = 0xFA
+	CIRCULAR_TANGENT_ARC_TO_NV                                 = 0xFC
 	CLAMP_READ_COLOR                                           = 0x891C
 	CLAMP_TO_BORDER                                            = 0x812D
+	CLAMP_TO_BORDER_ARB                                        = 0x812D
 	CLAMP_TO_EDGE                                              = 0x812F
 	CLEAR                                                      = 0x1500
 	CLEAR_BUFFER                                               = 0x82B4
@@ -3067,7 +5304,14 @@ const (
 	CLIP_DISTANCE6                                             = 0x3006
 	CLIP_DISTANCE7                                             = 0x3007
 	CLIP_ORIGIN                                                = 0x935C
+	CLOSE_PATH_NV                                              = 0x00
 	COLOR                                                      = 0x1800
+	COLORBURN_KHR                                              = 0x929A
+	COLORBURN_NV                                               = 0x929A
+	COLORDODGE_KHR                                             = 0x9299
+	COLORDODGE_NV                                              = 0x9299
+	COLOR_ARRAY_ADDRESS_NV                                     = 0x8F23
+	COLOR_ARRAY_LENGTH_NV                                      = 0x8F2D
 	COLOR_ATTACHMENT0                                          = 0x8CE0
 	COLOR_ATTACHMENT1                                          = 0x8CE1
 	COLOR_ATTACHMENT10                                         = 0x8CEA
@@ -3076,8 +5320,24 @@ const (
 	COLOR_ATTACHMENT13                                         = 0x8CED
 	COLOR_ATTACHMENT14                                         = 0x8CEE
 	COLOR_ATTACHMENT15                                         = 0x8CEF
+	COLOR_ATTACHMENT16                                         = 0x8CF0
+	COLOR_ATTACHMENT17                                         = 0x8CF1
+	COLOR_ATTACHMENT18                                         = 0x8CF2
+	COLOR_ATTACHMENT19                                         = 0x8CF3
 	COLOR_ATTACHMENT2                                          = 0x8CE2
+	COLOR_ATTACHMENT20                                         = 0x8CF4
+	COLOR_ATTACHMENT21                                         = 0x8CF5
+	COLOR_ATTACHMENT22                                         = 0x8CF6
+	COLOR_ATTACHMENT23                                         = 0x8CF7
+	COLOR_ATTACHMENT24                                         = 0x8CF8
+	COLOR_ATTACHMENT25                                         = 0x8CF9
+	COLOR_ATTACHMENT26                                         = 0x8CFA
+	COLOR_ATTACHMENT27                                         = 0x8CFB
+	COLOR_ATTACHMENT28                                         = 0x8CFC
+	COLOR_ATTACHMENT29                                         = 0x8CFD
 	COLOR_ATTACHMENT3                                          = 0x8CE3
+	COLOR_ATTACHMENT30                                         = 0x8CFE
+	COLOR_ATTACHMENT31                                         = 0x8CFF
 	COLOR_ATTACHMENT4                                          = 0x8CE4
 	COLOR_ATTACHMENT5                                          = 0x8CE5
 	COLOR_ATTACHMENT6                                          = 0x8CE6
@@ -3090,11 +5350,14 @@ const (
 	COLOR_ENCODING                                             = 0x8296
 	COLOR_LOGIC_OP                                             = 0x0BF2
 	COLOR_RENDERABLE                                           = 0x8286
+	COLOR_SAMPLES_NV                                           = 0x8E20
 	COLOR_WRITEMASK                                            = 0x0C23
 	COMMAND_BARRIER_BIT                                        = 0x00000040
 	COMPARE_REF_TO_TEXTURE                                     = 0x884E
 	COMPATIBLE_SUBROUTINES                                     = 0x8E4B
 	COMPILE_STATUS                                             = 0x8B81
+	COMPLETION_STATUS_ARB                                      = 0x91B1
+	COMPLETION_STATUS_KHR                                      = 0x91B1
 	COMPRESSED_R11_EAC                                         = 0x9270
 	COMPRESSED_RED                                             = 0x8225
 	COMPRESSED_RED_RGTC1                                       = 0x8DBB
@@ -3121,10 +5384,14 @@ const (
 	COMPRESSED_RGBA_ASTC_8x8_KHR                               = 0x93B7
 	COMPRESSED_RGBA_BPTC_UNORM                                 = 0x8E8C
 	COMPRESSED_RGBA_BPTC_UNORM_ARB                             = 0x8E8C
+	COMPRESSED_RGBA_S3TC_DXT1_EXT                              = 0x83F1
+	COMPRESSED_RGBA_S3TC_DXT3_EXT                              = 0x83F2
+	COMPRESSED_RGBA_S3TC_DXT5_EXT                              = 0x83F3
 	COMPRESSED_RGB_BPTC_SIGNED_FLOAT                           = 0x8E8E
 	COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB                       = 0x8E8E
 	COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT                         = 0x8E8F
 	COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB                     = 0x8E8F
+	COMPRESSED_RGB_S3TC_DXT1_EXT                               = 0x83F0
 	COMPRESSED_RG_RGTC2                                        = 0x8DBD
 	COMPRESSED_SIGNED_R11_EAC                                  = 0x9271
 	COMPRESSED_SIGNED_RED_RGTC1                                = 0x8DBC
@@ -3160,6 +5427,18 @@ const (
 	COMPUTE_TEXTURE                                            = 0x82A0
 	COMPUTE_WORK_GROUP_SIZE                                    = 0x8267
 	CONDITION_SATISFIED                                        = 0x911C
+	CONFORMANT_NV                                              = 0x9374
+	CONIC_CURVE_TO_NV                                          = 0x1A
+	CONJOINT_NV                                                = 0x9284
+	CONSERVATIVE_RASTERIZATION_INTEL                           = 0x83FE
+	CONSERVATIVE_RASTERIZATION_NV                              = 0x9346
+	CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV                  = 0x937B
+	CONSERVATIVE_RASTER_DILATE_NV                              = 0x9379
+	CONSERVATIVE_RASTER_DILATE_RANGE_NV                        = 0x937A
+	CONSERVATIVE_RASTER_MODE_NV                                = 0x954D
+	CONSERVATIVE_RASTER_MODE_POST_SNAP_NV                      = 0x954E
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV                       = 0x9550
+	CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV             = 0x954F
 	CONSTANT_ALPHA                                             = 0x8003
 	CONSTANT_COLOR                                             = 0x8001
 	CONTEXT_COMPATIBILITY_PROFILE_BIT                          = 0x00000002
@@ -3168,6 +5447,7 @@ const (
 	CONTEXT_FLAG_DEBUG_BIT                                     = 0x00000002
 	CONTEXT_FLAG_DEBUG_BIT_KHR                                 = 0x00000002
 	CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT                        = 0x00000001
+	CONTEXT_FLAG_NO_ERROR_BIT_KHR                              = 0x00000008
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT                             = 0x00000004
 	CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB                         = 0x00000004
 	CONTEXT_LOST                                               = 0x0507
@@ -3179,18 +5459,30 @@ const (
 	CONTEXT_RELEASE_BEHAVIOR_KHR                               = 0x82FB
 	CONTEXT_ROBUST_ACCESS                                      = 0x90F3
 	CONTEXT_ROBUST_ACCESS_KHR                                  = 0x90F3
+	CONTRAST_NV                                                = 0x92A1
+	CONVEX_HULL_NV                                             = 0x908B
 	COPY                                                       = 0x1503
 	COPY_INVERTED                                              = 0x150C
 	COPY_READ_BUFFER                                           = 0x8F36
 	COPY_READ_BUFFER_BINDING                                   = 0x8F36
 	COPY_WRITE_BUFFER                                          = 0x8F37
 	COPY_WRITE_BUFFER_BINDING                                  = 0x8F37
+	COUNTER_RANGE_AMD                                          = 0x8BC1
+	COUNTER_TYPE_AMD                                           = 0x8BC0
+	COUNT_DOWN_NV                                              = 0x9089
+	COUNT_UP_NV                                                = 0x9088
+	COVERAGE_MODULATION_NV                                     = 0x9332
+	COVERAGE_MODULATION_TABLE_NV                               = 0x9331
+	COVERAGE_MODULATION_TABLE_SIZE_NV                          = 0x9333
+	CUBIC_CURVE_TO_NV                                          = 0x0C
 	CULL_FACE                                                  = 0x0B44
 	CULL_FACE_MODE                                             = 0x0B45
 	CURRENT_PROGRAM                                            = 0x8B8D
 	CURRENT_QUERY                                              = 0x8865
 	CURRENT_VERTEX_ATTRIB                                      = 0x8626
 	CW                                                         = 0x0900
+	DARKEN_KHR                                                 = 0x9297
+	DARKEN_NV                                                  = 0x9297
 	DEBUG_CALLBACK_FUNCTION                                    = 0x8244
 	DEBUG_CALLBACK_FUNCTION_ARB                                = 0x8244
 	DEBUG_CALLBACK_FUNCTION_KHR                                = 0x8244
@@ -3263,6 +5555,7 @@ const (
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR                              = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_ARB                          = 0x824E
 	DEBUG_TYPE_UNDEFINED_BEHAVIOR_KHR                          = 0x824E
+	DECODE_EXT                                                 = 0x8A49
 	DECR                                                       = 0x1E03
 	DECR_WRAP                                                  = 0x8508
 	DELETE_STATUS                                              = 0x8B80
@@ -3282,11 +5575,15 @@ const (
 	DEPTH_FUNC                                                 = 0x0B74
 	DEPTH_RANGE                                                = 0x0B70
 	DEPTH_RENDERABLE                                           = 0x8287
+	DEPTH_SAMPLES_NV                                           = 0x932D
 	DEPTH_STENCIL                                              = 0x84F9
 	DEPTH_STENCIL_ATTACHMENT                                   = 0x821A
 	DEPTH_STENCIL_TEXTURE_MODE                                 = 0x90EA
 	DEPTH_TEST                                                 = 0x0B71
 	DEPTH_WRITEMASK                                            = 0x0B72
+	DIFFERENCE_KHR                                             = 0x929E
+	DIFFERENCE_NV                                              = 0x929E
+	DISJOINT_NV                                                = 0x9283
 	DISPATCH_INDIRECT_BUFFER                                   = 0x90EE
 	DISPATCH_INDIRECT_BUFFER_BINDING                           = 0x90EF
 	DITHER                                                     = 0x0BD0
@@ -3305,6 +5602,9 @@ const (
 	DOUBLE_VEC2                                                = 0x8FFC
 	DOUBLE_VEC3                                                = 0x8FFD
 	DOUBLE_VEC4                                                = 0x8FFE
+	DRAW_ARRAYS_COMMAND_NV                                     = 0x0003
+	DRAW_ARRAYS_INSTANCED_COMMAND_NV                           = 0x0007
+	DRAW_ARRAYS_STRIP_COMMAND_NV                               = 0x0005
 	DRAW_BUFFER                                                = 0x0C01
 	DRAW_BUFFER0                                               = 0x8825
 	DRAW_BUFFER1                                               = 0x8826
@@ -3322,30 +5622,62 @@ const (
 	DRAW_BUFFER7                                               = 0x882C
 	DRAW_BUFFER8                                               = 0x882D
 	DRAW_BUFFER9                                               = 0x882E
+	DRAW_ELEMENTS_COMMAND_NV                                   = 0x0002
+	DRAW_ELEMENTS_INSTANCED_COMMAND_NV                         = 0x0006
+	DRAW_ELEMENTS_STRIP_COMMAND_NV                             = 0x0004
 	DRAW_FRAMEBUFFER                                           = 0x8CA9
 	DRAW_FRAMEBUFFER_BINDING                                   = 0x8CA6
+	DRAW_INDIRECT_ADDRESS_NV                                   = 0x8F41
 	DRAW_INDIRECT_BUFFER                                       = 0x8F3F
 	DRAW_INDIRECT_BUFFER_BINDING                               = 0x8F43
+	DRAW_INDIRECT_LENGTH_NV                                    = 0x8F42
+	DRAW_INDIRECT_UNIFIED_NV                                   = 0x8F40
 	DST_ALPHA                                                  = 0x0304
+	DST_ATOP_NV                                                = 0x928F
 	DST_COLOR                                                  = 0x0306
+	DST_IN_NV                                                  = 0x928B
+	DST_NV                                                     = 0x9287
+	DST_OUT_NV                                                 = 0x928D
+	DST_OVER_NV                                                = 0x9289
+	DUP_FIRST_CUBIC_CURVE_TO_NV                                = 0xF2
+	DUP_LAST_CUBIC_CURVE_TO_NV                                 = 0xF4
 	DYNAMIC_COPY                                               = 0x88EA
 	DYNAMIC_DRAW                                               = 0x88E8
 	DYNAMIC_READ                                               = 0x88E9
 	DYNAMIC_STORAGE_BIT                                        = 0x0100
+	EDGE_FLAG_ARRAY_ADDRESS_NV                                 = 0x8F26
+	EDGE_FLAG_ARRAY_LENGTH_NV                                  = 0x8F30
+	EFFECTIVE_RASTER_SAMPLES_EXT                               = 0x932C
+	ELEMENT_ADDRESS_COMMAND_NV                                 = 0x0008
+	ELEMENT_ARRAY_ADDRESS_NV                                   = 0x8F29
 	ELEMENT_ARRAY_BARRIER_BIT                                  = 0x00000002
 	ELEMENT_ARRAY_BUFFER                                       = 0x8893
 	ELEMENT_ARRAY_BUFFER_BINDING                               = 0x8895
+	ELEMENT_ARRAY_LENGTH_NV                                    = 0x8F33
+	ELEMENT_ARRAY_UNIFIED_NV                                   = 0x8F1F
 	EQUAL                                                      = 0x0202
 	EQUIV                                                      = 0x1509
+	EXCLUSION_KHR                                              = 0x92A0
+	EXCLUSION_NV                                               = 0x92A0
+	EXCLUSIVE_EXT                                              = 0x8F11
 	EXTENSIONS                                                 = 0x1F03
+	FACTOR_MAX_AMD                                             = 0x901D
+	FACTOR_MIN_AMD                                             = 0x901C
 	FALSE                                                      = 0
 	FASTEST                                                    = 0x1101
+	FILE_NAME_NV                                               = 0x9074
 	FILL                                                       = 0x1B02
+	FILL_RECTANGLE_NV                                          = 0x933C
 	FILTER                                                     = 0x829A
+	FIRST_TO_REST_NV                                           = 0x90AF
 	FIRST_VERTEX_CONVENTION                                    = 0x8E4D
 	FIXED                                                      = 0x140C
 	FIXED_ONLY                                                 = 0x891D
 	FLOAT                                                      = 0x1406
+	FLOAT16_NV                                                 = 0x8FF8
+	FLOAT16_VEC2_NV                                            = 0x8FF9
+	FLOAT16_VEC3_NV                                            = 0x8FFA
+	FLOAT16_VEC4_NV                                            = 0x8FFB
 	FLOAT_32_UNSIGNED_INT_24_8_REV                             = 0x8DAD
 	FLOAT_MAT2                                                 = 0x8B5A
 	FLOAT_MAT2x3                                               = 0x8B65
@@ -3359,12 +5691,37 @@ const (
 	FLOAT_VEC2                                                 = 0x8B50
 	FLOAT_VEC3                                                 = 0x8B51
 	FLOAT_VEC4                                                 = 0x8B52
+	FOG_COORD_ARRAY_ADDRESS_NV                                 = 0x8F28
+	FOG_COORD_ARRAY_LENGTH_NV                                  = 0x8F32
+	FONT_ASCENDER_BIT_NV                                       = 0x00200000
+	FONT_DESCENDER_BIT_NV                                      = 0x00400000
+	FONT_GLYPHS_AVAILABLE_NV                                   = 0x9368
+	FONT_HAS_KERNING_BIT_NV                                    = 0x10000000
+	FONT_HEIGHT_BIT_NV                                         = 0x00800000
+	FONT_MAX_ADVANCE_HEIGHT_BIT_NV                             = 0x02000000
+	FONT_MAX_ADVANCE_WIDTH_BIT_NV                              = 0x01000000
+	FONT_NUM_GLYPH_INDICES_BIT_NV                              = 0x20000000
+	FONT_TARGET_UNAVAILABLE_NV                                 = 0x9369
+	FONT_UNAVAILABLE_NV                                        = 0x936A
+	FONT_UNDERLINE_POSITION_BIT_NV                             = 0x04000000
+	FONT_UNDERLINE_THICKNESS_BIT_NV                            = 0x08000000
+	FONT_UNINTELLIGIBLE_NV                                     = 0x936B
+	FONT_UNITS_PER_EM_BIT_NV                                   = 0x00100000
+	FONT_X_MAX_BOUNDS_BIT_NV                                   = 0x00040000
+	FONT_X_MIN_BOUNDS_BIT_NV                                   = 0x00010000
+	FONT_Y_MAX_BOUNDS_BIT_NV                                   = 0x00080000
+	FONT_Y_MIN_BOUNDS_BIT_NV                                   = 0x00020000
 	FRACTIONAL_EVEN                                            = 0x8E7C
 	FRACTIONAL_ODD                                             = 0x8E7B
+	FRAGMENT_COVERAGE_COLOR_NV                                 = 0x92DE
+	FRAGMENT_COVERAGE_TO_COLOR_NV                              = 0x92DD
+	FRAGMENT_INPUT_NV                                          = 0x936D
 	FRAGMENT_INTERPOLATION_OFFSET_BITS                         = 0x8E5D
 	FRAGMENT_SHADER                                            = 0x8B30
 	FRAGMENT_SHADER_BIT                                        = 0x00000002
+	FRAGMENT_SHADER_BIT_EXT                                    = 0x00000002
 	FRAGMENT_SHADER_DERIVATIVE_HINT                            = 0x8B8B
+	FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT                       = 0x8A52
 	FRAGMENT_SHADER_INVOCATIONS_ARB                            = 0x82F4
 	FRAGMENT_SUBROUTINE                                        = 0x92EC
 	FRAGMENT_SUBROUTINE_UNIFORM                                = 0x92F2
@@ -3377,13 +5734,16 @@ const (
 	FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE                          = 0x8216
 	FRAMEBUFFER_ATTACHMENT_GREEN_SIZE                          = 0x8213
 	FRAMEBUFFER_ATTACHMENT_LAYERED                             = 0x8DA7
+	FRAMEBUFFER_ATTACHMENT_LAYERED_ARB                         = 0x8DA7
 	FRAMEBUFFER_ATTACHMENT_OBJECT_NAME                         = 0x8CD1
 	FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE                         = 0x8CD0
 	FRAMEBUFFER_ATTACHMENT_RED_SIZE                            = 0x8212
 	FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE                        = 0x8217
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR         = 0x9632
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE               = 0x8CD3
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER                       = 0x8CD4
 	FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL                       = 0x8CD2
+	FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR               = 0x9630
 	FRAMEBUFFER_BARRIER_BIT                                    = 0x00000400
 	FRAMEBUFFER_BINDING                                        = 0x8CA6
 	FRAMEBUFFER_BLEND                                          = 0x828B
@@ -3396,18 +5756,26 @@ const (
 	FRAMEBUFFER_DEFAULT_WIDTH                                  = 0x9310
 	FRAMEBUFFER_INCOMPLETE_ATTACHMENT                          = 0x8CD6
 	FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER                         = 0x8CDB
+	FRAMEBUFFER_INCOMPLETE_LAYER_COUNT_ARB                     = 0x8DA9
 	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS                       = 0x8DA8
+	FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS_ARB                   = 0x8DA8
 	FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT                  = 0x8CD7
 	FRAMEBUFFER_INCOMPLETE_MULTISAMPLE                         = 0x8D56
 	FRAMEBUFFER_INCOMPLETE_READ_BUFFER                         = 0x8CDC
+	FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR                    = 0x9633
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB              = 0x9342
+	FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV               = 0x9342
 	FRAMEBUFFER_RENDERABLE                                     = 0x8289
 	FRAMEBUFFER_RENDERABLE_LAYERED                             = 0x828A
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB                 = 0x9343
+	FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV                  = 0x9343
 	FRAMEBUFFER_SRGB                                           = 0x8DB9
 	FRAMEBUFFER_UNDEFINED                                      = 0x8219
 	FRAMEBUFFER_UNSUPPORTED                                    = 0x8CDD
 	FRONT                                                      = 0x0404
 	FRONT_AND_BACK                                             = 0x0408
 	FRONT_FACE                                                 = 0x0B46
+	FRONT_FACE_COMMAND_NV                                      = 0x0012
 	FRONT_LEFT                                                 = 0x0400
 	FRONT_RIGHT                                                = 0x0401
 	FULL_SUPPORT                                               = 0x82B7
@@ -3415,8 +5783,11 @@ const (
 	FUNC_REVERSE_SUBTRACT                                      = 0x800B
 	FUNC_SUBTRACT                                              = 0x800A
 	GEOMETRY_INPUT_TYPE                                        = 0x8917
+	GEOMETRY_INPUT_TYPE_ARB                                    = 0x8DDB
 	GEOMETRY_OUTPUT_TYPE                                       = 0x8918
+	GEOMETRY_OUTPUT_TYPE_ARB                                   = 0x8DDC
 	GEOMETRY_SHADER                                            = 0x8DD9
+	GEOMETRY_SHADER_ARB                                        = 0x8DD9
 	GEOMETRY_SHADER_BIT                                        = 0x00000004
 	GEOMETRY_SHADER_INVOCATIONS                                = 0x887F
 	GEOMETRY_SHADER_PRIMITIVES_EMITTED_ARB                     = 0x82F3
@@ -3424,18 +5795,42 @@ const (
 	GEOMETRY_SUBROUTINE_UNIFORM                                = 0x92F1
 	GEOMETRY_TEXTURE                                           = 0x829E
 	GEOMETRY_VERTICES_OUT                                      = 0x8916
+	GEOMETRY_VERTICES_OUT_ARB                                  = 0x8DDA
 	GEQUAL                                                     = 0x0206
 	GET_TEXTURE_IMAGE_FORMAT                                   = 0x8291
 	GET_TEXTURE_IMAGE_TYPE                                     = 0x8292
+	GLYPH_HAS_KERNING_BIT_NV                                   = 0x100
+	GLYPH_HEIGHT_BIT_NV                                        = 0x02
+	GLYPH_HORIZONTAL_BEARING_ADVANCE_BIT_NV                    = 0x10
+	GLYPH_HORIZONTAL_BEARING_X_BIT_NV                          = 0x04
+	GLYPH_HORIZONTAL_BEARING_Y_BIT_NV                          = 0x08
+	GLYPH_VERTICAL_BEARING_ADVANCE_BIT_NV                      = 0x80
+	GLYPH_VERTICAL_BEARING_X_BIT_NV                            = 0x20
+	GLYPH_VERTICAL_BEARING_Y_BIT_NV                            = 0x40
+	GLYPH_WIDTH_BIT_NV                                         = 0x01
+	GPU_ADDRESS_NV                                             = 0x8F34
 	GREATER                                                    = 0x0204
 	GREEN                                                      = 0x1904
 	GREEN_INTEGER                                              = 0x8D95
+	GREEN_NV                                                   = 0x1904
 	GUILTY_CONTEXT_RESET                                       = 0x8253
 	GUILTY_CONTEXT_RESET_ARB                                   = 0x8253
 	GUILTY_CONTEXT_RESET_KHR                                   = 0x8253
 	HALF_FLOAT                                                 = 0x140B
+	HARDLIGHT_KHR                                              = 0x929B
+	HARDLIGHT_NV                                               = 0x929B
+	HARDMIX_NV                                                 = 0x92A9
 	HIGH_FLOAT                                                 = 0x8DF2
 	HIGH_INT                                                   = 0x8DF5
+	HORIZONTAL_LINE_TO_NV                                      = 0x06
+	HSL_COLOR_KHR                                              = 0x92AF
+	HSL_COLOR_NV                                               = 0x92AF
+	HSL_HUE_KHR                                                = 0x92AD
+	HSL_HUE_NV                                                 = 0x92AD
+	HSL_LUMINOSITY_KHR                                         = 0x92B0
+	HSL_LUMINOSITY_NV                                          = 0x92B0
+	HSL_SATURATION_KHR                                         = 0x92AE
+	HSL_SATURATION_NV                                          = 0x92AE
 	IMAGE_1D                                                   = 0x904C
 	IMAGE_1D_ARRAY                                             = 0x9052
 	IMAGE_2D                                                   = 0x904D
@@ -3473,13 +5868,32 @@ const (
 	IMAGE_TEXEL_SIZE                                           = 0x82A7
 	IMPLEMENTATION_COLOR_READ_FORMAT                           = 0x8B9B
 	IMPLEMENTATION_COLOR_READ_TYPE                             = 0x8B9A
+	INCLUSIVE_EXT                                              = 0x8F10
 	INCR                                                       = 0x1E02
 	INCR_WRAP                                                  = 0x8507
+	INDEX_ARRAY_ADDRESS_NV                                     = 0x8F24
+	INDEX_ARRAY_LENGTH_NV                                      = 0x8F2E
 	INFO_LOG_LENGTH                                            = 0x8B84
 	INNOCENT_CONTEXT_RESET                                     = 0x8254
 	INNOCENT_CONTEXT_RESET_ARB                                 = 0x8254
 	INNOCENT_CONTEXT_RESET_KHR                                 = 0x8254
 	INT                                                        = 0x1404
+	INT16_NV                                                   = 0x8FE4
+	INT16_VEC2_NV                                              = 0x8FE5
+	INT16_VEC3_NV                                              = 0x8FE6
+	INT16_VEC4_NV                                              = 0x8FE7
+	INT64_ARB                                                  = 0x140E
+	INT64_NV                                                   = 0x140E
+	INT64_VEC2_ARB                                             = 0x8FE9
+	INT64_VEC2_NV                                              = 0x8FE9
+	INT64_VEC3_ARB                                             = 0x8FEA
+	INT64_VEC3_NV                                              = 0x8FEA
+	INT64_VEC4_ARB                                             = 0x8FEB
+	INT64_VEC4_NV                                              = 0x8FEB
+	INT8_NV                                                    = 0x8FE0
+	INT8_VEC2_NV                                               = 0x8FE1
+	INT8_VEC3_NV                                               = 0x8FE2
+	INT8_VEC4_NV                                               = 0x8FE3
 	INTERLEAVED_ATTRIBS                                        = 0x8C8C
 	INTERNALFORMAT_ALPHA_SIZE                                  = 0x8274
 	INTERNALFORMAT_ALPHA_TYPE                                  = 0x827B
@@ -3529,27 +5943,41 @@ const (
 	INVALID_OPERATION                                          = 0x0502
 	INVALID_VALUE                                              = 0x0501
 	INVERT                                                     = 0x150A
+	INVERT_OVG_NV                                              = 0x92B4
+	INVERT_RGB_NV                                              = 0x92A3
 	ISOLINES                                                   = 0x8E7A
 	IS_PER_PATCH                                               = 0x92E7
 	IS_ROW_MAJOR                                               = 0x9300
+	ITALIC_BIT_NV                                              = 0x02
 	KEEP                                                       = 0x1E00
+	LARGE_CCW_ARC_TO_NV                                        = 0x16
+	LARGE_CW_ARC_TO_NV                                         = 0x18
 	LAST_VERTEX_CONVENTION                                     = 0x8E4E
 	LAYER_PROVOKING_VERTEX                                     = 0x825E
 	LEFT                                                       = 0x0406
 	LEQUAL                                                     = 0x0203
 	LESS                                                       = 0x0201
+	LIGHTEN_KHR                                                = 0x9298
+	LIGHTEN_NV                                                 = 0x9298
 	LINE                                                       = 0x1B01
 	LINEAR                                                     = 0x2601
+	LINEARBURN_NV                                              = 0x92A5
+	LINEARDODGE_NV                                             = 0x92A4
+	LINEARLIGHT_NV                                             = 0x92A7
 	LINEAR_MIPMAP_LINEAR                                       = 0x2703
 	LINEAR_MIPMAP_NEAREST                                      = 0x2701
 	LINES                                                      = 0x0001
 	LINES_ADJACENCY                                            = 0x000A
+	LINES_ADJACENCY_ARB                                        = 0x000A
 	LINE_LOOP                                                  = 0x0002
 	LINE_SMOOTH                                                = 0x0B20
 	LINE_SMOOTH_HINT                                           = 0x0C52
 	LINE_STRIP                                                 = 0x0003
 	LINE_STRIP_ADJACENCY                                       = 0x000B
+	LINE_STRIP_ADJACENCY_ARB                                   = 0x000B
+	LINE_TO_NV                                                 = 0x04
 	LINE_WIDTH                                                 = 0x0B21
+	LINE_WIDTH_COMMAND_NV                                      = 0x000D
 	LINE_WIDTH_GRANULARITY                                     = 0x0B23
 	LINE_WIDTH_RANGE                                           = 0x0B22
 	LINK_STATUS                                                = 0x8B82
@@ -3649,12 +6077,17 @@ const (
 	MAX_GEOMETRY_INPUT_COMPONENTS                              = 0x9123
 	MAX_GEOMETRY_OUTPUT_COMPONENTS                             = 0x9124
 	MAX_GEOMETRY_OUTPUT_VERTICES                               = 0x8DE0
+	MAX_GEOMETRY_OUTPUT_VERTICES_ARB                           = 0x8DE0
 	MAX_GEOMETRY_SHADER_INVOCATIONS                            = 0x8E5A
 	MAX_GEOMETRY_SHADER_STORAGE_BLOCKS                         = 0x90D7
 	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS                           = 0x8C29
+	MAX_GEOMETRY_TEXTURE_IMAGE_UNITS_ARB                       = 0x8C29
 	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS                       = 0x8DE1
+	MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS_ARB                   = 0x8DE1
 	MAX_GEOMETRY_UNIFORM_BLOCKS                                = 0x8A2C
 	MAX_GEOMETRY_UNIFORM_COMPONENTS                            = 0x8DDF
+	MAX_GEOMETRY_UNIFORM_COMPONENTS_ARB                        = 0x8DDF
+	MAX_GEOMETRY_VARYING_COMPONENTS_ARB                        = 0x8DDD
 	MAX_HEIGHT                                                 = 0x827F
 	MAX_IMAGE_SAMPLES                                          = 0x906D
 	MAX_IMAGE_UNITS                                            = 0x8F38
@@ -3662,6 +6095,7 @@ const (
 	MAX_LABEL_LENGTH                                           = 0x82E8
 	MAX_LABEL_LENGTH_KHR                                       = 0x82E8
 	MAX_LAYERS                                                 = 0x8281
+	MAX_MULTISAMPLE_COVERAGE_MODES_NV                          = 0x8E11
 	MAX_NAME_LENGTH                                            = 0x92F6
 	MAX_NUM_ACTIVE_VARIABLES                                   = 0x92F7
 	MAX_NUM_COMPATIBLE_SUBROUTINES                             = 0x92F8
@@ -3670,16 +6104,21 @@ const (
 	MAX_PROGRAM_TEXTURE_GATHER_COMPONENTS_ARB                  = 0x8F9F
 	MAX_PROGRAM_TEXTURE_GATHER_OFFSET                          = 0x8E5F
 	MAX_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5F
+	MAX_RASTER_SAMPLES_EXT                                     = 0x9329
 	MAX_RECTANGLE_TEXTURE_SIZE                                 = 0x84F8
 	MAX_RENDERBUFFER_SIZE                                      = 0x84E8
 	MAX_SAMPLES                                                = 0x8D57
 	MAX_SAMPLE_MASK_WORDS                                      = 0x8E59
 	MAX_SERVER_WAIT_TIMEOUT                                    = 0x9111
+	MAX_SHADER_BUFFER_ADDRESS_NV                               = 0x8F35
+	MAX_SHADER_COMPILER_THREADS_ARB                            = 0x91B0
+	MAX_SHADER_COMPILER_THREADS_KHR                            = 0x91B0
 	MAX_SHADER_STORAGE_BLOCK_SIZE                              = 0x90DE
 	MAX_SHADER_STORAGE_BUFFER_BINDINGS                         = 0x90DD
 	MAX_SPARSE_3D_TEXTURE_SIZE_ARB                             = 0x9199
 	MAX_SPARSE_ARRAY_TEXTURE_LAYERS_ARB                        = 0x919A
 	MAX_SPARSE_TEXTURE_SIZE_ARB                                = 0x9198
+	MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV                        = 0x9349
 	MAX_SUBROUTINES                                            = 0x8DE7
 	MAX_SUBROUTINE_UNIFORM_LOCATIONS                           = 0x8DE8
 	MAX_TESS_CONTROL_ATOMIC_COUNTERS                           = 0x92D3
@@ -3704,8 +6143,10 @@ const (
 	MAX_TESS_GEN_LEVEL                                         = 0x8E7E
 	MAX_TESS_PATCH_COMPONENTS                                  = 0x8E84
 	MAX_TEXTURE_BUFFER_SIZE                                    = 0x8C2B
+	MAX_TEXTURE_BUFFER_SIZE_ARB                                = 0x8C2B
 	MAX_TEXTURE_IMAGE_UNITS                                    = 0x8872
 	MAX_TEXTURE_LOD_BIAS                                       = 0x84FD
+	MAX_TEXTURE_MAX_ANISOTROPY                                 = 0x84FF
 	MAX_TEXTURE_SIZE                                           = 0x0D33
 	MAX_TRANSFORM_FEEDBACK_BUFFERS                             = 0x8E70
 	MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS              = 0x8C8A
@@ -3731,13 +6172,18 @@ const (
 	MAX_VERTEX_UNIFORM_BLOCKS                                  = 0x8A2B
 	MAX_VERTEX_UNIFORM_COMPONENTS                              = 0x8B4A
 	MAX_VERTEX_UNIFORM_VECTORS                                 = 0x8DFB
+	MAX_VERTEX_VARYING_COMPONENTS_ARB                          = 0x8DDE
 	MAX_VIEWPORTS                                              = 0x825B
 	MAX_VIEWPORT_DIMS                                          = 0x0D3A
+	MAX_VIEWS_OVR                                              = 0x9631
 	MAX_WIDTH                                                  = 0x827E
+	MAX_WINDOW_RECTANGLES_EXT                                  = 0x8F14
 	MEDIUM_FLOAT                                               = 0x8DF1
 	MEDIUM_INT                                                 = 0x8DF4
 	MIN                                                        = 0x8007
 	MINOR_VERSION                                              = 0x821C
+	MINUS_CLAMPED_NV                                           = 0x92B3
+	MINUS_NV                                                   = 0x929F
 	MIN_FRAGMENT_INTERPOLATION_OFFSET                          = 0x8E5B
 	MIN_MAP_BUFFER_ALIGNMENT                                   = 0x90BC
 	MIN_PROGRAM_TEXEL_OFFSET                                   = 0x8904
@@ -3745,11 +6191,25 @@ const (
 	MIN_PROGRAM_TEXTURE_GATHER_OFFSET_ARB                      = 0x8E5E
 	MIN_SAMPLE_SHADING_VALUE                                   = 0x8C37
 	MIN_SAMPLE_SHADING_VALUE_ARB                               = 0x8C37
-	MIN_SPARSE_LEVEL_ARB                                       = 0x919B
 	MIPMAP                                                     = 0x8293
 	MIRRORED_REPEAT                                            = 0x8370
+	MIRRORED_REPEAT_ARB                                        = 0x8370
 	MIRROR_CLAMP_TO_EDGE                                       = 0x8743
+	MITER_REVERT_NV                                            = 0x90A7
+	MITER_TRUNCATE_NV                                          = 0x90A8
+	MIXED_DEPTH_SAMPLES_SUPPORTED_NV                           = 0x932F
+	MIXED_STENCIL_SAMPLES_SUPPORTED_NV                         = 0x9330
+	MOVE_TO_CONTINUES_NV                                       = 0x90B6
+	MOVE_TO_NV                                                 = 0x02
+	MOVE_TO_RESETS_NV                                          = 0x90B5
+	MULTIPLY_KHR                                               = 0x9294
+	MULTIPLY_NV                                                = 0x9294
 	MULTISAMPLE                                                = 0x809D
+	MULTISAMPLES_NV                                            = 0x9371
+	MULTISAMPLE_COVERAGE_MODES_NV                              = 0x8E12
+	MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB                     = 0x9382
+	MULTISAMPLE_LINE_WIDTH_RANGE_ARB                           = 0x9381
+	MULTISAMPLE_RASTERIZATION_ALLOWED_EXT                      = 0x932B
 	NAMED_STRING_LENGTH_ARB                                    = 0x8DE9
 	NAMED_STRING_TYPE_ARB                                      = 0x8DEA
 	NAME_LENGTH                                                = 0x92F9
@@ -3762,7 +6222,10 @@ const (
 	NICEST                                                     = 0x1102
 	NONE                                                       = 0
 	NOOP                                                       = 0x1505
+	NOP_COMMAND_NV                                             = 0x0001
 	NOR                                                        = 0x1508
+	NORMAL_ARRAY_ADDRESS_NV                                    = 0x8F22
+	NORMAL_ARRAY_LENGTH_NV                                     = 0x8F2C
 	NOTEQUAL                                                   = 0x0205
 	NO_ERROR                                                   = 0
 	NO_RESET_NOTIFICATION                                      = 0x8261
@@ -3776,7 +6239,10 @@ const (
 	NUM_SAMPLE_COUNTS                                          = 0x9380
 	NUM_SHADER_BINARY_FORMATS                                  = 0x8DF9
 	NUM_SHADING_LANGUAGE_VERSIONS                              = 0x82E9
+	NUM_SPARSE_LEVELS_ARB                                      = 0x91AA
+	NUM_SPIR_V_EXTENSIONS                                      = 0x9554
 	NUM_VIRTUAL_PAGE_SIZES_ARB                                 = 0x91A8
+	NUM_WINDOW_RECTANGLES_EXT                                  = 0x8F15
 	OBJECT_TYPE                                                = 0x9112
 	OFFSET                                                     = 0x92FC
 	ONE                                                        = 1
@@ -3792,6 +6258,8 @@ const (
 	OR_INVERTED                                                = 0x150D
 	OR_REVERSE                                                 = 0x150B
 	OUT_OF_MEMORY                                              = 0x0505
+	OVERLAY_KHR                                                = 0x9296
+	OVERLAY_NV                                                 = 0x9296
 	PACK_ALIGNMENT                                             = 0x0D05
 	PACK_COMPRESSED_BLOCK_DEPTH                                = 0x912D
 	PACK_COMPRESSED_BLOCK_HEIGHT                               = 0x912C
@@ -3810,11 +6278,90 @@ const (
 	PATCH_DEFAULT_INNER_LEVEL                                  = 0x8E73
 	PATCH_DEFAULT_OUTER_LEVEL                                  = 0x8E74
 	PATCH_VERTICES                                             = 0x8E72
+	PATH_CLIENT_LENGTH_NV                                      = 0x907F
+	PATH_COMMAND_COUNT_NV                                      = 0x909D
+	PATH_COMPUTED_LENGTH_NV                                    = 0x90A0
+	PATH_COORD_COUNT_NV                                        = 0x909E
+	PATH_COVER_DEPTH_FUNC_NV                                   = 0x90BF
+	PATH_DASH_ARRAY_COUNT_NV                                   = 0x909F
+	PATH_DASH_CAPS_NV                                          = 0x907B
+	PATH_DASH_OFFSET_NV                                        = 0x907E
+	PATH_DASH_OFFSET_RESET_NV                                  = 0x90B4
+	PATH_END_CAPS_NV                                           = 0x9076
+	PATH_ERROR_POSITION_NV                                     = 0x90AB
+	PATH_FILL_BOUNDING_BOX_NV                                  = 0x90A1
+	PATH_FILL_COVER_MODE_NV                                    = 0x9082
+	PATH_FILL_MASK_NV                                          = 0x9081
+	PATH_FILL_MODE_NV                                          = 0x9080
+	PATH_FORMAT_PS_NV                                          = 0x9071
+	PATH_FORMAT_SVG_NV                                         = 0x9070
+	PATH_GEN_COEFF_NV                                          = 0x90B1
+	PATH_GEN_COMPONENTS_NV                                     = 0x90B3
+	PATH_GEN_MODE_NV                                           = 0x90B0
+	PATH_INITIAL_DASH_CAP_NV                                   = 0x907C
+	PATH_INITIAL_END_CAP_NV                                    = 0x9077
+	PATH_JOIN_STYLE_NV                                         = 0x9079
+	PATH_MAX_MODELVIEW_STACK_DEPTH_NV                          = 0x0D36
+	PATH_MAX_PROJECTION_STACK_DEPTH_NV                         = 0x0D38
+	PATH_MITER_LIMIT_NV                                        = 0x907A
+	PATH_MODELVIEW_MATRIX_NV                                   = 0x0BA6
+	PATH_MODELVIEW_NV                                          = 0x1700
+	PATH_MODELVIEW_STACK_DEPTH_NV                              = 0x0BA3
+	PATH_OBJECT_BOUNDING_BOX_NV                                = 0x908A
+	PATH_PROJECTION_MATRIX_NV                                  = 0x0BA7
+	PATH_PROJECTION_NV                                         = 0x1701
+	PATH_PROJECTION_STACK_DEPTH_NV                             = 0x0BA4
+	PATH_STENCIL_DEPTH_OFFSET_FACTOR_NV                        = 0x90BD
+	PATH_STENCIL_DEPTH_OFFSET_UNITS_NV                         = 0x90BE
+	PATH_STENCIL_FUNC_NV                                       = 0x90B7
+	PATH_STENCIL_REF_NV                                        = 0x90B8
+	PATH_STENCIL_VALUE_MASK_NV                                 = 0x90B9
+	PATH_STROKE_BOUNDING_BOX_NV                                = 0x90A2
+	PATH_STROKE_COVER_MODE_NV                                  = 0x9083
+	PATH_STROKE_MASK_NV                                        = 0x9084
+	PATH_STROKE_WIDTH_NV                                       = 0x9075
+	PATH_TERMINAL_DASH_CAP_NV                                  = 0x907D
+	PATH_TERMINAL_END_CAP_NV                                   = 0x9078
+	PATH_TRANSPOSE_MODELVIEW_MATRIX_NV                         = 0x84E3
+	PATH_TRANSPOSE_PROJECTION_MATRIX_NV                        = 0x84E4
+	PERCENTAGE_AMD                                             = 0x8BC3
+	PERFMON_RESULT_AMD                                         = 0x8BC6
+	PERFMON_RESULT_AVAILABLE_AMD                               = 0x8BC4
+	PERFMON_RESULT_SIZE_AMD                                    = 0x8BC5
+	PERFQUERY_COUNTER_DATA_BOOL32_INTEL                        = 0x94FC
+	PERFQUERY_COUNTER_DATA_DOUBLE_INTEL                        = 0x94FB
+	PERFQUERY_COUNTER_DATA_FLOAT_INTEL                         = 0x94FA
+	PERFQUERY_COUNTER_DATA_UINT32_INTEL                        = 0x94F8
+	PERFQUERY_COUNTER_DATA_UINT64_INTEL                        = 0x94F9
+	PERFQUERY_COUNTER_DESC_LENGTH_MAX_INTEL                    = 0x94FF
+	PERFQUERY_COUNTER_DURATION_NORM_INTEL                      = 0x94F1
+	PERFQUERY_COUNTER_DURATION_RAW_INTEL                       = 0x94F2
+	PERFQUERY_COUNTER_EVENT_INTEL                              = 0x94F0
+	PERFQUERY_COUNTER_NAME_LENGTH_MAX_INTEL                    = 0x94FE
+	PERFQUERY_COUNTER_RAW_INTEL                                = 0x94F4
+	PERFQUERY_COUNTER_THROUGHPUT_INTEL                         = 0x94F3
+	PERFQUERY_COUNTER_TIMESTAMP_INTEL                          = 0x94F5
+	PERFQUERY_DONOT_FLUSH_INTEL                                = 0x83F9
+	PERFQUERY_FLUSH_INTEL                                      = 0x83FA
+	PERFQUERY_GLOBAL_CONTEXT_INTEL                             = 0x00000001
+	PERFQUERY_GPA_EXTENDED_COUNTERS_INTEL                      = 0x9500
+	PERFQUERY_QUERY_NAME_LENGTH_MAX_INTEL                      = 0x94FD
+	PERFQUERY_SINGLE_CONTEXT_INTEL                             = 0x00000000
+	PERFQUERY_WAIT_INTEL                                       = 0x83FB
+	PINLIGHT_NV                                                = 0x92A8
 	PIXEL_BUFFER_BARRIER_BIT                                   = 0x00000080
 	PIXEL_PACK_BUFFER                                          = 0x88EB
+	PIXEL_PACK_BUFFER_ARB                                      = 0x88EB
 	PIXEL_PACK_BUFFER_BINDING                                  = 0x88ED
+	PIXEL_PACK_BUFFER_BINDING_ARB                              = 0x88ED
 	PIXEL_UNPACK_BUFFER                                        = 0x88EC
+	PIXEL_UNPACK_BUFFER_ARB                                    = 0x88EC
 	PIXEL_UNPACK_BUFFER_BINDING                                = 0x88EF
+	PIXEL_UNPACK_BUFFER_BINDING_ARB                            = 0x88EF
+	PLUS_CLAMPED_ALPHA_NV                                      = 0x92B2
+	PLUS_CLAMPED_NV                                            = 0x92B1
+	PLUS_DARKER_NV                                             = 0x9292
+	PLUS_NV                                                    = 0x9291
 	POINT                                                      = 0x1B00
 	POINTS                                                     = 0x0000
 	POINT_FADE_THRESHOLD_SIZE                                  = 0x8128
@@ -3823,6 +6370,9 @@ const (
 	POINT_SIZE_RANGE                                           = 0x0B12
 	POINT_SPRITE_COORD_ORIGIN                                  = 0x8CA0
 	POLYGON_MODE                                               = 0x0B40
+	POLYGON_OFFSET_CLAMP                                       = 0x8E1B
+	POLYGON_OFFSET_CLAMP_EXT                                   = 0x8E1B
+	POLYGON_OFFSET_COMMAND_NV                                  = 0x000E
 	POLYGON_OFFSET_FACTOR                                      = 0x8038
 	POLYGON_OFFSET_FILL                                        = 0x8037
 	POLYGON_OFFSET_LINE                                        = 0x2A02
@@ -3832,21 +6382,34 @@ const (
 	POLYGON_SMOOTH_HINT                                        = 0x0C53
 	PRIMITIVES_GENERATED                                       = 0x8C87
 	PRIMITIVES_SUBMITTED_ARB                                   = 0x82EF
+	PRIMITIVE_BOUNDING_BOX_ARB                                 = 0x92BE
 	PRIMITIVE_RESTART                                          = 0x8F9D
 	PRIMITIVE_RESTART_FIXED_INDEX                              = 0x8D69
 	PRIMITIVE_RESTART_FOR_PATCHES_SUPPORTED                    = 0x8221
 	PRIMITIVE_RESTART_INDEX                                    = 0x8F9E
 	PROGRAM                                                    = 0x82E2
+	PROGRAMMABLE_SAMPLE_LOCATION_ARB                           = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_NV                            = 0x9341
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB                = 0x9340
+	PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV                 = 0x9340
 	PROGRAM_BINARY_FORMATS                                     = 0x87FF
 	PROGRAM_BINARY_LENGTH                                      = 0x8741
 	PROGRAM_BINARY_RETRIEVABLE_HINT                            = 0x8257
 	PROGRAM_INPUT                                              = 0x92E3
 	PROGRAM_KHR                                                = 0x82E2
+	PROGRAM_MATRIX_EXT                                         = 0x8E2D
+	PROGRAM_MATRIX_STACK_DEPTH_EXT                             = 0x8E2F
+	PROGRAM_OBJECT_EXT                                         = 0x8B40
 	PROGRAM_OUTPUT                                             = 0x92E4
 	PROGRAM_PIPELINE                                           = 0x82E4
 	PROGRAM_PIPELINE_BINDING                                   = 0x825A
+	PROGRAM_PIPELINE_BINDING_EXT                               = 0x825A
+	PROGRAM_PIPELINE_KHR                                       = 0x82E4
+	PROGRAM_PIPELINE_OBJECT_EXT                                = 0x8A4F
 	PROGRAM_POINT_SIZE                                         = 0x8642
+	PROGRAM_POINT_SIZE_ARB                                     = 0x8642
 	PROGRAM_SEPARABLE                                          = 0x8258
+	PROGRAM_SEPARABLE_EXT                                      = 0x8258
 	PROVOKING_VERTEX                                           = 0x8E4F
 	PROXY_TEXTURE_1D                                           = 0x8063
 	PROXY_TEXTURE_1D_ARRAY                                     = 0x8C19
@@ -3859,6 +6422,7 @@ const (
 	PROXY_TEXTURE_CUBE_MAP_ARRAY                               = 0x900B
 	PROXY_TEXTURE_CUBE_MAP_ARRAY_ARB                           = 0x900B
 	PROXY_TEXTURE_RECTANGLE                                    = 0x84F7
+	QUADRATIC_CURVE_TO_NV                                      = 0x0A
 	QUADS                                                      = 0x0007
 	QUADS_FOLLOW_PROVOKING_VERTEX_CONVENTION                   = 0x8E4C
 	QUERY                                                      = 0x82E3
@@ -3867,18 +6431,23 @@ const (
 	QUERY_BUFFER_BINDING                                       = 0x9193
 	QUERY_BY_REGION_NO_WAIT                                    = 0x8E16
 	QUERY_BY_REGION_NO_WAIT_INVERTED                           = 0x8E1A
+	QUERY_BY_REGION_NO_WAIT_NV                                 = 0x8E16
 	QUERY_BY_REGION_WAIT                                       = 0x8E15
 	QUERY_BY_REGION_WAIT_INVERTED                              = 0x8E19
+	QUERY_BY_REGION_WAIT_NV                                    = 0x8E15
 	QUERY_COUNTER_BITS                                         = 0x8864
 	QUERY_KHR                                                  = 0x82E3
 	QUERY_NO_WAIT                                              = 0x8E14
 	QUERY_NO_WAIT_INVERTED                                     = 0x8E18
+	QUERY_NO_WAIT_NV                                           = 0x8E14
+	QUERY_OBJECT_EXT                                           = 0x9153
 	QUERY_RESULT                                               = 0x8866
 	QUERY_RESULT_AVAILABLE                                     = 0x8867
 	QUERY_RESULT_NO_WAIT                                       = 0x9194
 	QUERY_TARGET                                               = 0x82EA
 	QUERY_WAIT                                                 = 0x8E13
 	QUERY_WAIT_INVERTED                                        = 0x8E17
+	QUERY_WAIT_NV                                              = 0x8E13
 	R11F_G11F_B10F                                             = 0x8C3A
 	R16                                                        = 0x822A
 	R16F                                                       = 0x822D
@@ -3894,6 +6463,9 @@ const (
 	R8UI                                                       = 0x8232
 	R8_SNORM                                                   = 0x8F94
 	RASTERIZER_DISCARD                                         = 0x8C89
+	RASTER_FIXED_SAMPLE_LOCATIONS_EXT                          = 0x932A
+	RASTER_MULTISAMPLE_EXT                                     = 0x9327
+	RASTER_SAMPLES_EXT                                         = 0x9328
 	READ_BUFFER                                                = 0x0C02
 	READ_FRAMEBUFFER                                           = 0x8CA8
 	READ_FRAMEBUFFER_BINDING                                   = 0x8CAA
@@ -3902,18 +6474,41 @@ const (
 	READ_PIXELS_FORMAT                                         = 0x828D
 	READ_PIXELS_TYPE                                           = 0x828E
 	READ_WRITE                                                 = 0x88BA
+	RECT_NV                                                    = 0xF6
 	RED                                                        = 0x1903
 	RED_INTEGER                                                = 0x8D94
+	RED_NV                                                     = 0x1903
 	REFERENCED_BY_COMPUTE_SHADER                               = 0x930B
 	REFERENCED_BY_FRAGMENT_SHADER                              = 0x930A
 	REFERENCED_BY_GEOMETRY_SHADER                              = 0x9309
 	REFERENCED_BY_TESS_CONTROL_SHADER                          = 0x9307
 	REFERENCED_BY_TESS_EVALUATION_SHADER                       = 0x9308
 	REFERENCED_BY_VERTEX_SHADER                                = 0x9306
+	RELATIVE_ARC_TO_NV                                         = 0xFF
+	RELATIVE_CONIC_CURVE_TO_NV                                 = 0x1B
+	RELATIVE_CUBIC_CURVE_TO_NV                                 = 0x0D
+	RELATIVE_HORIZONTAL_LINE_TO_NV                             = 0x07
+	RELATIVE_LARGE_CCW_ARC_TO_NV                               = 0x17
+	RELATIVE_LARGE_CW_ARC_TO_NV                                = 0x19
+	RELATIVE_LINE_TO_NV                                        = 0x05
+	RELATIVE_MOVE_TO_NV                                        = 0x03
+	RELATIVE_QUADRATIC_CURVE_TO_NV                             = 0x0B
+	RELATIVE_RECT_NV                                           = 0xF7
+	RELATIVE_ROUNDED_RECT2_NV                                  = 0xEB
+	RELATIVE_ROUNDED_RECT4_NV                                  = 0xED
+	RELATIVE_ROUNDED_RECT8_NV                                  = 0xEF
+	RELATIVE_ROUNDED_RECT_NV                                   = 0xE9
+	RELATIVE_SMALL_CCW_ARC_TO_NV                               = 0x13
+	RELATIVE_SMALL_CW_ARC_TO_NV                                = 0x15
+	RELATIVE_SMOOTH_CUBIC_CURVE_TO_NV                          = 0x11
+	RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV                      = 0x0F
+	RELATIVE_VERTICAL_LINE_TO_NV                               = 0x09
 	RENDERBUFFER                                               = 0x8D41
 	RENDERBUFFER_ALPHA_SIZE                                    = 0x8D53
 	RENDERBUFFER_BINDING                                       = 0x8CA7
 	RENDERBUFFER_BLUE_SIZE                                     = 0x8D52
+	RENDERBUFFER_COLOR_SAMPLES_NV                              = 0x8E10
+	RENDERBUFFER_COVERAGE_SAMPLES_NV                           = 0x8CAB
 	RENDERBUFFER_DEPTH_SIZE                                    = 0x8D54
 	RENDERBUFFER_GREEN_SIZE                                    = 0x8D51
 	RENDERBUFFER_HEIGHT                                        = 0x8D43
@@ -3928,6 +6523,7 @@ const (
 	RESET_NOTIFICATION_STRATEGY                                = 0x8256
 	RESET_NOTIFICATION_STRATEGY_ARB                            = 0x8256
 	RESET_NOTIFICATION_STRATEGY_KHR                            = 0x8256
+	RESTART_PATH_NV                                            = 0xF0
 	RG                                                         = 0x8227
 	RG16                                                       = 0x822C
 	RG16F                                                      = 0x822F
@@ -3980,9 +6576,16 @@ const (
 	RGBA8UI                                                    = 0x8D7C
 	RGBA8_SNORM                                                = 0x8F97
 	RGBA_INTEGER                                               = 0x8D99
+	RGB_422_APPLE                                              = 0x8A1F
 	RGB_INTEGER                                                = 0x8D98
+	RGB_RAW_422_APPLE                                          = 0x8A51
 	RG_INTEGER                                                 = 0x8228
 	RIGHT                                                      = 0x0407
+	ROUNDED_RECT2_NV                                           = 0xEA
+	ROUNDED_RECT4_NV                                           = 0xEC
+	ROUNDED_RECT8_NV                                           = 0xEE
+	ROUNDED_RECT_NV                                            = 0xE8
+	ROUND_NV                                                   = 0x90A4
 	SAMPLER                                                    = 0x82E6
 	SAMPLER_1D                                                 = 0x8B5D
 	SAMPLER_1D_ARRAY                                           = 0x8DC0
@@ -4014,24 +6617,40 @@ const (
 	SAMPLE_COVERAGE                                            = 0x80A0
 	SAMPLE_COVERAGE_INVERT                                     = 0x80AB
 	SAMPLE_COVERAGE_VALUE                                      = 0x80AA
+	SAMPLE_LOCATION_ARB                                        = 0x8E50
+	SAMPLE_LOCATION_NV                                         = 0x8E50
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB                      = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV                       = 0x933F
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB                       = 0x933E
+	SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV                        = 0x933E
+	SAMPLE_LOCATION_SUBPIXEL_BITS_ARB                          = 0x933D
+	SAMPLE_LOCATION_SUBPIXEL_BITS_NV                           = 0x933D
 	SAMPLE_MASK                                                = 0x8E51
 	SAMPLE_MASK_VALUE                                          = 0x8E52
 	SAMPLE_POSITION                                            = 0x8E50
 	SAMPLE_SHADING                                             = 0x8C36
 	SAMPLE_SHADING_ARB                                         = 0x8C36
 	SCISSOR_BOX                                                = 0x0C10
+	SCISSOR_COMMAND_NV                                         = 0x0011
 	SCISSOR_TEST                                               = 0x0C11
+	SCREEN_KHR                                                 = 0x9295
+	SCREEN_NV                                                  = 0x9295
+	SECONDARY_COLOR_ARRAY_ADDRESS_NV                           = 0x8F27
+	SECONDARY_COLOR_ARRAY_LENGTH_NV                            = 0x8F31
 	SEPARATE_ATTRIBS                                           = 0x8C8D
 	SET                                                        = 0x150F
 	SHADER                                                     = 0x82E1
 	SHADER_BINARY_FORMATS                                      = 0x8DF8
+	SHADER_BINARY_FORMAT_SPIR_V_ARB                            = 0x9551
 	SHADER_COMPILER                                            = 0x8DFA
+	SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV                        = 0x00000010
 	SHADER_IMAGE_ACCESS_BARRIER_BIT                            = 0x00000020
 	SHADER_IMAGE_ATOMIC                                        = 0x82A6
 	SHADER_IMAGE_LOAD                                          = 0x82A4
 	SHADER_IMAGE_STORE                                         = 0x82A5
 	SHADER_INCLUDE_ARB                                         = 0x8DAE
 	SHADER_KHR                                                 = 0x82E1
+	SHADER_OBJECT_EXT                                          = 0x8B48
 	SHADER_SOURCE_LENGTH                                       = 0x8B88
 	SHADER_STORAGE_BARRIER_BIT                                 = 0x00002000
 	SHADER_STORAGE_BLOCK                                       = 0x92E6
@@ -4042,6 +6661,7 @@ const (
 	SHADER_STORAGE_BUFFER_START                                = 0x90D4
 	SHADER_TYPE                                                = 0x8B4F
 	SHADING_LANGUAGE_VERSION                                   = 0x8B8C
+	SHARED_EDGE_NV                                             = 0xC0
 	SHORT                                                      = 0x1402
 	SIGNALED                                                   = 0x9119
 	SIGNED_NORMALIZED                                          = 0x8F9C
@@ -4049,18 +6669,35 @@ const (
 	SIMULTANEOUS_TEXTURE_AND_DEPTH_WRITE                       = 0x82AE
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_TEST                      = 0x82AD
 	SIMULTANEOUS_TEXTURE_AND_STENCIL_WRITE                     = 0x82AF
+	SKIP_DECODE_EXT                                            = 0x8A4A
+	SKIP_MISSING_GLYPH_NV                                      = 0x90A9
+	SMALL_CCW_ARC_TO_NV                                        = 0x12
+	SMALL_CW_ARC_TO_NV                                         = 0x14
+	SMOOTH_CUBIC_CURVE_TO_NV                                   = 0x10
 	SMOOTH_LINE_WIDTH_GRANULARITY                              = 0x0B23
 	SMOOTH_LINE_WIDTH_RANGE                                    = 0x0B22
 	SMOOTH_POINT_SIZE_GRANULARITY                              = 0x0B13
 	SMOOTH_POINT_SIZE_RANGE                                    = 0x0B12
+	SMOOTH_QUADRATIC_CURVE_TO_NV                               = 0x0E
+	SM_COUNT_NV                                                = 0x933B
+	SOFTLIGHT_KHR                                              = 0x929C
+	SOFTLIGHT_NV                                               = 0x929C
 	SPARSE_BUFFER_PAGE_SIZE_ARB                                = 0x82F8
 	SPARSE_STORAGE_BIT_ARB                                     = 0x0400
 	SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB                 = 0x91A9
+	SPIR_V_BINARY_ARB                                          = 0x9552
+	SPIR_V_EXTENSIONS                                          = 0x9553
+	SQUARE_NV                                                  = 0x90A3
 	SRC1_ALPHA                                                 = 0x8589
 	SRC1_COLOR                                                 = 0x88F9
 	SRC_ALPHA                                                  = 0x0302
 	SRC_ALPHA_SATURATE                                         = 0x0308
+	SRC_ATOP_NV                                                = 0x928E
 	SRC_COLOR                                                  = 0x0300
+	SRC_IN_NV                                                  = 0x928A
+	SRC_NV                                                     = 0x9286
+	SRC_OUT_NV                                                 = 0x928C
+	SRC_OVER_NV                                                = 0x9288
 	SRGB                                                       = 0x8C40
 	SRGB8                                                      = 0x8C41
 	SRGB8_ALPHA8                                               = 0x8C43
@@ -4072,6 +6709,8 @@ const (
 	STACK_OVERFLOW_KHR                                         = 0x0503
 	STACK_UNDERFLOW                                            = 0x0504
 	STACK_UNDERFLOW_KHR                                        = 0x0504
+	STANDARD_FONT_FORMAT_NV                                    = 0x936C
+	STANDARD_FONT_NAME_NV                                      = 0x9072
 	STATIC_COPY                                                = 0x88E6
 	STATIC_DRAW                                                = 0x88E4
 	STATIC_READ                                                = 0x88E5
@@ -4097,7 +6736,9 @@ const (
 	STENCIL_PASS_DEPTH_FAIL                                    = 0x0B95
 	STENCIL_PASS_DEPTH_PASS                                    = 0x0B96
 	STENCIL_REF                                                = 0x0B97
+	STENCIL_REF_COMMAND_NV                                     = 0x000C
 	STENCIL_RENDERABLE                                         = 0x8288
+	STENCIL_SAMPLES_NV                                         = 0x932E
 	STENCIL_TEST                                               = 0x0B90
 	STENCIL_VALUE_MASK                                         = 0x0B93
 	STENCIL_WRITEMASK                                          = 0x0B98
@@ -4106,6 +6747,10 @@ const (
 	STREAM_DRAW                                                = 0x88E0
 	STREAM_READ                                                = 0x88E1
 	SUBPIXEL_BITS                                              = 0x0D50
+	SUBPIXEL_PRECISION_BIAS_X_BITS_NV                          = 0x9347
+	SUBPIXEL_PRECISION_BIAS_Y_BITS_NV                          = 0x9348
+	SUPERSAMPLE_SCALE_X_NV                                     = 0x9372
+	SUPERSAMPLE_SCALE_Y_NV                                     = 0x9373
 	SYNC_CL_EVENT_ARB                                          = 0x8240
 	SYNC_CL_EVENT_COMPLETE_ARB                                 = 0x8241
 	SYNC_CONDITION                                             = 0x9113
@@ -4114,6 +6759,8 @@ const (
 	SYNC_FLUSH_COMMANDS_BIT                                    = 0x00000001
 	SYNC_GPU_COMMANDS_COMPLETE                                 = 0x9117
 	SYNC_STATUS                                                = 0x9114
+	SYSTEM_FONT_NAME_NV                                        = 0x9073
+	TERMINATE_SEQUENCE_COMMAND_NV                              = 0x0000
 	TESS_CONTROL_OUTPUT_VERTICES                               = 0x8E75
 	TESS_CONTROL_SHADER                                        = 0x8E88
 	TESS_CONTROL_SHADER_BIT                                    = 0x00000008
@@ -4174,7 +6821,6 @@ const (
 	TEXTURE_ALPHA_SIZE                                         = 0x805F
 	TEXTURE_ALPHA_TYPE                                         = 0x8C13
 	TEXTURE_BASE_LEVEL                                         = 0x813C
-	TEXTURE_BINDING                                            = 0x82EB
 	TEXTURE_BINDING_1D                                         = 0x8068
 	TEXTURE_BINDING_1D_ARRAY                                   = 0x8C1C
 	TEXTURE_BINDING_2D                                         = 0x8069
@@ -4183,6 +6829,7 @@ const (
 	TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY                       = 0x9105
 	TEXTURE_BINDING_3D                                         = 0x806A
 	TEXTURE_BINDING_BUFFER                                     = 0x8C2C
+	TEXTURE_BINDING_BUFFER_ARB                                 = 0x8C2C
 	TEXTURE_BINDING_CUBE_MAP                                   = 0x8514
 	TEXTURE_BINDING_CUBE_MAP_ARRAY                             = 0x900A
 	TEXTURE_BINDING_CUBE_MAP_ARRAY_ARB                         = 0x900A
@@ -4191,8 +6838,11 @@ const (
 	TEXTURE_BLUE_TYPE                                          = 0x8C12
 	TEXTURE_BORDER_COLOR                                       = 0x1004
 	TEXTURE_BUFFER                                             = 0x8C2A
+	TEXTURE_BUFFER_ARB                                         = 0x8C2A
 	TEXTURE_BUFFER_BINDING                                     = 0x8C2A
 	TEXTURE_BUFFER_DATA_STORE_BINDING                          = 0x8C2D
+	TEXTURE_BUFFER_DATA_STORE_BINDING_ARB                      = 0x8C2D
+	TEXTURE_BUFFER_FORMAT_ARB                                  = 0x8C2E
 	TEXTURE_BUFFER_OFFSET                                      = 0x919D
 	TEXTURE_BUFFER_OFFSET_ALIGNMENT                            = 0x919F
 	TEXTURE_BUFFER_SIZE                                        = 0x919E
@@ -4204,6 +6854,8 @@ const (
 	TEXTURE_COMPRESSED_BLOCK_WIDTH                             = 0x82B1
 	TEXTURE_COMPRESSED_IMAGE_SIZE                              = 0x86A0
 	TEXTURE_COMPRESSION_HINT                                   = 0x84EF
+	TEXTURE_COORD_ARRAY_ADDRESS_NV                             = 0x8F25
+	TEXTURE_COORD_ARRAY_LENGTH_NV                              = 0x8F2F
 	TEXTURE_CUBE_MAP                                           = 0x8513
 	TEXTURE_CUBE_MAP_ARRAY                                     = 0x9009
 	TEXTURE_CUBE_MAP_ARRAY_ARB                                 = 0x9009
@@ -4231,17 +6883,21 @@ const (
 	TEXTURE_INTERNAL_FORMAT                                    = 0x1003
 	TEXTURE_LOD_BIAS                                           = 0x8501
 	TEXTURE_MAG_FILTER                                         = 0x2800
+	TEXTURE_MAX_ANISOTROPY                                     = 0x84FE
 	TEXTURE_MAX_LEVEL                                          = 0x813D
 	TEXTURE_MAX_LOD                                            = 0x813B
 	TEXTURE_MIN_FILTER                                         = 0x2801
 	TEXTURE_MIN_LOD                                            = 0x813A
 	TEXTURE_RECTANGLE                                          = 0x84F5
+	TEXTURE_REDUCTION_MODE_ARB                                 = 0x9366
+	TEXTURE_REDUCTION_MODE_EXT                                 = 0x9366
 	TEXTURE_RED_SIZE                                           = 0x805C
 	TEXTURE_RED_TYPE                                           = 0x8C10
 	TEXTURE_SAMPLES                                            = 0x9106
 	TEXTURE_SHADOW                                             = 0x82A1
 	TEXTURE_SHARED_SIZE                                        = 0x8C3F
 	TEXTURE_SPARSE_ARB                                         = 0x91A6
+	TEXTURE_SRGB_DECODE_EXT                                    = 0x8A48
 	TEXTURE_STENCIL_SIZE                                       = 0x88F1
 	TEXTURE_SWIZZLE_A                                          = 0x8E45
 	TEXTURE_SWIZZLE_B                                          = 0x8E44
@@ -4285,15 +6941,27 @@ const (
 	TRANSFORM_FEEDBACK_VARYING                                 = 0x92F4
 	TRANSFORM_FEEDBACK_VARYINGS                                = 0x8C83
 	TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH                      = 0x8C76
+	TRANSLATE_2D_NV                                            = 0x9090
+	TRANSLATE_3D_NV                                            = 0x9091
+	TRANSLATE_X_NV                                             = 0x908E
+	TRANSLATE_Y_NV                                             = 0x908F
+	TRANSPOSE_AFFINE_2D_NV                                     = 0x9096
+	TRANSPOSE_AFFINE_3D_NV                                     = 0x9098
+	TRANSPOSE_PROGRAM_MATRIX_EXT                               = 0x8E2E
 	TRIANGLES                                                  = 0x0004
 	TRIANGLES_ADJACENCY                                        = 0x000C
+	TRIANGLES_ADJACENCY_ARB                                    = 0x000C
 	TRIANGLE_FAN                                               = 0x0006
 	TRIANGLE_STRIP                                             = 0x0005
 	TRIANGLE_STRIP_ADJACENCY                                   = 0x000D
+	TRIANGLE_STRIP_ADJACENCY_ARB                               = 0x000D
+	TRIANGULAR_NV                                              = 0x90A5
 	TRUE                                                       = 1
 	TYPE                                                       = 0x92FA
+	UNCORRELATED_NV                                            = 0x9282
 	UNDEFINED_VERTEX                                           = 0x8260
 	UNIFORM                                                    = 0x92E1
+	UNIFORM_ADDRESS_COMMAND_NV                                 = 0x000A
 	UNIFORM_ARRAY_STRIDE                                       = 0x8A3C
 	UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX                        = 0x92DA
 	UNIFORM_BARRIER_BIT                                        = 0x00000004
@@ -4311,10 +6979,13 @@ const (
 	UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER         = 0x84F1
 	UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER                  = 0x8A44
 	UNIFORM_BUFFER                                             = 0x8A11
+	UNIFORM_BUFFER_ADDRESS_NV                                  = 0x936F
 	UNIFORM_BUFFER_BINDING                                     = 0x8A28
+	UNIFORM_BUFFER_LENGTH_NV                                   = 0x9370
 	UNIFORM_BUFFER_OFFSET_ALIGNMENT                            = 0x8A34
 	UNIFORM_BUFFER_SIZE                                        = 0x8A2A
 	UNIFORM_BUFFER_START                                       = 0x8A29
+	UNIFORM_BUFFER_UNIFIED_NV                                  = 0x936E
 	UNIFORM_IS_ROW_MAJOR                                       = 0x8A3E
 	UNIFORM_MATRIX_STRIDE                                      = 0x8A3D
 	UNIFORM_NAME_LENGTH                                        = 0x8A39
@@ -4341,7 +7012,23 @@ const (
 	UNSIGNED_BYTE_2_3_3_REV                                    = 0x8362
 	UNSIGNED_BYTE_3_3_2                                        = 0x8032
 	UNSIGNED_INT                                               = 0x1405
+	UNSIGNED_INT16_NV                                          = 0x8FF0
+	UNSIGNED_INT16_VEC2_NV                                     = 0x8FF1
+	UNSIGNED_INT16_VEC3_NV                                     = 0x8FF2
+	UNSIGNED_INT16_VEC4_NV                                     = 0x8FF3
+	UNSIGNED_INT64_AMD                                         = 0x8BC2
 	UNSIGNED_INT64_ARB                                         = 0x140F
+	UNSIGNED_INT64_NV                                          = 0x140F
+	UNSIGNED_INT64_VEC2_ARB                                    = 0x8FF5
+	UNSIGNED_INT64_VEC2_NV                                     = 0x8FF5
+	UNSIGNED_INT64_VEC3_ARB                                    = 0x8FF6
+	UNSIGNED_INT64_VEC3_NV                                     = 0x8FF6
+	UNSIGNED_INT64_VEC4_ARB                                    = 0x8FF7
+	UNSIGNED_INT64_VEC4_NV                                     = 0x8FF7
+	UNSIGNED_INT8_NV                                           = 0x8FEC
+	UNSIGNED_INT8_VEC2_NV                                      = 0x8FED
+	UNSIGNED_INT8_VEC3_NV                                      = 0x8FEE
+	UNSIGNED_INT8_VEC4_NV                                      = 0x8FEF
 	UNSIGNED_INT_10F_11F_11F_REV                               = 0x8C3B
 	UNSIGNED_INT_10_10_10_2                                    = 0x8036
 	UNSIGNED_INT_24_8                                          = 0x84FA
@@ -4384,24 +7071,36 @@ const (
 	UNSIGNED_SHORT_5_5_5_1                                     = 0x8034
 	UNSIGNED_SHORT_5_6_5                                       = 0x8363
 	UNSIGNED_SHORT_5_6_5_REV                                   = 0x8364
+	UNSIGNED_SHORT_8_8_APPLE                                   = 0x85BA
+	UNSIGNED_SHORT_8_8_REV_APPLE                               = 0x85BB
 	UPPER_LEFT                                                 = 0x8CA2
+	USE_MISSING_GLYPH_NV                                       = 0x90AA
+	UTF16_NV                                                   = 0x909B
+	UTF8_NV                                                    = 0x909A
 	VALIDATE_STATUS                                            = 0x8B83
 	VENDOR                                                     = 0x1F00
 	VERSION                                                    = 0x1F02
 	VERTEX_ARRAY                                               = 0x8074
+	VERTEX_ARRAY_ADDRESS_NV                                    = 0x8F21
 	VERTEX_ARRAY_BINDING                                       = 0x85B5
 	VERTEX_ARRAY_KHR                                           = 0x8074
+	VERTEX_ARRAY_LENGTH_NV                                     = 0x8F2B
+	VERTEX_ARRAY_OBJECT_EXT                                    = 0x9154
+	VERTEX_ATTRIB_ARRAY_ADDRESS_NV                             = 0x8F20
 	VERTEX_ATTRIB_ARRAY_BARRIER_BIT                            = 0x00000001
 	VERTEX_ATTRIB_ARRAY_BUFFER_BINDING                         = 0x889F
 	VERTEX_ATTRIB_ARRAY_DIVISOR                                = 0x88FE
+	VERTEX_ATTRIB_ARRAY_DIVISOR_ARB                            = 0x88FE
 	VERTEX_ATTRIB_ARRAY_ENABLED                                = 0x8622
 	VERTEX_ATTRIB_ARRAY_INTEGER                                = 0x88FD
+	VERTEX_ATTRIB_ARRAY_LENGTH_NV                              = 0x8F2A
 	VERTEX_ATTRIB_ARRAY_LONG                                   = 0x874E
 	VERTEX_ATTRIB_ARRAY_NORMALIZED                             = 0x886A
 	VERTEX_ATTRIB_ARRAY_POINTER                                = 0x8645
 	VERTEX_ATTRIB_ARRAY_SIZE                                   = 0x8623
 	VERTEX_ATTRIB_ARRAY_STRIDE                                 = 0x8624
 	VERTEX_ATTRIB_ARRAY_TYPE                                   = 0x8625
+	VERTEX_ATTRIB_ARRAY_UNIFIED_NV                             = 0x8F1E
 	VERTEX_ATTRIB_BINDING                                      = 0x82D4
 	VERTEX_ATTRIB_RELATIVE_OFFSET                              = 0x82D5
 	VERTEX_BINDING_BUFFER                                      = 0x8F4F
@@ -4411,15 +7110,33 @@ const (
 	VERTEX_PROGRAM_POINT_SIZE                                  = 0x8642
 	VERTEX_SHADER                                              = 0x8B31
 	VERTEX_SHADER_BIT                                          = 0x00000001
+	VERTEX_SHADER_BIT_EXT                                      = 0x00000001
 	VERTEX_SHADER_INVOCATIONS_ARB                              = 0x82F0
 	VERTEX_SUBROUTINE                                          = 0x92E8
 	VERTEX_SUBROUTINE_UNIFORM                                  = 0x92EE
 	VERTEX_TEXTURE                                             = 0x829B
+	VERTICAL_LINE_TO_NV                                        = 0x08
 	VERTICES_SUBMITTED_ARB                                     = 0x82EE
 	VIEWPORT                                                   = 0x0BA2
 	VIEWPORT_BOUNDS_RANGE                                      = 0x825D
+	VIEWPORT_COMMAND_NV                                        = 0x0010
 	VIEWPORT_INDEX_PROVOKING_VERTEX                            = 0x825F
+	VIEWPORT_POSITION_W_SCALE_NV                               = 0x937C
+	VIEWPORT_POSITION_W_SCALE_X_COEFF_NV                       = 0x937D
+	VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV                       = 0x937E
 	VIEWPORT_SUBPIXEL_BITS                                     = 0x825C
+	VIEWPORT_SWIZZLE_NEGATIVE_W_NV                             = 0x9357
+	VIEWPORT_SWIZZLE_NEGATIVE_X_NV                             = 0x9351
+	VIEWPORT_SWIZZLE_NEGATIVE_Y_NV                             = 0x9353
+	VIEWPORT_SWIZZLE_NEGATIVE_Z_NV                             = 0x9355
+	VIEWPORT_SWIZZLE_POSITIVE_W_NV                             = 0x9356
+	VIEWPORT_SWIZZLE_POSITIVE_X_NV                             = 0x9350
+	VIEWPORT_SWIZZLE_POSITIVE_Y_NV                             = 0x9352
+	VIEWPORT_SWIZZLE_POSITIVE_Z_NV                             = 0x9354
+	VIEWPORT_SWIZZLE_W_NV                                      = 0x935B
+	VIEWPORT_SWIZZLE_X_NV                                      = 0x9358
+	VIEWPORT_SWIZZLE_Y_NV                                      = 0x9359
+	VIEWPORT_SWIZZLE_Z_NV                                      = 0x935A
 	VIEW_CLASS_128_BITS                                        = 0x82C4
 	VIEW_CLASS_16_BITS                                         = 0x82CA
 	VIEW_CLASS_24_BITS                                         = 0x82C9
@@ -4441,726 +7158,1287 @@ const (
 	VIRTUAL_PAGE_SIZE_X_ARB                                    = 0x9195
 	VIRTUAL_PAGE_SIZE_Y_ARB                                    = 0x9196
 	VIRTUAL_PAGE_SIZE_Z_ARB                                    = 0x9197
+	VIVIDLIGHT_NV                                              = 0x92A6
 	WAIT_FAILED                                                = 0x911D
+	WARPS_PER_SM_NV                                            = 0x933A
+	WARP_SIZE_NV                                               = 0x9339
+	WEIGHTED_AVERAGE_ARB                                       = 0x9367
+	WEIGHTED_AVERAGE_EXT                                       = 0x9367
+	WINDOW_RECTANGLE_EXT                                       = 0x8F12
+	WINDOW_RECTANGLE_MODE_EXT                                  = 0x8F13
 	WRITE_ONLY                                                 = 0x88B9
 	XOR                                                        = 0x1506
+	XOR_NV                                                     = 0x1506
 	ZERO                                                       = 0
 	ZERO_TO_ONE                                                = 0x935F
 )
 
 var (
-	gpActiveShaderProgram                         C.GPACTIVESHADERPROGRAM
-	gpActiveTexture                               C.GPACTIVETEXTURE
-	gpAttachShader                                C.GPATTACHSHADER
-	gpBeginConditionalRender                      C.GPBEGINCONDITIONALRENDER
-	gpBeginQuery                                  C.GPBEGINQUERY
-	gpBeginQueryIndexed                           C.GPBEGINQUERYINDEXED
-	gpBeginTransformFeedback                      C.GPBEGINTRANSFORMFEEDBACK
-	gpBindAttribLocation                          C.GPBINDATTRIBLOCATION
-	gpBindBuffer                                  C.GPBINDBUFFER
-	gpBindBufferBase                              C.GPBINDBUFFERBASE
-	gpBindBufferRange                             C.GPBINDBUFFERRANGE
-	gpBindBuffersBase                             C.GPBINDBUFFERSBASE
-	gpBindBuffersRange                            C.GPBINDBUFFERSRANGE
-	gpBindFragDataLocation                        C.GPBINDFRAGDATALOCATION
-	gpBindFragDataLocationIndexed                 C.GPBINDFRAGDATALOCATIONINDEXED
-	gpBindFramebuffer                             C.GPBINDFRAMEBUFFER
-	gpBindImageTexture                            C.GPBINDIMAGETEXTURE
-	gpBindImageTextures                           C.GPBINDIMAGETEXTURES
-	gpBindProgramPipeline                         C.GPBINDPROGRAMPIPELINE
-	gpBindRenderbuffer                            C.GPBINDRENDERBUFFER
-	gpBindSampler                                 C.GPBINDSAMPLER
-	gpBindSamplers                                C.GPBINDSAMPLERS
-	gpBindTexture                                 C.GPBINDTEXTURE
-	gpBindTextureUnit                             C.GPBINDTEXTUREUNIT
-	gpBindTextures                                C.GPBINDTEXTURES
-	gpBindTransformFeedback                       C.GPBINDTRANSFORMFEEDBACK
-	gpBindVertexArray                             C.GPBINDVERTEXARRAY
-	gpBindVertexBuffer                            C.GPBINDVERTEXBUFFER
-	gpBindVertexBuffers                           C.GPBINDVERTEXBUFFERS
-	gpBlendColor                                  C.GPBLENDCOLOR
-	gpBlendEquation                               C.GPBLENDEQUATION
-	gpBlendEquationSeparate                       C.GPBLENDEQUATIONSEPARATE
-	gpBlendEquationSeparatei                      C.GPBLENDEQUATIONSEPARATEI
-	gpBlendEquationSeparateiARB                   C.GPBLENDEQUATIONSEPARATEIARB
-	gpBlendEquationi                              C.GPBLENDEQUATIONI
-	gpBlendEquationiARB                           C.GPBLENDEQUATIONIARB
-	gpBlendFunc                                   C.GPBLENDFUNC
-	gpBlendFuncSeparate                           C.GPBLENDFUNCSEPARATE
-	gpBlendFuncSeparatei                          C.GPBLENDFUNCSEPARATEI
-	gpBlendFuncSeparateiARB                       C.GPBLENDFUNCSEPARATEIARB
-	gpBlendFunci                                  C.GPBLENDFUNCI
-	gpBlendFunciARB                               C.GPBLENDFUNCIARB
-	gpBlitFramebuffer                             C.GPBLITFRAMEBUFFER
-	gpBlitNamedFramebuffer                        C.GPBLITNAMEDFRAMEBUFFER
-	gpBufferData                                  C.GPBUFFERDATA
-	gpBufferPageCommitmentARB                     C.GPBUFFERPAGECOMMITMENTARB
-	gpBufferStorage                               C.GPBUFFERSTORAGE
-	gpBufferSubData                               C.GPBUFFERSUBDATA
-	gpCheckFramebufferStatus                      C.GPCHECKFRAMEBUFFERSTATUS
-	gpCheckNamedFramebufferStatus                 C.GPCHECKNAMEDFRAMEBUFFERSTATUS
-	gpClampColor                                  C.GPCLAMPCOLOR
-	gpClear                                       C.GPCLEAR
-	gpClearBufferData                             C.GPCLEARBUFFERDATA
-	gpClearBufferSubData                          C.GPCLEARBUFFERSUBDATA
-	gpClearBufferfi                               C.GPCLEARBUFFERFI
-	gpClearBufferfv                               C.GPCLEARBUFFERFV
-	gpClearBufferiv                               C.GPCLEARBUFFERIV
-	gpClearBufferuiv                              C.GPCLEARBUFFERUIV
-	gpClearColor                                  C.GPCLEARCOLOR
-	gpClearDepth                                  C.GPCLEARDEPTH
-	gpClearDepthf                                 C.GPCLEARDEPTHF
-	gpClearNamedBufferData                        C.GPCLEARNAMEDBUFFERDATA
-	gpClearNamedBufferSubData                     C.GPCLEARNAMEDBUFFERSUBDATA
-	gpClearNamedFramebufferfi                     C.GPCLEARNAMEDFRAMEBUFFERFI
-	gpClearNamedFramebufferfv                     C.GPCLEARNAMEDFRAMEBUFFERFV
-	gpClearNamedFramebufferiv                     C.GPCLEARNAMEDFRAMEBUFFERIV
-	gpClearNamedFramebufferuiv                    C.GPCLEARNAMEDFRAMEBUFFERUIV
-	gpClearStencil                                C.GPCLEARSTENCIL
-	gpClearTexImage                               C.GPCLEARTEXIMAGE
-	gpClearTexSubImage                            C.GPCLEARTEXSUBIMAGE
-	gpClientWaitSync                              C.GPCLIENTWAITSYNC
-	gpClipControl                                 C.GPCLIPCONTROL
-	gpColorMask                                   C.GPCOLORMASK
-	gpColorMaski                                  C.GPCOLORMASKI
-	gpCompileShader                               C.GPCOMPILESHADER
-	gpCompileShaderIncludeARB                     C.GPCOMPILESHADERINCLUDEARB
-	gpCompressedTexImage1D                        C.GPCOMPRESSEDTEXIMAGE1D
-	gpCompressedTexImage2D                        C.GPCOMPRESSEDTEXIMAGE2D
-	gpCompressedTexImage3D                        C.GPCOMPRESSEDTEXIMAGE3D
-	gpCompressedTexSubImage1D                     C.GPCOMPRESSEDTEXSUBIMAGE1D
-	gpCompressedTexSubImage2D                     C.GPCOMPRESSEDTEXSUBIMAGE2D
-	gpCompressedTexSubImage3D                     C.GPCOMPRESSEDTEXSUBIMAGE3D
-	gpCompressedTextureSubImage1D                 C.GPCOMPRESSEDTEXTURESUBIMAGE1D
-	gpCompressedTextureSubImage2D                 C.GPCOMPRESSEDTEXTURESUBIMAGE2D
-	gpCompressedTextureSubImage3D                 C.GPCOMPRESSEDTEXTURESUBIMAGE3D
-	gpCopyBufferSubData                           C.GPCOPYBUFFERSUBDATA
-	gpCopyImageSubData                            C.GPCOPYIMAGESUBDATA
-	gpCopyNamedBufferSubData                      C.GPCOPYNAMEDBUFFERSUBDATA
-	gpCopyTexImage1D                              C.GPCOPYTEXIMAGE1D
-	gpCopyTexImage2D                              C.GPCOPYTEXIMAGE2D
-	gpCopyTexSubImage1D                           C.GPCOPYTEXSUBIMAGE1D
-	gpCopyTexSubImage2D                           C.GPCOPYTEXSUBIMAGE2D
-	gpCopyTexSubImage3D                           C.GPCOPYTEXSUBIMAGE3D
-	gpCopyTextureSubImage1D                       C.GPCOPYTEXTURESUBIMAGE1D
-	gpCopyTextureSubImage2D                       C.GPCOPYTEXTURESUBIMAGE2D
-	gpCopyTextureSubImage3D                       C.GPCOPYTEXTURESUBIMAGE3D
-	gpCreateBuffers                               C.GPCREATEBUFFERS
-	gpCreateFramebuffers                          C.GPCREATEFRAMEBUFFERS
-	gpCreateProgram                               C.GPCREATEPROGRAM
-	gpCreateProgramPipelines                      C.GPCREATEPROGRAMPIPELINES
-	gpCreateQueries                               C.GPCREATEQUERIES
-	gpCreateRenderbuffers                         C.GPCREATERENDERBUFFERS
-	gpCreateSamplers                              C.GPCREATESAMPLERS
-	gpCreateShader                                C.GPCREATESHADER
-	gpCreateShaderProgramv                        C.GPCREATESHADERPROGRAMV
-	gpCreateSyncFromCLeventARB                    C.GPCREATESYNCFROMCLEVENTARB
-	gpCreateTextures                              C.GPCREATETEXTURES
-	gpCreateTransformFeedbacks                    C.GPCREATETRANSFORMFEEDBACKS
-	gpCreateVertexArrays                          C.GPCREATEVERTEXARRAYS
-	gpCullFace                                    C.GPCULLFACE
-	gpDebugMessageCallback                        C.GPDEBUGMESSAGECALLBACK
-	gpDebugMessageCallbackARB                     C.GPDEBUGMESSAGECALLBACKARB
-	gpDebugMessageCallbackKHR                     C.GPDEBUGMESSAGECALLBACKKHR
-	gpDebugMessageControl                         C.GPDEBUGMESSAGECONTROL
-	gpDebugMessageControlARB                      C.GPDEBUGMESSAGECONTROLARB
-	gpDebugMessageControlKHR                      C.GPDEBUGMESSAGECONTROLKHR
-	gpDebugMessageInsert                          C.GPDEBUGMESSAGEINSERT
-	gpDebugMessageInsertARB                       C.GPDEBUGMESSAGEINSERTARB
-	gpDebugMessageInsertKHR                       C.GPDEBUGMESSAGEINSERTKHR
-	gpDeleteBuffers                               C.GPDELETEBUFFERS
-	gpDeleteFramebuffers                          C.GPDELETEFRAMEBUFFERS
-	gpDeleteNamedStringARB                        C.GPDELETENAMEDSTRINGARB
-	gpDeleteProgram                               C.GPDELETEPROGRAM
-	gpDeleteProgramPipelines                      C.GPDELETEPROGRAMPIPELINES
-	gpDeleteQueries                               C.GPDELETEQUERIES
-	gpDeleteRenderbuffers                         C.GPDELETERENDERBUFFERS
-	gpDeleteSamplers                              C.GPDELETESAMPLERS
-	gpDeleteShader                                C.GPDELETESHADER
-	gpDeleteSync                                  C.GPDELETESYNC
-	gpDeleteTextures                              C.GPDELETETEXTURES
-	gpDeleteTransformFeedbacks                    C.GPDELETETRANSFORMFEEDBACKS
-	gpDeleteVertexArrays                          C.GPDELETEVERTEXARRAYS
-	gpDepthFunc                                   C.GPDEPTHFUNC
-	gpDepthMask                                   C.GPDEPTHMASK
-	gpDepthRange                                  C.GPDEPTHRANGE
-	gpDepthRangeArrayv                            C.GPDEPTHRANGEARRAYV
-	gpDepthRangeIndexed                           C.GPDEPTHRANGEINDEXED
-	gpDepthRangef                                 C.GPDEPTHRANGEF
-	gpDetachShader                                C.GPDETACHSHADER
-	gpDisable                                     C.GPDISABLE
-	gpDisableVertexArrayAttrib                    C.GPDISABLEVERTEXARRAYATTRIB
-	gpDisableVertexAttribArray                    C.GPDISABLEVERTEXATTRIBARRAY
-	gpDisablei                                    C.GPDISABLEI
-	gpDispatchCompute                             C.GPDISPATCHCOMPUTE
-	gpDispatchComputeGroupSizeARB                 C.GPDISPATCHCOMPUTEGROUPSIZEARB
-	gpDispatchComputeIndirect                     C.GPDISPATCHCOMPUTEINDIRECT
-	gpDrawArrays                                  C.GPDRAWARRAYS
-	gpDrawArraysIndirect                          C.GPDRAWARRAYSINDIRECT
-	gpDrawArraysInstanced                         C.GPDRAWARRAYSINSTANCED
-	gpDrawArraysInstancedBaseInstance             C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
-	gpDrawBuffer                                  C.GPDRAWBUFFER
-	gpDrawBuffers                                 C.GPDRAWBUFFERS
-	gpDrawElements                                C.GPDRAWELEMENTS
-	gpDrawElementsBaseVertex                      C.GPDRAWELEMENTSBASEVERTEX
-	gpDrawElementsIndirect                        C.GPDRAWELEMENTSINDIRECT
-	gpDrawElementsInstanced                       C.GPDRAWELEMENTSINSTANCED
-	gpDrawElementsInstancedBaseInstance           C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
-	gpDrawElementsInstancedBaseVertex             C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
-	gpDrawElementsInstancedBaseVertexBaseInstance C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
-	gpDrawRangeElements                           C.GPDRAWRANGEELEMENTS
-	gpDrawRangeElementsBaseVertex                 C.GPDRAWRANGEELEMENTSBASEVERTEX
-	gpDrawTransformFeedback                       C.GPDRAWTRANSFORMFEEDBACK
-	gpDrawTransformFeedbackInstanced              C.GPDRAWTRANSFORMFEEDBACKINSTANCED
-	gpDrawTransformFeedbackStream                 C.GPDRAWTRANSFORMFEEDBACKSTREAM
-	gpDrawTransformFeedbackStreamInstanced        C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
-	gpEnable                                      C.GPENABLE
-	gpEnableVertexArrayAttrib                     C.GPENABLEVERTEXARRAYATTRIB
-	gpEnableVertexAttribArray                     C.GPENABLEVERTEXATTRIBARRAY
-	gpEnablei                                     C.GPENABLEI
-	gpEndConditionalRender                        C.GPENDCONDITIONALRENDER
-	gpEndQuery                                    C.GPENDQUERY
-	gpEndQueryIndexed                             C.GPENDQUERYINDEXED
-	gpEndTransformFeedback                        C.GPENDTRANSFORMFEEDBACK
-	gpFenceSync                                   C.GPFENCESYNC
-	gpFinish                                      C.GPFINISH
-	gpFlush                                       C.GPFLUSH
-	gpFlushMappedBufferRange                      C.GPFLUSHMAPPEDBUFFERRANGE
-	gpFlushMappedNamedBufferRange                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
-	gpFramebufferParameteri                       C.GPFRAMEBUFFERPARAMETERI
-	gpFramebufferRenderbuffer                     C.GPFRAMEBUFFERRENDERBUFFER
-	gpFramebufferTexture                          C.GPFRAMEBUFFERTEXTURE
-	gpFramebufferTexture1D                        C.GPFRAMEBUFFERTEXTURE1D
-	gpFramebufferTexture2D                        C.GPFRAMEBUFFERTEXTURE2D
-	gpFramebufferTexture3D                        C.GPFRAMEBUFFERTEXTURE3D
-	gpFramebufferTextureLayer                     C.GPFRAMEBUFFERTEXTURELAYER
-	gpFrontFace                                   C.GPFRONTFACE
-	gpGenBuffers                                  C.GPGENBUFFERS
-	gpGenFramebuffers                             C.GPGENFRAMEBUFFERS
-	gpGenProgramPipelines                         C.GPGENPROGRAMPIPELINES
-	gpGenQueries                                  C.GPGENQUERIES
-	gpGenRenderbuffers                            C.GPGENRENDERBUFFERS
-	gpGenSamplers                                 C.GPGENSAMPLERS
-	gpGenTextures                                 C.GPGENTEXTURES
-	gpGenTransformFeedbacks                       C.GPGENTRANSFORMFEEDBACKS
-	gpGenVertexArrays                             C.GPGENVERTEXARRAYS
-	gpGenerateMipmap                              C.GPGENERATEMIPMAP
-	gpGenerateTextureMipmap                       C.GPGENERATETEXTUREMIPMAP
-	gpGetActiveAtomicCounterBufferiv              C.GPGETACTIVEATOMICCOUNTERBUFFERIV
-	gpGetActiveAttrib                             C.GPGETACTIVEATTRIB
-	gpGetActiveSubroutineName                     C.GPGETACTIVESUBROUTINENAME
-	gpGetActiveSubroutineUniformName              C.GPGETACTIVESUBROUTINEUNIFORMNAME
-	gpGetActiveSubroutineUniformiv                C.GPGETACTIVESUBROUTINEUNIFORMIV
-	gpGetActiveUniform                            C.GPGETACTIVEUNIFORM
-	gpGetActiveUniformBlockName                   C.GPGETACTIVEUNIFORMBLOCKNAME
-	gpGetActiveUniformBlockiv                     C.GPGETACTIVEUNIFORMBLOCKIV
-	gpGetActiveUniformName                        C.GPGETACTIVEUNIFORMNAME
-	gpGetActiveUniformsiv                         C.GPGETACTIVEUNIFORMSIV
-	gpGetAttachedShaders                          C.GPGETATTACHEDSHADERS
-	gpGetAttribLocation                           C.GPGETATTRIBLOCATION
-	gpGetBooleani_v                               C.GPGETBOOLEANI_V
-	gpGetBooleanv                                 C.GPGETBOOLEANV
-	gpGetBufferParameteri64v                      C.GPGETBUFFERPARAMETERI64V
-	gpGetBufferParameteriv                        C.GPGETBUFFERPARAMETERIV
-	gpGetBufferPointerv                           C.GPGETBUFFERPOINTERV
-	gpGetBufferSubData                            C.GPGETBUFFERSUBDATA
-	gpGetCompressedTexImage                       C.GPGETCOMPRESSEDTEXIMAGE
-	gpGetCompressedTextureImage                   C.GPGETCOMPRESSEDTEXTUREIMAGE
-	gpGetCompressedTextureSubImage                C.GPGETCOMPRESSEDTEXTURESUBIMAGE
-	gpGetDebugMessageLog                          C.GPGETDEBUGMESSAGELOG
-	gpGetDebugMessageLogARB                       C.GPGETDEBUGMESSAGELOGARB
-	gpGetDebugMessageLogKHR                       C.GPGETDEBUGMESSAGELOGKHR
-	gpGetDoublei_v                                C.GPGETDOUBLEI_V
-	gpGetDoublev                                  C.GPGETDOUBLEV
-	gpGetError                                    C.GPGETERROR
-	gpGetFloati_v                                 C.GPGETFLOATI_V
-	gpGetFloatv                                   C.GPGETFLOATV
-	gpGetFragDataIndex                            C.GPGETFRAGDATAINDEX
-	gpGetFragDataLocation                         C.GPGETFRAGDATALOCATION
-	gpGetFramebufferAttachmentParameteriv         C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetFramebufferParameteriv                   C.GPGETFRAMEBUFFERPARAMETERIV
-	gpGetGraphicsResetStatus                      C.GPGETGRAPHICSRESETSTATUS
-	gpGetGraphicsResetStatusARB                   C.GPGETGRAPHICSRESETSTATUSARB
-	gpGetGraphicsResetStatusKHR                   C.GPGETGRAPHICSRESETSTATUSKHR
-	gpGetImageHandleARB                           C.GPGETIMAGEHANDLEARB
-	gpGetInteger64i_v                             C.GPGETINTEGER64I_V
-	gpGetInteger64v                               C.GPGETINTEGER64V
-	gpGetIntegeri_v                               C.GPGETINTEGERI_V
-	gpGetIntegerv                                 C.GPGETINTEGERV
-	gpGetInternalformati64v                       C.GPGETINTERNALFORMATI64V
-	gpGetInternalformativ                         C.GPGETINTERNALFORMATIV
-	gpGetMultisamplefv                            C.GPGETMULTISAMPLEFV
-	gpGetNamedBufferParameteri64v                 C.GPGETNAMEDBUFFERPARAMETERI64V
-	gpGetNamedBufferParameteriv                   C.GPGETNAMEDBUFFERPARAMETERIV
-	gpGetNamedBufferPointerv                      C.GPGETNAMEDBUFFERPOINTERV
-	gpGetNamedBufferSubData                       C.GPGETNAMEDBUFFERSUBDATA
-	gpGetNamedFramebufferAttachmentParameteriv    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
-	gpGetNamedFramebufferParameteriv              C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
-	gpGetNamedRenderbufferParameteriv             C.GPGETNAMEDRENDERBUFFERPARAMETERIV
-	gpGetNamedStringARB                           C.GPGETNAMEDSTRINGARB
-	gpGetNamedStringivARB                         C.GPGETNAMEDSTRINGIVARB
-	gpGetObjectLabel                              C.GPGETOBJECTLABEL
-	gpGetObjectLabelKHR                           C.GPGETOBJECTLABELKHR
-	gpGetObjectPtrLabel                           C.GPGETOBJECTPTRLABEL
-	gpGetObjectPtrLabelKHR                        C.GPGETOBJECTPTRLABELKHR
-	gpGetPointerv                                 C.GPGETPOINTERV
-	gpGetPointervKHR                              C.GPGETPOINTERVKHR
-	gpGetProgramBinary                            C.GPGETPROGRAMBINARY
-	gpGetProgramInfoLog                           C.GPGETPROGRAMINFOLOG
-	gpGetProgramInterfaceiv                       C.GPGETPROGRAMINTERFACEIV
-	gpGetProgramPipelineInfoLog                   C.GPGETPROGRAMPIPELINEINFOLOG
-	gpGetProgramPipelineiv                        C.GPGETPROGRAMPIPELINEIV
-	gpGetProgramResourceIndex                     C.GPGETPROGRAMRESOURCEINDEX
-	gpGetProgramResourceLocation                  C.GPGETPROGRAMRESOURCELOCATION
-	gpGetProgramResourceLocationIndex             C.GPGETPROGRAMRESOURCELOCATIONINDEX
-	gpGetProgramResourceName                      C.GPGETPROGRAMRESOURCENAME
-	gpGetProgramResourceiv                        C.GPGETPROGRAMRESOURCEIV
-	gpGetProgramStageiv                           C.GPGETPROGRAMSTAGEIV
-	gpGetProgramiv                                C.GPGETPROGRAMIV
-	gpGetQueryIndexediv                           C.GPGETQUERYINDEXEDIV
-	gpGetQueryObjecti64v                          C.GPGETQUERYOBJECTI64V
-	gpGetQueryObjectiv                            C.GPGETQUERYOBJECTIV
-	gpGetQueryObjectui64v                         C.GPGETQUERYOBJECTUI64V
-	gpGetQueryObjectuiv                           C.GPGETQUERYOBJECTUIV
-	gpGetQueryiv                                  C.GPGETQUERYIV
-	gpGetRenderbufferParameteriv                  C.GPGETRENDERBUFFERPARAMETERIV
-	gpGetSamplerParameterIiv                      C.GPGETSAMPLERPARAMETERIIV
-	gpGetSamplerParameterIuiv                     C.GPGETSAMPLERPARAMETERIUIV
-	gpGetSamplerParameterfv                       C.GPGETSAMPLERPARAMETERFV
-	gpGetSamplerParameteriv                       C.GPGETSAMPLERPARAMETERIV
-	gpGetShaderInfoLog                            C.GPGETSHADERINFOLOG
-	gpGetShaderPrecisionFormat                    C.GPGETSHADERPRECISIONFORMAT
-	gpGetShaderSource                             C.GPGETSHADERSOURCE
-	gpGetShaderiv                                 C.GPGETSHADERIV
-	gpGetString                                   C.GPGETSTRING
-	gpGetStringi                                  C.GPGETSTRINGI
-	gpGetSubroutineIndex                          C.GPGETSUBROUTINEINDEX
-	gpGetSubroutineUniformLocation                C.GPGETSUBROUTINEUNIFORMLOCATION
-	gpGetSynciv                                   C.GPGETSYNCIV
-	gpGetTexImage                                 C.GPGETTEXIMAGE
-	gpGetTexLevelParameterfv                      C.GPGETTEXLEVELPARAMETERFV
-	gpGetTexLevelParameteriv                      C.GPGETTEXLEVELPARAMETERIV
-	gpGetTexParameterIiv                          C.GPGETTEXPARAMETERIIV
-	gpGetTexParameterIuiv                         C.GPGETTEXPARAMETERIUIV
-	gpGetTexParameterfv                           C.GPGETTEXPARAMETERFV
-	gpGetTexParameteriv                           C.GPGETTEXPARAMETERIV
-	gpGetTextureHandleARB                         C.GPGETTEXTUREHANDLEARB
-	gpGetTextureImage                             C.GPGETTEXTUREIMAGE
-	gpGetTextureLevelParameterfv                  C.GPGETTEXTURELEVELPARAMETERFV
-	gpGetTextureLevelParameteriv                  C.GPGETTEXTURELEVELPARAMETERIV
-	gpGetTextureParameterIiv                      C.GPGETTEXTUREPARAMETERIIV
-	gpGetTextureParameterIuiv                     C.GPGETTEXTUREPARAMETERIUIV
-	gpGetTextureParameterfv                       C.GPGETTEXTUREPARAMETERFV
-	gpGetTextureParameteriv                       C.GPGETTEXTUREPARAMETERIV
-	gpGetTextureSamplerHandleARB                  C.GPGETTEXTURESAMPLERHANDLEARB
-	gpGetTextureSubImage                          C.GPGETTEXTURESUBIMAGE
-	gpGetTransformFeedbackVarying                 C.GPGETTRANSFORMFEEDBACKVARYING
-	gpGetTransformFeedbacki64_v                   C.GPGETTRANSFORMFEEDBACKI64_V
-	gpGetTransformFeedbacki_v                     C.GPGETTRANSFORMFEEDBACKI_V
-	gpGetTransformFeedbackiv                      C.GPGETTRANSFORMFEEDBACKIV
-	gpGetUniformBlockIndex                        C.GPGETUNIFORMBLOCKINDEX
-	gpGetUniformIndices                           C.GPGETUNIFORMINDICES
-	gpGetUniformLocation                          C.GPGETUNIFORMLOCATION
-	gpGetUniformSubroutineuiv                     C.GPGETUNIFORMSUBROUTINEUIV
-	gpGetUniformdv                                C.GPGETUNIFORMDV
-	gpGetUniformfv                                C.GPGETUNIFORMFV
-	gpGetUniformiv                                C.GPGETUNIFORMIV
-	gpGetUniformuiv                               C.GPGETUNIFORMUIV
-	gpGetVertexArrayIndexed64iv                   C.GPGETVERTEXARRAYINDEXED64IV
-	gpGetVertexArrayIndexediv                     C.GPGETVERTEXARRAYINDEXEDIV
-	gpGetVertexArrayiv                            C.GPGETVERTEXARRAYIV
-	gpGetVertexAttribIiv                          C.GPGETVERTEXATTRIBIIV
-	gpGetVertexAttribIuiv                         C.GPGETVERTEXATTRIBIUIV
-	gpGetVertexAttribLdv                          C.GPGETVERTEXATTRIBLDV
-	gpGetVertexAttribLui64vARB                    C.GPGETVERTEXATTRIBLUI64VARB
-	gpGetVertexAttribPointerv                     C.GPGETVERTEXATTRIBPOINTERV
-	gpGetVertexAttribdv                           C.GPGETVERTEXATTRIBDV
-	gpGetVertexAttribfv                           C.GPGETVERTEXATTRIBFV
-	gpGetVertexAttribiv                           C.GPGETVERTEXATTRIBIV
-	gpGetnCompressedTexImage                      C.GPGETNCOMPRESSEDTEXIMAGE
-	gpGetnCompressedTexImageARB                   C.GPGETNCOMPRESSEDTEXIMAGEARB
-	gpGetnTexImage                                C.GPGETNTEXIMAGE
-	gpGetnTexImageARB                             C.GPGETNTEXIMAGEARB
-	gpGetnUniformdv                               C.GPGETNUNIFORMDV
-	gpGetnUniformdvARB                            C.GPGETNUNIFORMDVARB
-	gpGetnUniformfv                               C.GPGETNUNIFORMFV
-	gpGetnUniformfvARB                            C.GPGETNUNIFORMFVARB
-	gpGetnUniformfvKHR                            C.GPGETNUNIFORMFVKHR
-	gpGetnUniformiv                               C.GPGETNUNIFORMIV
-	gpGetnUniformivARB                            C.GPGETNUNIFORMIVARB
-	gpGetnUniformivKHR                            C.GPGETNUNIFORMIVKHR
-	gpGetnUniformuiv                              C.GPGETNUNIFORMUIV
-	gpGetnUniformuivARB                           C.GPGETNUNIFORMUIVARB
-	gpGetnUniformuivKHR                           C.GPGETNUNIFORMUIVKHR
-	gpHint                                        C.GPHINT
-	gpInvalidateBufferData                        C.GPINVALIDATEBUFFERDATA
-	gpInvalidateBufferSubData                     C.GPINVALIDATEBUFFERSUBDATA
-	gpInvalidateFramebuffer                       C.GPINVALIDATEFRAMEBUFFER
-	gpInvalidateNamedFramebufferData              C.GPINVALIDATENAMEDFRAMEBUFFERDATA
-	gpInvalidateNamedFramebufferSubData           C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
-	gpInvalidateSubFramebuffer                    C.GPINVALIDATESUBFRAMEBUFFER
-	gpInvalidateTexImage                          C.GPINVALIDATETEXIMAGE
-	gpInvalidateTexSubImage                       C.GPINVALIDATETEXSUBIMAGE
-	gpIsBuffer                                    C.GPISBUFFER
-	gpIsEnabled                                   C.GPISENABLED
-	gpIsEnabledi                                  C.GPISENABLEDI
-	gpIsFramebuffer                               C.GPISFRAMEBUFFER
-	gpIsImageHandleResidentARB                    C.GPISIMAGEHANDLERESIDENTARB
-	gpIsNamedStringARB                            C.GPISNAMEDSTRINGARB
-	gpIsProgram                                   C.GPISPROGRAM
-	gpIsProgramPipeline                           C.GPISPROGRAMPIPELINE
-	gpIsQuery                                     C.GPISQUERY
-	gpIsRenderbuffer                              C.GPISRENDERBUFFER
-	gpIsSampler                                   C.GPISSAMPLER
-	gpIsShader                                    C.GPISSHADER
-	gpIsSync                                      C.GPISSYNC
-	gpIsTexture                                   C.GPISTEXTURE
-	gpIsTextureHandleResidentARB                  C.GPISTEXTUREHANDLERESIDENTARB
-	gpIsTransformFeedback                         C.GPISTRANSFORMFEEDBACK
-	gpIsVertexArray                               C.GPISVERTEXARRAY
-	gpLineWidth                                   C.GPLINEWIDTH
-	gpLinkProgram                                 C.GPLINKPROGRAM
-	gpLogicOp                                     C.GPLOGICOP
-	gpMakeImageHandleNonResidentARB               C.GPMAKEIMAGEHANDLENONRESIDENTARB
-	gpMakeImageHandleResidentARB                  C.GPMAKEIMAGEHANDLERESIDENTARB
-	gpMakeTextureHandleNonResidentARB             C.GPMAKETEXTUREHANDLENONRESIDENTARB
-	gpMakeTextureHandleResidentARB                C.GPMAKETEXTUREHANDLERESIDENTARB
-	gpMapBuffer                                   C.GPMAPBUFFER
-	gpMapBufferRange                              C.GPMAPBUFFERRANGE
-	gpMapNamedBuffer                              C.GPMAPNAMEDBUFFER
-	gpMapNamedBufferRange                         C.GPMAPNAMEDBUFFERRANGE
-	gpMemoryBarrier                               C.GPMEMORYBARRIER
-	gpMemoryBarrierByRegion                       C.GPMEMORYBARRIERBYREGION
-	gpMinSampleShading                            C.GPMINSAMPLESHADING
-	gpMinSampleShadingARB                         C.GPMINSAMPLESHADINGARB
-	gpMultiDrawArrays                             C.GPMULTIDRAWARRAYS
-	gpMultiDrawArraysIndirect                     C.GPMULTIDRAWARRAYSINDIRECT
-	gpMultiDrawArraysIndirectCountARB             C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
-	gpMultiDrawElements                           C.GPMULTIDRAWELEMENTS
-	gpMultiDrawElementsBaseVertex                 C.GPMULTIDRAWELEMENTSBASEVERTEX
-	gpMultiDrawElementsIndirect                   C.GPMULTIDRAWELEMENTSINDIRECT
-	gpMultiDrawElementsIndirectCountARB           C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
-	gpNamedBufferData                             C.GPNAMEDBUFFERDATA
-	gpNamedBufferPageCommitmentARB                C.GPNAMEDBUFFERPAGECOMMITMENTARB
-	gpNamedBufferPageCommitmentEXT                C.GPNAMEDBUFFERPAGECOMMITMENTEXT
-	gpNamedBufferStorage                          C.GPNAMEDBUFFERSTORAGE
-	gpNamedBufferSubData                          C.GPNAMEDBUFFERSUBDATA
-	gpNamedFramebufferDrawBuffer                  C.GPNAMEDFRAMEBUFFERDRAWBUFFER
-	gpNamedFramebufferDrawBuffers                 C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
-	gpNamedFramebufferParameteri                  C.GPNAMEDFRAMEBUFFERPARAMETERI
-	gpNamedFramebufferReadBuffer                  C.GPNAMEDFRAMEBUFFERREADBUFFER
-	gpNamedFramebufferRenderbuffer                C.GPNAMEDFRAMEBUFFERRENDERBUFFER
-	gpNamedFramebufferTexture                     C.GPNAMEDFRAMEBUFFERTEXTURE
-	gpNamedFramebufferTextureLayer                C.GPNAMEDFRAMEBUFFERTEXTURELAYER
-	gpNamedRenderbufferStorage                    C.GPNAMEDRENDERBUFFERSTORAGE
-	gpNamedRenderbufferStorageMultisample         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
-	gpNamedStringARB                              C.GPNAMEDSTRINGARB
-	gpObjectLabel                                 C.GPOBJECTLABEL
-	gpObjectLabelKHR                              C.GPOBJECTLABELKHR
-	gpObjectPtrLabel                              C.GPOBJECTPTRLABEL
-	gpObjectPtrLabelKHR                           C.GPOBJECTPTRLABELKHR
-	gpPatchParameterfv                            C.GPPATCHPARAMETERFV
-	gpPatchParameteri                             C.GPPATCHPARAMETERI
-	gpPauseTransformFeedback                      C.GPPAUSETRANSFORMFEEDBACK
-	gpPixelStoref                                 C.GPPIXELSTOREF
-	gpPixelStorei                                 C.GPPIXELSTOREI
-	gpPointParameterf                             C.GPPOINTPARAMETERF
-	gpPointParameterfv                            C.GPPOINTPARAMETERFV
-	gpPointParameteri                             C.GPPOINTPARAMETERI
-	gpPointParameteriv                            C.GPPOINTPARAMETERIV
-	gpPointSize                                   C.GPPOINTSIZE
-	gpPolygonMode                                 C.GPPOLYGONMODE
-	gpPolygonOffset                               C.GPPOLYGONOFFSET
-	gpPopDebugGroup                               C.GPPOPDEBUGGROUP
-	gpPopDebugGroupKHR                            C.GPPOPDEBUGGROUPKHR
-	gpPrimitiveRestartIndex                       C.GPPRIMITIVERESTARTINDEX
-	gpProgramBinary                               C.GPPROGRAMBINARY
-	gpProgramParameteri                           C.GPPROGRAMPARAMETERI
-	gpProgramUniform1d                            C.GPPROGRAMUNIFORM1D
-	gpProgramUniform1dv                           C.GPPROGRAMUNIFORM1DV
-	gpProgramUniform1f                            C.GPPROGRAMUNIFORM1F
-	gpProgramUniform1fv                           C.GPPROGRAMUNIFORM1FV
-	gpProgramUniform1i                            C.GPPROGRAMUNIFORM1I
-	gpProgramUniform1iv                           C.GPPROGRAMUNIFORM1IV
-	gpProgramUniform1ui                           C.GPPROGRAMUNIFORM1UI
-	gpProgramUniform1uiv                          C.GPPROGRAMUNIFORM1UIV
-	gpProgramUniform2d                            C.GPPROGRAMUNIFORM2D
-	gpProgramUniform2dv                           C.GPPROGRAMUNIFORM2DV
-	gpProgramUniform2f                            C.GPPROGRAMUNIFORM2F
-	gpProgramUniform2fv                           C.GPPROGRAMUNIFORM2FV
-	gpProgramUniform2i                            C.GPPROGRAMUNIFORM2I
-	gpProgramUniform2iv                           C.GPPROGRAMUNIFORM2IV
-	gpProgramUniform2ui                           C.GPPROGRAMUNIFORM2UI
-	gpProgramUniform2uiv                          C.GPPROGRAMUNIFORM2UIV
-	gpProgramUniform3d                            C.GPPROGRAMUNIFORM3D
-	gpProgramUniform3dv                           C.GPPROGRAMUNIFORM3DV
-	gpProgramUniform3f                            C.GPPROGRAMUNIFORM3F
-	gpProgramUniform3fv                           C.GPPROGRAMUNIFORM3FV
-	gpProgramUniform3i                            C.GPPROGRAMUNIFORM3I
-	gpProgramUniform3iv                           C.GPPROGRAMUNIFORM3IV
-	gpProgramUniform3ui                           C.GPPROGRAMUNIFORM3UI
-	gpProgramUniform3uiv                          C.GPPROGRAMUNIFORM3UIV
-	gpProgramUniform4d                            C.GPPROGRAMUNIFORM4D
-	gpProgramUniform4dv                           C.GPPROGRAMUNIFORM4DV
-	gpProgramUniform4f                            C.GPPROGRAMUNIFORM4F
-	gpProgramUniform4fv                           C.GPPROGRAMUNIFORM4FV
-	gpProgramUniform4i                            C.GPPROGRAMUNIFORM4I
-	gpProgramUniform4iv                           C.GPPROGRAMUNIFORM4IV
-	gpProgramUniform4ui                           C.GPPROGRAMUNIFORM4UI
-	gpProgramUniform4uiv                          C.GPPROGRAMUNIFORM4UIV
-	gpProgramUniformHandleui64ARB                 C.GPPROGRAMUNIFORMHANDLEUI64ARB
-	gpProgramUniformHandleui64vARB                C.GPPROGRAMUNIFORMHANDLEUI64VARB
-	gpProgramUniformMatrix2dv                     C.GPPROGRAMUNIFORMMATRIX2DV
-	gpProgramUniformMatrix2fv                     C.GPPROGRAMUNIFORMMATRIX2FV
-	gpProgramUniformMatrix2x3dv                   C.GPPROGRAMUNIFORMMATRIX2X3DV
-	gpProgramUniformMatrix2x3fv                   C.GPPROGRAMUNIFORMMATRIX2X3FV
-	gpProgramUniformMatrix2x4dv                   C.GPPROGRAMUNIFORMMATRIX2X4DV
-	gpProgramUniformMatrix2x4fv                   C.GPPROGRAMUNIFORMMATRIX2X4FV
-	gpProgramUniformMatrix3dv                     C.GPPROGRAMUNIFORMMATRIX3DV
-	gpProgramUniformMatrix3fv                     C.GPPROGRAMUNIFORMMATRIX3FV
-	gpProgramUniformMatrix3x2dv                   C.GPPROGRAMUNIFORMMATRIX3X2DV
-	gpProgramUniformMatrix3x2fv                   C.GPPROGRAMUNIFORMMATRIX3X2FV
-	gpProgramUniformMatrix3x4dv                   C.GPPROGRAMUNIFORMMATRIX3X4DV
-	gpProgramUniformMatrix3x4fv                   C.GPPROGRAMUNIFORMMATRIX3X4FV
-	gpProgramUniformMatrix4dv                     C.GPPROGRAMUNIFORMMATRIX4DV
-	gpProgramUniformMatrix4fv                     C.GPPROGRAMUNIFORMMATRIX4FV
-	gpProgramUniformMatrix4x2dv                   C.GPPROGRAMUNIFORMMATRIX4X2DV
-	gpProgramUniformMatrix4x2fv                   C.GPPROGRAMUNIFORMMATRIX4X2FV
-	gpProgramUniformMatrix4x3dv                   C.GPPROGRAMUNIFORMMATRIX4X3DV
-	gpProgramUniformMatrix4x3fv                   C.GPPROGRAMUNIFORMMATRIX4X3FV
-	gpProvokingVertex                             C.GPPROVOKINGVERTEX
-	gpPushDebugGroup                              C.GPPUSHDEBUGGROUP
-	gpPushDebugGroupKHR                           C.GPPUSHDEBUGGROUPKHR
-	gpQueryCounter                                C.GPQUERYCOUNTER
-	gpReadBuffer                                  C.GPREADBUFFER
-	gpReadPixels                                  C.GPREADPIXELS
-	gpReadnPixels                                 C.GPREADNPIXELS
-	gpReadnPixelsARB                              C.GPREADNPIXELSARB
-	gpReadnPixelsKHR                              C.GPREADNPIXELSKHR
-	gpReleaseShaderCompiler                       C.GPRELEASESHADERCOMPILER
-	gpRenderbufferStorage                         C.GPRENDERBUFFERSTORAGE
-	gpRenderbufferStorageMultisample              C.GPRENDERBUFFERSTORAGEMULTISAMPLE
-	gpResumeTransformFeedback                     C.GPRESUMETRANSFORMFEEDBACK
-	gpSampleCoverage                              C.GPSAMPLECOVERAGE
-	gpSampleMaski                                 C.GPSAMPLEMASKI
-	gpSamplerParameterIiv                         C.GPSAMPLERPARAMETERIIV
-	gpSamplerParameterIuiv                        C.GPSAMPLERPARAMETERIUIV
-	gpSamplerParameterf                           C.GPSAMPLERPARAMETERF
-	gpSamplerParameterfv                          C.GPSAMPLERPARAMETERFV
-	gpSamplerParameteri                           C.GPSAMPLERPARAMETERI
-	gpSamplerParameteriv                          C.GPSAMPLERPARAMETERIV
-	gpScissor                                     C.GPSCISSOR
-	gpScissorArrayv                               C.GPSCISSORARRAYV
-	gpScissorIndexed                              C.GPSCISSORINDEXED
-	gpScissorIndexedv                             C.GPSCISSORINDEXEDV
-	gpShaderBinary                                C.GPSHADERBINARY
-	gpShaderSource                                C.GPSHADERSOURCE
-	gpShaderStorageBlockBinding                   C.GPSHADERSTORAGEBLOCKBINDING
-	gpStencilFunc                                 C.GPSTENCILFUNC
-	gpStencilFuncSeparate                         C.GPSTENCILFUNCSEPARATE
-	gpStencilMask                                 C.GPSTENCILMASK
-	gpStencilMaskSeparate                         C.GPSTENCILMASKSEPARATE
-	gpStencilOp                                   C.GPSTENCILOP
-	gpStencilOpSeparate                           C.GPSTENCILOPSEPARATE
-	gpTexBuffer                                   C.GPTEXBUFFER
-	gpTexBufferRange                              C.GPTEXBUFFERRANGE
-	gpTexImage1D                                  C.GPTEXIMAGE1D
-	gpTexImage2D                                  C.GPTEXIMAGE2D
-	gpTexImage2DMultisample                       C.GPTEXIMAGE2DMULTISAMPLE
-	gpTexImage3D                                  C.GPTEXIMAGE3D
-	gpTexImage3DMultisample                       C.GPTEXIMAGE3DMULTISAMPLE
-	gpTexPageCommitmentARB                        C.GPTEXPAGECOMMITMENTARB
-	gpTexParameterIiv                             C.GPTEXPARAMETERIIV
-	gpTexParameterIuiv                            C.GPTEXPARAMETERIUIV
-	gpTexParameterf                               C.GPTEXPARAMETERF
-	gpTexParameterfv                              C.GPTEXPARAMETERFV
-	gpTexParameteri                               C.GPTEXPARAMETERI
-	gpTexParameteriv                              C.GPTEXPARAMETERIV
-	gpTexStorage1D                                C.GPTEXSTORAGE1D
-	gpTexStorage2D                                C.GPTEXSTORAGE2D
-	gpTexStorage2DMultisample                     C.GPTEXSTORAGE2DMULTISAMPLE
-	gpTexStorage3D                                C.GPTEXSTORAGE3D
-	gpTexStorage3DMultisample                     C.GPTEXSTORAGE3DMULTISAMPLE
-	gpTexSubImage1D                               C.GPTEXSUBIMAGE1D
-	gpTexSubImage2D                               C.GPTEXSUBIMAGE2D
-	gpTexSubImage3D                               C.GPTEXSUBIMAGE3D
-	gpTextureBarrier                              C.GPTEXTUREBARRIER
-	gpTextureBuffer                               C.GPTEXTUREBUFFER
-	gpTextureBufferRange                          C.GPTEXTUREBUFFERRANGE
-	gpTextureParameterIiv                         C.GPTEXTUREPARAMETERIIV
-	gpTextureParameterIuiv                        C.GPTEXTUREPARAMETERIUIV
-	gpTextureParameterf                           C.GPTEXTUREPARAMETERF
-	gpTextureParameterfv                          C.GPTEXTUREPARAMETERFV
-	gpTextureParameteri                           C.GPTEXTUREPARAMETERI
-	gpTextureParameteriv                          C.GPTEXTUREPARAMETERIV
-	gpTextureStorage1D                            C.GPTEXTURESTORAGE1D
-	gpTextureStorage2D                            C.GPTEXTURESTORAGE2D
-	gpTextureStorage2DMultisample                 C.GPTEXTURESTORAGE2DMULTISAMPLE
-	gpTextureStorage3D                            C.GPTEXTURESTORAGE3D
-	gpTextureStorage3DMultisample                 C.GPTEXTURESTORAGE3DMULTISAMPLE
-	gpTextureSubImage1D                           C.GPTEXTURESUBIMAGE1D
-	gpTextureSubImage2D                           C.GPTEXTURESUBIMAGE2D
-	gpTextureSubImage3D                           C.GPTEXTURESUBIMAGE3D
-	gpTextureView                                 C.GPTEXTUREVIEW
-	gpTransformFeedbackBufferBase                 C.GPTRANSFORMFEEDBACKBUFFERBASE
-	gpTransformFeedbackBufferRange                C.GPTRANSFORMFEEDBACKBUFFERRANGE
-	gpTransformFeedbackVaryings                   C.GPTRANSFORMFEEDBACKVARYINGS
-	gpUniform1d                                   C.GPUNIFORM1D
-	gpUniform1dv                                  C.GPUNIFORM1DV
-	gpUniform1f                                   C.GPUNIFORM1F
-	gpUniform1fv                                  C.GPUNIFORM1FV
-	gpUniform1i                                   C.GPUNIFORM1I
-	gpUniform1iv                                  C.GPUNIFORM1IV
-	gpUniform1ui                                  C.GPUNIFORM1UI
-	gpUniform1uiv                                 C.GPUNIFORM1UIV
-	gpUniform2d                                   C.GPUNIFORM2D
-	gpUniform2dv                                  C.GPUNIFORM2DV
-	gpUniform2f                                   C.GPUNIFORM2F
-	gpUniform2fv                                  C.GPUNIFORM2FV
-	gpUniform2i                                   C.GPUNIFORM2I
-	gpUniform2iv                                  C.GPUNIFORM2IV
-	gpUniform2ui                                  C.GPUNIFORM2UI
-	gpUniform2uiv                                 C.GPUNIFORM2UIV
-	gpUniform3d                                   C.GPUNIFORM3D
-	gpUniform3dv                                  C.GPUNIFORM3DV
-	gpUniform3f                                   C.GPUNIFORM3F
-	gpUniform3fv                                  C.GPUNIFORM3FV
-	gpUniform3i                                   C.GPUNIFORM3I
-	gpUniform3iv                                  C.GPUNIFORM3IV
-	gpUniform3ui                                  C.GPUNIFORM3UI
-	gpUniform3uiv                                 C.GPUNIFORM3UIV
-	gpUniform4d                                   C.GPUNIFORM4D
-	gpUniform4dv                                  C.GPUNIFORM4DV
-	gpUniform4f                                   C.GPUNIFORM4F
-	gpUniform4fv                                  C.GPUNIFORM4FV
-	gpUniform4i                                   C.GPUNIFORM4I
-	gpUniform4iv                                  C.GPUNIFORM4IV
-	gpUniform4ui                                  C.GPUNIFORM4UI
-	gpUniform4uiv                                 C.GPUNIFORM4UIV
-	gpUniformBlockBinding                         C.GPUNIFORMBLOCKBINDING
-	gpUniformHandleui64ARB                        C.GPUNIFORMHANDLEUI64ARB
-	gpUniformHandleui64vARB                       C.GPUNIFORMHANDLEUI64VARB
-	gpUniformMatrix2dv                            C.GPUNIFORMMATRIX2DV
-	gpUniformMatrix2fv                            C.GPUNIFORMMATRIX2FV
-	gpUniformMatrix2x3dv                          C.GPUNIFORMMATRIX2X3DV
-	gpUniformMatrix2x3fv                          C.GPUNIFORMMATRIX2X3FV
-	gpUniformMatrix2x4dv                          C.GPUNIFORMMATRIX2X4DV
-	gpUniformMatrix2x4fv                          C.GPUNIFORMMATRIX2X4FV
-	gpUniformMatrix3dv                            C.GPUNIFORMMATRIX3DV
-	gpUniformMatrix3fv                            C.GPUNIFORMMATRIX3FV
-	gpUniformMatrix3x2dv                          C.GPUNIFORMMATRIX3X2DV
-	gpUniformMatrix3x2fv                          C.GPUNIFORMMATRIX3X2FV
-	gpUniformMatrix3x4dv                          C.GPUNIFORMMATRIX3X4DV
-	gpUniformMatrix3x4fv                          C.GPUNIFORMMATRIX3X4FV
-	gpUniformMatrix4dv                            C.GPUNIFORMMATRIX4DV
-	gpUniformMatrix4fv                            C.GPUNIFORMMATRIX4FV
-	gpUniformMatrix4x2dv                          C.GPUNIFORMMATRIX4X2DV
-	gpUniformMatrix4x2fv                          C.GPUNIFORMMATRIX4X2FV
-	gpUniformMatrix4x3dv                          C.GPUNIFORMMATRIX4X3DV
-	gpUniformMatrix4x3fv                          C.GPUNIFORMMATRIX4X3FV
-	gpUniformSubroutinesuiv                       C.GPUNIFORMSUBROUTINESUIV
-	gpUnmapBuffer                                 C.GPUNMAPBUFFER
-	gpUnmapNamedBuffer                            C.GPUNMAPNAMEDBUFFER
-	gpUseProgram                                  C.GPUSEPROGRAM
-	gpUseProgramStages                            C.GPUSEPROGRAMSTAGES
-	gpValidateProgram                             C.GPVALIDATEPROGRAM
-	gpValidateProgramPipeline                     C.GPVALIDATEPROGRAMPIPELINE
-	gpVertexArrayAttribBinding                    C.GPVERTEXARRAYATTRIBBINDING
-	gpVertexArrayAttribFormat                     C.GPVERTEXARRAYATTRIBFORMAT
-	gpVertexArrayAttribIFormat                    C.GPVERTEXARRAYATTRIBIFORMAT
-	gpVertexArrayAttribLFormat                    C.GPVERTEXARRAYATTRIBLFORMAT
-	gpVertexArrayBindingDivisor                   C.GPVERTEXARRAYBINDINGDIVISOR
-	gpVertexArrayElementBuffer                    C.GPVERTEXARRAYELEMENTBUFFER
-	gpVertexArrayVertexBuffer                     C.GPVERTEXARRAYVERTEXBUFFER
-	gpVertexArrayVertexBuffers                    C.GPVERTEXARRAYVERTEXBUFFERS
-	gpVertexAttrib1d                              C.GPVERTEXATTRIB1D
-	gpVertexAttrib1dv                             C.GPVERTEXATTRIB1DV
-	gpVertexAttrib1f                              C.GPVERTEXATTRIB1F
-	gpVertexAttrib1fv                             C.GPVERTEXATTRIB1FV
-	gpVertexAttrib1s                              C.GPVERTEXATTRIB1S
-	gpVertexAttrib1sv                             C.GPVERTEXATTRIB1SV
-	gpVertexAttrib2d                              C.GPVERTEXATTRIB2D
-	gpVertexAttrib2dv                             C.GPVERTEXATTRIB2DV
-	gpVertexAttrib2f                              C.GPVERTEXATTRIB2F
-	gpVertexAttrib2fv                             C.GPVERTEXATTRIB2FV
-	gpVertexAttrib2s                              C.GPVERTEXATTRIB2S
-	gpVertexAttrib2sv                             C.GPVERTEXATTRIB2SV
-	gpVertexAttrib3d                              C.GPVERTEXATTRIB3D
-	gpVertexAttrib3dv                             C.GPVERTEXATTRIB3DV
-	gpVertexAttrib3f                              C.GPVERTEXATTRIB3F
-	gpVertexAttrib3fv                             C.GPVERTEXATTRIB3FV
-	gpVertexAttrib3s                              C.GPVERTEXATTRIB3S
-	gpVertexAttrib3sv                             C.GPVERTEXATTRIB3SV
-	gpVertexAttrib4Nbv                            C.GPVERTEXATTRIB4NBV
-	gpVertexAttrib4Niv                            C.GPVERTEXATTRIB4NIV
-	gpVertexAttrib4Nsv                            C.GPVERTEXATTRIB4NSV
-	gpVertexAttrib4Nub                            C.GPVERTEXATTRIB4NUB
-	gpVertexAttrib4Nubv                           C.GPVERTEXATTRIB4NUBV
-	gpVertexAttrib4Nuiv                           C.GPVERTEXATTRIB4NUIV
-	gpVertexAttrib4Nusv                           C.GPVERTEXATTRIB4NUSV
-	gpVertexAttrib4bv                             C.GPVERTEXATTRIB4BV
-	gpVertexAttrib4d                              C.GPVERTEXATTRIB4D
-	gpVertexAttrib4dv                             C.GPVERTEXATTRIB4DV
-	gpVertexAttrib4f                              C.GPVERTEXATTRIB4F
-	gpVertexAttrib4fv                             C.GPVERTEXATTRIB4FV
-	gpVertexAttrib4iv                             C.GPVERTEXATTRIB4IV
-	gpVertexAttrib4s                              C.GPVERTEXATTRIB4S
-	gpVertexAttrib4sv                             C.GPVERTEXATTRIB4SV
-	gpVertexAttrib4ubv                            C.GPVERTEXATTRIB4UBV
-	gpVertexAttrib4uiv                            C.GPVERTEXATTRIB4UIV
-	gpVertexAttrib4usv                            C.GPVERTEXATTRIB4USV
-	gpVertexAttribBinding                         C.GPVERTEXATTRIBBINDING
-	gpVertexAttribDivisor                         C.GPVERTEXATTRIBDIVISOR
-	gpVertexAttribFormat                          C.GPVERTEXATTRIBFORMAT
-	gpVertexAttribI1i                             C.GPVERTEXATTRIBI1I
-	gpVertexAttribI1iv                            C.GPVERTEXATTRIBI1IV
-	gpVertexAttribI1ui                            C.GPVERTEXATTRIBI1UI
-	gpVertexAttribI1uiv                           C.GPVERTEXATTRIBI1UIV
-	gpVertexAttribI2i                             C.GPVERTEXATTRIBI2I
-	gpVertexAttribI2iv                            C.GPVERTEXATTRIBI2IV
-	gpVertexAttribI2ui                            C.GPVERTEXATTRIBI2UI
-	gpVertexAttribI2uiv                           C.GPVERTEXATTRIBI2UIV
-	gpVertexAttribI3i                             C.GPVERTEXATTRIBI3I
-	gpVertexAttribI3iv                            C.GPVERTEXATTRIBI3IV
-	gpVertexAttribI3ui                            C.GPVERTEXATTRIBI3UI
-	gpVertexAttribI3uiv                           C.GPVERTEXATTRIBI3UIV
-	gpVertexAttribI4bv                            C.GPVERTEXATTRIBI4BV
-	gpVertexAttribI4i                             C.GPVERTEXATTRIBI4I
-	gpVertexAttribI4iv                            C.GPVERTEXATTRIBI4IV
-	gpVertexAttribI4sv                            C.GPVERTEXATTRIBI4SV
-	gpVertexAttribI4ubv                           C.GPVERTEXATTRIBI4UBV
-	gpVertexAttribI4ui                            C.GPVERTEXATTRIBI4UI
-	gpVertexAttribI4uiv                           C.GPVERTEXATTRIBI4UIV
-	gpVertexAttribI4usv                           C.GPVERTEXATTRIBI4USV
-	gpVertexAttribIFormat                         C.GPVERTEXATTRIBIFORMAT
-	gpVertexAttribIPointer                        C.GPVERTEXATTRIBIPOINTER
-	gpVertexAttribL1d                             C.GPVERTEXATTRIBL1D
-	gpVertexAttribL1dv                            C.GPVERTEXATTRIBL1DV
-	gpVertexAttribL1ui64ARB                       C.GPVERTEXATTRIBL1UI64ARB
-	gpVertexAttribL1ui64vARB                      C.GPVERTEXATTRIBL1UI64VARB
-	gpVertexAttribL2d                             C.GPVERTEXATTRIBL2D
-	gpVertexAttribL2dv                            C.GPVERTEXATTRIBL2DV
-	gpVertexAttribL3d                             C.GPVERTEXATTRIBL3D
-	gpVertexAttribL3dv                            C.GPVERTEXATTRIBL3DV
-	gpVertexAttribL4d                             C.GPVERTEXATTRIBL4D
-	gpVertexAttribL4dv                            C.GPVERTEXATTRIBL4DV
-	gpVertexAttribLFormat                         C.GPVERTEXATTRIBLFORMAT
-	gpVertexAttribLPointer                        C.GPVERTEXATTRIBLPOINTER
-	gpVertexAttribP1ui                            C.GPVERTEXATTRIBP1UI
-	gpVertexAttribP1uiv                           C.GPVERTEXATTRIBP1UIV
-	gpVertexAttribP2ui                            C.GPVERTEXATTRIBP2UI
-	gpVertexAttribP2uiv                           C.GPVERTEXATTRIBP2UIV
-	gpVertexAttribP3ui                            C.GPVERTEXATTRIBP3UI
-	gpVertexAttribP3uiv                           C.GPVERTEXATTRIBP3UIV
-	gpVertexAttribP4ui                            C.GPVERTEXATTRIBP4UI
-	gpVertexAttribP4uiv                           C.GPVERTEXATTRIBP4UIV
-	gpVertexAttribPointer                         C.GPVERTEXATTRIBPOINTER
-	gpVertexBindingDivisor                        C.GPVERTEXBINDINGDIVISOR
-	gpViewport                                    C.GPVIEWPORT
-	gpViewportArrayv                              C.GPVIEWPORTARRAYV
-	gpViewportIndexedf                            C.GPVIEWPORTINDEXEDF
-	gpViewportIndexedfv                           C.GPVIEWPORTINDEXEDFV
-	gpWaitSync                                    C.GPWAITSYNC
+	gpActiveProgramEXT                               C.GPACTIVEPROGRAMEXT
+	gpActiveShaderProgram                            C.GPACTIVESHADERPROGRAM
+	gpActiveShaderProgramEXT                         C.GPACTIVESHADERPROGRAMEXT
+	gpActiveTexture                                  C.GPACTIVETEXTURE
+	gpApplyFramebufferAttachmentCMAAINTEL            C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL
+	gpAttachShader                                   C.GPATTACHSHADER
+	gpBeginConditionalRender                         C.GPBEGINCONDITIONALRENDER
+	gpBeginConditionalRenderNV                       C.GPBEGINCONDITIONALRENDERNV
+	gpBeginPerfMonitorAMD                            C.GPBEGINPERFMONITORAMD
+	gpBeginPerfQueryINTEL                            C.GPBEGINPERFQUERYINTEL
+	gpBeginQuery                                     C.GPBEGINQUERY
+	gpBeginQueryIndexed                              C.GPBEGINQUERYINDEXED
+	gpBeginTransformFeedback                         C.GPBEGINTRANSFORMFEEDBACK
+	gpBindAttribLocation                             C.GPBINDATTRIBLOCATION
+	gpBindBuffer                                     C.GPBINDBUFFER
+	gpBindBufferBase                                 C.GPBINDBUFFERBASE
+	gpBindBufferRange                                C.GPBINDBUFFERRANGE
+	gpBindBuffersBase                                C.GPBINDBUFFERSBASE
+	gpBindBuffersRange                               C.GPBINDBUFFERSRANGE
+	gpBindFragDataLocation                           C.GPBINDFRAGDATALOCATION
+	gpBindFragDataLocationIndexed                    C.GPBINDFRAGDATALOCATIONINDEXED
+	gpBindFramebuffer                                C.GPBINDFRAMEBUFFER
+	gpBindImageTexture                               C.GPBINDIMAGETEXTURE
+	gpBindImageTextures                              C.GPBINDIMAGETEXTURES
+	gpBindMultiTextureEXT                            C.GPBINDMULTITEXTUREEXT
+	gpBindProgramPipeline                            C.GPBINDPROGRAMPIPELINE
+	gpBindProgramPipelineEXT                         C.GPBINDPROGRAMPIPELINEEXT
+	gpBindRenderbuffer                               C.GPBINDRENDERBUFFER
+	gpBindSampler                                    C.GPBINDSAMPLER
+	gpBindSamplers                                   C.GPBINDSAMPLERS
+	gpBindTexture                                    C.GPBINDTEXTURE
+	gpBindTextureUnit                                C.GPBINDTEXTUREUNIT
+	gpBindTextures                                   C.GPBINDTEXTURES
+	gpBindTransformFeedback                          C.GPBINDTRANSFORMFEEDBACK
+	gpBindVertexArray                                C.GPBINDVERTEXARRAY
+	gpBindVertexBuffer                               C.GPBINDVERTEXBUFFER
+	gpBindVertexBuffers                              C.GPBINDVERTEXBUFFERS
+	gpBlendBarrierKHR                                C.GPBLENDBARRIERKHR
+	gpBlendBarrierNV                                 C.GPBLENDBARRIERNV
+	gpBlendColor                                     C.GPBLENDCOLOR
+	gpBlendEquation                                  C.GPBLENDEQUATION
+	gpBlendEquationSeparate                          C.GPBLENDEQUATIONSEPARATE
+	gpBlendEquationSeparatei                         C.GPBLENDEQUATIONSEPARATEI
+	gpBlendEquationSeparateiARB                      C.GPBLENDEQUATIONSEPARATEIARB
+	gpBlendEquationi                                 C.GPBLENDEQUATIONI
+	gpBlendEquationiARB                              C.GPBLENDEQUATIONIARB
+	gpBlendFunc                                      C.GPBLENDFUNC
+	gpBlendFuncSeparate                              C.GPBLENDFUNCSEPARATE
+	gpBlendFuncSeparatei                             C.GPBLENDFUNCSEPARATEI
+	gpBlendFuncSeparateiARB                          C.GPBLENDFUNCSEPARATEIARB
+	gpBlendFunci                                     C.GPBLENDFUNCI
+	gpBlendFunciARB                                  C.GPBLENDFUNCIARB
+	gpBlendParameteriNV                              C.GPBLENDPARAMETERINV
+	gpBlitFramebuffer                                C.GPBLITFRAMEBUFFER
+	gpBlitNamedFramebuffer                           C.GPBLITNAMEDFRAMEBUFFER
+	gpBufferAddressRangeNV                           C.GPBUFFERADDRESSRANGENV
+	gpBufferData                                     C.GPBUFFERDATA
+	gpBufferPageCommitmentARB                        C.GPBUFFERPAGECOMMITMENTARB
+	gpBufferStorage                                  C.GPBUFFERSTORAGE
+	gpBufferSubData                                  C.GPBUFFERSUBDATA
+	gpCallCommandListNV                              C.GPCALLCOMMANDLISTNV
+	gpCheckFramebufferStatus                         C.GPCHECKFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatus                    C.GPCHECKNAMEDFRAMEBUFFERSTATUS
+	gpCheckNamedFramebufferStatusEXT                 C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT
+	gpClampColor                                     C.GPCLAMPCOLOR
+	gpClear                                          C.GPCLEAR
+	gpClearBufferData                                C.GPCLEARBUFFERDATA
+	gpClearBufferSubData                             C.GPCLEARBUFFERSUBDATA
+	gpClearBufferfi                                  C.GPCLEARBUFFERFI
+	gpClearBufferfv                                  C.GPCLEARBUFFERFV
+	gpClearBufferiv                                  C.GPCLEARBUFFERIV
+	gpClearBufferuiv                                 C.GPCLEARBUFFERUIV
+	gpClearColor                                     C.GPCLEARCOLOR
+	gpClearDepth                                     C.GPCLEARDEPTH
+	gpClearDepthf                                    C.GPCLEARDEPTHF
+	gpClearNamedBufferData                           C.GPCLEARNAMEDBUFFERDATA
+	gpClearNamedBufferDataEXT                        C.GPCLEARNAMEDBUFFERDATAEXT
+	gpClearNamedBufferSubData                        C.GPCLEARNAMEDBUFFERSUBDATA
+	gpClearNamedBufferSubDataEXT                     C.GPCLEARNAMEDBUFFERSUBDATAEXT
+	gpClearNamedFramebufferfi                        C.GPCLEARNAMEDFRAMEBUFFERFI
+	gpClearNamedFramebufferfv                        C.GPCLEARNAMEDFRAMEBUFFERFV
+	gpClearNamedFramebufferiv                        C.GPCLEARNAMEDFRAMEBUFFERIV
+	gpClearNamedFramebufferuiv                       C.GPCLEARNAMEDFRAMEBUFFERUIV
+	gpClearStencil                                   C.GPCLEARSTENCIL
+	gpClearTexImage                                  C.GPCLEARTEXIMAGE
+	gpClearTexSubImage                               C.GPCLEARTEXSUBIMAGE
+	gpClientAttribDefaultEXT                         C.GPCLIENTATTRIBDEFAULTEXT
+	gpClientWaitSync                                 C.GPCLIENTWAITSYNC
+	gpClipControl                                    C.GPCLIPCONTROL
+	gpColorFormatNV                                  C.GPCOLORFORMATNV
+	gpColorMask                                      C.GPCOLORMASK
+	gpColorMaski                                     C.GPCOLORMASKI
+	gpCommandListSegmentsNV                          C.GPCOMMANDLISTSEGMENTSNV
+	gpCompileCommandListNV                           C.GPCOMPILECOMMANDLISTNV
+	gpCompileShader                                  C.GPCOMPILESHADER
+	gpCompileShaderIncludeARB                        C.GPCOMPILESHADERINCLUDEARB
+	gpCompressedMultiTexImage1DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE1DEXT
+	gpCompressedMultiTexImage2DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE2DEXT
+	gpCompressedMultiTexImage3DEXT                   C.GPCOMPRESSEDMULTITEXIMAGE3DEXT
+	gpCompressedMultiTexSubImage1DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT
+	gpCompressedMultiTexSubImage2DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT
+	gpCompressedMultiTexSubImage3DEXT                C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT
+	gpCompressedTexImage1D                           C.GPCOMPRESSEDTEXIMAGE1D
+	gpCompressedTexImage2D                           C.GPCOMPRESSEDTEXIMAGE2D
+	gpCompressedTexImage3D                           C.GPCOMPRESSEDTEXIMAGE3D
+	gpCompressedTexSubImage1D                        C.GPCOMPRESSEDTEXSUBIMAGE1D
+	gpCompressedTexSubImage2D                        C.GPCOMPRESSEDTEXSUBIMAGE2D
+	gpCompressedTexSubImage3D                        C.GPCOMPRESSEDTEXSUBIMAGE3D
+	gpCompressedTextureImage1DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE1DEXT
+	gpCompressedTextureImage2DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE2DEXT
+	gpCompressedTextureImage3DEXT                    C.GPCOMPRESSEDTEXTUREIMAGE3DEXT
+	gpCompressedTextureSubImage1D                    C.GPCOMPRESSEDTEXTURESUBIMAGE1D
+	gpCompressedTextureSubImage1DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT
+	gpCompressedTextureSubImage2D                    C.GPCOMPRESSEDTEXTURESUBIMAGE2D
+	gpCompressedTextureSubImage2DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT
+	gpCompressedTextureSubImage3D                    C.GPCOMPRESSEDTEXTURESUBIMAGE3D
+	gpCompressedTextureSubImage3DEXT                 C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT
+	gpConservativeRasterParameterfNV                 C.GPCONSERVATIVERASTERPARAMETERFNV
+	gpConservativeRasterParameteriNV                 C.GPCONSERVATIVERASTERPARAMETERINV
+	gpCopyBufferSubData                              C.GPCOPYBUFFERSUBDATA
+	gpCopyImageSubData                               C.GPCOPYIMAGESUBDATA
+	gpCopyMultiTexImage1DEXT                         C.GPCOPYMULTITEXIMAGE1DEXT
+	gpCopyMultiTexImage2DEXT                         C.GPCOPYMULTITEXIMAGE2DEXT
+	gpCopyMultiTexSubImage1DEXT                      C.GPCOPYMULTITEXSUBIMAGE1DEXT
+	gpCopyMultiTexSubImage2DEXT                      C.GPCOPYMULTITEXSUBIMAGE2DEXT
+	gpCopyMultiTexSubImage3DEXT                      C.GPCOPYMULTITEXSUBIMAGE3DEXT
+	gpCopyNamedBufferSubData                         C.GPCOPYNAMEDBUFFERSUBDATA
+	gpCopyPathNV                                     C.GPCOPYPATHNV
+	gpCopyTexImage1D                                 C.GPCOPYTEXIMAGE1D
+	gpCopyTexImage2D                                 C.GPCOPYTEXIMAGE2D
+	gpCopyTexSubImage1D                              C.GPCOPYTEXSUBIMAGE1D
+	gpCopyTexSubImage2D                              C.GPCOPYTEXSUBIMAGE2D
+	gpCopyTexSubImage3D                              C.GPCOPYTEXSUBIMAGE3D
+	gpCopyTextureImage1DEXT                          C.GPCOPYTEXTUREIMAGE1DEXT
+	gpCopyTextureImage2DEXT                          C.GPCOPYTEXTUREIMAGE2DEXT
+	gpCopyTextureSubImage1D                          C.GPCOPYTEXTURESUBIMAGE1D
+	gpCopyTextureSubImage1DEXT                       C.GPCOPYTEXTURESUBIMAGE1DEXT
+	gpCopyTextureSubImage2D                          C.GPCOPYTEXTURESUBIMAGE2D
+	gpCopyTextureSubImage2DEXT                       C.GPCOPYTEXTURESUBIMAGE2DEXT
+	gpCopyTextureSubImage3D                          C.GPCOPYTEXTURESUBIMAGE3D
+	gpCopyTextureSubImage3DEXT                       C.GPCOPYTEXTURESUBIMAGE3DEXT
+	gpCoverFillPathInstancedNV                       C.GPCOVERFILLPATHINSTANCEDNV
+	gpCoverFillPathNV                                C.GPCOVERFILLPATHNV
+	gpCoverStrokePathInstancedNV                     C.GPCOVERSTROKEPATHINSTANCEDNV
+	gpCoverStrokePathNV                              C.GPCOVERSTROKEPATHNV
+	gpCoverageModulationNV                           C.GPCOVERAGEMODULATIONNV
+	gpCoverageModulationTableNV                      C.GPCOVERAGEMODULATIONTABLENV
+	gpCreateBuffers                                  C.GPCREATEBUFFERS
+	gpCreateCommandListsNV                           C.GPCREATECOMMANDLISTSNV
+	gpCreateFramebuffers                             C.GPCREATEFRAMEBUFFERS
+	gpCreatePerfQueryINTEL                           C.GPCREATEPERFQUERYINTEL
+	gpCreateProgram                                  C.GPCREATEPROGRAM
+	gpCreateProgramPipelines                         C.GPCREATEPROGRAMPIPELINES
+	gpCreateQueries                                  C.GPCREATEQUERIES
+	gpCreateRenderbuffers                            C.GPCREATERENDERBUFFERS
+	gpCreateSamplers                                 C.GPCREATESAMPLERS
+	gpCreateShader                                   C.GPCREATESHADER
+	gpCreateShaderProgramEXT                         C.GPCREATESHADERPROGRAMEXT
+	gpCreateShaderProgramv                           C.GPCREATESHADERPROGRAMV
+	gpCreateShaderProgramvEXT                        C.GPCREATESHADERPROGRAMVEXT
+	gpCreateStatesNV                                 C.GPCREATESTATESNV
+	gpCreateSyncFromCLeventARB                       C.GPCREATESYNCFROMCLEVENTARB
+	gpCreateTextures                                 C.GPCREATETEXTURES
+	gpCreateTransformFeedbacks                       C.GPCREATETRANSFORMFEEDBACKS
+	gpCreateVertexArrays                             C.GPCREATEVERTEXARRAYS
+	gpCullFace                                       C.GPCULLFACE
+	gpDebugMessageCallback                           C.GPDEBUGMESSAGECALLBACK
+	gpDebugMessageCallbackARB                        C.GPDEBUGMESSAGECALLBACKARB
+	gpDebugMessageCallbackKHR                        C.GPDEBUGMESSAGECALLBACKKHR
+	gpDebugMessageControl                            C.GPDEBUGMESSAGECONTROL
+	gpDebugMessageControlARB                         C.GPDEBUGMESSAGECONTROLARB
+	gpDebugMessageControlKHR                         C.GPDEBUGMESSAGECONTROLKHR
+	gpDebugMessageInsert                             C.GPDEBUGMESSAGEINSERT
+	gpDebugMessageInsertARB                          C.GPDEBUGMESSAGEINSERTARB
+	gpDebugMessageInsertKHR                          C.GPDEBUGMESSAGEINSERTKHR
+	gpDeleteBuffers                                  C.GPDELETEBUFFERS
+	gpDeleteCommandListsNV                           C.GPDELETECOMMANDLISTSNV
+	gpDeleteFramebuffers                             C.GPDELETEFRAMEBUFFERS
+	gpDeleteNamedStringARB                           C.GPDELETENAMEDSTRINGARB
+	gpDeletePathsNV                                  C.GPDELETEPATHSNV
+	gpDeletePerfMonitorsAMD                          C.GPDELETEPERFMONITORSAMD
+	gpDeletePerfQueryINTEL                           C.GPDELETEPERFQUERYINTEL
+	gpDeleteProgram                                  C.GPDELETEPROGRAM
+	gpDeleteProgramPipelines                         C.GPDELETEPROGRAMPIPELINES
+	gpDeleteProgramPipelinesEXT                      C.GPDELETEPROGRAMPIPELINESEXT
+	gpDeleteQueries                                  C.GPDELETEQUERIES
+	gpDeleteRenderbuffers                            C.GPDELETERENDERBUFFERS
+	gpDeleteSamplers                                 C.GPDELETESAMPLERS
+	gpDeleteShader                                   C.GPDELETESHADER
+	gpDeleteStatesNV                                 C.GPDELETESTATESNV
+	gpDeleteSync                                     C.GPDELETESYNC
+	gpDeleteTextures                                 C.GPDELETETEXTURES
+	gpDeleteTransformFeedbacks                       C.GPDELETETRANSFORMFEEDBACKS
+	gpDeleteVertexArrays                             C.GPDELETEVERTEXARRAYS
+	gpDepthFunc                                      C.GPDEPTHFUNC
+	gpDepthMask                                      C.GPDEPTHMASK
+	gpDepthRange                                     C.GPDEPTHRANGE
+	gpDepthRangeArrayv                               C.GPDEPTHRANGEARRAYV
+	gpDepthRangeIndexed                              C.GPDEPTHRANGEINDEXED
+	gpDepthRangef                                    C.GPDEPTHRANGEF
+	gpDetachShader                                   C.GPDETACHSHADER
+	gpDisable                                        C.GPDISABLE
+	gpDisableClientStateIndexedEXT                   C.GPDISABLECLIENTSTATEINDEXEDEXT
+	gpDisableClientStateiEXT                         C.GPDISABLECLIENTSTATEIEXT
+	gpDisableIndexedEXT                              C.GPDISABLEINDEXEDEXT
+	gpDisableVertexArrayAttrib                       C.GPDISABLEVERTEXARRAYATTRIB
+	gpDisableVertexArrayAttribEXT                    C.GPDISABLEVERTEXARRAYATTRIBEXT
+	gpDisableVertexArrayEXT                          C.GPDISABLEVERTEXARRAYEXT
+	gpDisableVertexAttribArray                       C.GPDISABLEVERTEXATTRIBARRAY
+	gpDisablei                                       C.GPDISABLEI
+	gpDispatchCompute                                C.GPDISPATCHCOMPUTE
+	gpDispatchComputeGroupSizeARB                    C.GPDISPATCHCOMPUTEGROUPSIZEARB
+	gpDispatchComputeIndirect                        C.GPDISPATCHCOMPUTEINDIRECT
+	gpDrawArrays                                     C.GPDRAWARRAYS
+	gpDrawArraysIndirect                             C.GPDRAWARRAYSINDIRECT
+	gpDrawArraysInstanced                            C.GPDRAWARRAYSINSTANCED
+	gpDrawArraysInstancedARB                         C.GPDRAWARRAYSINSTANCEDARB
+	gpDrawArraysInstancedBaseInstance                C.GPDRAWARRAYSINSTANCEDBASEINSTANCE
+	gpDrawArraysInstancedEXT                         C.GPDRAWARRAYSINSTANCEDEXT
+	gpDrawBuffer                                     C.GPDRAWBUFFER
+	gpDrawBuffers                                    C.GPDRAWBUFFERS
+	gpDrawCommandsAddressNV                          C.GPDRAWCOMMANDSADDRESSNV
+	gpDrawCommandsNV                                 C.GPDRAWCOMMANDSNV
+	gpDrawCommandsStatesAddressNV                    C.GPDRAWCOMMANDSSTATESADDRESSNV
+	gpDrawCommandsStatesNV                           C.GPDRAWCOMMANDSSTATESNV
+	gpDrawElements                                   C.GPDRAWELEMENTS
+	gpDrawElementsBaseVertex                         C.GPDRAWELEMENTSBASEVERTEX
+	gpDrawElementsIndirect                           C.GPDRAWELEMENTSINDIRECT
+	gpDrawElementsInstanced                          C.GPDRAWELEMENTSINSTANCED
+	gpDrawElementsInstancedARB                       C.GPDRAWELEMENTSINSTANCEDARB
+	gpDrawElementsInstancedBaseInstance              C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE
+	gpDrawElementsInstancedBaseVertex                C.GPDRAWELEMENTSINSTANCEDBASEVERTEX
+	gpDrawElementsInstancedBaseVertexBaseInstance    C.GPDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCE
+	gpDrawElementsInstancedEXT                       C.GPDRAWELEMENTSINSTANCEDEXT
+	gpDrawRangeElements                              C.GPDRAWRANGEELEMENTS
+	gpDrawRangeElementsBaseVertex                    C.GPDRAWRANGEELEMENTSBASEVERTEX
+	gpDrawTransformFeedback                          C.GPDRAWTRANSFORMFEEDBACK
+	gpDrawTransformFeedbackInstanced                 C.GPDRAWTRANSFORMFEEDBACKINSTANCED
+	gpDrawTransformFeedbackStream                    C.GPDRAWTRANSFORMFEEDBACKSTREAM
+	gpDrawTransformFeedbackStreamInstanced           C.GPDRAWTRANSFORMFEEDBACKSTREAMINSTANCED
+	gpDrawVkImageNV                                  C.GPDRAWVKIMAGENV
+	gpEdgeFlagFormatNV                               C.GPEDGEFLAGFORMATNV
+	gpEnable                                         C.GPENABLE
+	gpEnableClientStateIndexedEXT                    C.GPENABLECLIENTSTATEINDEXEDEXT
+	gpEnableClientStateiEXT                          C.GPENABLECLIENTSTATEIEXT
+	gpEnableIndexedEXT                               C.GPENABLEINDEXEDEXT
+	gpEnableVertexArrayAttrib                        C.GPENABLEVERTEXARRAYATTRIB
+	gpEnableVertexArrayAttribEXT                     C.GPENABLEVERTEXARRAYATTRIBEXT
+	gpEnableVertexArrayEXT                           C.GPENABLEVERTEXARRAYEXT
+	gpEnableVertexAttribArray                        C.GPENABLEVERTEXATTRIBARRAY
+	gpEnablei                                        C.GPENABLEI
+	gpEndConditionalRender                           C.GPENDCONDITIONALRENDER
+	gpEndConditionalRenderNV                         C.GPENDCONDITIONALRENDERNV
+	gpEndPerfMonitorAMD                              C.GPENDPERFMONITORAMD
+	gpEndPerfQueryINTEL                              C.GPENDPERFQUERYINTEL
+	gpEndQuery                                       C.GPENDQUERY
+	gpEndQueryIndexed                                C.GPENDQUERYINDEXED
+	gpEndTransformFeedback                           C.GPENDTRANSFORMFEEDBACK
+	gpEvaluateDepthValuesARB                         C.GPEVALUATEDEPTHVALUESARB
+	gpFenceSync                                      C.GPFENCESYNC
+	gpFinish                                         C.GPFINISH
+	gpFlush                                          C.GPFLUSH
+	gpFlushMappedBufferRange                         C.GPFLUSHMAPPEDBUFFERRANGE
+	gpFlushMappedNamedBufferRange                    C.GPFLUSHMAPPEDNAMEDBUFFERRANGE
+	gpFlushMappedNamedBufferRangeEXT                 C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT
+	gpFogCoordFormatNV                               C.GPFOGCOORDFORMATNV
+	gpFragmentCoverageColorNV                        C.GPFRAGMENTCOVERAGECOLORNV
+	gpFramebufferDrawBufferEXT                       C.GPFRAMEBUFFERDRAWBUFFEREXT
+	gpFramebufferDrawBuffersEXT                      C.GPFRAMEBUFFERDRAWBUFFERSEXT
+	gpFramebufferFetchBarrierEXT                     C.GPFRAMEBUFFERFETCHBARRIEREXT
+	gpFramebufferParameteri                          C.GPFRAMEBUFFERPARAMETERI
+	gpFramebufferReadBufferEXT                       C.GPFRAMEBUFFERREADBUFFEREXT
+	gpFramebufferRenderbuffer                        C.GPFRAMEBUFFERRENDERBUFFER
+	gpFramebufferSampleLocationsfvARB                C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpFramebufferSampleLocationsfvNV                 C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpFramebufferTexture                             C.GPFRAMEBUFFERTEXTURE
+	gpFramebufferTexture1D                           C.GPFRAMEBUFFERTEXTURE1D
+	gpFramebufferTexture2D                           C.GPFRAMEBUFFERTEXTURE2D
+	gpFramebufferTexture3D                           C.GPFRAMEBUFFERTEXTURE3D
+	gpFramebufferTextureARB                          C.GPFRAMEBUFFERTEXTUREARB
+	gpFramebufferTextureFaceARB                      C.GPFRAMEBUFFERTEXTUREFACEARB
+	gpFramebufferTextureLayer                        C.GPFRAMEBUFFERTEXTURELAYER
+	gpFramebufferTextureLayerARB                     C.GPFRAMEBUFFERTEXTURELAYERARB
+	gpFramebufferTextureMultiviewOVR                 C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR
+	gpFrontFace                                      C.GPFRONTFACE
+	gpGenBuffers                                     C.GPGENBUFFERS
+	gpGenFramebuffers                                C.GPGENFRAMEBUFFERS
+	gpGenPathsNV                                     C.GPGENPATHSNV
+	gpGenPerfMonitorsAMD                             C.GPGENPERFMONITORSAMD
+	gpGenProgramPipelines                            C.GPGENPROGRAMPIPELINES
+	gpGenProgramPipelinesEXT                         C.GPGENPROGRAMPIPELINESEXT
+	gpGenQueries                                     C.GPGENQUERIES
+	gpGenRenderbuffers                               C.GPGENRENDERBUFFERS
+	gpGenSamplers                                    C.GPGENSAMPLERS
+	gpGenTextures                                    C.GPGENTEXTURES
+	gpGenTransformFeedbacks                          C.GPGENTRANSFORMFEEDBACKS
+	gpGenVertexArrays                                C.GPGENVERTEXARRAYS
+	gpGenerateMipmap                                 C.GPGENERATEMIPMAP
+	gpGenerateMultiTexMipmapEXT                      C.GPGENERATEMULTITEXMIPMAPEXT
+	gpGenerateTextureMipmap                          C.GPGENERATETEXTUREMIPMAP
+	gpGenerateTextureMipmapEXT                       C.GPGENERATETEXTUREMIPMAPEXT
+	gpGetActiveAtomicCounterBufferiv                 C.GPGETACTIVEATOMICCOUNTERBUFFERIV
+	gpGetActiveAttrib                                C.GPGETACTIVEATTRIB
+	gpGetActiveSubroutineName                        C.GPGETACTIVESUBROUTINENAME
+	gpGetActiveSubroutineUniformName                 C.GPGETACTIVESUBROUTINEUNIFORMNAME
+	gpGetActiveSubroutineUniformiv                   C.GPGETACTIVESUBROUTINEUNIFORMIV
+	gpGetActiveUniform                               C.GPGETACTIVEUNIFORM
+	gpGetActiveUniformBlockName                      C.GPGETACTIVEUNIFORMBLOCKNAME
+	gpGetActiveUniformBlockiv                        C.GPGETACTIVEUNIFORMBLOCKIV
+	gpGetActiveUniformName                           C.GPGETACTIVEUNIFORMNAME
+	gpGetActiveUniformsiv                            C.GPGETACTIVEUNIFORMSIV
+	gpGetAttachedShaders                             C.GPGETATTACHEDSHADERS
+	gpGetAttribLocation                              C.GPGETATTRIBLOCATION
+	gpGetBooleanIndexedvEXT                          C.GPGETBOOLEANINDEXEDVEXT
+	gpGetBooleani_v                                  C.GPGETBOOLEANI_V
+	gpGetBooleanv                                    C.GPGETBOOLEANV
+	gpGetBufferParameteri64v                         C.GPGETBUFFERPARAMETERI64V
+	gpGetBufferParameteriv                           C.GPGETBUFFERPARAMETERIV
+	gpGetBufferParameterui64vNV                      C.GPGETBUFFERPARAMETERUI64VNV
+	gpGetBufferPointerv                              C.GPGETBUFFERPOINTERV
+	gpGetBufferSubData                               C.GPGETBUFFERSUBDATA
+	gpGetCommandHeaderNV                             C.GPGETCOMMANDHEADERNV
+	gpGetCompressedMultiTexImageEXT                  C.GPGETCOMPRESSEDMULTITEXIMAGEEXT
+	gpGetCompressedTexImage                          C.GPGETCOMPRESSEDTEXIMAGE
+	gpGetCompressedTextureImage                      C.GPGETCOMPRESSEDTEXTUREIMAGE
+	gpGetCompressedTextureImageEXT                   C.GPGETCOMPRESSEDTEXTUREIMAGEEXT
+	gpGetCompressedTextureSubImage                   C.GPGETCOMPRESSEDTEXTURESUBIMAGE
+	gpGetCoverageModulationTableNV                   C.GPGETCOVERAGEMODULATIONTABLENV
+	gpGetDebugMessageLog                             C.GPGETDEBUGMESSAGELOG
+	gpGetDebugMessageLogARB                          C.GPGETDEBUGMESSAGELOGARB
+	gpGetDebugMessageLogKHR                          C.GPGETDEBUGMESSAGELOGKHR
+	gpGetDoubleIndexedvEXT                           C.GPGETDOUBLEINDEXEDVEXT
+	gpGetDoublei_v                                   C.GPGETDOUBLEI_V
+	gpGetDoublei_vEXT                                C.GPGETDOUBLEI_VEXT
+	gpGetDoublev                                     C.GPGETDOUBLEV
+	gpGetError                                       C.GPGETERROR
+	gpGetFirstPerfQueryIdINTEL                       C.GPGETFIRSTPERFQUERYIDINTEL
+	gpGetFloatIndexedvEXT                            C.GPGETFLOATINDEXEDVEXT
+	gpGetFloati_v                                    C.GPGETFLOATI_V
+	gpGetFloati_vEXT                                 C.GPGETFLOATI_VEXT
+	gpGetFloatv                                      C.GPGETFLOATV
+	gpGetFragDataIndex                               C.GPGETFRAGDATAINDEX
+	gpGetFragDataLocation                            C.GPGETFRAGDATALOCATION
+	gpGetFramebufferAttachmentParameteriv            C.GPGETFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetFramebufferParameteriv                      C.GPGETFRAMEBUFFERPARAMETERIV
+	gpGetFramebufferParameterivEXT                   C.GPGETFRAMEBUFFERPARAMETERIVEXT
+	gpGetGraphicsResetStatus                         C.GPGETGRAPHICSRESETSTATUS
+	gpGetGraphicsResetStatusARB                      C.GPGETGRAPHICSRESETSTATUSARB
+	gpGetGraphicsResetStatusKHR                      C.GPGETGRAPHICSRESETSTATUSKHR
+	gpGetImageHandleARB                              C.GPGETIMAGEHANDLEARB
+	gpGetImageHandleNV                               C.GPGETIMAGEHANDLENV
+	gpGetInteger64i_v                                C.GPGETINTEGER64I_V
+	gpGetInteger64v                                  C.GPGETINTEGER64V
+	gpGetIntegerIndexedvEXT                          C.GPGETINTEGERINDEXEDVEXT
+	gpGetIntegeri_v                                  C.GPGETINTEGERI_V
+	gpGetIntegerui64i_vNV                            C.GPGETINTEGERUI64I_VNV
+	gpGetIntegerui64vNV                              C.GPGETINTEGERUI64VNV
+	gpGetIntegerv                                    C.GPGETINTEGERV
+	gpGetInternalformatSampleivNV                    C.GPGETINTERNALFORMATSAMPLEIVNV
+	gpGetInternalformati64v                          C.GPGETINTERNALFORMATI64V
+	gpGetInternalformativ                            C.GPGETINTERNALFORMATIV
+	gpGetMultiTexEnvfvEXT                            C.GPGETMULTITEXENVFVEXT
+	gpGetMultiTexEnvivEXT                            C.GPGETMULTITEXENVIVEXT
+	gpGetMultiTexGendvEXT                            C.GPGETMULTITEXGENDVEXT
+	gpGetMultiTexGenfvEXT                            C.GPGETMULTITEXGENFVEXT
+	gpGetMultiTexGenivEXT                            C.GPGETMULTITEXGENIVEXT
+	gpGetMultiTexImageEXT                            C.GPGETMULTITEXIMAGEEXT
+	gpGetMultiTexLevelParameterfvEXT                 C.GPGETMULTITEXLEVELPARAMETERFVEXT
+	gpGetMultiTexLevelParameterivEXT                 C.GPGETMULTITEXLEVELPARAMETERIVEXT
+	gpGetMultiTexParameterIivEXT                     C.GPGETMULTITEXPARAMETERIIVEXT
+	gpGetMultiTexParameterIuivEXT                    C.GPGETMULTITEXPARAMETERIUIVEXT
+	gpGetMultiTexParameterfvEXT                      C.GPGETMULTITEXPARAMETERFVEXT
+	gpGetMultiTexParameterivEXT                      C.GPGETMULTITEXPARAMETERIVEXT
+	gpGetMultisamplefv                               C.GPGETMULTISAMPLEFV
+	gpGetNamedBufferParameteri64v                    C.GPGETNAMEDBUFFERPARAMETERI64V
+	gpGetNamedBufferParameteriv                      C.GPGETNAMEDBUFFERPARAMETERIV
+	gpGetNamedBufferParameterivEXT                   C.GPGETNAMEDBUFFERPARAMETERIVEXT
+	gpGetNamedBufferParameterui64vNV                 C.GPGETNAMEDBUFFERPARAMETERUI64VNV
+	gpGetNamedBufferPointerv                         C.GPGETNAMEDBUFFERPOINTERV
+	gpGetNamedBufferPointervEXT                      C.GPGETNAMEDBUFFERPOINTERVEXT
+	gpGetNamedBufferSubData                          C.GPGETNAMEDBUFFERSUBDATA
+	gpGetNamedBufferSubDataEXT                       C.GPGETNAMEDBUFFERSUBDATAEXT
+	gpGetNamedFramebufferAttachmentParameteriv       C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV
+	gpGetNamedFramebufferAttachmentParameterivEXT    C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT
+	gpGetNamedFramebufferParameteriv                 C.GPGETNAMEDFRAMEBUFFERPARAMETERIV
+	gpGetNamedFramebufferParameterivEXT              C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT
+	gpGetNamedProgramLocalParameterIivEXT            C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT
+	gpGetNamedProgramLocalParameterIuivEXT           C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT
+	gpGetNamedProgramLocalParameterdvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT
+	gpGetNamedProgramLocalParameterfvEXT             C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT
+	gpGetNamedProgramStringEXT                       C.GPGETNAMEDPROGRAMSTRINGEXT
+	gpGetNamedProgramivEXT                           C.GPGETNAMEDPROGRAMIVEXT
+	gpGetNamedRenderbufferParameteriv                C.GPGETNAMEDRENDERBUFFERPARAMETERIV
+	gpGetNamedRenderbufferParameterivEXT             C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT
+	gpGetNamedStringARB                              C.GPGETNAMEDSTRINGARB
+	gpGetNamedStringivARB                            C.GPGETNAMEDSTRINGIVARB
+	gpGetNextPerfQueryIdINTEL                        C.GPGETNEXTPERFQUERYIDINTEL
+	gpGetObjectLabel                                 C.GPGETOBJECTLABEL
+	gpGetObjectLabelEXT                              C.GPGETOBJECTLABELEXT
+	gpGetObjectLabelKHR                              C.GPGETOBJECTLABELKHR
+	gpGetObjectPtrLabel                              C.GPGETOBJECTPTRLABEL
+	gpGetObjectPtrLabelKHR                           C.GPGETOBJECTPTRLABELKHR
+	gpGetPathCommandsNV                              C.GPGETPATHCOMMANDSNV
+	gpGetPathCoordsNV                                C.GPGETPATHCOORDSNV
+	gpGetPathDashArrayNV                             C.GPGETPATHDASHARRAYNV
+	gpGetPathLengthNV                                C.GPGETPATHLENGTHNV
+	gpGetPathMetricRangeNV                           C.GPGETPATHMETRICRANGENV
+	gpGetPathMetricsNV                               C.GPGETPATHMETRICSNV
+	gpGetPathParameterfvNV                           C.GPGETPATHPARAMETERFVNV
+	gpGetPathParameterivNV                           C.GPGETPATHPARAMETERIVNV
+	gpGetPathSpacingNV                               C.GPGETPATHSPACINGNV
+	gpGetPerfCounterInfoINTEL                        C.GPGETPERFCOUNTERINFOINTEL
+	gpGetPerfMonitorCounterDataAMD                   C.GPGETPERFMONITORCOUNTERDATAAMD
+	gpGetPerfMonitorCounterInfoAMD                   C.GPGETPERFMONITORCOUNTERINFOAMD
+	gpGetPerfMonitorCounterStringAMD                 C.GPGETPERFMONITORCOUNTERSTRINGAMD
+	gpGetPerfMonitorCountersAMD                      C.GPGETPERFMONITORCOUNTERSAMD
+	gpGetPerfMonitorGroupStringAMD                   C.GPGETPERFMONITORGROUPSTRINGAMD
+	gpGetPerfMonitorGroupsAMD                        C.GPGETPERFMONITORGROUPSAMD
+	gpGetPerfQueryDataINTEL                          C.GPGETPERFQUERYDATAINTEL
+	gpGetPerfQueryIdByNameINTEL                      C.GPGETPERFQUERYIDBYNAMEINTEL
+	gpGetPerfQueryInfoINTEL                          C.GPGETPERFQUERYINFOINTEL
+	gpGetPointerIndexedvEXT                          C.GPGETPOINTERINDEXEDVEXT
+	gpGetPointeri_vEXT                               C.GPGETPOINTERI_VEXT
+	gpGetPointerv                                    C.GPGETPOINTERV
+	gpGetPointervKHR                                 C.GPGETPOINTERVKHR
+	gpGetProgramBinary                               C.GPGETPROGRAMBINARY
+	gpGetProgramInfoLog                              C.GPGETPROGRAMINFOLOG
+	gpGetProgramInterfaceiv                          C.GPGETPROGRAMINTERFACEIV
+	gpGetProgramPipelineInfoLog                      C.GPGETPROGRAMPIPELINEINFOLOG
+	gpGetProgramPipelineInfoLogEXT                   C.GPGETPROGRAMPIPELINEINFOLOGEXT
+	gpGetProgramPipelineiv                           C.GPGETPROGRAMPIPELINEIV
+	gpGetProgramPipelineivEXT                        C.GPGETPROGRAMPIPELINEIVEXT
+	gpGetProgramResourceIndex                        C.GPGETPROGRAMRESOURCEINDEX
+	gpGetProgramResourceLocation                     C.GPGETPROGRAMRESOURCELOCATION
+	gpGetProgramResourceLocationIndex                C.GPGETPROGRAMRESOURCELOCATIONINDEX
+	gpGetProgramResourceName                         C.GPGETPROGRAMRESOURCENAME
+	gpGetProgramResourcefvNV                         C.GPGETPROGRAMRESOURCEFVNV
+	gpGetProgramResourceiv                           C.GPGETPROGRAMRESOURCEIV
+	gpGetProgramStageiv                              C.GPGETPROGRAMSTAGEIV
+	gpGetProgramiv                                   C.GPGETPROGRAMIV
+	gpGetQueryBufferObjecti64v                       C.GPGETQUERYBUFFEROBJECTI64V
+	gpGetQueryBufferObjectiv                         C.GPGETQUERYBUFFEROBJECTIV
+	gpGetQueryBufferObjectui64v                      C.GPGETQUERYBUFFEROBJECTUI64V
+	gpGetQueryBufferObjectuiv                        C.GPGETQUERYBUFFEROBJECTUIV
+	gpGetQueryIndexediv                              C.GPGETQUERYINDEXEDIV
+	gpGetQueryObjecti64v                             C.GPGETQUERYOBJECTI64V
+	gpGetQueryObjectiv                               C.GPGETQUERYOBJECTIV
+	gpGetQueryObjectui64v                            C.GPGETQUERYOBJECTUI64V
+	gpGetQueryObjectuiv                              C.GPGETQUERYOBJECTUIV
+	gpGetQueryiv                                     C.GPGETQUERYIV
+	gpGetRenderbufferParameteriv                     C.GPGETRENDERBUFFERPARAMETERIV
+	gpGetSamplerParameterIiv                         C.GPGETSAMPLERPARAMETERIIV
+	gpGetSamplerParameterIuiv                        C.GPGETSAMPLERPARAMETERIUIV
+	gpGetSamplerParameterfv                          C.GPGETSAMPLERPARAMETERFV
+	gpGetSamplerParameteriv                          C.GPGETSAMPLERPARAMETERIV
+	gpGetShaderInfoLog                               C.GPGETSHADERINFOLOG
+	gpGetShaderPrecisionFormat                       C.GPGETSHADERPRECISIONFORMAT
+	gpGetShaderSource                                C.GPGETSHADERSOURCE
+	gpGetShaderiv                                    C.GPGETSHADERIV
+	gpGetStageIndexNV                                C.GPGETSTAGEINDEXNV
+	gpGetString                                      C.GPGETSTRING
+	gpGetStringi                                     C.GPGETSTRINGI
+	gpGetSubroutineIndex                             C.GPGETSUBROUTINEINDEX
+	gpGetSubroutineUniformLocation                   C.GPGETSUBROUTINEUNIFORMLOCATION
+	gpGetSynciv                                      C.GPGETSYNCIV
+	gpGetTexImage                                    C.GPGETTEXIMAGE
+	gpGetTexLevelParameterfv                         C.GPGETTEXLEVELPARAMETERFV
+	gpGetTexLevelParameteriv                         C.GPGETTEXLEVELPARAMETERIV
+	gpGetTexParameterIiv                             C.GPGETTEXPARAMETERIIV
+	gpGetTexParameterIuiv                            C.GPGETTEXPARAMETERIUIV
+	gpGetTexParameterfv                              C.GPGETTEXPARAMETERFV
+	gpGetTexParameteriv                              C.GPGETTEXPARAMETERIV
+	gpGetTextureHandleARB                            C.GPGETTEXTUREHANDLEARB
+	gpGetTextureHandleNV                             C.GPGETTEXTUREHANDLENV
+	gpGetTextureImage                                C.GPGETTEXTUREIMAGE
+	gpGetTextureImageEXT                             C.GPGETTEXTUREIMAGEEXT
+	gpGetTextureLevelParameterfv                     C.GPGETTEXTURELEVELPARAMETERFV
+	gpGetTextureLevelParameterfvEXT                  C.GPGETTEXTURELEVELPARAMETERFVEXT
+	gpGetTextureLevelParameteriv                     C.GPGETTEXTURELEVELPARAMETERIV
+	gpGetTextureLevelParameterivEXT                  C.GPGETTEXTURELEVELPARAMETERIVEXT
+	gpGetTextureParameterIiv                         C.GPGETTEXTUREPARAMETERIIV
+	gpGetTextureParameterIivEXT                      C.GPGETTEXTUREPARAMETERIIVEXT
+	gpGetTextureParameterIuiv                        C.GPGETTEXTUREPARAMETERIUIV
+	gpGetTextureParameterIuivEXT                     C.GPGETTEXTUREPARAMETERIUIVEXT
+	gpGetTextureParameterfv                          C.GPGETTEXTUREPARAMETERFV
+	gpGetTextureParameterfvEXT                       C.GPGETTEXTUREPARAMETERFVEXT
+	gpGetTextureParameteriv                          C.GPGETTEXTUREPARAMETERIV
+	gpGetTextureParameterivEXT                       C.GPGETTEXTUREPARAMETERIVEXT
+	gpGetTextureSamplerHandleARB                     C.GPGETTEXTURESAMPLERHANDLEARB
+	gpGetTextureSamplerHandleNV                      C.GPGETTEXTURESAMPLERHANDLENV
+	gpGetTextureSubImage                             C.GPGETTEXTURESUBIMAGE
+	gpGetTransformFeedbackVarying                    C.GPGETTRANSFORMFEEDBACKVARYING
+	gpGetTransformFeedbacki64_v                      C.GPGETTRANSFORMFEEDBACKI64_V
+	gpGetTransformFeedbacki_v                        C.GPGETTRANSFORMFEEDBACKI_V
+	gpGetTransformFeedbackiv                         C.GPGETTRANSFORMFEEDBACKIV
+	gpGetUniformBlockIndex                           C.GPGETUNIFORMBLOCKINDEX
+	gpGetUniformIndices                              C.GPGETUNIFORMINDICES
+	gpGetUniformLocation                             C.GPGETUNIFORMLOCATION
+	gpGetUniformSubroutineuiv                        C.GPGETUNIFORMSUBROUTINEUIV
+	gpGetUniformdv                                   C.GPGETUNIFORMDV
+	gpGetUniformfv                                   C.GPGETUNIFORMFV
+	gpGetUniformi64vARB                              C.GPGETUNIFORMI64VARB
+	gpGetUniformi64vNV                               C.GPGETUNIFORMI64VNV
+	gpGetUniformiv                                   C.GPGETUNIFORMIV
+	gpGetUniformui64vARB                             C.GPGETUNIFORMUI64VARB
+	gpGetUniformui64vNV                              C.GPGETUNIFORMUI64VNV
+	gpGetUniformuiv                                  C.GPGETUNIFORMUIV
+	gpGetVertexArrayIndexed64iv                      C.GPGETVERTEXARRAYINDEXED64IV
+	gpGetVertexArrayIndexediv                        C.GPGETVERTEXARRAYINDEXEDIV
+	gpGetVertexArrayIntegeri_vEXT                    C.GPGETVERTEXARRAYINTEGERI_VEXT
+	gpGetVertexArrayIntegervEXT                      C.GPGETVERTEXARRAYINTEGERVEXT
+	gpGetVertexArrayPointeri_vEXT                    C.GPGETVERTEXARRAYPOINTERI_VEXT
+	gpGetVertexArrayPointervEXT                      C.GPGETVERTEXARRAYPOINTERVEXT
+	gpGetVertexArrayiv                               C.GPGETVERTEXARRAYIV
+	gpGetVertexAttribIiv                             C.GPGETVERTEXATTRIBIIV
+	gpGetVertexAttribIuiv                            C.GPGETVERTEXATTRIBIUIV
+	gpGetVertexAttribLdv                             C.GPGETVERTEXATTRIBLDV
+	gpGetVertexAttribLi64vNV                         C.GPGETVERTEXATTRIBLI64VNV
+	gpGetVertexAttribLui64vARB                       C.GPGETVERTEXATTRIBLUI64VARB
+	gpGetVertexAttribLui64vNV                        C.GPGETVERTEXATTRIBLUI64VNV
+	gpGetVertexAttribPointerv                        C.GPGETVERTEXATTRIBPOINTERV
+	gpGetVertexAttribdv                              C.GPGETVERTEXATTRIBDV
+	gpGetVertexAttribfv                              C.GPGETVERTEXATTRIBFV
+	gpGetVertexAttribiv                              C.GPGETVERTEXATTRIBIV
+	gpGetVkProcAddrNV                                C.GPGETVKPROCADDRNV
+	gpGetnCompressedTexImage                         C.GPGETNCOMPRESSEDTEXIMAGE
+	gpGetnCompressedTexImageARB                      C.GPGETNCOMPRESSEDTEXIMAGEARB
+	gpGetnTexImage                                   C.GPGETNTEXIMAGE
+	gpGetnTexImageARB                                C.GPGETNTEXIMAGEARB
+	gpGetnUniformdv                                  C.GPGETNUNIFORMDV
+	gpGetnUniformdvARB                               C.GPGETNUNIFORMDVARB
+	gpGetnUniformfv                                  C.GPGETNUNIFORMFV
+	gpGetnUniformfvARB                               C.GPGETNUNIFORMFVARB
+	gpGetnUniformfvKHR                               C.GPGETNUNIFORMFVKHR
+	gpGetnUniformi64vARB                             C.GPGETNUNIFORMI64VARB
+	gpGetnUniformiv                                  C.GPGETNUNIFORMIV
+	gpGetnUniformivARB                               C.GPGETNUNIFORMIVARB
+	gpGetnUniformivKHR                               C.GPGETNUNIFORMIVKHR
+	gpGetnUniformui64vARB                            C.GPGETNUNIFORMUI64VARB
+	gpGetnUniformuiv                                 C.GPGETNUNIFORMUIV
+	gpGetnUniformuivARB                              C.GPGETNUNIFORMUIVARB
+	gpGetnUniformuivKHR                              C.GPGETNUNIFORMUIVKHR
+	gpHint                                           C.GPHINT
+	gpIndexFormatNV                                  C.GPINDEXFORMATNV
+	gpInsertEventMarkerEXT                           C.GPINSERTEVENTMARKEREXT
+	gpInterpolatePathsNV                             C.GPINTERPOLATEPATHSNV
+	gpInvalidateBufferData                           C.GPINVALIDATEBUFFERDATA
+	gpInvalidateBufferSubData                        C.GPINVALIDATEBUFFERSUBDATA
+	gpInvalidateFramebuffer                          C.GPINVALIDATEFRAMEBUFFER
+	gpInvalidateNamedFramebufferData                 C.GPINVALIDATENAMEDFRAMEBUFFERDATA
+	gpInvalidateNamedFramebufferSubData              C.GPINVALIDATENAMEDFRAMEBUFFERSUBDATA
+	gpInvalidateSubFramebuffer                       C.GPINVALIDATESUBFRAMEBUFFER
+	gpInvalidateTexImage                             C.GPINVALIDATETEXIMAGE
+	gpInvalidateTexSubImage                          C.GPINVALIDATETEXSUBIMAGE
+	gpIsBuffer                                       C.GPISBUFFER
+	gpIsBufferResidentNV                             C.GPISBUFFERRESIDENTNV
+	gpIsCommandListNV                                C.GPISCOMMANDLISTNV
+	gpIsEnabled                                      C.GPISENABLED
+	gpIsEnabledIndexedEXT                            C.GPISENABLEDINDEXEDEXT
+	gpIsEnabledi                                     C.GPISENABLEDI
+	gpIsFramebuffer                                  C.GPISFRAMEBUFFER
+	gpIsImageHandleResidentARB                       C.GPISIMAGEHANDLERESIDENTARB
+	gpIsImageHandleResidentNV                        C.GPISIMAGEHANDLERESIDENTNV
+	gpIsNamedBufferResidentNV                        C.GPISNAMEDBUFFERRESIDENTNV
+	gpIsNamedStringARB                               C.GPISNAMEDSTRINGARB
+	gpIsPathNV                                       C.GPISPATHNV
+	gpIsPointInFillPathNV                            C.GPISPOINTINFILLPATHNV
+	gpIsPointInStrokePathNV                          C.GPISPOINTINSTROKEPATHNV
+	gpIsProgram                                      C.GPISPROGRAM
+	gpIsProgramPipeline                              C.GPISPROGRAMPIPELINE
+	gpIsProgramPipelineEXT                           C.GPISPROGRAMPIPELINEEXT
+	gpIsQuery                                        C.GPISQUERY
+	gpIsRenderbuffer                                 C.GPISRENDERBUFFER
+	gpIsSampler                                      C.GPISSAMPLER
+	gpIsShader                                       C.GPISSHADER
+	gpIsStateNV                                      C.GPISSTATENV
+	gpIsSync                                         C.GPISSYNC
+	gpIsTexture                                      C.GPISTEXTURE
+	gpIsTextureHandleResidentARB                     C.GPISTEXTUREHANDLERESIDENTARB
+	gpIsTextureHandleResidentNV                      C.GPISTEXTUREHANDLERESIDENTNV
+	gpIsTransformFeedback                            C.GPISTRANSFORMFEEDBACK
+	gpIsVertexArray                                  C.GPISVERTEXARRAY
+	gpLabelObjectEXT                                 C.GPLABELOBJECTEXT
+	gpLineWidth                                      C.GPLINEWIDTH
+	gpLinkProgram                                    C.GPLINKPROGRAM
+	gpListDrawCommandsStatesClientNV                 C.GPLISTDRAWCOMMANDSSTATESCLIENTNV
+	gpLogicOp                                        C.GPLOGICOP
+	gpMakeBufferNonResidentNV                        C.GPMAKEBUFFERNONRESIDENTNV
+	gpMakeBufferResidentNV                           C.GPMAKEBUFFERRESIDENTNV
+	gpMakeImageHandleNonResidentARB                  C.GPMAKEIMAGEHANDLENONRESIDENTARB
+	gpMakeImageHandleNonResidentNV                   C.GPMAKEIMAGEHANDLENONRESIDENTNV
+	gpMakeImageHandleResidentARB                     C.GPMAKEIMAGEHANDLERESIDENTARB
+	gpMakeImageHandleResidentNV                      C.GPMAKEIMAGEHANDLERESIDENTNV
+	gpMakeNamedBufferNonResidentNV                   C.GPMAKENAMEDBUFFERNONRESIDENTNV
+	gpMakeNamedBufferResidentNV                      C.GPMAKENAMEDBUFFERRESIDENTNV
+	gpMakeTextureHandleNonResidentARB                C.GPMAKETEXTUREHANDLENONRESIDENTARB
+	gpMakeTextureHandleNonResidentNV                 C.GPMAKETEXTUREHANDLENONRESIDENTNV
+	gpMakeTextureHandleResidentARB                   C.GPMAKETEXTUREHANDLERESIDENTARB
+	gpMakeTextureHandleResidentNV                    C.GPMAKETEXTUREHANDLERESIDENTNV
+	gpMapBuffer                                      C.GPMAPBUFFER
+	gpMapBufferRange                                 C.GPMAPBUFFERRANGE
+	gpMapNamedBuffer                                 C.GPMAPNAMEDBUFFER
+	gpMapNamedBufferEXT                              C.GPMAPNAMEDBUFFEREXT
+	gpMapNamedBufferRange                            C.GPMAPNAMEDBUFFERRANGE
+	gpMapNamedBufferRangeEXT                         C.GPMAPNAMEDBUFFERRANGEEXT
+	gpMatrixFrustumEXT                               C.GPMATRIXFRUSTUMEXT
+	gpMatrixLoad3x2fNV                               C.GPMATRIXLOAD3X2FNV
+	gpMatrixLoad3x3fNV                               C.GPMATRIXLOAD3X3FNV
+	gpMatrixLoadIdentityEXT                          C.GPMATRIXLOADIDENTITYEXT
+	gpMatrixLoadTranspose3x3fNV                      C.GPMATRIXLOADTRANSPOSE3X3FNV
+	gpMatrixLoadTransposedEXT                        C.GPMATRIXLOADTRANSPOSEDEXT
+	gpMatrixLoadTransposefEXT                        C.GPMATRIXLOADTRANSPOSEFEXT
+	gpMatrixLoaddEXT                                 C.GPMATRIXLOADDEXT
+	gpMatrixLoadfEXT                                 C.GPMATRIXLOADFEXT
+	gpMatrixMult3x2fNV                               C.GPMATRIXMULT3X2FNV
+	gpMatrixMult3x3fNV                               C.GPMATRIXMULT3X3FNV
+	gpMatrixMultTranspose3x3fNV                      C.GPMATRIXMULTTRANSPOSE3X3FNV
+	gpMatrixMultTransposedEXT                        C.GPMATRIXMULTTRANSPOSEDEXT
+	gpMatrixMultTransposefEXT                        C.GPMATRIXMULTTRANSPOSEFEXT
+	gpMatrixMultdEXT                                 C.GPMATRIXMULTDEXT
+	gpMatrixMultfEXT                                 C.GPMATRIXMULTFEXT
+	gpMatrixOrthoEXT                                 C.GPMATRIXORTHOEXT
+	gpMatrixPopEXT                                   C.GPMATRIXPOPEXT
+	gpMatrixPushEXT                                  C.GPMATRIXPUSHEXT
+	gpMatrixRotatedEXT                               C.GPMATRIXROTATEDEXT
+	gpMatrixRotatefEXT                               C.GPMATRIXROTATEFEXT
+	gpMatrixScaledEXT                                C.GPMATRIXSCALEDEXT
+	gpMatrixScalefEXT                                C.GPMATRIXSCALEFEXT
+	gpMatrixTranslatedEXT                            C.GPMATRIXTRANSLATEDEXT
+	gpMatrixTranslatefEXT                            C.GPMATRIXTRANSLATEFEXT
+	gpMaxShaderCompilerThreadsARB                    C.GPMAXSHADERCOMPILERTHREADSARB
+	gpMaxShaderCompilerThreadsKHR                    C.GPMAXSHADERCOMPILERTHREADSKHR
+	gpMemoryBarrier                                  C.GPMEMORYBARRIER
+	gpMemoryBarrierByRegion                          C.GPMEMORYBARRIERBYREGION
+	gpMinSampleShading                               C.GPMINSAMPLESHADING
+	gpMinSampleShadingARB                            C.GPMINSAMPLESHADINGARB
+	gpMultiDrawArrays                                C.GPMULTIDRAWARRAYS
+	gpMultiDrawArraysIndirect                        C.GPMULTIDRAWARRAYSINDIRECT
+	gpMultiDrawArraysIndirectBindlessCountNV         C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawArraysIndirectBindlessNV              C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV
+	gpMultiDrawArraysIndirectCountARB                C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB
+	gpMultiDrawElements                              C.GPMULTIDRAWELEMENTS
+	gpMultiDrawElementsBaseVertex                    C.GPMULTIDRAWELEMENTSBASEVERTEX
+	gpMultiDrawElementsIndirect                      C.GPMULTIDRAWELEMENTSINDIRECT
+	gpMultiDrawElementsIndirectBindlessCountNV       C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV
+	gpMultiDrawElementsIndirectBindlessNV            C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV
+	gpMultiDrawElementsIndirectCountARB              C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB
+	gpMultiTexBufferEXT                              C.GPMULTITEXBUFFEREXT
+	gpMultiTexCoordPointerEXT                        C.GPMULTITEXCOORDPOINTEREXT
+	gpMultiTexEnvfEXT                                C.GPMULTITEXENVFEXT
+	gpMultiTexEnvfvEXT                               C.GPMULTITEXENVFVEXT
+	gpMultiTexEnviEXT                                C.GPMULTITEXENVIEXT
+	gpMultiTexEnvivEXT                               C.GPMULTITEXENVIVEXT
+	gpMultiTexGendEXT                                C.GPMULTITEXGENDEXT
+	gpMultiTexGendvEXT                               C.GPMULTITEXGENDVEXT
+	gpMultiTexGenfEXT                                C.GPMULTITEXGENFEXT
+	gpMultiTexGenfvEXT                               C.GPMULTITEXGENFVEXT
+	gpMultiTexGeniEXT                                C.GPMULTITEXGENIEXT
+	gpMultiTexGenivEXT                               C.GPMULTITEXGENIVEXT
+	gpMultiTexImage1DEXT                             C.GPMULTITEXIMAGE1DEXT
+	gpMultiTexImage2DEXT                             C.GPMULTITEXIMAGE2DEXT
+	gpMultiTexImage3DEXT                             C.GPMULTITEXIMAGE3DEXT
+	gpMultiTexParameterIivEXT                        C.GPMULTITEXPARAMETERIIVEXT
+	gpMultiTexParameterIuivEXT                       C.GPMULTITEXPARAMETERIUIVEXT
+	gpMultiTexParameterfEXT                          C.GPMULTITEXPARAMETERFEXT
+	gpMultiTexParameterfvEXT                         C.GPMULTITEXPARAMETERFVEXT
+	gpMultiTexParameteriEXT                          C.GPMULTITEXPARAMETERIEXT
+	gpMultiTexParameterivEXT                         C.GPMULTITEXPARAMETERIVEXT
+	gpMultiTexRenderbufferEXT                        C.GPMULTITEXRENDERBUFFEREXT
+	gpMultiTexSubImage1DEXT                          C.GPMULTITEXSUBIMAGE1DEXT
+	gpMultiTexSubImage2DEXT                          C.GPMULTITEXSUBIMAGE2DEXT
+	gpMultiTexSubImage3DEXT                          C.GPMULTITEXSUBIMAGE3DEXT
+	gpNamedBufferData                                C.GPNAMEDBUFFERDATA
+	gpNamedBufferDataEXT                             C.GPNAMEDBUFFERDATAEXT
+	gpNamedBufferPageCommitmentARB                   C.GPNAMEDBUFFERPAGECOMMITMENTARB
+	gpNamedBufferPageCommitmentEXT                   C.GPNAMEDBUFFERPAGECOMMITMENTEXT
+	gpNamedBufferStorage                             C.GPNAMEDBUFFERSTORAGE
+	gpNamedBufferStorageEXT                          C.GPNAMEDBUFFERSTORAGEEXT
+	gpNamedBufferSubData                             C.GPNAMEDBUFFERSUBDATA
+	gpNamedBufferSubDataEXT                          C.GPNAMEDBUFFERSUBDATAEXT
+	gpNamedCopyBufferSubDataEXT                      C.GPNAMEDCOPYBUFFERSUBDATAEXT
+	gpNamedFramebufferDrawBuffer                     C.GPNAMEDFRAMEBUFFERDRAWBUFFER
+	gpNamedFramebufferDrawBuffers                    C.GPNAMEDFRAMEBUFFERDRAWBUFFERS
+	gpNamedFramebufferParameteri                     C.GPNAMEDFRAMEBUFFERPARAMETERI
+	gpNamedFramebufferParameteriEXT                  C.GPNAMEDFRAMEBUFFERPARAMETERIEXT
+	gpNamedFramebufferReadBuffer                     C.GPNAMEDFRAMEBUFFERREADBUFFER
+	gpNamedFramebufferRenderbuffer                   C.GPNAMEDFRAMEBUFFERRENDERBUFFER
+	gpNamedFramebufferRenderbufferEXT                C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT
+	gpNamedFramebufferSampleLocationsfvARB           C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB
+	gpNamedFramebufferSampleLocationsfvNV            C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV
+	gpNamedFramebufferTexture                        C.GPNAMEDFRAMEBUFFERTEXTURE
+	gpNamedFramebufferTexture1DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT
+	gpNamedFramebufferTexture2DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT
+	gpNamedFramebufferTexture3DEXT                   C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT
+	gpNamedFramebufferTextureEXT                     C.GPNAMEDFRAMEBUFFERTEXTUREEXT
+	gpNamedFramebufferTextureFaceEXT                 C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT
+	gpNamedFramebufferTextureLayer                   C.GPNAMEDFRAMEBUFFERTEXTURELAYER
+	gpNamedFramebufferTextureLayerEXT                C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT
+	gpNamedProgramLocalParameter4dEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT
+	gpNamedProgramLocalParameter4dvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT
+	gpNamedProgramLocalParameter4fEXT                C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT
+	gpNamedProgramLocalParameter4fvEXT               C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT
+	gpNamedProgramLocalParameterI4iEXT               C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT
+	gpNamedProgramLocalParameterI4ivEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT
+	gpNamedProgramLocalParameterI4uiEXT              C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT
+	gpNamedProgramLocalParameterI4uivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT
+	gpNamedProgramLocalParameters4fvEXT              C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT
+	gpNamedProgramLocalParametersI4ivEXT             C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT
+	gpNamedProgramLocalParametersI4uivEXT            C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT
+	gpNamedProgramStringEXT                          C.GPNAMEDPROGRAMSTRINGEXT
+	gpNamedRenderbufferStorage                       C.GPNAMEDRENDERBUFFERSTORAGE
+	gpNamedRenderbufferStorageEXT                    C.GPNAMEDRENDERBUFFERSTORAGEEXT
+	gpNamedRenderbufferStorageMultisample            C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE
+	gpNamedRenderbufferStorageMultisampleCoverageEXT C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT
+	gpNamedRenderbufferStorageMultisampleEXT         C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT
+	gpNamedStringARB                                 C.GPNAMEDSTRINGARB
+	gpNormalFormatNV                                 C.GPNORMALFORMATNV
+	gpObjectLabel                                    C.GPOBJECTLABEL
+	gpObjectLabelKHR                                 C.GPOBJECTLABELKHR
+	gpObjectPtrLabel                                 C.GPOBJECTPTRLABEL
+	gpObjectPtrLabelKHR                              C.GPOBJECTPTRLABELKHR
+	gpPatchParameterfv                               C.GPPATCHPARAMETERFV
+	gpPatchParameteri                                C.GPPATCHPARAMETERI
+	gpPathCommandsNV                                 C.GPPATHCOMMANDSNV
+	gpPathCoordsNV                                   C.GPPATHCOORDSNV
+	gpPathCoverDepthFuncNV                           C.GPPATHCOVERDEPTHFUNCNV
+	gpPathDashArrayNV                                C.GPPATHDASHARRAYNV
+	gpPathGlyphIndexArrayNV                          C.GPPATHGLYPHINDEXARRAYNV
+	gpPathGlyphIndexRangeNV                          C.GPPATHGLYPHINDEXRANGENV
+	gpPathGlyphRangeNV                               C.GPPATHGLYPHRANGENV
+	gpPathGlyphsNV                                   C.GPPATHGLYPHSNV
+	gpPathMemoryGlyphIndexArrayNV                    C.GPPATHMEMORYGLYPHINDEXARRAYNV
+	gpPathParameterfNV                               C.GPPATHPARAMETERFNV
+	gpPathParameterfvNV                              C.GPPATHPARAMETERFVNV
+	gpPathParameteriNV                               C.GPPATHPARAMETERINV
+	gpPathParameterivNV                              C.GPPATHPARAMETERIVNV
+	gpPathStencilDepthOffsetNV                       C.GPPATHSTENCILDEPTHOFFSETNV
+	gpPathStencilFuncNV                              C.GPPATHSTENCILFUNCNV
+	gpPathStringNV                                   C.GPPATHSTRINGNV
+	gpPathSubCommandsNV                              C.GPPATHSUBCOMMANDSNV
+	gpPathSubCoordsNV                                C.GPPATHSUBCOORDSNV
+	gpPauseTransformFeedback                         C.GPPAUSETRANSFORMFEEDBACK
+	gpPixelStoref                                    C.GPPIXELSTOREF
+	gpPixelStorei                                    C.GPPIXELSTOREI
+	gpPointAlongPathNV                               C.GPPOINTALONGPATHNV
+	gpPointParameterf                                C.GPPOINTPARAMETERF
+	gpPointParameterfv                               C.GPPOINTPARAMETERFV
+	gpPointParameteri                                C.GPPOINTPARAMETERI
+	gpPointParameteriv                               C.GPPOINTPARAMETERIV
+	gpPointSize                                      C.GPPOINTSIZE
+	gpPolygonMode                                    C.GPPOLYGONMODE
+	gpPolygonOffset                                  C.GPPOLYGONOFFSET
+	gpPolygonOffsetClamp                             C.GPPOLYGONOFFSETCLAMP
+	gpPolygonOffsetClampEXT                          C.GPPOLYGONOFFSETCLAMPEXT
+	gpPopDebugGroup                                  C.GPPOPDEBUGGROUP
+	gpPopDebugGroupKHR                               C.GPPOPDEBUGGROUPKHR
+	gpPopGroupMarkerEXT                              C.GPPOPGROUPMARKEREXT
+	gpPrimitiveBoundingBoxARB                        C.GPPRIMITIVEBOUNDINGBOXARB
+	gpPrimitiveRestartIndex                          C.GPPRIMITIVERESTARTINDEX
+	gpProgramBinary                                  C.GPPROGRAMBINARY
+	gpProgramParameteri                              C.GPPROGRAMPARAMETERI
+	gpProgramParameteriARB                           C.GPPROGRAMPARAMETERIARB
+	gpProgramParameteriEXT                           C.GPPROGRAMPARAMETERIEXT
+	gpProgramPathFragmentInputGenNV                  C.GPPROGRAMPATHFRAGMENTINPUTGENNV
+	gpProgramUniform1d                               C.GPPROGRAMUNIFORM1D
+	gpProgramUniform1dEXT                            C.GPPROGRAMUNIFORM1DEXT
+	gpProgramUniform1dv                              C.GPPROGRAMUNIFORM1DV
+	gpProgramUniform1dvEXT                           C.GPPROGRAMUNIFORM1DVEXT
+	gpProgramUniform1f                               C.GPPROGRAMUNIFORM1F
+	gpProgramUniform1fEXT                            C.GPPROGRAMUNIFORM1FEXT
+	gpProgramUniform1fv                              C.GPPROGRAMUNIFORM1FV
+	gpProgramUniform1fvEXT                           C.GPPROGRAMUNIFORM1FVEXT
+	gpProgramUniform1i                               C.GPPROGRAMUNIFORM1I
+	gpProgramUniform1i64ARB                          C.GPPROGRAMUNIFORM1I64ARB
+	gpProgramUniform1i64NV                           C.GPPROGRAMUNIFORM1I64NV
+	gpProgramUniform1i64vARB                         C.GPPROGRAMUNIFORM1I64VARB
+	gpProgramUniform1i64vNV                          C.GPPROGRAMUNIFORM1I64VNV
+	gpProgramUniform1iEXT                            C.GPPROGRAMUNIFORM1IEXT
+	gpProgramUniform1iv                              C.GPPROGRAMUNIFORM1IV
+	gpProgramUniform1ivEXT                           C.GPPROGRAMUNIFORM1IVEXT
+	gpProgramUniform1ui                              C.GPPROGRAMUNIFORM1UI
+	gpProgramUniform1ui64ARB                         C.GPPROGRAMUNIFORM1UI64ARB
+	gpProgramUniform1ui64NV                          C.GPPROGRAMUNIFORM1UI64NV
+	gpProgramUniform1ui64vARB                        C.GPPROGRAMUNIFORM1UI64VARB
+	gpProgramUniform1ui64vNV                         C.GPPROGRAMUNIFORM1UI64VNV
+	gpProgramUniform1uiEXT                           C.GPPROGRAMUNIFORM1UIEXT
+	gpProgramUniform1uiv                             C.GPPROGRAMUNIFORM1UIV
+	gpProgramUniform1uivEXT                          C.GPPROGRAMUNIFORM1UIVEXT
+	gpProgramUniform2d                               C.GPPROGRAMUNIFORM2D
+	gpProgramUniform2dEXT                            C.GPPROGRAMUNIFORM2DEXT
+	gpProgramUniform2dv                              C.GPPROGRAMUNIFORM2DV
+	gpProgramUniform2dvEXT                           C.GPPROGRAMUNIFORM2DVEXT
+	gpProgramUniform2f                               C.GPPROGRAMUNIFORM2F
+	gpProgramUniform2fEXT                            C.GPPROGRAMUNIFORM2FEXT
+	gpProgramUniform2fv                              C.GPPROGRAMUNIFORM2FV
+	gpProgramUniform2fvEXT                           C.GPPROGRAMUNIFORM2FVEXT
+	gpProgramUniform2i                               C.GPPROGRAMUNIFORM2I
+	gpProgramUniform2i64ARB                          C.GPPROGRAMUNIFORM2I64ARB
+	gpProgramUniform2i64NV                           C.GPPROGRAMUNIFORM2I64NV
+	gpProgramUniform2i64vARB                         C.GPPROGRAMUNIFORM2I64VARB
+	gpProgramUniform2i64vNV                          C.GPPROGRAMUNIFORM2I64VNV
+	gpProgramUniform2iEXT                            C.GPPROGRAMUNIFORM2IEXT
+	gpProgramUniform2iv                              C.GPPROGRAMUNIFORM2IV
+	gpProgramUniform2ivEXT                           C.GPPROGRAMUNIFORM2IVEXT
+	gpProgramUniform2ui                              C.GPPROGRAMUNIFORM2UI
+	gpProgramUniform2ui64ARB                         C.GPPROGRAMUNIFORM2UI64ARB
+	gpProgramUniform2ui64NV                          C.GPPROGRAMUNIFORM2UI64NV
+	gpProgramUniform2ui64vARB                        C.GPPROGRAMUNIFORM2UI64VARB
+	gpProgramUniform2ui64vNV                         C.GPPROGRAMUNIFORM2UI64VNV
+	gpProgramUniform2uiEXT                           C.GPPROGRAMUNIFORM2UIEXT
+	gpProgramUniform2uiv                             C.GPPROGRAMUNIFORM2UIV
+	gpProgramUniform2uivEXT                          C.GPPROGRAMUNIFORM2UIVEXT
+	gpProgramUniform3d                               C.GPPROGRAMUNIFORM3D
+	gpProgramUniform3dEXT                            C.GPPROGRAMUNIFORM3DEXT
+	gpProgramUniform3dv                              C.GPPROGRAMUNIFORM3DV
+	gpProgramUniform3dvEXT                           C.GPPROGRAMUNIFORM3DVEXT
+	gpProgramUniform3f                               C.GPPROGRAMUNIFORM3F
+	gpProgramUniform3fEXT                            C.GPPROGRAMUNIFORM3FEXT
+	gpProgramUniform3fv                              C.GPPROGRAMUNIFORM3FV
+	gpProgramUniform3fvEXT                           C.GPPROGRAMUNIFORM3FVEXT
+	gpProgramUniform3i                               C.GPPROGRAMUNIFORM3I
+	gpProgramUniform3i64ARB                          C.GPPROGRAMUNIFORM3I64ARB
+	gpProgramUniform3i64NV                           C.GPPROGRAMUNIFORM3I64NV
+	gpProgramUniform3i64vARB                         C.GPPROGRAMUNIFORM3I64VARB
+	gpProgramUniform3i64vNV                          C.GPPROGRAMUNIFORM3I64VNV
+	gpProgramUniform3iEXT                            C.GPPROGRAMUNIFORM3IEXT
+	gpProgramUniform3iv                              C.GPPROGRAMUNIFORM3IV
+	gpProgramUniform3ivEXT                           C.GPPROGRAMUNIFORM3IVEXT
+	gpProgramUniform3ui                              C.GPPROGRAMUNIFORM3UI
+	gpProgramUniform3ui64ARB                         C.GPPROGRAMUNIFORM3UI64ARB
+	gpProgramUniform3ui64NV                          C.GPPROGRAMUNIFORM3UI64NV
+	gpProgramUniform3ui64vARB                        C.GPPROGRAMUNIFORM3UI64VARB
+	gpProgramUniform3ui64vNV                         C.GPPROGRAMUNIFORM3UI64VNV
+	gpProgramUniform3uiEXT                           C.GPPROGRAMUNIFORM3UIEXT
+	gpProgramUniform3uiv                             C.GPPROGRAMUNIFORM3UIV
+	gpProgramUniform3uivEXT                          C.GPPROGRAMUNIFORM3UIVEXT
+	gpProgramUniform4d                               C.GPPROGRAMUNIFORM4D
+	gpProgramUniform4dEXT                            C.GPPROGRAMUNIFORM4DEXT
+	gpProgramUniform4dv                              C.GPPROGRAMUNIFORM4DV
+	gpProgramUniform4dvEXT                           C.GPPROGRAMUNIFORM4DVEXT
+	gpProgramUniform4f                               C.GPPROGRAMUNIFORM4F
+	gpProgramUniform4fEXT                            C.GPPROGRAMUNIFORM4FEXT
+	gpProgramUniform4fv                              C.GPPROGRAMUNIFORM4FV
+	gpProgramUniform4fvEXT                           C.GPPROGRAMUNIFORM4FVEXT
+	gpProgramUniform4i                               C.GPPROGRAMUNIFORM4I
+	gpProgramUniform4i64ARB                          C.GPPROGRAMUNIFORM4I64ARB
+	gpProgramUniform4i64NV                           C.GPPROGRAMUNIFORM4I64NV
+	gpProgramUniform4i64vARB                         C.GPPROGRAMUNIFORM4I64VARB
+	gpProgramUniform4i64vNV                          C.GPPROGRAMUNIFORM4I64VNV
+	gpProgramUniform4iEXT                            C.GPPROGRAMUNIFORM4IEXT
+	gpProgramUniform4iv                              C.GPPROGRAMUNIFORM4IV
+	gpProgramUniform4ivEXT                           C.GPPROGRAMUNIFORM4IVEXT
+	gpProgramUniform4ui                              C.GPPROGRAMUNIFORM4UI
+	gpProgramUniform4ui64ARB                         C.GPPROGRAMUNIFORM4UI64ARB
+	gpProgramUniform4ui64NV                          C.GPPROGRAMUNIFORM4UI64NV
+	gpProgramUniform4ui64vARB                        C.GPPROGRAMUNIFORM4UI64VARB
+	gpProgramUniform4ui64vNV                         C.GPPROGRAMUNIFORM4UI64VNV
+	gpProgramUniform4uiEXT                           C.GPPROGRAMUNIFORM4UIEXT
+	gpProgramUniform4uiv                             C.GPPROGRAMUNIFORM4UIV
+	gpProgramUniform4uivEXT                          C.GPPROGRAMUNIFORM4UIVEXT
+	gpProgramUniformHandleui64ARB                    C.GPPROGRAMUNIFORMHANDLEUI64ARB
+	gpProgramUniformHandleui64NV                     C.GPPROGRAMUNIFORMHANDLEUI64NV
+	gpProgramUniformHandleui64vARB                   C.GPPROGRAMUNIFORMHANDLEUI64VARB
+	gpProgramUniformHandleui64vNV                    C.GPPROGRAMUNIFORMHANDLEUI64VNV
+	gpProgramUniformMatrix2dv                        C.GPPROGRAMUNIFORMMATRIX2DV
+	gpProgramUniformMatrix2dvEXT                     C.GPPROGRAMUNIFORMMATRIX2DVEXT
+	gpProgramUniformMatrix2fv                        C.GPPROGRAMUNIFORMMATRIX2FV
+	gpProgramUniformMatrix2fvEXT                     C.GPPROGRAMUNIFORMMATRIX2FVEXT
+	gpProgramUniformMatrix2x3dv                      C.GPPROGRAMUNIFORMMATRIX2X3DV
+	gpProgramUniformMatrix2x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3DVEXT
+	gpProgramUniformMatrix2x3fv                      C.GPPROGRAMUNIFORMMATRIX2X3FV
+	gpProgramUniformMatrix2x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X3FVEXT
+	gpProgramUniformMatrix2x4dv                      C.GPPROGRAMUNIFORMMATRIX2X4DV
+	gpProgramUniformMatrix2x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4DVEXT
+	gpProgramUniformMatrix2x4fv                      C.GPPROGRAMUNIFORMMATRIX2X4FV
+	gpProgramUniformMatrix2x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX2X4FVEXT
+	gpProgramUniformMatrix3dv                        C.GPPROGRAMUNIFORMMATRIX3DV
+	gpProgramUniformMatrix3dvEXT                     C.GPPROGRAMUNIFORMMATRIX3DVEXT
+	gpProgramUniformMatrix3fv                        C.GPPROGRAMUNIFORMMATRIX3FV
+	gpProgramUniformMatrix3fvEXT                     C.GPPROGRAMUNIFORMMATRIX3FVEXT
+	gpProgramUniformMatrix3x2dv                      C.GPPROGRAMUNIFORMMATRIX3X2DV
+	gpProgramUniformMatrix3x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2DVEXT
+	gpProgramUniformMatrix3x2fv                      C.GPPROGRAMUNIFORMMATRIX3X2FV
+	gpProgramUniformMatrix3x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X2FVEXT
+	gpProgramUniformMatrix3x4dv                      C.GPPROGRAMUNIFORMMATRIX3X4DV
+	gpProgramUniformMatrix3x4dvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4DVEXT
+	gpProgramUniformMatrix3x4fv                      C.GPPROGRAMUNIFORMMATRIX3X4FV
+	gpProgramUniformMatrix3x4fvEXT                   C.GPPROGRAMUNIFORMMATRIX3X4FVEXT
+	gpProgramUniformMatrix4dv                        C.GPPROGRAMUNIFORMMATRIX4DV
+	gpProgramUniformMatrix4dvEXT                     C.GPPROGRAMUNIFORMMATRIX4DVEXT
+	gpProgramUniformMatrix4fv                        C.GPPROGRAMUNIFORMMATRIX4FV
+	gpProgramUniformMatrix4fvEXT                     C.GPPROGRAMUNIFORMMATRIX4FVEXT
+	gpProgramUniformMatrix4x2dv                      C.GPPROGRAMUNIFORMMATRIX4X2DV
+	gpProgramUniformMatrix4x2dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2DVEXT
+	gpProgramUniformMatrix4x2fv                      C.GPPROGRAMUNIFORMMATRIX4X2FV
+	gpProgramUniformMatrix4x2fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X2FVEXT
+	gpProgramUniformMatrix4x3dv                      C.GPPROGRAMUNIFORMMATRIX4X3DV
+	gpProgramUniformMatrix4x3dvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3DVEXT
+	gpProgramUniformMatrix4x3fv                      C.GPPROGRAMUNIFORMMATRIX4X3FV
+	gpProgramUniformMatrix4x3fvEXT                   C.GPPROGRAMUNIFORMMATRIX4X3FVEXT
+	gpProgramUniformui64NV                           C.GPPROGRAMUNIFORMUI64NV
+	gpProgramUniformui64vNV                          C.GPPROGRAMUNIFORMUI64VNV
+	gpProvokingVertex                                C.GPPROVOKINGVERTEX
+	gpPushClientAttribDefaultEXT                     C.GPPUSHCLIENTATTRIBDEFAULTEXT
+	gpPushDebugGroup                                 C.GPPUSHDEBUGGROUP
+	gpPushDebugGroupKHR                              C.GPPUSHDEBUGGROUPKHR
+	gpPushGroupMarkerEXT                             C.GPPUSHGROUPMARKEREXT
+	gpQueryCounter                                   C.GPQUERYCOUNTER
+	gpRasterSamplesEXT                               C.GPRASTERSAMPLESEXT
+	gpReadBuffer                                     C.GPREADBUFFER
+	gpReadPixels                                     C.GPREADPIXELS
+	gpReadnPixels                                    C.GPREADNPIXELS
+	gpReadnPixelsARB                                 C.GPREADNPIXELSARB
+	gpReadnPixelsKHR                                 C.GPREADNPIXELSKHR
+	gpReleaseShaderCompiler                          C.GPRELEASESHADERCOMPILER
+	gpRenderbufferStorage                            C.GPRENDERBUFFERSTORAGE
+	gpRenderbufferStorageMultisample                 C.GPRENDERBUFFERSTORAGEMULTISAMPLE
+	gpRenderbufferStorageMultisampleCoverageNV       C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV
+	gpResolveDepthValuesNV                           C.GPRESOLVEDEPTHVALUESNV
+	gpResumeTransformFeedback                        C.GPRESUMETRANSFORMFEEDBACK
+	gpSampleCoverage                                 C.GPSAMPLECOVERAGE
+	gpSampleMaski                                    C.GPSAMPLEMASKI
+	gpSamplerParameterIiv                            C.GPSAMPLERPARAMETERIIV
+	gpSamplerParameterIuiv                           C.GPSAMPLERPARAMETERIUIV
+	gpSamplerParameterf                              C.GPSAMPLERPARAMETERF
+	gpSamplerParameterfv                             C.GPSAMPLERPARAMETERFV
+	gpSamplerParameteri                              C.GPSAMPLERPARAMETERI
+	gpSamplerParameteriv                             C.GPSAMPLERPARAMETERIV
+	gpScissor                                        C.GPSCISSOR
+	gpScissorArrayv                                  C.GPSCISSORARRAYV
+	gpScissorIndexed                                 C.GPSCISSORINDEXED
+	gpScissorIndexedv                                C.GPSCISSORINDEXEDV
+	gpSecondaryColorFormatNV                         C.GPSECONDARYCOLORFORMATNV
+	gpSelectPerfMonitorCountersAMD                   C.GPSELECTPERFMONITORCOUNTERSAMD
+	gpShaderBinary                                   C.GPSHADERBINARY
+	gpShaderSource                                   C.GPSHADERSOURCE
+	gpShaderStorageBlockBinding                      C.GPSHADERSTORAGEBLOCKBINDING
+	gpSignalVkFenceNV                                C.GPSIGNALVKFENCENV
+	gpSignalVkSemaphoreNV                            C.GPSIGNALVKSEMAPHORENV
+	gpSpecializeShaderARB                            C.GPSPECIALIZESHADERARB
+	gpStateCaptureNV                                 C.GPSTATECAPTURENV
+	gpStencilFillPathInstancedNV                     C.GPSTENCILFILLPATHINSTANCEDNV
+	gpStencilFillPathNV                              C.GPSTENCILFILLPATHNV
+	gpStencilFunc                                    C.GPSTENCILFUNC
+	gpStencilFuncSeparate                            C.GPSTENCILFUNCSEPARATE
+	gpStencilMask                                    C.GPSTENCILMASK
+	gpStencilMaskSeparate                            C.GPSTENCILMASKSEPARATE
+	gpStencilOp                                      C.GPSTENCILOP
+	gpStencilOpSeparate                              C.GPSTENCILOPSEPARATE
+	gpStencilStrokePathInstancedNV                   C.GPSTENCILSTROKEPATHINSTANCEDNV
+	gpStencilStrokePathNV                            C.GPSTENCILSTROKEPATHNV
+	gpStencilThenCoverFillPathInstancedNV            C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV
+	gpStencilThenCoverFillPathNV                     C.GPSTENCILTHENCOVERFILLPATHNV
+	gpStencilThenCoverStrokePathInstancedNV          C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV
+	gpStencilThenCoverStrokePathNV                   C.GPSTENCILTHENCOVERSTROKEPATHNV
+	gpSubpixelPrecisionBiasNV                        C.GPSUBPIXELPRECISIONBIASNV
+	gpTexBuffer                                      C.GPTEXBUFFER
+	gpTexBufferARB                                   C.GPTEXBUFFERARB
+	gpTexBufferRange                                 C.GPTEXBUFFERRANGE
+	gpTexCoordFormatNV                               C.GPTEXCOORDFORMATNV
+	gpTexImage1D                                     C.GPTEXIMAGE1D
+	gpTexImage2D                                     C.GPTEXIMAGE2D
+	gpTexImage2DMultisample                          C.GPTEXIMAGE2DMULTISAMPLE
+	gpTexImage3D                                     C.GPTEXIMAGE3D
+	gpTexImage3DMultisample                          C.GPTEXIMAGE3DMULTISAMPLE
+	gpTexPageCommitmentARB                           C.GPTEXPAGECOMMITMENTARB
+	gpTexParameterIiv                                C.GPTEXPARAMETERIIV
+	gpTexParameterIuiv                               C.GPTEXPARAMETERIUIV
+	gpTexParameterf                                  C.GPTEXPARAMETERF
+	gpTexParameterfv                                 C.GPTEXPARAMETERFV
+	gpTexParameteri                                  C.GPTEXPARAMETERI
+	gpTexParameteriv                                 C.GPTEXPARAMETERIV
+	gpTexStorage1D                                   C.GPTEXSTORAGE1D
+	gpTexStorage2D                                   C.GPTEXSTORAGE2D
+	gpTexStorage2DMultisample                        C.GPTEXSTORAGE2DMULTISAMPLE
+	gpTexStorage3D                                   C.GPTEXSTORAGE3D
+	gpTexStorage3DMultisample                        C.GPTEXSTORAGE3DMULTISAMPLE
+	gpTexSubImage1D                                  C.GPTEXSUBIMAGE1D
+	gpTexSubImage2D                                  C.GPTEXSUBIMAGE2D
+	gpTexSubImage3D                                  C.GPTEXSUBIMAGE3D
+	gpTextureBarrier                                 C.GPTEXTUREBARRIER
+	gpTextureBarrierNV                               C.GPTEXTUREBARRIERNV
+	gpTextureBuffer                                  C.GPTEXTUREBUFFER
+	gpTextureBufferEXT                               C.GPTEXTUREBUFFEREXT
+	gpTextureBufferRange                             C.GPTEXTUREBUFFERRANGE
+	gpTextureBufferRangeEXT                          C.GPTEXTUREBUFFERRANGEEXT
+	gpTextureImage1DEXT                              C.GPTEXTUREIMAGE1DEXT
+	gpTextureImage2DEXT                              C.GPTEXTUREIMAGE2DEXT
+	gpTextureImage3DEXT                              C.GPTEXTUREIMAGE3DEXT
+	gpTexturePageCommitmentEXT                       C.GPTEXTUREPAGECOMMITMENTEXT
+	gpTextureParameterIiv                            C.GPTEXTUREPARAMETERIIV
+	gpTextureParameterIivEXT                         C.GPTEXTUREPARAMETERIIVEXT
+	gpTextureParameterIuiv                           C.GPTEXTUREPARAMETERIUIV
+	gpTextureParameterIuivEXT                        C.GPTEXTUREPARAMETERIUIVEXT
+	gpTextureParameterf                              C.GPTEXTUREPARAMETERF
+	gpTextureParameterfEXT                           C.GPTEXTUREPARAMETERFEXT
+	gpTextureParameterfv                             C.GPTEXTUREPARAMETERFV
+	gpTextureParameterfvEXT                          C.GPTEXTUREPARAMETERFVEXT
+	gpTextureParameteri                              C.GPTEXTUREPARAMETERI
+	gpTextureParameteriEXT                           C.GPTEXTUREPARAMETERIEXT
+	gpTextureParameteriv                             C.GPTEXTUREPARAMETERIV
+	gpTextureParameterivEXT                          C.GPTEXTUREPARAMETERIVEXT
+	gpTextureRenderbufferEXT                         C.GPTEXTURERENDERBUFFEREXT
+	gpTextureStorage1D                               C.GPTEXTURESTORAGE1D
+	gpTextureStorage1DEXT                            C.GPTEXTURESTORAGE1DEXT
+	gpTextureStorage2D                               C.GPTEXTURESTORAGE2D
+	gpTextureStorage2DEXT                            C.GPTEXTURESTORAGE2DEXT
+	gpTextureStorage2DMultisample                    C.GPTEXTURESTORAGE2DMULTISAMPLE
+	gpTextureStorage2DMultisampleEXT                 C.GPTEXTURESTORAGE2DMULTISAMPLEEXT
+	gpTextureStorage3D                               C.GPTEXTURESTORAGE3D
+	gpTextureStorage3DEXT                            C.GPTEXTURESTORAGE3DEXT
+	gpTextureStorage3DMultisample                    C.GPTEXTURESTORAGE3DMULTISAMPLE
+	gpTextureStorage3DMultisampleEXT                 C.GPTEXTURESTORAGE3DMULTISAMPLEEXT
+	gpTextureSubImage1D                              C.GPTEXTURESUBIMAGE1D
+	gpTextureSubImage1DEXT                           C.GPTEXTURESUBIMAGE1DEXT
+	gpTextureSubImage2D                              C.GPTEXTURESUBIMAGE2D
+	gpTextureSubImage2DEXT                           C.GPTEXTURESUBIMAGE2DEXT
+	gpTextureSubImage3D                              C.GPTEXTURESUBIMAGE3D
+	gpTextureSubImage3DEXT                           C.GPTEXTURESUBIMAGE3DEXT
+	gpTextureView                                    C.GPTEXTUREVIEW
+	gpTransformFeedbackBufferBase                    C.GPTRANSFORMFEEDBACKBUFFERBASE
+	gpTransformFeedbackBufferRange                   C.GPTRANSFORMFEEDBACKBUFFERRANGE
+	gpTransformFeedbackVaryings                      C.GPTRANSFORMFEEDBACKVARYINGS
+	gpTransformPathNV                                C.GPTRANSFORMPATHNV
+	gpUniform1d                                      C.GPUNIFORM1D
+	gpUniform1dv                                     C.GPUNIFORM1DV
+	gpUniform1f                                      C.GPUNIFORM1F
+	gpUniform1fv                                     C.GPUNIFORM1FV
+	gpUniform1i                                      C.GPUNIFORM1I
+	gpUniform1i64ARB                                 C.GPUNIFORM1I64ARB
+	gpUniform1i64NV                                  C.GPUNIFORM1I64NV
+	gpUniform1i64vARB                                C.GPUNIFORM1I64VARB
+	gpUniform1i64vNV                                 C.GPUNIFORM1I64VNV
+	gpUniform1iv                                     C.GPUNIFORM1IV
+	gpUniform1ui                                     C.GPUNIFORM1UI
+	gpUniform1ui64ARB                                C.GPUNIFORM1UI64ARB
+	gpUniform1ui64NV                                 C.GPUNIFORM1UI64NV
+	gpUniform1ui64vARB                               C.GPUNIFORM1UI64VARB
+	gpUniform1ui64vNV                                C.GPUNIFORM1UI64VNV
+	gpUniform1uiv                                    C.GPUNIFORM1UIV
+	gpUniform2d                                      C.GPUNIFORM2D
+	gpUniform2dv                                     C.GPUNIFORM2DV
+	gpUniform2f                                      C.GPUNIFORM2F
+	gpUniform2fv                                     C.GPUNIFORM2FV
+	gpUniform2i                                      C.GPUNIFORM2I
+	gpUniform2i64ARB                                 C.GPUNIFORM2I64ARB
+	gpUniform2i64NV                                  C.GPUNIFORM2I64NV
+	gpUniform2i64vARB                                C.GPUNIFORM2I64VARB
+	gpUniform2i64vNV                                 C.GPUNIFORM2I64VNV
+	gpUniform2iv                                     C.GPUNIFORM2IV
+	gpUniform2ui                                     C.GPUNIFORM2UI
+	gpUniform2ui64ARB                                C.GPUNIFORM2UI64ARB
+	gpUniform2ui64NV                                 C.GPUNIFORM2UI64NV
+	gpUniform2ui64vARB                               C.GPUNIFORM2UI64VARB
+	gpUniform2ui64vNV                                C.GPUNIFORM2UI64VNV
+	gpUniform2uiv                                    C.GPUNIFORM2UIV
+	gpUniform3d                                      C.GPUNIFORM3D
+	gpUniform3dv                                     C.GPUNIFORM3DV
+	gpUniform3f                                      C.GPUNIFORM3F
+	gpUniform3fv                                     C.GPUNIFORM3FV
+	gpUniform3i                                      C.GPUNIFORM3I
+	gpUniform3i64ARB                                 C.GPUNIFORM3I64ARB
+	gpUniform3i64NV                                  C.GPUNIFORM3I64NV
+	gpUniform3i64vARB                                C.GPUNIFORM3I64VARB
+	gpUniform3i64vNV                                 C.GPUNIFORM3I64VNV
+	gpUniform3iv                                     C.GPUNIFORM3IV
+	gpUniform3ui                                     C.GPUNIFORM3UI
+	gpUniform3ui64ARB                                C.GPUNIFORM3UI64ARB
+	gpUniform3ui64NV                                 C.GPUNIFORM3UI64NV
+	gpUniform3ui64vARB                               C.GPUNIFORM3UI64VARB
+	gpUniform3ui64vNV                                C.GPUNIFORM3UI64VNV
+	gpUniform3uiv                                    C.GPUNIFORM3UIV
+	gpUniform4d                                      C.GPUNIFORM4D
+	gpUniform4dv                                     C.GPUNIFORM4DV
+	gpUniform4f                                      C.GPUNIFORM4F
+	gpUniform4fv                                     C.GPUNIFORM4FV
+	gpUniform4i                                      C.GPUNIFORM4I
+	gpUniform4i64ARB                                 C.GPUNIFORM4I64ARB
+	gpUniform4i64NV                                  C.GPUNIFORM4I64NV
+	gpUniform4i64vARB                                C.GPUNIFORM4I64VARB
+	gpUniform4i64vNV                                 C.GPUNIFORM4I64VNV
+	gpUniform4iv                                     C.GPUNIFORM4IV
+	gpUniform4ui                                     C.GPUNIFORM4UI
+	gpUniform4ui64ARB                                C.GPUNIFORM4UI64ARB
+	gpUniform4ui64NV                                 C.GPUNIFORM4UI64NV
+	gpUniform4ui64vARB                               C.GPUNIFORM4UI64VARB
+	gpUniform4ui64vNV                                C.GPUNIFORM4UI64VNV
+	gpUniform4uiv                                    C.GPUNIFORM4UIV
+	gpUniformBlockBinding                            C.GPUNIFORMBLOCKBINDING
+	gpUniformHandleui64ARB                           C.GPUNIFORMHANDLEUI64ARB
+	gpUniformHandleui64NV                            C.GPUNIFORMHANDLEUI64NV
+	gpUniformHandleui64vARB                          C.GPUNIFORMHANDLEUI64VARB
+	gpUniformHandleui64vNV                           C.GPUNIFORMHANDLEUI64VNV
+	gpUniformMatrix2dv                               C.GPUNIFORMMATRIX2DV
+	gpUniformMatrix2fv                               C.GPUNIFORMMATRIX2FV
+	gpUniformMatrix2x3dv                             C.GPUNIFORMMATRIX2X3DV
+	gpUniformMatrix2x3fv                             C.GPUNIFORMMATRIX2X3FV
+	gpUniformMatrix2x4dv                             C.GPUNIFORMMATRIX2X4DV
+	gpUniformMatrix2x4fv                             C.GPUNIFORMMATRIX2X4FV
+	gpUniformMatrix3dv                               C.GPUNIFORMMATRIX3DV
+	gpUniformMatrix3fv                               C.GPUNIFORMMATRIX3FV
+	gpUniformMatrix3x2dv                             C.GPUNIFORMMATRIX3X2DV
+	gpUniformMatrix3x2fv                             C.GPUNIFORMMATRIX3X2FV
+	gpUniformMatrix3x4dv                             C.GPUNIFORMMATRIX3X4DV
+	gpUniformMatrix3x4fv                             C.GPUNIFORMMATRIX3X4FV
+	gpUniformMatrix4dv                               C.GPUNIFORMMATRIX4DV
+	gpUniformMatrix4fv                               C.GPUNIFORMMATRIX4FV
+	gpUniformMatrix4x2dv                             C.GPUNIFORMMATRIX4X2DV
+	gpUniformMatrix4x2fv                             C.GPUNIFORMMATRIX4X2FV
+	gpUniformMatrix4x3dv                             C.GPUNIFORMMATRIX4X3DV
+	gpUniformMatrix4x3fv                             C.GPUNIFORMMATRIX4X3FV
+	gpUniformSubroutinesuiv                          C.GPUNIFORMSUBROUTINESUIV
+	gpUniformui64NV                                  C.GPUNIFORMUI64NV
+	gpUniformui64vNV                                 C.GPUNIFORMUI64VNV
+	gpUnmapBuffer                                    C.GPUNMAPBUFFER
+	gpUnmapNamedBuffer                               C.GPUNMAPNAMEDBUFFER
+	gpUnmapNamedBufferEXT                            C.GPUNMAPNAMEDBUFFEREXT
+	gpUseProgram                                     C.GPUSEPROGRAM
+	gpUseProgramStages                               C.GPUSEPROGRAMSTAGES
+	gpUseProgramStagesEXT                            C.GPUSEPROGRAMSTAGESEXT
+	gpUseShaderProgramEXT                            C.GPUSESHADERPROGRAMEXT
+	gpValidateProgram                                C.GPVALIDATEPROGRAM
+	gpValidateProgramPipeline                        C.GPVALIDATEPROGRAMPIPELINE
+	gpValidateProgramPipelineEXT                     C.GPVALIDATEPROGRAMPIPELINEEXT
+	gpVertexArrayAttribBinding                       C.GPVERTEXARRAYATTRIBBINDING
+	gpVertexArrayAttribFormat                        C.GPVERTEXARRAYATTRIBFORMAT
+	gpVertexArrayAttribIFormat                       C.GPVERTEXARRAYATTRIBIFORMAT
+	gpVertexArrayAttribLFormat                       C.GPVERTEXARRAYATTRIBLFORMAT
+	gpVertexArrayBindVertexBufferEXT                 C.GPVERTEXARRAYBINDVERTEXBUFFEREXT
+	gpVertexArrayBindingDivisor                      C.GPVERTEXARRAYBINDINGDIVISOR
+	gpVertexArrayColorOffsetEXT                      C.GPVERTEXARRAYCOLOROFFSETEXT
+	gpVertexArrayEdgeFlagOffsetEXT                   C.GPVERTEXARRAYEDGEFLAGOFFSETEXT
+	gpVertexArrayElementBuffer                       C.GPVERTEXARRAYELEMENTBUFFER
+	gpVertexArrayFogCoordOffsetEXT                   C.GPVERTEXARRAYFOGCOORDOFFSETEXT
+	gpVertexArrayIndexOffsetEXT                      C.GPVERTEXARRAYINDEXOFFSETEXT
+	gpVertexArrayMultiTexCoordOffsetEXT              C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT
+	gpVertexArrayNormalOffsetEXT                     C.GPVERTEXARRAYNORMALOFFSETEXT
+	gpVertexArraySecondaryColorOffsetEXT             C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT
+	gpVertexArrayTexCoordOffsetEXT                   C.GPVERTEXARRAYTEXCOORDOFFSETEXT
+	gpVertexArrayVertexAttribBindingEXT              C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT
+	gpVertexArrayVertexAttribDivisorEXT              C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT
+	gpVertexArrayVertexAttribFormatEXT               C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT
+	gpVertexArrayVertexAttribIFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT
+	gpVertexArrayVertexAttribIOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT
+	gpVertexArrayVertexAttribLFormatEXT              C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT
+	gpVertexArrayVertexAttribLOffsetEXT              C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT
+	gpVertexArrayVertexAttribOffsetEXT               C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT
+	gpVertexArrayVertexBindingDivisorEXT             C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT
+	gpVertexArrayVertexBuffer                        C.GPVERTEXARRAYVERTEXBUFFER
+	gpVertexArrayVertexBuffers                       C.GPVERTEXARRAYVERTEXBUFFERS
+	gpVertexArrayVertexOffsetEXT                     C.GPVERTEXARRAYVERTEXOFFSETEXT
+	gpVertexAttrib1d                                 C.GPVERTEXATTRIB1D
+	gpVertexAttrib1dv                                C.GPVERTEXATTRIB1DV
+	gpVertexAttrib1f                                 C.GPVERTEXATTRIB1F
+	gpVertexAttrib1fv                                C.GPVERTEXATTRIB1FV
+	gpVertexAttrib1s                                 C.GPVERTEXATTRIB1S
+	gpVertexAttrib1sv                                C.GPVERTEXATTRIB1SV
+	gpVertexAttrib2d                                 C.GPVERTEXATTRIB2D
+	gpVertexAttrib2dv                                C.GPVERTEXATTRIB2DV
+	gpVertexAttrib2f                                 C.GPVERTEXATTRIB2F
+	gpVertexAttrib2fv                                C.GPVERTEXATTRIB2FV
+	gpVertexAttrib2s                                 C.GPVERTEXATTRIB2S
+	gpVertexAttrib2sv                                C.GPVERTEXATTRIB2SV
+	gpVertexAttrib3d                                 C.GPVERTEXATTRIB3D
+	gpVertexAttrib3dv                                C.GPVERTEXATTRIB3DV
+	gpVertexAttrib3f                                 C.GPVERTEXATTRIB3F
+	gpVertexAttrib3fv                                C.GPVERTEXATTRIB3FV
+	gpVertexAttrib3s                                 C.GPVERTEXATTRIB3S
+	gpVertexAttrib3sv                                C.GPVERTEXATTRIB3SV
+	gpVertexAttrib4Nbv                               C.GPVERTEXATTRIB4NBV
+	gpVertexAttrib4Niv                               C.GPVERTEXATTRIB4NIV
+	gpVertexAttrib4Nsv                               C.GPVERTEXATTRIB4NSV
+	gpVertexAttrib4Nub                               C.GPVERTEXATTRIB4NUB
+	gpVertexAttrib4Nubv                              C.GPVERTEXATTRIB4NUBV
+	gpVertexAttrib4Nuiv                              C.GPVERTEXATTRIB4NUIV
+	gpVertexAttrib4Nusv                              C.GPVERTEXATTRIB4NUSV
+	gpVertexAttrib4bv                                C.GPVERTEXATTRIB4BV
+	gpVertexAttrib4d                                 C.GPVERTEXATTRIB4D
+	gpVertexAttrib4dv                                C.GPVERTEXATTRIB4DV
+	gpVertexAttrib4f                                 C.GPVERTEXATTRIB4F
+	gpVertexAttrib4fv                                C.GPVERTEXATTRIB4FV
+	gpVertexAttrib4iv                                C.GPVERTEXATTRIB4IV
+	gpVertexAttrib4s                                 C.GPVERTEXATTRIB4S
+	gpVertexAttrib4sv                                C.GPVERTEXATTRIB4SV
+	gpVertexAttrib4ubv                               C.GPVERTEXATTRIB4UBV
+	gpVertexAttrib4uiv                               C.GPVERTEXATTRIB4UIV
+	gpVertexAttrib4usv                               C.GPVERTEXATTRIB4USV
+	gpVertexAttribBinding                            C.GPVERTEXATTRIBBINDING
+	gpVertexAttribDivisor                            C.GPVERTEXATTRIBDIVISOR
+	gpVertexAttribDivisorARB                         C.GPVERTEXATTRIBDIVISORARB
+	gpVertexAttribFormat                             C.GPVERTEXATTRIBFORMAT
+	gpVertexAttribFormatNV                           C.GPVERTEXATTRIBFORMATNV
+	gpVertexAttribI1i                                C.GPVERTEXATTRIBI1I
+	gpVertexAttribI1iv                               C.GPVERTEXATTRIBI1IV
+	gpVertexAttribI1ui                               C.GPVERTEXATTRIBI1UI
+	gpVertexAttribI1uiv                              C.GPVERTEXATTRIBI1UIV
+	gpVertexAttribI2i                                C.GPVERTEXATTRIBI2I
+	gpVertexAttribI2iv                               C.GPVERTEXATTRIBI2IV
+	gpVertexAttribI2ui                               C.GPVERTEXATTRIBI2UI
+	gpVertexAttribI2uiv                              C.GPVERTEXATTRIBI2UIV
+	gpVertexAttribI3i                                C.GPVERTEXATTRIBI3I
+	gpVertexAttribI3iv                               C.GPVERTEXATTRIBI3IV
+	gpVertexAttribI3ui                               C.GPVERTEXATTRIBI3UI
+	gpVertexAttribI3uiv                              C.GPVERTEXATTRIBI3UIV
+	gpVertexAttribI4bv                               C.GPVERTEXATTRIBI4BV
+	gpVertexAttribI4i                                C.GPVERTEXATTRIBI4I
+	gpVertexAttribI4iv                               C.GPVERTEXATTRIBI4IV
+	gpVertexAttribI4sv                               C.GPVERTEXATTRIBI4SV
+	gpVertexAttribI4ubv                              C.GPVERTEXATTRIBI4UBV
+	gpVertexAttribI4ui                               C.GPVERTEXATTRIBI4UI
+	gpVertexAttribI4uiv                              C.GPVERTEXATTRIBI4UIV
+	gpVertexAttribI4usv                              C.GPVERTEXATTRIBI4USV
+	gpVertexAttribIFormat                            C.GPVERTEXATTRIBIFORMAT
+	gpVertexAttribIFormatNV                          C.GPVERTEXATTRIBIFORMATNV
+	gpVertexAttribIPointer                           C.GPVERTEXATTRIBIPOINTER
+	gpVertexAttribL1d                                C.GPVERTEXATTRIBL1D
+	gpVertexAttribL1dv                               C.GPVERTEXATTRIBL1DV
+	gpVertexAttribL1i64NV                            C.GPVERTEXATTRIBL1I64NV
+	gpVertexAttribL1i64vNV                           C.GPVERTEXATTRIBL1I64VNV
+	gpVertexAttribL1ui64ARB                          C.GPVERTEXATTRIBL1UI64ARB
+	gpVertexAttribL1ui64NV                           C.GPVERTEXATTRIBL1UI64NV
+	gpVertexAttribL1ui64vARB                         C.GPVERTEXATTRIBL1UI64VARB
+	gpVertexAttribL1ui64vNV                          C.GPVERTEXATTRIBL1UI64VNV
+	gpVertexAttribL2d                                C.GPVERTEXATTRIBL2D
+	gpVertexAttribL2dv                               C.GPVERTEXATTRIBL2DV
+	gpVertexAttribL2i64NV                            C.GPVERTEXATTRIBL2I64NV
+	gpVertexAttribL2i64vNV                           C.GPVERTEXATTRIBL2I64VNV
+	gpVertexAttribL2ui64NV                           C.GPVERTEXATTRIBL2UI64NV
+	gpVertexAttribL2ui64vNV                          C.GPVERTEXATTRIBL2UI64VNV
+	gpVertexAttribL3d                                C.GPVERTEXATTRIBL3D
+	gpVertexAttribL3dv                               C.GPVERTEXATTRIBL3DV
+	gpVertexAttribL3i64NV                            C.GPVERTEXATTRIBL3I64NV
+	gpVertexAttribL3i64vNV                           C.GPVERTEXATTRIBL3I64VNV
+	gpVertexAttribL3ui64NV                           C.GPVERTEXATTRIBL3UI64NV
+	gpVertexAttribL3ui64vNV                          C.GPVERTEXATTRIBL3UI64VNV
+	gpVertexAttribL4d                                C.GPVERTEXATTRIBL4D
+	gpVertexAttribL4dv                               C.GPVERTEXATTRIBL4DV
+	gpVertexAttribL4i64NV                            C.GPVERTEXATTRIBL4I64NV
+	gpVertexAttribL4i64vNV                           C.GPVERTEXATTRIBL4I64VNV
+	gpVertexAttribL4ui64NV                           C.GPVERTEXATTRIBL4UI64NV
+	gpVertexAttribL4ui64vNV                          C.GPVERTEXATTRIBL4UI64VNV
+	gpVertexAttribLFormat                            C.GPVERTEXATTRIBLFORMAT
+	gpVertexAttribLFormatNV                          C.GPVERTEXATTRIBLFORMATNV
+	gpVertexAttribLPointer                           C.GPVERTEXATTRIBLPOINTER
+	gpVertexAttribP1ui                               C.GPVERTEXATTRIBP1UI
+	gpVertexAttribP1uiv                              C.GPVERTEXATTRIBP1UIV
+	gpVertexAttribP2ui                               C.GPVERTEXATTRIBP2UI
+	gpVertexAttribP2uiv                              C.GPVERTEXATTRIBP2UIV
+	gpVertexAttribP3ui                               C.GPVERTEXATTRIBP3UI
+	gpVertexAttribP3uiv                              C.GPVERTEXATTRIBP3UIV
+	gpVertexAttribP4ui                               C.GPVERTEXATTRIBP4UI
+	gpVertexAttribP4uiv                              C.GPVERTEXATTRIBP4UIV
+	gpVertexAttribPointer                            C.GPVERTEXATTRIBPOINTER
+	gpVertexBindingDivisor                           C.GPVERTEXBINDINGDIVISOR
+	gpVertexFormatNV                                 C.GPVERTEXFORMATNV
+	gpViewport                                       C.GPVIEWPORT
+	gpViewportArrayv                                 C.GPVIEWPORTARRAYV
+	gpViewportIndexedf                               C.GPVIEWPORTINDEXEDF
+	gpViewportIndexedfv                              C.GPVIEWPORTINDEXEDFV
+	gpViewportPositionWScaleNV                       C.GPVIEWPORTPOSITIONWSCALENV
+	gpViewportSwizzleNV                              C.GPVIEWPORTSWIZZLENV
+	gpWaitSync                                       C.GPWAITSYNC
+	gpWaitVkSemaphoreNV                              C.GPWAITVKSEMAPHORENV
+	gpWeightPathsNV                                  C.GPWEIGHTPATHSNV
+	gpWindowRectanglesEXT                            C.GPWINDOWRECTANGLESEXT
 )
 
 // Helper functions
@@ -5170,15 +8448,24 @@ func boolToInt(b bool) int {
 	}
 	return 0
 }
+func ActiveProgramEXT(program uint32) {
+	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
+}
 
 // set the active program object for a program pipeline object
 func ActiveShaderProgram(pipeline uint32, program uint32) {
 	C.glowActiveShaderProgram(gpActiveShaderProgram, (C.GLuint)(pipeline), (C.GLuint)(program))
 }
+func ActiveShaderProgramEXT(pipeline uint32, program uint32) {
+	C.glowActiveShaderProgramEXT(gpActiveShaderProgramEXT, (C.GLuint)(pipeline), (C.GLuint)(program))
+}
 
 // select active texture unit
 func ActiveTexture(texture uint32) {
 	C.glowActiveTexture(gpActiveTexture, (C.GLenum)(texture))
+}
+func ApplyFramebufferAttachmentCMAAINTEL() {
+	C.glowApplyFramebufferAttachmentCMAAINTEL(gpApplyFramebufferAttachmentCMAAINTEL)
 }
 
 // Attaches a shader object to a program object
@@ -5189,6 +8476,15 @@ func AttachShader(program uint32, shader uint32) {
 // start conditional rendering
 func BeginConditionalRender(id uint32, mode uint32) {
 	C.glowBeginConditionalRender(gpBeginConditionalRender, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginConditionalRenderNV(id uint32, mode uint32) {
+	C.glowBeginConditionalRenderNV(gpBeginConditionalRenderNV, (C.GLuint)(id), (C.GLenum)(mode))
+}
+func BeginPerfMonitorAMD(monitor uint32) {
+	C.glowBeginPerfMonitorAMD(gpBeginPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func BeginPerfQueryINTEL(queryHandle uint32) {
+	C.glowBeginPerfQueryINTEL(gpBeginPerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // delimit the boundaries of a query object
@@ -5258,10 +8554,16 @@ func BindImageTexture(unit uint32, texture uint32, level int32, layered bool, la
 func BindImageTextures(first uint32, count int32, textures *uint32) {
 	C.glowBindImageTextures(gpBindImageTextures, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(textures)))
 }
+func BindMultiTextureEXT(texunit uint32, target uint32, texture uint32) {
+	C.glowBindMultiTextureEXT(gpBindMultiTextureEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(texture))
+}
 
 // bind a program pipeline to the current context
 func BindProgramPipeline(pipeline uint32) {
 	C.glowBindProgramPipeline(gpBindProgramPipeline, (C.GLuint)(pipeline))
+}
+func BindProgramPipelineEXT(pipeline uint32) {
+	C.glowBindProgramPipelineEXT(gpBindProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 
 // bind a renderbuffer to a renderbuffer target
@@ -5313,6 +8615,12 @@ func BindVertexBuffer(bindingindex uint32, buffer uint32, offset int, stride int
 func BindVertexBuffers(first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowBindVertexBuffers(gpBindVertexBuffers, (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
 }
+func BlendBarrierKHR() {
+	C.glowBlendBarrierKHR(gpBlendBarrierKHR)
+}
+func BlendBarrierNV() {
+	C.glowBlendBarrierNV(gpBlendBarrierNV)
+}
 
 // set the blend color
 func BlendColor(red float32, green float32, blue float32, alpha float32) {
@@ -5362,6 +8670,9 @@ func BlendFunci(buf uint32, src uint32, dst uint32) {
 func BlendFunciARB(buf uint32, src uint32, dst uint32) {
 	C.glowBlendFunciARB(gpBlendFunciARB, (C.GLuint)(buf), (C.GLenum)(src), (C.GLenum)(dst))
 }
+func BlendParameteriNV(pname uint32, value int32) {
+	C.glowBlendParameteriNV(gpBlendParameteriNV, (C.GLenum)(pname), (C.GLint)(value))
+}
 
 // copy a block of pixels from one framebuffer object to another
 func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
@@ -5372,13 +8683,16 @@ func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 i
 func BlitNamedFramebuffer(readFramebuffer uint32, drawFramebuffer uint32, srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
 	C.glowBlitNamedFramebuffer(gpBlitNamedFramebuffer, (C.GLuint)(readFramebuffer), (C.GLuint)(drawFramebuffer), (C.GLint)(srcX0), (C.GLint)(srcY0), (C.GLint)(srcX1), (C.GLint)(srcY1), (C.GLint)(dstX0), (C.GLint)(dstY0), (C.GLint)(dstX1), (C.GLint)(dstY1), (C.GLbitfield)(mask), (C.GLenum)(filter))
 }
+func BufferAddressRangeNV(pname uint32, index uint32, address uint64, length int) {
+	C.glowBufferAddressRangeNV(gpBufferAddressRangeNV, (C.GLenum)(pname), (C.GLuint)(index), (C.GLuint64EXT)(address), (C.GLsizeiptr)(length))
+}
 
 // creates and initializes a buffer object's data     store
 func BufferData(target uint32, size int, data unsafe.Pointer, usage uint32) {
 	C.glowBufferData(gpBufferData, (C.GLenum)(target), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func BufferPageCommitmentARB(target uint32, offset int, size int32, commit bool) {
-	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func BufferPageCommitmentARB(target uint32, offset int, size int, commit bool) {
+	C.glowBufferPageCommitmentARB(gpBufferPageCommitmentARB, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
@@ -5390,6 +8704,9 @@ func BufferStorage(target uint32, size int, data unsafe.Pointer, flags uint32) {
 func BufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowBufferSubData(gpBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
+func CallCommandListNV(list uint32) {
+	C.glowCallCommandListNV(gpCallCommandListNV, (C.GLuint)(list))
+}
 
 // check the completeness status of a framebuffer
 func CheckFramebufferStatus(target uint32) uint32 {
@@ -5400,6 +8717,10 @@ func CheckFramebufferStatus(target uint32) uint32 {
 // check the completeness status of a framebuffer
 func CheckNamedFramebufferStatus(framebuffer uint32, target uint32) uint32 {
 	ret := C.glowCheckNamedFramebufferStatus(gpCheckNamedFramebufferStatus, (C.GLuint)(framebuffer), (C.GLenum)(target))
+	return (uint32)(ret)
+}
+func CheckNamedFramebufferStatusEXT(framebuffer uint32, target uint32) uint32 {
+	ret := C.glowCheckNamedFramebufferStatusEXT(gpCheckNamedFramebufferStatusEXT, (C.GLuint)(framebuffer), (C.GLenum)(target))
 	return (uint32)(ret)
 }
 
@@ -5444,6 +8765,8 @@ func ClearColor(red float32, green float32, blue float32, alpha float32) {
 func ClearDepth(depth float64) {
 	C.glowClearDepth(gpClearDepth, (C.GLdouble)(depth))
 }
+
+// specify the clear value for the depth buffer
 func ClearDepthf(d float32) {
 	C.glowClearDepthf(gpClearDepthf, (C.GLfloat)(d))
 }
@@ -5452,13 +8775,19 @@ func ClearDepthf(d float32) {
 func ClearNamedBufferData(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearNamedBufferData(gpClearNamedBufferData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClearNamedBufferDataEXT(buffer uint32, internalformat uint32, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferDataEXT(gpClearNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
 
 // fill all or part of buffer object's data store with a fixed value
-func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int32, format uint32, xtype uint32, data unsafe.Pointer) {
-	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+func ClearNamedBufferSubData(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubData(gpClearNamedBufferSubData, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
-func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, depth float32, stencil int32) {
-	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLfloat)(depth), (C.GLint)(stencil))
+func ClearNamedBufferSubDataEXT(buffer uint32, internalformat uint32, offset int, size int, format uint32, xtype uint32, data unsafe.Pointer) {
+	C.glowClearNamedBufferSubDataEXT(gpClearNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLenum)(internalformat), (C.GLsizeiptr)(offset), (C.GLsizeiptr)(size), (C.GLenum)(format), (C.GLenum)(xtype), data)
+}
+func ClearNamedFramebufferfi(framebuffer uint32, buffer uint32, drawbuffer int32, depth float32, stencil int32) {
+	C.glowClearNamedFramebufferfi(gpClearNamedFramebufferfi, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (C.GLfloat)(depth), (C.GLint)(stencil))
 }
 func ClearNamedFramebufferfv(framebuffer uint32, buffer uint32, drawbuffer int32, value *float32) {
 	C.glowClearNamedFramebufferfv(gpClearNamedFramebufferfv, (C.GLuint)(framebuffer), (C.GLenum)(buffer), (C.GLint)(drawbuffer), (*C.GLfloat)(unsafe.Pointer(value)))
@@ -5484,9 +8813,12 @@ func ClearTexImage(texture uint32, level int32, format uint32, xtype uint32, dat
 func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, data unsafe.Pointer) {
 	C.glowClearTexSubImage(gpClearTexSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), data)
 }
+func ClientAttribDefaultEXT(mask uint32) {
+	C.glowClientAttribDefaultEXT(gpClientAttribDefaultEXT, (C.GLbitfield)(mask))
+}
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -5495,11 +8827,20 @@ func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
 func ClipControl(origin uint32, depth uint32) {
 	C.glowClipControl(gpClipControl, (C.GLenum)(origin), (C.GLenum)(depth))
 }
+func ColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowColorFormatNV(gpColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func ColorMask(red bool, green bool, blue bool, alpha bool) {
 	C.glowColorMask(gpColorMask, (C.GLboolean)(boolToInt(red)), (C.GLboolean)(boolToInt(green)), (C.GLboolean)(boolToInt(blue)), (C.GLboolean)(boolToInt(alpha)))
 }
 func ColorMaski(index uint32, r bool, g bool, b bool, a bool) {
 	C.glowColorMaski(gpColorMaski, (C.GLuint)(index), (C.GLboolean)(boolToInt(r)), (C.GLboolean)(boolToInt(g)), (C.GLboolean)(boolToInt(b)), (C.GLboolean)(boolToInt(a)))
+}
+func CommandListSegmentsNV(list uint32, segments uint32) {
+	C.glowCommandListSegmentsNV(gpCommandListSegmentsNV, (C.GLuint)(list), (C.GLuint)(segments))
+}
+func CompileCommandListNV(list uint32) {
+	C.glowCompileCommandListNV(gpCompileCommandListNV, (C.GLuint)(list))
 }
 
 // Compiles a shader object
@@ -5508,6 +8849,24 @@ func CompileShader(shader uint32) {
 }
 func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
+}
+func CompressedMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage1DEXT(gpCompressedMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage2DEXT(gpCompressedMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexImage3DEXT(gpCompressedMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage1DEXT(gpCompressedMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage2DEXT(gpCompressedMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func CompressedMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedMultiTexSubImage3DEXT(gpCompressedMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a one-dimensional texture image in a compressed format
@@ -5539,20 +8898,44 @@ func CompressedTexSubImage2D(target uint32, level int32, xoffset int32, yoffset 
 func CompressedTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTexSubImage3D(gpCompressedTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage1DEXT(gpCompressedTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage2DEXT(gpCompressedTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
+func CompressedTextureImage3DEXT(texture uint32, target uint32, level int32, internalformat uint32, width int32, height int32, depth int32, border int32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureImage3DEXT(gpCompressedTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a one-dimensional texture subimage in a compressed     format
 func CompressedTextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage1D(gpCompressedTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage1DEXT(gpCompressedTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
 }
 
 // specify a two-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage2D(gpCompressedTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
 }
+func CompressedTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage2DEXT(gpCompressedTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
 
 // specify a three-dimensional texture subimage in a compressed format
 func CompressedTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, data unsafe.Pointer) {
 	C.glowCompressedTextureSubImage3D(gpCompressedTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), data)
+}
+func CompressedTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, imageSize int32, bits unsafe.Pointer) {
+	C.glowCompressedTextureSubImage3DEXT(gpCompressedTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLsizei)(imageSize), bits)
+}
+func ConservativeRasterParameterfNV(pname uint32, value float32) {
+	C.glowConservativeRasterParameterfNV(gpConservativeRasterParameterfNV, (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func ConservativeRasterParameteriNV(pname uint32, param int32) {
+	C.glowConservativeRasterParameteriNV(gpConservativeRasterParameteriNV, (C.GLenum)(pname), (C.GLint)(param))
 }
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
@@ -5564,10 +8947,28 @@ func CopyBufferSubData(readTarget uint32, writeTarget uint32, readOffset int, wr
 func CopyImageSubData(srcName uint32, srcTarget uint32, srcLevel int32, srcX int32, srcY int32, srcZ int32, dstName uint32, dstTarget uint32, dstLevel int32, dstX int32, dstY int32, dstZ int32, srcWidth int32, srcHeight int32, srcDepth int32) {
 	C.glowCopyImageSubData(gpCopyImageSubData, (C.GLuint)(srcName), (C.GLenum)(srcTarget), (C.GLint)(srcLevel), (C.GLint)(srcX), (C.GLint)(srcY), (C.GLint)(srcZ), (C.GLuint)(dstName), (C.GLenum)(dstTarget), (C.GLint)(dstLevel), (C.GLint)(dstX), (C.GLint)(dstY), (C.GLint)(dstZ), (C.GLsizei)(srcWidth), (C.GLsizei)(srcHeight), (C.GLsizei)(srcDepth))
 }
+func CopyMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyMultiTexImage1DEXT(gpCopyMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyMultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyMultiTexImage2DEXT(gpCopyMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
+func CopyMultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyMultiTexSubImage1DEXT(gpCopyMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyMultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage2DEXT(gpCopyMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyMultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyMultiTexSubImage3DEXT(gpCopyMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy all or part of the data store of a buffer object to the data store of another buffer object
-func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int32) {
-	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizei)(size))
+func CopyNamedBufferSubData(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowCopyNamedBufferSubData(gpCopyNamedBufferSubData, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
+}
+func CopyPathNV(resultPath uint32, srcPath uint32) {
+	C.glowCopyPathNV(gpCopyPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath))
 }
 
 // copy pixels into a 1D texture image
@@ -5594,30 +8995,69 @@ func CopyTexSubImage2D(target uint32, level int32, xoffset int32, yoffset int32,
 func CopyTexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTexSubImage3D(gpCopyTexSubImage3D, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureImage1DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, border int32) {
+	C.glowCopyTextureImage1DEXT(gpCopyTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLint)(border))
+}
+func CopyTextureImage2DEXT(texture uint32, target uint32, level int32, internalformat uint32, x int32, y int32, width int32, height int32, border int32) {
+	C.glowCopyTextureImage2DEXT(gpCopyTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(internalformat), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border))
+}
 
 // copy a one-dimensional texture subimage
 func CopyTextureSubImage1D(texture uint32, level int32, xoffset int32, x int32, y int32, width int32) {
 	C.glowCopyTextureSubImage1D(gpCopyTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
+}
+func CopyTextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, x int32, y int32, width int32) {
+	C.glowCopyTextureSubImage1DEXT(gpCopyTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width))
 }
 
 // copy a two-dimensional texture subimage
 func CopyTextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage2D(gpCopyTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func CopyTextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage2DEXT(gpCopyTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 
 // copy a three-dimensional texture subimage
 func CopyTextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
 	C.glowCopyTextureSubImage3D(gpCopyTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CopyTextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, x int32, y int32, width int32, height int32) {
+	C.glowCopyTextureSubImage3DEXT(gpCopyTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLint)(x), (C.GLint)(y), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func CoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverFillPathInstancedNV(gpCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverFillPathNV(path uint32, coverMode uint32) {
+	C.glowCoverFillPathNV(gpCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowCoverStrokePathInstancedNV(gpCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func CoverStrokePathNV(path uint32, coverMode uint32) {
+	C.glowCoverStrokePathNV(gpCoverStrokePathNV, (C.GLuint)(path), (C.GLenum)(coverMode))
+}
+func CoverageModulationNV(components uint32) {
+	C.glowCoverageModulationNV(gpCoverageModulationNV, (C.GLenum)(components))
+}
+func CoverageModulationTableNV(n int32, v *float32) {
+	C.glowCoverageModulationTableNV(gpCoverageModulationTableNV, (C.GLsizei)(n), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // create buffer objects
 func CreateBuffers(n int32, buffers *uint32) {
 	C.glowCreateBuffers(gpCreateBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func CreateCommandListsNV(n int32, lists *uint32) {
+	C.glowCreateCommandListsNV(gpCreateCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // create framebuffer objects
 func CreateFramebuffers(n int32, framebuffers *uint32) {
 	C.glowCreateFramebuffers(gpCreateFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
+}
+func CreatePerfQueryINTEL(queryId uint32, queryHandle *uint32) {
+	C.glowCreatePerfQueryINTEL(gpCreatePerfQueryINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(queryHandle)))
 }
 
 // Creates a program object
@@ -5651,15 +9091,26 @@ func CreateShader(xtype uint32) uint32 {
 	ret := C.glowCreateShader(gpCreateShader, (C.GLenum)(xtype))
 	return (uint32)(ret)
 }
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
+	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
+	return (uint32)(ret)
+}
 
 // create a stand-alone program from an array of null-terminated source code strings
 func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
+	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
+	return (uint32)(ret)
+}
+func CreateStatesNV(n int32, states *uint32) {
+	C.glowCreateStatesNV(gpCreateStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -5722,6 +9173,9 @@ func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint
 func DeleteBuffers(n int32, buffers *uint32) {
 	C.glowDeleteBuffers(gpDeleteBuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
+func DeleteCommandListsNV(n int32, lists *uint32) {
+	C.glowDeleteCommandListsNV(gpDeleteCommandListsNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(lists)))
+}
 
 // delete framebuffer objects
 func DeleteFramebuffers(n int32, framebuffers *uint32) {
@@ -5729,6 +9183,15 @@ func DeleteFramebuffers(n int32, framebuffers *uint32) {
 }
 func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+}
+func DeletePathsNV(path uint32, xrange int32) {
+	C.glowDeletePathsNV(gpDeletePathsNV, (C.GLuint)(path), (C.GLsizei)(xrange))
+}
+func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowDeletePerfMonitorsAMD(gpDeletePerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
+func DeletePerfQueryINTEL(queryHandle uint32) {
+	C.glowDeletePerfQueryINTEL(gpDeletePerfQueryINTEL, (C.GLuint)(queryHandle))
 }
 
 // Deletes a program object
@@ -5739,6 +9202,9 @@ func DeleteProgram(program uint32) {
 // delete program pipeline objects
 func DeleteProgramPipelines(n int32, pipelines *uint32) {
 	C.glowDeleteProgramPipelines(gpDeleteProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func DeleteProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowDeleteProgramPipelinesEXT(gpDeleteProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // delete named query objects
@@ -5760,9 +9226,12 @@ func DeleteSamplers(count int32, samplers *uint32) {
 func DeleteShader(shader uint32) {
 	C.glowDeleteShader(gpDeleteShader, (C.GLuint)(shader))
 }
+func DeleteStatesNV(n int32, states *uint32) {
+	C.glowDeleteStatesNV(gpDeleteStatesNV, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(states)))
+}
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -5803,6 +9272,8 @@ func DepthRangeArrayv(first uint32, count int32, v *float64) {
 func DepthRangeIndexed(index uint32, n float64, f float64) {
 	C.glowDepthRangeIndexed(gpDepthRangeIndexed, (C.GLuint)(index), (C.GLdouble)(n), (C.GLdouble)(f))
 }
+
+// specify mapping of depth values from normalized device coordinates to window coordinates
 func DepthRangef(n float32, f float32) {
 	C.glowDepthRangef(gpDepthRangef, (C.GLfloat)(n), (C.GLfloat)(f))
 }
@@ -5814,10 +9285,25 @@ func DetachShader(program uint32, shader uint32) {
 func Disable(cap uint32) {
 	C.glowDisable(gpDisable, (C.GLenum)(cap))
 }
+func DisableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowDisableClientStateIndexedEXT(gpDisableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableClientStateiEXT(array uint32, index uint32) {
+	C.glowDisableClientStateiEXT(gpDisableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func DisableIndexedEXT(target uint32, index uint32) {
+	C.glowDisableIndexedEXT(gpDisableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func DisableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowDisableVertexArrayAttrib(gpDisableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowDisableVertexArrayAttribEXT(gpDisableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func DisableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowDisableVertexArrayEXT(gpDisableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -5855,10 +9341,16 @@ func DrawArraysIndirect(mode uint32, indirect unsafe.Pointer) {
 func DrawArraysInstanced(mode uint32, first int32, count int32, instancecount int32) {
 	C.glowDrawArraysInstanced(gpDrawArraysInstanced, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount))
 }
+func DrawArraysInstancedARB(mode uint32, first int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedARB(gpDrawArraysInstancedARB, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a range of elements with offset applied to instanced attributes
 func DrawArraysInstancedBaseInstance(mode uint32, first int32, count int32, instancecount int32, baseinstance uint32) {
 	C.glowDrawArraysInstancedBaseInstance(gpDrawArraysInstancedBaseInstance, (C.GLenum)(mode), (C.GLint)(first), (C.GLsizei)(count), (C.GLsizei)(instancecount), (C.GLuint)(baseinstance))
+}
+func DrawArraysInstancedEXT(mode uint32, start int32, count int32, primcount int32) {
+	C.glowDrawArraysInstancedEXT(gpDrawArraysInstancedEXT, (C.GLenum)(mode), (C.GLint)(start), (C.GLsizei)(count), (C.GLsizei)(primcount))
 }
 
 // specify which color buffers are to be drawn into
@@ -5869,6 +9361,18 @@ func DrawBuffer(buf uint32) {
 // Specifies a list of color buffers to be drawn     into
 func DrawBuffers(n int32, bufs *uint32) {
 	C.glowDrawBuffers(gpDrawBuffers, (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func DrawCommandsAddressNV(primitiveMode uint32, indirects *uint64, sizes *int32, count uint32) {
+	C.glowDrawCommandsAddressNV(gpDrawCommandsAddressNV, (C.GLenum)(primitiveMode), (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsNV(primitiveMode uint32, buffer uint32, indirects *int, sizes *int32, count uint32) {
+	C.glowDrawCommandsNV(gpDrawCommandsNV, (C.GLenum)(primitiveMode), (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (C.GLuint)(count))
+}
+func DrawCommandsStatesAddressNV(indirects *uint64, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesAddressNV(gpDrawCommandsStatesAddressNV, (*C.GLuint64)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
+func DrawCommandsStatesNV(buffer uint32, indirects *int, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowDrawCommandsStatesNV(gpDrawCommandsStatesNV, (C.GLuint)(buffer), (*C.GLintptr)(unsafe.Pointer(indirects)), (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
 }
 
 // render primitives from array data
@@ -5890,6 +9394,9 @@ func DrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer) {
 func DrawElementsInstanced(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32) {
 	C.glowDrawElementsInstanced(gpDrawElementsInstanced, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount))
 }
+func DrawElementsInstancedARB(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedARB(gpDrawElementsInstancedARB, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
+}
 
 // draw multiple instances of a set of elements with offset applied to instanced attributes
 func DrawElementsInstancedBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, baseinstance uint32) {
@@ -5904,6 +9411,9 @@ func DrawElementsInstancedBaseVertex(mode uint32, count int32, xtype uint32, ind
 // render multiple instances of a set of primitives from array data with a per-element offset
 func DrawElementsInstancedBaseVertexBaseInstance(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, instancecount int32, basevertex int32, baseinstance uint32) {
 	C.glowDrawElementsInstancedBaseVertexBaseInstance(gpDrawElementsInstancedBaseVertexBaseInstance, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(instancecount), (C.GLint)(basevertex), (C.GLuint)(baseinstance))
+}
+func DrawElementsInstancedEXT(mode uint32, count int32, xtype uint32, indices unsafe.Pointer, primcount int32) {
+	C.glowDrawElementsInstancedEXT(gpDrawElementsInstancedEXT, (C.GLenum)(mode), (C.GLsizei)(count), (C.GLenum)(xtype), indices, (C.GLsizei)(primcount))
 }
 
 // render primitives from array data
@@ -5935,15 +9445,36 @@ func DrawTransformFeedbackStream(mode uint32, id uint32, stream uint32) {
 func DrawTransformFeedbackStreamInstanced(mode uint32, id uint32, stream uint32, instancecount int32) {
 	C.glowDrawTransformFeedbackStreamInstanced(gpDrawTransformFeedbackStreamInstanced, (C.GLenum)(mode), (C.GLuint)(id), (C.GLuint)(stream), (C.GLsizei)(instancecount))
 }
+func DrawVkImageNV(vkImage uint64, sampler uint32, x0 float32, y0 float32, x1 float32, y1 float32, z float32, s0 float32, t0 float32, s1 float32, t1 float32) {
+	C.glowDrawVkImageNV(gpDrawVkImageNV, (C.GLuint64)(vkImage), (C.GLuint)(sampler), (C.GLfloat)(x0), (C.GLfloat)(y0), (C.GLfloat)(x1), (C.GLfloat)(y1), (C.GLfloat)(z), (C.GLfloat)(s0), (C.GLfloat)(t0), (C.GLfloat)(s1), (C.GLfloat)(t1))
+}
+func EdgeFlagFormatNV(stride int32) {
+	C.glowEdgeFlagFormatNV(gpEdgeFlagFormatNV, (C.GLsizei)(stride))
+}
 
 // enable or disable server-side GL capabilities
 func Enable(cap uint32) {
 	C.glowEnable(gpEnable, (C.GLenum)(cap))
 }
+func EnableClientStateIndexedEXT(array uint32, index uint32) {
+	C.glowEnableClientStateIndexedEXT(gpEnableClientStateIndexedEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableClientStateiEXT(array uint32, index uint32) {
+	C.glowEnableClientStateiEXT(gpEnableClientStateiEXT, (C.GLenum)(array), (C.GLuint)(index))
+}
+func EnableIndexedEXT(target uint32, index uint32) {
+	C.glowEnableIndexedEXT(gpEnableIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
+}
 
 // Enable or disable a generic vertex attribute     array
 func EnableVertexArrayAttrib(vaobj uint32, index uint32) {
 	C.glowEnableVertexArrayAttrib(gpEnableVertexArrayAttrib, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayAttribEXT(vaobj uint32, index uint32) {
+	C.glowEnableVertexArrayAttribEXT(gpEnableVertexArrayAttribEXT, (C.GLuint)(vaobj), (C.GLuint)(index))
+}
+func EnableVertexArrayEXT(vaobj uint32, array uint32) {
+	C.glowEnableVertexArrayEXT(gpEnableVertexArrayEXT, (C.GLuint)(vaobj), (C.GLenum)(array))
 }
 
 // Enable or disable a generic vertex attribute     array
@@ -5956,6 +9487,15 @@ func Enablei(target uint32, index uint32) {
 func EndConditionalRender() {
 	C.glowEndConditionalRender(gpEndConditionalRender)
 }
+func EndConditionalRenderNV() {
+	C.glowEndConditionalRenderNV(gpEndConditionalRenderNV)
+}
+func EndPerfMonitorAMD(monitor uint32) {
+	C.glowEndPerfMonitorAMD(gpEndPerfMonitorAMD, (C.GLuint)(monitor))
+}
+func EndPerfQueryINTEL(queryHandle uint32) {
+	C.glowEndPerfQueryINTEL(gpEndPerfQueryINTEL, (C.GLuint)(queryHandle))
+}
 func EndQuery(target uint32) {
 	C.glowEndQuery(gpEndQuery, (C.GLenum)(target))
 }
@@ -5965,11 +9505,14 @@ func EndQueryIndexed(target uint32, index uint32) {
 func EndTransformFeedback() {
 	C.glowEndTransformFeedback(gpEndTransformFeedback)
 }
+func EvaluateDepthValuesARB() {
+	C.glowEvaluateDepthValuesARB(gpEvaluateDepthValuesARB)
+}
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -5988,18 +9531,45 @@ func FlushMappedBufferRange(target uint32, offset int, length int) {
 }
 
 // indicate modifications to a range of a mapped buffer
-func FlushMappedNamedBufferRange(buffer uint32, offset int, length int32) {
-	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length))
+func FlushMappedNamedBufferRange(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRange(gpFlushMappedNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FlushMappedNamedBufferRangeEXT(buffer uint32, offset int, length int) {
+	C.glowFlushMappedNamedBufferRangeEXT(gpFlushMappedNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length))
+}
+func FogCoordFormatNV(xtype uint32, stride int32) {
+	C.glowFogCoordFormatNV(gpFogCoordFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func FragmentCoverageColorNV(color uint32) {
+	C.glowFragmentCoverageColorNV(gpFragmentCoverageColorNV, (C.GLuint)(color))
+}
+func FramebufferDrawBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferDrawBufferEXT(gpFramebufferDrawBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
+func FramebufferDrawBuffersEXT(framebuffer uint32, n int32, bufs *uint32) {
+	C.glowFramebufferDrawBuffersEXT(gpFramebufferDrawBuffersEXT, (C.GLuint)(framebuffer), (C.GLsizei)(n), (*C.GLenum)(unsafe.Pointer(bufs)))
+}
+func FramebufferFetchBarrierEXT() {
+	C.glowFramebufferFetchBarrierEXT(gpFramebufferFetchBarrierEXT)
 }
 
 // set a named parameter of a framebuffer object
 func FramebufferParameteri(target uint32, pname uint32, param int32) {
 	C.glowFramebufferParameteri(gpFramebufferParameteri, (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
 }
+func FramebufferReadBufferEXT(framebuffer uint32, mode uint32) {
+	C.glowFramebufferReadBufferEXT(gpFramebufferReadBufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(mode))
+}
 
 // attach a renderbuffer as a logical buffer of a framebuffer object
 func FramebufferRenderbuffer(target uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowFramebufferRenderbuffer(gpFramebufferRenderbuffer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func FramebufferSampleLocationsfvARB(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvARB(gpFramebufferSampleLocationsfvARB, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func FramebufferSampleLocationsfvNV(target uint32, start uint32, count int32, v *float32) {
+	C.glowFramebufferSampleLocationsfvNV(gpFramebufferSampleLocationsfvNV, (C.GLenum)(target), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // attach a level of a texture object as a logical buffer of a framebuffer object
@@ -6009,16 +9579,30 @@ func FramebufferTexture(target uint32, attachment uint32, texture uint32, level 
 func FramebufferTexture1D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture1D(gpFramebufferTexture1D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
+
+// attach a level of a texture object as a logical buffer to the currently bound framebuffer object
 func FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	C.glowFramebufferTexture2D(gpFramebufferTexture2D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
 }
 func FramebufferTexture3D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
 	C.glowFramebufferTexture3D(gpFramebufferTexture3D, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
 }
+func FramebufferTextureARB(target uint32, attachment uint32, texture uint32, level int32) {
+	C.glowFramebufferTextureARB(gpFramebufferTextureARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func FramebufferTextureFaceARB(target uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowFramebufferTextureFaceARB(gpFramebufferTextureFaceARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
+}
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func FramebufferTextureLayer(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowFramebufferTextureLayer(gpFramebufferTextureLayer, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureLayerARB(target uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowFramebufferTextureLayerARB(gpFramebufferTextureLayerARB, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func FramebufferTextureMultiviewOVR(target uint32, attachment uint32, texture uint32, level int32, baseViewIndex int32, numViews int32) {
+	C.glowFramebufferTextureMultiviewOVR(gpFramebufferTextureMultiviewOVR, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(baseViewIndex), (C.GLsizei)(numViews))
 }
 
 // define front- and back-facing polygons
@@ -6035,10 +9619,20 @@ func GenBuffers(n int32, buffers *uint32) {
 func GenFramebuffers(n int32, framebuffers *uint32) {
 	C.glowGenFramebuffers(gpGenFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
 }
+func GenPathsNV(xrange int32) uint32 {
+	ret := C.glowGenPathsNV(gpGenPathsNV, (C.GLsizei)(xrange))
+	return (uint32)(ret)
+}
+func GenPerfMonitorsAMD(n int32, monitors *uint32) {
+	C.glowGenPerfMonitorsAMD(gpGenPerfMonitorsAMD, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(monitors)))
+}
 
 // reserve program pipeline object names
 func GenProgramPipelines(n int32, pipelines *uint32) {
 	C.glowGenProgramPipelines(gpGenProgramPipelines, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
+}
+func GenProgramPipelinesEXT(n int32, pipelines *uint32) {
+	C.glowGenProgramPipelinesEXT(gpGenProgramPipelinesEXT, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(pipelines)))
 }
 
 // generate query object names
@@ -6075,10 +9669,16 @@ func GenVertexArrays(n int32, arrays *uint32) {
 func GenerateMipmap(target uint32) {
 	C.glowGenerateMipmap(gpGenerateMipmap, (C.GLenum)(target))
 }
+func GenerateMultiTexMipmapEXT(texunit uint32, target uint32) {
+	C.glowGenerateMultiTexMipmapEXT(gpGenerateMultiTexMipmapEXT, (C.GLenum)(texunit), (C.GLenum)(target))
+}
 
 // generate mipmaps for a specified texture object
 func GenerateTextureMipmap(texture uint32) {
 	C.glowGenerateTextureMipmap(gpGenerateTextureMipmap, (C.GLuint)(texture))
+}
+func GenerateTextureMipmapEXT(texture uint32, target uint32) {
+	C.glowGenerateTextureMipmapEXT(gpGenerateTextureMipmapEXT, (C.GLuint)(texture), (C.GLenum)(target))
 }
 
 // retrieve information about the set of active atomic counter buffers for a program
@@ -6113,6 +9713,8 @@ func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32
 func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
+
+// query information about an active uniform block
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformBlockiv(gpGetActiveUniformBlockiv, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6137,6 +9739,9 @@ func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
+func GetBooleanIndexedvEXT(target uint32, index uint32, data *bool) {
+	C.glowGetBooleanIndexedvEXT(gpGetBooleanIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
+}
 func GetBooleani_v(target uint32, index uint32, data *bool) {
 	C.glowGetBooleani_v(gpGetBooleani_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLboolean)(unsafe.Pointer(data)))
 }
@@ -6153,6 +9758,9 @@ func GetBufferParameteri64v(target uint32, pname uint32, params *int64) {
 func GetBufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetBufferParameteriv(gpGetBufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetBufferParameterui64vNV(target uint32, pname uint32, params *uint64) {
+	C.glowGetBufferParameterui64vNV(gpGetBufferParameterui64vNV, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
@@ -6162,6 +9770,13 @@ func GetBufferPointerv(target uint32, pname uint32, params *unsafe.Pointer) {
 // returns a subset of a buffer object's data store
 func GetBufferSubData(target uint32, offset int, size int, data unsafe.Pointer) {
 	C.glowGetBufferSubData(gpGetBufferSubData, (C.GLenum)(target), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetCommandHeaderNV(tokenID uint32, size uint32) uint32 {
+	ret := C.glowGetCommandHeaderNV(gpGetCommandHeaderNV, (C.GLenum)(tokenID), (C.GLuint)(size))
+	return (uint32)(ret)
+}
+func GetCompressedMultiTexImageEXT(texunit uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedMultiTexImageEXT(gpGetCompressedMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(lod), img)
 }
 
 // return a compressed texture image
@@ -6173,10 +9788,16 @@ func GetCompressedTexImage(target uint32, level int32, img unsafe.Pointer) {
 func GetCompressedTextureImage(texture uint32, level int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureImage(gpGetCompressedTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLsizei)(bufSize), pixels)
 }
+func GetCompressedTextureImageEXT(texture uint32, target uint32, lod int32, img unsafe.Pointer) {
+	C.glowGetCompressedTextureImageEXT(gpGetCompressedTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(lod), img)
+}
 
 // retrieve a sub-region of a compressed texture image from a     compressed texture object
 func GetCompressedTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetCompressedTextureSubImage(gpGetCompressedTextureSubImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLsizei)(bufSize), pixels)
+}
+func GetCoverageModulationTableNV(bufsize int32, v *float32) {
+	C.glowGetCoverageModulationTableNV(gpGetCoverageModulationTableNV, (C.GLsizei)(bufsize), (*C.GLfloat)(unsafe.Pointer(v)))
 }
 
 // retrieve messages from the debug message log
@@ -6192,8 +9813,14 @@ func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
+func GetDoubleIndexedvEXT(target uint32, index uint32, data *float64) {
+	C.glowGetDoubleIndexedvEXT(gpGetDoubleIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
 func GetDoublei_v(target uint32, index uint32, data *float64) {
 	C.glowGetDoublei_v(gpGetDoublei_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(data)))
+}
+func GetDoublei_vEXT(pname uint32, index uint32, params *float64) {
+	C.glowGetDoublei_vEXT(gpGetDoublei_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
 }
 func GetDoublev(pname uint32, data *float64) {
 	C.glowGetDoublev(gpGetDoublev, (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(data)))
@@ -6204,8 +9831,17 @@ func GetError() uint32 {
 	ret := C.glowGetError(gpGetError)
 	return (uint32)(ret)
 }
+func GetFirstPerfQueryIdINTEL(queryId *uint32) {
+	C.glowGetFirstPerfQueryIdINTEL(gpGetFirstPerfQueryIdINTEL, (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetFloatIndexedvEXT(target uint32, index uint32, data *float32) {
+	C.glowGetFloatIndexedvEXT(gpGetFloatIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
 func GetFloati_v(target uint32, index uint32, data *float32) {
 	C.glowGetFloati_v(gpGetFloati_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(data)))
+}
+func GetFloati_vEXT(pname uint32, index uint32, params *float32) {
+	C.glowGetFloati_vEXT(gpGetFloati_vEXT, (C.GLenum)(pname), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetFloatv(pname uint32, data *float32) {
 	C.glowGetFloatv(gpGetFloatv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(data)))
@@ -6223,14 +9859,17 @@ func GetFragDataLocation(program uint32, name *uint8) int32 {
 	return (int32)(ret)
 }
 
-// retrieve information about attachments of a framebuffer object
+// retrieve information about attachments of a bound framebuffer object
 func GetFramebufferAttachmentParameteriv(target uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferAttachmentParameteriv(gpGetFramebufferAttachmentParameteriv, (C.GLenum)(target), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a framebuffer object
+// retrieve a named parameter from a framebuffer
 func GetFramebufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetFramebufferParameteriv(gpGetFramebufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetFramebufferParameterivEXT(gpGetFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // check if the rendering context has not been lost due to software or hardware issues
@@ -6250,23 +9889,77 @@ func GetImageHandleARB(texture uint32, level int32, layered bool, layer int32, f
 	ret := C.glowGetImageHandleARB(gpGetImageHandleARB, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
 	return (uint64)(ret)
 }
+func GetImageHandleNV(texture uint32, level int32, layered bool, layer int32, format uint32) uint64 {
+	ret := C.glowGetImageHandleNV(gpGetImageHandleNV, (C.GLuint)(texture), (C.GLint)(level), (C.GLboolean)(boolToInt(layered)), (C.GLint)(layer), (C.GLenum)(format))
+	return (uint64)(ret)
+}
 func GetInteger64i_v(target uint32, index uint32, data *int64) {
 	C.glowGetInteger64i_v(gpGetInteger64i_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint64)(unsafe.Pointer(data)))
 }
 func GetInteger64v(pname uint32, data *int64) {
 	C.glowGetInteger64v(gpGetInteger64v, (C.GLenum)(pname), (*C.GLint64)(unsafe.Pointer(data)))
 }
+func GetIntegerIndexedvEXT(target uint32, index uint32, data *int32) {
+	C.glowGetIntegerIndexedvEXT(gpGetIntegerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
 func GetIntegeri_v(target uint32, index uint32, data *int32) {
 	C.glowGetIntegeri_v(gpGetIntegeri_v, (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(data)))
+}
+func GetIntegerui64i_vNV(value uint32, index uint32, result *uint64) {
+	C.glowGetIntegerui64i_vNV(gpGetIntegerui64i_vNV, (C.GLenum)(value), (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(result)))
+}
+func GetIntegerui64vNV(value uint32, result *uint64) {
+	C.glowGetIntegerui64vNV(gpGetIntegerui64vNV, (C.GLenum)(value), (*C.GLuint64EXT)(unsafe.Pointer(result)))
 }
 func GetIntegerv(pname uint32, data *int32) {
 	C.glowGetIntegerv(gpGetIntegerv, (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(data)))
 }
+func GetInternalformatSampleivNV(target uint32, internalformat uint32, samples int32, pname uint32, bufSize int32, params *int32) {
+	C.glowGetInternalformatSampleivNV(gpGetInternalformatSampleivNV, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLsizei)(samples), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetInternalformati64v(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int64) {
 	C.glowGetInternalformati64v(gpGetInternalformati64v, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
 }
+
+// retrieve information about implementation-dependent support for internal formats
 func GetInternalformativ(target uint32, internalformat uint32, pname uint32, bufSize int32, params *int32) {
 	C.glowGetInternalformativ(gpGetInternalformativ, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexEnvfvEXT(gpGetMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexEnvivEXT(gpGetMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowGetMultiTexGendvEXT(gpGetMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexGenfvEXT(gpGetMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexGenivEXT(gpGetMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexImageEXT(texunit uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetMultiTexImageEXT(gpGetMultiTexImageEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func GetMultiTexLevelParameterfvEXT(texunit uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetMultiTexLevelParameterfvEXT(gpGetMultiTexLevelParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexLevelParameterivEXT(texunit uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetMultiTexLevelParameterivEXT(gpGetMultiTexLevelParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterIivEXT(gpGetMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetMultiTexParameterIuivEXT(gpGetMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetMultiTexParameterfvEXT(gpGetMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetMultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetMultiTexParameterivEXT(gpGetMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // retrieve the location of a sample
@@ -6283,30 +9976,69 @@ func GetNamedBufferParameteri64v(buffer uint32, pname uint32, params *int64) {
 func GetNamedBufferParameteriv(buffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedBufferParameteriv(gpGetNamedBufferParameteriv, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedBufferParameterivEXT(buffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedBufferParameterivEXT(gpGetNamedBufferParameterivEXT, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedBufferParameterui64vNV(buffer uint32, pname uint32, params *uint64) {
+	C.glowGetNamedBufferParameterui64vNV(gpGetNamedBufferParameterui64vNV, (C.GLuint)(buffer), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
 
 // return the pointer to a mapped buffer object's data store
 func GetNamedBufferPointerv(buffer uint32, pname uint32, params *unsafe.Pointer) {
 	C.glowGetNamedBufferPointerv(gpGetNamedBufferPointerv, (C.GLuint)(buffer), (C.GLenum)(pname), params)
 }
+func GetNamedBufferPointervEXT(buffer uint32, pname uint32, params *unsafe.Pointer) {
+	C.glowGetNamedBufferPointervEXT(gpGetNamedBufferPointervEXT, (C.GLuint)(buffer), (C.GLenum)(pname), params)
+}
 
 // returns a subset of a buffer object's data store
-func GetNamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func GetNamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubData(gpGetNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func GetNamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowGetNamedBufferSubDataEXT(gpGetNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
 }
 
 // retrieve information about attachments of a framebuffer object
 func GetNamedFramebufferAttachmentParameteriv(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
 	C.glowGetNamedFramebufferAttachmentParameteriv(gpGetNamedFramebufferAttachmentParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNamedFramebufferAttachmentParameterivEXT(framebuffer uint32, attachment uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferAttachmentParameterivEXT(gpGetNamedFramebufferAttachmentParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a framebuffer object
 func GetNamedFramebufferParameteriv(framebuffer uint32, pname uint32, param *int32) {
 	C.glowGetNamedFramebufferParameteriv(gpGetNamedFramebufferParameteriv, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
 }
+func GetNamedFramebufferParameterivEXT(framebuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedFramebufferParameterivEXT(gpGetNamedFramebufferParameterivEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowGetNamedProgramLocalParameterIivEXT(gpGetNamedProgramLocalParameterIivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterIuivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowGetNamedProgramLocalParameterIuivEXT(gpGetNamedProgramLocalParameterIuivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterdvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowGetNamedProgramLocalParameterdvEXT(gpGetNamedProgramLocalParameterdvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func GetNamedProgramLocalParameterfvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowGetNamedProgramLocalParameterfvEXT(gpGetNamedProgramLocalParameterfvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetNamedProgramStringEXT(program uint32, target uint32, pname uint32, xstring unsafe.Pointer) {
+	C.glowGetNamedProgramStringEXT(gpGetNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), xstring)
+}
+func GetNamedProgramivEXT(program uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetNamedProgramivEXT(gpGetNamedProgramivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 
 // query a named parameter of a renderbuffer object
 func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameteriv(gpGetNamedRenderbufferParameteriv, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetNamedRenderbufferParameterivEXT(renderbuffer uint32, pname uint32, params *int32) {
+	C.glowGetNamedRenderbufferParameterivEXT(gpGetNamedRenderbufferParameterivEXT, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
@@ -6314,10 +10046,16 @@ func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int
 func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
+	C.glowGetNextPerfQueryIdINTEL(gpGetNextPerfQueryIdINTEL, (C.GLuint)(queryId), (*C.GLuint)(unsafe.Pointer(nextQueryId)))
+}
 
 // retrieve the label of a named object identified within a namespace
 func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
+	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
@@ -6329,6 +10067,70 @@ func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *
 }
 func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
+}
+func GetPathCommandsNV(path uint32, commands *uint8) {
+	C.glowGetPathCommandsNV(gpGetPathCommandsNV, (C.GLuint)(path), (*C.GLubyte)(unsafe.Pointer(commands)))
+}
+func GetPathCoordsNV(path uint32, coords *float32) {
+	C.glowGetPathCoordsNV(gpGetPathCoordsNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(coords)))
+}
+func GetPathDashArrayNV(path uint32, dashArray *float32) {
+	C.glowGetPathDashArrayNV(gpGetPathDashArrayNV, (C.GLuint)(path), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func GetPathLengthNV(path uint32, startSegment int32, numSegments int32) float32 {
+	ret := C.glowGetPathLengthNV(gpGetPathLengthNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments))
+	return (float32)(ret)
+}
+func GetPathMetricRangeNV(metricQueryMask uint32, firstPathName uint32, numPaths int32, stride int32, metrics *float32) {
+	C.glowGetPathMetricRangeNV(gpGetPathMetricRangeNV, (C.GLbitfield)(metricQueryMask), (C.GLuint)(firstPathName), (C.GLsizei)(numPaths), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathMetricsNV(metricQueryMask uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, stride int32, metrics *float32) {
+	C.glowGetPathMetricsNV(gpGetPathMetricsNV, (C.GLbitfield)(metricQueryMask), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLsizei)(stride), (*C.GLfloat)(unsafe.Pointer(metrics)))
+}
+func GetPathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowGetPathParameterfvNV(gpGetPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func GetPathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowGetPathParameterivNV(gpGetPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func GetPathSpacingNV(pathListMode uint32, numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, advanceScale float32, kerningScale float32, transformType uint32, returnedSpacing *float32) {
+	C.glowGetPathSpacingNV(gpGetPathSpacingNV, (C.GLenum)(pathListMode), (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLfloat)(advanceScale), (C.GLfloat)(kerningScale), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(returnedSpacing)))
+}
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
+}
+func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
+	C.glowGetPerfMonitorCounterDataAMD(gpGetPerfMonitorCounterDataAMD, (C.GLuint)(monitor), (C.GLenum)(pname), (C.GLsizei)(dataSize), (*C.GLuint)(unsafe.Pointer(data)), (*C.GLint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
+	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
+}
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
+	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
+}
+func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
+	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
+}
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
+	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
+}
+func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
+	C.glowGetPerfMonitorGroupsAMD(gpGetPerfMonitorGroupsAMD, (*C.GLint)(unsafe.Pointer(numGroups)), (C.GLsizei)(groupsSize), (*C.GLuint)(unsafe.Pointer(groups)))
+}
+func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
+	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
+}
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
+	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
+}
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
+}
+func GetPointerIndexedvEXT(target uint32, index uint32, data *unsafe.Pointer) {
+	C.glowGetPointerIndexedvEXT(gpGetPointerIndexedvEXT, (C.GLenum)(target), (C.GLuint)(index), data)
+}
+func GetPointeri_vEXT(pname uint32, index uint32, params *unsafe.Pointer) {
+	C.glowGetPointeri_vEXT(gpGetPointeri_vEXT, (C.GLenum)(pname), (C.GLuint)(index), params)
 }
 
 // return the address of the specified pointer
@@ -6356,8 +10158,14 @@ func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32
 func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
+	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
+}
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
 	C.glowGetProgramPipelineiv(gpGetProgramPipelineiv, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
+	C.glowGetProgramPipelineivEXT(gpGetProgramPipelineivEXT, (C.GLuint)(pipeline), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
 // query the index of a named resource within a program
@@ -6382,6 +10190,9 @@ func GetProgramResourceLocationIndex(program uint32, programInterface uint32, na
 func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
+func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
+	C.glowGetProgramResourcefvNV(gpGetProgramResourcefvNV, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLfloat)(unsafe.Pointer(params)))
+}
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
 	C.glowGetProgramResourceiv(gpGetProgramResourceiv, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(propCount), (*C.GLenum)(unsafe.Pointer(props)), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6392,6 +10203,18 @@ func GetProgramStageiv(program uint32, shadertype uint32, pname uint32, values *
 // Returns a parameter from a program object
 func GetProgramiv(program uint32, pname uint32, params *int32) {
 	C.glowGetProgramiv(gpGetProgramiv, (C.GLuint)(program), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetQueryBufferObjecti64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjecti64v(gpGetQueryBufferObjecti64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectiv(gpGetQueryBufferObjectiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectui64v(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectui64v(gpGetQueryBufferObjectui64v, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
+}
+func GetQueryBufferObjectuiv(id uint32, buffer uint32, pname uint32, offset int) {
+	C.glowGetQueryBufferObjectuiv(gpGetQueryBufferObjectuiv, (C.GLuint)(id), (C.GLuint)(buffer), (C.GLenum)(pname), (C.GLintptr)(offset))
 }
 
 // return parameters of an indexed query object target
@@ -6407,6 +10230,8 @@ func GetQueryObjectiv(id uint32, pname uint32, params *int32) {
 func GetQueryObjectui64v(id uint32, pname uint32, params *uint64) {
 	C.glowGetQueryObjectui64v(gpGetQueryObjectui64v, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint64)(unsafe.Pointer(params)))
 }
+
+// return parameters of a query object
 func GetQueryObjectuiv(id uint32, pname uint32, params *uint32) {
 	C.glowGetQueryObjectuiv(gpGetQueryObjectuiv, (C.GLuint)(id), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
@@ -6416,7 +10241,7 @@ func GetQueryiv(target uint32, pname uint32, params *int32) {
 	C.glowGetQueryiv(gpGetQueryiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 
-// query a named parameter of a renderbuffer object
+// retrieve information about a bound renderbuffer object
 func GetRenderbufferParameteriv(target uint32, pname uint32, params *int32) {
 	C.glowGetRenderbufferParameteriv(gpGetRenderbufferParameteriv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6452,6 +10277,10 @@ func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8)
 func GetShaderiv(shader uint32, pname uint32, params *int32) {
 	C.glowGetShaderiv(gpGetShaderiv, (C.GLuint)(shader), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetStageIndexNV(shadertype uint32) uint16 {
+	ret := C.glowGetStageIndexNV(gpGetStageIndexNV, (C.GLenum)(shadertype))
+	return (uint16)(ret)
+}
 
 // return a string describing the current GL connection
 func GetString(name uint32) *uint8 {
@@ -6476,7 +10305,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 
@@ -6506,31 +10335,60 @@ func GetTextureHandleARB(texture uint32) uint64 {
 	ret := C.glowGetTextureHandleARB(gpGetTextureHandleARB, (C.GLuint)(texture))
 	return (uint64)(ret)
 }
+func GetTextureHandleNV(texture uint32) uint64 {
+	ret := C.glowGetTextureHandleNV(gpGetTextureHandleNV, (C.GLuint)(texture))
+	return (uint64)(ret)
+}
 
 // return a texture image
 func GetTextureImage(texture uint32, level int32, format uint32, xtype uint32, bufSize int32, pixels unsafe.Pointer) {
 	C.glowGetTextureImage(gpGetTextureImage, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), (C.GLsizei)(bufSize), pixels)
 }
+func GetTextureImageEXT(texture uint32, target uint32, level int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowGetTextureImageEXT(gpGetTextureImageEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 func GetTextureLevelParameterfv(texture uint32, level int32, pname uint32, params *float32) {
 	C.glowGetTextureLevelParameterfv(gpGetTextureLevelParameterfv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureLevelParameterfvEXT(texture uint32, target uint32, level int32, pname uint32, params *float32) {
+	C.glowGetTextureLevelParameterfvEXT(gpGetTextureLevelParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureLevelParameteriv(texture uint32, level int32, pname uint32, params *int32) {
 	C.glowGetTextureLevelParameteriv(gpGetTextureLevelParameteriv, (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureLevelParameterivEXT(texture uint32, target uint32, level int32, pname uint32, params *int32) {
+	C.glowGetTextureLevelParameterivEXT(gpGetTextureLevelParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameterIiv(gpGetTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetTextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterIivEXT(gpGetTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetTextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowGetTextureParameterIuiv(gpGetTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowGetTextureParameterIuivEXT(gpGetTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
 func GetTextureParameterfv(texture uint32, pname uint32, params *float32) {
 	C.glowGetTextureParameterfv(gpGetTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func GetTextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowGetTextureParameterfvEXT(gpGetTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func GetTextureParameteriv(texture uint32, pname uint32, params *int32) {
 	C.glowGetTextureParameteriv(gpGetTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func GetTextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowGetTextureParameterivEXT(gpGetTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func GetTextureSamplerHandleARB(texture uint32, sampler uint32) uint64 {
 	ret := C.glowGetTextureSamplerHandleARB(gpGetTextureSamplerHandleARB, (C.GLuint)(texture), (C.GLuint)(sampler))
+	return (uint64)(ret)
+}
+func GetTextureSamplerHandleNV(texture uint32, sampler uint32) uint64 {
+	ret := C.glowGetTextureSamplerHandleNV(gpGetTextureSamplerHandleNV, (C.GLuint)(texture), (C.GLuint)(sampler))
 	return (uint64)(ret)
 }
 
@@ -6582,10 +10440,22 @@ func GetUniformdv(program uint32, location int32, params *float64) {
 func GetUniformfv(program uint32, location int32, params *float32) {
 	C.glowGetUniformfv(gpGetUniformfv, (C.GLuint)(program), (C.GLint)(location), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetUniformi64vARB(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vARB(gpGetUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64)(unsafe.Pointer(params)))
+}
+func GetUniformi64vNV(program uint32, location int32, params *int64) {
+	C.glowGetUniformi64vNV(gpGetUniformi64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 
 // Returns the value of a uniform variable
 func GetUniformiv(program uint32, location int32, params *int32) {
 	C.glowGetUniformiv(gpGetUniformiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetUniformui64vARB(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vARB(gpGetUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64)(unsafe.Pointer(params)))
+}
+func GetUniformui64vNV(program uint32, location int32, params *uint64) {
+	C.glowGetUniformui64vNV(gpGetUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 func GetUniformuiv(program uint32, location int32, params *uint32) {
 	C.glowGetUniformuiv(gpGetUniformuiv, (C.GLuint)(program), (C.GLint)(location), (*C.GLuint)(unsafe.Pointer(params)))
@@ -6595,6 +10465,18 @@ func GetVertexArrayIndexed64iv(vaobj uint32, index uint32, pname uint32, param *
 }
 func GetVertexArrayIndexediv(vaobj uint32, index uint32, pname uint32, param *int32) {
 	C.glowGetVertexArrayIndexediv(gpGetVertexArrayIndexediv, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegeri_vEXT(vaobj uint32, index uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegeri_vEXT(gpGetVertexArrayIntegeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayIntegervEXT(vaobj uint32, pname uint32, param *int32) {
+	C.glowGetVertexArrayIntegervEXT(gpGetVertexArrayIntegervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func GetVertexArrayPointeri_vEXT(vaobj uint32, index uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointeri_vEXT(gpGetVertexArrayPointeri_vEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLenum)(pname), param)
+}
+func GetVertexArrayPointervEXT(vaobj uint32, pname uint32, param *unsafe.Pointer) {
+	C.glowGetVertexArrayPointervEXT(gpGetVertexArrayPointervEXT, (C.GLuint)(vaobj), (C.GLenum)(pname), param)
 }
 
 // retrieve parameters of a vertex array object
@@ -6616,8 +10498,14 @@ func GetVertexAttribIuiv(index uint32, pname uint32, params *uint32) {
 func GetVertexAttribLdv(index uint32, pname uint32, params *float64) {
 	C.glowGetVertexAttribLdv(gpGetVertexAttribLdv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
 }
+func GetVertexAttribLi64vNV(index uint32, pname uint32, params *int64) {
+	C.glowGetVertexAttribLi64vNV(gpGetVertexAttribLi64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint64EXT)(unsafe.Pointer(params)))
+}
 func GetVertexAttribLui64vARB(index uint32, pname uint32, params *uint64) {
 	C.glowGetVertexAttribLui64vARB(gpGetVertexAttribLui64vARB, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
+}
+func GetVertexAttribLui64vNV(index uint32, pname uint32, params *uint64) {
+	C.glowGetVertexAttribLui64vNV(gpGetVertexAttribLui64vNV, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLuint64EXT)(unsafe.Pointer(params)))
 }
 
 // return the address of the specified generic vertex attribute pointer
@@ -6638,6 +10526,10 @@ func GetVertexAttribfv(index uint32, pname uint32, params *float32) {
 // Return a generic vertex attribute parameter
 func GetVertexAttribiv(index uint32, pname uint32, params *int32) {
 	C.glowGetVertexAttribiv(gpGetVertexAttribiv, (C.GLuint)(index), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetVkProcAddrNV(name *uint8) C.GLVULKANPROCNV {
+	ret := C.glowGetVkProcAddrNV(gpGetVkProcAddrNV, (*C.GLchar)(unsafe.Pointer(name)))
+	return (C.GLVULKANPROCNV)(ret)
 }
 
 // return a compressed texture image
@@ -6670,6 +10562,9 @@ func GetnUniformfvARB(program uint32, location int32, bufSize int32, params *flo
 func GetnUniformfvKHR(program uint32, location int32, bufSize int32, params *float32) {
 	C.glowGetnUniformfvKHR(gpGetnUniformfvKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLfloat)(unsafe.Pointer(params)))
 }
+func GetnUniformi64vARB(program uint32, location int32, bufSize int32, params *int64) {
+	C.glowGetnUniformi64vARB(gpGetnUniformi64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint64)(unsafe.Pointer(params)))
+}
 func GetnUniformiv(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformiv(gpGetnUniformiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
 }
@@ -6678,6 +10573,9 @@ func GetnUniformivARB(program uint32, location int32, bufSize int32, params *int
 }
 func GetnUniformivKHR(program uint32, location int32, bufSize int32, params *int32) {
 	C.glowGetnUniformivKHR(gpGetnUniformivKHR, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(params)))
+}
+func GetnUniformui64vARB(program uint32, location int32, bufSize int32, params *uint64) {
+	C.glowGetnUniformui64vARB(gpGetnUniformui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint64)(unsafe.Pointer(params)))
 }
 func GetnUniformuiv(program uint32, location int32, bufSize int32, params *uint32) {
 	C.glowGetnUniformuiv(gpGetnUniformuiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(bufSize), (*C.GLuint)(unsafe.Pointer(params)))
@@ -6692,6 +10590,15 @@ func GetnUniformuivKHR(program uint32, location int32, bufSize int32, params *ui
 // specify implementation-specific hints
 func Hint(target uint32, mode uint32) {
 	C.glowHint(gpHint, (C.GLenum)(target), (C.GLenum)(mode))
+}
+func IndexFormatNV(xtype uint32, stride int32) {
+	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func InsertEventMarkerEXT(length int32, marker *uint8) {
+	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
+func InterpolatePathsNV(resultPath uint32, pathA uint32, pathB uint32, weight float32) {
+	C.glowInterpolatePathsNV(gpInterpolatePathsNV, (C.GLuint)(resultPath), (C.GLuint)(pathA), (C.GLuint)(pathB), (C.GLfloat)(weight))
 }
 
 // invalidate the content of a buffer object's data store
@@ -6739,8 +10646,20 @@ func IsBuffer(buffer uint32) bool {
 	ret := C.glowIsBuffer(gpIsBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func IsBufferResidentNV(target uint32) bool {
+	ret := C.glowIsBufferResidentNV(gpIsBufferResidentNV, (C.GLenum)(target))
+	return ret == TRUE
+}
+func IsCommandListNV(list uint32) bool {
+	ret := C.glowIsCommandListNV(gpIsCommandListNV, (C.GLuint)(list))
+	return ret == TRUE
+}
 func IsEnabled(cap uint32) bool {
 	ret := C.glowIsEnabled(gpIsEnabled, (C.GLenum)(cap))
+	return ret == TRUE
+}
+func IsEnabledIndexedEXT(target uint32, index uint32) bool {
+	ret := C.glowIsEnabledIndexedEXT(gpIsEnabledIndexedEXT, (C.GLenum)(target), (C.GLuint)(index))
 	return ret == TRUE
 }
 func IsEnabledi(target uint32, index uint32) bool {
@@ -6757,8 +10676,28 @@ func IsImageHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsImageHandleResidentARB(gpIsImageHandleResidentARB, (C.GLuint64)(handle))
 	return ret == TRUE
 }
+func IsImageHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsImageHandleResidentNV(gpIsImageHandleResidentNV, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsNamedBufferResidentNV(buffer uint32) bool {
+	ret := C.glowIsNamedBufferResidentNV(gpIsNamedBufferResidentNV, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
+	return ret == TRUE
+}
+func IsPathNV(path uint32) bool {
+	ret := C.glowIsPathNV(gpIsPathNV, (C.GLuint)(path))
+	return ret == TRUE
+}
+func IsPointInFillPathNV(path uint32, mask uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInFillPathNV(gpIsPointInFillPathNV, (C.GLuint)(path), (C.GLuint)(mask), (C.GLfloat)(x), (C.GLfloat)(y))
+	return ret == TRUE
+}
+func IsPointInStrokePathNV(path uint32, x float32, y float32) bool {
+	ret := C.glowIsPointInStrokePathNV(gpIsPointInStrokePathNV, (C.GLuint)(path), (C.GLfloat)(x), (C.GLfloat)(y))
 	return ret == TRUE
 }
 
@@ -6771,6 +10710,10 @@ func IsProgram(program uint32) bool {
 // determine if a name corresponds to a program pipeline object
 func IsProgramPipeline(pipeline uint32) bool {
 	ret := C.glowIsProgramPipeline(gpIsProgramPipeline, (C.GLuint)(pipeline))
+	return ret == TRUE
+}
+func IsProgramPipelineEXT(pipeline uint32) bool {
+	ret := C.glowIsProgramPipelineEXT(gpIsProgramPipelineEXT, (C.GLuint)(pipeline))
 	return ret == TRUE
 }
 
@@ -6797,9 +10740,13 @@ func IsShader(shader uint32) bool {
 	ret := C.glowIsShader(gpIsShader, (C.GLuint)(shader))
 	return ret == TRUE
 }
+func IsStateNV(state uint32) bool {
+	ret := C.glowIsStateNV(gpIsStateNV, (C.GLuint)(state))
+	return ret == TRUE
+}
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -6811,6 +10758,10 @@ func IsTexture(texture uint32) bool {
 }
 func IsTextureHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsTextureHandleResidentARB(gpIsTextureHandleResidentARB, (C.GLuint64)(handle))
+	return ret == TRUE
+}
+func IsTextureHandleResidentNV(handle uint64) bool {
+	ret := C.glowIsTextureHandleResidentNV(gpIsTextureHandleResidentNV, (C.GLuint64)(handle))
 	return ret == TRUE
 }
 
@@ -6825,6 +10776,9 @@ func IsVertexArray(array uint32) bool {
 	ret := C.glowIsVertexArray(gpIsVertexArray, (C.GLuint)(array))
 	return ret == TRUE
 }
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
+	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
+}
 
 // specify the width of rasterized lines
 func LineWidth(width float32) {
@@ -6835,22 +10789,49 @@ func LineWidth(width float32) {
 func LinkProgram(program uint32) {
 	C.glowLinkProgram(gpLinkProgram, (C.GLuint)(program))
 }
+func ListDrawCommandsStatesClientNV(list uint32, segment uint32, indirects *unsafe.Pointer, sizes *int32, states *uint32, fbos *uint32, count uint32) {
+	C.glowListDrawCommandsStatesClientNV(gpListDrawCommandsStatesClientNV, (C.GLuint)(list), (C.GLuint)(segment), indirects, (*C.GLsizei)(unsafe.Pointer(sizes)), (*C.GLuint)(unsafe.Pointer(states)), (*C.GLuint)(unsafe.Pointer(fbos)), (C.GLuint)(count))
+}
 
 // specify a logical pixel operation for rendering
 func LogicOp(opcode uint32) {
 	C.glowLogicOp(gpLogicOp, (C.GLenum)(opcode))
 }
+func MakeBufferNonResidentNV(target uint32) {
+	C.glowMakeBufferNonResidentNV(gpMakeBufferNonResidentNV, (C.GLenum)(target))
+}
+func MakeBufferResidentNV(target uint32, access uint32) {
+	C.glowMakeBufferResidentNV(gpMakeBufferResidentNV, (C.GLenum)(target), (C.GLenum)(access))
+}
 func MakeImageHandleNonResidentARB(handle uint64) {
 	C.glowMakeImageHandleNonResidentARB(gpMakeImageHandleNonResidentARB, (C.GLuint64)(handle))
+}
+func MakeImageHandleNonResidentNV(handle uint64) {
+	C.glowMakeImageHandleNonResidentNV(gpMakeImageHandleNonResidentNV, (C.GLuint64)(handle))
 }
 func MakeImageHandleResidentARB(handle uint64, access uint32) {
 	C.glowMakeImageHandleResidentARB(gpMakeImageHandleResidentARB, (C.GLuint64)(handle), (C.GLenum)(access))
 }
+func MakeImageHandleResidentNV(handle uint64, access uint32) {
+	C.glowMakeImageHandleResidentNV(gpMakeImageHandleResidentNV, (C.GLuint64)(handle), (C.GLenum)(access))
+}
+func MakeNamedBufferNonResidentNV(buffer uint32) {
+	C.glowMakeNamedBufferNonResidentNV(gpMakeNamedBufferNonResidentNV, (C.GLuint)(buffer))
+}
+func MakeNamedBufferResidentNV(buffer uint32, access uint32) {
+	C.glowMakeNamedBufferResidentNV(gpMakeNamedBufferResidentNV, (C.GLuint)(buffer), (C.GLenum)(access))
+}
 func MakeTextureHandleNonResidentARB(handle uint64) {
 	C.glowMakeTextureHandleNonResidentARB(gpMakeTextureHandleNonResidentARB, (C.GLuint64)(handle))
 }
+func MakeTextureHandleNonResidentNV(handle uint64) {
+	C.glowMakeTextureHandleNonResidentNV(gpMakeTextureHandleNonResidentNV, (C.GLuint64)(handle))
+}
 func MakeTextureHandleResidentARB(handle uint64) {
 	C.glowMakeTextureHandleResidentARB(gpMakeTextureHandleResidentARB, (C.GLuint64)(handle))
+}
+func MakeTextureHandleResidentNV(handle uint64) {
+	C.glowMakeTextureHandleResidentNV(gpMakeTextureHandleResidentNV, (C.GLuint64)(handle))
 }
 
 // map all of a buffer object's data store into the client's address space
@@ -6870,11 +10851,100 @@ func MapNamedBuffer(buffer uint32, access uint32) unsafe.Pointer {
 	ret := C.glowMapNamedBuffer(gpMapNamedBuffer, (C.GLuint)(buffer), (C.GLenum)(access))
 	return (unsafe.Pointer)(ret)
 }
+func MapNamedBufferEXT(buffer uint32, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferEXT(gpMapNamedBufferEXT, (C.GLuint)(buffer), (C.GLenum)(access))
+	return (unsafe.Pointer)(ret)
+}
 
 // map all or part of a buffer object's data store into the client's address space
-func MapNamedBufferRange(buffer uint32, offset int, length int32, access uint32) unsafe.Pointer {
-	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(length), (C.GLbitfield)(access))
+func MapNamedBufferRange(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRange(gpMapNamedBufferRange, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
 	return (unsafe.Pointer)(ret)
+}
+func MapNamedBufferRangeEXT(buffer uint32, offset int, length int, access uint32) unsafe.Pointer {
+	ret := C.glowMapNamedBufferRangeEXT(gpMapNamedBufferRangeEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(length), (C.GLbitfield)(access))
+	return (unsafe.Pointer)(ret)
+}
+func MatrixFrustumEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixFrustumEXT(gpMatrixFrustumEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixLoad3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x2fNV(gpMatrixLoad3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoad3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoad3x3fNV(gpMatrixLoad3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadIdentityEXT(mode uint32) {
+	C.glowMatrixLoadIdentityEXT(gpMatrixLoadIdentityEXT, (C.GLenum)(mode))
+}
+func MatrixLoadTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixLoadTranspose3x3fNV(gpMatrixLoadTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixLoadTransposedEXT(gpMatrixLoadTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadTransposefEXT(gpMatrixLoadTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixLoaddEXT(mode uint32, m *float64) {
+	C.glowMatrixLoaddEXT(gpMatrixLoaddEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixLoadfEXT(mode uint32, m *float32) {
+	C.glowMatrixLoadfEXT(gpMatrixLoadfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x2fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x2fNV(gpMatrixMult3x2fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMult3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMult3x3fNV(gpMatrixMult3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTranspose3x3fNV(matrixMode uint32, m *float32) {
+	C.glowMatrixMultTranspose3x3fNV(gpMatrixMultTranspose3x3fNV, (C.GLenum)(matrixMode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposedEXT(mode uint32, m *float64) {
+	C.glowMatrixMultTransposedEXT(gpMatrixMultTransposedEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultTransposefEXT(mode uint32, m *float32) {
+	C.glowMatrixMultTransposefEXT(gpMatrixMultTransposefEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixMultdEXT(mode uint32, m *float64) {
+	C.glowMatrixMultdEXT(gpMatrixMultdEXT, (C.GLenum)(mode), (*C.GLdouble)(unsafe.Pointer(m)))
+}
+func MatrixMultfEXT(mode uint32, m *float32) {
+	C.glowMatrixMultfEXT(gpMatrixMultfEXT, (C.GLenum)(mode), (*C.GLfloat)(unsafe.Pointer(m)))
+}
+func MatrixOrthoEXT(mode uint32, left float64, right float64, bottom float64, top float64, zNear float64, zFar float64) {
+	C.glowMatrixOrthoEXT(gpMatrixOrthoEXT, (C.GLenum)(mode), (C.GLdouble)(left), (C.GLdouble)(right), (C.GLdouble)(bottom), (C.GLdouble)(top), (C.GLdouble)(zNear), (C.GLdouble)(zFar))
+}
+func MatrixPopEXT(mode uint32) {
+	C.glowMatrixPopEXT(gpMatrixPopEXT, (C.GLenum)(mode))
+}
+func MatrixPushEXT(mode uint32) {
+	C.glowMatrixPushEXT(gpMatrixPushEXT, (C.GLenum)(mode))
+}
+func MatrixRotatedEXT(mode uint32, angle float64, x float64, y float64, z float64) {
+	C.glowMatrixRotatedEXT(gpMatrixRotatedEXT, (C.GLenum)(mode), (C.GLdouble)(angle), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixRotatefEXT(mode uint32, angle float32, x float32, y float32, z float32) {
+	C.glowMatrixRotatefEXT(gpMatrixRotatefEXT, (C.GLenum)(mode), (C.GLfloat)(angle), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixScaledEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixScaledEXT(gpMatrixScaledEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixScalefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixScalefEXT(gpMatrixScalefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MatrixTranslatedEXT(mode uint32, x float64, y float64, z float64) {
+	C.glowMatrixTranslatedEXT(gpMatrixTranslatedEXT, (C.GLenum)(mode), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
+func MatrixTranslatefEXT(mode uint32, x float32, y float32, z float32) {
+	C.glowMatrixTranslatefEXT(gpMatrixTranslatefEXT, (C.GLenum)(mode), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z))
+}
+func MaxShaderCompilerThreadsARB(count uint32) {
+	C.glowMaxShaderCompilerThreadsARB(gpMaxShaderCompilerThreadsARB, (C.GLuint)(count))
+}
+func MaxShaderCompilerThreadsKHR(count uint32) {
+	C.glowMaxShaderCompilerThreadsKHR(gpMaxShaderCompilerThreadsKHR, (C.GLuint)(count))
 }
 
 // defines a barrier ordering memory transactions
@@ -6902,8 +10972,14 @@ func MultiDrawArrays(mode uint32, first *int32, count *int32, drawcount int32) {
 func MultiDrawArraysIndirect(mode uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawArraysIndirect(gpMultiDrawArraysIndirect, (C.GLenum)(mode), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawArraysIndirectCountARB(mode uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawArraysIndirectBindlessCountNV(mode uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessCountNV(gpMultiDrawArraysIndirectBindlessCountNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectBindlessNV(mode uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawArraysIndirectBindlessNV(gpMultiDrawArraysIndirectBindlessNV, (C.GLenum)(mode), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawArraysIndirectCountARB(mode uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawArraysIndirectCountARB(gpMultiDrawArraysIndirectCountARB, (C.GLenum)(mode), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
 }
 
 // render multiple sets of primitives by specifying indices of array data elements
@@ -6920,29 +10996,122 @@ func MultiDrawElementsBaseVertex(mode uint32, count *int32, xtype uint32, indice
 func MultiDrawElementsIndirect(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int32, stride int32) {
 	C.glowMultiDrawElementsIndirect(gpMultiDrawElementsIndirect, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawcount), (C.GLsizei)(stride))
 }
-func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect int, drawcount int, maxdrawcount int32, stride int32) {
-	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), (C.GLintptr)(indirect), (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+func MultiDrawElementsIndirectBindlessCountNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, maxDrawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessCountNV(gpMultiDrawElementsIndirectBindlessCountNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(maxDrawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectBindlessNV(mode uint32, xtype uint32, indirect unsafe.Pointer, drawCount int32, stride int32, vertexBufferCount int32) {
+	C.glowMultiDrawElementsIndirectBindlessNV(gpMultiDrawElementsIndirectBindlessNV, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLsizei)(drawCount), (C.GLsizei)(stride), (C.GLint)(vertexBufferCount))
+}
+func MultiDrawElementsIndirectCountARB(mode uint32, xtype uint32, indirect unsafe.Pointer, drawcount int, maxdrawcount int32, stride int32) {
+	C.glowMultiDrawElementsIndirectCountARB(gpMultiDrawElementsIndirectCountARB, (C.GLenum)(mode), (C.GLenum)(xtype), indirect, (C.GLintptr)(drawcount), (C.GLsizei)(maxdrawcount), (C.GLsizei)(stride))
+}
+func MultiTexBufferEXT(texunit uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowMultiTexBufferEXT(gpMultiTexBufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
+func MultiTexCoordPointerEXT(texunit uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
+	C.glowMultiTexCoordPointerEXT(gpMultiTexCoordPointerEXT, (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
+}
+func MultiTexEnvfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexEnvfEXT(gpMultiTexEnvfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexEnvfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexEnvfvEXT(gpMultiTexEnvfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexEnviEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexEnviEXT(gpMultiTexEnviEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexEnvivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexEnvivEXT(gpMultiTexEnvivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexGendEXT(texunit uint32, coord uint32, pname uint32, param float64) {
+	C.glowMultiTexGendEXT(gpMultiTexGendEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLdouble)(param))
+}
+func MultiTexGendvEXT(texunit uint32, coord uint32, pname uint32, params *float64) {
+	C.glowMultiTexGendvEXT(gpMultiTexGendvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func MultiTexGenfEXT(texunit uint32, coord uint32, pname uint32, param float32) {
+	C.glowMultiTexGenfEXT(gpMultiTexGenfEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexGenfvEXT(texunit uint32, coord uint32, pname uint32, params *float32) {
+	C.glowMultiTexGenfvEXT(gpMultiTexGenfvEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexGeniEXT(texunit uint32, coord uint32, pname uint32, param int32) {
+	C.glowMultiTexGeniEXT(gpMultiTexGeniEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexGenivEXT(texunit uint32, coord uint32, pname uint32, params *int32) {
+	C.glowMultiTexGenivEXT(gpMultiTexGenivEXT, (C.GLenum)(texunit), (C.GLenum)(coord), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage1DEXT(gpMultiTexImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage2DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage2DEXT(gpMultiTexImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexImage3DEXT(texunit uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexImage3DEXT(gpMultiTexImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexParameterIivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterIivEXT(gpMultiTexParameterIivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterIuivEXT(texunit uint32, target uint32, pname uint32, params *uint32) {
+	C.glowMultiTexParameterIuivEXT(gpMultiTexParameterIuivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func MultiTexParameterfEXT(texunit uint32, target uint32, pname uint32, param float32) {
+	C.glowMultiTexParameterfEXT(gpMultiTexParameterfEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
+func MultiTexParameterfvEXT(texunit uint32, target uint32, pname uint32, params *float32) {
+	C.glowMultiTexParameterfvEXT(gpMultiTexParameterfvEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func MultiTexParameteriEXT(texunit uint32, target uint32, pname uint32, param int32) {
+	C.glowMultiTexParameteriEXT(gpMultiTexParameteriEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
+func MultiTexParameterivEXT(texunit uint32, target uint32, pname uint32, params *int32) {
+	C.glowMultiTexParameterivEXT(gpMultiTexParameterivEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func MultiTexRenderbufferEXT(texunit uint32, target uint32, renderbuffer uint32) {
+	C.glowMultiTexRenderbufferEXT(gpMultiTexRenderbufferEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLuint)(renderbuffer))
+}
+func MultiTexSubImage1DEXT(texunit uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage1DEXT(gpMultiTexSubImage1DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage2DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage2DEXT(gpMultiTexSubImage2DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func MultiTexSubImage3DEXT(texunit uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowMultiTexSubImage3DEXT(gpMultiTexSubImage3DEXT, (C.GLenum)(texunit), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // creates and initializes a buffer object's data     store
-func NamedBufferData(buffer uint32, size int32, data unsafe.Pointer, usage uint32) {
-	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLenum)(usage))
+func NamedBufferData(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferData(gpNamedBufferData, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferDataEXT(buffer uint32, size int, data unsafe.Pointer, usage uint32) {
+	C.glowNamedBufferDataEXT(gpNamedBufferDataEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLenum)(usage))
 }
-func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int32, commit bool) {
-	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), (C.GLboolean)(boolToInt(commit)))
+func NamedBufferPageCommitmentARB(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentARB(gpNamedBufferPageCommitmentARB, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
+}
+func NamedBufferPageCommitmentEXT(buffer uint32, offset int, size int, commit bool) {
+	C.glowNamedBufferPageCommitmentEXT(gpNamedBufferPageCommitmentEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), (C.GLboolean)(boolToInt(commit)))
 }
 
 // creates and initializes a buffer object's immutable data     store
-func NamedBufferStorage(buffer uint32, size int32, data unsafe.Pointer, flags uint32) {
-	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizei)(size), data, (C.GLbitfield)(flags))
+func NamedBufferStorage(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorage(gpNamedBufferStorage, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
+}
+func NamedBufferStorageEXT(buffer uint32, size int, data unsafe.Pointer, flags uint32) {
+	C.glowNamedBufferStorageEXT(gpNamedBufferStorageEXT, (C.GLuint)(buffer), (C.GLsizeiptr)(size), data, (C.GLbitfield)(flags))
 }
 
 // updates a subset of a buffer object's data store
-func NamedBufferSubData(buffer uint32, offset int, size int32, data unsafe.Pointer) {
-	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size), data)
+func NamedBufferSubData(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubData(gpNamedBufferSubData, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedBufferSubDataEXT(buffer uint32, offset int, size int, data unsafe.Pointer) {
+	C.glowNamedBufferSubDataEXT(gpNamedBufferSubDataEXT, (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size), data)
+}
+func NamedCopyBufferSubDataEXT(readBuffer uint32, writeBuffer uint32, readOffset int, writeOffset int, size int) {
+	C.glowNamedCopyBufferSubDataEXT(gpNamedCopyBufferSubDataEXT, (C.GLuint)(readBuffer), (C.GLuint)(writeBuffer), (C.GLintptr)(readOffset), (C.GLintptr)(writeOffset), (C.GLsizeiptr)(size))
 }
 
 // specify which color buffers are to be drawn into
@@ -6959,6 +11128,9 @@ func NamedFramebufferDrawBuffers(framebuffer uint32, n int32, bufs *uint32) {
 func NamedFramebufferParameteri(framebuffer uint32, pname uint32, param int32) {
 	C.glowNamedFramebufferParameteri(gpNamedFramebufferParameteri, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
 }
+func NamedFramebufferParameteriEXT(framebuffer uint32, pname uint32, param int32) {
+	C.glowNamedFramebufferParameteriEXT(gpNamedFramebufferParameteriEXT, (C.GLuint)(framebuffer), (C.GLenum)(pname), (C.GLint)(param))
+}
 
 // select a color buffer source for pixels
 func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
@@ -6969,26 +11141,101 @@ func NamedFramebufferReadBuffer(framebuffer uint32, src uint32) {
 func NamedFramebufferRenderbuffer(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
 	C.glowNamedFramebufferRenderbuffer(gpNamedFramebufferRenderbuffer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
 }
+func NamedFramebufferRenderbufferEXT(framebuffer uint32, attachment uint32, renderbuffertarget uint32, renderbuffer uint32) {
+	C.glowNamedFramebufferRenderbufferEXT(gpNamedFramebufferRenderbufferEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(renderbuffertarget), (C.GLuint)(renderbuffer))
+}
+func NamedFramebufferSampleLocationsfvARB(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvARB(gpNamedFramebufferSampleLocationsfvARB, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
+func NamedFramebufferSampleLocationsfvNV(framebuffer uint32, start uint32, count int32, v *float32) {
+	C.glowNamedFramebufferSampleLocationsfvNV(gpNamedFramebufferSampleLocationsfvNV, (C.GLuint)(framebuffer), (C.GLuint)(start), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(v)))
+}
 func NamedFramebufferTexture(framebuffer uint32, attachment uint32, texture uint32, level int32) {
 	C.glowNamedFramebufferTexture(gpNamedFramebufferTexture, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture1DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture1DEXT(gpNamedFramebufferTexture1DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture2DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTexture2DEXT(gpNamedFramebufferTexture2DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTexture3DEXT(framebuffer uint32, attachment uint32, textarget uint32, texture uint32, level int32, zoffset int32) {
+	C.glowNamedFramebufferTexture3DEXT(gpNamedFramebufferTexture3DEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLenum)(textarget), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(zoffset))
+}
+func NamedFramebufferTextureEXT(framebuffer uint32, attachment uint32, texture uint32, level int32) {
+	C.glowNamedFramebufferTextureEXT(gpNamedFramebufferTextureEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level))
+}
+func NamedFramebufferTextureFaceEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, face uint32) {
+	C.glowNamedFramebufferTextureFaceEXT(gpNamedFramebufferTextureFaceEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLenum)(face))
 }
 
 // attach a single layer of a texture object as a logical buffer of a framebuffer object
 func NamedFramebufferTextureLayer(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
 	C.glowNamedFramebufferTextureLayer(gpNamedFramebufferTextureLayer, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
 }
+func NamedFramebufferTextureLayerEXT(framebuffer uint32, attachment uint32, texture uint32, level int32, layer int32) {
+	C.glowNamedFramebufferTextureLayerEXT(gpNamedFramebufferTextureLayerEXT, (C.GLuint)(framebuffer), (C.GLenum)(attachment), (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(layer))
+}
+func NamedProgramLocalParameter4dEXT(program uint32, target uint32, index uint32, x float64, y float64, z float64, w float64) {
+	C.glowNamedProgramLocalParameter4dEXT(gpNamedProgramLocalParameter4dEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
+func NamedProgramLocalParameter4dvEXT(program uint32, target uint32, index uint32, params *float64) {
+	C.glowNamedProgramLocalParameter4dvEXT(gpNamedProgramLocalParameter4dvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameter4fEXT(program uint32, target uint32, index uint32, x float32, y float32, z float32, w float32) {
+	C.glowNamedProgramLocalParameter4fEXT(gpNamedProgramLocalParameter4fEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLfloat)(x), (C.GLfloat)(y), (C.GLfloat)(z), (C.GLfloat)(w))
+}
+func NamedProgramLocalParameter4fvEXT(program uint32, target uint32, index uint32, params *float32) {
+	C.glowNamedProgramLocalParameter4fvEXT(gpNamedProgramLocalParameter4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4iEXT(program uint32, target uint32, index uint32, x int32, y int32, z int32, w int32) {
+	C.glowNamedProgramLocalParameterI4iEXT(gpNamedProgramLocalParameterI4iEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLint)(x), (C.GLint)(y), (C.GLint)(z), (C.GLint)(w))
+}
+func NamedProgramLocalParameterI4ivEXT(program uint32, target uint32, index uint32, params *int32) {
+	C.glowNamedProgramLocalParameterI4ivEXT(gpNamedProgramLocalParameterI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameterI4uiEXT(program uint32, target uint32, index uint32, x uint32, y uint32, z uint32, w uint32) {
+	C.glowNamedProgramLocalParameterI4uiEXT(gpNamedProgramLocalParameterI4uiEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(x), (C.GLuint)(y), (C.GLuint)(z), (C.GLuint)(w))
+}
+func NamedProgramLocalParameterI4uivEXT(program uint32, target uint32, index uint32, params *uint32) {
+	C.glowNamedProgramLocalParameterI4uivEXT(gpNamedProgramLocalParameterI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParameters4fvEXT(program uint32, target uint32, index uint32, count int32, params *float32) {
+	C.glowNamedProgramLocalParameters4fvEXT(gpNamedProgramLocalParameters4fvEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4ivEXT(program uint32, target uint32, index uint32, count int32, params *int32) {
+	C.glowNamedProgramLocalParametersI4ivEXT(gpNamedProgramLocalParametersI4ivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(params)))
+}
+func NamedProgramLocalParametersI4uivEXT(program uint32, target uint32, index uint32, count int32, params *uint32) {
+	C.glowNamedProgramLocalParametersI4uivEXT(gpNamedProgramLocalParametersI4uivEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLuint)(index), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func NamedProgramStringEXT(program uint32, target uint32, format uint32, len int32, xstring unsafe.Pointer) {
+	C.glowNamedProgramStringEXT(gpNamedProgramStringEXT, (C.GLuint)(program), (C.GLenum)(target), (C.GLenum)(format), (C.GLsizei)(len), xstring)
+}
 
 // establish data storage, format and dimensions of a     renderbuffer object's image
 func NamedRenderbufferStorage(renderbuffer uint32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorage(gpNamedRenderbufferStorage, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageEXT(renderbuffer uint32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageEXT(gpNamedRenderbufferStorageEXT, (C.GLuint)(renderbuffer), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func NamedRenderbufferStorageMultisample(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisample(gpNamedRenderbufferStorageMultisample, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
+func NamedRenderbufferStorageMultisampleCoverageEXT(renderbuffer uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleCoverageEXT(gpNamedRenderbufferStorageMultisampleCoverageEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func NamedRenderbufferStorageMultisampleEXT(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
+	C.glowNamedRenderbufferStorageMultisampleEXT(gpNamedRenderbufferStorageMultisampleEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
 func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
+}
+func NormalFormatNV(xtype uint32, stride int32) {
+	C.glowNormalFormatNV(gpNormalFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // label a named object identified within a namespace
@@ -7009,8 +11256,67 @@ func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 func PatchParameterfv(pname uint32, values *float32) {
 	C.glowPatchParameterfv(gpPatchParameterfv, (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(values)))
 }
+
+// specifies the parameters for patch primitives
 func PatchParameteri(pname uint32, value int32) {
 	C.glowPatchParameteri(gpPatchParameteri, (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathCommandsNV(path uint32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCommandsNV(gpPathCommandsNV, (C.GLuint)(path), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoordsNV(path uint32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathCoordsNV(gpPathCoordsNV, (C.GLuint)(path), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathCoverDepthFuncNV(xfunc uint32) {
+	C.glowPathCoverDepthFuncNV(gpPathCoverDepthFuncNV, (C.GLenum)(xfunc))
+}
+func PathDashArrayNV(path uint32, dashCount int32, dashArray *float32) {
+	C.glowPathDashArrayNV(gpPathDashArrayNV, (C.GLuint)(path), (C.GLsizei)(dashCount), (*C.GLfloat)(unsafe.Pointer(dashArray)))
+}
+func PathGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathGlyphIndexArrayNV(gpPathGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathGlyphIndexRangeNV(fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, pathParameterTemplate uint32, emScale float32, baseAndCount *uint32) uint32 {
+	ret := C.glowPathGlyphIndexRangeNV(gpPathGlyphIndexRangeNV, (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale), (*C.GLuint)(unsafe.Pointer(baseAndCount)))
+	return (uint32)(ret)
+}
+func PathGlyphRangeNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, firstGlyph uint32, numGlyphs int32, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphRangeNV(gpPathGlyphRangeNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLuint)(firstGlyph), (C.GLsizei)(numGlyphs), (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathGlyphsNV(firstPathName uint32, fontTarget uint32, fontName unsafe.Pointer, fontStyle uint32, numGlyphs int32, xtype uint32, charcodes unsafe.Pointer, handleMissingGlyphs uint32, pathParameterTemplate uint32, emScale float32) {
+	C.glowPathGlyphsNV(gpPathGlyphsNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), fontName, (C.GLbitfield)(fontStyle), (C.GLsizei)(numGlyphs), (C.GLenum)(xtype), charcodes, (C.GLenum)(handleMissingGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+}
+func PathMemoryGlyphIndexArrayNV(firstPathName uint32, fontTarget uint32, fontSize int, fontData unsafe.Pointer, faceIndex int32, firstGlyphIndex uint32, numGlyphs int32, pathParameterTemplate uint32, emScale float32) uint32 {
+	ret := C.glowPathMemoryGlyphIndexArrayNV(gpPathMemoryGlyphIndexArrayNV, (C.GLuint)(firstPathName), (C.GLenum)(fontTarget), (C.GLsizeiptr)(fontSize), fontData, (C.GLsizei)(faceIndex), (C.GLuint)(firstGlyphIndex), (C.GLsizei)(numGlyphs), (C.GLuint)(pathParameterTemplate), (C.GLfloat)(emScale))
+	return (uint32)(ret)
+}
+func PathParameterfNV(path uint32, pname uint32, value float32) {
+	C.glowPathParameterfNV(gpPathParameterfNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLfloat)(value))
+}
+func PathParameterfvNV(path uint32, pname uint32, value *float32) {
+	C.glowPathParameterfvNV(gpPathParameterfvNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func PathParameteriNV(path uint32, pname uint32, value int32) {
+	C.glowPathParameteriNV(gpPathParameteriNV, (C.GLuint)(path), (C.GLenum)(pname), (C.GLint)(value))
+}
+func PathParameterivNV(path uint32, pname uint32, value *int32) {
+	C.glowPathParameterivNV(gpPathParameterivNV, (C.GLuint)(path), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
+}
+func PathStencilDepthOffsetNV(factor float32, units float32) {
+	C.glowPathStencilDepthOffsetNV(gpPathStencilDepthOffsetNV, (C.GLfloat)(factor), (C.GLfloat)(units))
+}
+func PathStencilFuncNV(xfunc uint32, ref int32, mask uint32) {
+	C.glowPathStencilFuncNV(gpPathStencilFuncNV, (C.GLenum)(xfunc), (C.GLint)(ref), (C.GLuint)(mask))
+}
+func PathStringNV(path uint32, format uint32, length int32, pathString unsafe.Pointer) {
+	C.glowPathStringNV(gpPathStringNV, (C.GLuint)(path), (C.GLenum)(format), (C.GLsizei)(length), pathString)
+}
+func PathSubCommandsNV(path uint32, commandStart int32, commandsToDelete int32, numCommands int32, commands *uint8, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCommandsNV(gpPathSubCommandsNV, (C.GLuint)(path), (C.GLsizei)(commandStart), (C.GLsizei)(commandsToDelete), (C.GLsizei)(numCommands), (*C.GLubyte)(unsafe.Pointer(commands)), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
+}
+func PathSubCoordsNV(path uint32, coordStart int32, numCoords int32, coordType uint32, coords unsafe.Pointer) {
+	C.glowPathSubCoordsNV(gpPathSubCoordsNV, (C.GLuint)(path), (C.GLsizei)(coordStart), (C.GLsizei)(numCoords), (C.GLenum)(coordType), coords)
 }
 
 // pause transform feedback operations
@@ -7020,8 +11326,14 @@ func PauseTransformFeedback() {
 func PixelStoref(pname uint32, param float32) {
 	C.glowPixelStoref(gpPixelStoref, (C.GLenum)(pname), (C.GLfloat)(param))
 }
+
+// set pixel storage modes
 func PixelStorei(pname uint32, param int32) {
 	C.glowPixelStorei(gpPixelStorei, (C.GLenum)(pname), (C.GLint)(param))
+}
+func PointAlongPathNV(path uint32, startSegment int32, numSegments int32, distance float32, x *float32, y *float32, tangentX *float32, tangentY *float32) bool {
+	ret := C.glowPointAlongPathNV(gpPointAlongPathNV, (C.GLuint)(path), (C.GLsizei)(startSegment), (C.GLsizei)(numSegments), (C.GLfloat)(distance), (*C.GLfloat)(unsafe.Pointer(x)), (*C.GLfloat)(unsafe.Pointer(y)), (*C.GLfloat)(unsafe.Pointer(tangentX)), (*C.GLfloat)(unsafe.Pointer(tangentY)))
+	return ret == TRUE
 }
 func PointParameterf(pname uint32, param float32) {
 	C.glowPointParameterf(gpPointParameterf, (C.GLenum)(pname), (C.GLfloat)(param))
@@ -7050,6 +11362,12 @@ func PolygonMode(face uint32, mode uint32) {
 func PolygonOffset(factor float32, units float32) {
 	C.glowPolygonOffset(gpPolygonOffset, (C.GLfloat)(factor), (C.GLfloat)(units))
 }
+func PolygonOffsetClamp(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClamp(gpPolygonOffsetClamp, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
+func PolygonOffsetClampEXT(factor float32, units float32, clamp float32) {
+	C.glowPolygonOffsetClampEXT(gpPolygonOffsetClampEXT, (C.GLfloat)(factor), (C.GLfloat)(units), (C.GLfloat)(clamp))
+}
 
 // pop the active debug group
 func PopDebugGroup() {
@@ -7057,6 +11375,12 @@ func PopDebugGroup() {
 }
 func PopDebugGroupKHR() {
 	C.glowPopDebugGroupKHR(gpPopDebugGroupKHR)
+}
+func PopGroupMarkerEXT() {
+	C.glowPopGroupMarkerEXT(gpPopGroupMarkerEXT)
+}
+func PrimitiveBoundingBoxARB(minX float32, minY float32, minZ float32, minW float32, maxX float32, maxY float32, maxZ float32, maxW float32) {
+	C.glowPrimitiveBoundingBoxARB(gpPrimitiveBoundingBoxARB, (C.GLfloat)(minX), (C.GLfloat)(minY), (C.GLfloat)(minZ), (C.GLfloat)(minW), (C.GLfloat)(maxX), (C.GLfloat)(maxY), (C.GLfloat)(maxZ), (C.GLfloat)(maxW))
 }
 
 // specify the primitive restart index
@@ -7068,235 +11392,507 @@ func PrimitiveRestartIndex(index uint32) {
 func ProgramBinary(program uint32, binaryFormat uint32, binary unsafe.Pointer, length int32) {
 	C.glowProgramBinary(gpProgramBinary, (C.GLuint)(program), (C.GLenum)(binaryFormat), binary, (C.GLsizei)(length))
 }
+
+// specify a parameter for a program object
 func ProgramParameteri(program uint32, pname uint32, value int32) {
 	C.glowProgramParameteri(gpProgramParameteri, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriARB(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriARB(gpProgramParameteriARB, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramParameteriEXT(program uint32, pname uint32, value int32) {
+	C.glowProgramParameteriEXT(gpProgramParameteriEXT, (C.GLuint)(program), (C.GLenum)(pname), (C.GLint)(value))
+}
+func ProgramPathFragmentInputGenNV(program uint32, location int32, genMode uint32, components int32, coeffs *float32) {
+	C.glowProgramPathFragmentInputGenNV(gpProgramPathFragmentInputGenNV, (C.GLuint)(program), (C.GLint)(location), (C.GLenum)(genMode), (C.GLint)(components), (*C.GLfloat)(unsafe.Pointer(coeffs)))
 }
 func ProgramUniform1d(program uint32, location int32, v0 float64) {
 	C.glowProgramUniform1d(gpProgramUniform1d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0))
 }
+func ProgramUniform1dEXT(program uint32, location int32, x float64) {
+	C.glowProgramUniform1dEXT(gpProgramUniform1dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x))
+}
 func ProgramUniform1dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform1dv(gpProgramUniform1dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform1dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform1dvEXT(gpProgramUniform1dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1f(program uint32, location int32, v0 float32) {
 	C.glowProgramUniform1f(gpProgramUniform1f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
 }
+func ProgramUniform1fEXT(program uint32, location int32, v0 float32) {
+	C.glowProgramUniform1fEXT(gpProgramUniform1fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform1fv(gpProgramUniform1fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform1fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform1fvEXT(gpProgramUniform1fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1i(program uint32, location int32, v0 int32) {
 	C.glowProgramUniform1i(gpProgramUniform1i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
 }
+func ProgramUniform1i64ARB(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64ARB(gpProgramUniform1i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x))
+}
+func ProgramUniform1i64NV(program uint32, location int32, x int64) {
+	C.glowProgramUniform1i64NV(gpProgramUniform1i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func ProgramUniform1i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vARB(gpProgramUniform1i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform1i64vNV(gpProgramUniform1i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1iEXT(program uint32, location int32, v0 int32) {
+	C.glowProgramUniform1iEXT(gpProgramUniform1iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform1iv(gpProgramUniform1iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform1ivEXT(gpProgramUniform1ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1ui(program uint32, location int32, v0 uint32) {
 	C.glowProgramUniform1ui(gpProgramUniform1ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
 }
+func ProgramUniform1ui64ARB(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64ARB(gpProgramUniform1ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x))
+}
+func ProgramUniform1ui64NV(program uint32, location int32, x uint64) {
+	C.glowProgramUniform1ui64NV(gpProgramUniform1ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func ProgramUniform1ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vARB(gpProgramUniform1ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform1ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform1ui64vNV(gpProgramUniform1ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform1uiEXT(program uint32, location int32, v0 uint32) {
+	C.glowProgramUniform1uiEXT(gpProgramUniform1uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform1uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform1uiv(gpProgramUniform1uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform1uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform1uivEXT(gpProgramUniform1uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform2d(program uint32, location int32, v0 float64, v1 float64) {
 	C.glowProgramUniform2d(gpProgramUniform2d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1))
 }
+func ProgramUniform2dEXT(program uint32, location int32, x float64, y float64) {
+	C.glowProgramUniform2dEXT(gpProgramUniform2dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y))
+}
 func ProgramUniform2dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform2dv(gpProgramUniform2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform2dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform2dvEXT(gpProgramUniform2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2f(program uint32, location int32, v0 float32, v1 float32) {
 	C.glowProgramUniform2f(gpProgramUniform2f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
 }
+func ProgramUniform2fEXT(program uint32, location int32, v0 float32, v1 float32) {
+	C.glowProgramUniform2fEXT(gpProgramUniform2fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform2fv(gpProgramUniform2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform2fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform2fvEXT(gpProgramUniform2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2i(program uint32, location int32, v0 int32, v1 int32) {
 	C.glowProgramUniform2i(gpProgramUniform2i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func ProgramUniform2i64ARB(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64ARB(gpProgramUniform2i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func ProgramUniform2i64NV(program uint32, location int32, x int64, y int64) {
+	C.glowProgramUniform2i64NV(gpProgramUniform2i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func ProgramUniform2i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vARB(gpProgramUniform2i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform2i64vNV(gpProgramUniform2i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2iEXT(program uint32, location int32, v0 int32, v1 int32) {
+	C.glowProgramUniform2iEXT(gpProgramUniform2iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform2iv(gpProgramUniform2iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform2ivEXT(gpProgramUniform2ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2ui(program uint32, location int32, v0 uint32, v1 uint32) {
 	C.glowProgramUniform2ui(gpProgramUniform2ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
 }
+func ProgramUniform2ui64ARB(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64ARB(gpProgramUniform2ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func ProgramUniform2ui64NV(program uint32, location int32, x uint64, y uint64) {
+	C.glowProgramUniform2ui64NV(gpProgramUniform2ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func ProgramUniform2ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vARB(gpProgramUniform2ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform2ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform2ui64vNV(gpProgramUniform2ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform2uiEXT(program uint32, location int32, v0 uint32, v1 uint32) {
+	C.glowProgramUniform2uiEXT(gpProgramUniform2uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform2uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform2uiv(gpProgramUniform2uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform2uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform2uivEXT(gpProgramUniform2uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform3d(program uint32, location int32, v0 float64, v1 float64, v2 float64) {
 	C.glowProgramUniform3d(gpProgramUniform3d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2))
 }
+func ProgramUniform3dEXT(program uint32, location int32, x float64, y float64, z float64) {
+	C.glowProgramUniform3dEXT(gpProgramUniform3dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
+}
 func ProgramUniform3dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform3dv(gpProgramUniform3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform3dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform3dvEXT(gpProgramUniform3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3f(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
 	C.glowProgramUniform3f(gpProgramUniform3f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
 }
+func ProgramUniform3fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32) {
+	C.glowProgramUniform3fEXT(gpProgramUniform3fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform3fv(gpProgramUniform3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform3fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform3fvEXT(gpProgramUniform3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3i(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowProgramUniform3i(gpProgramUniform3i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func ProgramUniform3i64ARB(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64ARB(gpProgramUniform3i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func ProgramUniform3i64NV(program uint32, location int32, x int64, y int64, z int64) {
+	C.glowProgramUniform3i64NV(gpProgramUniform3i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func ProgramUniform3i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vARB(gpProgramUniform3i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform3i64vNV(gpProgramUniform3i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32) {
+	C.glowProgramUniform3iEXT(gpProgramUniform3iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform3iv(gpProgramUniform3iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform3ivEXT(gpProgramUniform3ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowProgramUniform3ui(gpProgramUniform3ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
 }
+func ProgramUniform3ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64ARB(gpProgramUniform3ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func ProgramUniform3ui64NV(program uint32, location int32, x uint64, y uint64, z uint64) {
+	C.glowProgramUniform3ui64NV(gpProgramUniform3ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func ProgramUniform3ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vARB(gpProgramUniform3ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform3ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform3ui64vNV(gpProgramUniform3ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform3uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32) {
+	C.glowProgramUniform3uiEXT(gpProgramUniform3uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform3uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform3uiv(gpProgramUniform3uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform3uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform3uivEXT(gpProgramUniform3uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniform4d(program uint32, location int32, v0 float64, v1 float64, v2 float64, v3 float64) {
 	C.glowProgramUniform4d(gpProgramUniform4d, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(v0), (C.GLdouble)(v1), (C.GLdouble)(v2), (C.GLdouble)(v3))
 }
+func ProgramUniform4dEXT(program uint32, location int32, x float64, y float64, z float64, w float64) {
+	C.glowProgramUniform4dEXT(gpProgramUniform4dEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
+}
 func ProgramUniform4dv(program uint32, location int32, count int32, value *float64) {
 	C.glowProgramUniform4dv(gpProgramUniform4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniform4dvEXT(program uint32, location int32, count int32, value *float64) {
+	C.glowProgramUniform4dvEXT(gpProgramUniform4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4f(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
 	C.glowProgramUniform4f(gpProgramUniform4f, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
 }
+func ProgramUniform4fEXT(program uint32, location int32, v0 float32, v1 float32, v2 float32, v3 float32) {
+	C.glowProgramUniform4fEXT(gpProgramUniform4fEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLfloat)(v0), (C.GLfloat)(v1), (C.GLfloat)(v2), (C.GLfloat)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4fv(program uint32, location int32, count int32, value *float32) {
 	C.glowProgramUniform4fv(gpProgramUniform4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniform4fvEXT(program uint32, location int32, count int32, value *float32) {
+	C.glowProgramUniform4fvEXT(gpProgramUniform4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLfloat)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4i(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowProgramUniform4i(gpProgramUniform4i, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func ProgramUniform4i64ARB(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64ARB(gpProgramUniform4i64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func ProgramUniform4i64NV(program uint32, location int32, x int64, y int64, z int64, w int64) {
+	C.glowProgramUniform4i64NV(gpProgramUniform4i64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func ProgramUniform4i64vARB(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vARB(gpProgramUniform4i64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4i64vNV(program uint32, location int32, count int32, value *int64) {
+	C.glowProgramUniform4i64vNV(gpProgramUniform4i64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4iEXT(program uint32, location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
+	C.glowProgramUniform4iEXT(gpProgramUniform4iEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4iv(program uint32, location int32, count int32, value *int32) {
 	C.glowProgramUniform4iv(gpProgramUniform4iv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ivEXT(program uint32, location int32, count int32, value *int32) {
+	C.glowProgramUniform4ivEXT(gpProgramUniform4ivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4ui(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowProgramUniform4ui(gpProgramUniform4ui, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
 }
+func ProgramUniform4ui64ARB(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64ARB(gpProgramUniform4ui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func ProgramUniform4ui64NV(program uint32, location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowProgramUniform4ui64NV(gpProgramUniform4ui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func ProgramUniform4ui64vARB(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vARB(gpProgramUniform4ui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func ProgramUniform4ui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniform4ui64vNV(gpProgramUniform4ui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
+func ProgramUniform4uiEXT(program uint32, location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
+	C.glowProgramUniform4uiEXT(gpProgramUniform4uiEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniform4uiv(program uint32, location int32, count int32, value *uint32) {
 	C.glowProgramUniform4uiv(gpProgramUniform4uiv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
 }
+func ProgramUniform4uivEXT(program uint32, location int32, count int32, value *uint32) {
+	C.glowProgramUniform4uivEXT(gpProgramUniform4uivEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(value)))
+}
 func ProgramUniformHandleui64ARB(program uint32, location int32, value uint64) {
 	C.glowProgramUniformHandleui64ARB(gpProgramUniformHandleui64ARB, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
+}
+func ProgramUniformHandleui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformHandleui64NV(gpProgramUniformHandleui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64)(value))
 }
 func ProgramUniformHandleui64vARB(program uint32, location int32, count int32, values *uint64) {
 	C.glowProgramUniformHandleui64vARB(gpProgramUniformHandleui64vARB, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
 }
+func ProgramUniformHandleui64vNV(program uint32, location int32, count int32, values *uint64) {
+	C.glowProgramUniformHandleui64vNV(gpProgramUniformHandleui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(values)))
+}
 func ProgramUniformMatrix2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2dv(gpProgramUniformMatrix2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2dvEXT(gpProgramUniformMatrix2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2fv(gpProgramUniformMatrix2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2fvEXT(gpProgramUniformMatrix2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x3dv(gpProgramUniformMatrix2x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x3dvEXT(gpProgramUniformMatrix2x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x3fv(gpProgramUniformMatrix2x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x3fvEXT(gpProgramUniformMatrix2x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix2x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix2x4dv(gpProgramUniformMatrix2x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix2x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix2x4dvEXT(gpProgramUniformMatrix2x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix2x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix2x4fv(gpProgramUniformMatrix2x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix2x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix2x4fvEXT(gpProgramUniformMatrix2x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3dv(gpProgramUniformMatrix3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3dvEXT(gpProgramUniformMatrix3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3fv(gpProgramUniformMatrix3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3fvEXT(gpProgramUniformMatrix3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x2dv(gpProgramUniformMatrix3x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x2dvEXT(gpProgramUniformMatrix3x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x2fv(gpProgramUniformMatrix3x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x2fvEXT(gpProgramUniformMatrix3x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix3x4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix3x4dv(gpProgramUniformMatrix3x4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix3x4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix3x4dvEXT(gpProgramUniformMatrix3x4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix3x4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix3x4fv(gpProgramUniformMatrix3x4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix3x4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix3x4fvEXT(gpProgramUniformMatrix3x4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4dv(gpProgramUniformMatrix4dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4dvEXT(gpProgramUniformMatrix4dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4fv(gpProgramUniformMatrix4fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4fvEXT(gpProgramUniformMatrix4fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x2dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x2dv(gpProgramUniformMatrix4x2dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x2dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x2dvEXT(gpProgramUniformMatrix4x2dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x2fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x2fv(gpProgramUniformMatrix4x2fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x2fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x2fvEXT(gpProgramUniformMatrix4x2fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
 func ProgramUniformMatrix4x3dv(program uint32, location int32, count int32, transpose bool, value *float64) {
 	C.glowProgramUniformMatrix4x3dv(gpProgramUniformMatrix4x3dv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
+}
+func ProgramUniformMatrix4x3dvEXT(program uint32, location int32, count int32, transpose bool, value *float64) {
+	C.glowProgramUniformMatrix4x3dvEXT(gpProgramUniformMatrix4x3dvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for a specified program object
 func ProgramUniformMatrix4x3fv(program uint32, location int32, count int32, transpose bool, value *float32) {
 	C.glowProgramUniformMatrix4x3fv(gpProgramUniformMatrix4x3fv, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
 }
+func ProgramUniformMatrix4x3fvEXT(program uint32, location int32, count int32, transpose bool, value *float32) {
+	C.glowProgramUniformMatrix4x3fvEXT(gpProgramUniformMatrix4x3fvEXT, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLfloat)(unsafe.Pointer(value)))
+}
+func ProgramUniformui64NV(program uint32, location int32, value uint64) {
+	C.glowProgramUniformui64NV(gpProgramUniformui64NV, (C.GLuint)(program), (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func ProgramUniformui64vNV(program uint32, location int32, count int32, value *uint64) {
+	C.glowProgramUniformui64vNV(gpProgramUniformui64vNV, (C.GLuint)(program), (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // specifiy the vertex to be used as the source of data for flat shaded varyings
 func ProvokingVertex(mode uint32) {
 	C.glowProvokingVertex(gpProvokingVertex, (C.GLenum)(mode))
+}
+func PushClientAttribDefaultEXT(mask uint32) {
+	C.glowPushClientAttribDefaultEXT(gpPushClientAttribDefaultEXT, (C.GLbitfield)(mask))
 }
 
 // push a named debug group into the command stream
@@ -7306,10 +11902,16 @@ func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
+func PushGroupMarkerEXT(length int32, marker *uint8) {
+	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
+}
 
 // record the GL time into a query object after all previous commands have reached the GL server but have not yet necessarily executed.
 func QueryCounter(id uint32, target uint32) {
 	C.glowQueryCounter(gpQueryCounter, (C.GLuint)(id), (C.GLenum)(target))
+}
+func RasterSamplesEXT(samples uint32, fixedsamplelocations bool) {
+	C.glowRasterSamplesEXT(gpRasterSamplesEXT, (C.GLuint)(samples), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
 
 // select a color buffer source for pixels
@@ -7346,6 +11948,12 @@ func RenderbufferStorage(target uint32, internalformat uint32, width int32, heig
 // establish data storage, format, dimensions and sample count of     a renderbuffer object's image
 func RenderbufferStorageMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowRenderbufferStorageMultisample(gpRenderbufferStorageMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func RenderbufferStorageMultisampleCoverageNV(target uint32, coverageSamples int32, colorSamples int32, internalformat uint32, width int32, height int32) {
+	C.glowRenderbufferStorageMultisampleCoverageNV(gpRenderbufferStorageMultisampleCoverageNV, (C.GLenum)(target), (C.GLsizei)(coverageSamples), (C.GLsizei)(colorSamples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func ResolveDepthValuesNV() {
+	C.glowResolveDepthValuesNV(gpResolveDepthValuesNV)
 }
 
 // resume transform feedback operations
@@ -7396,6 +12004,12 @@ func ScissorIndexed(index uint32, left int32, bottom int32, width int32, height 
 func ScissorIndexedv(index uint32, v *int32) {
 	C.glowScissorIndexedv(gpScissorIndexedv, (C.GLuint)(index), (*C.GLint)(unsafe.Pointer(v)))
 }
+func SecondaryColorFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowSecondaryColorFormatNV(gpSecondaryColorFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
+func SelectPerfMonitorCountersAMD(monitor uint32, enable bool, group uint32, numCounters int32, counterList *uint32) {
+	C.glowSelectPerfMonitorCountersAMD(gpSelectPerfMonitorCountersAMD, (C.GLuint)(monitor), (C.GLboolean)(boolToInt(enable)), (C.GLuint)(group), (C.GLint)(numCounters), (*C.GLuint)(unsafe.Pointer(counterList)))
+}
 
 // load pre-compiled shader binaries
 func ShaderBinary(count int32, shaders *uint32, binaryformat uint32, binary unsafe.Pointer, length int32) {
@@ -7410,6 +12024,24 @@ func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 // change an active shader storage block binding
 func ShaderStorageBlockBinding(program uint32, storageBlockIndex uint32, storageBlockBinding uint32) {
 	C.glowShaderStorageBlockBinding(gpShaderStorageBlockBinding, (C.GLuint)(program), (C.GLuint)(storageBlockIndex), (C.GLuint)(storageBlockBinding))
+}
+func SignalVkFenceNV(vkFence uint64) {
+	C.glowSignalVkFenceNV(gpSignalVkFenceNV, (C.GLuint64)(vkFence))
+}
+func SignalVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowSignalVkSemaphoreNV(gpSignalVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func SpecializeShaderARB(shader uint32, pEntryPoint *uint8, numSpecializationConstants uint32, pConstantIndex *uint32, pConstantValue *uint32) {
+	C.glowSpecializeShaderARB(gpSpecializeShaderARB, (C.GLuint)(shader), (*C.GLchar)(unsafe.Pointer(pEntryPoint)), (C.GLuint)(numSpecializationConstants), (*C.GLuint)(unsafe.Pointer(pConstantIndex)), (*C.GLuint)(unsafe.Pointer(pConstantValue)))
+}
+func StateCaptureNV(state uint32, mode uint32) {
+	C.glowStateCaptureNV(gpStateCaptureNV, (C.GLuint)(state), (C.GLenum)(mode))
+}
+func StencilFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilFillPathInstancedNV(gpStencilFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilFillPathNV(path uint32, fillMode uint32, mask uint32) {
+	C.glowStencilFillPathNV(gpStencilFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask))
 }
 
 // set front and back function and reference value for stencil testing
@@ -7441,15 +12073,42 @@ func StencilOp(fail uint32, zfail uint32, zpass uint32) {
 func StencilOpSeparate(face uint32, sfail uint32, dpfail uint32, dppass uint32) {
 	C.glowStencilOpSeparate(gpStencilOpSeparate, (C.GLenum)(face), (C.GLenum)(sfail), (C.GLenum)(dpfail), (C.GLenum)(dppass))
 }
+func StencilStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilStrokePathInstancedNV(gpStencilStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilStrokePathNV(path uint32, reference int32, mask uint32) {
+	C.glowStencilStrokePathNV(gpStencilStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask))
+}
+func StencilThenCoverFillPathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, fillMode uint32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverFillPathInstancedNV(gpStencilThenCoverFillPathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverFillPathNV(path uint32, fillMode uint32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverFillPathNV(gpStencilThenCoverFillPathNV, (C.GLuint)(path), (C.GLenum)(fillMode), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func StencilThenCoverStrokePathInstancedNV(numPaths int32, pathNameType uint32, paths unsafe.Pointer, pathBase uint32, reference int32, mask uint32, coverMode uint32, transformType uint32, transformValues *float32) {
+	C.glowStencilThenCoverStrokePathInstancedNV(gpStencilThenCoverStrokePathInstancedNV, (C.GLsizei)(numPaths), (C.GLenum)(pathNameType), paths, (C.GLuint)(pathBase), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
+}
+func StencilThenCoverStrokePathNV(path uint32, reference int32, mask uint32, coverMode uint32) {
+	C.glowStencilThenCoverStrokePathNV(gpStencilThenCoverStrokePathNV, (C.GLuint)(path), (C.GLint)(reference), (C.GLuint)(mask), (C.GLenum)(coverMode))
+}
+func SubpixelPrecisionBiasNV(xbits uint32, ybits uint32) {
+	C.glowSubpixelPrecisionBiasNV(gpSubpixelPrecisionBiasNV, (C.GLuint)(xbits), (C.GLuint)(ybits))
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TexBuffer(target uint32, internalformat uint32, buffer uint32) {
 	C.glowTexBuffer(gpTexBuffer, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TexBufferARB(target uint32, internalformat uint32, buffer uint32) {
+	C.glowTexBufferARB(gpTexBufferARB, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
 func TexBufferRange(target uint32, internalformat uint32, buffer uint32, offset int, size int) {
 	C.glowTexBufferRange(gpTexBufferRange, (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TexCoordFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowTexCoordFormatNV(gpTexCoordFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 
 // specify a one-dimensional texture image
@@ -7476,8 +12135,8 @@ func TexImage3D(target uint32, level int32, internalformat int32, width int32, h
 func TexImage3DMultisample(target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTexImage3DMultisample(gpTexImage3DMultisample, (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
-func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, resident bool) {
-	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(resident)))
+func TexPageCommitmentARB(target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexPageCommitmentARB(gpTexPageCommitmentARB, (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TexParameterIiv(target uint32, pname uint32, params *int32) {
 	C.glowTexParameterIiv(gpTexParameterIiv, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
@@ -7542,73 +12201,139 @@ func TexSubImage3D(target uint32, level int32, xoffset int32, yoffset int32, zof
 func TextureBarrier() {
 	C.glowTextureBarrier(gpTextureBarrier)
 }
+func TextureBarrierNV() {
+	C.glowTextureBarrierNV(gpTextureBarrierNV)
+}
 
 // attach a buffer object's data store to a buffer texture object
 func TextureBuffer(texture uint32, internalformat uint32, buffer uint32) {
 	C.glowTextureBuffer(gpTextureBuffer, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer))
 }
+func TextureBufferEXT(texture uint32, target uint32, internalformat uint32, buffer uint32) {
+	C.glowTextureBufferEXT(gpTextureBufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer))
+}
 
 // attach a range of a buffer object's data store to a buffer texture object
-func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int32) {
-	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TextureBufferRange(texture uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRange(gpTextureBufferRange, (C.GLuint)(texture), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureBufferRangeEXT(texture uint32, target uint32, internalformat uint32, buffer uint32, offset int, size int) {
+	C.glowTextureBufferRangeEXT(gpTextureBufferRangeEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(internalformat), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
+}
+func TextureImage1DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage1DEXT(gpTextureImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage2DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage2DEXT(gpTextureImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureImage3DEXT(texture uint32, target uint32, level int32, internalformat int32, width int32, height int32, depth int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureImage3DEXT(gpTextureImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLint)(border), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TexturePageCommitmentEXT(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, commit bool) {
+	C.glowTexturePageCommitmentEXT(gpTexturePageCommitmentEXT, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(commit)))
 }
 func TextureParameterIiv(texture uint32, pname uint32, params *int32) {
 	C.glowTextureParameterIiv(gpTextureParameterIiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
+func TextureParameterIivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterIivEXT(gpTextureParameterIivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
 func TextureParameterIuiv(texture uint32, pname uint32, params *uint32) {
 	C.glowTextureParameterIuiv(gpTextureParameterIuiv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
+}
+func TextureParameterIuivEXT(texture uint32, target uint32, pname uint32, params *uint32) {
+	C.glowTextureParameterIuivEXT(gpTextureParameterIuivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLuint)(unsafe.Pointer(params)))
 }
 func TextureParameterf(texture uint32, pname uint32, param float32) {
 	C.glowTextureParameterf(gpTextureParameterf, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLfloat)(param))
 }
+func TextureParameterfEXT(texture uint32, target uint32, pname uint32, param float32) {
+	C.glowTextureParameterfEXT(gpTextureParameterfEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLfloat)(param))
+}
 func TextureParameterfv(texture uint32, pname uint32, param *float32) {
 	C.glowTextureParameterfv(gpTextureParameterfv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(param)))
+}
+func TextureParameterfvEXT(texture uint32, target uint32, pname uint32, params *float32) {
+	C.glowTextureParameterfvEXT(gpTextureParameterfvEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLfloat)(unsafe.Pointer(params)))
 }
 func TextureParameteri(texture uint32, pname uint32, param int32) {
 	C.glowTextureParameteri(gpTextureParameteri, (C.GLuint)(texture), (C.GLenum)(pname), (C.GLint)(param))
 }
+func TextureParameteriEXT(texture uint32, target uint32, pname uint32, param int32) {
+	C.glowTextureParameteriEXT(gpTextureParameteriEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (C.GLint)(param))
+}
 func TextureParameteriv(texture uint32, pname uint32, param *int32) {
 	C.glowTextureParameteriv(gpTextureParameteriv, (C.GLuint)(texture), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(param)))
+}
+func TextureParameterivEXT(texture uint32, target uint32, pname uint32, params *int32) {
+	C.glowTextureParameterivEXT(gpTextureParameterivEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
+}
+func TextureRenderbufferEXT(texture uint32, target uint32, renderbuffer uint32) {
+	C.glowTextureRenderbufferEXT(gpTextureRenderbufferEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLuint)(renderbuffer))
 }
 
 // simultaneously specify storage for all levels of a one-dimensional texture
 func TextureStorage1D(texture uint32, levels int32, internalformat uint32, width int32) {
 	C.glowTextureStorage1D(gpTextureStorage1D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
 }
+func TextureStorage1DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32) {
+	C.glowTextureStorage1DEXT(gpTextureStorage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width))
+}
 
 // simultaneously specify storage for all levels of a two-dimensional or one-dimensional array texture
 func TextureStorage2D(texture uint32, levels int32, internalformat uint32, width int32, height int32) {
 	C.glowTextureStorage2D(gpTextureStorage2D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
+}
+func TextureStorage2DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32) {
+	C.glowTextureStorage2DEXT(gpTextureStorage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
 
 // specify storage for a two-dimensional multisample texture
 func TextureStorage2DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
 	C.glowTextureStorage2DMultisample(gpTextureStorage2DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage2DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, fixedsamplelocations bool) {
+	C.glowTextureStorage2DMultisampleEXT(gpTextureStorage2DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // simultaneously specify storage for all levels of a three-dimensional, two-dimensional array or cube-map array texture
 func TextureStorage3D(texture uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
 	C.glowTextureStorage3D(gpTextureStorage3D, (C.GLuint)(texture), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
+}
+func TextureStorage3DEXT(texture uint32, target uint32, levels int32, internalformat uint32, width int32, height int32, depth int32) {
+	C.glowTextureStorage3DEXT(gpTextureStorage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(levels), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth))
 }
 
 // specify storage for a two-dimensional multisample array texture
 func TextureStorage3DMultisample(texture uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
 	C.glowTextureStorage3DMultisample(gpTextureStorage3DMultisample, (C.GLuint)(texture), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
 }
+func TextureStorage3DMultisampleEXT(texture uint32, target uint32, samples int32, internalformat uint32, width int32, height int32, depth int32, fixedsamplelocations bool) {
+	C.glowTextureStorage3DMultisampleEXT(gpTextureStorage3DMultisampleEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLboolean)(boolToInt(fixedsamplelocations)))
+}
 
 // specify a one-dimensional texture subimage
 func TextureSubImage1D(texture uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage1D(gpTextureSubImage1D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage1DEXT(texture uint32, target uint32, level int32, xoffset int32, width int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage1DEXT(gpTextureSubImage1DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLsizei)(width), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // specify a two-dimensional texture subimage
 func TextureSubImage2D(texture uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage2D(gpTextureSubImage2D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
+func TextureSubImage2DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage2DEXT(gpTextureSubImage2DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
 
 // specify a three-dimensional texture subimage
 func TextureSubImage3D(texture uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 	C.glowTextureSubImage3D(gpTextureSubImage3D, (C.GLuint)(texture), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
+}
+func TextureSubImage3DEXT(texture uint32, target uint32, level int32, xoffset int32, yoffset int32, zoffset int32, width int32, height int32, depth int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
+	C.glowTextureSubImage3DEXT(gpTextureSubImage3DEXT, (C.GLuint)(texture), (C.GLenum)(target), (C.GLint)(level), (C.GLint)(xoffset), (C.GLint)(yoffset), (C.GLint)(zoffset), (C.GLsizei)(width), (C.GLsizei)(height), (C.GLsizei)(depth), (C.GLenum)(format), (C.GLenum)(xtype), pixels)
 }
 
 // initialize a texture as a data alias of another texture's data store
@@ -7622,13 +12347,16 @@ func TransformFeedbackBufferBase(xfb uint32, index uint32, buffer uint32) {
 }
 
 // bind a range within a buffer object to a transform feedback buffer object
-func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int32) {
-	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(size))
+func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offset int, size int) {
+	C.glowTransformFeedbackBufferRange(gpTransformFeedbackBufferRange, (C.GLuint)(xfb), (C.GLuint)(index), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizeiptr)(size))
 }
 
 // specify values to record in transform feedback buffers
 func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
+}
+func TransformPathNV(resultPath uint32, srcPath uint32, transformType uint32, transformValues *float32) {
+	C.glowTransformPathNV(gpTransformPathNV, (C.GLuint)(resultPath), (C.GLuint)(srcPath), (C.GLenum)(transformType), (*C.GLfloat)(unsafe.Pointer(transformValues)))
 }
 func Uniform1d(location int32, x float64) {
 	C.glowUniform1d(gpUniform1d, (C.GLint)(location), (C.GLdouble)(x))
@@ -7651,6 +12379,18 @@ func Uniform1fv(location int32, count int32, value *float32) {
 func Uniform1i(location int32, v0 int32) {
 	C.glowUniform1i(gpUniform1i, (C.GLint)(location), (C.GLint)(v0))
 }
+func Uniform1i64ARB(location int32, x int64) {
+	C.glowUniform1i64ARB(gpUniform1i64ARB, (C.GLint)(location), (C.GLint64)(x))
+}
+func Uniform1i64NV(location int32, x int64) {
+	C.glowUniform1i64NV(gpUniform1i64NV, (C.GLint)(location), (C.GLint64EXT)(x))
+}
+func Uniform1i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform1i64vARB(gpUniform1i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform1i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform1i64vNV(gpUniform1i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform1iv(location int32, count int32, value *int32) {
@@ -7660,6 +12400,18 @@ func Uniform1iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform1ui(location int32, v0 uint32) {
 	C.glowUniform1ui(gpUniform1ui, (C.GLint)(location), (C.GLuint)(v0))
+}
+func Uniform1ui64ARB(location int32, x uint64) {
+	C.glowUniform1ui64ARB(gpUniform1ui64ARB, (C.GLint)(location), (C.GLuint64)(x))
+}
+func Uniform1ui64NV(location int32, x uint64) {
+	C.glowUniform1ui64NV(gpUniform1ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x))
+}
+func Uniform1ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vARB(gpUniform1ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform1ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform1ui64vNV(gpUniform1ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7687,6 +12439,18 @@ func Uniform2fv(location int32, count int32, value *float32) {
 func Uniform2i(location int32, v0 int32, v1 int32) {
 	C.glowUniform2i(gpUniform2i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1))
 }
+func Uniform2i64ARB(location int32, x int64, y int64) {
+	C.glowUniform2i64ARB(gpUniform2i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y))
+}
+func Uniform2i64NV(location int32, x int64, y int64) {
+	C.glowUniform2i64NV(gpUniform2i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func Uniform2i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform2i64vARB(gpUniform2i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform2i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform2i64vNV(gpUniform2i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform2iv(location int32, count int32, value *int32) {
@@ -7696,6 +12460,18 @@ func Uniform2iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform2ui(location int32, v0 uint32, v1 uint32) {
 	C.glowUniform2ui(gpUniform2ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1))
+}
+func Uniform2ui64ARB(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64ARB(gpUniform2ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y))
+}
+func Uniform2ui64NV(location int32, x uint64, y uint64) {
+	C.glowUniform2ui64NV(gpUniform2ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func Uniform2ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vARB(gpUniform2ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform2ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform2ui64vNV(gpUniform2ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7723,6 +12499,18 @@ func Uniform3fv(location int32, count int32, value *float32) {
 func Uniform3i(location int32, v0 int32, v1 int32, v2 int32) {
 	C.glowUniform3i(gpUniform3i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2))
 }
+func Uniform3i64ARB(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64ARB(gpUniform3i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z))
+}
+func Uniform3i64NV(location int32, x int64, y int64, z int64) {
+	C.glowUniform3i64NV(gpUniform3i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func Uniform3i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform3i64vARB(gpUniform3i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform3i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform3i64vNV(gpUniform3i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform3iv(location int32, count int32, value *int32) {
@@ -7732,6 +12520,18 @@ func Uniform3iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform3ui(location int32, v0 uint32, v1 uint32, v2 uint32) {
 	C.glowUniform3ui(gpUniform3ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2))
+}
+func Uniform3ui64ARB(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64ARB(gpUniform3ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z))
+}
+func Uniform3ui64NV(location int32, x uint64, y uint64, z uint64) {
+	C.glowUniform3ui64NV(gpUniform3ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func Uniform3ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vARB(gpUniform3ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform3ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform3ui64vNV(gpUniform3ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7759,6 +12559,18 @@ func Uniform4fv(location int32, count int32, value *float32) {
 func Uniform4i(location int32, v0 int32, v1 int32, v2 int32, v3 int32) {
 	C.glowUniform4i(gpUniform4i, (C.GLint)(location), (C.GLint)(v0), (C.GLint)(v1), (C.GLint)(v2), (C.GLint)(v3))
 }
+func Uniform4i64ARB(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64ARB(gpUniform4i64ARB, (C.GLint)(location), (C.GLint64)(x), (C.GLint64)(y), (C.GLint64)(z), (C.GLint64)(w))
+}
+func Uniform4i64NV(location int32, x int64, y int64, z int64, w int64) {
+	C.glowUniform4i64NV(gpUniform4i64NV, (C.GLint)(location), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func Uniform4i64vARB(location int32, count int32, value *int64) {
+	C.glowUniform4i64vARB(gpUniform4i64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64)(unsafe.Pointer(value)))
+}
+func Uniform4i64vNV(location int32, count int32, value *int64) {
+	C.glowUniform4i64vNV(gpUniform4i64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLint64EXT)(unsafe.Pointer(value)))
+}
 
 // Specify the value of a uniform variable for the current program object
 func Uniform4iv(location int32, count int32, value *int32) {
@@ -7768,6 +12580,18 @@ func Uniform4iv(location int32, count int32, value *int32) {
 // Specify the value of a uniform variable for the current program object
 func Uniform4ui(location int32, v0 uint32, v1 uint32, v2 uint32, v3 uint32) {
 	C.glowUniform4ui(gpUniform4ui, (C.GLint)(location), (C.GLuint)(v0), (C.GLuint)(v1), (C.GLuint)(v2), (C.GLuint)(v3))
+}
+func Uniform4ui64ARB(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64ARB(gpUniform4ui64ARB, (C.GLint)(location), (C.GLuint64)(x), (C.GLuint64)(y), (C.GLuint64)(z), (C.GLuint64)(w))
+}
+func Uniform4ui64NV(location int32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowUniform4ui64NV(gpUniform4ui64NV, (C.GLint)(location), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func Uniform4ui64vARB(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vARB(gpUniform4ui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func Uniform4ui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniform4ui64vNV(gpUniform4ui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
 }
 
 // Specify the value of a uniform variable for the current program object
@@ -7782,8 +12606,14 @@ func UniformBlockBinding(program uint32, uniformBlockIndex uint32, uniformBlockB
 func UniformHandleui64ARB(location int32, value uint64) {
 	C.glowUniformHandleui64ARB(gpUniformHandleui64ARB, (C.GLint)(location), (C.GLuint64)(value))
 }
+func UniformHandleui64NV(location int32, value uint64) {
+	C.glowUniformHandleui64NV(gpUniformHandleui64NV, (C.GLint)(location), (C.GLuint64)(value))
+}
 func UniformHandleui64vARB(location int32, count int32, value *uint64) {
 	C.glowUniformHandleui64vARB(gpUniformHandleui64vARB, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
+}
+func UniformHandleui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformHandleui64vNV(gpUniformHandleui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64)(unsafe.Pointer(value)))
 }
 func UniformMatrix2dv(location int32, count int32, transpose bool, value *float64) {
 	C.glowUniformMatrix2dv(gpUniformMatrix2dv, (C.GLint)(location), (C.GLsizei)(count), (C.GLboolean)(boolToInt(transpose)), (*C.GLdouble)(unsafe.Pointer(value)))
@@ -7860,6 +12690,12 @@ func UniformMatrix4x3fv(location int32, count int32, transpose bool, value *floa
 func UniformSubroutinesuiv(shadertype uint32, count int32, indices *uint32) {
 	C.glowUniformSubroutinesuiv(gpUniformSubroutinesuiv, (C.GLenum)(shadertype), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(indices)))
 }
+func Uniformui64NV(location int32, value uint64) {
+	C.glowUniformui64NV(gpUniformui64NV, (C.GLint)(location), (C.GLuint64EXT)(value))
+}
+func Uniformui64vNV(location int32, count int32, value *uint64) {
+	C.glowUniformui64vNV(gpUniformui64vNV, (C.GLint)(location), (C.GLsizei)(count), (*C.GLuint64EXT)(unsafe.Pointer(value)))
+}
 
 // release the mapping of a buffer object's data store into the client's address space
 func UnmapBuffer(target uint32) bool {
@@ -7872,6 +12708,10 @@ func UnmapNamedBuffer(buffer uint32) bool {
 	ret := C.glowUnmapNamedBuffer(gpUnmapNamedBuffer, (C.GLuint)(buffer))
 	return ret == TRUE
 }
+func UnmapNamedBufferEXT(buffer uint32) bool {
+	ret := C.glowUnmapNamedBufferEXT(gpUnmapNamedBufferEXT, (C.GLuint)(buffer))
+	return ret == TRUE
+}
 
 // Installs a program object as part of current rendering state
 func UseProgram(program uint32) {
@@ -7882,6 +12722,12 @@ func UseProgram(program uint32) {
 func UseProgramStages(pipeline uint32, stages uint32, program uint32) {
 	C.glowUseProgramStages(gpUseProgramStages, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
 }
+func UseProgramStagesEXT(pipeline uint32, stages uint32, program uint32) {
+	C.glowUseProgramStagesEXT(gpUseProgramStagesEXT, (C.GLuint)(pipeline), (C.GLbitfield)(stages), (C.GLuint)(program))
+}
+func UseShaderProgramEXT(xtype uint32, program uint32) {
+	C.glowUseShaderProgramEXT(gpUseShaderProgramEXT, (C.GLenum)(xtype), (C.GLuint)(program))
+}
 
 // Validates a program object
 func ValidateProgram(program uint32) {
@@ -7891,6 +12737,9 @@ func ValidateProgram(program uint32) {
 // validate a program pipeline object against current GL state
 func ValidateProgramPipeline(pipeline uint32) {
 	C.glowValidateProgramPipeline(gpValidateProgramPipeline, (C.GLuint)(pipeline))
+}
+func ValidateProgramPipelineEXT(pipeline uint32) {
+	C.glowValidateProgramPipelineEXT(gpValidateProgramPipelineEXT, (C.GLuint)(pipeline))
 }
 func VertexArrayAttribBinding(vaobj uint32, attribindex uint32, bindingindex uint32) {
 	C.glowVertexArrayAttribBinding(gpVertexArrayAttribBinding, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
@@ -7906,15 +12755,69 @@ func VertexArrayAttribIFormat(vaobj uint32, attribindex uint32, size int32, xtyp
 func VertexArrayAttribLFormat(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexArrayAttribLFormat(gpVertexArrayAttribLFormat, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexArrayBindVertexBufferEXT(vaobj uint32, bindingindex uint32, buffer uint32, offset int, stride int32) {
+	C.glowVertexArrayBindVertexBufferEXT(gpVertexArrayBindVertexBufferEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(buffer), (C.GLintptr)(offset), (C.GLsizei)(stride))
+}
 
 // modify the rate at which generic vertex attributes     advance
 func VertexArrayBindingDivisor(vaobj uint32, bindingindex uint32, divisor uint32) {
 	C.glowVertexArrayBindingDivisor(gpVertexArrayBindingDivisor, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexArrayColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayColorOffsetEXT(gpVertexArrayColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayEdgeFlagOffsetEXT(vaobj uint32, buffer uint32, stride int32, offset int) {
+	C.glowVertexArrayEdgeFlagOffsetEXT(gpVertexArrayEdgeFlagOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
 
 // configures element array buffer binding of a vertex array object
 func VertexArrayElementBuffer(vaobj uint32, buffer uint32) {
 	C.glowVertexArrayElementBuffer(gpVertexArrayElementBuffer, (C.GLuint)(vaobj), (C.GLuint)(buffer))
+}
+func VertexArrayFogCoordOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayFogCoordOffsetEXT(gpVertexArrayFogCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayIndexOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayIndexOffsetEXT(gpVertexArrayIndexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayMultiTexCoordOffsetEXT(vaobj uint32, buffer uint32, texunit uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayMultiTexCoordOffsetEXT(gpVertexArrayMultiTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(texunit), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayNormalOffsetEXT(vaobj uint32, buffer uint32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayNormalOffsetEXT(gpVertexArrayNormalOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArraySecondaryColorOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArraySecondaryColorOffsetEXT(gpVertexArraySecondaryColorOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayTexCoordOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayTexCoordOffsetEXT(gpVertexArrayTexCoordOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribBindingEXT(vaobj uint32, attribindex uint32, bindingindex uint32) {
+	C.glowVertexArrayVertexAttribBindingEXT(gpVertexArrayVertexAttribBindingEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLuint)(bindingindex))
+}
+func VertexArrayVertexAttribDivisorEXT(vaobj uint32, index uint32, divisor uint32) {
+	C.glowVertexArrayVertexAttribDivisorEXT(gpVertexArrayVertexAttribDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(index), (C.GLuint)(divisor))
+}
+func VertexArrayVertexAttribFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribFormatEXT(gpVertexArrayVertexAttribFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribIFormatEXT(gpVertexArrayVertexAttribIFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribIOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribIOffsetEXT(gpVertexArrayVertexAttribIOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribLFormatEXT(vaobj uint32, attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
+	C.glowVertexArrayVertexAttribLFormatEXT(gpVertexArrayVertexAttribLFormatEXT, (C.GLuint)(vaobj), (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexArrayVertexAttribLOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribLOffsetEXT(gpVertexArrayVertexAttribLOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexAttribOffsetEXT(vaobj uint32, buffer uint32, index uint32, size int32, xtype uint32, normalized bool, stride int32, offset int) {
+	C.glowVertexArrayVertexAttribOffsetEXT(gpVertexArrayVertexAttribOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride), (C.GLintptr)(offset))
+}
+func VertexArrayVertexBindingDivisorEXT(vaobj uint32, bindingindex uint32, divisor uint32) {
+	C.glowVertexArrayVertexBindingDivisorEXT(gpVertexArrayVertexBindingDivisorEXT, (C.GLuint)(vaobj), (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
 
 // bind a buffer to a vertex buffer bind point
@@ -7925,6 +12828,9 @@ func VertexArrayVertexBuffer(vaobj uint32, bindingindex uint32, buffer uint32, o
 // attach multiple buffer objects to a vertex array object
 func VertexArrayVertexBuffers(vaobj uint32, first uint32, count int32, buffers *uint32, offsets *int, strides *int32) {
 	C.glowVertexArrayVertexBuffers(gpVertexArrayVertexBuffers, (C.GLuint)(vaobj), (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizei)(unsafe.Pointer(strides)))
+}
+func VertexArrayVertexOffsetEXT(vaobj uint32, buffer uint32, size int32, xtype uint32, stride int32, offset int) {
+	C.glowVertexArrayVertexOffsetEXT(gpVertexArrayVertexOffsetEXT, (C.GLuint)(vaobj), (C.GLuint)(buffer), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), (C.GLintptr)(offset))
 }
 func VertexAttrib1d(index uint32, x float64) {
 	C.glowVertexAttrib1d(gpVertexAttrib1d, (C.GLuint)(index), (C.GLdouble)(x))
@@ -8044,10 +12950,16 @@ func VertexAttribBinding(attribindex uint32, bindingindex uint32) {
 func VertexAttribDivisor(index uint32, divisor uint32) {
 	C.glowVertexAttribDivisor(gpVertexAttribDivisor, (C.GLuint)(index), (C.GLuint)(divisor))
 }
+func VertexAttribDivisorARB(index uint32, divisor uint32) {
+	C.glowVertexAttribDivisorARB(gpVertexAttribDivisorARB, (C.GLuint)(index), (C.GLuint)(divisor))
+}
 
 // specify the organization of vertex arrays
 func VertexAttribFormat(attribindex uint32, size int32, xtype uint32, normalized bool, relativeoffset uint32) {
 	C.glowVertexAttribFormat(gpVertexAttribFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLuint)(relativeoffset))
+}
+func VertexAttribFormatNV(index uint32, size int32, xtype uint32, normalized bool, stride int32) {
+	C.glowVertexAttribFormatNV(gpVertexAttribFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride))
 }
 func VertexAttribI1i(index uint32, x int32) {
 	C.glowVertexAttribI1i(gpVertexAttribI1i, (C.GLuint)(index), (C.GLint)(x))
@@ -8112,6 +13024,9 @@ func VertexAttribI4usv(index uint32, v *uint16) {
 func VertexAttribIFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribIFormat(gpVertexAttribIFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
 }
+func VertexAttribIFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribIFormatNV(gpVertexAttribIFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 func VertexAttribIPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribIPointer(gpVertexAttribIPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
 }
@@ -8121,11 +13036,23 @@ func VertexAttribL1d(index uint32, x float64) {
 func VertexAttribL1dv(index uint32, v *float64) {
 	C.glowVertexAttribL1dv(gpVertexAttribL1dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL1i64NV(index uint32, x int64) {
+	C.glowVertexAttribL1i64NV(gpVertexAttribL1i64NV, (C.GLuint)(index), (C.GLint64EXT)(x))
+}
+func VertexAttribL1i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL1i64vNV(gpVertexAttribL1i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL1ui64ARB(index uint32, x uint64) {
 	C.glowVertexAttribL1ui64ARB(gpVertexAttribL1ui64ARB, (C.GLuint)(index), (C.GLuint64EXT)(x))
 }
+func VertexAttribL1ui64NV(index uint32, x uint64) {
+	C.glowVertexAttribL1ui64NV(gpVertexAttribL1ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x))
+}
 func VertexAttribL1ui64vARB(index uint32, v *uint64) {
 	C.glowVertexAttribL1ui64vARB(gpVertexAttribL1ui64vARB, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL1ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL1ui64vNV(gpVertexAttribL1ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL2d(index uint32, x float64, y float64) {
 	C.glowVertexAttribL2d(gpVertexAttribL2d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y))
@@ -8133,11 +13060,35 @@ func VertexAttribL2d(index uint32, x float64, y float64) {
 func VertexAttribL2dv(index uint32, v *float64) {
 	C.glowVertexAttribL2dv(gpVertexAttribL2dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL2i64NV(index uint32, x int64, y int64) {
+	C.glowVertexAttribL2i64NV(gpVertexAttribL2i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y))
+}
+func VertexAttribL2i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL2i64vNV(gpVertexAttribL2i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL2ui64NV(index uint32, x uint64, y uint64) {
+	C.glowVertexAttribL2ui64NV(gpVertexAttribL2ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y))
+}
+func VertexAttribL2ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL2ui64vNV(gpVertexAttribL2ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribL3d(index uint32, x float64, y float64, z float64) {
 	C.glowVertexAttribL3d(gpVertexAttribL3d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z))
 }
 func VertexAttribL3dv(index uint32, v *float64) {
 	C.glowVertexAttribL3dv(gpVertexAttribL3dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
+}
+func VertexAttribL3i64NV(index uint32, x int64, y int64, z int64) {
+	C.glowVertexAttribL3i64NV(gpVertexAttribL3i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z))
+}
+func VertexAttribL3i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL3i64vNV(gpVertexAttribL3i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL3ui64NV(index uint32, x uint64, y uint64, z uint64) {
+	C.glowVertexAttribL3ui64NV(gpVertexAttribL3ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z))
+}
+func VertexAttribL3ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL3ui64vNV(gpVertexAttribL3ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
 }
 func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 	C.glowVertexAttribL4d(gpVertexAttribL4d, (C.GLuint)(index), (C.GLdouble)(x), (C.GLdouble)(y), (C.GLdouble)(z), (C.GLdouble)(w))
@@ -8145,8 +13096,23 @@ func VertexAttribL4d(index uint32, x float64, y float64, z float64, w float64) {
 func VertexAttribL4dv(index uint32, v *float64) {
 	C.glowVertexAttribL4dv(gpVertexAttribL4dv, (C.GLuint)(index), (*C.GLdouble)(unsafe.Pointer(v)))
 }
+func VertexAttribL4i64NV(index uint32, x int64, y int64, z int64, w int64) {
+	C.glowVertexAttribL4i64NV(gpVertexAttribL4i64NV, (C.GLuint)(index), (C.GLint64EXT)(x), (C.GLint64EXT)(y), (C.GLint64EXT)(z), (C.GLint64EXT)(w))
+}
+func VertexAttribL4i64vNV(index uint32, v *int64) {
+	C.glowVertexAttribL4i64vNV(gpVertexAttribL4i64vNV, (C.GLuint)(index), (*C.GLint64EXT)(unsafe.Pointer(v)))
+}
+func VertexAttribL4ui64NV(index uint32, x uint64, y uint64, z uint64, w uint64) {
+	C.glowVertexAttribL4ui64NV(gpVertexAttribL4ui64NV, (C.GLuint)(index), (C.GLuint64EXT)(x), (C.GLuint64EXT)(y), (C.GLuint64EXT)(z), (C.GLuint64EXT)(w))
+}
+func VertexAttribL4ui64vNV(index uint32, v *uint64) {
+	C.glowVertexAttribL4ui64vNV(gpVertexAttribL4ui64vNV, (C.GLuint)(index), (*C.GLuint64EXT)(unsafe.Pointer(v)))
+}
 func VertexAttribLFormat(attribindex uint32, size int32, xtype uint32, relativeoffset uint32) {
 	C.glowVertexAttribLFormat(gpVertexAttribLFormat, (C.GLuint)(attribindex), (C.GLint)(size), (C.GLenum)(xtype), (C.GLuint)(relativeoffset))
+}
+func VertexAttribLFormatNV(index uint32, size int32, xtype uint32, stride int32) {
+	C.glowVertexAttribLFormatNV(gpVertexAttribLFormatNV, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
 }
 func VertexAttribLPointer(index uint32, size int32, xtype uint32, stride int32, pointer unsafe.Pointer) {
 	C.glowVertexAttribLPointer(gpVertexAttribLPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride), pointer)
@@ -8185,6 +13151,9 @@ func VertexAttribPointer(index uint32, size int32, xtype uint32, normalized bool
 func VertexBindingDivisor(bindingindex uint32, divisor uint32) {
 	C.glowVertexBindingDivisor(gpVertexBindingDivisor, (C.GLuint)(bindingindex), (C.GLuint)(divisor))
 }
+func VertexFormatNV(size int32, xtype uint32, stride int32) {
+	C.glowVertexFormatNV(gpVertexFormatNV, (C.GLint)(size), (C.GLenum)(xtype), (C.GLsizei)(stride))
+}
 
 // set the viewport
 func Viewport(x int32, y int32, width int32, height int32) {
@@ -8199,10 +13168,25 @@ func ViewportIndexedf(index uint32, x float32, y float32, w float32, h float32) 
 func ViewportIndexedfv(index uint32, v *float32) {
 	C.glowViewportIndexedfv(gpViewportIndexedfv, (C.GLuint)(index), (*C.GLfloat)(unsafe.Pointer(v)))
 }
+func ViewportPositionWScaleNV(index uint32, xcoeff float32, ycoeff float32) {
+	C.glowViewportPositionWScaleNV(gpViewportPositionWScaleNV, (C.GLuint)(index), (C.GLfloat)(xcoeff), (C.GLfloat)(ycoeff))
+}
+func ViewportSwizzleNV(index uint32, swizzlex uint32, swizzley uint32, swizzlez uint32, swizzlew uint32) {
+	C.glowViewportSwizzleNV(gpViewportSwizzleNV, (C.GLuint)(index), (C.GLenum)(swizzlex), (C.GLenum)(swizzley), (C.GLenum)(swizzlez), (C.GLenum)(swizzlew))
+}
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
+}
+func WaitVkSemaphoreNV(vkSemaphore uint64) {
+	C.glowWaitVkSemaphoreNV(gpWaitVkSemaphoreNV, (C.GLuint64)(vkSemaphore))
+}
+func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {
+	C.glowWeightPathsNV(gpWeightPathsNV, (C.GLuint)(resultPath), (C.GLsizei)(numPaths), (*C.GLuint)(unsafe.Pointer(paths)), (*C.GLfloat)(unsafe.Pointer(weights)))
+}
+func WindowRectanglesEXT(mode uint32, count int32, box *int32) {
+	C.glowWindowRectanglesEXT(gpWindowRectanglesEXT, (C.GLenum)(mode), (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(box)))
 }
 
 // Init initializes the OpenGL bindings by loading the function pointers (for
@@ -8232,14 +13216,17 @@ func Init() error {
 // function pointer loading function. For more cases Init should be used
 // instead.
 func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
+	gpActiveProgramEXT = (C.GPACTIVEPROGRAMEXT)(getProcAddr("glActiveProgramEXT"))
 	gpActiveShaderProgram = (C.GPACTIVESHADERPROGRAM)(getProcAddr("glActiveShaderProgram"))
 	if gpActiveShaderProgram == nil {
 		return errors.New("glActiveShaderProgram")
 	}
+	gpActiveShaderProgramEXT = (C.GPACTIVESHADERPROGRAMEXT)(getProcAddr("glActiveShaderProgramEXT"))
 	gpActiveTexture = (C.GPACTIVETEXTURE)(getProcAddr("glActiveTexture"))
 	if gpActiveTexture == nil {
 		return errors.New("glActiveTexture")
 	}
+	gpApplyFramebufferAttachmentCMAAINTEL = (C.GPAPPLYFRAMEBUFFERATTACHMENTCMAAINTEL)(getProcAddr("glApplyFramebufferAttachmentCMAAINTEL"))
 	gpAttachShader = (C.GPATTACHSHADER)(getProcAddr("glAttachShader"))
 	if gpAttachShader == nil {
 		return errors.New("glAttachShader")
@@ -8248,6 +13235,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBeginConditionalRender == nil {
 		return errors.New("glBeginConditionalRender")
 	}
+	gpBeginConditionalRenderNV = (C.GPBEGINCONDITIONALRENDERNV)(getProcAddr("glBeginConditionalRenderNV"))
+	gpBeginPerfMonitorAMD = (C.GPBEGINPERFMONITORAMD)(getProcAddr("glBeginPerfMonitorAMD"))
+	gpBeginPerfQueryINTEL = (C.GPBEGINPERFQUERYINTEL)(getProcAddr("glBeginPerfQueryINTEL"))
 	gpBeginQuery = (C.GPBEGINQUERY)(getProcAddr("glBeginQuery"))
 	if gpBeginQuery == nil {
 		return errors.New("glBeginQuery")
@@ -8304,10 +13294,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBindImageTextures == nil {
 		return errors.New("glBindImageTextures")
 	}
+	gpBindMultiTextureEXT = (C.GPBINDMULTITEXTUREEXT)(getProcAddr("glBindMultiTextureEXT"))
 	gpBindProgramPipeline = (C.GPBINDPROGRAMPIPELINE)(getProcAddr("glBindProgramPipeline"))
 	if gpBindProgramPipeline == nil {
 		return errors.New("glBindProgramPipeline")
 	}
+	gpBindProgramPipelineEXT = (C.GPBINDPROGRAMPIPELINEEXT)(getProcAddr("glBindProgramPipelineEXT"))
 	gpBindRenderbuffer = (C.GPBINDRENDERBUFFER)(getProcAddr("glBindRenderbuffer"))
 	if gpBindRenderbuffer == nil {
 		return errors.New("glBindRenderbuffer")
@@ -8348,6 +13340,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBindVertexBuffers == nil {
 		return errors.New("glBindVertexBuffers")
 	}
+	gpBlendBarrierKHR = (C.GPBLENDBARRIERKHR)(getProcAddr("glBlendBarrierKHR"))
+	gpBlendBarrierNV = (C.GPBLENDBARRIERNV)(getProcAddr("glBlendBarrierNV"))
 	gpBlendColor = (C.GPBLENDCOLOR)(getProcAddr("glBlendColor"))
 	if gpBlendColor == nil {
 		return errors.New("glBlendColor")
@@ -8388,6 +13382,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glBlendFunci")
 	}
 	gpBlendFunciARB = (C.GPBLENDFUNCIARB)(getProcAddr("glBlendFunciARB"))
+	gpBlendParameteriNV = (C.GPBLENDPARAMETERINV)(getProcAddr("glBlendParameteriNV"))
 	gpBlitFramebuffer = (C.GPBLITFRAMEBUFFER)(getProcAddr("glBlitFramebuffer"))
 	if gpBlitFramebuffer == nil {
 		return errors.New("glBlitFramebuffer")
@@ -8396,6 +13391,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBlitNamedFramebuffer == nil {
 		return errors.New("glBlitNamedFramebuffer")
 	}
+	gpBufferAddressRangeNV = (C.GPBUFFERADDRESSRANGENV)(getProcAddr("glBufferAddressRangeNV"))
 	gpBufferData = (C.GPBUFFERDATA)(getProcAddr("glBufferData"))
 	if gpBufferData == nil {
 		return errors.New("glBufferData")
@@ -8409,6 +13405,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpBufferSubData == nil {
 		return errors.New("glBufferSubData")
 	}
+	gpCallCommandListNV = (C.GPCALLCOMMANDLISTNV)(getProcAddr("glCallCommandListNV"))
 	gpCheckFramebufferStatus = (C.GPCHECKFRAMEBUFFERSTATUS)(getProcAddr("glCheckFramebufferStatus"))
 	if gpCheckFramebufferStatus == nil {
 		return errors.New("glCheckFramebufferStatus")
@@ -8417,6 +13414,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCheckNamedFramebufferStatus == nil {
 		return errors.New("glCheckNamedFramebufferStatus")
 	}
+	gpCheckNamedFramebufferStatusEXT = (C.GPCHECKNAMEDFRAMEBUFFERSTATUSEXT)(getProcAddr("glCheckNamedFramebufferStatusEXT"))
 	gpClampColor = (C.GPCLAMPCOLOR)(getProcAddr("glClampColor"))
 	if gpClampColor == nil {
 		return errors.New("glClampColor")
@@ -8465,10 +13463,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpClearNamedBufferData == nil {
 		return errors.New("glClearNamedBufferData")
 	}
+	gpClearNamedBufferDataEXT = (C.GPCLEARNAMEDBUFFERDATAEXT)(getProcAddr("glClearNamedBufferDataEXT"))
 	gpClearNamedBufferSubData = (C.GPCLEARNAMEDBUFFERSUBDATA)(getProcAddr("glClearNamedBufferSubData"))
 	if gpClearNamedBufferSubData == nil {
 		return errors.New("glClearNamedBufferSubData")
 	}
+	gpClearNamedBufferSubDataEXT = (C.GPCLEARNAMEDBUFFERSUBDATAEXT)(getProcAddr("glClearNamedBufferSubDataEXT"))
 	gpClearNamedFramebufferfi = (C.GPCLEARNAMEDFRAMEBUFFERFI)(getProcAddr("glClearNamedFramebufferfi"))
 	if gpClearNamedFramebufferfi == nil {
 		return errors.New("glClearNamedFramebufferfi")
@@ -8497,6 +13497,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpClearTexSubImage == nil {
 		return errors.New("glClearTexSubImage")
 	}
+	gpClientAttribDefaultEXT = (C.GPCLIENTATTRIBDEFAULTEXT)(getProcAddr("glClientAttribDefaultEXT"))
 	gpClientWaitSync = (C.GPCLIENTWAITSYNC)(getProcAddr("glClientWaitSync"))
 	if gpClientWaitSync == nil {
 		return errors.New("glClientWaitSync")
@@ -8505,6 +13506,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpClipControl == nil {
 		return errors.New("glClipControl")
 	}
+	gpColorFormatNV = (C.GPCOLORFORMATNV)(getProcAddr("glColorFormatNV"))
 	gpColorMask = (C.GPCOLORMASK)(getProcAddr("glColorMask"))
 	if gpColorMask == nil {
 		return errors.New("glColorMask")
@@ -8513,11 +13515,19 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpColorMaski == nil {
 		return errors.New("glColorMaski")
 	}
+	gpCommandListSegmentsNV = (C.GPCOMMANDLISTSEGMENTSNV)(getProcAddr("glCommandListSegmentsNV"))
+	gpCompileCommandListNV = (C.GPCOMPILECOMMANDLISTNV)(getProcAddr("glCompileCommandListNV"))
 	gpCompileShader = (C.GPCOMPILESHADER)(getProcAddr("glCompileShader"))
 	if gpCompileShader == nil {
 		return errors.New("glCompileShader")
 	}
 	gpCompileShaderIncludeARB = (C.GPCOMPILESHADERINCLUDEARB)(getProcAddr("glCompileShaderIncludeARB"))
+	gpCompressedMultiTexImage1DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE1DEXT)(getProcAddr("glCompressedMultiTexImage1DEXT"))
+	gpCompressedMultiTexImage2DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE2DEXT)(getProcAddr("glCompressedMultiTexImage2DEXT"))
+	gpCompressedMultiTexImage3DEXT = (C.GPCOMPRESSEDMULTITEXIMAGE3DEXT)(getProcAddr("glCompressedMultiTexImage3DEXT"))
+	gpCompressedMultiTexSubImage1DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCompressedMultiTexSubImage1DEXT"))
+	gpCompressedMultiTexSubImage2DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCompressedMultiTexSubImage2DEXT"))
+	gpCompressedMultiTexSubImage3DEXT = (C.GPCOMPRESSEDMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCompressedMultiTexSubImage3DEXT"))
 	gpCompressedTexImage1D = (C.GPCOMPRESSEDTEXIMAGE1D)(getProcAddr("glCompressedTexImage1D"))
 	if gpCompressedTexImage1D == nil {
 		return errors.New("glCompressedTexImage1D")
@@ -8542,18 +13552,26 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCompressedTexSubImage3D == nil {
 		return errors.New("glCompressedTexSubImage3D")
 	}
+	gpCompressedTextureImage1DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE1DEXT)(getProcAddr("glCompressedTextureImage1DEXT"))
+	gpCompressedTextureImage2DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE2DEXT)(getProcAddr("glCompressedTextureImage2DEXT"))
+	gpCompressedTextureImage3DEXT = (C.GPCOMPRESSEDTEXTUREIMAGE3DEXT)(getProcAddr("glCompressedTextureImage3DEXT"))
 	gpCompressedTextureSubImage1D = (C.GPCOMPRESSEDTEXTURESUBIMAGE1D)(getProcAddr("glCompressedTextureSubImage1D"))
 	if gpCompressedTextureSubImage1D == nil {
 		return errors.New("glCompressedTextureSubImage1D")
 	}
+	gpCompressedTextureSubImage1DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE1DEXT)(getProcAddr("glCompressedTextureSubImage1DEXT"))
 	gpCompressedTextureSubImage2D = (C.GPCOMPRESSEDTEXTURESUBIMAGE2D)(getProcAddr("glCompressedTextureSubImage2D"))
 	if gpCompressedTextureSubImage2D == nil {
 		return errors.New("glCompressedTextureSubImage2D")
 	}
+	gpCompressedTextureSubImage2DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE2DEXT)(getProcAddr("glCompressedTextureSubImage2DEXT"))
 	gpCompressedTextureSubImage3D = (C.GPCOMPRESSEDTEXTURESUBIMAGE3D)(getProcAddr("glCompressedTextureSubImage3D"))
 	if gpCompressedTextureSubImage3D == nil {
 		return errors.New("glCompressedTextureSubImage3D")
 	}
+	gpCompressedTextureSubImage3DEXT = (C.GPCOMPRESSEDTEXTURESUBIMAGE3DEXT)(getProcAddr("glCompressedTextureSubImage3DEXT"))
+	gpConservativeRasterParameterfNV = (C.GPCONSERVATIVERASTERPARAMETERFNV)(getProcAddr("glConservativeRasterParameterfNV"))
+	gpConservativeRasterParameteriNV = (C.GPCONSERVATIVERASTERPARAMETERINV)(getProcAddr("glConservativeRasterParameteriNV"))
 	gpCopyBufferSubData = (C.GPCOPYBUFFERSUBDATA)(getProcAddr("glCopyBufferSubData"))
 	if gpCopyBufferSubData == nil {
 		return errors.New("glCopyBufferSubData")
@@ -8562,10 +13580,16 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCopyImageSubData == nil {
 		return errors.New("glCopyImageSubData")
 	}
+	gpCopyMultiTexImage1DEXT = (C.GPCOPYMULTITEXIMAGE1DEXT)(getProcAddr("glCopyMultiTexImage1DEXT"))
+	gpCopyMultiTexImage2DEXT = (C.GPCOPYMULTITEXIMAGE2DEXT)(getProcAddr("glCopyMultiTexImage2DEXT"))
+	gpCopyMultiTexSubImage1DEXT = (C.GPCOPYMULTITEXSUBIMAGE1DEXT)(getProcAddr("glCopyMultiTexSubImage1DEXT"))
+	gpCopyMultiTexSubImage2DEXT = (C.GPCOPYMULTITEXSUBIMAGE2DEXT)(getProcAddr("glCopyMultiTexSubImage2DEXT"))
+	gpCopyMultiTexSubImage3DEXT = (C.GPCOPYMULTITEXSUBIMAGE3DEXT)(getProcAddr("glCopyMultiTexSubImage3DEXT"))
 	gpCopyNamedBufferSubData = (C.GPCOPYNAMEDBUFFERSUBDATA)(getProcAddr("glCopyNamedBufferSubData"))
 	if gpCopyNamedBufferSubData == nil {
 		return errors.New("glCopyNamedBufferSubData")
 	}
+	gpCopyPathNV = (C.GPCOPYPATHNV)(getProcAddr("glCopyPathNV"))
 	gpCopyTexImage1D = (C.GPCOPYTEXIMAGE1D)(getProcAddr("glCopyTexImage1D"))
 	if gpCopyTexImage1D == nil {
 		return errors.New("glCopyTexImage1D")
@@ -8586,26 +13610,39 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCopyTexSubImage3D == nil {
 		return errors.New("glCopyTexSubImage3D")
 	}
+	gpCopyTextureImage1DEXT = (C.GPCOPYTEXTUREIMAGE1DEXT)(getProcAddr("glCopyTextureImage1DEXT"))
+	gpCopyTextureImage2DEXT = (C.GPCOPYTEXTUREIMAGE2DEXT)(getProcAddr("glCopyTextureImage2DEXT"))
 	gpCopyTextureSubImage1D = (C.GPCOPYTEXTURESUBIMAGE1D)(getProcAddr("glCopyTextureSubImage1D"))
 	if gpCopyTextureSubImage1D == nil {
 		return errors.New("glCopyTextureSubImage1D")
 	}
+	gpCopyTextureSubImage1DEXT = (C.GPCOPYTEXTURESUBIMAGE1DEXT)(getProcAddr("glCopyTextureSubImage1DEXT"))
 	gpCopyTextureSubImage2D = (C.GPCOPYTEXTURESUBIMAGE2D)(getProcAddr("glCopyTextureSubImage2D"))
 	if gpCopyTextureSubImage2D == nil {
 		return errors.New("glCopyTextureSubImage2D")
 	}
+	gpCopyTextureSubImage2DEXT = (C.GPCOPYTEXTURESUBIMAGE2DEXT)(getProcAddr("glCopyTextureSubImage2DEXT"))
 	gpCopyTextureSubImage3D = (C.GPCOPYTEXTURESUBIMAGE3D)(getProcAddr("glCopyTextureSubImage3D"))
 	if gpCopyTextureSubImage3D == nil {
 		return errors.New("glCopyTextureSubImage3D")
 	}
+	gpCopyTextureSubImage3DEXT = (C.GPCOPYTEXTURESUBIMAGE3DEXT)(getProcAddr("glCopyTextureSubImage3DEXT"))
+	gpCoverFillPathInstancedNV = (C.GPCOVERFILLPATHINSTANCEDNV)(getProcAddr("glCoverFillPathInstancedNV"))
+	gpCoverFillPathNV = (C.GPCOVERFILLPATHNV)(getProcAddr("glCoverFillPathNV"))
+	gpCoverStrokePathInstancedNV = (C.GPCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glCoverStrokePathInstancedNV"))
+	gpCoverStrokePathNV = (C.GPCOVERSTROKEPATHNV)(getProcAddr("glCoverStrokePathNV"))
+	gpCoverageModulationNV = (C.GPCOVERAGEMODULATIONNV)(getProcAddr("glCoverageModulationNV"))
+	gpCoverageModulationTableNV = (C.GPCOVERAGEMODULATIONTABLENV)(getProcAddr("glCoverageModulationTableNV"))
 	gpCreateBuffers = (C.GPCREATEBUFFERS)(getProcAddr("glCreateBuffers"))
 	if gpCreateBuffers == nil {
 		return errors.New("glCreateBuffers")
 	}
+	gpCreateCommandListsNV = (C.GPCREATECOMMANDLISTSNV)(getProcAddr("glCreateCommandListsNV"))
 	gpCreateFramebuffers = (C.GPCREATEFRAMEBUFFERS)(getProcAddr("glCreateFramebuffers"))
 	if gpCreateFramebuffers == nil {
 		return errors.New("glCreateFramebuffers")
 	}
+	gpCreatePerfQueryINTEL = (C.GPCREATEPERFQUERYINTEL)(getProcAddr("glCreatePerfQueryINTEL"))
 	gpCreateProgram = (C.GPCREATEPROGRAM)(getProcAddr("glCreateProgram"))
 	if gpCreateProgram == nil {
 		return errors.New("glCreateProgram")
@@ -8630,10 +13667,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpCreateShader == nil {
 		return errors.New("glCreateShader")
 	}
+	gpCreateShaderProgramEXT = (C.GPCREATESHADERPROGRAMEXT)(getProcAddr("glCreateShaderProgramEXT"))
 	gpCreateShaderProgramv = (C.GPCREATESHADERPROGRAMV)(getProcAddr("glCreateShaderProgramv"))
 	if gpCreateShaderProgramv == nil {
 		return errors.New("glCreateShaderProgramv")
 	}
+	gpCreateShaderProgramvEXT = (C.GPCREATESHADERPROGRAMVEXT)(getProcAddr("glCreateShaderProgramvEXT"))
+	gpCreateStatesNV = (C.GPCREATESTATESNV)(getProcAddr("glCreateStatesNV"))
 	gpCreateSyncFromCLeventARB = (C.GPCREATESYNCFROMCLEVENTARB)(getProcAddr("glCreateSyncFromCLeventARB"))
 	gpCreateTextures = (C.GPCREATETEXTURES)(getProcAddr("glCreateTextures"))
 	if gpCreateTextures == nil {
@@ -8673,11 +13713,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteBuffers == nil {
 		return errors.New("glDeleteBuffers")
 	}
+	gpDeleteCommandListsNV = (C.GPDELETECOMMANDLISTSNV)(getProcAddr("glDeleteCommandListsNV"))
 	gpDeleteFramebuffers = (C.GPDELETEFRAMEBUFFERS)(getProcAddr("glDeleteFramebuffers"))
 	if gpDeleteFramebuffers == nil {
 		return errors.New("glDeleteFramebuffers")
 	}
 	gpDeleteNamedStringARB = (C.GPDELETENAMEDSTRINGARB)(getProcAddr("glDeleteNamedStringARB"))
+	gpDeletePathsNV = (C.GPDELETEPATHSNV)(getProcAddr("glDeletePathsNV"))
+	gpDeletePerfMonitorsAMD = (C.GPDELETEPERFMONITORSAMD)(getProcAddr("glDeletePerfMonitorsAMD"))
+	gpDeletePerfQueryINTEL = (C.GPDELETEPERFQUERYINTEL)(getProcAddr("glDeletePerfQueryINTEL"))
 	gpDeleteProgram = (C.GPDELETEPROGRAM)(getProcAddr("glDeleteProgram"))
 	if gpDeleteProgram == nil {
 		return errors.New("glDeleteProgram")
@@ -8686,6 +13730,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteProgramPipelines == nil {
 		return errors.New("glDeleteProgramPipelines")
 	}
+	gpDeleteProgramPipelinesEXT = (C.GPDELETEPROGRAMPIPELINESEXT)(getProcAddr("glDeleteProgramPipelinesEXT"))
 	gpDeleteQueries = (C.GPDELETEQUERIES)(getProcAddr("glDeleteQueries"))
 	if gpDeleteQueries == nil {
 		return errors.New("glDeleteQueries")
@@ -8702,6 +13747,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDeleteShader == nil {
 		return errors.New("glDeleteShader")
 	}
+	gpDeleteStatesNV = (C.GPDELETESTATESNV)(getProcAddr("glDeleteStatesNV"))
 	gpDeleteSync = (C.GPDELETESYNC)(getProcAddr("glDeleteSync"))
 	if gpDeleteSync == nil {
 		return errors.New("glDeleteSync")
@@ -8750,10 +13796,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDisable == nil {
 		return errors.New("glDisable")
 	}
+	gpDisableClientStateIndexedEXT = (C.GPDISABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glDisableClientStateIndexedEXT"))
+	gpDisableClientStateiEXT = (C.GPDISABLECLIENTSTATEIEXT)(getProcAddr("glDisableClientStateiEXT"))
+	gpDisableIndexedEXT = (C.GPDISABLEINDEXEDEXT)(getProcAddr("glDisableIndexedEXT"))
 	gpDisableVertexArrayAttrib = (C.GPDISABLEVERTEXARRAYATTRIB)(getProcAddr("glDisableVertexArrayAttrib"))
 	if gpDisableVertexArrayAttrib == nil {
 		return errors.New("glDisableVertexArrayAttrib")
 	}
+	gpDisableVertexArrayAttribEXT = (C.GPDISABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glDisableVertexArrayAttribEXT"))
+	gpDisableVertexArrayEXT = (C.GPDISABLEVERTEXARRAYEXT)(getProcAddr("glDisableVertexArrayEXT"))
 	gpDisableVertexAttribArray = (C.GPDISABLEVERTEXATTRIBARRAY)(getProcAddr("glDisableVertexAttribArray"))
 	if gpDisableVertexAttribArray == nil {
 		return errors.New("glDisableVertexAttribArray")
@@ -8783,10 +13834,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawArraysInstanced == nil {
 		return errors.New("glDrawArraysInstanced")
 	}
+	gpDrawArraysInstancedARB = (C.GPDRAWARRAYSINSTANCEDARB)(getProcAddr("glDrawArraysInstancedARB"))
 	gpDrawArraysInstancedBaseInstance = (C.GPDRAWARRAYSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawArraysInstancedBaseInstance"))
 	if gpDrawArraysInstancedBaseInstance == nil {
 		return errors.New("glDrawArraysInstancedBaseInstance")
 	}
+	gpDrawArraysInstancedEXT = (C.GPDRAWARRAYSINSTANCEDEXT)(getProcAddr("glDrawArraysInstancedEXT"))
 	gpDrawBuffer = (C.GPDRAWBUFFER)(getProcAddr("glDrawBuffer"))
 	if gpDrawBuffer == nil {
 		return errors.New("glDrawBuffer")
@@ -8795,6 +13848,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawBuffers == nil {
 		return errors.New("glDrawBuffers")
 	}
+	gpDrawCommandsAddressNV = (C.GPDRAWCOMMANDSADDRESSNV)(getProcAddr("glDrawCommandsAddressNV"))
+	gpDrawCommandsNV = (C.GPDRAWCOMMANDSNV)(getProcAddr("glDrawCommandsNV"))
+	gpDrawCommandsStatesAddressNV = (C.GPDRAWCOMMANDSSTATESADDRESSNV)(getProcAddr("glDrawCommandsStatesAddressNV"))
+	gpDrawCommandsStatesNV = (C.GPDRAWCOMMANDSSTATESNV)(getProcAddr("glDrawCommandsStatesNV"))
 	gpDrawElements = (C.GPDRAWELEMENTS)(getProcAddr("glDrawElements"))
 	if gpDrawElements == nil {
 		return errors.New("glDrawElements")
@@ -8811,6 +13868,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawElementsInstanced == nil {
 		return errors.New("glDrawElementsInstanced")
 	}
+	gpDrawElementsInstancedARB = (C.GPDRAWELEMENTSINSTANCEDARB)(getProcAddr("glDrawElementsInstancedARB"))
 	gpDrawElementsInstancedBaseInstance = (C.GPDRAWELEMENTSINSTANCEDBASEINSTANCE)(getProcAddr("glDrawElementsInstancedBaseInstance"))
 	if gpDrawElementsInstancedBaseInstance == nil {
 		return errors.New("glDrawElementsInstancedBaseInstance")
@@ -8823,6 +13881,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawElementsInstancedBaseVertexBaseInstance == nil {
 		return errors.New("glDrawElementsInstancedBaseVertexBaseInstance")
 	}
+	gpDrawElementsInstancedEXT = (C.GPDRAWELEMENTSINSTANCEDEXT)(getProcAddr("glDrawElementsInstancedEXT"))
 	gpDrawRangeElements = (C.GPDRAWRANGEELEMENTS)(getProcAddr("glDrawRangeElements"))
 	if gpDrawRangeElements == nil {
 		return errors.New("glDrawRangeElements")
@@ -8847,14 +13906,21 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpDrawTransformFeedbackStreamInstanced == nil {
 		return errors.New("glDrawTransformFeedbackStreamInstanced")
 	}
+	gpDrawVkImageNV = (C.GPDRAWVKIMAGENV)(getProcAddr("glDrawVkImageNV"))
+	gpEdgeFlagFormatNV = (C.GPEDGEFLAGFORMATNV)(getProcAddr("glEdgeFlagFormatNV"))
 	gpEnable = (C.GPENABLE)(getProcAddr("glEnable"))
 	if gpEnable == nil {
 		return errors.New("glEnable")
 	}
+	gpEnableClientStateIndexedEXT = (C.GPENABLECLIENTSTATEINDEXEDEXT)(getProcAddr("glEnableClientStateIndexedEXT"))
+	gpEnableClientStateiEXT = (C.GPENABLECLIENTSTATEIEXT)(getProcAddr("glEnableClientStateiEXT"))
+	gpEnableIndexedEXT = (C.GPENABLEINDEXEDEXT)(getProcAddr("glEnableIndexedEXT"))
 	gpEnableVertexArrayAttrib = (C.GPENABLEVERTEXARRAYATTRIB)(getProcAddr("glEnableVertexArrayAttrib"))
 	if gpEnableVertexArrayAttrib == nil {
 		return errors.New("glEnableVertexArrayAttrib")
 	}
+	gpEnableVertexArrayAttribEXT = (C.GPENABLEVERTEXARRAYATTRIBEXT)(getProcAddr("glEnableVertexArrayAttribEXT"))
+	gpEnableVertexArrayEXT = (C.GPENABLEVERTEXARRAYEXT)(getProcAddr("glEnableVertexArrayEXT"))
 	gpEnableVertexAttribArray = (C.GPENABLEVERTEXATTRIBARRAY)(getProcAddr("glEnableVertexAttribArray"))
 	if gpEnableVertexAttribArray == nil {
 		return errors.New("glEnableVertexAttribArray")
@@ -8867,6 +13933,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEndConditionalRender == nil {
 		return errors.New("glEndConditionalRender")
 	}
+	gpEndConditionalRenderNV = (C.GPENDCONDITIONALRENDERNV)(getProcAddr("glEndConditionalRenderNV"))
+	gpEndPerfMonitorAMD = (C.GPENDPERFMONITORAMD)(getProcAddr("glEndPerfMonitorAMD"))
+	gpEndPerfQueryINTEL = (C.GPENDPERFQUERYINTEL)(getProcAddr("glEndPerfQueryINTEL"))
 	gpEndQuery = (C.GPENDQUERY)(getProcAddr("glEndQuery"))
 	if gpEndQuery == nil {
 		return errors.New("glEndQuery")
@@ -8879,6 +13948,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpEndTransformFeedback == nil {
 		return errors.New("glEndTransformFeedback")
 	}
+	gpEvaluateDepthValuesARB = (C.GPEVALUATEDEPTHVALUESARB)(getProcAddr("glEvaluateDepthValuesARB"))
 	gpFenceSync = (C.GPFENCESYNC)(getProcAddr("glFenceSync"))
 	if gpFenceSync == nil {
 		return errors.New("glFenceSync")
@@ -8899,14 +13969,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpFlushMappedNamedBufferRange == nil {
 		return errors.New("glFlushMappedNamedBufferRange")
 	}
+	gpFlushMappedNamedBufferRangeEXT = (C.GPFLUSHMAPPEDNAMEDBUFFERRANGEEXT)(getProcAddr("glFlushMappedNamedBufferRangeEXT"))
+	gpFogCoordFormatNV = (C.GPFOGCOORDFORMATNV)(getProcAddr("glFogCoordFormatNV"))
+	gpFragmentCoverageColorNV = (C.GPFRAGMENTCOVERAGECOLORNV)(getProcAddr("glFragmentCoverageColorNV"))
+	gpFramebufferDrawBufferEXT = (C.GPFRAMEBUFFERDRAWBUFFEREXT)(getProcAddr("glFramebufferDrawBufferEXT"))
+	gpFramebufferDrawBuffersEXT = (C.GPFRAMEBUFFERDRAWBUFFERSEXT)(getProcAddr("glFramebufferDrawBuffersEXT"))
+	gpFramebufferFetchBarrierEXT = (C.GPFRAMEBUFFERFETCHBARRIEREXT)(getProcAddr("glFramebufferFetchBarrierEXT"))
 	gpFramebufferParameteri = (C.GPFRAMEBUFFERPARAMETERI)(getProcAddr("glFramebufferParameteri"))
 	if gpFramebufferParameteri == nil {
 		return errors.New("glFramebufferParameteri")
 	}
+	gpFramebufferReadBufferEXT = (C.GPFRAMEBUFFERREADBUFFEREXT)(getProcAddr("glFramebufferReadBufferEXT"))
 	gpFramebufferRenderbuffer = (C.GPFRAMEBUFFERRENDERBUFFER)(getProcAddr("glFramebufferRenderbuffer"))
 	if gpFramebufferRenderbuffer == nil {
 		return errors.New("glFramebufferRenderbuffer")
 	}
+	gpFramebufferSampleLocationsfvARB = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glFramebufferSampleLocationsfvARB"))
+	gpFramebufferSampleLocationsfvNV = (C.GPFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glFramebufferSampleLocationsfvNV"))
 	gpFramebufferTexture = (C.GPFRAMEBUFFERTEXTURE)(getProcAddr("glFramebufferTexture"))
 	if gpFramebufferTexture == nil {
 		return errors.New("glFramebufferTexture")
@@ -8923,10 +14002,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpFramebufferTexture3D == nil {
 		return errors.New("glFramebufferTexture3D")
 	}
+	gpFramebufferTextureARB = (C.GPFRAMEBUFFERTEXTUREARB)(getProcAddr("glFramebufferTextureARB"))
+	gpFramebufferTextureFaceARB = (C.GPFRAMEBUFFERTEXTUREFACEARB)(getProcAddr("glFramebufferTextureFaceARB"))
 	gpFramebufferTextureLayer = (C.GPFRAMEBUFFERTEXTURELAYER)(getProcAddr("glFramebufferTextureLayer"))
 	if gpFramebufferTextureLayer == nil {
 		return errors.New("glFramebufferTextureLayer")
 	}
+	gpFramebufferTextureLayerARB = (C.GPFRAMEBUFFERTEXTURELAYERARB)(getProcAddr("glFramebufferTextureLayerARB"))
+	gpFramebufferTextureMultiviewOVR = (C.GPFRAMEBUFFERTEXTUREMULTIVIEWOVR)(getProcAddr("glFramebufferTextureMultiviewOVR"))
 	gpFrontFace = (C.GPFRONTFACE)(getProcAddr("glFrontFace"))
 	if gpFrontFace == nil {
 		return errors.New("glFrontFace")
@@ -8939,10 +14022,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenFramebuffers == nil {
 		return errors.New("glGenFramebuffers")
 	}
+	gpGenPathsNV = (C.GPGENPATHSNV)(getProcAddr("glGenPathsNV"))
+	gpGenPerfMonitorsAMD = (C.GPGENPERFMONITORSAMD)(getProcAddr("glGenPerfMonitorsAMD"))
 	gpGenProgramPipelines = (C.GPGENPROGRAMPIPELINES)(getProcAddr("glGenProgramPipelines"))
 	if gpGenProgramPipelines == nil {
 		return errors.New("glGenProgramPipelines")
 	}
+	gpGenProgramPipelinesEXT = (C.GPGENPROGRAMPIPELINESEXT)(getProcAddr("glGenProgramPipelinesEXT"))
 	gpGenQueries = (C.GPGENQUERIES)(getProcAddr("glGenQueries"))
 	if gpGenQueries == nil {
 		return errors.New("glGenQueries")
@@ -8971,10 +14057,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGenerateMipmap == nil {
 		return errors.New("glGenerateMipmap")
 	}
+	gpGenerateMultiTexMipmapEXT = (C.GPGENERATEMULTITEXMIPMAPEXT)(getProcAddr("glGenerateMultiTexMipmapEXT"))
 	gpGenerateTextureMipmap = (C.GPGENERATETEXTUREMIPMAP)(getProcAddr("glGenerateTextureMipmap"))
 	if gpGenerateTextureMipmap == nil {
 		return errors.New("glGenerateTextureMipmap")
 	}
+	gpGenerateTextureMipmapEXT = (C.GPGENERATETEXTUREMIPMAPEXT)(getProcAddr("glGenerateTextureMipmapEXT"))
 	gpGetActiveAtomicCounterBufferiv = (C.GPGETACTIVEATOMICCOUNTERBUFFERIV)(getProcAddr("glGetActiveAtomicCounterBufferiv"))
 	if gpGetActiveAtomicCounterBufferiv == nil {
 		return errors.New("glGetActiveAtomicCounterBufferiv")
@@ -9023,6 +14111,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetAttribLocation == nil {
 		return errors.New("glGetAttribLocation")
 	}
+	gpGetBooleanIndexedvEXT = (C.GPGETBOOLEANINDEXEDVEXT)(getProcAddr("glGetBooleanIndexedvEXT"))
 	gpGetBooleani_v = (C.GPGETBOOLEANI_V)(getProcAddr("glGetBooleani_v"))
 	if gpGetBooleani_v == nil {
 		return errors.New("glGetBooleani_v")
@@ -9039,6 +14128,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetBufferParameteriv == nil {
 		return errors.New("glGetBufferParameteriv")
 	}
+	gpGetBufferParameterui64vNV = (C.GPGETBUFFERPARAMETERUI64VNV)(getProcAddr("glGetBufferParameterui64vNV"))
 	gpGetBufferPointerv = (C.GPGETBUFFERPOINTERV)(getProcAddr("glGetBufferPointerv"))
 	if gpGetBufferPointerv == nil {
 		return errors.New("glGetBufferPointerv")
@@ -9047,6 +14137,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetBufferSubData == nil {
 		return errors.New("glGetBufferSubData")
 	}
+	gpGetCommandHeaderNV = (C.GPGETCOMMANDHEADERNV)(getProcAddr("glGetCommandHeaderNV"))
+	gpGetCompressedMultiTexImageEXT = (C.GPGETCOMPRESSEDMULTITEXIMAGEEXT)(getProcAddr("glGetCompressedMultiTexImageEXT"))
 	gpGetCompressedTexImage = (C.GPGETCOMPRESSEDTEXIMAGE)(getProcAddr("glGetCompressedTexImage"))
 	if gpGetCompressedTexImage == nil {
 		return errors.New("glGetCompressedTexImage")
@@ -9055,20 +14147,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetCompressedTextureImage == nil {
 		return errors.New("glGetCompressedTextureImage")
 	}
+	gpGetCompressedTextureImageEXT = (C.GPGETCOMPRESSEDTEXTUREIMAGEEXT)(getProcAddr("glGetCompressedTextureImageEXT"))
 	gpGetCompressedTextureSubImage = (C.GPGETCOMPRESSEDTEXTURESUBIMAGE)(getProcAddr("glGetCompressedTextureSubImage"))
 	if gpGetCompressedTextureSubImage == nil {
 		return errors.New("glGetCompressedTextureSubImage")
 	}
+	gpGetCoverageModulationTableNV = (C.GPGETCOVERAGEMODULATIONTABLENV)(getProcAddr("glGetCoverageModulationTableNV"))
 	gpGetDebugMessageLog = (C.GPGETDEBUGMESSAGELOG)(getProcAddr("glGetDebugMessageLog"))
 	if gpGetDebugMessageLog == nil {
 		return errors.New("glGetDebugMessageLog")
 	}
 	gpGetDebugMessageLogARB = (C.GPGETDEBUGMESSAGELOGARB)(getProcAddr("glGetDebugMessageLogARB"))
 	gpGetDebugMessageLogKHR = (C.GPGETDEBUGMESSAGELOGKHR)(getProcAddr("glGetDebugMessageLogKHR"))
+	gpGetDoubleIndexedvEXT = (C.GPGETDOUBLEINDEXEDVEXT)(getProcAddr("glGetDoubleIndexedvEXT"))
 	gpGetDoublei_v = (C.GPGETDOUBLEI_V)(getProcAddr("glGetDoublei_v"))
 	if gpGetDoublei_v == nil {
 		return errors.New("glGetDoublei_v")
 	}
+	gpGetDoublei_vEXT = (C.GPGETDOUBLEI_VEXT)(getProcAddr("glGetDoublei_vEXT"))
 	gpGetDoublev = (C.GPGETDOUBLEV)(getProcAddr("glGetDoublev"))
 	if gpGetDoublev == nil {
 		return errors.New("glGetDoublev")
@@ -9077,10 +14173,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetError == nil {
 		return errors.New("glGetError")
 	}
+	gpGetFirstPerfQueryIdINTEL = (C.GPGETFIRSTPERFQUERYIDINTEL)(getProcAddr("glGetFirstPerfQueryIdINTEL"))
+	gpGetFloatIndexedvEXT = (C.GPGETFLOATINDEXEDVEXT)(getProcAddr("glGetFloatIndexedvEXT"))
 	gpGetFloati_v = (C.GPGETFLOATI_V)(getProcAddr("glGetFloati_v"))
 	if gpGetFloati_v == nil {
 		return errors.New("glGetFloati_v")
 	}
+	gpGetFloati_vEXT = (C.GPGETFLOATI_VEXT)(getProcAddr("glGetFloati_vEXT"))
 	gpGetFloatv = (C.GPGETFLOATV)(getProcAddr("glGetFloatv"))
 	if gpGetFloatv == nil {
 		return errors.New("glGetFloatv")
@@ -9101,6 +14200,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetFramebufferParameteriv == nil {
 		return errors.New("glGetFramebufferParameteriv")
 	}
+	gpGetFramebufferParameterivEXT = (C.GPGETFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetFramebufferParameterivEXT"))
 	gpGetGraphicsResetStatus = (C.GPGETGRAPHICSRESETSTATUS)(getProcAddr("glGetGraphicsResetStatus"))
 	if gpGetGraphicsResetStatus == nil {
 		return errors.New("glGetGraphicsResetStatus")
@@ -9108,6 +14208,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetGraphicsResetStatusARB = (C.GPGETGRAPHICSRESETSTATUSARB)(getProcAddr("glGetGraphicsResetStatusARB"))
 	gpGetGraphicsResetStatusKHR = (C.GPGETGRAPHICSRESETSTATUSKHR)(getProcAddr("glGetGraphicsResetStatusKHR"))
 	gpGetImageHandleARB = (C.GPGETIMAGEHANDLEARB)(getProcAddr("glGetImageHandleARB"))
+	gpGetImageHandleNV = (C.GPGETIMAGEHANDLENV)(getProcAddr("glGetImageHandleNV"))
 	gpGetInteger64i_v = (C.GPGETINTEGER64I_V)(getProcAddr("glGetInteger64i_v"))
 	if gpGetInteger64i_v == nil {
 		return errors.New("glGetInteger64i_v")
@@ -9116,14 +14217,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetInteger64v == nil {
 		return errors.New("glGetInteger64v")
 	}
+	gpGetIntegerIndexedvEXT = (C.GPGETINTEGERINDEXEDVEXT)(getProcAddr("glGetIntegerIndexedvEXT"))
 	gpGetIntegeri_v = (C.GPGETINTEGERI_V)(getProcAddr("glGetIntegeri_v"))
 	if gpGetIntegeri_v == nil {
 		return errors.New("glGetIntegeri_v")
 	}
+	gpGetIntegerui64i_vNV = (C.GPGETINTEGERUI64I_VNV)(getProcAddr("glGetIntegerui64i_vNV"))
+	gpGetIntegerui64vNV = (C.GPGETINTEGERUI64VNV)(getProcAddr("glGetIntegerui64vNV"))
 	gpGetIntegerv = (C.GPGETINTEGERV)(getProcAddr("glGetIntegerv"))
 	if gpGetIntegerv == nil {
 		return errors.New("glGetIntegerv")
 	}
+	gpGetInternalformatSampleivNV = (C.GPGETINTERNALFORMATSAMPLEIVNV)(getProcAddr("glGetInternalformatSampleivNV"))
 	gpGetInternalformati64v = (C.GPGETINTERNALFORMATI64V)(getProcAddr("glGetInternalformati64v"))
 	if gpGetInternalformati64v == nil {
 		return errors.New("glGetInternalformati64v")
@@ -9132,6 +14237,18 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetInternalformativ == nil {
 		return errors.New("glGetInternalformativ")
 	}
+	gpGetMultiTexEnvfvEXT = (C.GPGETMULTITEXENVFVEXT)(getProcAddr("glGetMultiTexEnvfvEXT"))
+	gpGetMultiTexEnvivEXT = (C.GPGETMULTITEXENVIVEXT)(getProcAddr("glGetMultiTexEnvivEXT"))
+	gpGetMultiTexGendvEXT = (C.GPGETMULTITEXGENDVEXT)(getProcAddr("glGetMultiTexGendvEXT"))
+	gpGetMultiTexGenfvEXT = (C.GPGETMULTITEXGENFVEXT)(getProcAddr("glGetMultiTexGenfvEXT"))
+	gpGetMultiTexGenivEXT = (C.GPGETMULTITEXGENIVEXT)(getProcAddr("glGetMultiTexGenivEXT"))
+	gpGetMultiTexImageEXT = (C.GPGETMULTITEXIMAGEEXT)(getProcAddr("glGetMultiTexImageEXT"))
+	gpGetMultiTexLevelParameterfvEXT = (C.GPGETMULTITEXLEVELPARAMETERFVEXT)(getProcAddr("glGetMultiTexLevelParameterfvEXT"))
+	gpGetMultiTexLevelParameterivEXT = (C.GPGETMULTITEXLEVELPARAMETERIVEXT)(getProcAddr("glGetMultiTexLevelParameterivEXT"))
+	gpGetMultiTexParameterIivEXT = (C.GPGETMULTITEXPARAMETERIIVEXT)(getProcAddr("glGetMultiTexParameterIivEXT"))
+	gpGetMultiTexParameterIuivEXT = (C.GPGETMULTITEXPARAMETERIUIVEXT)(getProcAddr("glGetMultiTexParameterIuivEXT"))
+	gpGetMultiTexParameterfvEXT = (C.GPGETMULTITEXPARAMETERFVEXT)(getProcAddr("glGetMultiTexParameterfvEXT"))
+	gpGetMultiTexParameterivEXT = (C.GPGETMULTITEXPARAMETERIVEXT)(getProcAddr("glGetMultiTexParameterivEXT"))
 	gpGetMultisamplefv = (C.GPGETMULTISAMPLEFV)(getProcAddr("glGetMultisamplefv"))
 	if gpGetMultisamplefv == nil {
 		return errors.New("glGetMultisamplefv")
@@ -9144,38 +14261,74 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetNamedBufferParameteriv == nil {
 		return errors.New("glGetNamedBufferParameteriv")
 	}
+	gpGetNamedBufferParameterivEXT = (C.GPGETNAMEDBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedBufferParameterivEXT"))
+	gpGetNamedBufferParameterui64vNV = (C.GPGETNAMEDBUFFERPARAMETERUI64VNV)(getProcAddr("glGetNamedBufferParameterui64vNV"))
 	gpGetNamedBufferPointerv = (C.GPGETNAMEDBUFFERPOINTERV)(getProcAddr("glGetNamedBufferPointerv"))
 	if gpGetNamedBufferPointerv == nil {
 		return errors.New("glGetNamedBufferPointerv")
 	}
+	gpGetNamedBufferPointervEXT = (C.GPGETNAMEDBUFFERPOINTERVEXT)(getProcAddr("glGetNamedBufferPointervEXT"))
 	gpGetNamedBufferSubData = (C.GPGETNAMEDBUFFERSUBDATA)(getProcAddr("glGetNamedBufferSubData"))
 	if gpGetNamedBufferSubData == nil {
 		return errors.New("glGetNamedBufferSubData")
 	}
+	gpGetNamedBufferSubDataEXT = (C.GPGETNAMEDBUFFERSUBDATAEXT)(getProcAddr("glGetNamedBufferSubDataEXT"))
 	gpGetNamedFramebufferAttachmentParameteriv = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIV)(getProcAddr("glGetNamedFramebufferAttachmentParameteriv"))
 	if gpGetNamedFramebufferAttachmentParameteriv == nil {
 		return errors.New("glGetNamedFramebufferAttachmentParameteriv")
 	}
+	gpGetNamedFramebufferAttachmentParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferAttachmentParameterivEXT"))
 	gpGetNamedFramebufferParameteriv = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIV)(getProcAddr("glGetNamedFramebufferParameteriv"))
 	if gpGetNamedFramebufferParameteriv == nil {
 		return errors.New("glGetNamedFramebufferParameteriv")
 	}
+	gpGetNamedFramebufferParameterivEXT = (C.GPGETNAMEDFRAMEBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedFramebufferParameterivEXT"))
+	gpGetNamedProgramLocalParameterIivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIivEXT"))
+	gpGetNamedProgramLocalParameterIuivEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERIUIVEXT)(getProcAddr("glGetNamedProgramLocalParameterIuivEXT"))
+	gpGetNamedProgramLocalParameterdvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERDVEXT)(getProcAddr("glGetNamedProgramLocalParameterdvEXT"))
+	gpGetNamedProgramLocalParameterfvEXT = (C.GPGETNAMEDPROGRAMLOCALPARAMETERFVEXT)(getProcAddr("glGetNamedProgramLocalParameterfvEXT"))
+	gpGetNamedProgramStringEXT = (C.GPGETNAMEDPROGRAMSTRINGEXT)(getProcAddr("glGetNamedProgramStringEXT"))
+	gpGetNamedProgramivEXT = (C.GPGETNAMEDPROGRAMIVEXT)(getProcAddr("glGetNamedProgramivEXT"))
 	gpGetNamedRenderbufferParameteriv = (C.GPGETNAMEDRENDERBUFFERPARAMETERIV)(getProcAddr("glGetNamedRenderbufferParameteriv"))
 	if gpGetNamedRenderbufferParameteriv == nil {
 		return errors.New("glGetNamedRenderbufferParameteriv")
 	}
+	gpGetNamedRenderbufferParameterivEXT = (C.GPGETNAMEDRENDERBUFFERPARAMETERIVEXT)(getProcAddr("glGetNamedRenderbufferParameterivEXT"))
 	gpGetNamedStringARB = (C.GPGETNAMEDSTRINGARB)(getProcAddr("glGetNamedStringARB"))
 	gpGetNamedStringivARB = (C.GPGETNAMEDSTRINGIVARB)(getProcAddr("glGetNamedStringivARB"))
+	gpGetNextPerfQueryIdINTEL = (C.GPGETNEXTPERFQUERYIDINTEL)(getProcAddr("glGetNextPerfQueryIdINTEL"))
 	gpGetObjectLabel = (C.GPGETOBJECTLABEL)(getProcAddr("glGetObjectLabel"))
 	if gpGetObjectLabel == nil {
 		return errors.New("glGetObjectLabel")
 	}
+	gpGetObjectLabelEXT = (C.GPGETOBJECTLABELEXT)(getProcAddr("glGetObjectLabelEXT"))
 	gpGetObjectLabelKHR = (C.GPGETOBJECTLABELKHR)(getProcAddr("glGetObjectLabelKHR"))
 	gpGetObjectPtrLabel = (C.GPGETOBJECTPTRLABEL)(getProcAddr("glGetObjectPtrLabel"))
 	if gpGetObjectPtrLabel == nil {
 		return errors.New("glGetObjectPtrLabel")
 	}
 	gpGetObjectPtrLabelKHR = (C.GPGETOBJECTPTRLABELKHR)(getProcAddr("glGetObjectPtrLabelKHR"))
+	gpGetPathCommandsNV = (C.GPGETPATHCOMMANDSNV)(getProcAddr("glGetPathCommandsNV"))
+	gpGetPathCoordsNV = (C.GPGETPATHCOORDSNV)(getProcAddr("glGetPathCoordsNV"))
+	gpGetPathDashArrayNV = (C.GPGETPATHDASHARRAYNV)(getProcAddr("glGetPathDashArrayNV"))
+	gpGetPathLengthNV = (C.GPGETPATHLENGTHNV)(getProcAddr("glGetPathLengthNV"))
+	gpGetPathMetricRangeNV = (C.GPGETPATHMETRICRANGENV)(getProcAddr("glGetPathMetricRangeNV"))
+	gpGetPathMetricsNV = (C.GPGETPATHMETRICSNV)(getProcAddr("glGetPathMetricsNV"))
+	gpGetPathParameterfvNV = (C.GPGETPATHPARAMETERFVNV)(getProcAddr("glGetPathParameterfvNV"))
+	gpGetPathParameterivNV = (C.GPGETPATHPARAMETERIVNV)(getProcAddr("glGetPathParameterivNV"))
+	gpGetPathSpacingNV = (C.GPGETPATHSPACINGNV)(getProcAddr("glGetPathSpacingNV"))
+	gpGetPerfCounterInfoINTEL = (C.GPGETPERFCOUNTERINFOINTEL)(getProcAddr("glGetPerfCounterInfoINTEL"))
+	gpGetPerfMonitorCounterDataAMD = (C.GPGETPERFMONITORCOUNTERDATAAMD)(getProcAddr("glGetPerfMonitorCounterDataAMD"))
+	gpGetPerfMonitorCounterInfoAMD = (C.GPGETPERFMONITORCOUNTERINFOAMD)(getProcAddr("glGetPerfMonitorCounterInfoAMD"))
+	gpGetPerfMonitorCounterStringAMD = (C.GPGETPERFMONITORCOUNTERSTRINGAMD)(getProcAddr("glGetPerfMonitorCounterStringAMD"))
+	gpGetPerfMonitorCountersAMD = (C.GPGETPERFMONITORCOUNTERSAMD)(getProcAddr("glGetPerfMonitorCountersAMD"))
+	gpGetPerfMonitorGroupStringAMD = (C.GPGETPERFMONITORGROUPSTRINGAMD)(getProcAddr("glGetPerfMonitorGroupStringAMD"))
+	gpGetPerfMonitorGroupsAMD = (C.GPGETPERFMONITORGROUPSAMD)(getProcAddr("glGetPerfMonitorGroupsAMD"))
+	gpGetPerfQueryDataINTEL = (C.GPGETPERFQUERYDATAINTEL)(getProcAddr("glGetPerfQueryDataINTEL"))
+	gpGetPerfQueryIdByNameINTEL = (C.GPGETPERFQUERYIDBYNAMEINTEL)(getProcAddr("glGetPerfQueryIdByNameINTEL"))
+	gpGetPerfQueryInfoINTEL = (C.GPGETPERFQUERYINFOINTEL)(getProcAddr("glGetPerfQueryInfoINTEL"))
+	gpGetPointerIndexedvEXT = (C.GPGETPOINTERINDEXEDVEXT)(getProcAddr("glGetPointerIndexedvEXT"))
+	gpGetPointeri_vEXT = (C.GPGETPOINTERI_VEXT)(getProcAddr("glGetPointeri_vEXT"))
 	gpGetPointerv = (C.GPGETPOINTERV)(getProcAddr("glGetPointerv"))
 	if gpGetPointerv == nil {
 		return errors.New("glGetPointerv")
@@ -9197,10 +14350,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetProgramPipelineInfoLog == nil {
 		return errors.New("glGetProgramPipelineInfoLog")
 	}
+	gpGetProgramPipelineInfoLogEXT = (C.GPGETPROGRAMPIPELINEINFOLOGEXT)(getProcAddr("glGetProgramPipelineInfoLogEXT"))
 	gpGetProgramPipelineiv = (C.GPGETPROGRAMPIPELINEIV)(getProcAddr("glGetProgramPipelineiv"))
 	if gpGetProgramPipelineiv == nil {
 		return errors.New("glGetProgramPipelineiv")
 	}
+	gpGetProgramPipelineivEXT = (C.GPGETPROGRAMPIPELINEIVEXT)(getProcAddr("glGetProgramPipelineivEXT"))
 	gpGetProgramResourceIndex = (C.GPGETPROGRAMRESOURCEINDEX)(getProcAddr("glGetProgramResourceIndex"))
 	if gpGetProgramResourceIndex == nil {
 		return errors.New("glGetProgramResourceIndex")
@@ -9217,6 +14372,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetProgramResourceName == nil {
 		return errors.New("glGetProgramResourceName")
 	}
+	gpGetProgramResourcefvNV = (C.GPGETPROGRAMRESOURCEFVNV)(getProcAddr("glGetProgramResourcefvNV"))
 	gpGetProgramResourceiv = (C.GPGETPROGRAMRESOURCEIV)(getProcAddr("glGetProgramResourceiv"))
 	if gpGetProgramResourceiv == nil {
 		return errors.New("glGetProgramResourceiv")
@@ -9228,6 +14384,22 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpGetProgramiv = (C.GPGETPROGRAMIV)(getProcAddr("glGetProgramiv"))
 	if gpGetProgramiv == nil {
 		return errors.New("glGetProgramiv")
+	}
+	gpGetQueryBufferObjecti64v = (C.GPGETQUERYBUFFEROBJECTI64V)(getProcAddr("glGetQueryBufferObjecti64v"))
+	if gpGetQueryBufferObjecti64v == nil {
+		return errors.New("glGetQueryBufferObjecti64v")
+	}
+	gpGetQueryBufferObjectiv = (C.GPGETQUERYBUFFEROBJECTIV)(getProcAddr("glGetQueryBufferObjectiv"))
+	if gpGetQueryBufferObjectiv == nil {
+		return errors.New("glGetQueryBufferObjectiv")
+	}
+	gpGetQueryBufferObjectui64v = (C.GPGETQUERYBUFFEROBJECTUI64V)(getProcAddr("glGetQueryBufferObjectui64v"))
+	if gpGetQueryBufferObjectui64v == nil {
+		return errors.New("glGetQueryBufferObjectui64v")
+	}
+	gpGetQueryBufferObjectuiv = (C.GPGETQUERYBUFFEROBJECTUIV)(getProcAddr("glGetQueryBufferObjectuiv"))
+	if gpGetQueryBufferObjectuiv == nil {
+		return errors.New("glGetQueryBufferObjectuiv")
 	}
 	gpGetQueryIndexediv = (C.GPGETQUERYINDEXEDIV)(getProcAddr("glGetQueryIndexediv"))
 	if gpGetQueryIndexediv == nil {
@@ -9289,6 +14461,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetShaderiv == nil {
 		return errors.New("glGetShaderiv")
 	}
+	gpGetStageIndexNV = (C.GPGETSTAGEINDEXNV)(getProcAddr("glGetStageIndexNV"))
 	gpGetString = (C.GPGETSTRING)(getProcAddr("glGetString"))
 	if gpGetString == nil {
 		return errors.New("glGetString")
@@ -9338,35 +14511,44 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glGetTexParameteriv")
 	}
 	gpGetTextureHandleARB = (C.GPGETTEXTUREHANDLEARB)(getProcAddr("glGetTextureHandleARB"))
+	gpGetTextureHandleNV = (C.GPGETTEXTUREHANDLENV)(getProcAddr("glGetTextureHandleNV"))
 	gpGetTextureImage = (C.GPGETTEXTUREIMAGE)(getProcAddr("glGetTextureImage"))
 	if gpGetTextureImage == nil {
 		return errors.New("glGetTextureImage")
 	}
+	gpGetTextureImageEXT = (C.GPGETTEXTUREIMAGEEXT)(getProcAddr("glGetTextureImageEXT"))
 	gpGetTextureLevelParameterfv = (C.GPGETTEXTURELEVELPARAMETERFV)(getProcAddr("glGetTextureLevelParameterfv"))
 	if gpGetTextureLevelParameterfv == nil {
 		return errors.New("glGetTextureLevelParameterfv")
 	}
+	gpGetTextureLevelParameterfvEXT = (C.GPGETTEXTURELEVELPARAMETERFVEXT)(getProcAddr("glGetTextureLevelParameterfvEXT"))
 	gpGetTextureLevelParameteriv = (C.GPGETTEXTURELEVELPARAMETERIV)(getProcAddr("glGetTextureLevelParameteriv"))
 	if gpGetTextureLevelParameteriv == nil {
 		return errors.New("glGetTextureLevelParameteriv")
 	}
+	gpGetTextureLevelParameterivEXT = (C.GPGETTEXTURELEVELPARAMETERIVEXT)(getProcAddr("glGetTextureLevelParameterivEXT"))
 	gpGetTextureParameterIiv = (C.GPGETTEXTUREPARAMETERIIV)(getProcAddr("glGetTextureParameterIiv"))
 	if gpGetTextureParameterIiv == nil {
 		return errors.New("glGetTextureParameterIiv")
 	}
+	gpGetTextureParameterIivEXT = (C.GPGETTEXTUREPARAMETERIIVEXT)(getProcAddr("glGetTextureParameterIivEXT"))
 	gpGetTextureParameterIuiv = (C.GPGETTEXTUREPARAMETERIUIV)(getProcAddr("glGetTextureParameterIuiv"))
 	if gpGetTextureParameterIuiv == nil {
 		return errors.New("glGetTextureParameterIuiv")
 	}
+	gpGetTextureParameterIuivEXT = (C.GPGETTEXTUREPARAMETERIUIVEXT)(getProcAddr("glGetTextureParameterIuivEXT"))
 	gpGetTextureParameterfv = (C.GPGETTEXTUREPARAMETERFV)(getProcAddr("glGetTextureParameterfv"))
 	if gpGetTextureParameterfv == nil {
 		return errors.New("glGetTextureParameterfv")
 	}
+	gpGetTextureParameterfvEXT = (C.GPGETTEXTUREPARAMETERFVEXT)(getProcAddr("glGetTextureParameterfvEXT"))
 	gpGetTextureParameteriv = (C.GPGETTEXTUREPARAMETERIV)(getProcAddr("glGetTextureParameteriv"))
 	if gpGetTextureParameteriv == nil {
 		return errors.New("glGetTextureParameteriv")
 	}
+	gpGetTextureParameterivEXT = (C.GPGETTEXTUREPARAMETERIVEXT)(getProcAddr("glGetTextureParameterivEXT"))
 	gpGetTextureSamplerHandleARB = (C.GPGETTEXTURESAMPLERHANDLEARB)(getProcAddr("glGetTextureSamplerHandleARB"))
+	gpGetTextureSamplerHandleNV = (C.GPGETTEXTURESAMPLERHANDLENV)(getProcAddr("glGetTextureSamplerHandleNV"))
 	gpGetTextureSubImage = (C.GPGETTEXTURESUBIMAGE)(getProcAddr("glGetTextureSubImage"))
 	if gpGetTextureSubImage == nil {
 		return errors.New("glGetTextureSubImage")
@@ -9411,10 +14593,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetUniformfv == nil {
 		return errors.New("glGetUniformfv")
 	}
+	gpGetUniformi64vARB = (C.GPGETUNIFORMI64VARB)(getProcAddr("glGetUniformi64vARB"))
+	gpGetUniformi64vNV = (C.GPGETUNIFORMI64VNV)(getProcAddr("glGetUniformi64vNV"))
 	gpGetUniformiv = (C.GPGETUNIFORMIV)(getProcAddr("glGetUniformiv"))
 	if gpGetUniformiv == nil {
 		return errors.New("glGetUniformiv")
 	}
+	gpGetUniformui64vARB = (C.GPGETUNIFORMUI64VARB)(getProcAddr("glGetUniformui64vARB"))
+	gpGetUniformui64vNV = (C.GPGETUNIFORMUI64VNV)(getProcAddr("glGetUniformui64vNV"))
 	gpGetUniformuiv = (C.GPGETUNIFORMUIV)(getProcAddr("glGetUniformuiv"))
 	if gpGetUniformuiv == nil {
 		return errors.New("glGetUniformuiv")
@@ -9427,6 +14613,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetVertexArrayIndexediv == nil {
 		return errors.New("glGetVertexArrayIndexediv")
 	}
+	gpGetVertexArrayIntegeri_vEXT = (C.GPGETVERTEXARRAYINTEGERI_VEXT)(getProcAddr("glGetVertexArrayIntegeri_vEXT"))
+	gpGetVertexArrayIntegervEXT = (C.GPGETVERTEXARRAYINTEGERVEXT)(getProcAddr("glGetVertexArrayIntegervEXT"))
+	gpGetVertexArrayPointeri_vEXT = (C.GPGETVERTEXARRAYPOINTERI_VEXT)(getProcAddr("glGetVertexArrayPointeri_vEXT"))
+	gpGetVertexArrayPointervEXT = (C.GPGETVERTEXARRAYPOINTERVEXT)(getProcAddr("glGetVertexArrayPointervEXT"))
 	gpGetVertexArrayiv = (C.GPGETVERTEXARRAYIV)(getProcAddr("glGetVertexArrayiv"))
 	if gpGetVertexArrayiv == nil {
 		return errors.New("glGetVertexArrayiv")
@@ -9443,7 +14633,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetVertexAttribLdv == nil {
 		return errors.New("glGetVertexAttribLdv")
 	}
+	gpGetVertexAttribLi64vNV = (C.GPGETVERTEXATTRIBLI64VNV)(getProcAddr("glGetVertexAttribLi64vNV"))
 	gpGetVertexAttribLui64vARB = (C.GPGETVERTEXATTRIBLUI64VARB)(getProcAddr("glGetVertexAttribLui64vARB"))
+	gpGetVertexAttribLui64vNV = (C.GPGETVERTEXATTRIBLUI64VNV)(getProcAddr("glGetVertexAttribLui64vNV"))
 	gpGetVertexAttribPointerv = (C.GPGETVERTEXATTRIBPOINTERV)(getProcAddr("glGetVertexAttribPointerv"))
 	if gpGetVertexAttribPointerv == nil {
 		return errors.New("glGetVertexAttribPointerv")
@@ -9460,6 +14652,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpGetVertexAttribiv == nil {
 		return errors.New("glGetVertexAttribiv")
 	}
+	gpGetVkProcAddrNV = (C.GPGETVKPROCADDRNV)(getProcAddr("glGetVkProcAddrNV"))
 	gpGetnCompressedTexImage = (C.GPGETNCOMPRESSEDTEXIMAGE)(getProcAddr("glGetnCompressedTexImage"))
 	if gpGetnCompressedTexImage == nil {
 		return errors.New("glGetnCompressedTexImage")
@@ -9481,12 +14674,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	}
 	gpGetnUniformfvARB = (C.GPGETNUNIFORMFVARB)(getProcAddr("glGetnUniformfvARB"))
 	gpGetnUniformfvKHR = (C.GPGETNUNIFORMFVKHR)(getProcAddr("glGetnUniformfvKHR"))
+	gpGetnUniformi64vARB = (C.GPGETNUNIFORMI64VARB)(getProcAddr("glGetnUniformi64vARB"))
 	gpGetnUniformiv = (C.GPGETNUNIFORMIV)(getProcAddr("glGetnUniformiv"))
 	if gpGetnUniformiv == nil {
 		return errors.New("glGetnUniformiv")
 	}
 	gpGetnUniformivARB = (C.GPGETNUNIFORMIVARB)(getProcAddr("glGetnUniformivARB"))
 	gpGetnUniformivKHR = (C.GPGETNUNIFORMIVKHR)(getProcAddr("glGetnUniformivKHR"))
+	gpGetnUniformui64vARB = (C.GPGETNUNIFORMUI64VARB)(getProcAddr("glGetnUniformui64vARB"))
 	gpGetnUniformuiv = (C.GPGETNUNIFORMUIV)(getProcAddr("glGetnUniformuiv"))
 	if gpGetnUniformuiv == nil {
 		return errors.New("glGetnUniformuiv")
@@ -9497,6 +14692,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpHint == nil {
 		return errors.New("glHint")
 	}
+	gpIndexFormatNV = (C.GPINDEXFORMATNV)(getProcAddr("glIndexFormatNV"))
+	gpInsertEventMarkerEXT = (C.GPINSERTEVENTMARKEREXT)(getProcAddr("glInsertEventMarkerEXT"))
+	gpInterpolatePathsNV = (C.GPINTERPOLATEPATHSNV)(getProcAddr("glInterpolatePathsNV"))
 	gpInvalidateBufferData = (C.GPINVALIDATEBUFFERDATA)(getProcAddr("glInvalidateBufferData"))
 	if gpInvalidateBufferData == nil {
 		return errors.New("glInvalidateBufferData")
@@ -9533,10 +14731,13 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsBuffer == nil {
 		return errors.New("glIsBuffer")
 	}
+	gpIsBufferResidentNV = (C.GPISBUFFERRESIDENTNV)(getProcAddr("glIsBufferResidentNV"))
+	gpIsCommandListNV = (C.GPISCOMMANDLISTNV)(getProcAddr("glIsCommandListNV"))
 	gpIsEnabled = (C.GPISENABLED)(getProcAddr("glIsEnabled"))
 	if gpIsEnabled == nil {
 		return errors.New("glIsEnabled")
 	}
+	gpIsEnabledIndexedEXT = (C.GPISENABLEDINDEXEDEXT)(getProcAddr("glIsEnabledIndexedEXT"))
 	gpIsEnabledi = (C.GPISENABLEDI)(getProcAddr("glIsEnabledi"))
 	if gpIsEnabledi == nil {
 		return errors.New("glIsEnabledi")
@@ -9546,7 +14747,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsFramebuffer")
 	}
 	gpIsImageHandleResidentARB = (C.GPISIMAGEHANDLERESIDENTARB)(getProcAddr("glIsImageHandleResidentARB"))
+	gpIsImageHandleResidentNV = (C.GPISIMAGEHANDLERESIDENTNV)(getProcAddr("glIsImageHandleResidentNV"))
+	gpIsNamedBufferResidentNV = (C.GPISNAMEDBUFFERRESIDENTNV)(getProcAddr("glIsNamedBufferResidentNV"))
 	gpIsNamedStringARB = (C.GPISNAMEDSTRINGARB)(getProcAddr("glIsNamedStringARB"))
+	gpIsPathNV = (C.GPISPATHNV)(getProcAddr("glIsPathNV"))
+	gpIsPointInFillPathNV = (C.GPISPOINTINFILLPATHNV)(getProcAddr("glIsPointInFillPathNV"))
+	gpIsPointInStrokePathNV = (C.GPISPOINTINSTROKEPATHNV)(getProcAddr("glIsPointInStrokePathNV"))
 	gpIsProgram = (C.GPISPROGRAM)(getProcAddr("glIsProgram"))
 	if gpIsProgram == nil {
 		return errors.New("glIsProgram")
@@ -9555,6 +14761,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsProgramPipeline == nil {
 		return errors.New("glIsProgramPipeline")
 	}
+	gpIsProgramPipelineEXT = (C.GPISPROGRAMPIPELINEEXT)(getProcAddr("glIsProgramPipelineEXT"))
 	gpIsQuery = (C.GPISQUERY)(getProcAddr("glIsQuery"))
 	if gpIsQuery == nil {
 		return errors.New("glIsQuery")
@@ -9571,6 +14778,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsShader == nil {
 		return errors.New("glIsShader")
 	}
+	gpIsStateNV = (C.GPISSTATENV)(getProcAddr("glIsStateNV"))
 	gpIsSync = (C.GPISSYNC)(getProcAddr("glIsSync"))
 	if gpIsSync == nil {
 		return errors.New("glIsSync")
@@ -9580,6 +14788,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glIsTexture")
 	}
 	gpIsTextureHandleResidentARB = (C.GPISTEXTUREHANDLERESIDENTARB)(getProcAddr("glIsTextureHandleResidentARB"))
+	gpIsTextureHandleResidentNV = (C.GPISTEXTUREHANDLERESIDENTNV)(getProcAddr("glIsTextureHandleResidentNV"))
 	gpIsTransformFeedback = (C.GPISTRANSFORMFEEDBACK)(getProcAddr("glIsTransformFeedback"))
 	if gpIsTransformFeedback == nil {
 		return errors.New("glIsTransformFeedback")
@@ -9588,6 +14797,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpIsVertexArray == nil {
 		return errors.New("glIsVertexArray")
 	}
+	gpLabelObjectEXT = (C.GPLABELOBJECTEXT)(getProcAddr("glLabelObjectEXT"))
 	gpLineWidth = (C.GPLINEWIDTH)(getProcAddr("glLineWidth"))
 	if gpLineWidth == nil {
 		return errors.New("glLineWidth")
@@ -9596,14 +14806,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpLinkProgram == nil {
 		return errors.New("glLinkProgram")
 	}
+	gpListDrawCommandsStatesClientNV = (C.GPLISTDRAWCOMMANDSSTATESCLIENTNV)(getProcAddr("glListDrawCommandsStatesClientNV"))
 	gpLogicOp = (C.GPLOGICOP)(getProcAddr("glLogicOp"))
 	if gpLogicOp == nil {
 		return errors.New("glLogicOp")
 	}
+	gpMakeBufferNonResidentNV = (C.GPMAKEBUFFERNONRESIDENTNV)(getProcAddr("glMakeBufferNonResidentNV"))
+	gpMakeBufferResidentNV = (C.GPMAKEBUFFERRESIDENTNV)(getProcAddr("glMakeBufferResidentNV"))
 	gpMakeImageHandleNonResidentARB = (C.GPMAKEIMAGEHANDLENONRESIDENTARB)(getProcAddr("glMakeImageHandleNonResidentARB"))
+	gpMakeImageHandleNonResidentNV = (C.GPMAKEIMAGEHANDLENONRESIDENTNV)(getProcAddr("glMakeImageHandleNonResidentNV"))
 	gpMakeImageHandleResidentARB = (C.GPMAKEIMAGEHANDLERESIDENTARB)(getProcAddr("glMakeImageHandleResidentARB"))
+	gpMakeImageHandleResidentNV = (C.GPMAKEIMAGEHANDLERESIDENTNV)(getProcAddr("glMakeImageHandleResidentNV"))
+	gpMakeNamedBufferNonResidentNV = (C.GPMAKENAMEDBUFFERNONRESIDENTNV)(getProcAddr("glMakeNamedBufferNonResidentNV"))
+	gpMakeNamedBufferResidentNV = (C.GPMAKENAMEDBUFFERRESIDENTNV)(getProcAddr("glMakeNamedBufferResidentNV"))
 	gpMakeTextureHandleNonResidentARB = (C.GPMAKETEXTUREHANDLENONRESIDENTARB)(getProcAddr("glMakeTextureHandleNonResidentARB"))
+	gpMakeTextureHandleNonResidentNV = (C.GPMAKETEXTUREHANDLENONRESIDENTNV)(getProcAddr("glMakeTextureHandleNonResidentNV"))
 	gpMakeTextureHandleResidentARB = (C.GPMAKETEXTUREHANDLERESIDENTARB)(getProcAddr("glMakeTextureHandleResidentARB"))
+	gpMakeTextureHandleResidentNV = (C.GPMAKETEXTUREHANDLERESIDENTNV)(getProcAddr("glMakeTextureHandleResidentNV"))
 	gpMapBuffer = (C.GPMAPBUFFER)(getProcAddr("glMapBuffer"))
 	if gpMapBuffer == nil {
 		return errors.New("glMapBuffer")
@@ -9616,10 +14835,39 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpMapNamedBuffer == nil {
 		return errors.New("glMapNamedBuffer")
 	}
+	gpMapNamedBufferEXT = (C.GPMAPNAMEDBUFFEREXT)(getProcAddr("glMapNamedBufferEXT"))
 	gpMapNamedBufferRange = (C.GPMAPNAMEDBUFFERRANGE)(getProcAddr("glMapNamedBufferRange"))
 	if gpMapNamedBufferRange == nil {
 		return errors.New("glMapNamedBufferRange")
 	}
+	gpMapNamedBufferRangeEXT = (C.GPMAPNAMEDBUFFERRANGEEXT)(getProcAddr("glMapNamedBufferRangeEXT"))
+	gpMatrixFrustumEXT = (C.GPMATRIXFRUSTUMEXT)(getProcAddr("glMatrixFrustumEXT"))
+	gpMatrixLoad3x2fNV = (C.GPMATRIXLOAD3X2FNV)(getProcAddr("glMatrixLoad3x2fNV"))
+	gpMatrixLoad3x3fNV = (C.GPMATRIXLOAD3X3FNV)(getProcAddr("glMatrixLoad3x3fNV"))
+	gpMatrixLoadIdentityEXT = (C.GPMATRIXLOADIDENTITYEXT)(getProcAddr("glMatrixLoadIdentityEXT"))
+	gpMatrixLoadTranspose3x3fNV = (C.GPMATRIXLOADTRANSPOSE3X3FNV)(getProcAddr("glMatrixLoadTranspose3x3fNV"))
+	gpMatrixLoadTransposedEXT = (C.GPMATRIXLOADTRANSPOSEDEXT)(getProcAddr("glMatrixLoadTransposedEXT"))
+	gpMatrixLoadTransposefEXT = (C.GPMATRIXLOADTRANSPOSEFEXT)(getProcAddr("glMatrixLoadTransposefEXT"))
+	gpMatrixLoaddEXT = (C.GPMATRIXLOADDEXT)(getProcAddr("glMatrixLoaddEXT"))
+	gpMatrixLoadfEXT = (C.GPMATRIXLOADFEXT)(getProcAddr("glMatrixLoadfEXT"))
+	gpMatrixMult3x2fNV = (C.GPMATRIXMULT3X2FNV)(getProcAddr("glMatrixMult3x2fNV"))
+	gpMatrixMult3x3fNV = (C.GPMATRIXMULT3X3FNV)(getProcAddr("glMatrixMult3x3fNV"))
+	gpMatrixMultTranspose3x3fNV = (C.GPMATRIXMULTTRANSPOSE3X3FNV)(getProcAddr("glMatrixMultTranspose3x3fNV"))
+	gpMatrixMultTransposedEXT = (C.GPMATRIXMULTTRANSPOSEDEXT)(getProcAddr("glMatrixMultTransposedEXT"))
+	gpMatrixMultTransposefEXT = (C.GPMATRIXMULTTRANSPOSEFEXT)(getProcAddr("glMatrixMultTransposefEXT"))
+	gpMatrixMultdEXT = (C.GPMATRIXMULTDEXT)(getProcAddr("glMatrixMultdEXT"))
+	gpMatrixMultfEXT = (C.GPMATRIXMULTFEXT)(getProcAddr("glMatrixMultfEXT"))
+	gpMatrixOrthoEXT = (C.GPMATRIXORTHOEXT)(getProcAddr("glMatrixOrthoEXT"))
+	gpMatrixPopEXT = (C.GPMATRIXPOPEXT)(getProcAddr("glMatrixPopEXT"))
+	gpMatrixPushEXT = (C.GPMATRIXPUSHEXT)(getProcAddr("glMatrixPushEXT"))
+	gpMatrixRotatedEXT = (C.GPMATRIXROTATEDEXT)(getProcAddr("glMatrixRotatedEXT"))
+	gpMatrixRotatefEXT = (C.GPMATRIXROTATEFEXT)(getProcAddr("glMatrixRotatefEXT"))
+	gpMatrixScaledEXT = (C.GPMATRIXSCALEDEXT)(getProcAddr("glMatrixScaledEXT"))
+	gpMatrixScalefEXT = (C.GPMATRIXSCALEFEXT)(getProcAddr("glMatrixScalefEXT"))
+	gpMatrixTranslatedEXT = (C.GPMATRIXTRANSLATEDEXT)(getProcAddr("glMatrixTranslatedEXT"))
+	gpMatrixTranslatefEXT = (C.GPMATRIXTRANSLATEFEXT)(getProcAddr("glMatrixTranslatefEXT"))
+	gpMaxShaderCompilerThreadsARB = (C.GPMAXSHADERCOMPILERTHREADSARB)(getProcAddr("glMaxShaderCompilerThreadsARB"))
+	gpMaxShaderCompilerThreadsKHR = (C.GPMAXSHADERCOMPILERTHREADSKHR)(getProcAddr("glMaxShaderCompilerThreadsKHR"))
 	gpMemoryBarrier = (C.GPMEMORYBARRIER)(getProcAddr("glMemoryBarrier"))
 	if gpMemoryBarrier == nil {
 		return errors.New("glMemoryBarrier")
@@ -9641,6 +14889,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpMultiDrawArraysIndirect == nil {
 		return errors.New("glMultiDrawArraysIndirect")
 	}
+	gpMultiDrawArraysIndirectBindlessCountNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawArraysIndirectBindlessCountNV"))
+	gpMultiDrawArraysIndirectBindlessNV = (C.GPMULTIDRAWARRAYSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawArraysIndirectBindlessNV"))
 	gpMultiDrawArraysIndirectCountARB = (C.GPMULTIDRAWARRAYSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawArraysIndirectCountARB"))
 	gpMultiDrawElements = (C.GPMULTIDRAWELEMENTS)(getProcAddr("glMultiDrawElements"))
 	if gpMultiDrawElements == nil {
@@ -9654,21 +14904,52 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpMultiDrawElementsIndirect == nil {
 		return errors.New("glMultiDrawElementsIndirect")
 	}
+	gpMultiDrawElementsIndirectBindlessCountNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSCOUNTNV)(getProcAddr("glMultiDrawElementsIndirectBindlessCountNV"))
+	gpMultiDrawElementsIndirectBindlessNV = (C.GPMULTIDRAWELEMENTSINDIRECTBINDLESSNV)(getProcAddr("glMultiDrawElementsIndirectBindlessNV"))
 	gpMultiDrawElementsIndirectCountARB = (C.GPMULTIDRAWELEMENTSINDIRECTCOUNTARB)(getProcAddr("glMultiDrawElementsIndirectCountARB"))
+	gpMultiTexBufferEXT = (C.GPMULTITEXBUFFEREXT)(getProcAddr("glMultiTexBufferEXT"))
+	gpMultiTexCoordPointerEXT = (C.GPMULTITEXCOORDPOINTEREXT)(getProcAddr("glMultiTexCoordPointerEXT"))
+	gpMultiTexEnvfEXT = (C.GPMULTITEXENVFEXT)(getProcAddr("glMultiTexEnvfEXT"))
+	gpMultiTexEnvfvEXT = (C.GPMULTITEXENVFVEXT)(getProcAddr("glMultiTexEnvfvEXT"))
+	gpMultiTexEnviEXT = (C.GPMULTITEXENVIEXT)(getProcAddr("glMultiTexEnviEXT"))
+	gpMultiTexEnvivEXT = (C.GPMULTITEXENVIVEXT)(getProcAddr("glMultiTexEnvivEXT"))
+	gpMultiTexGendEXT = (C.GPMULTITEXGENDEXT)(getProcAddr("glMultiTexGendEXT"))
+	gpMultiTexGendvEXT = (C.GPMULTITEXGENDVEXT)(getProcAddr("glMultiTexGendvEXT"))
+	gpMultiTexGenfEXT = (C.GPMULTITEXGENFEXT)(getProcAddr("glMultiTexGenfEXT"))
+	gpMultiTexGenfvEXT = (C.GPMULTITEXGENFVEXT)(getProcAddr("glMultiTexGenfvEXT"))
+	gpMultiTexGeniEXT = (C.GPMULTITEXGENIEXT)(getProcAddr("glMultiTexGeniEXT"))
+	gpMultiTexGenivEXT = (C.GPMULTITEXGENIVEXT)(getProcAddr("glMultiTexGenivEXT"))
+	gpMultiTexImage1DEXT = (C.GPMULTITEXIMAGE1DEXT)(getProcAddr("glMultiTexImage1DEXT"))
+	gpMultiTexImage2DEXT = (C.GPMULTITEXIMAGE2DEXT)(getProcAddr("glMultiTexImage2DEXT"))
+	gpMultiTexImage3DEXT = (C.GPMULTITEXIMAGE3DEXT)(getProcAddr("glMultiTexImage3DEXT"))
+	gpMultiTexParameterIivEXT = (C.GPMULTITEXPARAMETERIIVEXT)(getProcAddr("glMultiTexParameterIivEXT"))
+	gpMultiTexParameterIuivEXT = (C.GPMULTITEXPARAMETERIUIVEXT)(getProcAddr("glMultiTexParameterIuivEXT"))
+	gpMultiTexParameterfEXT = (C.GPMULTITEXPARAMETERFEXT)(getProcAddr("glMultiTexParameterfEXT"))
+	gpMultiTexParameterfvEXT = (C.GPMULTITEXPARAMETERFVEXT)(getProcAddr("glMultiTexParameterfvEXT"))
+	gpMultiTexParameteriEXT = (C.GPMULTITEXPARAMETERIEXT)(getProcAddr("glMultiTexParameteriEXT"))
+	gpMultiTexParameterivEXT = (C.GPMULTITEXPARAMETERIVEXT)(getProcAddr("glMultiTexParameterivEXT"))
+	gpMultiTexRenderbufferEXT = (C.GPMULTITEXRENDERBUFFEREXT)(getProcAddr("glMultiTexRenderbufferEXT"))
+	gpMultiTexSubImage1DEXT = (C.GPMULTITEXSUBIMAGE1DEXT)(getProcAddr("glMultiTexSubImage1DEXT"))
+	gpMultiTexSubImage2DEXT = (C.GPMULTITEXSUBIMAGE2DEXT)(getProcAddr("glMultiTexSubImage2DEXT"))
+	gpMultiTexSubImage3DEXT = (C.GPMULTITEXSUBIMAGE3DEXT)(getProcAddr("glMultiTexSubImage3DEXT"))
 	gpNamedBufferData = (C.GPNAMEDBUFFERDATA)(getProcAddr("glNamedBufferData"))
 	if gpNamedBufferData == nil {
 		return errors.New("glNamedBufferData")
 	}
+	gpNamedBufferDataEXT = (C.GPNAMEDBUFFERDATAEXT)(getProcAddr("glNamedBufferDataEXT"))
 	gpNamedBufferPageCommitmentARB = (C.GPNAMEDBUFFERPAGECOMMITMENTARB)(getProcAddr("glNamedBufferPageCommitmentARB"))
 	gpNamedBufferPageCommitmentEXT = (C.GPNAMEDBUFFERPAGECOMMITMENTEXT)(getProcAddr("glNamedBufferPageCommitmentEXT"))
 	gpNamedBufferStorage = (C.GPNAMEDBUFFERSTORAGE)(getProcAddr("glNamedBufferStorage"))
 	if gpNamedBufferStorage == nil {
 		return errors.New("glNamedBufferStorage")
 	}
+	gpNamedBufferStorageEXT = (C.GPNAMEDBUFFERSTORAGEEXT)(getProcAddr("glNamedBufferStorageEXT"))
 	gpNamedBufferSubData = (C.GPNAMEDBUFFERSUBDATA)(getProcAddr("glNamedBufferSubData"))
 	if gpNamedBufferSubData == nil {
 		return errors.New("glNamedBufferSubData")
 	}
+	gpNamedBufferSubDataEXT = (C.GPNAMEDBUFFERSUBDATAEXT)(getProcAddr("glNamedBufferSubDataEXT"))
+	gpNamedCopyBufferSubDataEXT = (C.GPNAMEDCOPYBUFFERSUBDATAEXT)(getProcAddr("glNamedCopyBufferSubDataEXT"))
 	gpNamedFramebufferDrawBuffer = (C.GPNAMEDFRAMEBUFFERDRAWBUFFER)(getProcAddr("glNamedFramebufferDrawBuffer"))
 	if gpNamedFramebufferDrawBuffer == nil {
 		return errors.New("glNamedFramebufferDrawBuffer")
@@ -9681,6 +14962,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpNamedFramebufferParameteri == nil {
 		return errors.New("glNamedFramebufferParameteri")
 	}
+	gpNamedFramebufferParameteriEXT = (C.GPNAMEDFRAMEBUFFERPARAMETERIEXT)(getProcAddr("glNamedFramebufferParameteriEXT"))
 	gpNamedFramebufferReadBuffer = (C.GPNAMEDFRAMEBUFFERREADBUFFER)(getProcAddr("glNamedFramebufferReadBuffer"))
 	if gpNamedFramebufferReadBuffer == nil {
 		return errors.New("glNamedFramebufferReadBuffer")
@@ -9689,23 +14971,48 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpNamedFramebufferRenderbuffer == nil {
 		return errors.New("glNamedFramebufferRenderbuffer")
 	}
+	gpNamedFramebufferRenderbufferEXT = (C.GPNAMEDFRAMEBUFFERRENDERBUFFEREXT)(getProcAddr("glNamedFramebufferRenderbufferEXT"))
+	gpNamedFramebufferSampleLocationsfvARB = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARB)(getProcAddr("glNamedFramebufferSampleLocationsfvARB"))
+	gpNamedFramebufferSampleLocationsfvNV = (C.GPNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNV)(getProcAddr("glNamedFramebufferSampleLocationsfvNV"))
 	gpNamedFramebufferTexture = (C.GPNAMEDFRAMEBUFFERTEXTURE)(getProcAddr("glNamedFramebufferTexture"))
 	if gpNamedFramebufferTexture == nil {
 		return errors.New("glNamedFramebufferTexture")
 	}
+	gpNamedFramebufferTexture1DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE1DEXT)(getProcAddr("glNamedFramebufferTexture1DEXT"))
+	gpNamedFramebufferTexture2DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE2DEXT)(getProcAddr("glNamedFramebufferTexture2DEXT"))
+	gpNamedFramebufferTexture3DEXT = (C.GPNAMEDFRAMEBUFFERTEXTURE3DEXT)(getProcAddr("glNamedFramebufferTexture3DEXT"))
+	gpNamedFramebufferTextureEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREEXT)(getProcAddr("glNamedFramebufferTextureEXT"))
+	gpNamedFramebufferTextureFaceEXT = (C.GPNAMEDFRAMEBUFFERTEXTUREFACEEXT)(getProcAddr("glNamedFramebufferTextureFaceEXT"))
 	gpNamedFramebufferTextureLayer = (C.GPNAMEDFRAMEBUFFERTEXTURELAYER)(getProcAddr("glNamedFramebufferTextureLayer"))
 	if gpNamedFramebufferTextureLayer == nil {
 		return errors.New("glNamedFramebufferTextureLayer")
 	}
+	gpNamedFramebufferTextureLayerEXT = (C.GPNAMEDFRAMEBUFFERTEXTURELAYEREXT)(getProcAddr("glNamedFramebufferTextureLayerEXT"))
+	gpNamedProgramLocalParameter4dEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DEXT)(getProcAddr("glNamedProgramLocalParameter4dEXT"))
+	gpNamedProgramLocalParameter4dvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4DVEXT)(getProcAddr("glNamedProgramLocalParameter4dvEXT"))
+	gpNamedProgramLocalParameter4fEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FEXT)(getProcAddr("glNamedProgramLocalParameter4fEXT"))
+	gpNamedProgramLocalParameter4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETER4FVEXT)(getProcAddr("glNamedProgramLocalParameter4fvEXT"))
+	gpNamedProgramLocalParameterI4iEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IEXT)(getProcAddr("glNamedProgramLocalParameterI4iEXT"))
+	gpNamedProgramLocalParameterI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4IVEXT)(getProcAddr("glNamedProgramLocalParameterI4ivEXT"))
+	gpNamedProgramLocalParameterI4uiEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIEXT)(getProcAddr("glNamedProgramLocalParameterI4uiEXT"))
+	gpNamedProgramLocalParameterI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERI4UIVEXT)(getProcAddr("glNamedProgramLocalParameterI4uivEXT"))
+	gpNamedProgramLocalParameters4fvEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERS4FVEXT)(getProcAddr("glNamedProgramLocalParameters4fvEXT"))
+	gpNamedProgramLocalParametersI4ivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4IVEXT)(getProcAddr("glNamedProgramLocalParametersI4ivEXT"))
+	gpNamedProgramLocalParametersI4uivEXT = (C.GPNAMEDPROGRAMLOCALPARAMETERSI4UIVEXT)(getProcAddr("glNamedProgramLocalParametersI4uivEXT"))
+	gpNamedProgramStringEXT = (C.GPNAMEDPROGRAMSTRINGEXT)(getProcAddr("glNamedProgramStringEXT"))
 	gpNamedRenderbufferStorage = (C.GPNAMEDRENDERBUFFERSTORAGE)(getProcAddr("glNamedRenderbufferStorage"))
 	if gpNamedRenderbufferStorage == nil {
 		return errors.New("glNamedRenderbufferStorage")
 	}
+	gpNamedRenderbufferStorageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEEXT)(getProcAddr("glNamedRenderbufferStorageEXT"))
 	gpNamedRenderbufferStorageMultisample = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLE)(getProcAddr("glNamedRenderbufferStorageMultisample"))
 	if gpNamedRenderbufferStorageMultisample == nil {
 		return errors.New("glNamedRenderbufferStorageMultisample")
 	}
+	gpNamedRenderbufferStorageMultisampleCoverageEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLECOVERAGEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleCoverageEXT"))
+	gpNamedRenderbufferStorageMultisampleEXT = (C.GPNAMEDRENDERBUFFERSTORAGEMULTISAMPLEEXT)(getProcAddr("glNamedRenderbufferStorageMultisampleEXT"))
 	gpNamedStringARB = (C.GPNAMEDSTRINGARB)(getProcAddr("glNamedStringARB"))
+	gpNormalFormatNV = (C.GPNORMALFORMATNV)(getProcAddr("glNormalFormatNV"))
 	gpObjectLabel = (C.GPOBJECTLABEL)(getProcAddr("glObjectLabel"))
 	if gpObjectLabel == nil {
 		return errors.New("glObjectLabel")
@@ -9724,6 +15031,24 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPatchParameteri == nil {
 		return errors.New("glPatchParameteri")
 	}
+	gpPathCommandsNV = (C.GPPATHCOMMANDSNV)(getProcAddr("glPathCommandsNV"))
+	gpPathCoordsNV = (C.GPPATHCOORDSNV)(getProcAddr("glPathCoordsNV"))
+	gpPathCoverDepthFuncNV = (C.GPPATHCOVERDEPTHFUNCNV)(getProcAddr("glPathCoverDepthFuncNV"))
+	gpPathDashArrayNV = (C.GPPATHDASHARRAYNV)(getProcAddr("glPathDashArrayNV"))
+	gpPathGlyphIndexArrayNV = (C.GPPATHGLYPHINDEXARRAYNV)(getProcAddr("glPathGlyphIndexArrayNV"))
+	gpPathGlyphIndexRangeNV = (C.GPPATHGLYPHINDEXRANGENV)(getProcAddr("glPathGlyphIndexRangeNV"))
+	gpPathGlyphRangeNV = (C.GPPATHGLYPHRANGENV)(getProcAddr("glPathGlyphRangeNV"))
+	gpPathGlyphsNV = (C.GPPATHGLYPHSNV)(getProcAddr("glPathGlyphsNV"))
+	gpPathMemoryGlyphIndexArrayNV = (C.GPPATHMEMORYGLYPHINDEXARRAYNV)(getProcAddr("glPathMemoryGlyphIndexArrayNV"))
+	gpPathParameterfNV = (C.GPPATHPARAMETERFNV)(getProcAddr("glPathParameterfNV"))
+	gpPathParameterfvNV = (C.GPPATHPARAMETERFVNV)(getProcAddr("glPathParameterfvNV"))
+	gpPathParameteriNV = (C.GPPATHPARAMETERINV)(getProcAddr("glPathParameteriNV"))
+	gpPathParameterivNV = (C.GPPATHPARAMETERIVNV)(getProcAddr("glPathParameterivNV"))
+	gpPathStencilDepthOffsetNV = (C.GPPATHSTENCILDEPTHOFFSETNV)(getProcAddr("glPathStencilDepthOffsetNV"))
+	gpPathStencilFuncNV = (C.GPPATHSTENCILFUNCNV)(getProcAddr("glPathStencilFuncNV"))
+	gpPathStringNV = (C.GPPATHSTRINGNV)(getProcAddr("glPathStringNV"))
+	gpPathSubCommandsNV = (C.GPPATHSUBCOMMANDSNV)(getProcAddr("glPathSubCommandsNV"))
+	gpPathSubCoordsNV = (C.GPPATHSUBCOORDSNV)(getProcAddr("glPathSubCoordsNV"))
 	gpPauseTransformFeedback = (C.GPPAUSETRANSFORMFEEDBACK)(getProcAddr("glPauseTransformFeedback"))
 	if gpPauseTransformFeedback == nil {
 		return errors.New("glPauseTransformFeedback")
@@ -9736,6 +15061,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPixelStorei == nil {
 		return errors.New("glPixelStorei")
 	}
+	gpPointAlongPathNV = (C.GPPOINTALONGPATHNV)(getProcAddr("glPointAlongPathNV"))
 	gpPointParameterf = (C.GPPOINTPARAMETERF)(getProcAddr("glPointParameterf"))
 	if gpPointParameterf == nil {
 		return errors.New("glPointParameterf")
@@ -9764,11 +15090,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpPolygonOffset == nil {
 		return errors.New("glPolygonOffset")
 	}
+	gpPolygonOffsetClamp = (C.GPPOLYGONOFFSETCLAMP)(getProcAddr("glPolygonOffsetClamp"))
+	gpPolygonOffsetClampEXT = (C.GPPOLYGONOFFSETCLAMPEXT)(getProcAddr("glPolygonOffsetClampEXT"))
 	gpPopDebugGroup = (C.GPPOPDEBUGGROUP)(getProcAddr("glPopDebugGroup"))
 	if gpPopDebugGroup == nil {
 		return errors.New("glPopDebugGroup")
 	}
 	gpPopDebugGroupKHR = (C.GPPOPDEBUGGROUPKHR)(getProcAddr("glPopDebugGroupKHR"))
+	gpPopGroupMarkerEXT = (C.GPPOPGROUPMARKEREXT)(getProcAddr("glPopGroupMarkerEXT"))
+	gpPrimitiveBoundingBoxARB = (C.GPPRIMITIVEBOUNDINGBOXARB)(getProcAddr("glPrimitiveBoundingBoxARB"))
 	gpPrimitiveRestartIndex = (C.GPPRIMITIVERESTARTINDEX)(getProcAddr("glPrimitiveRestartIndex"))
 	if gpPrimitiveRestartIndex == nil {
 		return errors.New("glPrimitiveRestartIndex")
@@ -9781,221 +15111,313 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpProgramParameteri == nil {
 		return errors.New("glProgramParameteri")
 	}
+	gpProgramParameteriARB = (C.GPPROGRAMPARAMETERIARB)(getProcAddr("glProgramParameteriARB"))
+	gpProgramParameteriEXT = (C.GPPROGRAMPARAMETERIEXT)(getProcAddr("glProgramParameteriEXT"))
+	gpProgramPathFragmentInputGenNV = (C.GPPROGRAMPATHFRAGMENTINPUTGENNV)(getProcAddr("glProgramPathFragmentInputGenNV"))
 	gpProgramUniform1d = (C.GPPROGRAMUNIFORM1D)(getProcAddr("glProgramUniform1d"))
 	if gpProgramUniform1d == nil {
 		return errors.New("glProgramUniform1d")
 	}
+	gpProgramUniform1dEXT = (C.GPPROGRAMUNIFORM1DEXT)(getProcAddr("glProgramUniform1dEXT"))
 	gpProgramUniform1dv = (C.GPPROGRAMUNIFORM1DV)(getProcAddr("glProgramUniform1dv"))
 	if gpProgramUniform1dv == nil {
 		return errors.New("glProgramUniform1dv")
 	}
+	gpProgramUniform1dvEXT = (C.GPPROGRAMUNIFORM1DVEXT)(getProcAddr("glProgramUniform1dvEXT"))
 	gpProgramUniform1f = (C.GPPROGRAMUNIFORM1F)(getProcAddr("glProgramUniform1f"))
 	if gpProgramUniform1f == nil {
 		return errors.New("glProgramUniform1f")
 	}
+	gpProgramUniform1fEXT = (C.GPPROGRAMUNIFORM1FEXT)(getProcAddr("glProgramUniform1fEXT"))
 	gpProgramUniform1fv = (C.GPPROGRAMUNIFORM1FV)(getProcAddr("glProgramUniform1fv"))
 	if gpProgramUniform1fv == nil {
 		return errors.New("glProgramUniform1fv")
 	}
+	gpProgramUniform1fvEXT = (C.GPPROGRAMUNIFORM1FVEXT)(getProcAddr("glProgramUniform1fvEXT"))
 	gpProgramUniform1i = (C.GPPROGRAMUNIFORM1I)(getProcAddr("glProgramUniform1i"))
 	if gpProgramUniform1i == nil {
 		return errors.New("glProgramUniform1i")
 	}
+	gpProgramUniform1i64ARB = (C.GPPROGRAMUNIFORM1I64ARB)(getProcAddr("glProgramUniform1i64ARB"))
+	gpProgramUniform1i64NV = (C.GPPROGRAMUNIFORM1I64NV)(getProcAddr("glProgramUniform1i64NV"))
+	gpProgramUniform1i64vARB = (C.GPPROGRAMUNIFORM1I64VARB)(getProcAddr("glProgramUniform1i64vARB"))
+	gpProgramUniform1i64vNV = (C.GPPROGRAMUNIFORM1I64VNV)(getProcAddr("glProgramUniform1i64vNV"))
+	gpProgramUniform1iEXT = (C.GPPROGRAMUNIFORM1IEXT)(getProcAddr("glProgramUniform1iEXT"))
 	gpProgramUniform1iv = (C.GPPROGRAMUNIFORM1IV)(getProcAddr("glProgramUniform1iv"))
 	if gpProgramUniform1iv == nil {
 		return errors.New("glProgramUniform1iv")
 	}
+	gpProgramUniform1ivEXT = (C.GPPROGRAMUNIFORM1IVEXT)(getProcAddr("glProgramUniform1ivEXT"))
 	gpProgramUniform1ui = (C.GPPROGRAMUNIFORM1UI)(getProcAddr("glProgramUniform1ui"))
 	if gpProgramUniform1ui == nil {
 		return errors.New("glProgramUniform1ui")
 	}
+	gpProgramUniform1ui64ARB = (C.GPPROGRAMUNIFORM1UI64ARB)(getProcAddr("glProgramUniform1ui64ARB"))
+	gpProgramUniform1ui64NV = (C.GPPROGRAMUNIFORM1UI64NV)(getProcAddr("glProgramUniform1ui64NV"))
+	gpProgramUniform1ui64vARB = (C.GPPROGRAMUNIFORM1UI64VARB)(getProcAddr("glProgramUniform1ui64vARB"))
+	gpProgramUniform1ui64vNV = (C.GPPROGRAMUNIFORM1UI64VNV)(getProcAddr("glProgramUniform1ui64vNV"))
+	gpProgramUniform1uiEXT = (C.GPPROGRAMUNIFORM1UIEXT)(getProcAddr("glProgramUniform1uiEXT"))
 	gpProgramUniform1uiv = (C.GPPROGRAMUNIFORM1UIV)(getProcAddr("glProgramUniform1uiv"))
 	if gpProgramUniform1uiv == nil {
 		return errors.New("glProgramUniform1uiv")
 	}
+	gpProgramUniform1uivEXT = (C.GPPROGRAMUNIFORM1UIVEXT)(getProcAddr("glProgramUniform1uivEXT"))
 	gpProgramUniform2d = (C.GPPROGRAMUNIFORM2D)(getProcAddr("glProgramUniform2d"))
 	if gpProgramUniform2d == nil {
 		return errors.New("glProgramUniform2d")
 	}
+	gpProgramUniform2dEXT = (C.GPPROGRAMUNIFORM2DEXT)(getProcAddr("glProgramUniform2dEXT"))
 	gpProgramUniform2dv = (C.GPPROGRAMUNIFORM2DV)(getProcAddr("glProgramUniform2dv"))
 	if gpProgramUniform2dv == nil {
 		return errors.New("glProgramUniform2dv")
 	}
+	gpProgramUniform2dvEXT = (C.GPPROGRAMUNIFORM2DVEXT)(getProcAddr("glProgramUniform2dvEXT"))
 	gpProgramUniform2f = (C.GPPROGRAMUNIFORM2F)(getProcAddr("glProgramUniform2f"))
 	if gpProgramUniform2f == nil {
 		return errors.New("glProgramUniform2f")
 	}
+	gpProgramUniform2fEXT = (C.GPPROGRAMUNIFORM2FEXT)(getProcAddr("glProgramUniform2fEXT"))
 	gpProgramUniform2fv = (C.GPPROGRAMUNIFORM2FV)(getProcAddr("glProgramUniform2fv"))
 	if gpProgramUniform2fv == nil {
 		return errors.New("glProgramUniform2fv")
 	}
+	gpProgramUniform2fvEXT = (C.GPPROGRAMUNIFORM2FVEXT)(getProcAddr("glProgramUniform2fvEXT"))
 	gpProgramUniform2i = (C.GPPROGRAMUNIFORM2I)(getProcAddr("glProgramUniform2i"))
 	if gpProgramUniform2i == nil {
 		return errors.New("glProgramUniform2i")
 	}
+	gpProgramUniform2i64ARB = (C.GPPROGRAMUNIFORM2I64ARB)(getProcAddr("glProgramUniform2i64ARB"))
+	gpProgramUniform2i64NV = (C.GPPROGRAMUNIFORM2I64NV)(getProcAddr("glProgramUniform2i64NV"))
+	gpProgramUniform2i64vARB = (C.GPPROGRAMUNIFORM2I64VARB)(getProcAddr("glProgramUniform2i64vARB"))
+	gpProgramUniform2i64vNV = (C.GPPROGRAMUNIFORM2I64VNV)(getProcAddr("glProgramUniform2i64vNV"))
+	gpProgramUniform2iEXT = (C.GPPROGRAMUNIFORM2IEXT)(getProcAddr("glProgramUniform2iEXT"))
 	gpProgramUniform2iv = (C.GPPROGRAMUNIFORM2IV)(getProcAddr("glProgramUniform2iv"))
 	if gpProgramUniform2iv == nil {
 		return errors.New("glProgramUniform2iv")
 	}
+	gpProgramUniform2ivEXT = (C.GPPROGRAMUNIFORM2IVEXT)(getProcAddr("glProgramUniform2ivEXT"))
 	gpProgramUniform2ui = (C.GPPROGRAMUNIFORM2UI)(getProcAddr("glProgramUniform2ui"))
 	if gpProgramUniform2ui == nil {
 		return errors.New("glProgramUniform2ui")
 	}
+	gpProgramUniform2ui64ARB = (C.GPPROGRAMUNIFORM2UI64ARB)(getProcAddr("glProgramUniform2ui64ARB"))
+	gpProgramUniform2ui64NV = (C.GPPROGRAMUNIFORM2UI64NV)(getProcAddr("glProgramUniform2ui64NV"))
+	gpProgramUniform2ui64vARB = (C.GPPROGRAMUNIFORM2UI64VARB)(getProcAddr("glProgramUniform2ui64vARB"))
+	gpProgramUniform2ui64vNV = (C.GPPROGRAMUNIFORM2UI64VNV)(getProcAddr("glProgramUniform2ui64vNV"))
+	gpProgramUniform2uiEXT = (C.GPPROGRAMUNIFORM2UIEXT)(getProcAddr("glProgramUniform2uiEXT"))
 	gpProgramUniform2uiv = (C.GPPROGRAMUNIFORM2UIV)(getProcAddr("glProgramUniform2uiv"))
 	if gpProgramUniform2uiv == nil {
 		return errors.New("glProgramUniform2uiv")
 	}
+	gpProgramUniform2uivEXT = (C.GPPROGRAMUNIFORM2UIVEXT)(getProcAddr("glProgramUniform2uivEXT"))
 	gpProgramUniform3d = (C.GPPROGRAMUNIFORM3D)(getProcAddr("glProgramUniform3d"))
 	if gpProgramUniform3d == nil {
 		return errors.New("glProgramUniform3d")
 	}
+	gpProgramUniform3dEXT = (C.GPPROGRAMUNIFORM3DEXT)(getProcAddr("glProgramUniform3dEXT"))
 	gpProgramUniform3dv = (C.GPPROGRAMUNIFORM3DV)(getProcAddr("glProgramUniform3dv"))
 	if gpProgramUniform3dv == nil {
 		return errors.New("glProgramUniform3dv")
 	}
+	gpProgramUniform3dvEXT = (C.GPPROGRAMUNIFORM3DVEXT)(getProcAddr("glProgramUniform3dvEXT"))
 	gpProgramUniform3f = (C.GPPROGRAMUNIFORM3F)(getProcAddr("glProgramUniform3f"))
 	if gpProgramUniform3f == nil {
 		return errors.New("glProgramUniform3f")
 	}
+	gpProgramUniform3fEXT = (C.GPPROGRAMUNIFORM3FEXT)(getProcAddr("glProgramUniform3fEXT"))
 	gpProgramUniform3fv = (C.GPPROGRAMUNIFORM3FV)(getProcAddr("glProgramUniform3fv"))
 	if gpProgramUniform3fv == nil {
 		return errors.New("glProgramUniform3fv")
 	}
+	gpProgramUniform3fvEXT = (C.GPPROGRAMUNIFORM3FVEXT)(getProcAddr("glProgramUniform3fvEXT"))
 	gpProgramUniform3i = (C.GPPROGRAMUNIFORM3I)(getProcAddr("glProgramUniform3i"))
 	if gpProgramUniform3i == nil {
 		return errors.New("glProgramUniform3i")
 	}
+	gpProgramUniform3i64ARB = (C.GPPROGRAMUNIFORM3I64ARB)(getProcAddr("glProgramUniform3i64ARB"))
+	gpProgramUniform3i64NV = (C.GPPROGRAMUNIFORM3I64NV)(getProcAddr("glProgramUniform3i64NV"))
+	gpProgramUniform3i64vARB = (C.GPPROGRAMUNIFORM3I64VARB)(getProcAddr("glProgramUniform3i64vARB"))
+	gpProgramUniform3i64vNV = (C.GPPROGRAMUNIFORM3I64VNV)(getProcAddr("glProgramUniform3i64vNV"))
+	gpProgramUniform3iEXT = (C.GPPROGRAMUNIFORM3IEXT)(getProcAddr("glProgramUniform3iEXT"))
 	gpProgramUniform3iv = (C.GPPROGRAMUNIFORM3IV)(getProcAddr("glProgramUniform3iv"))
 	if gpProgramUniform3iv == nil {
 		return errors.New("glProgramUniform3iv")
 	}
+	gpProgramUniform3ivEXT = (C.GPPROGRAMUNIFORM3IVEXT)(getProcAddr("glProgramUniform3ivEXT"))
 	gpProgramUniform3ui = (C.GPPROGRAMUNIFORM3UI)(getProcAddr("glProgramUniform3ui"))
 	if gpProgramUniform3ui == nil {
 		return errors.New("glProgramUniform3ui")
 	}
+	gpProgramUniform3ui64ARB = (C.GPPROGRAMUNIFORM3UI64ARB)(getProcAddr("glProgramUniform3ui64ARB"))
+	gpProgramUniform3ui64NV = (C.GPPROGRAMUNIFORM3UI64NV)(getProcAddr("glProgramUniform3ui64NV"))
+	gpProgramUniform3ui64vARB = (C.GPPROGRAMUNIFORM3UI64VARB)(getProcAddr("glProgramUniform3ui64vARB"))
+	gpProgramUniform3ui64vNV = (C.GPPROGRAMUNIFORM3UI64VNV)(getProcAddr("glProgramUniform3ui64vNV"))
+	gpProgramUniform3uiEXT = (C.GPPROGRAMUNIFORM3UIEXT)(getProcAddr("glProgramUniform3uiEXT"))
 	gpProgramUniform3uiv = (C.GPPROGRAMUNIFORM3UIV)(getProcAddr("glProgramUniform3uiv"))
 	if gpProgramUniform3uiv == nil {
 		return errors.New("glProgramUniform3uiv")
 	}
+	gpProgramUniform3uivEXT = (C.GPPROGRAMUNIFORM3UIVEXT)(getProcAddr("glProgramUniform3uivEXT"))
 	gpProgramUniform4d = (C.GPPROGRAMUNIFORM4D)(getProcAddr("glProgramUniform4d"))
 	if gpProgramUniform4d == nil {
 		return errors.New("glProgramUniform4d")
 	}
+	gpProgramUniform4dEXT = (C.GPPROGRAMUNIFORM4DEXT)(getProcAddr("glProgramUniform4dEXT"))
 	gpProgramUniform4dv = (C.GPPROGRAMUNIFORM4DV)(getProcAddr("glProgramUniform4dv"))
 	if gpProgramUniform4dv == nil {
 		return errors.New("glProgramUniform4dv")
 	}
+	gpProgramUniform4dvEXT = (C.GPPROGRAMUNIFORM4DVEXT)(getProcAddr("glProgramUniform4dvEXT"))
 	gpProgramUniform4f = (C.GPPROGRAMUNIFORM4F)(getProcAddr("glProgramUniform4f"))
 	if gpProgramUniform4f == nil {
 		return errors.New("glProgramUniform4f")
 	}
+	gpProgramUniform4fEXT = (C.GPPROGRAMUNIFORM4FEXT)(getProcAddr("glProgramUniform4fEXT"))
 	gpProgramUniform4fv = (C.GPPROGRAMUNIFORM4FV)(getProcAddr("glProgramUniform4fv"))
 	if gpProgramUniform4fv == nil {
 		return errors.New("glProgramUniform4fv")
 	}
+	gpProgramUniform4fvEXT = (C.GPPROGRAMUNIFORM4FVEXT)(getProcAddr("glProgramUniform4fvEXT"))
 	gpProgramUniform4i = (C.GPPROGRAMUNIFORM4I)(getProcAddr("glProgramUniform4i"))
 	if gpProgramUniform4i == nil {
 		return errors.New("glProgramUniform4i")
 	}
+	gpProgramUniform4i64ARB = (C.GPPROGRAMUNIFORM4I64ARB)(getProcAddr("glProgramUniform4i64ARB"))
+	gpProgramUniform4i64NV = (C.GPPROGRAMUNIFORM4I64NV)(getProcAddr("glProgramUniform4i64NV"))
+	gpProgramUniform4i64vARB = (C.GPPROGRAMUNIFORM4I64VARB)(getProcAddr("glProgramUniform4i64vARB"))
+	gpProgramUniform4i64vNV = (C.GPPROGRAMUNIFORM4I64VNV)(getProcAddr("glProgramUniform4i64vNV"))
+	gpProgramUniform4iEXT = (C.GPPROGRAMUNIFORM4IEXT)(getProcAddr("glProgramUniform4iEXT"))
 	gpProgramUniform4iv = (C.GPPROGRAMUNIFORM4IV)(getProcAddr("glProgramUniform4iv"))
 	if gpProgramUniform4iv == nil {
 		return errors.New("glProgramUniform4iv")
 	}
+	gpProgramUniform4ivEXT = (C.GPPROGRAMUNIFORM4IVEXT)(getProcAddr("glProgramUniform4ivEXT"))
 	gpProgramUniform4ui = (C.GPPROGRAMUNIFORM4UI)(getProcAddr("glProgramUniform4ui"))
 	if gpProgramUniform4ui == nil {
 		return errors.New("glProgramUniform4ui")
 	}
+	gpProgramUniform4ui64ARB = (C.GPPROGRAMUNIFORM4UI64ARB)(getProcAddr("glProgramUniform4ui64ARB"))
+	gpProgramUniform4ui64NV = (C.GPPROGRAMUNIFORM4UI64NV)(getProcAddr("glProgramUniform4ui64NV"))
+	gpProgramUniform4ui64vARB = (C.GPPROGRAMUNIFORM4UI64VARB)(getProcAddr("glProgramUniform4ui64vARB"))
+	gpProgramUniform4ui64vNV = (C.GPPROGRAMUNIFORM4UI64VNV)(getProcAddr("glProgramUniform4ui64vNV"))
+	gpProgramUniform4uiEXT = (C.GPPROGRAMUNIFORM4UIEXT)(getProcAddr("glProgramUniform4uiEXT"))
 	gpProgramUniform4uiv = (C.GPPROGRAMUNIFORM4UIV)(getProcAddr("glProgramUniform4uiv"))
 	if gpProgramUniform4uiv == nil {
 		return errors.New("glProgramUniform4uiv")
 	}
+	gpProgramUniform4uivEXT = (C.GPPROGRAMUNIFORM4UIVEXT)(getProcAddr("glProgramUniform4uivEXT"))
 	gpProgramUniformHandleui64ARB = (C.GPPROGRAMUNIFORMHANDLEUI64ARB)(getProcAddr("glProgramUniformHandleui64ARB"))
+	gpProgramUniformHandleui64NV = (C.GPPROGRAMUNIFORMHANDLEUI64NV)(getProcAddr("glProgramUniformHandleui64NV"))
 	gpProgramUniformHandleui64vARB = (C.GPPROGRAMUNIFORMHANDLEUI64VARB)(getProcAddr("glProgramUniformHandleui64vARB"))
+	gpProgramUniformHandleui64vNV = (C.GPPROGRAMUNIFORMHANDLEUI64VNV)(getProcAddr("glProgramUniformHandleui64vNV"))
 	gpProgramUniformMatrix2dv = (C.GPPROGRAMUNIFORMMATRIX2DV)(getProcAddr("glProgramUniformMatrix2dv"))
 	if gpProgramUniformMatrix2dv == nil {
 		return errors.New("glProgramUniformMatrix2dv")
 	}
+	gpProgramUniformMatrix2dvEXT = (C.GPPROGRAMUNIFORMMATRIX2DVEXT)(getProcAddr("glProgramUniformMatrix2dvEXT"))
 	gpProgramUniformMatrix2fv = (C.GPPROGRAMUNIFORMMATRIX2FV)(getProcAddr("glProgramUniformMatrix2fv"))
 	if gpProgramUniformMatrix2fv == nil {
 		return errors.New("glProgramUniformMatrix2fv")
 	}
+	gpProgramUniformMatrix2fvEXT = (C.GPPROGRAMUNIFORMMATRIX2FVEXT)(getProcAddr("glProgramUniformMatrix2fvEXT"))
 	gpProgramUniformMatrix2x3dv = (C.GPPROGRAMUNIFORMMATRIX2X3DV)(getProcAddr("glProgramUniformMatrix2x3dv"))
 	if gpProgramUniformMatrix2x3dv == nil {
 		return errors.New("glProgramUniformMatrix2x3dv")
 	}
+	gpProgramUniformMatrix2x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3DVEXT)(getProcAddr("glProgramUniformMatrix2x3dvEXT"))
 	gpProgramUniformMatrix2x3fv = (C.GPPROGRAMUNIFORMMATRIX2X3FV)(getProcAddr("glProgramUniformMatrix2x3fv"))
 	if gpProgramUniformMatrix2x3fv == nil {
 		return errors.New("glProgramUniformMatrix2x3fv")
 	}
+	gpProgramUniformMatrix2x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X3FVEXT)(getProcAddr("glProgramUniformMatrix2x3fvEXT"))
 	gpProgramUniformMatrix2x4dv = (C.GPPROGRAMUNIFORMMATRIX2X4DV)(getProcAddr("glProgramUniformMatrix2x4dv"))
 	if gpProgramUniformMatrix2x4dv == nil {
 		return errors.New("glProgramUniformMatrix2x4dv")
 	}
+	gpProgramUniformMatrix2x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4DVEXT)(getProcAddr("glProgramUniformMatrix2x4dvEXT"))
 	gpProgramUniformMatrix2x4fv = (C.GPPROGRAMUNIFORMMATRIX2X4FV)(getProcAddr("glProgramUniformMatrix2x4fv"))
 	if gpProgramUniformMatrix2x4fv == nil {
 		return errors.New("glProgramUniformMatrix2x4fv")
 	}
+	gpProgramUniformMatrix2x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX2X4FVEXT)(getProcAddr("glProgramUniformMatrix2x4fvEXT"))
 	gpProgramUniformMatrix3dv = (C.GPPROGRAMUNIFORMMATRIX3DV)(getProcAddr("glProgramUniformMatrix3dv"))
 	if gpProgramUniformMatrix3dv == nil {
 		return errors.New("glProgramUniformMatrix3dv")
 	}
+	gpProgramUniformMatrix3dvEXT = (C.GPPROGRAMUNIFORMMATRIX3DVEXT)(getProcAddr("glProgramUniformMatrix3dvEXT"))
 	gpProgramUniformMatrix3fv = (C.GPPROGRAMUNIFORMMATRIX3FV)(getProcAddr("glProgramUniformMatrix3fv"))
 	if gpProgramUniformMatrix3fv == nil {
 		return errors.New("glProgramUniformMatrix3fv")
 	}
+	gpProgramUniformMatrix3fvEXT = (C.GPPROGRAMUNIFORMMATRIX3FVEXT)(getProcAddr("glProgramUniformMatrix3fvEXT"))
 	gpProgramUniformMatrix3x2dv = (C.GPPROGRAMUNIFORMMATRIX3X2DV)(getProcAddr("glProgramUniformMatrix3x2dv"))
 	if gpProgramUniformMatrix3x2dv == nil {
 		return errors.New("glProgramUniformMatrix3x2dv")
 	}
+	gpProgramUniformMatrix3x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2DVEXT)(getProcAddr("glProgramUniformMatrix3x2dvEXT"))
 	gpProgramUniformMatrix3x2fv = (C.GPPROGRAMUNIFORMMATRIX3X2FV)(getProcAddr("glProgramUniformMatrix3x2fv"))
 	if gpProgramUniformMatrix3x2fv == nil {
 		return errors.New("glProgramUniformMatrix3x2fv")
 	}
+	gpProgramUniformMatrix3x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X2FVEXT)(getProcAddr("glProgramUniformMatrix3x2fvEXT"))
 	gpProgramUniformMatrix3x4dv = (C.GPPROGRAMUNIFORMMATRIX3X4DV)(getProcAddr("glProgramUniformMatrix3x4dv"))
 	if gpProgramUniformMatrix3x4dv == nil {
 		return errors.New("glProgramUniformMatrix3x4dv")
 	}
+	gpProgramUniformMatrix3x4dvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4DVEXT)(getProcAddr("glProgramUniformMatrix3x4dvEXT"))
 	gpProgramUniformMatrix3x4fv = (C.GPPROGRAMUNIFORMMATRIX3X4FV)(getProcAddr("glProgramUniformMatrix3x4fv"))
 	if gpProgramUniformMatrix3x4fv == nil {
 		return errors.New("glProgramUniformMatrix3x4fv")
 	}
+	gpProgramUniformMatrix3x4fvEXT = (C.GPPROGRAMUNIFORMMATRIX3X4FVEXT)(getProcAddr("glProgramUniformMatrix3x4fvEXT"))
 	gpProgramUniformMatrix4dv = (C.GPPROGRAMUNIFORMMATRIX4DV)(getProcAddr("glProgramUniformMatrix4dv"))
 	if gpProgramUniformMatrix4dv == nil {
 		return errors.New("glProgramUniformMatrix4dv")
 	}
+	gpProgramUniformMatrix4dvEXT = (C.GPPROGRAMUNIFORMMATRIX4DVEXT)(getProcAddr("glProgramUniformMatrix4dvEXT"))
 	gpProgramUniformMatrix4fv = (C.GPPROGRAMUNIFORMMATRIX4FV)(getProcAddr("glProgramUniformMatrix4fv"))
 	if gpProgramUniformMatrix4fv == nil {
 		return errors.New("glProgramUniformMatrix4fv")
 	}
+	gpProgramUniformMatrix4fvEXT = (C.GPPROGRAMUNIFORMMATRIX4FVEXT)(getProcAddr("glProgramUniformMatrix4fvEXT"))
 	gpProgramUniformMatrix4x2dv = (C.GPPROGRAMUNIFORMMATRIX4X2DV)(getProcAddr("glProgramUniformMatrix4x2dv"))
 	if gpProgramUniformMatrix4x2dv == nil {
 		return errors.New("glProgramUniformMatrix4x2dv")
 	}
+	gpProgramUniformMatrix4x2dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2DVEXT)(getProcAddr("glProgramUniformMatrix4x2dvEXT"))
 	gpProgramUniformMatrix4x2fv = (C.GPPROGRAMUNIFORMMATRIX4X2FV)(getProcAddr("glProgramUniformMatrix4x2fv"))
 	if gpProgramUniformMatrix4x2fv == nil {
 		return errors.New("glProgramUniformMatrix4x2fv")
 	}
+	gpProgramUniformMatrix4x2fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X2FVEXT)(getProcAddr("glProgramUniformMatrix4x2fvEXT"))
 	gpProgramUniformMatrix4x3dv = (C.GPPROGRAMUNIFORMMATRIX4X3DV)(getProcAddr("glProgramUniformMatrix4x3dv"))
 	if gpProgramUniformMatrix4x3dv == nil {
 		return errors.New("glProgramUniformMatrix4x3dv")
 	}
+	gpProgramUniformMatrix4x3dvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3DVEXT)(getProcAddr("glProgramUniformMatrix4x3dvEXT"))
 	gpProgramUniformMatrix4x3fv = (C.GPPROGRAMUNIFORMMATRIX4X3FV)(getProcAddr("glProgramUniformMatrix4x3fv"))
 	if gpProgramUniformMatrix4x3fv == nil {
 		return errors.New("glProgramUniformMatrix4x3fv")
 	}
+	gpProgramUniformMatrix4x3fvEXT = (C.GPPROGRAMUNIFORMMATRIX4X3FVEXT)(getProcAddr("glProgramUniformMatrix4x3fvEXT"))
+	gpProgramUniformui64NV = (C.GPPROGRAMUNIFORMUI64NV)(getProcAddr("glProgramUniformui64NV"))
+	gpProgramUniformui64vNV = (C.GPPROGRAMUNIFORMUI64VNV)(getProcAddr("glProgramUniformui64vNV"))
 	gpProvokingVertex = (C.GPPROVOKINGVERTEX)(getProcAddr("glProvokingVertex"))
 	if gpProvokingVertex == nil {
 		return errors.New("glProvokingVertex")
 	}
+	gpPushClientAttribDefaultEXT = (C.GPPUSHCLIENTATTRIBDEFAULTEXT)(getProcAddr("glPushClientAttribDefaultEXT"))
 	gpPushDebugGroup = (C.GPPUSHDEBUGGROUP)(getProcAddr("glPushDebugGroup"))
 	if gpPushDebugGroup == nil {
 		return errors.New("glPushDebugGroup")
 	}
 	gpPushDebugGroupKHR = (C.GPPUSHDEBUGGROUPKHR)(getProcAddr("glPushDebugGroupKHR"))
+	gpPushGroupMarkerEXT = (C.GPPUSHGROUPMARKEREXT)(getProcAddr("glPushGroupMarkerEXT"))
 	gpQueryCounter = (C.GPQUERYCOUNTER)(getProcAddr("glQueryCounter"))
 	if gpQueryCounter == nil {
 		return errors.New("glQueryCounter")
 	}
+	gpRasterSamplesEXT = (C.GPRASTERSAMPLESEXT)(getProcAddr("glRasterSamplesEXT"))
 	gpReadBuffer = (C.GPREADBUFFER)(getProcAddr("glReadBuffer"))
 	if gpReadBuffer == nil {
 		return errors.New("glReadBuffer")
@@ -10022,6 +15444,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpRenderbufferStorageMultisample == nil {
 		return errors.New("glRenderbufferStorageMultisample")
 	}
+	gpRenderbufferStorageMultisampleCoverageNV = (C.GPRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENV)(getProcAddr("glRenderbufferStorageMultisampleCoverageNV"))
+	gpResolveDepthValuesNV = (C.GPRESOLVEDEPTHVALUESNV)(getProcAddr("glResolveDepthValuesNV"))
 	gpResumeTransformFeedback = (C.GPRESUMETRANSFORMFEEDBACK)(getProcAddr("glResumeTransformFeedback"))
 	if gpResumeTransformFeedback == nil {
 		return errors.New("glResumeTransformFeedback")
@@ -10074,6 +15498,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpScissorIndexedv == nil {
 		return errors.New("glScissorIndexedv")
 	}
+	gpSecondaryColorFormatNV = (C.GPSECONDARYCOLORFORMATNV)(getProcAddr("glSecondaryColorFormatNV"))
+	gpSelectPerfMonitorCountersAMD = (C.GPSELECTPERFMONITORCOUNTERSAMD)(getProcAddr("glSelectPerfMonitorCountersAMD"))
 	gpShaderBinary = (C.GPSHADERBINARY)(getProcAddr("glShaderBinary"))
 	if gpShaderBinary == nil {
 		return errors.New("glShaderBinary")
@@ -10086,6 +15512,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpShaderStorageBlockBinding == nil {
 		return errors.New("glShaderStorageBlockBinding")
 	}
+	gpSignalVkFenceNV = (C.GPSIGNALVKFENCENV)(getProcAddr("glSignalVkFenceNV"))
+	gpSignalVkSemaphoreNV = (C.GPSIGNALVKSEMAPHORENV)(getProcAddr("glSignalVkSemaphoreNV"))
+	gpSpecializeShaderARB = (C.GPSPECIALIZESHADERARB)(getProcAddr("glSpecializeShaderARB"))
+	gpStateCaptureNV = (C.GPSTATECAPTURENV)(getProcAddr("glStateCaptureNV"))
+	gpStencilFillPathInstancedNV = (C.GPSTENCILFILLPATHINSTANCEDNV)(getProcAddr("glStencilFillPathInstancedNV"))
+	gpStencilFillPathNV = (C.GPSTENCILFILLPATHNV)(getProcAddr("glStencilFillPathNV"))
 	gpStencilFunc = (C.GPSTENCILFUNC)(getProcAddr("glStencilFunc"))
 	if gpStencilFunc == nil {
 		return errors.New("glStencilFunc")
@@ -10110,14 +15542,23 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpStencilOpSeparate == nil {
 		return errors.New("glStencilOpSeparate")
 	}
+	gpStencilStrokePathInstancedNV = (C.GPSTENCILSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilStrokePathInstancedNV"))
+	gpStencilStrokePathNV = (C.GPSTENCILSTROKEPATHNV)(getProcAddr("glStencilStrokePathNV"))
+	gpStencilThenCoverFillPathInstancedNV = (C.GPSTENCILTHENCOVERFILLPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverFillPathInstancedNV"))
+	gpStencilThenCoverFillPathNV = (C.GPSTENCILTHENCOVERFILLPATHNV)(getProcAddr("glStencilThenCoverFillPathNV"))
+	gpStencilThenCoverStrokePathInstancedNV = (C.GPSTENCILTHENCOVERSTROKEPATHINSTANCEDNV)(getProcAddr("glStencilThenCoverStrokePathInstancedNV"))
+	gpStencilThenCoverStrokePathNV = (C.GPSTENCILTHENCOVERSTROKEPATHNV)(getProcAddr("glStencilThenCoverStrokePathNV"))
+	gpSubpixelPrecisionBiasNV = (C.GPSUBPIXELPRECISIONBIASNV)(getProcAddr("glSubpixelPrecisionBiasNV"))
 	gpTexBuffer = (C.GPTEXBUFFER)(getProcAddr("glTexBuffer"))
 	if gpTexBuffer == nil {
 		return errors.New("glTexBuffer")
 	}
+	gpTexBufferARB = (C.GPTEXBUFFERARB)(getProcAddr("glTexBufferARB"))
 	gpTexBufferRange = (C.GPTEXBUFFERRANGE)(getProcAddr("glTexBufferRange"))
 	if gpTexBufferRange == nil {
 		return errors.New("glTexBufferRange")
 	}
+	gpTexCoordFormatNV = (C.GPTEXCOORDFORMATNV)(getProcAddr("glTexCoordFormatNV"))
 	gpTexImage1D = (C.GPTEXIMAGE1D)(getProcAddr("glTexImage1D"))
 	if gpTexImage1D == nil {
 		return errors.New("glTexImage1D")
@@ -10199,70 +15640,92 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpTextureBarrier == nil {
 		return errors.New("glTextureBarrier")
 	}
+	gpTextureBarrierNV = (C.GPTEXTUREBARRIERNV)(getProcAddr("glTextureBarrierNV"))
 	gpTextureBuffer = (C.GPTEXTUREBUFFER)(getProcAddr("glTextureBuffer"))
 	if gpTextureBuffer == nil {
 		return errors.New("glTextureBuffer")
 	}
+	gpTextureBufferEXT = (C.GPTEXTUREBUFFEREXT)(getProcAddr("glTextureBufferEXT"))
 	gpTextureBufferRange = (C.GPTEXTUREBUFFERRANGE)(getProcAddr("glTextureBufferRange"))
 	if gpTextureBufferRange == nil {
 		return errors.New("glTextureBufferRange")
 	}
+	gpTextureBufferRangeEXT = (C.GPTEXTUREBUFFERRANGEEXT)(getProcAddr("glTextureBufferRangeEXT"))
+	gpTextureImage1DEXT = (C.GPTEXTUREIMAGE1DEXT)(getProcAddr("glTextureImage1DEXT"))
+	gpTextureImage2DEXT = (C.GPTEXTUREIMAGE2DEXT)(getProcAddr("glTextureImage2DEXT"))
+	gpTextureImage3DEXT = (C.GPTEXTUREIMAGE3DEXT)(getProcAddr("glTextureImage3DEXT"))
+	gpTexturePageCommitmentEXT = (C.GPTEXTUREPAGECOMMITMENTEXT)(getProcAddr("glTexturePageCommitmentEXT"))
 	gpTextureParameterIiv = (C.GPTEXTUREPARAMETERIIV)(getProcAddr("glTextureParameterIiv"))
 	if gpTextureParameterIiv == nil {
 		return errors.New("glTextureParameterIiv")
 	}
+	gpTextureParameterIivEXT = (C.GPTEXTUREPARAMETERIIVEXT)(getProcAddr("glTextureParameterIivEXT"))
 	gpTextureParameterIuiv = (C.GPTEXTUREPARAMETERIUIV)(getProcAddr("glTextureParameterIuiv"))
 	if gpTextureParameterIuiv == nil {
 		return errors.New("glTextureParameterIuiv")
 	}
+	gpTextureParameterIuivEXT = (C.GPTEXTUREPARAMETERIUIVEXT)(getProcAddr("glTextureParameterIuivEXT"))
 	gpTextureParameterf = (C.GPTEXTUREPARAMETERF)(getProcAddr("glTextureParameterf"))
 	if gpTextureParameterf == nil {
 		return errors.New("glTextureParameterf")
 	}
+	gpTextureParameterfEXT = (C.GPTEXTUREPARAMETERFEXT)(getProcAddr("glTextureParameterfEXT"))
 	gpTextureParameterfv = (C.GPTEXTUREPARAMETERFV)(getProcAddr("glTextureParameterfv"))
 	if gpTextureParameterfv == nil {
 		return errors.New("glTextureParameterfv")
 	}
+	gpTextureParameterfvEXT = (C.GPTEXTUREPARAMETERFVEXT)(getProcAddr("glTextureParameterfvEXT"))
 	gpTextureParameteri = (C.GPTEXTUREPARAMETERI)(getProcAddr("glTextureParameteri"))
 	if gpTextureParameteri == nil {
 		return errors.New("glTextureParameteri")
 	}
+	gpTextureParameteriEXT = (C.GPTEXTUREPARAMETERIEXT)(getProcAddr("glTextureParameteriEXT"))
 	gpTextureParameteriv = (C.GPTEXTUREPARAMETERIV)(getProcAddr("glTextureParameteriv"))
 	if gpTextureParameteriv == nil {
 		return errors.New("glTextureParameteriv")
 	}
+	gpTextureParameterivEXT = (C.GPTEXTUREPARAMETERIVEXT)(getProcAddr("glTextureParameterivEXT"))
+	gpTextureRenderbufferEXT = (C.GPTEXTURERENDERBUFFEREXT)(getProcAddr("glTextureRenderbufferEXT"))
 	gpTextureStorage1D = (C.GPTEXTURESTORAGE1D)(getProcAddr("glTextureStorage1D"))
 	if gpTextureStorage1D == nil {
 		return errors.New("glTextureStorage1D")
 	}
+	gpTextureStorage1DEXT = (C.GPTEXTURESTORAGE1DEXT)(getProcAddr("glTextureStorage1DEXT"))
 	gpTextureStorage2D = (C.GPTEXTURESTORAGE2D)(getProcAddr("glTextureStorage2D"))
 	if gpTextureStorage2D == nil {
 		return errors.New("glTextureStorage2D")
 	}
+	gpTextureStorage2DEXT = (C.GPTEXTURESTORAGE2DEXT)(getProcAddr("glTextureStorage2DEXT"))
 	gpTextureStorage2DMultisample = (C.GPTEXTURESTORAGE2DMULTISAMPLE)(getProcAddr("glTextureStorage2DMultisample"))
 	if gpTextureStorage2DMultisample == nil {
 		return errors.New("glTextureStorage2DMultisample")
 	}
+	gpTextureStorage2DMultisampleEXT = (C.GPTEXTURESTORAGE2DMULTISAMPLEEXT)(getProcAddr("glTextureStorage2DMultisampleEXT"))
 	gpTextureStorage3D = (C.GPTEXTURESTORAGE3D)(getProcAddr("glTextureStorage3D"))
 	if gpTextureStorage3D == nil {
 		return errors.New("glTextureStorage3D")
 	}
+	gpTextureStorage3DEXT = (C.GPTEXTURESTORAGE3DEXT)(getProcAddr("glTextureStorage3DEXT"))
 	gpTextureStorage3DMultisample = (C.GPTEXTURESTORAGE3DMULTISAMPLE)(getProcAddr("glTextureStorage3DMultisample"))
 	if gpTextureStorage3DMultisample == nil {
 		return errors.New("glTextureStorage3DMultisample")
 	}
+	gpTextureStorage3DMultisampleEXT = (C.GPTEXTURESTORAGE3DMULTISAMPLEEXT)(getProcAddr("glTextureStorage3DMultisampleEXT"))
 	gpTextureSubImage1D = (C.GPTEXTURESUBIMAGE1D)(getProcAddr("glTextureSubImage1D"))
 	if gpTextureSubImage1D == nil {
 		return errors.New("glTextureSubImage1D")
 	}
+	gpTextureSubImage1DEXT = (C.GPTEXTURESUBIMAGE1DEXT)(getProcAddr("glTextureSubImage1DEXT"))
 	gpTextureSubImage2D = (C.GPTEXTURESUBIMAGE2D)(getProcAddr("glTextureSubImage2D"))
 	if gpTextureSubImage2D == nil {
 		return errors.New("glTextureSubImage2D")
 	}
+	gpTextureSubImage2DEXT = (C.GPTEXTURESUBIMAGE2DEXT)(getProcAddr("glTextureSubImage2DEXT"))
 	gpTextureSubImage3D = (C.GPTEXTURESUBIMAGE3D)(getProcAddr("glTextureSubImage3D"))
 	if gpTextureSubImage3D == nil {
 		return errors.New("glTextureSubImage3D")
 	}
+	gpTextureSubImage3DEXT = (C.GPTEXTURESUBIMAGE3DEXT)(getProcAddr("glTextureSubImage3DEXT"))
 	gpTextureView = (C.GPTEXTUREVIEW)(getProcAddr("glTextureView"))
 	if gpTextureView == nil {
 		return errors.New("glTextureView")
@@ -10279,6 +15742,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpTransformFeedbackVaryings == nil {
 		return errors.New("glTransformFeedbackVaryings")
 	}
+	gpTransformPathNV = (C.GPTRANSFORMPATHNV)(getProcAddr("glTransformPathNV"))
 	gpUniform1d = (C.GPUNIFORM1D)(getProcAddr("glUniform1d"))
 	if gpUniform1d == nil {
 		return errors.New("glUniform1d")
@@ -10299,6 +15763,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1i == nil {
 		return errors.New("glUniform1i")
 	}
+	gpUniform1i64ARB = (C.GPUNIFORM1I64ARB)(getProcAddr("glUniform1i64ARB"))
+	gpUniform1i64NV = (C.GPUNIFORM1I64NV)(getProcAddr("glUniform1i64NV"))
+	gpUniform1i64vARB = (C.GPUNIFORM1I64VARB)(getProcAddr("glUniform1i64vARB"))
+	gpUniform1i64vNV = (C.GPUNIFORM1I64VNV)(getProcAddr("glUniform1i64vNV"))
 	gpUniform1iv = (C.GPUNIFORM1IV)(getProcAddr("glUniform1iv"))
 	if gpUniform1iv == nil {
 		return errors.New("glUniform1iv")
@@ -10307,6 +15775,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform1ui == nil {
 		return errors.New("glUniform1ui")
 	}
+	gpUniform1ui64ARB = (C.GPUNIFORM1UI64ARB)(getProcAddr("glUniform1ui64ARB"))
+	gpUniform1ui64NV = (C.GPUNIFORM1UI64NV)(getProcAddr("glUniform1ui64NV"))
+	gpUniform1ui64vARB = (C.GPUNIFORM1UI64VARB)(getProcAddr("glUniform1ui64vARB"))
+	gpUniform1ui64vNV = (C.GPUNIFORM1UI64VNV)(getProcAddr("glUniform1ui64vNV"))
 	gpUniform1uiv = (C.GPUNIFORM1UIV)(getProcAddr("glUniform1uiv"))
 	if gpUniform1uiv == nil {
 		return errors.New("glUniform1uiv")
@@ -10331,6 +15803,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2i == nil {
 		return errors.New("glUniform2i")
 	}
+	gpUniform2i64ARB = (C.GPUNIFORM2I64ARB)(getProcAddr("glUniform2i64ARB"))
+	gpUniform2i64NV = (C.GPUNIFORM2I64NV)(getProcAddr("glUniform2i64NV"))
+	gpUniform2i64vARB = (C.GPUNIFORM2I64VARB)(getProcAddr("glUniform2i64vARB"))
+	gpUniform2i64vNV = (C.GPUNIFORM2I64VNV)(getProcAddr("glUniform2i64vNV"))
 	gpUniform2iv = (C.GPUNIFORM2IV)(getProcAddr("glUniform2iv"))
 	if gpUniform2iv == nil {
 		return errors.New("glUniform2iv")
@@ -10339,6 +15815,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform2ui == nil {
 		return errors.New("glUniform2ui")
 	}
+	gpUniform2ui64ARB = (C.GPUNIFORM2UI64ARB)(getProcAddr("glUniform2ui64ARB"))
+	gpUniform2ui64NV = (C.GPUNIFORM2UI64NV)(getProcAddr("glUniform2ui64NV"))
+	gpUniform2ui64vARB = (C.GPUNIFORM2UI64VARB)(getProcAddr("glUniform2ui64vARB"))
+	gpUniform2ui64vNV = (C.GPUNIFORM2UI64VNV)(getProcAddr("glUniform2ui64vNV"))
 	gpUniform2uiv = (C.GPUNIFORM2UIV)(getProcAddr("glUniform2uiv"))
 	if gpUniform2uiv == nil {
 		return errors.New("glUniform2uiv")
@@ -10363,6 +15843,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3i == nil {
 		return errors.New("glUniform3i")
 	}
+	gpUniform3i64ARB = (C.GPUNIFORM3I64ARB)(getProcAddr("glUniform3i64ARB"))
+	gpUniform3i64NV = (C.GPUNIFORM3I64NV)(getProcAddr("glUniform3i64NV"))
+	gpUniform3i64vARB = (C.GPUNIFORM3I64VARB)(getProcAddr("glUniform3i64vARB"))
+	gpUniform3i64vNV = (C.GPUNIFORM3I64VNV)(getProcAddr("glUniform3i64vNV"))
 	gpUniform3iv = (C.GPUNIFORM3IV)(getProcAddr("glUniform3iv"))
 	if gpUniform3iv == nil {
 		return errors.New("glUniform3iv")
@@ -10371,6 +15855,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform3ui == nil {
 		return errors.New("glUniform3ui")
 	}
+	gpUniform3ui64ARB = (C.GPUNIFORM3UI64ARB)(getProcAddr("glUniform3ui64ARB"))
+	gpUniform3ui64NV = (C.GPUNIFORM3UI64NV)(getProcAddr("glUniform3ui64NV"))
+	gpUniform3ui64vARB = (C.GPUNIFORM3UI64VARB)(getProcAddr("glUniform3ui64vARB"))
+	gpUniform3ui64vNV = (C.GPUNIFORM3UI64VNV)(getProcAddr("glUniform3ui64vNV"))
 	gpUniform3uiv = (C.GPUNIFORM3UIV)(getProcAddr("glUniform3uiv"))
 	if gpUniform3uiv == nil {
 		return errors.New("glUniform3uiv")
@@ -10395,6 +15883,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4i == nil {
 		return errors.New("glUniform4i")
 	}
+	gpUniform4i64ARB = (C.GPUNIFORM4I64ARB)(getProcAddr("glUniform4i64ARB"))
+	gpUniform4i64NV = (C.GPUNIFORM4I64NV)(getProcAddr("glUniform4i64NV"))
+	gpUniform4i64vARB = (C.GPUNIFORM4I64VARB)(getProcAddr("glUniform4i64vARB"))
+	gpUniform4i64vNV = (C.GPUNIFORM4I64VNV)(getProcAddr("glUniform4i64vNV"))
 	gpUniform4iv = (C.GPUNIFORM4IV)(getProcAddr("glUniform4iv"))
 	if gpUniform4iv == nil {
 		return errors.New("glUniform4iv")
@@ -10403,6 +15895,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniform4ui == nil {
 		return errors.New("glUniform4ui")
 	}
+	gpUniform4ui64ARB = (C.GPUNIFORM4UI64ARB)(getProcAddr("glUniform4ui64ARB"))
+	gpUniform4ui64NV = (C.GPUNIFORM4UI64NV)(getProcAddr("glUniform4ui64NV"))
+	gpUniform4ui64vARB = (C.GPUNIFORM4UI64VARB)(getProcAddr("glUniform4ui64vARB"))
+	gpUniform4ui64vNV = (C.GPUNIFORM4UI64VNV)(getProcAddr("glUniform4ui64vNV"))
 	gpUniform4uiv = (C.GPUNIFORM4UIV)(getProcAddr("glUniform4uiv"))
 	if gpUniform4uiv == nil {
 		return errors.New("glUniform4uiv")
@@ -10412,7 +15908,9 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 		return errors.New("glUniformBlockBinding")
 	}
 	gpUniformHandleui64ARB = (C.GPUNIFORMHANDLEUI64ARB)(getProcAddr("glUniformHandleui64ARB"))
+	gpUniformHandleui64NV = (C.GPUNIFORMHANDLEUI64NV)(getProcAddr("glUniformHandleui64NV"))
 	gpUniformHandleui64vARB = (C.GPUNIFORMHANDLEUI64VARB)(getProcAddr("glUniformHandleui64vARB"))
+	gpUniformHandleui64vNV = (C.GPUNIFORMHANDLEUI64VNV)(getProcAddr("glUniformHandleui64vNV"))
 	gpUniformMatrix2dv = (C.GPUNIFORMMATRIX2DV)(getProcAddr("glUniformMatrix2dv"))
 	if gpUniformMatrix2dv == nil {
 		return errors.New("glUniformMatrix2dv")
@@ -10489,6 +15987,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUniformSubroutinesuiv == nil {
 		return errors.New("glUniformSubroutinesuiv")
 	}
+	gpUniformui64NV = (C.GPUNIFORMUI64NV)(getProcAddr("glUniformui64NV"))
+	gpUniformui64vNV = (C.GPUNIFORMUI64VNV)(getProcAddr("glUniformui64vNV"))
 	gpUnmapBuffer = (C.GPUNMAPBUFFER)(getProcAddr("glUnmapBuffer"))
 	if gpUnmapBuffer == nil {
 		return errors.New("glUnmapBuffer")
@@ -10497,6 +15997,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUnmapNamedBuffer == nil {
 		return errors.New("glUnmapNamedBuffer")
 	}
+	gpUnmapNamedBufferEXT = (C.GPUNMAPNAMEDBUFFEREXT)(getProcAddr("glUnmapNamedBufferEXT"))
 	gpUseProgram = (C.GPUSEPROGRAM)(getProcAddr("glUseProgram"))
 	if gpUseProgram == nil {
 		return errors.New("glUseProgram")
@@ -10505,6 +16006,8 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpUseProgramStages == nil {
 		return errors.New("glUseProgramStages")
 	}
+	gpUseProgramStagesEXT = (C.GPUSEPROGRAMSTAGESEXT)(getProcAddr("glUseProgramStagesEXT"))
+	gpUseShaderProgramEXT = (C.GPUSESHADERPROGRAMEXT)(getProcAddr("glUseShaderProgramEXT"))
 	gpValidateProgram = (C.GPVALIDATEPROGRAM)(getProcAddr("glValidateProgram"))
 	if gpValidateProgram == nil {
 		return errors.New("glValidateProgram")
@@ -10513,6 +16016,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpValidateProgramPipeline == nil {
 		return errors.New("glValidateProgramPipeline")
 	}
+	gpValidateProgramPipelineEXT = (C.GPVALIDATEPROGRAMPIPELINEEXT)(getProcAddr("glValidateProgramPipelineEXT"))
 	gpVertexArrayAttribBinding = (C.GPVERTEXARRAYATTRIBBINDING)(getProcAddr("glVertexArrayAttribBinding"))
 	if gpVertexArrayAttribBinding == nil {
 		return errors.New("glVertexArrayAttribBinding")
@@ -10529,14 +16033,32 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexArrayAttribLFormat == nil {
 		return errors.New("glVertexArrayAttribLFormat")
 	}
+	gpVertexArrayBindVertexBufferEXT = (C.GPVERTEXARRAYBINDVERTEXBUFFEREXT)(getProcAddr("glVertexArrayBindVertexBufferEXT"))
 	gpVertexArrayBindingDivisor = (C.GPVERTEXARRAYBINDINGDIVISOR)(getProcAddr("glVertexArrayBindingDivisor"))
 	if gpVertexArrayBindingDivisor == nil {
 		return errors.New("glVertexArrayBindingDivisor")
 	}
+	gpVertexArrayColorOffsetEXT = (C.GPVERTEXARRAYCOLOROFFSETEXT)(getProcAddr("glVertexArrayColorOffsetEXT"))
+	gpVertexArrayEdgeFlagOffsetEXT = (C.GPVERTEXARRAYEDGEFLAGOFFSETEXT)(getProcAddr("glVertexArrayEdgeFlagOffsetEXT"))
 	gpVertexArrayElementBuffer = (C.GPVERTEXARRAYELEMENTBUFFER)(getProcAddr("glVertexArrayElementBuffer"))
 	if gpVertexArrayElementBuffer == nil {
 		return errors.New("glVertexArrayElementBuffer")
 	}
+	gpVertexArrayFogCoordOffsetEXT = (C.GPVERTEXARRAYFOGCOORDOFFSETEXT)(getProcAddr("glVertexArrayFogCoordOffsetEXT"))
+	gpVertexArrayIndexOffsetEXT = (C.GPVERTEXARRAYINDEXOFFSETEXT)(getProcAddr("glVertexArrayIndexOffsetEXT"))
+	gpVertexArrayMultiTexCoordOffsetEXT = (C.GPVERTEXARRAYMULTITEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayMultiTexCoordOffsetEXT"))
+	gpVertexArrayNormalOffsetEXT = (C.GPVERTEXARRAYNORMALOFFSETEXT)(getProcAddr("glVertexArrayNormalOffsetEXT"))
+	gpVertexArraySecondaryColorOffsetEXT = (C.GPVERTEXARRAYSECONDARYCOLOROFFSETEXT)(getProcAddr("glVertexArraySecondaryColorOffsetEXT"))
+	gpVertexArrayTexCoordOffsetEXT = (C.GPVERTEXARRAYTEXCOORDOFFSETEXT)(getProcAddr("glVertexArrayTexCoordOffsetEXT"))
+	gpVertexArrayVertexAttribBindingEXT = (C.GPVERTEXARRAYVERTEXATTRIBBINDINGEXT)(getProcAddr("glVertexArrayVertexAttribBindingEXT"))
+	gpVertexArrayVertexAttribDivisorEXT = (C.GPVERTEXARRAYVERTEXATTRIBDIVISOREXT)(getProcAddr("glVertexArrayVertexAttribDivisorEXT"))
+	gpVertexArrayVertexAttribFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBFORMATEXT)(getProcAddr("glVertexArrayVertexAttribFormatEXT"))
+	gpVertexArrayVertexAttribIFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBIFORMATEXT)(getProcAddr("glVertexArrayVertexAttribIFormatEXT"))
+	gpVertexArrayVertexAttribIOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBIOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribIOffsetEXT"))
+	gpVertexArrayVertexAttribLFormatEXT = (C.GPVERTEXARRAYVERTEXATTRIBLFORMATEXT)(getProcAddr("glVertexArrayVertexAttribLFormatEXT"))
+	gpVertexArrayVertexAttribLOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBLOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribLOffsetEXT"))
+	gpVertexArrayVertexAttribOffsetEXT = (C.GPVERTEXARRAYVERTEXATTRIBOFFSETEXT)(getProcAddr("glVertexArrayVertexAttribOffsetEXT"))
+	gpVertexArrayVertexBindingDivisorEXT = (C.GPVERTEXARRAYVERTEXBINDINGDIVISOREXT)(getProcAddr("glVertexArrayVertexBindingDivisorEXT"))
 	gpVertexArrayVertexBuffer = (C.GPVERTEXARRAYVERTEXBUFFER)(getProcAddr("glVertexArrayVertexBuffer"))
 	if gpVertexArrayVertexBuffer == nil {
 		return errors.New("glVertexArrayVertexBuffer")
@@ -10545,6 +16067,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexArrayVertexBuffers == nil {
 		return errors.New("glVertexArrayVertexBuffers")
 	}
+	gpVertexArrayVertexOffsetEXT = (C.GPVERTEXARRAYVERTEXOFFSETEXT)(getProcAddr("glVertexArrayVertexOffsetEXT"))
 	gpVertexAttrib1d = (C.GPVERTEXATTRIB1D)(getProcAddr("glVertexAttrib1d"))
 	if gpVertexAttrib1d == nil {
 		return errors.New("glVertexAttrib1d")
@@ -10697,10 +16220,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribDivisor == nil {
 		return errors.New("glVertexAttribDivisor")
 	}
+	gpVertexAttribDivisorARB = (C.GPVERTEXATTRIBDIVISORARB)(getProcAddr("glVertexAttribDivisorARB"))
 	gpVertexAttribFormat = (C.GPVERTEXATTRIBFORMAT)(getProcAddr("glVertexAttribFormat"))
 	if gpVertexAttribFormat == nil {
 		return errors.New("glVertexAttribFormat")
 	}
+	gpVertexAttribFormatNV = (C.GPVERTEXATTRIBFORMATNV)(getProcAddr("glVertexAttribFormatNV"))
 	gpVertexAttribI1i = (C.GPVERTEXATTRIBI1I)(getProcAddr("glVertexAttribI1i"))
 	if gpVertexAttribI1i == nil {
 		return errors.New("glVertexAttribI1i")
@@ -10785,6 +16310,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribIFormat == nil {
 		return errors.New("glVertexAttribIFormat")
 	}
+	gpVertexAttribIFormatNV = (C.GPVERTEXATTRIBIFORMATNV)(getProcAddr("glVertexAttribIFormatNV"))
 	gpVertexAttribIPointer = (C.GPVERTEXATTRIBIPOINTER)(getProcAddr("glVertexAttribIPointer"))
 	if gpVertexAttribIPointer == nil {
 		return errors.New("glVertexAttribIPointer")
@@ -10797,8 +16323,12 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL1dv == nil {
 		return errors.New("glVertexAttribL1dv")
 	}
+	gpVertexAttribL1i64NV = (C.GPVERTEXATTRIBL1I64NV)(getProcAddr("glVertexAttribL1i64NV"))
+	gpVertexAttribL1i64vNV = (C.GPVERTEXATTRIBL1I64VNV)(getProcAddr("glVertexAttribL1i64vNV"))
 	gpVertexAttribL1ui64ARB = (C.GPVERTEXATTRIBL1UI64ARB)(getProcAddr("glVertexAttribL1ui64ARB"))
+	gpVertexAttribL1ui64NV = (C.GPVERTEXATTRIBL1UI64NV)(getProcAddr("glVertexAttribL1ui64NV"))
 	gpVertexAttribL1ui64vARB = (C.GPVERTEXATTRIBL1UI64VARB)(getProcAddr("glVertexAttribL1ui64vARB"))
+	gpVertexAttribL1ui64vNV = (C.GPVERTEXATTRIBL1UI64VNV)(getProcAddr("glVertexAttribL1ui64vNV"))
 	gpVertexAttribL2d = (C.GPVERTEXATTRIBL2D)(getProcAddr("glVertexAttribL2d"))
 	if gpVertexAttribL2d == nil {
 		return errors.New("glVertexAttribL2d")
@@ -10807,6 +16337,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL2dv == nil {
 		return errors.New("glVertexAttribL2dv")
 	}
+	gpVertexAttribL2i64NV = (C.GPVERTEXATTRIBL2I64NV)(getProcAddr("glVertexAttribL2i64NV"))
+	gpVertexAttribL2i64vNV = (C.GPVERTEXATTRIBL2I64VNV)(getProcAddr("glVertexAttribL2i64vNV"))
+	gpVertexAttribL2ui64NV = (C.GPVERTEXATTRIBL2UI64NV)(getProcAddr("glVertexAttribL2ui64NV"))
+	gpVertexAttribL2ui64vNV = (C.GPVERTEXATTRIBL2UI64VNV)(getProcAddr("glVertexAttribL2ui64vNV"))
 	gpVertexAttribL3d = (C.GPVERTEXATTRIBL3D)(getProcAddr("glVertexAttribL3d"))
 	if gpVertexAttribL3d == nil {
 		return errors.New("glVertexAttribL3d")
@@ -10815,6 +16349,10 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL3dv == nil {
 		return errors.New("glVertexAttribL3dv")
 	}
+	gpVertexAttribL3i64NV = (C.GPVERTEXATTRIBL3I64NV)(getProcAddr("glVertexAttribL3i64NV"))
+	gpVertexAttribL3i64vNV = (C.GPVERTEXATTRIBL3I64VNV)(getProcAddr("glVertexAttribL3i64vNV"))
+	gpVertexAttribL3ui64NV = (C.GPVERTEXATTRIBL3UI64NV)(getProcAddr("glVertexAttribL3ui64NV"))
+	gpVertexAttribL3ui64vNV = (C.GPVERTEXATTRIBL3UI64VNV)(getProcAddr("glVertexAttribL3ui64vNV"))
 	gpVertexAttribL4d = (C.GPVERTEXATTRIBL4D)(getProcAddr("glVertexAttribL4d"))
 	if gpVertexAttribL4d == nil {
 		return errors.New("glVertexAttribL4d")
@@ -10823,10 +16361,15 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexAttribL4dv == nil {
 		return errors.New("glVertexAttribL4dv")
 	}
+	gpVertexAttribL4i64NV = (C.GPVERTEXATTRIBL4I64NV)(getProcAddr("glVertexAttribL4i64NV"))
+	gpVertexAttribL4i64vNV = (C.GPVERTEXATTRIBL4I64VNV)(getProcAddr("glVertexAttribL4i64vNV"))
+	gpVertexAttribL4ui64NV = (C.GPVERTEXATTRIBL4UI64NV)(getProcAddr("glVertexAttribL4ui64NV"))
+	gpVertexAttribL4ui64vNV = (C.GPVERTEXATTRIBL4UI64VNV)(getProcAddr("glVertexAttribL4ui64vNV"))
 	gpVertexAttribLFormat = (C.GPVERTEXATTRIBLFORMAT)(getProcAddr("glVertexAttribLFormat"))
 	if gpVertexAttribLFormat == nil {
 		return errors.New("glVertexAttribLFormat")
 	}
+	gpVertexAttribLFormatNV = (C.GPVERTEXATTRIBLFORMATNV)(getProcAddr("glVertexAttribLFormatNV"))
 	gpVertexAttribLPointer = (C.GPVERTEXATTRIBLPOINTER)(getProcAddr("glVertexAttribLPointer"))
 	if gpVertexAttribLPointer == nil {
 		return errors.New("glVertexAttribLPointer")
@@ -10871,6 +16414,7 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpVertexBindingDivisor == nil {
 		return errors.New("glVertexBindingDivisor")
 	}
+	gpVertexFormatNV = (C.GPVERTEXFORMATNV)(getProcAddr("glVertexFormatNV"))
 	gpViewport = (C.GPVIEWPORT)(getProcAddr("glViewport"))
 	if gpViewport == nil {
 		return errors.New("glViewport")
@@ -10887,9 +16431,14 @@ func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	if gpViewportIndexedfv == nil {
 		return errors.New("glViewportIndexedfv")
 	}
+	gpViewportPositionWScaleNV = (C.GPVIEWPORTPOSITIONWSCALENV)(getProcAddr("glViewportPositionWScaleNV"))
+	gpViewportSwizzleNV = (C.GPVIEWPORTSWIZZLENV)(getProcAddr("glViewportSwizzleNV"))
 	gpWaitSync = (C.GPWAITSYNC)(getProcAddr("glWaitSync"))
 	if gpWaitSync == nil {
 		return errors.New("glWaitSync")
 	}
+	gpWaitVkSemaphoreNV = (C.GPWAITVKSEMAPHORENV)(getProcAddr("glWaitVkSemaphoreNV"))
+	gpWeightPathsNV = (C.GPWEIGHTPATHSNV)(getProcAddr("glWeightPathsNV"))
+	gpWindowRectanglesEXT = (C.GPWINDOWRECTANGLESEXT)(getProcAddr("glWindowRectanglesEXT"))
 	return nil
 }

--- a/v4.5-core/gl/procaddr.go
+++ b/v4.5-core/gl/procaddr.go
@@ -51,7 +51,7 @@ package gl
 	#include <stdlib.h>
 	#include <GL/glx.h>
 	void* GlowGetProcAddress_glcore45(const char* name) {
-		return glXGetProcAddress(name);
+		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
 */


### PR DESCRIPTION
Despite being entirely generated, we should review this PR with higher scrutiny. This uses the new source of XML data, and there are some changes and additions to the existing packages. We should make sure everything looks good before committing to this (otherwise, we might need to change `glow` first).

This is based on top of go-gl/glow#95.

Done with latest version of glow and newly downloaded XML data:

```
go generate -tags=gen github.com/go-gl/gl
```